### PR TITLE
Fix 25% opacity in MoneyRequestView and TaskView

### DIFF
--- a/src/components/ReportActionItem/MoneyRequestView.js
+++ b/src/components/ReportActionItem/MoneyRequestView.js
@@ -108,13 +108,15 @@ function MoneyRequestView({report, parentReport, shouldShowHorizontalRule, trans
             </View>
 
             {hasReceipt && (
-                <View style={styles.moneyRequestViewImage}>
-                    <ReportActionItemImage
-                        thumbnail={receiptURIs.thumbnail}
-                        image={receiptURIs.image}
-                        enablePreviewModal
-                    />
-                </View>
+                <OfflineWithFeedback pendingAction={lodashGet(transaction, 'pendingAction')}>
+                    <View style={styles.moneyRequestViewImage}>
+                        <ReportActionItemImage
+                            thumbnail={receiptURIs.thumbnail}
+                            image={receiptURIs.image}
+                            enablePreviewModal
+                        />
+                    </View>
+                </OfflineWithFeedback>
             )}
             <OfflineWithFeedback pendingAction={lodashGet(transaction, 'pendingFields.amount') || lodashGet(transaction, 'pendingAction')}>
                 <MenuItemWithTopDescription

--- a/src/components/ReportActionItem/MoneyRequestView.js
+++ b/src/components/ReportActionItem/MoneyRequestView.js
@@ -96,6 +96,8 @@ function MoneyRequestView({report, parentReport, shouldShowHorizontalRule, trans
     }
 
     const isDistanceRequest = TransactionUtils.isDistanceRequest(transaction);
+    const pendingAction = lodashGet(transaction, 'pendingAction');
+    const getPendingFieldAction = (fieldPath) => lodashGet(transaction, fieldPath) || pendingAction;
 
     return (
         <View>
@@ -108,7 +110,7 @@ function MoneyRequestView({report, parentReport, shouldShowHorizontalRule, trans
             </View>
 
             {hasReceipt && (
-                <OfflineWithFeedback pendingAction={lodashGet(transaction, 'pendingAction')}>
+                <OfflineWithFeedback pendingAction={pendingAction}>
                     <View style={styles.moneyRequestViewImage}>
                         <ReportActionItemImage
                             thumbnail={receiptURIs.thumbnail}
@@ -118,7 +120,7 @@ function MoneyRequestView({report, parentReport, shouldShowHorizontalRule, trans
                     </View>
                 </OfflineWithFeedback>
             )}
-            <OfflineWithFeedback pendingAction={lodashGet(transaction, 'pendingFields.amount') || lodashGet(transaction, 'pendingAction')}>
+            <OfflineWithFeedback pendingAction={getPendingFieldAction('pendingFields.amount')}>
                 <MenuItemWithTopDescription
                     title={formattedTransactionAmount ? formattedTransactionAmount.toString() : ''}
                     shouldShowTitleIcon={isSettled}
@@ -133,7 +135,7 @@ function MoneyRequestView({report, parentReport, shouldShowHorizontalRule, trans
                     subtitleTextStyle={styles.textLabelError}
                 />
             </OfflineWithFeedback>
-            <OfflineWithFeedback pendingAction={lodashGet(transaction, 'pendingFields.comment') || lodashGet(transaction, 'pendingAction')}>
+            <OfflineWithFeedback pendingAction={getPendingFieldAction('pendingFields.comment')}>
                 <MenuItemWithTopDescription
                     description={translate('common.description')}
                     shouldParseTitle
@@ -146,7 +148,7 @@ function MoneyRequestView({report, parentReport, shouldShowHorizontalRule, trans
                     numberOfLinesTitle={0}
                 />
             </OfflineWithFeedback>
-            <OfflineWithFeedback pendingAction={lodashGet(transaction, 'pendingFields.created') || lodashGet(transaction, 'pendingAction')}>
+            <OfflineWithFeedback pendingAction={getPendingFieldAction('pendingFields.created')}>
                 <MenuItemWithTopDescription
                     description={translate('common.date')}
                     title={transactionDate}
@@ -159,7 +161,7 @@ function MoneyRequestView({report, parentReport, shouldShowHorizontalRule, trans
                     subtitleTextStyle={styles.textLabelError}
                 />
             </OfflineWithFeedback>
-            <OfflineWithFeedback pendingAction={lodashGet(transaction, 'pendingFields.merchant') || lodashGet(transaction, 'pendingAction')}>
+            <OfflineWithFeedback pendingAction={getPendingFieldAction('pendingFields.merchant')}>
                 <MenuItemWithTopDescription
                     description={isDistanceRequest ? translate('common.distance') : translate('common.merchant')}
                     title={transactionMerchant}

--- a/src/pages/home/report/ReportActionItem.js
+++ b/src/pages/home/report/ReportActionItem.js
@@ -511,12 +511,10 @@ function ReportActionItem(props) {
                         checkIfContextMenuActive: toggleContextMenuFromActiveReportAction,
                     }}
                 >
-                    <OfflineWithFeedback pendingAction={props.action.pendingAction}>
-                        <MoneyRequestView
-                            report={props.report}
-                            shouldShowHorizontalRule={!props.shouldHideThreadDividerLine}
-                        />
-                    </OfflineWithFeedback>
+                    <MoneyRequestView
+                        report={props.report}
+                        shouldShowHorizontalRule={!props.shouldHideThreadDividerLine}
+                    />
                 </ShowContextMenuContext.Provider>
             );
         }
@@ -538,12 +536,10 @@ function ReportActionItem(props) {
             }
 
             return (
-                <OfflineWithFeedback pendingAction={props.action.pendingAction}>
-                    <TaskView
-                        report={props.report}
-                        shouldShowHorizontalRule={!props.shouldHideThreadDividerLine}
-                    />
-                </OfflineWithFeedback>
+                <TaskView
+                    report={props.report}
+                    shouldShowHorizontalRule={!props.shouldHideThreadDividerLine}
+                />
             );
         }
         if (ReportUtils.isExpenseReport(props.report) || ReportUtils.isIOUReport(props.report)) {


### PR DESCRIPTION
### Details
`MoneyRequestView` and `TaskView` content are wrapped by two`OfflineWithFeedback`. When requesting money or creating a task offline, its content has 25% opacity rather than 50% opacity.

### Fixed Issues
$ https://github.com/Expensify/App/issues/26235
PROPOSAL: https://github.com/Expensify/App/issues/26235#issuecomment-1698104402

### Tests
Scenario 1:
1. Be offline.
3. Requesting money.
3. Open the IOU details page.
4. Verify that the grayness is as usual (50%).
5. Be online.
6. Verify that there is no grayness in the content.
7. Be offline.
8. Update Amount, Description, Date, Merchant.
9. Verify that the grayness is as usual (50%).
10. Be online.
11. Verify that there is no grayness in the content.

Scenario 2:
1. Be offline.
2. Creating a task.
3. Open the task details page.
4. Verify that the grayness is as usual (50%).
5. Be online.
6. Verify that there is no grayness in the content.
7. Be offline.
8. Update Title, Description.
9. Verify that the grayness is as usual (50%).
10. Be online.
11. Verify that there is no grayness in the content.
- [x] Verify that no errors appear in the JS console

### Offline tests
Same as tests
### QA Steps
Same as tests
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.
--->

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>



https://github.com/Expensify/App/assets/13113013/531a5f2f-8f74-4d9d-8545-1f989b881ec3





https://github.com/Expensify/App/assets/13113013/b2256090-0ed9-4a63-b70b-5d5b09286aa5
















</details>

<details>
<summary>Mobile Web - Safari</summary>




https://github.com/Expensify/App/assets/13113013/48f7297e-c00a-4fb5-b307-b1b2b7d70245




https://github.com/Expensify/App/assets/13113013/303e9af1-5d5a-4f04-9944-c1d441beef0a


















</details>

<details>
<summary>Mobile Web - Chrome</summary>



https://github.com/Expensify/App/assets/13113013/e043c26d-f440-4da0-97a3-3c646e642ef2



https://github.com/Expensify/App/assets/13113013/ea2bca2d-5702-4463-88ee-fbea1387d096
















</details>

<details>
<summary>Desktop</summary>






https://github.com/Expensify/App/assets/13113013/07076696-12bc-4030-8774-ab291f617084




https://github.com/Expensify/App/assets/13113013/75822aec-fd40-4cc4-8eaf-939702160abd










</details>

<details>
<summary>iOS</summary>




https://github.com/Expensify/App/assets/13113013/a70630d1-00a4-497e-8dc1-de99424dfab3




https://github.com/Expensify/App/assets/13113013/9e010eb6-e4f3-40ba-af5d-b11ae099fa96











</details>

<details>

<summary>Android</summary>



https://github.com/Expensify/App/assets/13113013/dbbe26f1-d84a-46ed-bb0a-8539437a9a01




https://github.com/Expensify/App/assets/13113013/735881b2-e579-4ab3-9a92-a4ea0f38cd7e











</details>
