### PR TITLE
refactor: migrated WalletStatementModal to function component

### DIFF
--- a/src/CONST.ts
+++ b/src/CONST.ts
@@ -982,6 +982,10 @@ const CONST = {
             GOLD: 'GOLD',
             SILVER: 'SILVER',
         },
+        STATEMENT_WEB_MESSAGE_TYPE: {
+            STATEMENT: 'STATEMENT_NAVIGATE',
+            CONCIERGE: 'CONCIERGE_NAVIGATE',
+        },
     },
 
     PLAID: {

--- a/src/CONST.ts
+++ b/src/CONST.ts
@@ -982,7 +982,7 @@ const CONST = {
             GOLD: 'GOLD',
             SILVER: 'SILVER',
         },
-        STATEMENT_WEB_MESSAGE_TYPE: {
+        WEB_MESSAGE_TYPE: {
             STATEMENT: 'STATEMENT_NAVIGATE',
             CONCIERGE: 'CONCIERGE_NAVIGATE',
         },

--- a/src/components/WalletStatementModal/index.js
+++ b/src/components/WalletStatementModal/index.js
@@ -24,15 +24,15 @@ function WalletStatementModal({statementPageURL, session}) {
      * @param {MessageEvent} event
      */
     const navigate = (event) => {
-        if (!event.data || !event.data.type || (event.data.type !== 'STATEMENT_NAVIGATE' && event.data.type !== 'CONCIERGE_NAVIGATE')) {
+        if (!event.data || !event.data.type || (event.data.type !== CONST.WALLET.WEB_MESSAGE_TYPE.STATEMENT && event.data.type !== CONST.WALLET.WEB_MESSAGE_TYPE.CONCIERGE)) {
             return;
         }
 
-        if (event.data.type === CONST.WALLET.STATEMENT_WEB_MESSAGE_TYPE.CONCIERGE) {
+        if (event.data.type === CONST.WALLET.WEB_MESSAGE_TYPE.CONCIERGE) {
             Report.navigateToConciergeChat();
         }
 
-        if (event.data.type === CONST.WALLET.STATEMENT_WEB_MESSAGE_TYPE.STATEMENT && event.data.url) {
+        if (event.data.type === CONST.WALLET.WEB_MESSAGE_TYPE.STATEMENT && event.data.url) {
             const iouRoutes = [ROUTES.IOU_REQUEST, ROUTES.IOU_SEND];
             const navigateToIOURoute = _.find(iouRoutes, (iouRoute) => event.data.url.includes(iouRoute));
             if (navigateToIOURoute) {

--- a/src/components/WalletStatementModal/index.js
+++ b/src/components/WalletStatementModal/index.js
@@ -12,6 +12,7 @@ import FullScreenLoadingIndicator from '../FullscreenLoadingIndicator';
 import ROUTES from '../../ROUTES';
 import Navigation from '../../libs/Navigation/Navigation';
 import * as Report from '../../libs/actions/Report';
+import CONST from '../../CONST';
 
 function WalletStatementModal({statementPageURL, session}) {
     const [isLoading, setIsLoading] = useState(true);
@@ -27,11 +28,11 @@ function WalletStatementModal({statementPageURL, session}) {
             return;
         }
 
-        if (event.data.type === 'CONCIERGE_NAVIGATE') {
+        if (event.data.type === CONST.WALLET.STATEMENT_WEB_MESSAGE_TYPE.CONCIERGE) {
             Report.navigateToConciergeChat();
         }
 
-        if (event.data.type === 'STATEMENT_NAVIGATE' && event.data.url) {
+        if (event.data.type === CONST.WALLET.STATEMENT_WEB_MESSAGE_TYPE.STATEMENT && event.data.url) {
             const iouRoutes = [ROUTES.IOU_REQUEST, ROUTES.IOU_SEND];
             const navigateToIOURoute = _.find(iouRoutes, (iouRoute) => event.data.url.includes(iouRoute));
             if (navigateToIOURoute) {

--- a/src/components/WalletStatementModal/index.native.js
+++ b/src/components/WalletStatementModal/index.native.js
@@ -27,16 +27,16 @@ function WalletStatementModal({statementPageURL, session}) {
      */
     const handleNavigationStateChange = useCallback(
         ({type, url}) => {
-            if (!webViewRef.current || (type !== 'STATEMENT_NAVIGATE' && type !== 'CONCIERGE_NAVIGATE')) {
+            if (!webViewRef.current || (type !== CONST.WALLET.WEB_MESSAGE_TYPE.STATEMENT && type !== CONST.WALLET.WEB_MESSAGE_TYPE.CONCIERGE)) {
                 return;
             }
 
-            if (type === CONST.WALLET.STATEMENT_WEB_MESSAGE_TYPE.CONCIERGE) {
+            if (type === CONST.WALLET.WEB_MESSAGE_TYPE.CONCIERGE) {
                 webViewRef.current.stopLoading();
                 Report.navigateToConciergeChat();
             }
 
-            if (type === CONST.WALLET.STATEMENT_WEB_MESSAGE_TYPE.STATEMENT && url) {
+            if (type === CONST.WALLET.WEB_MESSAGE_TYPE.STATEMENT && url) {
                 const iouRoute = _.find(IOU_ROUTES, (item) => url.includes(item));
 
                 if (iouRoute) {

--- a/src/components/WalletStatementModal/index.native.js
+++ b/src/components/WalletStatementModal/index.native.js
@@ -10,6 +10,7 @@ import * as Report from '../../libs/actions/Report';
 import Navigation from '../../libs/Navigation/Navigation';
 import ROUTES from '../../ROUTES';
 import ONYXKEYS from '../../ONYXKEYS';
+import CONST from '../../CONST';
 
 const IOU_ROUTES = [ROUTES.IOU_REQUEST, ROUTES.IOU_SEND];
 const renderLoading = () => <FullScreenLoadingIndicator />;
@@ -30,12 +31,12 @@ function WalletStatementModal({statementPageURL, session}) {
                 return;
             }
 
-            if (type === 'CONCIERGE_NAVIGATE') {
+            if (type === CONST.WALLET.STATEMENT_WEB_MESSAGE_TYPE.CONCIERGE) {
                 webViewRef.current.stopLoading();
                 Report.navigateToConciergeChat();
             }
 
-            if (type === 'STATEMENT_NAVIGATE' && url) {
+            if (type === CONST.WALLET.STATEMENT_WEB_MESSAGE_TYPE.STATEMENT && url) {
                 const iouRoute = _.find(IOU_ROUTES, (item) => url.includes(item));
 
                 if (iouRoute) {

--- a/src/components/WalletStatementModal/index.native.js
+++ b/src/components/WalletStatementModal/index.native.js
@@ -3,12 +3,13 @@ import {WebView} from 'react-native-webview';
 import lodashGet from 'lodash/get';
 import {withOnyx} from 'react-native-onyx';
 import _ from 'underscore';
-import {useNavigation} from '@react-navigation/native';
-import ONYXKEYS from '../../ONYXKEYS';
+
 import {walletStatementPropTypes, walletStatementDefaultProps} from './WalletStatementModalPropTypes';
 import FullScreenLoadingIndicator from '../FullscreenLoadingIndicator';
 import * as Report from '../../libs/actions/Report';
+import Navigation from '../../libs/Navigation/Navigation';
 import ROUTES from '../../ROUTES';
+import ONYXKEYS from '../../ONYXKEYS';
 
 const IOU_ROUTES = [ROUTES.IOU_REQUEST, ROUTES.IOU_SEND];
 const renderLoading = () => <FullScreenLoadingIndicator />;
@@ -16,7 +17,6 @@ const renderLoading = () => <FullScreenLoadingIndicator />;
 function WalletStatementModal({statementPageURL, session}) {
     const webViewRef = useRef();
     const authToken = lodashGet(session, 'authToken', null);
-    const {navigate} = useNavigation();
 
     /**
      * Handles in-app navigation for webview links
@@ -40,11 +40,11 @@ function WalletStatementModal({statementPageURL, session}) {
 
                 if (iouRoute) {
                     webViewRef.current.stopLoading();
-                    navigate(iouRoute);
+                    Navigation.navigate(iouRoute);
                 }
             }
         },
-        [webViewRef, navigate],
+        [webViewRef],
     );
 
     return (

--- a/src/components/WalletStatementModal/index.native.js
+++ b/src/components/WalletStatementModal/index.native.js
@@ -3,7 +3,6 @@ import {WebView} from 'react-native-webview';
 import lodashGet from 'lodash/get';
 import {withOnyx} from 'react-native-onyx';
 import _ from 'underscore';
-
 import {walletStatementPropTypes, walletStatementDefaultProps} from './WalletStatementModalPropTypes';
 import FullScreenLoadingIndicator from '../FullscreenLoadingIndicator';
 import * as Report from '../../libs/actions/Report';

--- a/src/components/WalletStatementModal/index.native.js
+++ b/src/components/WalletStatementModal/index.native.js
@@ -1,24 +1,22 @@
-import React from 'react';
+import React, {useCallback, useRef} from 'react';
 import {WebView} from 'react-native-webview';
 import lodashGet from 'lodash/get';
 import {withOnyx} from 'react-native-onyx';
 import _ from 'underscore';
-import withLocalize from '../withLocalize';
+import {useNavigation} from '@react-navigation/native';
 import ONYXKEYS from '../../ONYXKEYS';
-import compose from '../../libs/compose';
 import {walletStatementPropTypes, walletStatementDefaultProps} from './WalletStatementModalPropTypes';
 import FullScreenLoadingIndicator from '../FullscreenLoadingIndicator';
 import * as Report from '../../libs/actions/Report';
-import Navigation from '../../libs/Navigation/Navigation';
 import ROUTES from '../../ROUTES';
 
-class WalletStatementModal extends React.Component {
-    constructor(props) {
-        super(props);
+const IOU_ROUTES = [ROUTES.IOU_REQUEST, ROUTES.IOU_SEND];
+const renderLoading = () => <FullScreenLoadingIndicator />;
 
-        this.authToken = lodashGet(props, 'session.authToken', null);
-        this.navigate = this.navigate.bind(this);
-    }
+function WalletStatementModal({statementPageURL, session}) {
+    const webViewRef = useRef();
+    const authToken = lodashGet(session, 'authToken', null);
+    const {navigate} = useNavigation();
 
     /**
      * Handles in-app navigation for webview links
@@ -26,54 +24,53 @@ class WalletStatementModal extends React.Component {
      * @param {String} params.type
      * @param {String} params.url
      */
-    navigate({type, url}) {
-        if (!this.webview || (type !== 'STATEMENT_NAVIGATE' && type !== 'CONCIERGE_NAVIGATE')) {
-            return;
-        }
-
-        if (type === 'CONCIERGE_NAVIGATE') {
-            this.webview.stopLoading();
-            Report.navigateToConciergeChat();
-        }
-
-        if (type === 'STATEMENT_NAVIGATE' && url) {
-            const iouRoutes = [ROUTES.IOU_REQUEST, ROUTES.IOU_SEND];
-            const navigateToIOURoute = _.find(iouRoutes, (iouRoute) => url.includes(iouRoute));
-            if (navigateToIOURoute) {
-                this.webview.stopLoading();
-                Navigation.navigate(navigateToIOURoute);
+    const handleNavigationStateChange = useCallback(
+        ({type, url}) => {
+            if (!webViewRef.current || (type !== 'STATEMENT_NAVIGATE' && type !== 'CONCIERGE_NAVIGATE')) {
+                return;
             }
-        }
-    }
 
-    render() {
-        return (
-            <WebView
-                ref={(node) => (this.webview = node)}
-                originWhitelist={['https://*']}
-                source={{
-                    uri: this.props.statementPageURL,
-                    headers: {
-                        Cookie: `authToken=${this.authToken}`,
-                    },
-                }}
-                incognito // 'incognito' prop required for Android, issue here https://github.com/react-native-webview/react-native-webview/issues/1352
-                startInLoadingState
-                renderLoading={() => <FullScreenLoadingIndicator />}
-                onNavigationStateChange={this.navigate}
-            />
-        );
-    }
+            if (type === 'CONCIERGE_NAVIGATE') {
+                webViewRef.current.stopLoading();
+                Report.navigateToConciergeChat();
+            }
+
+            if (type === 'STATEMENT_NAVIGATE' && url) {
+                const iouRoute = _.find(IOU_ROUTES, (item) => url.includes(item));
+
+                if (iouRoute) {
+                    webViewRef.current.stopLoading();
+                    navigate(iouRoute);
+                }
+            }
+        },
+        [webViewRef, navigate],
+    );
+
+    return (
+        <WebView
+            ref={webViewRef}
+            originWhitelist={['https://*']}
+            source={{
+                uri: statementPageURL,
+                headers: {
+                    Cookie: `authToken=${authToken}`,
+                },
+            }}
+            incognito // 'incognito' prop required for Android, issue here https://github.com/react-native-webview/react-native-webview/issues/1352
+            startInLoadingState
+            renderLoading={renderLoading}
+            onNavigationStateChange={handleNavigationStateChange}
+        />
+    );
 }
 
+WalletStatementModal.displayName = 'WalletStatementModal';
 WalletStatementModal.propTypes = walletStatementPropTypes;
 WalletStatementModal.defaultProps = walletStatementDefaultProps;
 
-export default compose(
-    withLocalize,
-    withOnyx({
-        session: {
-            key: ONYXKEYS.SESSION,
-        },
-    }),
-)(WalletStatementModal);
+export default withOnyx({
+    session: {
+        key: ONYXKEYS.SESSION,
+    },
+})(WalletStatementModal);


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ [16217](https://github.com/Expensify/App/issues/16217)
PROPOSAL:  [16217](https://github.com/Expensify/App/issues/16217)


### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->
1. Go to http://localhost:8082/statements/202308 - parameter is a date with format YYYYMM
2.  Verify that there is no error in the console in local environment

- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->
1. Go to http://localhost:8082/statements/202308 - parameter is a date with format YYYYMM
2.  Verify that there is no error in the console in local environment (you won't see a statement, just a blank page, but that's expected).

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] If we are not using the full Onyx data that we loaded, I've added the proper selector in order to ensure the component only re-renders when the data it is using changes
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
``` 

note: In that PR to create screenshots need to hardcode the path because 
this feature is available for US citizens only.
That's why the web view is empty. However, nothing changed in passing the proper url.
```
<details>
<summary>Web</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Mobile Web - Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Mobile Web - Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Desktop</summary>

<!-- add screenshots or videos here -->
<img width="1194" alt="Screenshot 2023-09-21 at 13 40 12" src="https://github.com/Expensify/App/assets/7682108/29966a83-b1bd-4829-80f9-5c805f271f0d">


</details>

<details>
<summary>iOS</summary>

<!-- add screenshots or videos here -->
![Screenshot 2023-09-21 at 13 40 30](https://github.com/Expensify/App/assets/7682108/9b861fe5-0577-4610-a15f-29a2db042ba9)

</details>

<details>
<summary>Android</summary>

<!-- add screenshots or videos here -->
![Screenshot 2023-09-21 at 13 34 40](https://github.com/Expensify/App/assets/7682108/49d529ed-e4ec-4012-90ee-141bf502424c)


</details>
