### PR TITLE
fix: send message - user navigates to Room tab when dragging to select e-mail from Chat tab

### DIFF
--- a/src/components/MapView/responder/index.ts
+++ b/src/components/MapView/responder/index.ts
@@ -1,8 +1,3 @@
-import {PanResponder} from 'react-native';
+import SwipeInterceptPanResponder from '../../SwipeInterceptPanResponder';
 
-const responder = PanResponder.create({
-    onMoveShouldSetPanResponder: () => true,
-    onPanResponderTerminationRequest: () => false,
-});
-
-export default responder;
+export default SwipeInterceptPanResponder;

--- a/src/components/OptionsSelector/BaseOptionsSelector.js
+++ b/src/components/OptionsSelector/BaseOptionsSelector.js
@@ -364,6 +364,7 @@ class BaseOptionsSelector extends Component {
                 selectTextOnFocus
                 blurOnSubmit={Boolean(this.state.allOptions.length)}
                 spellCheck={false}
+                interceptSwipe
             />
         );
         const optionsList = (

--- a/src/components/OptionsSelector/BaseOptionsSelector.js
+++ b/src/components/OptionsSelector/BaseOptionsSelector.js
@@ -364,7 +364,7 @@ class BaseOptionsSelector extends Component {
                 selectTextOnFocus
                 blurOnSubmit={Boolean(this.state.allOptions.length)}
                 spellCheck={false}
-                shouldInterceptSwipe
+                shouldInterceptSwipe={this.props.shouldTextInputInterceptSwipe}
             />
         );
         const optionsList = (

--- a/src/components/OptionsSelector/BaseOptionsSelector.js
+++ b/src/components/OptionsSelector/BaseOptionsSelector.js
@@ -364,7 +364,7 @@ class BaseOptionsSelector extends Component {
                 selectTextOnFocus
                 blurOnSubmit={Boolean(this.state.allOptions.length)}
                 spellCheck={false}
-                interceptSwipe
+                canInterceptSwipe
             />
         );
         const optionsList = (

--- a/src/components/OptionsSelector/BaseOptionsSelector.js
+++ b/src/components/OptionsSelector/BaseOptionsSelector.js
@@ -364,7 +364,7 @@ class BaseOptionsSelector extends Component {
                 selectTextOnFocus
                 blurOnSubmit={Boolean(this.state.allOptions.length)}
                 spellCheck={false}
-                canInterceptSwipe
+                shouldInterceptSwipe
             />
         );
         const optionsList = (

--- a/src/components/OptionsSelector/index.js
+++ b/src/components/OptionsSelector/index.js
@@ -6,6 +6,7 @@ const OptionsSelector = forwardRef((props, ref) => (
         // eslint-disable-next-line react/jsx-props-no-spreading
         {...props}
         ref={ref}
+        shouldTextInputInterceptSwipe
     />
 ));
 

--- a/src/components/OptionsSelector/optionsSelectorPropTypes.js
+++ b/src/components/OptionsSelector/optionsSelectorPropTypes.js
@@ -124,6 +124,9 @@ const propTypes = {
 
     /** Initial focused index value */
     initialFocusedIndex: PropTypes.number,
+
+    /** Whether the text input should intercept swipes or not */
+    shouldTextInputInterceptSwipe: PropTypes.bool,
 };
 
 const defaultProps = {
@@ -160,6 +163,7 @@ const defaultProps = {
     shouldUseStyleForChildren: true,
     isRowMultilineSupported: false,
     initialFocusedIndex: undefined,
+    shouldTextInputInterceptSwipe: false,
 };
 
 export {propTypes, defaultProps};

--- a/src/components/RoomNameInput/index.js
+++ b/src/components/RoomNameInput/index.js
@@ -62,7 +62,7 @@ function RoomNameInput({isFocused, autoFocus, disabled, errorText, forwardedRef,
             autoFocus={isFocused && autoFocus}
             maxLength={CONST.REPORT.MAX_ROOM_NAME_LENGTH}
             spellCheck={false}
-            interceptSwipe
+            canInterceptSwipe
         />
     );
 }

--- a/src/components/RoomNameInput/index.js
+++ b/src/components/RoomNameInput/index.js
@@ -62,7 +62,7 @@ function RoomNameInput({isFocused, autoFocus, disabled, errorText, forwardedRef,
             autoFocus={isFocused && autoFocus}
             maxLength={CONST.REPORT.MAX_ROOM_NAME_LENGTH}
             spellCheck={false}
-            canInterceptSwipe
+            shouldInterceptSwipe
         />
     );
 }

--- a/src/components/RoomNameInput/index.js
+++ b/src/components/RoomNameInput/index.js
@@ -62,6 +62,7 @@ function RoomNameInput({isFocused, autoFocus, disabled, errorText, forwardedRef,
             autoFocus={isFocused && autoFocus}
             maxLength={CONST.REPORT.MAX_ROOM_NAME_LENGTH}
             spellCheck={false}
+            interceptSwipe
         />
     );
 }

--- a/src/components/SwipeInterceptPanResponder.js
+++ b/src/components/SwipeInterceptPanResponder.js
@@ -1,0 +1,8 @@
+import {PanResponder} from 'react-native';
+
+const SwipeInterceptPanResponder = PanResponder.create({
+    onMoveShouldSetPanResponder: () => true,
+    onPanResponderTerminationRequest: () => false,
+});
+
+export default SwipeInterceptPanResponder;

--- a/src/components/TextInput/BaseTextInput.js
+++ b/src/components/TextInput/BaseTextInput.js
@@ -261,7 +261,7 @@ function BaseTextInput(props) {
             <View
                 style={styles.pointerEventsNone}
                 // eslint-disable-next-line react/jsx-props-no-spreading
-                {...(props.interceptSwipe && SwipeInterceptPanResponder.panHandlers)}
+                {...(props.canInterceptSwipe && SwipeInterceptPanResponder.panHandlers)}
             >
                 <PressableWithoutFeedback
                     onPress={onPress}

--- a/src/components/TextInput/BaseTextInput.js
+++ b/src/components/TextInput/BaseTextInput.js
@@ -261,7 +261,7 @@ function BaseTextInput(props) {
             <View
                 style={styles.pointerEventsNone}
                 // eslint-disable-next-line react/jsx-props-no-spreading
-                {...(props.canInterceptSwipe && SwipeInterceptPanResponder.panHandlers)}
+                {...(props.shouldInterceptSwipe && SwipeInterceptPanResponder.panHandlers)}
             >
                 <PressableWithoutFeedback
                     onPress={onPress}

--- a/src/components/TextInput/BaseTextInput.js
+++ b/src/components/TextInput/BaseTextInput.js
@@ -22,6 +22,7 @@ import PressableWithoutFeedback from '../Pressable/PressableWithoutFeedback';
 import withLocalize from '../withLocalize';
 import useNativeDriver from '../../libs/useNativeDriver';
 import * as Browser from '../../libs/Browser';
+import SwipeInterceptPanResponder from '../SwipeInterceptPanResponder';
 
 function BaseTextInput(props) {
     const inputValue = props.value || props.defaultValue || '';
@@ -257,7 +258,11 @@ function BaseTextInput(props) {
 
     return (
         <>
-            <View style={styles.pointerEventsNone}>
+            <View
+                style={styles.pointerEventsNone}
+                // eslint-disable-next-line react/jsx-props-no-spreading
+                {...(props.interceptSwipe && SwipeInterceptPanResponder.panHandlers)}
+            >
                 <PressableWithoutFeedback
                     onPress={onPress}
                     focusable={false}

--- a/src/components/TextInput/baseTextInputPropTypes.js
+++ b/src/components/TextInput/baseTextInputPropTypes.js
@@ -95,7 +95,7 @@ const propTypes = {
     shouldUseDefaultValue: PropTypes.bool,
 
     /** Indicate whether or not the input should prevent swipe actions in tabs */
-    canInterceptSwipe: PropTypes.bool,
+    shouldInterceptSwipe: PropTypes.bool,
 };
 
 const defaultProps = {
@@ -132,7 +132,7 @@ const defaultProps = {
     icon: null,
     shouldUseDefaultValue: false,
     multiline: false,
-    canInterceptSwipe: false,
+    shouldInterceptSwipe: false,
 };
 
 export {propTypes, defaultProps};

--- a/src/components/TextInput/baseTextInputPropTypes.js
+++ b/src/components/TextInput/baseTextInputPropTypes.js
@@ -95,7 +95,7 @@ const propTypes = {
     shouldUseDefaultValue: PropTypes.bool,
 
     /** Indicate whether or not the input should prevent swipe actions in tabs */
-    interceptSwipe: PropTypes.bool,
+    canInterceptSwipe: PropTypes.bool,
 };
 
 const defaultProps = {
@@ -132,7 +132,7 @@ const defaultProps = {
     icon: null,
     shouldUseDefaultValue: false,
     multiline: false,
-    interceptSwipe: false,
+    canInterceptSwipe: false,
 };
 
 export {propTypes, defaultProps};

--- a/src/components/TextInput/baseTextInputPropTypes.js
+++ b/src/components/TextInput/baseTextInputPropTypes.js
@@ -93,6 +93,9 @@ const propTypes = {
 
     /** Set the default value to the input if there is a valid saved value */
     shouldUseDefaultValue: PropTypes.bool,
+
+    /** Indicate whether or not the input should prevent swipe actions in tabs */
+    interceptSwipe: PropTypes.bool,
 };
 
 const defaultProps = {
@@ -129,6 +132,7 @@ const defaultProps = {
     icon: null,
     shouldUseDefaultValue: false,
     multiline: false,
+    interceptSwipe: false,
 };
 
 export {propTypes, defaultProps};


### PR DESCRIPTION
### Details
Adds the `canInterceptSwipe` prop to `BaseTextInput` which is used to stop a tab from swiping when interacting with a focused text input within the tab.

### Fixed Issues
$ https://github.com/Expensify/App/issues/28047 
PROPOSAL: https://github.com/Expensify/App/issues/28047#issuecomment-1732206570

### Tests
1. Enable the rooms beta, or modify `canUseAllBetas` to return `true`.
2. Launch Expensify
3. Open the global create menu and select Send message
4. Enter an email address in the text input in the Chat tab
5. On web and desktop, verify that attempting to select the text in the text input does result in a swipe to the Room tab.
6. On native iOS, verify that when the text is in selection mode, dragging the text selection handles does not result in a swipe to the Room tab.
7. On native Android, verify that when the text input is focused, dragging within the text input does not result in a swipe to the Room tab.
8. Switch to the Room tab.
9. Enter some text for the room name.
10. Run the same verifications for steps 5 through 7 with the room name input.

- [x] Verify that no errors appear in the JS console

### Offline tests
Same as tests.

### QA Steps
Same as tests.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] If we are not using the full Onyx data that we loaded, I've added the proper selector in order to ensure the component only re-renders when the data it is using changes
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>

https://github.com/Expensify/App/assets/4160319/229fad29-1961-4a2a-8826-80cebf32adbf

</details>

<details>
<summary>Mobile Web - Chrome</summary>

![28047-android-chrome](https://github.com/Expensify/App/assets/4160319/a83bb131-fb29-46ba-9b23-8665c4077803)

</details>

<details>
<summary>Mobile Web - Safari</summary>

https://github.com/Expensify/App/assets/4160319/4859d485-7004-45b5-a0ee-da8fba4ee870

</details>

<details>
<summary>Desktop</summary>

https://github.com/Expensify/App/assets/4160319/0844e35a-fc91-4e4b-8eae-6266e909c50d

</details>

<details>
<summary>iOS</summary>

https://github.com/Expensify/App/assets/4160319/2f6dfbd7-3972-4ce9-8c69-81a2d6f785c3

</details>

<details>
<summary>Android</summary>

![28047-android-native](https://github.com/Expensify/App/assets/4160319/c090ab6d-20e2-4af9-959e-5d3e11cffe1d)

</details>
