### PR TITLE
[NoQA] Reattempt using OSBotify installation token in actions

### DIFF
--- a/.github/actions/composite/setupGitForOSBotify/action.yml
+++ b/.github/actions/composite/setupGitForOSBotify/action.yml
@@ -1,10 +1,22 @@
-name: 'Setup Git for OSBotify'
-description: 'Setup Git for OSBotify'
+name: "Setup Git for OSBotify"
+description: "Setup Git for OSBotify"
 
 inputs:
   GPG_PASSPHRASE:
-    description: 'Passphrase used to decrypt GPG key'
+    description: "Passphrase used to decrypt GPG key"
     required: true
+  OS_BOTIFY_APP_ID:
+    description: "Application ID for OS Botify"
+    required: true
+  OS_BOTIFY_PRIVATE_KEY:
+    description: "OS Botify's private key"
+    required: true
+
+outputs:
+  # Do not try to use this for committing code. Use `secrets.OS_BOTIFY_COMMIT_TOKEN` instead
+  OS_BOTIFY_API_TOKEN:
+    description: Token to use for GitHub API interactions.
+    value: ${{ steps.generateToken.outputs.token }}
 
 runs:
   using: composite
@@ -29,3 +41,10 @@ runs:
       shell: bash
       if: runner.debug == '1'
       run: echo "GIT_TRACE=true" >> "$GITHUB_ENV"
+
+    - name: Generate a token
+      id: generateToken
+      uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a
+      with:
+        app_id: ${{ inputs.OS_BOTIFY_APP_ID }}
+        private_key: ${{ inputs.OS_BOTIFY_PRIVATE_KEY }}

--- a/.github/workflows/cherryPick.yml
+++ b/.github/workflows/cherryPick.yml
@@ -44,12 +44,14 @@ jobs:
         uses: Expensify/App/.github/actions/composite/setupGitForOSBotify@main
         with:
           GPG_PASSPHRASE: ${{ secrets.LARGE_SECRET_PASSPHRASE }}
+          OS_BOTIFY_APP_ID: ${{ secrets.OS_BOTIFY_APP_ID }}
+          OS_BOTIFY_PRIVATE_KEY: ${{ secrets.OS_BOTIFY_PRIVATE_KEY }}
 
       - name: Get previous app version
         id: getPreviousVersion
         uses: Expensify/App/.github/actions/javascript/getPreviousVersion@main
         with:
-          SEMVER_LEVEL: 'PATCH'
+          SEMVER_LEVEL: "PATCH"
 
       - name: Fetch history of relevant refs
         run: |
@@ -119,7 +121,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.OS_BOTIFY_TOKEN }}
 
-      - name: 'Announces a CP failure in the #announce Slack room'
+      - name: "Announces a CP failure in the #announce Slack room"
         uses: 8398a7/action-slack@v3
         if: ${{ failure() }}
         with:

--- a/.github/workflows/cherryPick.yml
+++ b/.github/workflows/cherryPick.yml
@@ -41,7 +41,7 @@ jobs:
           token: ${{ secrets.OS_BOTIFY_TOKEN }}
 
       - name: Set up git for OSBotify
-        uses: Expensify/App/.github/actions/composite/setupGitForOSBotify@main
+        uses: ./.github/actions/composite/setupGitForOSBotify
         with:
           GPG_PASSPHRASE: ${{ secrets.LARGE_SECRET_PASSPHRASE }}
           OS_BOTIFY_APP_ID: ${{ secrets.OS_BOTIFY_APP_ID }}

--- a/.github/workflows/createNewVersion.yml
+++ b/.github/workflows/createNewVersion.yml
@@ -26,11 +26,17 @@ on:
       LARGE_SECRET_PASSPHRASE:
         description: Passphrase used to decrypt GPG key
         required: true
-      OS_BOTIFY_TOKEN:
-        description: Token for the OSBotify user
-        required: true
       SLACK_WEBHOOK:
         description: Webhook used to comment in slack
+        required: true
+      OS_BOTIFY_COMMIT_TOKEN:
+        description: OSBotify personal access token, used to workaround committing to protected branch
+        required: true
+      OS_BOTIFY_APP_ID:
+        description: Application ID for OS Botify App
+        required: true
+      OS_BOTIFY_PRIVATE_KEY:
+        description: OSBotify private key
         required: true
 
 jobs:
@@ -43,7 +49,7 @@ jobs:
         id: getUserPermissions
         run: echo "PERMISSION=$(gh api /repos/${{ github.repository }}/collaborators/${{ github.actor }}/permission | jq -r '.permission')" >> "$GITHUB_OUTPUT"
         env:
-          GITHUB_TOKEN: ${{ secrets.OS_BOTIFY_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.OS_BOTIFY_COMMIT_TOKEN }}
 
   createNewVersion:
     runs-on: macos-latest
@@ -65,18 +71,23 @@ jobs:
         uses: actions/checkout@v3
         with:
           ref: main
-          token: ${{ secrets.OS_BOTIFY_TOKEN }}
+          # The OS_BOTIFY_COMMIT_TOKEN is a personal access token tied to osbotify
+          # This is a workaround to allow pushes to a protected branch
+          token: ${{ secrets.OS_BOTIFY_COMMIT_TOKEN }}
 
       - name: Setup git for OSBotify
         uses: Expensify/App/.github/actions/composite/setupGitForOSBotify@main
+        id: setupGitForOSBotify
         with:
           GPG_PASSPHRASE: ${{ secrets.LARGE_SECRET_PASSPHRASE }}
+          OS_BOTIFY_APP_ID: ${{ secrets.OS_BOTIFY_APP_ID }}
+          OS_BOTIFY_PRIVATE_KEY: ${{ secrets.OS_BOTIFY_PRIVATE_KEY }}
 
       - name: Generate version
         id: bumpVersion
         uses: Expensify/App/.github/actions/javascript/bumpVersion@main
         with:
-          GITHUB_TOKEN: ${{ secrets.OS_BOTIFY_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.setupGitForOSBotify.outputs.OS_BOTIFY_API_TOKEN }}
           SEMVER_LEVEL: ${{ inputs.SEMVER_LEVEL }}
 
       - name: Commit new version

--- a/.github/workflows/createNewVersion.yml
+++ b/.github/workflows/createNewVersion.yml
@@ -76,7 +76,7 @@ jobs:
           token: ${{ secrets.OS_BOTIFY_COMMIT_TOKEN }}
 
       - name: Setup git for OSBotify
-        uses: Expensify/App/.github/actions/composite/setupGitForOSBotify@main
+        uses: ./.github/actions/composite/setupGitForOSBotify
         id: setupGitForOSBotify
         with:
           GPG_PASSPHRASE: ${{ secrets.LARGE_SECRET_PASSPHRASE }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -46,11 +46,6 @@ jobs:
           ref: production
           token: ${{ steps.setupGitForOSBotify.outputs.OS_BOTIFY_API_TOKEN }}
 
-      - name: Setup git for OSBotify
-        uses: ./.github/actions/composite/setupGitForOSBotify
-        with:
-          GPG_PASSPHRASE: ${{ secrets.LARGE_SECRET_PASSPHRASE }}
-
       - name: Get current app version
         run: echo "PRODUCTION_VERSION=$(npm run print-version --silent)" >> "$GITHUB_ENV"
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,16 +9,18 @@ jobs:
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/staging'
     steps:
+      - uses: Expensify/App/.github/actions/composite/setupGitForOSBotify@main
+        id: setupGitForOSBotify
+        with:
+          GPG_PASSPHRASE: ${{ secrets.LARGE_SECRET_PASSPHRASE }}
+          OS_BOTIFY_APP_ID: ${{ secrets.OS_BOTIFY_APP_ID }}
+          OS_BOTIFY_PRIVATE_KEY: ${{ secrets.OS_BOTIFY_PRIVATE_KEY }}
+
       - name: Checkout staging branch
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
         with:
           ref: staging
-          token: ${{ secrets.OS_BOTIFY_TOKEN }}
-
-      - name: Setup git for OSBotify
-        uses: Expensify/App/.github/actions/composite/setupGitForOSBotify@main
-        with:
-          GPG_PASSPHRASE: ${{ secrets.LARGE_SECRET_PASSPHRASE }}
+          token: ${{ steps.setupGitForOSBotify.outputs.OS_BOTIFY_API_TOKEN }}
 
       - name: Tag version
         run: git tag "$(npm run print-version --silent)"
@@ -30,11 +32,19 @@ jobs:
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/production'
     steps:
+      - uses: Expensify/App/.github/actions/composite/setupGitForOSBotify@main
+        id: setupGitForOSBotify
+        with:
+          GPG_PASSPHRASE: ${{ secrets.LARGE_SECRET_PASSPHRASE }}
+          OS_BOTIFY_APP_ID: ${{ secrets.OS_BOTIFY_APP_ID }}
+          OS_BOTIFY_PRIVATE_KEY: ${{ secrets.OS_BOTIFY_PRIVATE_KEY }}
+
+      - uses: actions/checkout@v3
       - name: Checkout
         uses: actions/checkout@v3
         with:
           ref: production
-          token: ${{ secrets.OS_BOTIFY_TOKEN }}
+          token: ${{ steps.setupGitForOSBotify.outputs.OS_BOTIFY_API_TOKEN }}
 
       - name: Setup git for OSBotify
         uses: Expensify/App/.github/actions/composite/setupGitForOSBotify@main
@@ -49,7 +59,7 @@ jobs:
         uses: Expensify/App/.github/actions/javascript/getDeployPullRequestList@main
         with:
           TAG: ${{ env.PRODUCTION_VERSION }}
-          GITHUB_TOKEN: ${{ secrets.OS_BOTIFY_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.setupGitForOSBotify.outputs.OS_BOTIFY_API_TOKEN }}
           IS_PRODUCTION_DEPLOY: true
 
       - name: Generate Release Body
@@ -64,4 +74,4 @@ jobs:
           tag_name: ${{ env.PRODUCTION_VERSION }}
           body: ${{ steps.getReleaseBody.outputs.RELEASE_BODY }}
         env:
-          GITHUB_TOKEN: ${{ secrets.OS_BOTIFY_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.setupGitForOSBotify.outputs.OS_BOTIFY_API_TOKEN }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/staging'
     steps:
-      - uses: Expensify/App/.github/actions/composite/setupGitForOSBotify@main
+      - uses: ./.github/actions/composite/setupGitForOSBotify
         id: setupGitForOSBotify
         with:
           GPG_PASSPHRASE: ${{ secrets.LARGE_SECRET_PASSPHRASE }}
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/production'
     steps:
-      - uses: Expensify/App/.github/actions/composite/setupGitForOSBotify@main
+      - uses: ./.github/actions/composite/setupGitForOSBotify
         id: setupGitForOSBotify
         with:
           GPG_PASSPHRASE: ${{ secrets.LARGE_SECRET_PASSPHRASE }}
@@ -47,7 +47,7 @@ jobs:
           token: ${{ steps.setupGitForOSBotify.outputs.OS_BOTIFY_API_TOKEN }}
 
       - name: Setup git for OSBotify
-        uses: Expensify/App/.github/actions/composite/setupGitForOSBotify@main
+        uses: ./.github/actions/composite/setupGitForOSBotify
         with:
           GPG_PASSPHRASE: ${{ secrets.LARGE_SECRET_PASSPHRASE }}
 

--- a/.github/workflows/finishReleaseCycle.yml
+++ b/.github/workflows/finishReleaseCycle.yml
@@ -12,6 +12,13 @@ jobs:
     outputs:
       isValid: ${{ fromJSON(steps.isDeployer.outputs.IS_DEPLOYER) && !fromJSON(steps.checkDeployBlockers.outputs.HAS_DEPLOY_BLOCKERS) }}
     steps:
+      - uses: Expensify/App/.github/actions/composite/setupGitForOSBotify@main
+        id: setupGitForOSBotify
+        with:
+          GPG_PASSPHRASE: ${{ secrets.LARGE_SECRET_PASSPHRASE }}
+          OS_BOTIFY_APP_ID: ${{ secrets.OS_BOTIFY_APP_ID }}
+          OS_BOTIFY_PRIVATE_KEY: ${{ secrets.OS_BOTIFY_PRIVATE_KEY }}
+
       - name: Validate actor is deployer
         id: isDeployer
         run: |
@@ -21,13 +28,13 @@ jobs:
             echo "IS_DEPLOYER=false" >> "$GITHUB_OUTPUT"
           fi
         env:
-          GITHUB_TOKEN: ${{ secrets.OS_BOTIFY_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.setupGitForOSBotify.outputs.OS_BOTIFY_API_TOKEN }}
 
       - name: Reopen and comment on issue (not a team member)
         if: ${{ !fromJSON(steps.isDeployer.outputs.IS_DEPLOYER) }}
         uses: Expensify/App/.github/actions/javascript/reopenIssueWithComment@main
         with:
-          GITHUB_TOKEN: ${{ secrets.OS_BOTIFY_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.setupGitForOSBotify.outputs.OS_BOTIFY_API_TOKEN }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}
           COMMENT: |
             Sorry, only members of @Expensify/Mobile-Deployers can close deploy checklists.
@@ -38,14 +45,14 @@ jobs:
         id: checkDeployBlockers
         uses: Expensify/App/.github/actions/javascript/checkDeployBlockers@main
         with:
-          GITHUB_TOKEN: ${{ secrets.OS_BOTIFY_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.setupGitForOSBotify.outputs.OS_BOTIFY_API_TOKEN }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}
 
       - name: Reopen and comment on issue (has blockers)
         if: ${{ fromJSON(steps.isDeployer.outputs.IS_DEPLOYER) && fromJSON(steps.checkDeployBlockers.outputs.HAS_DEPLOY_BLOCKERS || 'false') }}
         uses: Expensify/App/.github/actions/javascript/reopenIssueWithComment@main
         with:
-          GITHUB_TOKEN: ${{ secrets.OS_BOTIFY_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.setupGitForOSBotify.outputs.OS_BOTIFY_API_TOKEN }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}
           COMMENT: |
             This issue either has unchecked items or has not yet been marked with the `:shipit:` emoji of approval.
@@ -70,9 +77,12 @@ jobs:
           token: ${{ secrets.OS_BOTIFY_TOKEN }}
 
       - name: Setup Git for OSBotify
+        id: setupGitForOSBotify
         uses: Expensify/App/.github/actions/composite/setupGitForOSBotify@main
         with:
           GPG_PASSPHRASE: ${{ secrets.LARGE_SECRET_PASSPHRASE }}
+          OS_BOTIFY_APP_ID: ${{ secrets.OS_BOTIFY_APP_ID }}
+          OS_BOTIFY_PRIVATE_KEY: ${{ secrets.OS_BOTIFY_PRIVATE_KEY }}
 
       - name: Update production branch
         run: |
@@ -112,6 +122,8 @@ jobs:
         uses: Expensify/App/.github/actions/composite/setupGitForOSBotify@main
         with:
           GPG_PASSPHRASE: ${{ secrets.LARGE_SECRET_PASSPHRASE }}
+          OS_BOTIFY_APP_ID: ${{ secrets.OS_BOTIFY_APP_ID }}
+          OS_BOTIFY_PRIVATE_KEY: ${{ secrets.OS_BOTIFY_PRIVATE_KEY }}
 
       - name: Update staging branch to trigger staging deploy
         run: |

--- a/.github/workflows/finishReleaseCycle.yml
+++ b/.github/workflows/finishReleaseCycle.yml
@@ -12,7 +12,7 @@ jobs:
     outputs:
       isValid: ${{ fromJSON(steps.isDeployer.outputs.IS_DEPLOYER) && !fromJSON(steps.checkDeployBlockers.outputs.HAS_DEPLOY_BLOCKERS) }}
     steps:
-      - uses: Expensify/App/.github/actions/composite/setupGitForOSBotify@main
+      - uses: ./.github/actions/composite/setupGitForOSBotify
         id: setupGitForOSBotify
         with:
           GPG_PASSPHRASE: ${{ secrets.LARGE_SECRET_PASSPHRASE }}
@@ -78,7 +78,7 @@ jobs:
 
       - name: Setup Git for OSBotify
         id: setupGitForOSBotify
-        uses: Expensify/App/.github/actions/composite/setupGitForOSBotify@main
+        uses: ./.github/actions/composite/setupGitForOSBotify
         with:
           GPG_PASSPHRASE: ${{ secrets.LARGE_SECRET_PASSPHRASE }}
           OS_BOTIFY_APP_ID: ${{ secrets.OS_BOTIFY_APP_ID }}
@@ -119,7 +119,7 @@ jobs:
           token: ${{ secrets.OS_BOTIFY_TOKEN }}
 
       - name: Setup Git for OSBotify
-        uses: Expensify/App/.github/actions/composite/setupGitForOSBotify@main
+        uses: ./.github/actions/composite/setupGitForOSBotify
         with:
           GPG_PASSPHRASE: ${{ secrets.LARGE_SECRET_PASSPHRASE }}
           OS_BOTIFY_APP_ID: ${{ secrets.OS_BOTIFY_APP_ID }}

--- a/.github/workflows/preDeploy.yml
+++ b/.github/workflows/preDeploy.yml
@@ -95,6 +95,8 @@ jobs:
         uses: Expensify/App/.github/actions/composite/setupGitForOSBotify@main
         with:
           GPG_PASSPHRASE: ${{ secrets.LARGE_SECRET_PASSPHRASE }}
+          OS_BOTIFY_APP_ID: ${{ secrets.OS_BOTIFY_APP_ID }}
+          OS_BOTIFY_PRIVATE_KEY: ${{ secrets.OS_BOTIFY_PRIVATE_KEY }}
 
       - name: Update staging branch from main
         run: |

--- a/.github/workflows/preDeploy.yml
+++ b/.github/workflows/preDeploy.yml
@@ -92,7 +92,7 @@ jobs:
           token: ${{ secrets.OS_BOTIFY_TOKEN }}
 
       - name: Setup Git for OSBotify
-        uses: Expensify/App/.github/actions/composite/setupGitForOSBotify@main
+        uses: ./.github/actions/composite/setupGitForOSBotify
         with:
           GPG_PASSPHRASE: ${{ secrets.LARGE_SECRET_PASSPHRASE }}
           OS_BOTIFY_APP_ID: ${{ secrets.OS_BOTIFY_APP_ID }}


### PR DESCRIPTION
Reverts Expensify/App#28612

For https://github.com/Expensify/Expensify/issues/299601

Updating the actions again. Straight revert of the revert. My explanation is here https://expensify.slack.com/archives/C07J32337/p1696385889843479?thread_ts=1696229964.440459&cid=C07J32337

Looks like the last failure was just because of a stale branch.