### PR TITLE
The "Copy URL to clipboard" tooltip does not appear when hovering over a task description link

### DIFF
--- a/src/components/MenuItem.js
+++ b/src/components/MenuItem.js
@@ -120,7 +120,7 @@ const MenuItem = React.forwardRef((props, ref) => {
             return;
         }
         const parser = new ExpensiMark();
-        setHtml(parser.replace(convertToLTR(props.title)));
+        setHtml(parser.replace(props.title));
         titleRef.current = props.title;
     }, [props.title, props.shouldParseTitle]);
 

--- a/src/components/MenuItem.js
+++ b/src/components/MenuItem.js
@@ -125,15 +125,16 @@ const MenuItem = React.forwardRef((props, ref) => {
     }, [props.title, props.shouldParseTitle]);
 
     const getProcessedTitle = useMemo(() => {
+        let title = '';
         if (props.shouldRenderAsHTML) {
-            return convertToLTR(props.title);
+            title = convertToLTR(props.title);
         }
 
         if (props.shouldParseTitle) {
-            return html;
+            title = html;
         }
 
-        return '';
+        return title ? `<comment>${title}</comment>` : '';
     }, [props.title, props.shouldRenderAsHTML, props.shouldParseTitle, html]);
 
     const hasPressableRightComponent = props.onIconRightPress || props.iconRight || (props.rightComponent && props.shouldShowRightComponent);


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->

1. Private Notes - The strikethrough line of the link is displaying in white on the Private Notes page
2. The "Copy URL to clipboard" tooltip does not appear when hovering over a task description link
3. The strikethrough line of the link is displaying in white on the Private Notes page


### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/27812
$ https://github.com/Expensify/App/issues/28862
$ https://github.com/Expensify/App/issues/28859
PROPOSAL: https://github.com/Expensify/App/issues/27812#issuecomment-1726531560


### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

1. Open a chat.
2. Navigate to the "Assign task" section.
3. Enter a title and insert a link in the description, then create the task.
4. After task creation, right-click on the description link.
5. Observe that the tooltip for "Copy URL to clipboard" does not appear

-----

1. Navigate to staging.
2. Open any chat
3. Click on the header and go to Private notes
4. Go to My note > Notes
5. Add `~https://xyz.com/~` and save
6. Notice that the strikethrough line appears in white

-----

1. Go to staging
2. Go to any chat
3. Click on the header and navigate to Private notes
4. Go to My note > Notes
5. Add `# https://xvz.com/` and save it
6. Notice that the link following the hashtag is not displayed in bold



- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

1. Open a chat.
2. Navigate to the "Assign task" section.
3. Enter a title and insert a link in the description, then create the task.
4. After task creation, right-click on the description link.
5. Observe that the tooltip for "Copy URL to clipboard" does not appear

-----

1. Navigate to staging.
2. Open any chat
3. Click on the header and go to Private notes
4. Go to My note > Notes
5. Add `~https://xyz.com/~` and save
6. Notice that the strikethrough line appears in white

-----

1. Go to staging
2. Go to any chat
3. Click on the header and navigate to Private notes
4. Go to My note > Notes
5. Add `# https://xvz.com/` and save it
6. Notice that the link following the hashtag is not displayed in bold

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

1. Open a chat.
2. Navigate to the "Assign task" section.
3. Enter a title and insert a link in the description, then create the task.
4. After task creation, right-click on the description link.
5. Observe that the tooltip for "Copy URL to clipboard" does not appear

-----

1. Navigate to staging.
2. Open any chat
3. Click on the header and go to Private notes
4. Go to My note > Notes
5. Add `~https://xyz.com/~` and save
6. Notice that the strikethrough line appears in white

-----


1. Go to staging
2. Go to any chat
3. Click on the header and navigate to Private notes
4. Go to My note > Notes
5. Add `# https://xvz.com/` and save it
6. Notice that the link following the hashtag is not displayed in bold

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] If we are not using the full Onyx data that we loaded, I've added the proper selector in order to ensure the component only re-renders when the data it is using changes
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>

<!-- add screenshots or videos here -->

https://github.com/Expensify/App/assets/68128028/ffd62c3a-bed4-42dd-a45d-b8a785e23ea2

<img width="1480" alt="Screenshot 2023-10-05 at 20 38 31" src="https://github.com/Expensify/App/assets/68128028/0c75a61a-53f8-417a-8ba0-f1e4957306f8">

<img width="1480" alt="Screenshot 2023-10-05 at 20 39 33" src="https://github.com/Expensify/App/assets/68128028/7e79f823-0c20-4eba-98ef-1582f28ac388">

</details>

<details>
<summary>Mobile Web - Chrome</summary>

<!-- add screenshots or videos here -->

<img width="271" alt="Screenshot 2023-10-05 at 20 55 29" src="https://github.com/Expensify/App/assets/68128028/0e15dcf2-0c45-44b1-a697-2d0658a7c1d1">

<img width="271" alt="Screenshot 2023-10-05 at 20 56 00" src="https://github.com/Expensify/App/assets/68128028/8deb0a84-d098-4228-9efb-471c564c70fb">

</details>

<details>
<summary>Mobile Web - Safari</summary>

<!-- add screenshots or videos here -->

<img width="385" alt="Screenshot 2023-10-05 at 20 41 17" src="https://github.com/Expensify/App/assets/68128028/c234de70-2fa7-4340-9595-801c88375287">

<img width="385" alt="Screenshot 2023-10-05 at 20 40 56" src="https://github.com/Expensify/App/assets/68128028/1e6d5949-dcc3-4357-8084-52084d7494c0">

</details>

<details>
<summary>Desktop</summary>

<img width="828" alt="Screenshot 2023-10-05 at 20 43 34" src="https://github.com/Expensify/App/assets/68128028/a50aed8c-3993-4caf-946a-4744f4ba4d73">

<img width="828" alt="Screenshot 2023-10-05 at 20 43 03" src="https://github.com/Expensify/App/assets/68128028/224e0e47-fd92-48db-b7a5-e685df6ce7cb">

https://github.com/Expensify/App/assets/68128028/5b00d7a8-215f-484c-893d-9bea8d161b11


<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS</summary>

<!-- add screenshots or videos here -->

<img width="373" alt="Screenshot 2023-10-05 at 20 51 20" src="https://github.com/Expensify/App/assets/68128028/df1bba44-180e-4e6a-93ff-5d5323cbc40b">

<img width="373" alt="Screenshot 2023-10-05 at 20 51 44" src="https://github.com/Expensify/App/assets/68128028/bcb3e438-bce5-4dda-be67-d5bcacc5d04b">

</details>

<details>
<summary>Android</summary>

<!-- add screenshots or videos here -->
<img width="271" alt="Screenshot 2023-10-05 at 21 53 38" src="https://github.com/Expensify/App/assets/68128028/b5a53a6a-da55-48e9-8c5e-de9dd1ece103">

<img width="271" alt="Screenshot 2023-10-05 at 21 54 16" src="https://github.com/Expensify/App/assets/68128028/887128ef-8040-4858-8b0a-54b7e72f9632">

</details>
