### PR TITLE
Allow multiple emails to be added when inviting members to workspace

### DIFF
--- a/src/pages/workspace/WorkspaceInvitePage.js
+++ b/src/pages/workspace/WorkspaceInvitePage.js
@@ -84,17 +84,13 @@ function WorkspaceInvitePage(props) {
 
     useEffect(() => {
         let emails = searchTerm.replace(/\s,\s/g, ',').split(',');
-        emails = _.map(emails, word => word.trim());
+        emails = _.filter(_.map(emails, word => word.trim()), email => email !== '');
 
         const newUsersToInviteDict = {};
         const newPersonalDetailsDict = {};
         const newSelectedOptionsDict = {};
 
         _.forEach(emails, (email) => {
-            if (email === '') {
-                return;
-            }
-
             const inviteOptions = OptionsListUtils.getMemberInviteOptions(props.personalDetails, props.betas, email, excludedUsers);
     
             // Update selectedOptions with the latest personalDetails and policyMembers information

--- a/src/pages/workspace/WorkspaceInvitePage.js
+++ b/src/pages/workspace/WorkspaceInvitePage.js
@@ -124,9 +124,9 @@ function WorkspaceInvitePage(props) {
         });
 
         // Strip out dictionary keys and update arrays
-        setUsersToInvite(_.map(newUsersToInviteDict, (v) => v));
-        setPersonalDetails(_.map(newPersonalDetailsDict, (v) => v));
-        setSelectedOptions(_.map(newSelectedOptionsDict, (v) => v));
+        setUsersToInvite(_.values(newUsersToInviteDict));
+        setPersonalDetails(_.values(newPersonalDetailsDict));
+        setSelectedOptions(_.values(newSelectedOptionsDict));
 
         // eslint-disable-next-line react-hooks/exhaustive-deps -- we don't want to recalculate when selectedOptions change
     }, [props.personalDetails, props.policyMembers, props.betas, searchTerm, excludedUsers]);

--- a/src/pages/workspace/WorkspaceInvitePage.js
+++ b/src/pages/workspace/WorkspaceInvitePage.js
@@ -84,7 +84,10 @@ function WorkspaceInvitePage(props) {
 
     useEffect(() => {
         let emails = searchTerm.replace(/\s,\s/g, ',').split(',');
-        emails = _.filter(_.map(emails, word => word.trim()), email => email !== '');
+        emails = _.filter(
+            _.map(emails, (word) => word.trim()),
+            (email) => email !== '',
+        );
 
         const newUsersToInviteDict = {};
         const newPersonalDetailsDict = {};
@@ -92,23 +95,23 @@ function WorkspaceInvitePage(props) {
 
         _.forEach(emails, (email) => {
             const inviteOptions = OptionsListUtils.getMemberInviteOptions(props.personalDetails, props.betas, email, excludedUsers);
-    
+
             // Update selectedOptions with the latest personalDetails and policyMembers information
             const detailsMap = {};
             _.forEach(inviteOptions.personalDetails, (detail) => (detailsMap[detail.login] = OptionsListUtils.formatMemberForList(detail)));
-            
+
             const newSelectedOptions = [];
             _.forEach(selectedOptions, (option) => {
                 newSelectedOptions.push(_.has(detailsMap, option.login) ? {...detailsMap[option.login], isSelected: true} : option);
             });
-        
+
             const userToInvite = inviteOptions.userToInvite;
 
             // Only add the user to the invites list if it is valid
-            if (userToInvite) {    
+            if (userToInvite) {
                 newUsersToInviteDict[userToInvite.accountID] = userToInvite;
             }
-      
+
             // Add all personal details to the new dict
             _.forEach(inviteOptions.personalDetails, (details) => {
                 newPersonalDetailsDict[details.accountID] = details;
@@ -119,7 +122,7 @@ function WorkspaceInvitePage(props) {
                 newSelectedOptionsDict[option.accountID] = option;
             });
         });
-        
+
         // Strip out dictionary keys and update arrays
         setUsersToInvite(_.map(newUsersToInviteDict, (v) => v));
         setPersonalDetails(_.map(newPersonalDetailsDict, (v) => v));

--- a/src/pages/workspace/WorkspaceInvitePage.js
+++ b/src/pages/workspace/WorkspaceInvitePage.js
@@ -83,14 +83,18 @@ function WorkspaceInvitePage(props) {
     const excludedUsers = useMemo(() => PolicyUtils.getIneligibleInvitees(props.policyMembers, props.personalDetails), [props.policyMembers, props.personalDetails]);
 
     useEffect(() => {
-        let emails = searchTerm.replace(/,\s/g, ',').split(',');
+        let emails = searchTerm.replace(/\s,\s/g, ',').split(',');
         emails = _.map(emails, word => word.trim());
 
         const newUsersToInviteDict = {};
         const newPersonalDetailsDict = {};
         const newSelectedOptionsDict = {};
-        
-        emails.forEach((email) => {
+
+        _.forEach(emails, (email) => {
+            if (email === '') {
+                return;
+            }
+
             const inviteOptions = OptionsListUtils.getMemberInviteOptions(props.personalDetails, props.betas, email, excludedUsers);
     
             // Update selectedOptions with the latest personalDetails and policyMembers information

--- a/src/pages/workspace/WorkspaceInvitePage.js
+++ b/src/pages/workspace/WorkspaceInvitePage.js
@@ -83,25 +83,26 @@ function WorkspaceInvitePage(props) {
     const excludedUsers = useMemo(() => PolicyUtils.getIneligibleInvitees(props.policyMembers, props.personalDetails), [props.policyMembers, props.personalDetails]);
 
     useEffect(() => {
-        let emails = searchTerm.replace(/\s,\s/g, ',').split(',');
-        emails = _.filter(
-            _.map(emails, (word) => word.trim()),
-            (email) => email !== '',
+        const emails = _.compact(
+            searchTerm
+                .trim()
+                .replace(/\s*,\s*/g, ',')
+                .split(','),
         );
 
         const newUsersToInviteDict = {};
         const newPersonalDetailsDict = {};
         const newSelectedOptionsDict = {};
 
-        _.forEach(emails, (email) => {
+        _.each(emails, (email) => {
             const inviteOptions = OptionsListUtils.getMemberInviteOptions(props.personalDetails, props.betas, email, excludedUsers);
 
             // Update selectedOptions with the latest personalDetails and policyMembers information
             const detailsMap = {};
-            _.forEach(inviteOptions.personalDetails, (detail) => (detailsMap[detail.login] = OptionsListUtils.formatMemberForList(detail)));
+            _.each(inviteOptions.personalDetails, (detail) => (detailsMap[detail.login] = OptionsListUtils.formatMemberForList(detail)));
 
             const newSelectedOptions = [];
-            _.forEach(selectedOptions, (option) => {
+            _.each(selectedOptions, (option) => {
                 newSelectedOptions.push(_.has(detailsMap, option.login) ? {...detailsMap[option.login], isSelected: true} : option);
             });
 
@@ -113,12 +114,12 @@ function WorkspaceInvitePage(props) {
             }
 
             // Add all personal details to the new dict
-            _.forEach(inviteOptions.personalDetails, (details) => {
+            _.each(inviteOptions.personalDetails, (details) => {
                 newPersonalDetailsDict[details.accountID] = details;
             });
 
             // Add all selected options to the new dict
-            _.forEach(newSelectedOptions, (option) => {
+            _.each(newSelectedOptions, (option) => {
                 newSelectedOptionsDict[option.accountID] = option;
             });
         });
@@ -156,7 +157,7 @@ function WorkspaceInvitePage(props) {
         });
         indexOffset += personalDetailsFormatted.length;
 
-        _.forEach(usersToInvite, (userToInvite) => {
+        _.each(usersToInvite, (userToInvite) => {
             const hasUnselectedUserToInvite = !_.contains(selectedLogins, userToInvite.login);
 
             if (hasUnselectedUserToInvite) {

--- a/src/pages/workspace/WorkspaceInvitePage.js
+++ b/src/pages/workspace/WorkspaceInvitePage.js
@@ -66,7 +66,7 @@ function WorkspaceInvitePage(props) {
     const [searchTerm, setSearchTerm] = useState('');
     const [selectedOptions, setSelectedOptions] = useState([]);
     const [personalDetails, setPersonalDetails] = useState([]);
-    const [userToInvite, setUserToInvite] = useState(null);
+    const [usersToInvite, setUsersToInvite] = useState([]);
     const openWorkspaceInvitePage = () => {
         const policyMemberEmailsToAccountIDs = PolicyUtils.getMemberAccountIDsForWorkspace(props.policyMembers, props.personalDetails);
         Policy.openWorkspaceInvitePage(props.route.params.policyID, _.keys(policyMemberEmailsToAccountIDs));
@@ -83,19 +83,48 @@ function WorkspaceInvitePage(props) {
     const excludedUsers = useMemo(() => PolicyUtils.getIneligibleInvitees(props.policyMembers, props.personalDetails), [props.policyMembers, props.personalDetails]);
 
     useEffect(() => {
-        const inviteOptions = OptionsListUtils.getMemberInviteOptions(props.personalDetails, props.betas, searchTerm, excludedUsers);
+        let emails = searchTerm.replace(/,\s/g, ',').split(',');
+        emails = _.map(emails, word => word.trim());
 
-        // Update selectedOptions with the latest personalDetails and policyMembers information
-        const detailsMap = {};
-        _.forEach(inviteOptions.personalDetails, (detail) => (detailsMap[detail.login] = OptionsListUtils.formatMemberForList(detail)));
-        const newSelectedOptions = [];
-        _.forEach(selectedOptions, (option) => {
-            newSelectedOptions.push(_.has(detailsMap, option.login) ? {...detailsMap[option.login], isSelected: true} : option);
+        const newUsersToInviteDict = {};
+        const newPersonalDetailsDict = {};
+        const newSelectedOptionsDict = {};
+        
+        emails.forEach((email) => {
+            const inviteOptions = OptionsListUtils.getMemberInviteOptions(props.personalDetails, props.betas, email, excludedUsers);
+    
+            // Update selectedOptions with the latest personalDetails and policyMembers information
+            const detailsMap = {};
+            _.forEach(inviteOptions.personalDetails, (detail) => (detailsMap[detail.login] = OptionsListUtils.formatMemberForList(detail)));
+            
+            const newSelectedOptions = [];
+            _.forEach(selectedOptions, (option) => {
+                newSelectedOptions.push(_.has(detailsMap, option.login) ? {...detailsMap[option.login], isSelected: true} : option);
+            });
+        
+            const userToInvite = inviteOptions.userToInvite;
+
+            // Only add the user to the invites list if it is valid
+            if (userToInvite) {    
+                newUsersToInviteDict[userToInvite.accountID] = userToInvite;
+            }
+      
+            // Add all personal details to the new dict
+            _.forEach(inviteOptions.personalDetails, (details) => {
+                newPersonalDetailsDict[details.accountID] = details;
+            });
+
+            // Add all selected options to the new dict
+            _.forEach(newSelectedOptions, (option) => {
+                newSelectedOptionsDict[option.accountID] = option;
+            });
         });
+        
+        // Strip out dictionary keys and update arrays
+        setUsersToInvite(_.map(newUsersToInviteDict, (v) => v));
+        setPersonalDetails(_.map(newPersonalDetailsDict, (v) => v));
+        setSelectedOptions(_.map(newSelectedOptionsDict, (v) => v));
 
-        setUserToInvite(inviteOptions.userToInvite);
-        setPersonalDetails(inviteOptions.personalDetails);
-        setSelectedOptions(newSelectedOptions);
         // eslint-disable-next-line react-hooks/exhaustive-deps -- we don't want to recalculate when selectedOptions change
     }, [props.personalDetails, props.policyMembers, props.betas, searchTerm, excludedUsers]);
 
@@ -115,7 +144,6 @@ function WorkspaceInvitePage(props) {
         const selectedLogins = _.map(selectedOptions, ({login}) => login);
         const personalDetailsWithoutSelected = _.filter(personalDetails, ({login}) => !_.contains(selectedLogins, login));
         const personalDetailsFormatted = _.map(personalDetailsWithoutSelected, OptionsListUtils.formatMemberForList);
-        const hasUnselectedUserToInvite = userToInvite && !_.contains(selectedLogins, userToInvite.login);
 
         sections.push({
             title: translate('common.contacts'),
@@ -125,14 +153,18 @@ function WorkspaceInvitePage(props) {
         });
         indexOffset += personalDetailsFormatted.length;
 
-        if (hasUnselectedUserToInvite) {
-            sections.push({
-                title: undefined,
-                data: [OptionsListUtils.formatMemberForList(userToInvite)],
-                shouldShow: true,
-                indexOffset,
-            });
-        }
+        _.forEach(usersToInvite, (userToInvite) => {
+            const hasUnselectedUserToInvite = !_.contains(selectedLogins, userToInvite.login);
+
+            if (hasUnselectedUserToInvite) {
+                sections.push({
+                    title: undefined,
+                    data: [OptionsListUtils.formatMemberForList(userToInvite)],
+                    shouldShow: true,
+                    indexOffset: indexOffset++,
+                });
+            }
+        });
 
         return sections;
     };
@@ -187,14 +219,14 @@ function WorkspaceInvitePage(props) {
 
     const headerMessage = useMemo(() => {
         const searchValue = searchTerm.trim().toLowerCase();
-        if (!userToInvite && CONST.EXPENSIFY_EMAILS.includes(searchValue)) {
+        if (usersToInvite.length === 0 && CONST.EXPENSIFY_EMAILS.includes(searchValue)) {
             return translate('messages.errorMessageInvalidEmail');
         }
-        if (!userToInvite && excludedUsers.includes(searchValue)) {
+        if (usersToInvite.length === 0 && excludedUsers.includes(searchValue)) {
             return translate('messages.userIsAlreadyMemberOfWorkspace', {login: searchValue, workspace: policyName});
         }
-        return OptionsListUtils.getHeaderMessage(personalDetails.length !== 0, Boolean(userToInvite), searchValue);
-    }, [excludedUsers, translate, searchTerm, policyName, userToInvite, personalDetails]);
+        return OptionsListUtils.getHeaderMessage(personalDetails.length !== 0, usersToInvite.length > 0, searchValue);
+    }, [excludedUsers, translate, searchTerm, policyName, usersToInvite, personalDetails]);
 
     return (
         <ScreenWrapper


### PR DESCRIPTION
### Details
Allow multiple emails to be added when inviting members to workspace. Previously, only one email could be added at a time.

### Fixed Issues
$ https://github.com/Expensify/App/issues/26242
PROPOSAL: https://github.com/Expensify/App/issues/26242#issuecomment-1735705251

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

1. Log in with any account
2. Add multiple emails at once as members to a workspace, by using a comma as a delimiter
3. Observe how all valid emails/numbers appear in the list (and how invalid ones are ignored)

- [X] Verify that no errors appear in the JS console

### Offline tests
1. Add multiple emails at once as members to a workspace, by using a comma as a delimiter
2. Observe how all valid emails/numbers appear in the list (and how invalid ones are ignored)

### QA Steps
1. Log in with any account
2. Add multiple emails at once as members to a workspace, by using a comma as a delimiter
3. Observe how all valid emails/numbers appear in the list (and how invalid ones are ignored)

- [X] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [X] I linked the correct issue in the `### Fixed Issues` section above
- [X] I wrote clear testing steps that cover the changes made in this PR
    - [X] I added steps for local testing in the `Tests` section
    - [X] I added steps for the expected offline behavior in the `Offline steps` section
    - [X] I added steps for Staging and/or Production testing in the `QA steps` section
    - [X] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [X] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [X] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [X] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [X] I ran the tests on **all platforms** & verified they passed on:
    - [X] Android / native
    - [X] Android / Chrome
    - [X] iOS / native
    - [X] iOS / Safari
    - [X] MacOS / Chrome / Safari
    - [X] MacOS / Desktop
- [X] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [X] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [X] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [X] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [X] I verified that comments were added to code that is not self explanatory
    - [X] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [X] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [X] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [X] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [X] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [X] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [X] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [X] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [X] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [X] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [X] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [X] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [X] I verified that if a function's arguments changed that all usages have also been updated correctly
- [X] If a new component is created I verified that:
    - [X] A similar component doesn't exist in the codebase
    - [X] All props are defined accurately and each prop has a `/** comment above it */`
    - [X] The file is named correctly
    - [X] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [X] The only data being stored in the state is data necessary for rendering and nothing else
    - [X] If we are not using the full Onyx data that we loaded, I've added the proper selector in order to ensure the component only re-renders when the data it is using changes
    - [X] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [X] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [X] All JSX used for rendering exists in the render method
    - [X] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [X] If any new file was added I verified that:
    - [X] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [X] If a new CSS style is added I verified that:
    - [X] A similar style doesn't already exist
    - [X] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG)`)
- [X] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [X] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [X] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [X] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [X] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [X] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [X] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>

https://github.com/Expensify/App/assets/10816880/ac9b0b27-e1ea-487d-9c07-b873a993c04a

</details>

<details>
<summary>Mobile Web - Chrome</summary>

https://github.com/Expensify/App/assets/10816880/d952f7e9-c63d-4f7c-bf87-ea1bfe60aea1

</details>

<details>
<summary>Mobile Web - Safari</summary>

https://github.com/Expensify/App/assets/10816880/41aecff0-2f82-41b9-97b9-6b886a8cc55b

</details>

<details>
<summary>Desktop</summary>

https://github.com/Expensify/App/assets/10816880/560a4593-016d-4896-a621-a1ee199b1798

</details>

<details>
<summary>iOS</summary>

https://github.com/Expensify/App/assets/10816880/089ac5dc-99cf-4e09-a8f8-3924797440ed

</details>

<details>
<summary>Android</summary>

https://github.com/Expensify/App/assets/10816880/31ba7b0a-f1ec-489d-b3bf-337e0029612b

</details>
