### PR TITLE
added composer focus glitch fix

### DIFF
--- a/src/ONYXKEYS.ts
+++ b/src/ONYXKEYS.ts
@@ -47,6 +47,9 @@ const ONYXKEYS = {
     // draft status
     CUSTOM_STATUS_DRAFT: 'customStatusDraft',
 
+    // keep edit message focus state
+    INPUT_FOCUSED: 'inputFocused',
+
     /** Contains all the personalDetails the user has access to, keyed by accountID */
     PERSONAL_DETAILS_LIST: 'personalDetailsList',
 
@@ -312,6 +315,7 @@ type OnyxValues = {
     [ONYXKEYS.MODAL]: OnyxTypes.Modal;
     [ONYXKEYS.NETWORK]: OnyxTypes.Network;
     [ONYXKEYS.CUSTOM_STATUS_DRAFT]: OnyxTypes.CustomStatusDraft;
+    [ONYXKEYS.INPUT_FOCUSED]: boolean;
     [ONYXKEYS.PERSONAL_DETAILS_LIST]: Record<string, OnyxTypes.PersonalDetails>;
     [ONYXKEYS.PRIVATE_PERSONAL_DETAILS]: OnyxTypes.PrivatePersonalDetails;
     [ONYXKEYS.TASK]: OnyxTypes.Task;

--- a/src/libs/actions/InputFocus.ts
+++ b/src/libs/actions/InputFocus.ts
@@ -1,0 +1,21 @@
+import Onyx from 'react-native-onyx';
+import ONYXKEYS from '../../ONYXKEYS';
+import _ from 'lodash';
+
+let refSave: HTMLElement | undefined;
+export function composerFocusKeepFocusOn(ref: HTMLElement, isFocused: boolean, modal: any, onyxFocused: boolean) {
+    if (isFocused && !onyxFocused) {
+        inputFocusChange(true);
+        ref.focus();
+    }
+    if (isFocused) {
+        refSave = ref;
+    }
+    if (!isFocused && !onyxFocused && !modal.willAlertModalBecomeVisible && !modal.isVisible && refSave) {
+        refSave.focus();
+    }
+}
+
+export function inputFocusChange(focus: boolean) {
+    Onyx.set(ONYXKEYS.INPUT_FOCUSED, focus);
+}

--- a/src/libs/actions/InputFocus.ts
+++ b/src/libs/actions/InputFocus.ts
@@ -1,9 +1,12 @@
 import Onyx from 'react-native-onyx';
 import ONYXKEYS from '../../ONYXKEYS';
-import _ from 'lodash';
+
+function inputFocusChange(focus: boolean) {
+    Onyx.set(ONYXKEYS.INPUT_FOCUSED, focus);
+}
 
 let refSave: HTMLElement | undefined;
-export function composerFocusKeepFocusOn(ref: HTMLElement, isFocused: boolean, modal: any, onyxFocused: boolean) {
+function composerFocusKeepFocusOn(ref: HTMLElement, isFocused: boolean, modal: {willAlertModalBecomeVisible: boolean, isVisible: boolean}, onyxFocused: boolean) {
     if (isFocused && !onyxFocused) {
         inputFocusChange(true);
         ref.focus();
@@ -16,6 +19,5 @@ export function composerFocusKeepFocusOn(ref: HTMLElement, isFocused: boolean, m
     }
 }
 
-export function inputFocusChange(focus: boolean) {
-    Onyx.set(ONYXKEYS.INPUT_FOCUSED, focus);
-}
+
+export { composerFocusKeepFocusOn, inputFocusChange }

--- a/src/libs/actions/InputFocus.ts
+++ b/src/libs/actions/InputFocus.ts
@@ -6,7 +6,7 @@ function inputFocusChange(focus: boolean) {
 }
 
 let refSave: HTMLElement | undefined;
-function composerFocusKeepFocusOn(ref: HTMLElement, isFocused: boolean, modal: {willAlertModalBecomeVisible: boolean, isVisible: boolean}, onyxFocused: boolean) {
+function composerFocusKeepFocusOn(ref: HTMLElement, isFocused: boolean, modal: {willAlertModalBecomeVisible: boolean; isVisible: boolean}, onyxFocused: boolean) {
     if (isFocused && !onyxFocused) {
         inputFocusChange(true);
         ref.focus();
@@ -19,5 +19,4 @@ function composerFocusKeepFocusOn(ref: HTMLElement, isFocused: boolean, modal: {
     }
 }
 
-
-export { composerFocusKeepFocusOn, inputFocusChange }
+export {composerFocusKeepFocusOn, inputFocusChange};

--- a/src/libs/actions/InputFocus/index.desktop.ts
+++ b/src/libs/actions/InputFocus/index.desktop.ts
@@ -4,17 +4,11 @@ import * as Browser from '../../Browser';
 import ReportActionComposeFocusManager from '../../ReportActionComposeFocusManager';
 
 function inputFocusChange(focus: boolean) {
-    if (Browser.isMobile()) {
-        return;
-    }
     Onyx.set(ONYXKEYS.INPUT_FOCUSED, focus);
 }
 
 let refSave: HTMLElement | undefined;
 function composerFocusKeepFocusOn(ref: HTMLElement, isFocused: boolean, modal: { willAlertModalBecomeVisible: boolean; isVisible: boolean }, onyxFocused: boolean) {
-    if (Browser.isMobile()) {
-        return;
-    }
     if (isFocused && !onyxFocused) {
         inputFocusChange(true);
         ref.focus();
@@ -31,6 +25,6 @@ function composerFocusKeepFocusOn(ref: HTMLElement, isFocused: boolean, modal: {
     }
 }
 
-const callback = (method: () => void) => !Browser.isMobile() && method();
+const callback = (method: () => void) => method();
 
 export {composerFocusKeepFocusOn, inputFocusChange, callback};

--- a/src/libs/actions/InputFocus/index.desktop.ts
+++ b/src/libs/actions/InputFocus/index.desktop.ts
@@ -1,6 +1,5 @@
 import Onyx from 'react-native-onyx';
 import ONYXKEYS from '../../../ONYXKEYS';
-import * as Browser from '../../Browser';
 import ReportActionComposeFocusManager from '../../ReportActionComposeFocusManager';
 
 function inputFocusChange(focus: boolean) {
@@ -8,18 +7,18 @@ function inputFocusChange(focus: boolean) {
 }
 
 let refSave: HTMLElement | undefined;
-function composerFocusKeepFocusOn(ref: HTMLElement, isFocused: boolean, modal: { willAlertModalBecomeVisible: boolean; isVisible: boolean }, onyxFocused: boolean) {
+function composerFocusKeepFocusOn(ref: HTMLElement, isFocused: boolean, modal: {willAlertModalBecomeVisible: boolean; isVisible: boolean}, onyxFocused: boolean) {
     if (isFocused && !onyxFocused) {
         inputFocusChange(true);
         ref.focus();
-    }   
+    }
     if (isFocused) {
         refSave = ref;
     }
-    if (!isFocused && !onyxFocused && !modal.willAlertModalBecomeVisible && !modal.isVisible && refSave) {        
+    if (!isFocused && !onyxFocused && !modal.willAlertModalBecomeVisible && !modal.isVisible && refSave) {
         if (!ReportActionComposeFocusManager.isFocused()) {
             refSave.focus();
-        } else { 
+        } else {
             refSave = undefined;
         }
     }

--- a/src/libs/actions/InputFocus/index.ts
+++ b/src/libs/actions/InputFocus/index.ts
@@ -1,0 +1,5 @@
+function inputFocusChange() {}
+function composerFocusKeepFocusOn() {}
+const callback = () => {};
+
+export {composerFocusKeepFocusOn, inputFocusChange, callback};

--- a/src/libs/actions/InputFocus/index.website.ts
+++ b/src/libs/actions/InputFocus/index.website.ts
@@ -4,17 +4,11 @@ import * as Browser from '../../Browser';
 import ReportActionComposeFocusManager from '../../ReportActionComposeFocusManager';
 
 function inputFocusChange(focus: boolean) {
-    if (Browser.isMobile()) {
-        return;
-    }
     Onyx.set(ONYXKEYS.INPUT_FOCUSED, focus);
 }
 
 let refSave: HTMLElement | undefined;
 function composerFocusKeepFocusOn(ref: HTMLElement, isFocused: boolean, modal: {willAlertModalBecomeVisible: boolean; isVisible: boolean}, onyxFocused: boolean) {
-    if (Browser.isMobile()) {
-        return;
-    }
     if (isFocused && !onyxFocused) {
         inputFocusChange(true);
         ref.focus();

--- a/src/libs/actions/InputFocus/index.website.ts
+++ b/src/libs/actions/InputFocus/index.website.ts
@@ -11,21 +11,21 @@ function inputFocusChange(focus: boolean) {
 }
 
 let refSave: HTMLElement | undefined;
-function composerFocusKeepFocusOn(ref: HTMLElement, isFocused: boolean, modal: { willAlertModalBecomeVisible: boolean; isVisible: boolean }, onyxFocused: boolean) {
+function composerFocusKeepFocusOn(ref: HTMLElement, isFocused: boolean, modal: {willAlertModalBecomeVisible: boolean; isVisible: boolean}, onyxFocused: boolean) {
     if (Browser.isMobile()) {
         return;
     }
     if (isFocused && !onyxFocused) {
         inputFocusChange(true);
         ref.focus();
-    }   
+    }
     if (isFocused) {
         refSave = ref;
     }
-    if (!isFocused && !onyxFocused && !modal.willAlertModalBecomeVisible && !modal.isVisible && refSave) {        
+    if (!isFocused && !onyxFocused && !modal.willAlertModalBecomeVisible && !modal.isVisible && refSave) {
         if (!ReportActionComposeFocusManager.isFocused()) {
             refSave.focus();
-        } else { 
+        } else {
             refSave = undefined;
         }
     }

--- a/src/libs/actions/InputFocus/index.website.ts
+++ b/src/libs/actions/InputFocus/index.website.ts
@@ -1,12 +1,19 @@
 import Onyx from 'react-native-onyx';
-import ONYXKEYS from '../../ONYXKEYS';
+import ONYXKEYS from '../../../ONYXKEYS';
+import * as Browser from '../../Browser';
 
 function inputFocusChange(focus: boolean) {
+    if (Browser.isMobile()) {
+        return;
+    }
     Onyx.set(ONYXKEYS.INPUT_FOCUSED, focus);
 }
 
 let refSave: HTMLElement | undefined;
 function composerFocusKeepFocusOn(ref: HTMLElement, isFocused: boolean, modal: {willAlertModalBecomeVisible: boolean; isVisible: boolean}, onyxFocused: boolean) {
+    if (Browser.isMobile()) {
+        return;
+    }
     if (isFocused && !onyxFocused) {
         inputFocusChange(true);
         ref.focus();
@@ -19,4 +26,6 @@ function composerFocusKeepFocusOn(ref: HTMLElement, isFocused: boolean, modal: {
     }
 }
 
-export {composerFocusKeepFocusOn, inputFocusChange};
+const callback = (method: () => void) => !Browser.isMobile() && method();
+
+export {composerFocusKeepFocusOn, inputFocusChange, callback};

--- a/src/pages/home/report/ReportActionCompose/ComposerWithSuggestions.js
+++ b/src/pages/home/report/ReportActionCompose/ComposerWithSuggestions.js
@@ -374,7 +374,7 @@ function ComposerWithSuggestions({
         if (!suggestionsRef.current) {
             return false;
         }
-        InputFocus.inputFocusChange(false)
+        InputFocus.inputFocusChange(false);
         return suggestionsRef.current.setShouldBlockSuggestionCalc(false);
     }, [suggestionsRef]);
 

--- a/src/pages/home/report/ReportActionCompose/ComposerWithSuggestions.js
+++ b/src/pages/home/report/ReportActionCompose/ComposerWithSuggestions.js
@@ -374,6 +374,7 @@ function ComposerWithSuggestions({
         if (!suggestionsRef.current) {
             return false;
         }
+        InputFocus.inputFocusChange(false)
         return suggestionsRef.current.setShouldBlockSuggestionCalc(false);
     }, [suggestionsRef]);
 

--- a/src/pages/home/report/ReportActionCompose/ComposerWithSuggestions.js
+++ b/src/pages/home/report/ReportActionCompose/ComposerWithSuggestions.js
@@ -33,6 +33,7 @@ import withKeyboardState from '../../../../components/withKeyboardState';
 import {propTypes, defaultProps} from './composerWithSuggestionsProps';
 import focusWithDelay from '../../../../libs/focusWithDelay';
 import useDebounce from '../../../../hooks/useDebounce';
+import * as InputFocus from '../../../../libs/actions/InputFocus';
 
 const {RNTextInputReset} = NativeModules;
 
@@ -98,6 +99,7 @@ function ComposerWithSuggestions({
     animatedRef,
     forwardedRef,
     isNextModalWillOpenRef,
+    editFocused,
 }) {
     const {preferredLocale} = useLocalize();
     const isFocused = useIsFocused();
@@ -478,9 +480,12 @@ function ComposerWithSuggestions({
             return;
         }
 
+        if (editFocused) {
+            InputFocus.inputFocusChange(false);
+            return;
+        }
         focus();
-    }, [focus, prevIsFocused, prevIsModalVisible, isFocused, modal.isVisible, isNextModalWillOpenRef]);
-
+    }, [focus, prevIsFocused, editFocused, prevIsModalVisible, isFocused, modal.isVisible, isNextModalWillOpenRef]);
     useEffect(() => {
         if (value.length === 0) {
             return;
@@ -590,6 +595,9 @@ export default compose(
         preferredSkinTone: {
             key: ONYXKEYS.PREFERRED_EMOJI_SKIN_TONE,
             selector: EmojiUtils.getPreferredSkinToneIndex,
+        },
+        editFocused: {
+            key: ONYXKEYS.INPUT_FOCUSED,
         },
         parentReportActions: {
             key: ({report}) => `${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${report.parentReportID}`,

--- a/src/pages/home/report/ReportActionItemMessageEdit.js
+++ b/src/pages/home/report/ReportActionItemMessageEdit.js
@@ -1,6 +1,6 @@
 import lodashGet from 'lodash/get';
 import React, {useState, useRef, useMemo, useEffect, useCallback} from 'react';
-import {InteractionManager, Keyboard, Platform, View} from 'react-native';
+import {InteractionManager, Keyboard, View} from 'react-native';
 import PropTypes from 'prop-types';
 import _ from 'underscore';
 import ExpensiMark from 'expensify-common/lib/ExpensiMark';
@@ -130,9 +130,7 @@ function ReportActionItemMessageEdit(props) {
     }, [isFocused]);
 
     useEffect(() => {
-        if (Platform.OS === 'web' && !Browser.isMobile()) {
-            InputFocus.composerFocusKeepFocusOn(textInputRef.current, isFocused, modal, onyxFocused);
-        }
+        InputFocus.composerFocusKeepFocusOn(textInputRef.current, isFocused, modal, onyxFocused);
         return () => {};
     }, [isFocused, modal, onyxFocused]);
 
@@ -268,10 +266,8 @@ function ReportActionItemMessageEdit(props) {
      * Delete the draft of the comment being edited. This will take the comment out of "edit mode" with the old content.
      */
     const deleteDraft = useCallback(() => {
-        if (Platform.OS === 'web' && !Browser.isMobile()) {
-            setIsFocused(false);
-            InputFocus.inputFocusChange(false);
-        }
+        InputFocus.callback(() => setIsFocused(false));
+        InputFocus.inputFocusChange(false);
         debouncedSaveDraft.cancel();
         Report.saveReportActionDraft(props.reportID, props.action, '');
 

--- a/src/pages/home/report/ReportActionItemMessageEdit.js
+++ b/src/pages/home/report/ReportActionItemMessageEdit.js
@@ -131,7 +131,6 @@ function ReportActionItemMessageEdit(props) {
 
     useEffect(() => {
         InputFocus.composerFocusKeepFocusOn(textInputRef.current, isFocused, modal, onyxFocused);
-        return () => {};
     }, [isFocused, modal, onyxFocused]);
 
     useEffect(() => {

--- a/src/pages/home/report/ReportActionItemMessageEdit.js
+++ b/src/pages/home/report/ReportActionItemMessageEdit.js
@@ -37,6 +37,9 @@ import useReportScrollManager from '../../../hooks/useReportScrollManager';
 import * as EmojiPickerAction from '../../../libs/actions/EmojiPickerAction';
 import focusWithDelay from '../../../libs/focusWithDelay';
 import * as Browser from '../../../libs/Browser';
+import * as InputFocus from '../../../libs/actions/InputFocus';
+import onyxSubscribe from '../../../libs/onyxSubscribe';
+import ONYXKEYS from '../../../ONYXKEYS';
 
 const propTypes = {
     /** All the data of the action */
@@ -107,6 +110,8 @@ function ReportActionItemMessageEdit(props) {
     const [selection, setSelection] = useState(getInitialSelection());
     const [isFocused, setIsFocused] = useState(false);
     const [hasExceededMaxCommentLength, setHasExceededMaxCommentLength] = useState(false);
+    const [modal, setModal] = useState(false);
+    const [onyxFocused, setOnyxFocused] = useState(false);
 
     const textInputRef = useRef(null);
     const isFocusedRef = useRef(false);
@@ -123,6 +128,36 @@ function ReportActionItemMessageEdit(props) {
         // required for keeping last state of isFocused variable
         isFocusedRef.current = isFocused;
     }, [isFocused]);
+
+    useEffect(() => {
+        InputFocus.composerFocusKeepFocusOn(textInputRef.current, isFocused, modal, onyxFocused);
+    }, [isFocused, modal, onyxFocused]);
+
+    useEffect(() => {
+        const unsubscribeOnyxModal = onyxSubscribe({
+            key: ONYXKEYS.MODAL,
+            callback: (modalArg) => {
+                if (_.isNull(modalArg)) {
+                    return;
+                }
+                setModal(modalArg);
+            },
+        });
+
+        const unsubscribeOnyxFocused = onyxSubscribe({
+            key: ONYXKEYS.INPUT_FOCUSED,
+            callback: (modalArg) => {
+                if (_.isNull(modalArg)) {
+                    return;
+                }
+                setOnyxFocused(modalArg);
+            },
+        });
+        return () => {
+            unsubscribeOnyxModal();
+            unsubscribeOnyxFocused();
+        };
+    }, []);
 
     // We consider the report action active if it's focused, its emoji picker is open or its context menu is open
     const isActive = useCallback(
@@ -230,6 +265,8 @@ function ReportActionItemMessageEdit(props) {
      * Delete the draft of the comment being edited. This will take the comment out of "edit mode" with the old content.
      */
     const deleteDraft = useCallback(() => {
+        setIsFocused(false);
+        InputFocus.inputFocusChange(false);
         debouncedSaveDraft.cancel();
         Report.saveReportActionDraft(props.reportID, props.action, '');
 

--- a/src/pages/home/report/ReportActionItemMessageEdit.js
+++ b/src/pages/home/report/ReportActionItemMessageEdit.js
@@ -130,10 +130,10 @@ function ReportActionItemMessageEdit(props) {
     }, [isFocused]);
 
     useEffect(() => {
-        if (Platform.OS === "web" && !Browser.isMobile()) {
+        if (Platform.OS === 'web' && !Browser.isMobile()) {
             InputFocus.composerFocusKeepFocusOn(textInputRef.current, isFocused, modal, onyxFocused);
         }
-        return ()=>{}
+        return () => {};
     }, [isFocused, modal, onyxFocused]);
 
     useEffect(() => {
@@ -268,10 +268,10 @@ function ReportActionItemMessageEdit(props) {
      * Delete the draft of the comment being edited. This will take the comment out of "edit mode" with the old content.
      */
     const deleteDraft = useCallback(() => {
-        if (Platform.OS === "web" && !Browser.isMobile()) { 
+        if (Platform.OS === 'web' && !Browser.isMobile()) {
             setIsFocused(false);
             InputFocus.inputFocusChange(false);
-        }        
+        }
         debouncedSaveDraft.cancel();
         Report.saveReportActionDraft(props.reportID, props.action, '');
 

--- a/src/pages/home/report/ReportActionItemMessageEdit.js
+++ b/src/pages/home/report/ReportActionItemMessageEdit.js
@@ -1,6 +1,6 @@
 import lodashGet from 'lodash/get';
 import React, {useState, useRef, useMemo, useEffect, useCallback} from 'react';
-import {InteractionManager, Keyboard, View} from 'react-native';
+import {InteractionManager, Keyboard, Platform, View} from 'react-native';
 import PropTypes from 'prop-types';
 import _ from 'underscore';
 import ExpensiMark from 'expensify-common/lib/ExpensiMark';
@@ -130,7 +130,10 @@ function ReportActionItemMessageEdit(props) {
     }, [isFocused]);
 
     useEffect(() => {
-        InputFocus.composerFocusKeepFocusOn(textInputRef.current, isFocused, modal, onyxFocused);
+        if (Platform.OS === "web" && !Browser.isMobile()) {
+            InputFocus.composerFocusKeepFocusOn(textInputRef.current, isFocused, modal, onyxFocused);
+        }
+        return ()=>{}
     }, [isFocused, modal, onyxFocused]);
 
     useEffect(() => {
@@ -265,8 +268,10 @@ function ReportActionItemMessageEdit(props) {
      * Delete the draft of the comment being edited. This will take the comment out of "edit mode" with the old content.
      */
     const deleteDraft = useCallback(() => {
-        setIsFocused(false);
-        InputFocus.inputFocusChange(false);
+        if (Platform.OS === "web" && !Browser.isMobile()) { 
+            setIsFocused(false);
+            InputFocus.inputFocusChange(false);
+        }        
         debouncedSaveDraft.cancel();
         Report.saveReportActionDraft(props.reportID, props.action, '');
 


### PR DESCRIPTION
### Details
In this PR, I have added a method to maintain focus on the input box by passing its input reference and modal status. This prevents the composer from stealing focus away from that input box.

### Fixed Issues
1. $ https://github.com/Expensify/App/issues/26527
2. PROPOSAL: https://github.com/Expensify/App/issues/26527#issuecomment-1708380347

### Tests

1. Open the app
2. Open any report
3. Edit any message
4. Click CTRL+J to open keyboard shortcut or click on delete icon of some other chat to open delete modal
5. now close the modal
6. Edit message box should not glitch as it works currently on ESC from CTRL+K or CTRL+SHIFT+K shortcuts

- [x] Verify that no errors appear in the JS console

### Offline tests
same as online

### QA Steps
same as above

- [x] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] If we are not using the full Onyx data that we loaded, I've added the proper selector in order to ensure the component only re-renders when the data it is using changes
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Web</summary>

https://github.com/Expensify/App/assets/767439/802fc37f-163e-471c-b5ee-845f70a18a2c

https://github.com/Expensify/App/assets/767439/d7ab2394-46cc-4ba4-b3c0-e9c5f8860913

</details>

<details>
<summary>Mobile Web - Chrome </summary>

https://github.com/Expensify/App/assets/767439/8c534140-7939-4c6f-8e45-88d937bde925


</details>

<details>
<summary>Mobile Web - Safari</summary>

https://github.com/Expensify/App/assets/767439/57bc0b51-0ff9-414d-863a-edb61b44c030

</details>

<details>
<summary>Desktop</summary>

https://github.com/Expensify/App/assets/767439/a7bfe59a-f7b9-4506-a5b2-9af250d76bf3

</details>

<details>
<summary>iOS</summary>

Should work same as before

</details>

<details>
<summary>Android</summary>

Should work same as before

</details>
