### PR TITLE
feat: enable next button

### DIFF
--- a/src/components/DistanceRequest/DistanceRequestFooter.js
+++ b/src/components/DistanceRequest/DistanceRequestFooter.js
@@ -10,8 +10,6 @@ import ONYXKEYS from '../../ONYXKEYS';
 import styles from '../../styles/styles';
 import useNetwork from '../../hooks/useNetwork';
 import useLocalize from '../../hooks/useLocalize';
-import DotIndicatorMessage from '../DotIndicatorMessage';
-import * as ErrorUtils from '../../libs/ErrorUtils';
 import theme from '../../styles/themes/default';
 import * as TransactionUtils from '../../libs/TransactionUtils';
 import Button from '../Button';
@@ -32,9 +30,6 @@ const propTypes = {
         }),
     ),
 
-    /** Whether there is an error with the route */
-    hasRouteError: PropTypes.bool,
-
     /** Function to call when the user wants to add a new waypoint */
     navigateToWaypointEditPage: PropTypes.func.isRequired,
 
@@ -53,13 +48,12 @@ const propTypes = {
 
 const defaultProps = {
     waypoints: {},
-    hasRouteError: false,
     mapboxAccessToken: {
         token: '',
     },
     transaction: {},
 };
-function DistanceRequestFooter({waypoints, transaction, mapboxAccessToken, hasRouteError, navigateToWaypointEditPage}) {
+function DistanceRequestFooter({waypoints, transaction, mapboxAccessToken, navigateToWaypointEditPage}) {
     const {isOffline} = useNetwork();
     const {translate} = useLocalize();
 
@@ -103,13 +97,6 @@ function DistanceRequestFooter({waypoints, transaction, mapboxAccessToken, hasRo
 
     return (
         <>
-            {hasRouteError && (
-                <DotIndicatorMessage
-                    style={[styles.mh5, styles.mv3]}
-                    messages={ErrorUtils.getLatestErrorField(transaction, 'route')}
-                    type="error"
-                />
-            )}
             <View style={[styles.flexRow, styles.justifyContentCenter, styles.pt1]}>
                 <Button
                     small

--- a/src/components/DistanceRequest/index.js
+++ b/src/components/DistanceRequest/index.js
@@ -151,11 +151,12 @@ function DistanceRequest({transactionID, report, transaction, route, isEditingRe
             return ErrorUtils.getLatestErrorField(transaction, 'route');
         }
 
+        // Initially, both waypoints will be null, and if we give fallback value as empty string that will result in true condition, that's why different default values.
+        if (_.keys(waypoints).length === 2 && lodashGet(waypoints, 'waypoint0.address', 'address1') === lodashGet(waypoints, 'waypoint1.address', 'address2')) {
+            return {0: translate('iou.error.duplicateWaypointsErrorMessage')};
+        }
+
         if (_.size(validatedWaypoints) < 2) {
-            // Initially, both waypoints will be null, and if we give fallback value as empty string that will result in true condition, that's why different default values.
-            if (_.keys(waypoints).length === 2 && lodashGet(waypoints, 'waypoint0.address', 'address1') === lodashGet(waypoints, 'waypoint1.address', 'address2')) {
-                return {0: translate('iou.error.duplicateWaypointsErrorMessage')};
-            }
             return {0: translate('iou.error.emptyWaypointsErrorMessage')};
         }
     };
@@ -180,6 +181,15 @@ function DistanceRequest({transactionID, report, transaction, route, isEditingRe
         },
         [transactionID, waypoints, waypointsList],
     );
+
+    const onPress = useCallback(() => {
+        // If there is any error or loading state, don't let user go to next page.
+        if (_.size(validatedWaypoints) < 2 || hasRouteError || isLoadingRoute || isLoading) {
+            setHasError(true);
+            return;
+        }
+        onSubmit(waypoints);
+    }, [onSubmit, setHasError, hasRouteError, isLoadingRoute, isLoading, validatedWaypoints, waypoints]);
 
     const content = (
         <>
@@ -226,14 +236,7 @@ function DistanceRequest({transactionID, report, transaction, route, isEditingRe
                     allowBubble
                     pressOnEnter
                     style={[styles.w100, styles.mb4, styles.ph4, styles.flexShrink0]}
-                    onPress={() => {
-                        // If there is any error or loading state, don't let user go to next page.
-                        if (_.size(validatedWaypoints) < 2 || hasRouteError || isLoadingRoute || isLoading) {
-                            setHasError(true);
-                            return;
-                        }
-                        onSubmit(waypoints);
-                    }}
+                    onPress={onPress}
                     text={translate(isEditingRequest ? 'common.save' : 'common.next')}
                     isLoading={!isOffline && (isLoadingRoute || shouldFetchRoute || isLoading)}
                 />

--- a/src/components/DistanceRequest/index.js
+++ b/src/components/DistanceRequest/index.js
@@ -70,7 +70,7 @@ function DistanceRequest({transactionID, report, transaction, route, isEditingRe
     const {translate} = useLocalize();
 
     const [optimisticWaypoints, setOptimisticWaypoints] = useState(null);
-    const [userTriedSubmitting, setUserTriedSubmitting] = useState(false);
+    const [hasError, setHasError] = useState(false);
     const isEditing = lodashGet(route, 'path', '').includes('address');
     const reportID = lodashGet(report, 'reportID', '');
     const waypoints = useMemo(() => optimisticWaypoints || lodashGet(transaction, 'comment.waypoints', {waypoint0: {}, waypoint1: {}}), [optimisticWaypoints, transaction]);
@@ -105,7 +105,8 @@ function DistanceRequest({transactionID, report, transaction, route, isEditingRe
         // Create the initial start and stop waypoints
         Transaction.createInitialWaypoints(transactionID);
         return () => {
-            setUserTriedSubmitting(false);
+            // Whenever we reset the transaction, we need to set errors as empty/false.
+            setHasError(false);
         };
     }, [transaction, transactionID]);
 
@@ -125,10 +126,11 @@ function DistanceRequest({transactionID, report, transaction, route, isEditingRe
     }, [numberOfPreviousWaypoints, numberOfWaypoints]);
 
     useEffect(() => {
+        // Whenever we change waypoints we need to remove the error or it will keep showing the error.
         if (_.isEqual(previousWaypoints, waypoints)) {
             return;
         }
-        setUserTriedSubmitting(false);
+        setHasError(false);
     }, [waypoints, previousWaypoints]);
 
     const navigateBack = () => {
@@ -144,13 +146,13 @@ function DistanceRequest({transactionID, report, transaction, route, isEditingRe
     };
 
     const getError = () => {
-        // get route error if available else show the invalid number of waypoints error
+        // Get route error if available else show the invalid number of waypoints error.
         if (hasRouteError) {
             return ErrorUtils.getLatestErrorField(transaction, 'route');
         }
 
         if (_.size(validatedWaypoints) < 2) {
-            // initially, both waypoints will be null, and if we give fallback value as emmpty string that will result in true condition, that's why different default values
+            // Initially, both waypoints will be null, and if we give fallback value as empty string that will result in true condition, that's why different default values.
             if (_.keys(waypoints).length === 2 && lodashGet(waypoints, 'waypoint0.address', 'address1') === lodashGet(waypoints, 'waypoint1.address', 'address2')) {
                 return {0: translate('iou.error.duplicateWaypointsErrorMessage')};
             }
@@ -211,8 +213,8 @@ function DistanceRequest({transactionID, report, transaction, route, isEditingRe
                 />
             </View>
             <View style={[styles.w100, styles.pt2]}>
-                {/* show error message if there is route error or there are less than 2 routes and user has tried submitting */}
-                {((userTriedSubmitting && _.size(validatedWaypoints) < 2) || hasRouteError) && (
+                {/* Show error message if there is route error or there are less than 2 routes and user has tried submitting, */}
+                {((hasError && _.size(validatedWaypoints) < 2) || hasRouteError) && (
                     <DotIndicatorMessage
                         style={[styles.mh4, styles.mv3]}
                         messages={getError()}
@@ -225,9 +227,9 @@ function DistanceRequest({transactionID, report, transaction, route, isEditingRe
                     pressOnEnter
                     style={[styles.w100, styles.mb4, styles.ph4, styles.flexShrink0]}
                     onPress={() => {
-                        setUserTriedSubmitting(true);
-                        // if there is any error or loading state, don't let user go to next page
+                        // If there is any error or loading state, don't let user go to next page.
                         if (_.size(validatedWaypoints) < 2 || hasRouteError || isLoadingRoute || isLoading) {
+                            setHasError(true);
                             return;
                         }
                         onSubmit(waypoints);

--- a/src/components/DistanceRequest/index.js
+++ b/src/components/DistanceRequest/index.js
@@ -182,7 +182,7 @@ function DistanceRequest({transactionID, report, transaction, route, isEditingRe
         [transactionID, waypoints, waypointsList],
     );
 
-    const onPress = useCallback(() => {
+    const submitWaypoints = useCallback(() => {
         // If there is any error or loading state, don't let user go to next page.
         if (_.size(validatedWaypoints) < 2 || hasRouteError || isLoadingRoute || isLoading) {
             setHasError(true);
@@ -236,7 +236,7 @@ function DistanceRequest({transactionID, report, transaction, route, isEditingRe
                     allowBubble
                     pressOnEnter
                     style={[styles.w100, styles.mb4, styles.ph4, styles.flexShrink0]}
-                    onPress={onPress}
+                    onPress={submitWaypoints}
                     text={translate(isEditingRequest ? 'common.save' : 'common.next')}
                     isLoading={!isOffline && (isLoadingRoute || shouldFetchRoute || isLoading)}
                 />

--- a/src/languages/en.ts
+++ b/src/languages/en.ts
@@ -567,6 +567,8 @@ export default {
             genericDeleteFailureMessage: 'Unexpected error deleting the money request, please try again later',
             genericEditFailureMessage: 'Unexpected error editing the money request, please try again later',
             genericSmartscanFailureMessage: 'Transaction is missing fields',
+            duplicateWaypointsErrorMessage: 'There are duplicate waypoints',
+            emptyWaypointsErrorMessage: 'Please enter at least two waypoints',
         },
     },
     notificationPreferencesPage: {

--- a/src/languages/en.ts
+++ b/src/languages/en.ts
@@ -567,7 +567,7 @@ export default {
             genericDeleteFailureMessage: 'Unexpected error deleting the money request, please try again later',
             genericEditFailureMessage: 'Unexpected error editing the money request, please try again later',
             genericSmartscanFailureMessage: 'Transaction is missing fields',
-            duplicateWaypointsErrorMessage: 'There are duplicate waypoints',
+            duplicateWaypointsErrorMessage: 'Please remove duplicate waypoints',
             emptyWaypointsErrorMessage: 'Please enter at least two waypoints',
         },
     },

--- a/src/languages/es.ts
+++ b/src/languages/es.ts
@@ -561,7 +561,7 @@ export default {
             genericDeleteFailureMessage: 'Error inesperado eliminando la solicitud de dinero. Por favor, inténtalo más tarde',
             genericEditFailureMessage: 'Error inesperado al guardar la solicitud de dinero. Por favor, inténtalo más tarde',
             genericSmartscanFailureMessage: 'La transacción tiene campos vacíos',
-            duplicateWaypointsErrorMessage: 'Hay puntos de ruta duplicados',
+            duplicateWaypointsErrorMessage: 'Por favor elimina los puntos de ruta duplicados',
             emptyWaypointsErrorMessage: 'Por favor introduce al menos dos puntos de ruta',
         },
     },

--- a/src/languages/es.ts
+++ b/src/languages/es.ts
@@ -561,6 +561,8 @@ export default {
             genericDeleteFailureMessage: 'Error inesperado eliminando la solicitud de dinero. Por favor, inténtalo más tarde',
             genericEditFailureMessage: 'Error inesperado al guardar la solicitud de dinero. Por favor, inténtalo más tarde',
             genericSmartscanFailureMessage: 'La transacción tiene campos vacíos',
+            duplicateWaypointsErrorMessage: 'Hay puntos de ruta duplicados',
+            emptyWaypointsErrorMessage: 'Por favor introduce al menos dos waypoints',
         },
     },
     notificationPreferencesPage: {

--- a/src/languages/es.ts
+++ b/src/languages/es.ts
@@ -562,7 +562,7 @@ export default {
             genericEditFailureMessage: 'Error inesperado al guardar la solicitud de dinero. Por favor, inténtalo más tarde',
             genericSmartscanFailureMessage: 'La transacción tiene campos vacíos',
             duplicateWaypointsErrorMessage: 'Hay puntos de ruta duplicados',
-            emptyWaypointsErrorMessage: 'Por favor introduce al menos dos waypoints',
+            emptyWaypointsErrorMessage: 'Por favor introduce al menos dos puntos de ruta',
         },
     },
     notificationPreferencesPage: {


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->
Currently we don't have next button for distance request enabled by default, this PR will enable the distance request and display the error in case there is an error.

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/27045
PROPOSAL: https://github.com/Expensify/App/issues/27045#issuecomment-1711984411


### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

#### Test 1
1. Empty waypoints
2. Click next
3. Verify an error appears asking you to enter waypoints

#### Test 2
1. Start waypoint A
2. empty waypoint
3. Finish waypoint B
4. Click next
5. Verify that you are navigated without errors

#### Test 3
1. start waypoint A
2. finish waypoint A
3. Click next
4. Verify an error appears about duplicate waypoints

#### Test 4
1. start waypoint A
2. stop waypoint A
3. finish waypoint B
4. Click next
5. Verify that you are navigated without errors

#### Test 5
1. start waypoint A
2. stop waypoint B
3. stop waypoint B
4. finish waypoint A
5. Click next
6. Verify that you are navigated without error

- [X] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

- [X] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [X] I linked the correct issue in the `### Fixed Issues` section above
- [X] I wrote clear testing steps that cover the changes made in this PR
    - [X] I added steps for local testing in the `Tests` section
    - [X] I added steps for the expected offline behavior in the `Offline steps` section
    - [X] I added steps for Staging and/or Production testing in the `QA steps` section
    - [X] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [X] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [X] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [X] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [X] I ran the tests on **all platforms** & verified they passed on:
    - [X] Android: Native
    - [X] Android: mWeb Chrome
    - [X] iOS: Native
    - [X] iOS: mWeb Safari
    - [X] MacOS: Chrome / Safari
    - [X] MacOS: Desktop
- [X] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [X] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [X] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [X] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [X] I verified that comments were added to code that is not self explanatory
    - [X] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [X] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [X] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message: https://expensify.slack.com/archives/C01GTK53T8Q/p1696910414908269
    - [X] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [X] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [X] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [X] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [X] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [X] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [X] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [X] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [X] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [X] I verified that if a function's arguments changed that all usages have also been updated correctly
- [X] If a new component is created I verified that:
    - [X] A similar component doesn't exist in the codebase
    - [X] All props are defined accurately and each prop has a `/** comment above it */`
    - [X] The file is named correctly
    - [X] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [X] The only data being stored in the state is data necessary for rendering and nothing else
    - [X] If we are not using the full Onyx data that we loaded, I've added the proper selector in order to ensure the component only re-renders when the data it is using changes
    - [X] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [X] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [X] All JSX used for rendering exists in the render method
    - [X] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [X] If any new file was added I verified that:
    - [X] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [X] If a new CSS style is added I verified that:
    - [X] A similar style doesn't already exist
    - [X] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG)`)
- [X] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [X] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [X] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [X] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [X] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [X] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [X] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

https://github.com/Expensify/App/assets/27822551/187beb97-8ccc-4eaf-beb7-75c22fc54294


<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

https://github.com/Expensify/App/assets/27822551/58594af1-853f-4970-a563-988976219a54


</details>

<details>
<summary>iOS: Native</summary>

https://github.com/Expensify/App/assets/27822551/93155fdb-0601-4167-be1b-bc85333a6da8


<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

https://github.com/Expensify/App/assets/27822551/d17e2190-8c85-4004-9eac-091490bb89b3


<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

https://github.com/Expensify/App/assets/27822551/410d5126-1572-40b7-ac6d-f4039c15615a


<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Desktop</summary>

https://github.com/Expensify/App/assets/27822551/2dac22f9-8001-44ea-938a-aa942e956800


<!-- add screenshots or videos here -->

</details>
