### PR TITLE
update text and alternateText in getPolicyExpenseReportOption function

### DIFF
--- a/src/libs/OptionsListUtils.js
+++ b/src/libs/OptionsListUtils.js
@@ -553,6 +553,8 @@ function getPolicyExpenseReportOption(report) {
             forcePolicyNamePreview: false,
         },
     );
+
+    // Update text & alternateText because createOption returns workspace name only if report is owned by the user
     option.text = ReportUtils.getPolicyName(report);
     option.alternateText = Localize.translateLocal('workspace.common.workspace');
     option.selected = report.selected;

--- a/src/libs/OptionsListUtils.js
+++ b/src/libs/OptionsListUtils.js
@@ -555,7 +555,7 @@ function getPolicyExpenseReportOption(report) {
     );
 
     // Update text & alternateText because createOption returns workspace name only if report is owned by the user
-    option.text = ReportUtils.getPolicyName(report);
+    option.text = ReportUtils.getPolicyName(expenseReport);
     option.alternateText = Localize.translateLocal('workspace.common.workspace');
     option.selected = report.selected;
     return option;

--- a/src/libs/OptionsListUtils.js
+++ b/src/libs/OptionsListUtils.js
@@ -412,10 +412,9 @@ function getLastMessageTextForReport(report) {
  * @param {Object} options
  * @param {Boolean} [options.showChatPreviewLine]
  * @param {Boolean} [options.forcePolicyNamePreview]
- * @param {Boolean} [options.checkPolicyOwner]
  * @returns {Object}
  */
-function createOption(accountIDs, personalDetails, report, reportActions = {}, {showChatPreviewLine = false, forcePolicyNamePreview = false, checkPolicyOwner = true}) {
+function createOption(accountIDs, personalDetails, report, reportActions = {}, {showChatPreviewLine = false, forcePolicyNamePreview = false}) {
     const result = {
         text: null,
         alternateText: null,
@@ -486,7 +485,7 @@ function createOption(accountIDs, personalDetails, report, reportActions = {}, {
         result.policyID = report.policyID;
 
         hasMultipleParticipants = personalDetailList.length > 1 || result.isChatRoom || result.isPolicyExpenseChat;
-        subtitle = ReportUtils.getChatRoomSubtitle(report, checkPolicyOwner);
+        subtitle = ReportUtils.getChatRoomSubtitle(report);
 
         const lastMessageTextFromReport = getLastMessageTextForReport(report);
         const lastActorDetails = personalDetailMap[report.lastActorAccountID] || null;
@@ -512,12 +511,7 @@ function createOption(accountIDs, personalDetails, report, reportActions = {}, {
         } else {
             result.alternateText = showChatPreviewLine && lastMessageText ? lastMessageText : LocalePhoneNumber.formatPhoneNumber(personalDetail.login);
         }
-
-        if (result.isPolicyExpenseChat && !checkPolicyOwner) {
-            reportName = ReportUtils.getPolicyName(report);
-        } else {
-            reportName = ReportUtils.getReportName(report);
-        }
+        reportName = ReportUtils.getReportName(report);
     } else {
         reportName = ReportUtils.getDisplayNameForParticipant(accountIDs[0]);
         result.keyForList = String(accountIDs[0]);
@@ -557,9 +551,10 @@ function getPolicyExpenseReportOption(report) {
         {
             showChatPreviewLine: false,
             forcePolicyNamePreview: false,
-            checkPolicyOwner: false,
         },
     );
+    option.text = ReportUtils.getPolicyName(report);
+    option.alternateText = Localize.translateLocal('workspace.common.workspace');
     option.selected = report.selected;
     return option;
 }

--- a/src/libs/OptionsListUtils.js
+++ b/src/libs/OptionsListUtils.js
@@ -414,7 +414,7 @@ function getLastMessageTextForReport(report) {
  * @param {Boolean} [options.forcePolicyNamePreview]
  * @returns {Object}
  */
-function createOption(accountIDs, personalDetails, report, reportActions = {}, {showChatPreviewLine = false, forcePolicyNamePreview = false}) {
+function createOption(accountIDs, personalDetails, report, reportActions = {}, {showChatPreviewLine = false, forcePolicyNamePreview = false, checkPolicyOwner = true}) {
     const result = {
         text: null,
         alternateText: null,
@@ -485,7 +485,7 @@ function createOption(accountIDs, personalDetails, report, reportActions = {}, {
         result.policyID = report.policyID;
 
         hasMultipleParticipants = personalDetailList.length > 1 || result.isChatRoom || result.isPolicyExpenseChat;
-        subtitle = ReportUtils.getChatRoomSubtitle(report);
+        subtitle = ReportUtils.getChatRoomSubtitle(report, checkPolicyOwner);
 
         const lastMessageTextFromReport = getLastMessageTextForReport(report);
         const lastActorDetails = personalDetailMap[report.lastActorAccountID] || null;
@@ -511,7 +511,12 @@ function createOption(accountIDs, personalDetails, report, reportActions = {}, {
         } else {
             result.alternateText = showChatPreviewLine && lastMessageText ? lastMessageText : LocalePhoneNumber.formatPhoneNumber(personalDetail.login);
         }
-        reportName = ReportUtils.getReportName(report);
+
+        if (result.isPolicyExpenseChat && !checkPolicyOwner) {
+            reportName = ReportUtils.getPolicyName(report);
+        } else {
+            reportName = ReportUtils.getReportName(report);
+        }
     } else {
         reportName = ReportUtils.getDisplayNameForParticipant(accountIDs[0]);
         result.keyForList = String(accountIDs[0]);
@@ -551,6 +556,7 @@ function getPolicyExpenseReportOption(report) {
         {
             showChatPreviewLine: false,
             forcePolicyNamePreview: false,
+            checkPolicyOwner: false,
         },
     );
     option.selected = report.selected;

--- a/src/libs/OptionsListUtils.js
+++ b/src/libs/OptionsListUtils.js
@@ -412,6 +412,7 @@ function getLastMessageTextForReport(report) {
  * @param {Object} options
  * @param {Boolean} [options.showChatPreviewLine]
  * @param {Boolean} [options.forcePolicyNamePreview]
+ * @param {Boolean} [options.checkPolicyOwner]
  * @returns {Object}
  */
 function createOption(accountIDs, personalDetails, report, reportActions = {}, {showChatPreviewLine = false, forcePolicyNamePreview = false, checkPolicyOwner = true}) {

--- a/src/libs/ReportUtils.js
+++ b/src/libs/ReportUtils.js
@@ -1859,6 +1859,7 @@ function getRootReportAndWorkspaceName(report) {
 /**
  * Get either the policyName or domainName the chat is tied to
  * @param {Object} report
+ * @param {Boolean} checkPolicyOwner
  * @returns {String}
  */
 function getChatRoomSubtitle(report, checkPolicyOwner = true) {

--- a/src/libs/ReportUtils.js
+++ b/src/libs/ReportUtils.js
@@ -1859,10 +1859,9 @@ function getRootReportAndWorkspaceName(report) {
 /**
  * Get either the policyName or domainName the chat is tied to
  * @param {Object} report
- * @param {Boolean} checkPolicyOwner
  * @returns {String}
  */
-function getChatRoomSubtitle(report, checkPolicyOwner = true) {
+function getChatRoomSubtitle(report) {
     if (isChatThread(report)) {
         return '';
     }
@@ -1873,7 +1872,7 @@ function getChatRoomSubtitle(report, checkPolicyOwner = true) {
         // The domainAll rooms are just #domainName, so we ignore the prefix '#' to get the domainName
         return report.reportName.substring(1);
     }
-    if ((isPolicyExpenseChat(report) && (!checkPolicyOwner || report.isOwnPolicyExpenseChat)) || isExpenseReport(report)) {
+    if ((isPolicyExpenseChat(report) && report.isOwnPolicyExpenseChat) || isExpenseReport(report)) {
         return Localize.translateLocal('workspace.common.workspace');
     }
     if (isArchivedRoom(report)) {

--- a/src/libs/ReportUtils.js
+++ b/src/libs/ReportUtils.js
@@ -1861,7 +1861,7 @@ function getRootReportAndWorkspaceName(report) {
  * @param {Object} report
  * @returns {String}
  */
-function getChatRoomSubtitle(report) {
+function getChatRoomSubtitle(report, checkPolicyOwner = true) {
     if (isChatThread(report)) {
         return '';
     }
@@ -1872,7 +1872,7 @@ function getChatRoomSubtitle(report) {
         // The domainAll rooms are just #domainName, so we ignore the prefix '#' to get the domainName
         return report.reportName.substring(1);
     }
-    if ((isPolicyExpenseChat(report) && report.isOwnPolicyExpenseChat) || isExpenseReport(report)) {
+    if ((isPolicyExpenseChat(report) && (!checkPolicyOwner || report.isOwnPolicyExpenseChat)) || isExpenseReport(report)) {
         return Localize.translateLocal('workspace.common.workspace');
     }
     if (isArchivedRoom(report)) {


### PR DESCRIPTION
### Details
After the user B sends split request with the workspace of user A.
The split details page shows username instead of workspace name, when user A sees the details of split request message.

This is happening because the app currently shows workspace name only if the policy is owned by user.
We should update `text` and `alternateText` correctly inside `getPolicyExpenseReportOption` function.

### Fixed Issues
$ https://github.com/Expensify/App/issues/29219
PROPOSAL: https://github.com/Expensify/App/issues/29219#issuecomment-1756257496

### Tests
1. Open the app and login with user A.
2. Open the app using any other device and login with user B.
3. From user A, add user B as member in any of user A workspaces.
4. From user A, open workspace chat created newly after step 3.
5. From user B, click on green plus button situated in LHN of app.
6. From user B, click on request money->manual.
7. Type in any amount and click Next.
8. In the user list, click on split besides workspace name used in step 3 and finish the request money process.
9. From user A, click on split bill message and observe that in details.
10. Check if the split details page displays workspace name, not username.

- [x] Verify that no errors appear in the JS console

### Offline tests
Same as above.

### QA Steps
Same as above.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] If we are not using the full Onyx data that we loaded, I've added the proper selector in order to ensure the component only re-renders when the data it is using changes
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

[REC-20231012174106.webm](https://github.com/Expensify/App/assets/53784473/f9e4a940-5b45-4872-820e-be8206cc3af4)

</details>

<details>
<summary>Android: mWeb Chrome</summary>

https://github.com/Expensify/App/assets/53784473/006b8d29-e066-4ea2-804a-3873edc922db

</details>

<details>
<summary>iOS: Native</summary>

https://github.com/Expensify/App/assets/53784473/72e9a270-ac43-472c-a520-02326a91b784

</details>

<details>
<summary>iOS: mWeb Safari</summary>

https://github.com/Expensify/App/assets/53784473/1c98503f-e378-4110-809a-0c83db55801d

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

https://github.com/Expensify/App/assets/53784473/faf287a9-2b61-4ab3-bd3a-ba5e81d0f743

</details>

<details>
<summary>MacOS: Desktop</summary>

https://github.com/Expensify/App/assets/53784473/04b33cf5-0919-446b-8069-2fc8e2e11733

</details>
