### PR TITLE
[CP Staging] fixes: invalid file modal and delete option shown for setted IOU

### DIFF
--- a/src/components/AttachmentModal.js
+++ b/src/components/AttachmentModal.js
@@ -1,11 +1,11 @@
-import React, {useState, useCallback, useRef, useMemo} from 'react';
+import React, { useState, useCallback, useRef, useMemo } from 'react';
 import PropTypes from 'prop-types';
-import {View, Animated, Keyboard} from 'react-native';
+import { View, Animated, Keyboard } from 'react-native';
 import Str from 'expensify-common/lib/str';
 import lodashGet from 'lodash/get';
 import lodashExtend from 'lodash/extend';
 import _ from 'underscore';
-import {withOnyx} from 'react-native-onyx';
+import { withOnyx } from 'react-native-onyx';
 import CONST from '../CONST';
 import Modal from './Modal';
 import AttachmentView from './Attachments/AttachmentView';
@@ -16,11 +16,11 @@ import * as StyleUtils from '../styles/StyleUtils';
 import * as FileUtils from '../libs/fileDownload/FileUtils';
 import themeColors from '../styles/themes/default';
 import compose from '../libs/compose';
-import withWindowDimensions, {windowDimensionsPropTypes} from './withWindowDimensions';
+import withWindowDimensions, { windowDimensionsPropTypes } from './withWindowDimensions';
 import Button from './Button';
 import HeaderWithBackButton from './HeaderWithBackButton';
 import fileDownload from '../libs/fileDownload';
-import withLocalize, {withLocalizePropTypes} from './withLocalize';
+import withLocalize, { withLocalizePropTypes } from './withLocalize';
 import ConfirmModal from './ConfirmModal';
 import HeaderGap from './HeaderGap';
 import SafeAreaConsumer from './SafeAreaConsumer';
@@ -104,9 +104,9 @@ const defaultProps = {
     headerTitle: null,
     report: {},
     transaction: {},
-    onModalShow: () => {},
-    onModalHide: () => {},
-    onCarouselAttachmentChange: () => {},
+    onModalShow: () => { },
+    onModalHide: () => { },
+    onCarouselAttachmentChange: () => { },
     isWorkspaceAvatar: false,
 };
 
@@ -125,17 +125,17 @@ function AttachmentModal(props) {
     const [isConfirmButtonDisabled, setIsConfirmButtonDisabled] = useState(false);
     const [confirmButtonFadeAnimation] = useState(new Animated.Value(1));
     const [shouldShowDownloadButton, setShouldShowDownloadButton] = React.useState(true);
-    const {windowWidth} = useWindowDimensions();
+    const { windowWidth } = useWindowDimensions();
 
     const [file, setFile] = useState(
         props.originalFileName
             ? {
-                  name: props.originalFileName,
-              }
+                name: props.originalFileName,
+            }
             : undefined,
     );
-    const {translate} = useLocalize();
-    const {isOffline} = useNetwork();
+    const { translate } = useLocalize();
+    const { isOffline } = useNetwork();
 
     const onCarouselAttachmentChange = props.onCarouselAttachmentChange;
 
@@ -205,7 +205,7 @@ function AttachmentModal(props) {
         }
 
         if (props.onConfirm) {
-            props.onConfirm(lodashExtend(file, {source}));
+            props.onConfirm(lodashExtend(file, { source }));
         }
 
         setIsModalOpen(false);
@@ -292,7 +292,7 @@ function AttachmentModal(props) {
                 let updatedFile = fileObject;
                 const cleanName = FileUtils.cleanFileName(updatedFile.name);
                 if (updatedFile.name !== cleanName) {
-                    updatedFile = new File([updatedFile], cleanName, {type: updatedFile.type});
+                    updatedFile = new File([updatedFile], cleanName, { type: updatedFile.type });
                 }
                 const inputSource = URL.createObjectURL(updatedFile);
                 const inputModalType = getModalType(inputSource, updatedFile);
@@ -454,7 +454,7 @@ function AttachmentModal(props) {
                 {/* If we have an onConfirm method show a confirmation button */}
                 {Boolean(props.onConfirm) && (
                     <SafeAreaConsumer>
-                        {({safeAreaPaddingBottomStyle}) => (
+                        {({ safeAreaPaddingBottomStyle }) => (
                             <Animated.View style={[StyleUtils.fade(confirmButtonFadeAnimation), safeAreaPaddingBottomStyle]}>
                                 <Button
                                     success
@@ -482,15 +482,17 @@ function AttachmentModal(props) {
                     />
                 )}
             </Modal>
-            <ConfirmModal
-                title={attachmentInvalidReasonTitle ? translate(attachmentInvalidReasonTitle) : ''}
-                onConfirm={closeConfirmModal}
-                onCancel={closeConfirmModal}
-                isVisible={isAttachmentInvalid}
-                prompt={attachmentInvalidReason ? translate(attachmentInvalidReason) : ''}
-                confirmText={translate('common.close')}
-                shouldShowCancelButton={false}
-            />
+            {!isAttachmentReceipt && (
+                <ConfirmModal
+                    title={attachmentInvalidReasonTitle ? translate(attachmentInvalidReasonTitle) : ''}
+                    onConfirm={closeConfirmModal}
+                    onCancel={closeConfirmModal}
+                    isVisible={isAttachmentInvalid}
+                    prompt={attachmentInvalidReason ? translate(attachmentInvalidReason) : ''}
+                    confirmText={translate('common.close')}
+                    shouldShowCancelButton={false}
+                />
+            )}
 
             {props.children &&
                 props.children({
@@ -509,7 +511,7 @@ export default compose(
     withLocalize,
     withOnyx({
         transaction: {
-            key: ({report}) => {
+            key: ({ report }) => {
                 if (!report) {
                     return undefined;
                 }
@@ -519,13 +521,13 @@ export default compose(
             },
         },
         parentReport: {
-            key: ({report}) => `${ONYXKEYS.COLLECTION.REPORT}${report ? report.parentReportID : '0'}`,
+            key: ({ report }) => `${ONYXKEYS.COLLECTION.REPORT}${report ? report.parentReportID : '0'}`,
         },
         policy: {
-            key: ({report}) => `${ONYXKEYS.COLLECTION.POLICY}${report ? report.policyID : '0'}`,
+            key: ({ report }) => `${ONYXKEYS.COLLECTION.POLICY}${report ? report.policyID : '0'}`,
         },
         parentReportActions: {
-            key: ({report}) => `${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${report ? report.parentReportID : '0'}`,
+            key: ({ report }) => `${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${report ? report.parentReportID : '0'}`,
             canEvict: false,
         },
         session: {

--- a/src/components/AttachmentModal.js
+++ b/src/components/AttachmentModal.js
@@ -1,11 +1,11 @@
-import React, { useState, useCallback, useRef, useMemo } from 'react';
+import React, {useState, useCallback, useRef, useMemo} from 'react';
 import PropTypes from 'prop-types';
-import { View, Animated, Keyboard } from 'react-native';
+import {View, Animated, Keyboard} from 'react-native';
 import Str from 'expensify-common/lib/str';
 import lodashGet from 'lodash/get';
 import lodashExtend from 'lodash/extend';
 import _ from 'underscore';
-import { withOnyx } from 'react-native-onyx';
+import {withOnyx} from 'react-native-onyx';
 import CONST from '../CONST';
 import Modal from './Modal';
 import AttachmentView from './Attachments/AttachmentView';
@@ -16,11 +16,11 @@ import * as StyleUtils from '../styles/StyleUtils';
 import * as FileUtils from '../libs/fileDownload/FileUtils';
 import themeColors from '../styles/themes/default';
 import compose from '../libs/compose';
-import withWindowDimensions, { windowDimensionsPropTypes } from './withWindowDimensions';
+import withWindowDimensions, {windowDimensionsPropTypes} from './withWindowDimensions';
 import Button from './Button';
 import HeaderWithBackButton from './HeaderWithBackButton';
 import fileDownload from '../libs/fileDownload';
-import withLocalize, { withLocalizePropTypes } from './withLocalize';
+import withLocalize, {withLocalizePropTypes} from './withLocalize';
 import ConfirmModal from './ConfirmModal';
 import HeaderGap from './HeaderGap';
 import SafeAreaConsumer from './SafeAreaConsumer';
@@ -104,9 +104,9 @@ const defaultProps = {
     headerTitle: null,
     report: {},
     transaction: {},
-    onModalShow: () => { },
-    onModalHide: () => { },
-    onCarouselAttachmentChange: () => { },
+    onModalShow: () => {},
+    onModalHide: () => {},
+    onCarouselAttachmentChange: () => {},
     isWorkspaceAvatar: false,
 };
 
@@ -125,17 +125,17 @@ function AttachmentModal(props) {
     const [isConfirmButtonDisabled, setIsConfirmButtonDisabled] = useState(false);
     const [confirmButtonFadeAnimation] = useState(new Animated.Value(1));
     const [shouldShowDownloadButton, setShouldShowDownloadButton] = React.useState(true);
-    const { windowWidth } = useWindowDimensions();
+    const {windowWidth} = useWindowDimensions();
 
     const [file, setFile] = useState(
         props.originalFileName
             ? {
-                name: props.originalFileName,
-            }
+                  name: props.originalFileName,
+              }
             : undefined,
     );
-    const { translate } = useLocalize();
-    const { isOffline } = useNetwork();
+    const {translate} = useLocalize();
+    const {isOffline} = useNetwork();
 
     const onCarouselAttachmentChange = props.onCarouselAttachmentChange;
 
@@ -205,7 +205,7 @@ function AttachmentModal(props) {
         }
 
         if (props.onConfirm) {
-            props.onConfirm(lodashExtend(file, { source }));
+            props.onConfirm(lodashExtend(file, {source}));
         }
 
         setIsModalOpen(false);
@@ -292,7 +292,7 @@ function AttachmentModal(props) {
                 let updatedFile = fileObject;
                 const cleanName = FileUtils.cleanFileName(updatedFile.name);
                 if (updatedFile.name !== cleanName) {
-                    updatedFile = new File([updatedFile], cleanName, { type: updatedFile.type });
+                    updatedFile = new File([updatedFile], cleanName, {type: updatedFile.type});
                 }
                 const inputSource = URL.createObjectURL(updatedFile);
                 const inputModalType = getModalType(inputSource, updatedFile);
@@ -454,7 +454,7 @@ function AttachmentModal(props) {
                 {/* If we have an onConfirm method show a confirmation button */}
                 {Boolean(props.onConfirm) && (
                     <SafeAreaConsumer>
-                        {({ safeAreaPaddingBottomStyle }) => (
+                        {({safeAreaPaddingBottomStyle}) => (
                             <Animated.View style={[StyleUtils.fade(confirmButtonFadeAnimation), safeAreaPaddingBottomStyle]}>
                                 <Button
                                     success
@@ -511,7 +511,7 @@ export default compose(
     withLocalize,
     withOnyx({
         transaction: {
-            key: ({ report }) => {
+            key: ({report}) => {
                 if (!report) {
                     return undefined;
                 }
@@ -521,13 +521,13 @@ export default compose(
             },
         },
         parentReport: {
-            key: ({ report }) => `${ONYXKEYS.COLLECTION.REPORT}${report ? report.parentReportID : '0'}`,
+            key: ({report}) => `${ONYXKEYS.COLLECTION.REPORT}${report ? report.parentReportID : '0'}`,
         },
         policy: {
-            key: ({ report }) => `${ONYXKEYS.COLLECTION.POLICY}${report ? report.policyID : '0'}`,
+            key: ({report}) => `${ONYXKEYS.COLLECTION.POLICY}${report ? report.policyID : '0'}`,
         },
         parentReportActions: {
-            key: ({ report }) => `${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${report ? report.parentReportID : '0'}`,
+            key: ({report}) => `${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${report ? report.parentReportID : '0'}`,
             canEvict: false,
         },
         session: {

--- a/src/components/AttachmentModal.js
+++ b/src/components/AttachmentModal.js
@@ -376,7 +376,7 @@ function AttachmentModal(props) {
             text: props.translate('common.download'),
             onSelected: () => downloadAttachment(source),
         });
-        if (TransactionUtils.hasReceipt(props.transaction) && !TransactionUtils.isReceiptBeingScanned(props.transaction)&& !isSettled) {
+        if (TransactionUtils.hasReceipt(props.transaction) && !TransactionUtils.isReceiptBeingScanned(props.transaction) && !isSettled) {
             menuItems.push({
                 icon: Expensicons.Trashcan,
                 text: props.translate('receipt.deleteReceipt'),

--- a/src/components/AttachmentModal.js
+++ b/src/components/AttachmentModal.js
@@ -376,7 +376,7 @@ function AttachmentModal(props) {
             text: props.translate('common.download'),
             onSelected: () => downloadAttachment(source),
         });
-        if (TransactionUtils.hasReceipt(props.transaction) && !TransactionUtils.isReceiptBeingScanned(props.transaction)) {
+        if (TransactionUtils.hasReceipt(props.transaction) && !TransactionUtils.isReceiptBeingScanned(props.transaction)&& !isSettled) {
             menuItems.push({
                 icon: Expensicons.Trashcan,
                 text: props.translate('receipt.deleteReceipt'),
@@ -469,7 +469,7 @@ function AttachmentModal(props) {
                         )}
                     </SafeAreaConsumer>
                 )}
-                {isAttachmentReceipt ? (
+                {isAttachmentReceipt && (
                     <ConfirmModal
                         title={translate('receipt.deleteReceipt')}
                         isVisible={isDeleteReceiptConfirmModalVisible}
@@ -480,18 +480,17 @@ function AttachmentModal(props) {
                         cancelText={translate('common.cancel')}
                         danger
                     />
-                ) : (
-                    <ConfirmModal
-                        title={attachmentInvalidReasonTitle ? translate(attachmentInvalidReasonTitle) : ''}
-                        onConfirm={closeConfirmModal}
-                        onCancel={closeConfirmModal}
-                        isVisible={isAttachmentInvalid}
-                        prompt={attachmentInvalidReason ? translate(attachmentInvalidReason) : ''}
-                        confirmText={translate('common.close')}
-                        shouldShowCancelButton={false}
-                    />
                 )}
             </Modal>
+            <ConfirmModal
+                title={attachmentInvalidReasonTitle ? translate(attachmentInvalidReasonTitle) : ''}
+                onConfirm={closeConfirmModal}
+                onCancel={closeConfirmModal}
+                isVisible={isAttachmentInvalid}
+                prompt={attachmentInvalidReason ? translate(attachmentInvalidReason) : ''}
+                confirmText={translate('common.close')}
+                shouldShowCancelButton={false}
+            />
 
             {props.children &&
                 props.children({


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/29452
https://github.com/Expensify/App/issues/29475
PROPOSAL: https://github.com/Expensify/App/issues/29452#issuecomment-1760102567
https://github.com/Expensify/App/issues/29475#issuecomment-1760210163


### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

- [ ] Verify that no errors appear in the JS console
-
Test steps for #29475
1. Create a distance money request.
2. Open Iou details and click on receipt, then click on three dot, Verfy Delete Receipt option is visible
3. Now Go back and mark Request as "Pay elsewhere"
4. Open Iou details again and click on receipt, then click on three dot, Verfy Delete Receipt option is not visible

Test Steps for #29452 
1. Open a report and upload image more than 24MB and Verify Invalid modal appears>
2. Create a distance money request.
3. Open Iou details and click on receipt, then click on three dot, then click Delete Receipt and verify Confrm delete modal apppers


### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

- [x] Verify that no errors appear in the JS console

Test steps for #29475
1. Create a distance money request.
2. Open Iou details and click on receipt, then click on three dot, Verfy Delete Receipt option is visible
3. Now Go back and mark Request as "Pay elsewhere"
4. Open Iou details again and click on receipt, then click on three dot, Verfy Delete Receipt option is not visible

Test Steps for #29452 
1. Open a report and upload image more than 24MB and Verify Invalid modal appears>
2. Create a distance money request.
3. Open Iou details and click on receipt, then click on three dot, then click Delete Receipt and verify Confrm delete modal apppers
### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] If we are not using the full Onyx data that we loaded, I've added the proper selector in order to ensure the component only re-renders when the data it is using changes
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos

<details><summary>Videos for https://github.com/Expensify/App/issues/29452</summary>
<details>
<summary>Android: Native</summary>

Combined video for both issues

https://github.com/Expensify/App/assets/104348397/433f637c-0b1a-4cf6-b5d6-cfae4e371257



</details>

<details>
<summary>Android: mWeb Chrome</summary>

https://github.com/Expensify/App/assets/104348397/30e9b697-85fc-45a5-97c9-5cedf8fee7fb

</details>

<details>
<summary>iOS: Native</summary>

https://github.com/Expensify/App/assets/104348397/00cf449d-4b91-49ec-8c9d-6296df6f9a7e


</details>

<details>
<summary>iOS: mWeb Safari</summary>

https://github.com/Expensify/App/assets/104348397/203b0ccb-8638-4eda-b385-71bd84b9dd27


</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

https://github.com/Expensify/App/assets/104348397/006db303-b887-4930-a683-6fc254f92a71

</details>

<details>
<summary>MacOS: Desktop</summary>

https://github.com/Expensify/App/assets/104348397/b38a8dcb-d8a0-4b3e-a64b-802f5dbebb02


</details>
</details> 


<details><summary>Videos for https://github.com/Expensify/App/issues/29475</summary>
<details>
<summary>Android: Native</summary>
Combined video for both issues

https://github.com/Expensify/App/assets/104348397/433f637c-0b1a-4cf6-b5d6-cfae4e371257



</details>

<details>
<summary>Android: mWeb Chrome</summary>

https://github.com/Expensify/App/assets/104348397/616f1d29-a785-4f3e-ad8a-bbe436a8e29c

</details>

<details>
<summary>iOS: Native</summary>

https://github.com/Expensify/App/assets/104348397/09af4ef0-5aa1-4a98-9c4b-9e313c34f849

</details>

<details>
<summary>iOS: mWeb Safari</summary>

https://github.com/Expensify/App/assets/104348397/4aef467f-970a-446a-8984-b730d9625f45


</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

https://github.com/Expensify/App/assets/104348397/6b595228-c17c-41f3-be5c-499d574ef0a9

</details>

<details>
<summary>MacOS: Desktop</summary>


https://github.com/Expensify/App/assets/104348397/b5fda710-eef2-4cd6-bcfa-012f509a5df7

</details>
</details> 
