### PR TITLE
[CP Staging] Revert PR 28278

### DIFF
--- a/src/SCREENS.ts
+++ b/src/SCREENS.ts
@@ -2,17 +2,15 @@
  * This is a file containing constants for all of the screen names. In most cases, we should use the routes for
  * navigation. But there are situations where we may need to access screen names directly.
  */
-const PROTECTED_SCREENS = {
-    HOME: 'Home',
-    CONCIERGE: 'Concierge',
-    REPORT_ATTACHMENTS: 'ReportAttachments',
-} as const;
-
 export default {
-    ...PROTECTED_SCREENS,
+    HOME: 'Home',
     LOADING: 'Loading',
     REPORT: 'Report',
+    REPORT_ATTACHMENTS: 'ReportAttachments',
     NOT_FOUND: 'not-found',
+    TRANSITION_BETWEEN_APPS: 'TransitionBetweenApps',
+    VALIDATE_LOGIN: 'ValidateLogin',
+    CONCIERGE: 'Concierge',
     SETTINGS: {
         ROOT: 'Settings_Root',
         PREFERENCES: 'Settings_Preferences',
@@ -25,12 +23,10 @@ export default {
     SAVE_THE_WORLD: {
         ROOT: 'SaveTheWorld_Root',
     },
-    TRANSITION_BETWEEN_APPS: 'TransitionBetweenApps',
     SIGN_IN_WITH_APPLE_DESKTOP: 'AppleSignInDesktop',
     SIGN_IN_WITH_GOOGLE_DESKTOP: 'GoogleSignInDesktop',
     DESKTOP_SIGN_IN_REDIRECT: 'DesktopSignInRedirect',
     SAML_SIGN_IN: 'SAMLSignIn',
-    VALIDATE_LOGIN: 'ValidateLogin',
 
     // Iframe screens from olddot
     HOME_OLDDOT: 'Home_OLDDOT',
@@ -45,5 +41,3 @@ export default {
     GROUPS_WORKSPACES_OLDDOT: 'GroupWorkspaces_OLDDOT',
     CARDS_AND_DOMAINS_OLDDOT: 'CardsAndDomains_OLDDOT',
 } as const;
-
-export {PROTECTED_SCREENS};

--- a/src/libs/Navigation/Navigation.js
+++ b/src/libs/Navigation/Navigation.js
@@ -12,7 +12,7 @@ import originalGetTopmostReportId from './getTopmostReportId';
 import originalGetTopMostCentralPaneRouteName from './getTopMostCentralPaneRouteName';
 import originalGetTopmostReportActionId from './getTopmostReportActionID';
 import getStateFromPath from './getStateFromPath';
-import SCREENS, {PROTECTED_SCREENS} from '../../SCREENS';
+import SCREENS from '../../SCREENS';
 import CONST from '../../CONST';
 
 let resolveNavigationIsReadyPromise;
@@ -262,61 +262,6 @@ function setIsNavigationReady() {
     resolveNavigationIsReadyPromise();
 }
 
-/**
- *  Checks if the navigation state contains routes that are protected (over the auth wall).
- *
- *  @function
- *  @param {Object} state - react-navigation state object
- *
- *  @returns {Boolean}
- */
-function navContainsProtectedRoutes(state) {
-    if (!state || !state.routeNames || !_.isArray(state.routeNames)) {
-        return false;
-    }
-    const protectedScreensNames = _.values(PROTECTED_SCREENS);
-    const difference = _.difference(protectedScreensNames, state.routeNames);
-
-    return !difference.length;
-}
-
-/**
- * Waits for the navigation state to contain protected routes specified in PROTECTED_SCREENS constant
- * If the navigation is in a state, where protected routes are available, the promise will resolve immediately.
- *
- * @function
- * @returns {Promise<void>} A promise that resolves to `true` when the Concierge route is present.
- *                             Rejects with an error if the navigation is not ready.
- *
- * @example
- * waitForProtectedRoutes()
- *   .then(() => console.log('Protected routes are present!'))
- *   .catch(error => console.error(error.message));
- */
-function waitForProtectedRoutes() {
-    return new Promise((resolve, reject) => {
-        const isReady = navigationRef.current && navigationRef.current.isReady();
-        if (!isReady) {
-            reject(new Error('[Navigation] is not ready yet!'));
-            return;
-        }
-        const currentState = navigationRef.current.getState();
-        if (navContainsProtectedRoutes(currentState)) {
-            resolve();
-            return;
-        }
-        let unsubscribe;
-        const handleStateChange = ({data}) => {
-            const state = lodashGet(data, 'state');
-            if (navContainsProtectedRoutes(state)) {
-                unsubscribe();
-                resolve();
-            }
-        };
-        unsubscribe = navigationRef.current.addListener('state', handleStateChange);
-    });
-}
-
 export default {
     setShouldPopAllStateOnUP,
     canNavigate,
@@ -330,7 +275,6 @@ export default {
     setIsNavigationReady,
     getTopmostReportId,
     getRouteNameFromStateEvent,
-    waitForProtectedRoutes,
     getTopMostCentralPaneRouteName,
     getTopmostReportActionId,
 };

--- a/src/libs/actions/Report.js
+++ b/src/libs/actions/Report.js
@@ -1889,6 +1889,7 @@ function toggleEmojiReaction(reportID, reportAction, reactionObject, existingRea
  * @param {Boolean} isAuthenticated
  */
 function openReportFromDeepLink(url, isAuthenticated) {
+    const route = ReportUtils.getRouteFromLink(url);
     const reportID = ReportUtils.getReportIDFromLink(url);
 
     if (reportID && !isAuthenticated) {
@@ -1907,16 +1908,11 @@ function openReportFromDeepLink(url, isAuthenticated) {
     // Navigate to the report after sign-in/sign-up.
     InteractionManager.runAfterInteractions(() => {
         Session.waitForUserSignIn().then(() => {
-            Navigation.waitForProtectedRoutes()
-                .then(() => {
-                    const route = ReportUtils.getRouteFromLink(url);
-                    if (route === ROUTES.CONCIERGE) {
-                        navigateToConciergeChat(true);
-                        return;
-                    }
-                    Navigation.navigate(route, CONST.NAVIGATION.TYPE.PUSH);
-                })
-                .catch((error) => Log.warn(error.message));
+            if (route === ROUTES.CONCIERGE) {
+                navigateToConciergeChat(true);
+                return;
+            }
+            Navigation.navigate(route, CONST.NAVIGATION.TYPE.PUSH);
         });
     });
 }


### PR DESCRIPTION
### Details
Revert https://github.com/Expensify/App/pull/28278/

This is a straight revert BUT GH gave me an error trying to revert it itself, so I did the changes manually.

Related to https://github.com/Expensify/App/pull/29688
cc @lukemorawski for visibility


### Fixed Issues
$ https://github.com/Expensify/App/issues/29642
PROPOSAL: 


### Tests
0. [On dev only] update [this line](https://github.com/Expensify/App/blob/b808acef4b857ae59c6580ae982c7d7b871f2942/src/components/DeeplinkWrapper/index.website.js#L72) and remove the `CONFIG.ENVIRONMENT === CONST.ENVIRONMENT.DEV` condition
1. Copy a conversation URL from ND and log out to both web and Desktop (You can also reproduce with just Desktop being signed out)
2. Navigate to the copied link
3. Login and click to open in the app
4. Verify that no errors appear in the JS console


- [x] Verify that no errors appear in the JS console

### Offline tests
N/A

### QA Steps
Same as test steps

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist


- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] If we are not using the full Onyx data that we loaded, I've added the proper selector in order to ensure the component only re-renders when the data it is using changes
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

https://github.com/Expensify/App/assets/2229301/e576e04e-f9e1-406b-a0d7-6d22468637b0

</details>

<details>
<summary>MacOS: Desktop</summary>


https://github.com/Expensify/App/assets/2229301/e576e04e-f9e1-406b-a0d7-6d22468637b0


</details>
