### PR TITLE
Revert "webfix/27090 In Header Workspace, members are not shown."

### DIFF
--- a/src/pages/ReportDetailsPage.js
+++ b/src/pages/ReportDetailsPage.js
@@ -1,4 +1,4 @@
-import React, {useCallback, useEffect, useMemo} from 'react';
+import React, {useMemo} from 'react';
 import PropTypes from 'prop-types';
 import {withOnyx} from 'react-native-onyx';
 import _ from 'underscore';
@@ -16,7 +16,6 @@ import * as OptionsListUtils from '../libs/OptionsListUtils';
 import * as ReportUtils from '../libs/ReportUtils';
 import * as PolicyUtils from '../libs/PolicyUtils';
 import * as Report from '../libs/actions/Report';
-import * as Policy from '../libs/actions/Policy';
 import participantPropTypes from '../components/participantPropTypes';
 import * as Expensicons from '../components/Icon/Expensicons';
 import ROUTES from '../ROUTES';
@@ -73,12 +72,7 @@ function ReportDetailsPage(props) {
     const chatRoomSubtitle = useMemo(() => ReportUtils.getChatRoomSubtitle(props.report), [props.report, policy]);
     const parentNavigationSubtitleData = ReportUtils.getParentNavigationSubtitle(props.report);
     const canLeaveRoom = useMemo(() => ReportUtils.canLeaveRoom(props.report, !_.isEmpty(policy)), [policy, props.report]);
-    const workspaceMembers = useMemo(() => _.keys(PolicyUtils.getMemberAccountIDsForWorkspace(props.policyMembers, props.personalDetails)), [props.policyMembers, props.personalDetails]);
-
-    const participants = useMemo(
-        () => (props.report.policyID && !ReportUtils.isAdminRoom(props.report) ? workspaceMembers : ReportUtils.getParticipantsIDs(props.report)),
-        [props.report, workspaceMembers],
-    );
+    const participants = useMemo(() => ReportUtils.getParticipantsIDs(props.report), [props.report]);
 
     const isGroupDMChat = useMemo(() => ReportUtils.isDM(props.report) && participants.length > 1, [props.report, participants.length]);
 
@@ -162,16 +156,6 @@ function ReportDetailsPage(props) {
             {chatRoomSubtitle}
         </Text>
     ) : null;
-    const getWorkspaceMembers = useCallback(() => {
-        Policy.openWorkspaceMembersPage(props.report.policyID, workspaceMembers);
-    }, [props.report.policyID, workspaceMembers]);
-
-    useEffect(() => {
-        if (!props.report.policyID || ReportUtils.isAdminRoom(props.report)) {
-            return;
-        }
-        getWorkspaceMembers();
-    }, [getWorkspaceMembers, props.report]);
 
     return (
         <ScreenWrapper testID={ReportDetailsPage.displayName}>
@@ -258,9 +242,6 @@ export default compose(
         },
         policies: {
             key: ONYXKEYS.COLLECTION.POLICY,
-        },
-        policyMembers: {
-            key: (props) => `${ONYXKEYS.COLLECTION.POLICY_MEMBERS}${props.report.policyID}`,
         },
     }),
 )(ReportDetailsPage);

--- a/src/pages/ReportParticipantsPage.js
+++ b/src/pages/ReportParticipantsPage.js
@@ -4,7 +4,6 @@ import {View} from 'react-native';
 import PropTypes from 'prop-types';
 import {withOnyx} from 'react-native-onyx';
 import lodashGet from 'lodash/get';
-import lodashUniqBy from 'lodash/uniqBy';
 import styles from '../styles/styles';
 import ONYXKEYS from '../ONYXKEYS';
 import HeaderWithBackButton from '../components/HeaderWithBackButton';
@@ -84,39 +83,7 @@ const getAllParticipants = (report, personalDetails, translate) =>
         .value();
 
 function ReportParticipantsPage(props) {
-    const getMemberOptions = () => {
-        let result = [];
-        _.each(props.policyMembers, (__, accountID) => {
-            const details = lodashGet(props.personalDetails, accountID, {displayName: props.personalDetails.displayName || props.translate('common.hidden'), avatar: ''});
-
-            result.push({
-                keyForList: accountID,
-                accountID: Number(accountID),
-                text: details.displayName,
-                displayName: details.displayName,
-                alternateText: details.login,
-                icons: [
-                    {
-                        id: accountID,
-                        source: UserUtils.getAvatar(details.avatar, accountID),
-                        name: details.login,
-                        type: CONST.ICON_TYPE_AVATAR,
-                    },
-                ],
-            });
-        });
-
-        result = _.sortBy(lodashUniqBy(result, 'alternateText'), (value) => (value.text || '').toLowerCase());
-
-        return result;
-    };
-
-    const data =
-        props.report.policyID && props.policyMembers && !ReportUtils.isAdminRoom(props.report)
-            ? getMemberOptions()
-            : getAllParticipants(props.report, props.personalDetails, props.translate);
-
-    const participants = _.map(data, (participant) => ({
+    const participants = _.map(getAllParticipants(props.report, props.personalDetails, props.translate), (participant) => ({
         ...participant,
         isDisabled: ReportUtils.isOptimisticPersonalDetail(participant.accountID),
     }));
@@ -182,9 +149,6 @@ export default compose(
     withOnyx({
         personalDetails: {
             key: ONYXKEYS.PERSONAL_DETAILS_LIST,
-        },
-        policyMembers: {
-            key: (props) => `${ONYXKEYS.COLLECTION.POLICY_MEMBERS}${props.report.policyID}`,
         },
     }),
 )(ReportParticipantsPage);


### PR DESCRIPTION
Reverts Expensify/App#29420

We need to revert this PR because the issue that it fixes isn't actually a bug. We don't share workspace rooms by default with everyone in the workspace on creation, so it's expected that workspace rooms only have a single participant by default.