### PR TITLE
Added 'name' field to waypoint

### DIFF
--- a/src/components/AddressSearch/index.js
+++ b/src/components/AddressSearch/index.js
@@ -297,7 +297,6 @@ function AddressSearch(props) {
 
         getCurrentPosition(
             (successData) => {
-                console.log(successData);
                 if (!shouldTriggerGeolocationCallbacks.current) {
                     return;
                 }

--- a/src/components/AddressSearch/index.js
+++ b/src/components/AddressSearch/index.js
@@ -75,7 +75,7 @@ const propTypes = {
             description: PropTypes.string,
 
             /** The main name of the location */
-            name: PropTypes.name,
+            name: PropTypes.string,
 
             /** Data required by the google auto complete plugin to know where to put the markers on the map */
             geometry: PropTypes.shape({

--- a/src/components/AddressSearch/index.js
+++ b/src/components/AddressSearch/index.js
@@ -394,7 +394,7 @@ function AddressSearch(props) {
                             const subtitle = data.isPredefinedPlace ? data.description : data.structured_formatting.secondary_text;
                             return (
                                 <View>
-                                    <Text style={[styles.googleSearchText]}>{title ? title : subtitle}</Text>
+                                    <Text style={[styles.googleSearchText]}>{title || subtitle}</Text>
                                     <Text
                                         style={[styles.textLabelSupporting]}
                                         numberOfLines={2}

--- a/src/components/AddressSearch/index.js
+++ b/src/components/AddressSearch/index.js
@@ -307,7 +307,6 @@ function AddressSearch(props) {
                 const location = {
                     lat: successData.coords.latitude,
                     lng: successData.coords.longitude,
-                    name: CONST.YOUR_LOCATION_TEXT,
                     address: CONST.YOUR_LOCATION_TEXT,
                 };
                 props.onPress(location);

--- a/src/components/AddressSearch/index.js
+++ b/src/components/AddressSearch/index.js
@@ -74,7 +74,7 @@ const propTypes = {
             /** A description of the location (usually the address) */
             description: PropTypes.string,
 
-            /** The main name of the location */
+            /** The name of the location */
             name: PropTypes.string,
 
             /** Data required by the google auto complete plugin to know where to put the markers on the map */

--- a/src/components/AddressSearch/index.js
+++ b/src/components/AddressSearch/index.js
@@ -93,7 +93,6 @@ const propTypes = {
 
     /** A map of inputID key names */
     renamedInputKeys: PropTypes.shape({
-        name: PropTypes.string,
         street: PropTypes.string,
         street2: PropTypes.string,
         city: PropTypes.string,
@@ -128,7 +127,6 @@ const defaultProps = {
     isLimitedToUSA: false,
     canUseCurrentLocation: false,
     renamedInputKeys: {
-        name: 'name',
         street: 'addressStreet',
         street2: 'addressStreet2',
         city: 'addressCity',

--- a/src/components/AddressSearch/index.js
+++ b/src/components/AddressSearch/index.js
@@ -392,11 +392,16 @@ function AddressSearch(props) {
                         }
                         renderRow={(data) => {
                             const title = data.isPredefinedPlace ? data.name : data.structured_formatting.main_text;
-                            const subtitle = data.isPredefinedPlace ? data.description: data.structured_formatting.secondary_text;
+                            const subtitle = data.isPredefinedPlace ? data.description : data.structured_formatting.secondary_text;
                             return (
                                 <View>
                                     <Text style={[styles.googleSearchText]}>{title}</Text>
-                                    <Text style={[styles.textLabelSupporting]} numberOfLines={2}>{subtitle}</Text>
+                                    <Text
+                                        style={[styles.textLabelSupporting]}
+                                        numberOfLines={2}
+                                    >
+                                        {subtitle}
+                                    </Text>
                                 </View>
                             );
                         }}

--- a/src/components/AddressSearch/index.js
+++ b/src/components/AddressSearch/index.js
@@ -394,12 +394,12 @@ function AddressSearch(props) {
                             const subtitle = data.isPredefinedPlace ? data.description : data.structured_formatting.secondary_text;
                             return (
                                 <View>
-                                    <Text style={[styles.googleSearchText]}>{title}</Text>
+                                    <Text style={[styles.googleSearchText]}>{title ? title : subtitle}</Text>
                                     <Text
                                         style={[styles.textLabelSupporting]}
                                         numberOfLines={2}
                                     >
-                                        {subtitle}
+                                        {title && subtitle ? subtitle : ''}
                                     </Text>
                                 </View>
                             );

--- a/src/components/AddressSearch/index.js
+++ b/src/components/AddressSearch/index.js
@@ -172,10 +172,10 @@ function AddressSearch(props) {
             // amount of data massaging needs to happen for what the parent expects to get from this function.
             if (_.size(details)) {
                 props.onPress({
-                    address: lodashGet(details, 'description', ''),
+                    address: lodashGet(details, 'description'),
                     lat: lodashGet(details, 'geometry.location.lat', 0),
                     lng: lodashGet(details, 'geometry.location.lng', 0),
-                    name: lodashGet(details, 'name', ''),
+                    name: lodashGet(details, 'name'),
                 });
             }
             return;
@@ -395,12 +395,7 @@ function AddressSearch(props) {
                             return (
                                 <View>
                                     <Text style={[styles.googleSearchText]}>{title || subtitle}</Text>
-                                    <Text
-                                        style={[styles.textLabelSupporting]}
-                                        numberOfLines={2}
-                                    >
-                                        {title && subtitle ? subtitle : ''}
-                                    </Text>
+                                    {title && subtitle && <Text style={[styles.textLabelSupporting]}>{subtitle}</Text>}
                                 </View>
                             );
                         }}

--- a/src/components/AddressSearch/index.js
+++ b/src/components/AddressSearch/index.js
@@ -74,6 +74,9 @@ const propTypes = {
             /** A description of the location (usually the address) */
             description: PropTypes.string,
 
+            /** The main name of the location */
+            name: PropTypes.name,
+
             /** Data required by the google auto complete plugin to know where to put the markers on the map */
             geometry: PropTypes.shape({
                 /** Data about the location */
@@ -90,6 +93,7 @@ const propTypes = {
 
     /** A map of inputID key names */
     renamedInputKeys: PropTypes.shape({
+        name: PropTypes.string,
         street: PropTypes.string,
         street2: PropTypes.string,
         city: PropTypes.string,
@@ -124,6 +128,7 @@ const defaultProps = {
     isLimitedToUSA: false,
     canUseCurrentLocation: false,
     renamedInputKeys: {
+        name: 'name',
         street: 'addressStreet',
         street2: 'addressStreet2',
         city: 'addressCity',
@@ -170,6 +175,7 @@ function AddressSearch(props) {
                     address: lodashGet(details, 'description', ''),
                     lat: lodashGet(details, 'geometry.location.lat', 0),
                     lng: lodashGet(details, 'geometry.location.lng', 0),
+                    name: lodashGet(details, 'name', ''),
                 });
             }
             return;
@@ -220,7 +226,7 @@ function AddressSearch(props) {
 
         const values = {
             street: `${streetNumber} ${streetName}`.trim(),
-
+            name: lodashGet(details, 'name', ''),
             // Autocomplete returns any additional valid address fragments (e.g. Apt #) as subpremise.
             street2: subpremise,
             // Make sure country is updated first, since city and state will be reset if the country changes
@@ -291,6 +297,7 @@ function AddressSearch(props) {
 
         getCurrentPosition(
             (successData) => {
+                console.log(successData);
                 if (!shouldTriggerGeolocationCallbacks.current) {
                     return;
                 }
@@ -301,6 +308,7 @@ function AddressSearch(props) {
                 const location = {
                     lat: successData.coords.latitude,
                     lng: successData.coords.longitude,
+                    name: CONST.YOUR_LOCATION_TEXT,
                     address: CONST.YOUR_LOCATION_TEXT,
                 };
                 props.onPress(location);
@@ -382,6 +390,16 @@ function AddressSearch(props) {
                                 />
                             </View>
                         }
+                        renderRow={(data) => {
+                            const title = data.isPredefinedPlace ? data.name : data.structured_formatting.main_text;
+                            const subtitle = data.isPredefinedPlace ? data.description: data.structured_formatting.secondary_text;
+                            return (
+                                <View>
+                                    <Text style={[styles.googleSearchText]}>{title}</Text>
+                                    <Text style={[styles.textLabelSupporting]} numberOfLines={2}>{subtitle}</Text>
+                                </View>
+                            );
+                        }}
                         renderHeaderComponent={renderHeaderComponent}
                         onPress={(data, details) => {
                             saveLocationDetails(data, details);

--- a/src/components/AddressSearch/index.js
+++ b/src/components/AddressSearch/index.js
@@ -394,8 +394,8 @@ function AddressSearch(props) {
                             const subtitle = data.isPredefinedPlace ? data.description : data.structured_formatting.secondary_text;
                             return (
                                 <View>
-                                    <Text style={[styles.googleSearchText]}>{title || subtitle}</Text>
-                                    {title && subtitle && <Text style={[styles.textLabelSupporting]}>{subtitle}</Text>}
+                                    {title && <Text style={[styles.googleSearchText]}>{title}</Text>}
+                                    <Text style={[styles.textLabelSupporting]}>{subtitle}</Text>
                                 </View>
                             );
                         }}

--- a/src/components/DistanceEReceipt.js
+++ b/src/components/DistanceEReceipt.js
@@ -85,14 +85,16 @@ function DistanceEReceipt({transaction}) {
                             } else {
                                 descriptionKey += 'stop';
                             }
+                            const title = waypoint.name || waypoint.address;
+                            const subtitle = waypoint.name && waypoint.address ? waypoint.address : undefined;
                             return (
                                 <View
                                     style={styles.gap1}
                                     key={key}
                                 >
                                     <Text style={styles.eReceiptWaypointTitle}>{translate(descriptionKey)}</Text>
-                                    <Text style={styles.eReceiptWaypointAddress}>{waypoint.name || ''}</Text>
-                                    <Text style={styles.textLabelSupporting}>{waypoint.address || ''}</Text>
+                                    <Text style={styles.eReceiptWaypointAddress}>{title}</Text>
+                                    {subtitle && <Text style={styles.textLabelSupporting}>{subtitle}</Text>}
                                 </View>
                             );
                         })}

--- a/src/components/DistanceEReceipt.js
+++ b/src/components/DistanceEReceipt.js
@@ -91,7 +91,8 @@ function DistanceEReceipt({transaction}) {
                                     key={key}
                                 >
                                     <Text style={styles.eReceiptWaypointTitle}>{translate(descriptionKey)}</Text>
-                                    <Text style={styles.eReceiptWaypointAddress}>{waypoint.address || ''}</Text>
+                                    <Text style={styles.eReceiptWaypointAddress}>{waypoint.name || ''}</Text>
+                                    <Text style={styles.textLabelSupporting}>{waypoint.address || ''}</Text>
                                 </View>
                             );
                         })}

--- a/src/components/DistanceEReceipt.js
+++ b/src/components/DistanceEReceipt.js
@@ -85,16 +85,14 @@ function DistanceEReceipt({transaction}) {
                             } else {
                                 descriptionKey += 'stop';
                             }
-                            const title = waypoint.name || waypoint.address;
-                            const subtitle = waypoint.name && waypoint.address ? waypoint.address : undefined;
                             return (
                                 <View
                                     style={styles.gap1}
                                     key={key}
                                 >
                                     <Text style={styles.eReceiptWaypointTitle}>{translate(descriptionKey)}</Text>
-                                    <Text style={styles.eReceiptWaypointAddress}>{title}</Text>
-                                    {subtitle && <Text style={styles.textLabelSupporting}>{subtitle}</Text>}
+                                    {waypoint.name && <Text style={styles.eReceiptWaypointAddress}>{waypoint.name}</Text>}
+                                    {waypoint.address && <Text style={styles.textLabelSupporting}>{waypoint.address}</Text>}
                                 </View>
                             );
                         })}

--- a/src/components/DistanceRequest/DistanceRequestFooter.js
+++ b/src/components/DistanceRequest/DistanceRequestFooter.js
@@ -27,6 +27,7 @@ const propTypes = {
             lat: PropTypes.number,
             lng: PropTypes.number,
             address: PropTypes.string,
+            name: PropTypes.string,
         }),
     ),
 

--- a/src/components/DistanceRequest/DistanceRequestRenderItem.js
+++ b/src/components/DistanceRequest/DistanceRequestRenderItem.js
@@ -66,10 +66,13 @@ function DistanceRequestRenderItem({waypoints, item, onSecondaryInteraction, get
         waypointIcon = Expensicons.DotIndicator;
     }
 
+    const waypoint = lodashGet(waypoints, [`waypoint${index}`], {});
+    const title = waypoint.name || waypoint.address;
+
     return (
         <MenuItemWithTopDescription
             description={translate(descriptionKey)}
-            title={lodashGet(waypoints, [`waypoint${index}`, 'name'], '')}
+            title={title}
             icon={Expensicons.DragHandles}
             iconFill={theme.icon}
             secondaryIcon={waypointIcon}

--- a/src/components/DistanceRequest/DistanceRequestRenderItem.js
+++ b/src/components/DistanceRequest/DistanceRequestRenderItem.js
@@ -14,6 +14,7 @@ const propTypes = {
             lat: PropTypes.number,
             lng: PropTypes.number,
             address: PropTypes.string,
+            name: PropTypes.string,
         }),
     ),
 
@@ -68,7 +69,7 @@ function DistanceRequestRenderItem({waypoints, item, onSecondaryInteraction, get
     return (
         <MenuItemWithTopDescription
             description={translate(descriptionKey)}
-            title={lodashGet(waypoints, [`waypoint${index}`, 'address'], '')}
+            title={lodashGet(waypoints, [`waypoint${index}`, 'name'], '')}
             icon={Expensicons.DragHandles}
             iconFill={theme.icon}
             secondaryIcon={waypointIcon}

--- a/src/components/transactionPropTypes.js
+++ b/src/components/transactionPropTypes.js
@@ -47,7 +47,7 @@ export default PropTypes.shape({
             address: PropTypes.string,
 
             /** The name of the waypoint */
-            name: PropTypes.name,
+            name: PropTypes.string,
         }),
     }),
 

--- a/src/components/transactionPropTypes.js
+++ b/src/components/transactionPropTypes.js
@@ -45,6 +45,9 @@ export default PropTypes.shape({
 
             /** The address of the waypoint */
             address: PropTypes.string,
+
+            /** The name of the waypoint */
+            name: PropTypes.name,
         }),
     }),
 

--- a/src/libs/TransactionUtils.ts
+++ b/src/libs/TransactionUtils.ts
@@ -403,6 +403,13 @@ function waypointHasValidAddress(waypoint: RecentWaypoint | Waypoint): boolean {
     return !!waypoint?.address?.trim();
 }
 
+/** 
+ * Checks if a waypoint has a valid name
+ */
+function waypointHasValidName(waypoint: RecentWaypoint | Waypoint): boolean {
+    return !!waypoint?.name?.trim();
+}
+
 /**
  * Converts the key of a waypoint to its index
  */
@@ -427,7 +434,7 @@ function getValidWaypoints(waypoints: WaypointCollection, reArrangeIndexes = fal
         const previousWaypoint = waypointValues[lastWaypointIndex];
 
         // Check if the waypoint has a valid address
-        if (!waypointHasValidAddress(currentWaypoint)) {
+        if (!waypointHasValidName(currentWaypoint) || !waypointHasValidAddress(currentWaypoint)) {
             return acc;
         }
 

--- a/src/libs/TransactionUtils.ts
+++ b/src/libs/TransactionUtils.ts
@@ -400,10 +400,6 @@ function waypointHasValidAddress(waypoint: RecentWaypoint | Waypoint): boolean {
     return !!waypoint?.address?.trim();
 }
 
-function waypointHasValidName(waypoint: RecentWaypoint | Waypoint): boolean {
-    return !!waypoint?.name?.trim();
-}
-
 /**
  * Converts the key of a waypoint to its index
  */
@@ -428,7 +424,7 @@ function getValidWaypoints(waypoints: WaypointCollection, reArrangeIndexes = fal
         const previousWaypoint = waypointValues[lastWaypointIndex];
 
         // Check if the waypoint has a valid address
-        if (!waypointHasValidName(currentWaypoint) || !waypointHasValidAddress(currentWaypoint)) {
+        if (!waypointHasValidAddress(currentWaypoint)) {
             return acc;
         }
 

--- a/src/libs/TransactionUtils.ts
+++ b/src/libs/TransactionUtils.ts
@@ -396,16 +396,10 @@ function getAllReportTransactions(reportID?: string): Transaction[] {
     return transactions.filter((transaction) => `${transaction.reportID}` === `${reportID}`);
 }
 
-/**
- * Checks if a waypoint has a valid address
- */
 function waypointHasValidAddress(waypoint: RecentWaypoint | Waypoint): boolean {
     return !!waypoint?.address?.trim();
 }
 
-/**
- * Checks if a waypoint has a valid name
- */
 function waypointHasValidName(waypoint: RecentWaypoint | Waypoint): boolean {
     return !!waypoint?.name?.trim();
 }

--- a/src/libs/TransactionUtils.ts
+++ b/src/libs/TransactionUtils.ts
@@ -403,7 +403,7 @@ function waypointHasValidAddress(waypoint: RecentWaypoint | Waypoint): boolean {
     return !!waypoint?.address?.trim();
 }
 
-/** 
+/**
  * Checks if a waypoint has a valid name
  */
 function waypointHasValidName(waypoint: RecentWaypoint | Waypoint): boolean {

--- a/src/pages/iou/WaypointEditor.js
+++ b/src/pages/iou/WaypointEditor.js
@@ -146,7 +146,6 @@ function WaypointEditor({route: {params: {iouType = '', transactionID = '', wayp
             const waypoint = {
                 lat: null,
                 lng: null,
-                name: waypointValue,
                 address: waypointValue,
             };
             saveWaypoint(waypoint);
@@ -235,7 +234,7 @@ function WaypointEditor({route: {params: {iouType = '', transactionID = '', wayp
                             maxInputLength={CONST.FORM_CHARACTER_LIMIT}
                             renamedInputKeys={{
                                 address: `waypoint${waypointIndex}`,
-                                name: `waypoint${waypointIndex}`,
+                                name: null,
                                 city: null,
                                 country: null,
                                 street: null,

--- a/src/pages/iou/WaypointEditor.js
+++ b/src/pages/iou/WaypointEditor.js
@@ -45,6 +45,9 @@ const propTypes = {
 
     recentWaypoints: PropTypes.arrayOf(
         PropTypes.shape({
+            /** The name of the location */
+            name: PropTypes.name,
+
             /** A description of the location (usually the address) */
             description: PropTypes.string,
 
@@ -143,6 +146,7 @@ function WaypointEditor({route: {params: {iouType = '', transactionID = '', wayp
             const waypoint = {
                 lat: null,
                 lng: null,
+                name: waypointValue,
                 address: waypointValue,
             };
             saveWaypoint(waypoint);
@@ -159,10 +163,12 @@ function WaypointEditor({route: {params: {iouType = '', transactionID = '', wayp
     };
 
     const selectWaypoint = (values) => {
+        console.log(values);
         const waypoint = {
             lat: values.lat,
             lng: values.lng,
             address: values.address,
+            name: values.name,
         };
         Transaction.saveWaypoint(transactionID, waypointIndex, waypoint, isEditingWaypoint);
 
@@ -230,6 +236,7 @@ function WaypointEditor({route: {params: {iouType = '', transactionID = '', wayp
                             maxInputLength={CONST.FORM_CHARACTER_LIMIT}
                             renamedInputKeys={{
                                 address: `waypoint${waypointIndex}`,
+                                name: `waypoint${waypointIndex}`,
                                 city: null,
                                 country: null,
                                 street: null,
@@ -264,6 +271,7 @@ export default withOnyx({
         // that the google autocomplete component expects for it's "predefined places" feature.
         selector: (waypoints) =>
             _.map(waypoints ? waypoints.slice(0, 5) : [], (waypoint) => ({
+                name: waypoint.name,
                 description: waypoint.address,
                 geometry: {
                     location: {

--- a/src/pages/iou/WaypointEditor.js
+++ b/src/pages/iou/WaypointEditor.js
@@ -163,7 +163,6 @@ function WaypointEditor({route: {params: {iouType = '', transactionID = '', wayp
     };
 
     const selectWaypoint = (values) => {
-        console.log(values);
         const waypoint = {
             lat: values.lat,
             lng: values.lng,

--- a/src/pages/iou/WaypointEditor.js
+++ b/src/pages/iou/WaypointEditor.js
@@ -234,7 +234,6 @@ function WaypointEditor({route: {params: {iouType = '', transactionID = '', wayp
                             maxInputLength={CONST.FORM_CHARACTER_LIMIT}
                             renamedInputKeys={{
                                 address: `waypoint${waypointIndex}`,
-                                name: null,
                                 city: null,
                                 country: null,
                                 street: null,

--- a/src/pages/iou/WaypointEditor.js
+++ b/src/pages/iou/WaypointEditor.js
@@ -46,7 +46,7 @@ const propTypes = {
     recentWaypoints: PropTypes.arrayOf(
         PropTypes.shape({
             /** The name of the location */
-            name: PropTypes.name,
+            name: PropTypes.string,
 
             /** A description of the location (usually the address) */
             description: PropTypes.string,

--- a/src/types/onyx/RecentWaypoint.ts
+++ b/src/types/onyx/RecentWaypoint.ts
@@ -1,6 +1,6 @@
 type RecentWaypoint = {
-    /** The name of the waypoint */
-    name: string;
+    /** The name associated with the address of the waypoint */
+    name?: string;
 
     /** The full address of the waypoint */
     address: string;

--- a/src/types/onyx/RecentWaypoint.ts
+++ b/src/types/onyx/RecentWaypoint.ts
@@ -1,4 +1,7 @@
 type RecentWaypoint = {
+    /** The name of the waypoint */
+    name: string;
+
     /** The full address of the waypoint */
     address: string;
 

--- a/src/types/onyx/Transaction.ts
+++ b/src/types/onyx/Transaction.ts
@@ -6,7 +6,7 @@ import RecentWaypoint from './RecentWaypoint';
 type Waypoint = {
     /** The name of the waypoint */
     name?: string;
-    
+
     /** The full address of the waypoint */
     address?: string;
 

--- a/src/types/onyx/Transaction.ts
+++ b/src/types/onyx/Transaction.ts
@@ -4,7 +4,7 @@ import CONST from '../../CONST';
 import RecentWaypoint from './RecentWaypoint';
 
 type Waypoint = {
-    /** The name of the waypoint */
+    /** The name associated with the address of the waypoint */
     name?: string;
 
     /** The full address of the waypoint */

--- a/src/types/onyx/Transaction.ts
+++ b/src/types/onyx/Transaction.ts
@@ -4,6 +4,9 @@ import CONST from '../../CONST';
 import RecentWaypoint from './RecentWaypoint';
 
 type Waypoint = {
+    /** The name of the waypoint */
+    name?: string;
+    
     /** The full address of the waypoint */
     address?: string;
 


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->

Bifurcated the address search with title and description for each address with a new field called `name` for each address.

<image src="https://user-images.githubusercontent.com/26260477/274949789-e1561db2-61d7-494e-9089-99e38cc73a42.png" width="800" height="340"/>

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/29222
$ https://github.com/Expensify/App/issues/30255
PROPOSAL: https://github.com/Expensify/App/issues/29222#issuecomment-1761774827


### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

1. Click on request money.
2. Click on distance tab
3. Click on start and search for a location (as shown in video)
4. Make sure the places are shown with a title and a description.
5. Click on save and then select the finish place in the same way.
6. Make sure the waypoint names are shown like this:
<img width="369" alt="Screenshot 2023-10-19 at 7 45 27 AM" src="https://github.com/Expensify/App/assets/77237602/c9a1a3bb-5a94-4427-95d8-dd0161b37ca7">

7. Click on 'Next' and make sure the request is created successfully.
8. Go to the request and click on the receipt.
9. Make sure the receipt has the name of the place as well as description

- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
7. Upload an image via copy paste
10. Verify a modal appears displaying a preview of that image
--->

1. Click on request money.
2. Click on distance tab
3. Click on start and search for a location (as shown in video)
4. Make sure the places are shown with a title and a description.
5. Click on save and then select the finish place in the same way.
6. Make sure the waypoint names are shown like this:
<img width="369" alt="Screenshot 2023-10-19 at 7 45 27 AM" src="https://github.com/Expensify/App/assets/77237602/c9a1a3bb-5a94-4427-95d8-dd0161b37ca7">

7. Click on 'Next' and make sure the request is created successfully.
8. Go to the request and click on the receipt.
9. Make sure the receipt has the name of the place as well as description


- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] If we are not using the full Onyx data that we loaded, I've added the proper selector in order to ensure the component only re-renders when the data it is using changes
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

https://github.com/Expensify/App/assets/77237602/a50c3628-d8df-4f86-a7bd-2f6d0c41f7db


</details>

<details>
<summary>Android: mWeb Chrome</summary>

https://github.com/Expensify/App/assets/77237602/ee7c9a8d-405b-4fc9-8284-cf3e5213b2f0


<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

https://github.com/Expensify/App/assets/77237602/08064a28-c995-4e20-8b23-fc3925c30fad


</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

https://github.com/Expensify/App/assets/77237602/a4cf462c-9287-4d94-b1b2-d24c177fe05b


</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

https://github.com/Expensify/App/assets/77237602/05bdb408-dd20-4aca-93d0-f689ec850f45


</details>

<details>
<summary>MacOS: Desktop</summary>

<!-- add screenshots or videos here -->

https://github.com/Expensify/App/assets/77237602/a6ee2364-319e-4472-bcc9-ab061d6f2494


</details>
