### PR TITLE
Fix bug to show the secondary avatar when the repost is is a policy expense chat

### DIFF
--- a/src/pages/home/report/ReportActionItemSingle.js
+++ b/src/pages/home/report/ReportActionItemSingle.js
@@ -126,7 +126,10 @@ function ReportActionItemSingle(props) {
             id: secondaryAccountId,
         };
     } else if (!isWorkspaceActor) {
-        secondaryAvatar = ReportUtils.getIcons(props.report, {})[props.report.isOwnPolicyExpenseChat ? 0 : 1];
+        const avatarIconIndex = props.report.isOwnPolicyExpenseChat || ReportUtils.isPolicyExpenseChat(props.report) ? 0 : 1;
+        const reportIcons = ReportUtils.getIcons(props.report, {});
+
+        secondaryAvatar = reportIcons[avatarIconIndex];
     }
     const icon = {source: avatarSource, type: isWorkspaceActor ? CONST.ICON_TYPE_WORKSPACE : CONST.ICON_TYPE_AVATAR, name: primaryDisplayName, id: isWorkspaceActor ? '' : actorAccountID};
 

--- a/tests/unit/ReportActionItemSingleTest.js
+++ b/tests/unit/ReportActionItemSingleTest.js
@@ -67,17 +67,17 @@ describe('ReportActionItemSingle', () => {
             }
 
             it('renders secondary Avatar properly', () => {
-                return setup().then(() => {
-                    const expectedSecondaryIconTestId = 'SvgDefaultAvatar_w Icon';
+                const expectedSecondaryIconTestId = 'SvgDefaultAvatar_w Icon';
 
+                return setup().then(() => {
                     expect(screen.getByTestId(expectedSecondaryIconTestId)).toBeDefined();
                 });
             });
 
             it('renders Person information', () => {
-                return setup().then(() => {
-                    const [expectedPerson] = fakeReportAction.person;
+                const [expectedPerson] = fakeReportAction.person;
 
+                return setup().then(() => {
                     expect(screen.getByText(expectedPerson.text)).toBeDefined();
                 });
             });

--- a/tests/unit/ReportActionItemSingleTest.js
+++ b/tests/unit/ReportActionItemSingleTest.js
@@ -1,0 +1,86 @@
+import Onyx from 'react-native-onyx';
+import {cleanup, screen} from '@testing-library/react-native';
+import * as LHNTestUtils from '../utils/LHNTestUtils';
+import waitForBatchedUpdates from '../utils/waitForBatchedUpdates';
+import wrapOnyxWithWaitForBatchedUpdates from '../utils/wrapOnyxWithWaitForBatchedUpdates';
+
+const ONYXKEYS = {
+    PERSONAL_DETAILS_LIST: 'personalDetailsList',
+    IS_LOADING_REPORT_DATA: 'isLoadingReportData',
+    COLLECTION: {
+        REPORT_ACTIONS: 'reportActions_',
+        POLICY: 'policy_',
+    },
+    NETWORK: 'network',
+};
+
+describe('ReportActionItemSingle', () => {
+    beforeAll(() =>
+        Onyx.init({
+            keys: ONYXKEYS,
+            registerStorageEventListener: () => {},
+            safeEvictionKeys: [ONYXKEYS.COLLECTION.REPORT_ACTIONS],
+        }),
+    );
+
+    beforeEach(() => {
+        // Wrap Onyx each onyx action with waitForBatchedUpdates
+        wrapOnyxWithWaitForBatchedUpdates(Onyx);
+        // Initialize the network key for OfflineWithFeedback
+        return Onyx.merge(ONYXKEYS.NETWORK, {isOffline: false});
+    });
+
+    // Clear out Onyx after each test so that each test starts with a clean slate
+    afterEach(() => {
+        cleanup();
+        Onyx.clear();
+    });
+
+    describe('when the Report is a policy expense chat', () => {
+        describe('and the property "shouldShowSubscriptAvatar" is true', () => {
+            const shouldShowSubscriptAvatar = true;
+            const fakeReport = LHNTestUtils.getFakeReportWithPolicy([1, 2]);
+            const fakeReportAction = LHNTestUtils.getFakeAdvancedReportAction();
+            const fakePolicy = LHNTestUtils.getFakePolicy(fakeReport.policyID);
+            const fakePersonalDetails = {
+                [fakeReportAction.actorAccountID]: {
+                    accountID: fakeReportAction.actorAccountID,
+                    login: 'email1@test.com',
+                    displayName: 'Email One',
+                    avatar: 'https://example.com/avatar.png',
+                    firstName: 'One',
+                },
+            };
+
+            beforeEach(() => {
+                LHNTestUtils.getDefaultRenderedReportActionItemSingle(shouldShowSubscriptAvatar, fakeReport, fakeReportAction);
+            });
+
+            function setup() {
+                return waitForBatchedUpdates().then(() =>
+                    Onyx.multiSet({
+                        [ONYXKEYS.PERSONAL_DETAILS_LIST]: fakePersonalDetails,
+                        [ONYXKEYS.IS_LOADING_REPORT_DATA]: false,
+                        [`${ONYXKEYS.COLLECTION.POLICY}${fakeReport.policyID}`]: fakePolicy,
+                    }),
+                );
+            }
+
+            it('renders secondary Avatar properly', () => {
+                return setup().then(() => {
+                    const expectedSecondaryIconTestId = 'SvgDefaultAvatar_w Icon';
+
+                    expect(screen.getByTestId(expectedSecondaryIconTestId)).toBeDefined();
+                });
+            });
+
+            it('renders Person information', () => {
+                return setup().then(() => {
+                    const [expectedPerson] = fakeReportAction.person;
+
+                    expect(screen.getByText(expectedPerson.text)).toBeDefined();
+                });
+            });
+        });
+    });
+});

--- a/tests/utils/LHNTestUtils.js
+++ b/tests/utils/LHNTestUtils.js
@@ -327,7 +327,7 @@ function MockedReportActionItemSingle({shouldShowSubscriptAvatar, report, report
             displayName: 'Email One',
             avatar: 'https://example.com/avatar.png',
             firstName: 'One',
-        }
+        },
     };
 
     return (

--- a/tests/utils/LHNTestUtils.js
+++ b/tests/utils/LHNTestUtils.js
@@ -184,7 +184,7 @@ function getFakeReportWithPolicy(participantAccountIDs = [1, 2], millisecondsInT
         policyID: '08CE60F05A5D86E1',
         oldPolicyName: '',
         isOwnPolicyExpenseChat: false,
-        ownerAccountID: 1,
+        ownerAccountID: participantAccountIDs[0],
     };
 }
 

--- a/tests/utils/LHNTestUtils.js
+++ b/tests/utils/LHNTestUtils.js
@@ -190,7 +190,7 @@ function getFakeReportWithPolicy(participantAccountIDs = [1, 2], millisecondsInT
 
 /**
  * @param {Number} [id]
- * @param {String} [name] the number of milliseconds in the past for the last message timestamp (to order reports by most recent messages)
+ * @param {String} [name]
  * @returns {Object}
  */
 function getFakePolicy(id = 1, name = 'Workspace-Test-001') {

--- a/tests/utils/LHNTestUtils.js
+++ b/tests/utils/LHNTestUtils.js
@@ -5,10 +5,13 @@ import ComposeProviders from '../../src/components/ComposeProviders';
 import OnyxProvider from '../../src/components/OnyxProvider';
 import {LocaleContextProvider} from '../../src/components/LocaleContextProvider';
 import SidebarLinksData from '../../src/pages/home/sidebar/SidebarLinksData';
+import ReportActionItemSingle from '../../src/pages/home/report/ReportActionItemSingle';
 import {EnvironmentProvider} from '../../src/components/withEnvironment';
 import {CurrentReportIDContextProvider} from '../../src/components/withCurrentReportID';
 import CONST from '../../src/CONST';
 import DateUtils from '../../src/libs/DateUtils';
+import reportPropTypes from '../../src/pages/reportPropTypes';
+import reportActionPropTypes from '../../src/pages/home/report/reportActionPropTypes';
 
 // we have to mock `useIsFocused` because it's used in the SidebarLinks component
 const mockedNavigate = jest.fn();
@@ -168,6 +171,63 @@ function getAdvancedFakeReport(isArchived, isUserCreatedPolicyRoom, hasAddWorksp
 }
 
 /**
+ * @param {Number[]} participantAccountIDs
+ * @param {Number} millisecondsInThePast the number of milliseconds in the past for the last message timestamp (to order reports by most recent messages)
+ * @param {boolean} isUnread
+ * @returns {Object}
+ */
+function getFakeReportWithPolicy(participantAccountIDs = [1, 2], millisecondsInThePast = 0, isUnread = false) {
+    return {
+        ...getFakeReport([1, 2], 0, isUnread),
+        type: CONST.REPORT.TYPE.CHAT,
+        chatType: CONST.REPORT.CHAT_TYPE.POLICY_EXPENSE_CHAT,
+        policyID: '08CE60F05A5D86E1',
+        oldPolicyName: '',
+        isOwnPolicyExpenseChat: false,
+        ownerAccountID: 1,
+    };
+}
+
+/**
+ * @param {Number} id
+ * @param {String} name the number of milliseconds in the past for the last message timestamp (to order reports by most recent messages)
+ * @returns {Object}
+ */
+function getFakePolicy(id = 1, name = 'Workspace-Test-001') {
+    return {
+        id,
+        name,
+        isFromFullPolicy: false,
+        role: 'admin',
+        type: 'free',
+        owner: 'myuser@gmail.com',
+        outputCurrency: 'BRL',
+        avatar: '',
+        employeeList: [],
+        isPolicyExpenseChatEnabled: true,
+        areChatRoomsEnabled: true,
+        lastModified: 1697323926777105,
+        autoReporting: true,
+        autoReportingFrequency: 'immediate',
+        defaultBillable: false,
+        disabledFields: {defaultBillable: true, reimbursable: false},
+    };
+}
+
+/**
+ * @param {String} actionName
+ * @param {String} actor
+ * @param {Number} millisecondsInThePast the number of milliseconds in the past for the last message timestamp (to order reports by most recent messages)
+ * @returns {Object}
+ */
+function getFakeAdvancedReportAction(actionName = 'IOU', actor = 'email1@test.com', millisecondsInThePast = 0) {
+    return {
+        ...getFakeReportAction(actor, millisecondsInThePast),
+        actionName,
+    };
+}
+
+/**
  * @param {String} [currentReportID]
  */
 function getDefaultRenderedSidebarLinks(currentReportID = '') {
@@ -218,4 +278,94 @@ MockedSidebarLinks.defaultProps = {
     currentReportID: '',
 };
 
-export {fakePersonalDetails, getDefaultRenderedSidebarLinks, getAdvancedFakeReport, getFakeReport, getFakeReportAction, MockedSidebarLinks};
+/**
+ * @param {Boolean} shouldShowSubscriptAvatar
+ * @param {Object} report
+ * @param {Object} reportAction
+ */
+function getDefaultRenderedReportActionItemSingle(shouldShowSubscriptAvatar = true, report = null, reportAction = mull) {
+    const currentReport = report ?? getFakeReport();
+    const currentReportAction = reportAction ?? getFakeAdvancedReportAction();
+
+    internalRender(
+        <MockedReportActionItemSingle
+            shouldShowSubscriptAvatar={shouldShowSubscriptAvatar}
+            report={currentReport}
+            reportAction={currentReportAction}
+        />,
+    );
+}
+
+function internalRender(component) {
+    // A try-catch block needs to be added to the rendering so that any errors that happen while the component
+    // renders are caught and logged to the console. Without the try-catch block, Jest might only report the error
+    // as "The above error occurred in your component", without providing specific details. By using a try-catch block,
+    // any errors are caught and logged, allowing you to identify the exact error that might be causing a rendering issue
+    // when developing tests.
+
+    try {
+        render(component);
+    } catch (error) {
+        console.error(error);
+    }
+}
+
+/**
+ * @param {Boolean} shouldShowSubscriptAvatar
+ * @param {Object} report
+ * @param {Object} reportAction
+ * @returns {JSX.Element}
+ */
+function MockedReportActionItemSingle({shouldShowSubscriptAvatar, report, reportAction}) {
+    const personalDetailsList = {
+        [reportAction.actorAccountID]: {
+            accountID: reportAction.actorAccountID,
+            login: 'email1@test.com',
+            displayName: 'Email One',
+            avatar: 'https://example.com/avatar.png',
+            firstName: 'One',
+        }
+    };
+
+    return (
+        <ComposeProviders components={[OnyxProvider, LocaleContextProvider, EnvironmentProvider, CurrentReportIDContextProvider]}>
+            <ReportActionItemSingle
+                action={reportAction}
+                report={report}
+                personalDetailsList={personalDetailsList}
+                wrapperStyles={[{display: 'inline'}]}
+                showHeader={true}
+                shouldShowSubscriptAvatar={shouldShowSubscriptAvatar}
+                hasBeenFlagged={false}
+                iouReport={undefined}
+                isHovered={false}
+            />
+        </ComposeProviders>
+    );
+}
+
+MockedReportActionItemSingle.propTypes = {
+    shouldShowSubscriptAvatar: PropTypes.bool,
+    report: reportPropTypes,
+    reportAction: PropTypes.shape(reportActionPropTypes),
+};
+
+MockedReportActionItemSingle.defaultProps = {
+    shouldShowSubscriptAvatar: true,
+    report: null,
+    reportAction: null,
+};
+
+export {
+    fakePersonalDetails,
+    getDefaultRenderedSidebarLinks,
+    getAdvancedFakeReport,
+    getFakeReport,
+    getFakeReportAction,
+    MockedSidebarLinks,
+    getDefaultRenderedReportActionItemSingle,
+    MockedReportActionItemSingle,
+    getFakeReportWithPolicy,
+    getFakePolicy,
+    getFakeAdvancedReportAction,
+};

--- a/tests/utils/LHNTestUtils.js
+++ b/tests/utils/LHNTestUtils.js
@@ -178,7 +178,7 @@ function getAdvancedFakeReport(isArchived, isUserCreatedPolicyRoom, hasAddWorksp
  */
 function getFakeReportWithPolicy(participantAccountIDs = [1, 2], millisecondsInThePast = 0, isUnread = false) {
     return {
-        ...getFakeReport([1, 2], 0, isUnread),
+        ...getFakeReport(participantAccountIDs, millisecondsInThePast, isUnread),
         type: CONST.REPORT.TYPE.CHAT,
         chatType: CONST.REPORT.CHAT_TYPE.POLICY_EXPENSE_CHAT,
         policyID: '08CE60F05A5D86E1',
@@ -279,23 +279,8 @@ MockedSidebarLinks.defaultProps = {
 };
 
 /**
- * @param {Boolean} shouldShowSubscriptAvatar
- * @param {Object} report
- * @param {Object} reportAction
+ * @param {React.ReactElement} component
  */
-function getDefaultRenderedReportActionItemSingle(shouldShowSubscriptAvatar = true, report = null, reportAction = mull) {
-    const currentReport = report ?? getFakeReport();
-    const currentReportAction = reportAction ?? getFakeAdvancedReportAction();
-
-    internalRender(
-        <MockedReportActionItemSingle
-            shouldShowSubscriptAvatar={shouldShowSubscriptAvatar}
-            report={currentReport}
-            reportAction={currentReportAction}
-        />,
-    );
-}
-
 function internalRender(component) {
     // A try-catch block needs to be added to the rendering so that any errors that happen while the component
     // renders are caught and logged to the console. Without the try-catch block, Jest might only report the error
@@ -308,6 +293,24 @@ function internalRender(component) {
     } catch (error) {
         console.error(error);
     }
+}
+
+/**
+ * @param {Boolean} shouldShowSubscriptAvatar
+ * @param {Object} report
+ * @param {Object} reportAction
+ */
+function getDefaultRenderedReportActionItemSingle(shouldShowSubscriptAvatar = true, report = null, reportAction = null) {
+    const currentReport = report || getFakeReport();
+    const currentReportAction = reportAction || getFakeAdvancedReportAction();
+
+    internalRender(
+        <MockedReportActionItemSingle
+            shouldShowSubscriptAvatar={shouldShowSubscriptAvatar}
+            report={currentReport}
+            reportAction={currentReportAction}
+        />,
+    );
 }
 
 /**
@@ -334,7 +337,7 @@ function MockedReportActionItemSingle({shouldShowSubscriptAvatar, report, report
                 report={report}
                 personalDetailsList={personalDetailsList}
                 wrapperStyles={[{display: 'inline'}]}
-                showHeader={true}
+                showHeader
                 shouldShowSubscriptAvatar={shouldShowSubscriptAvatar}
                 hasBeenFlagged={false}
                 iouReport={undefined}

--- a/tests/utils/LHNTestUtils.js
+++ b/tests/utils/LHNTestUtils.js
@@ -171,9 +171,9 @@ function getAdvancedFakeReport(isArchived, isUserCreatedPolicyRoom, hasAddWorksp
 }
 
 /**
- * @param {Number[]} participantAccountIDs
- * @param {Number} millisecondsInThePast the number of milliseconds in the past for the last message timestamp (to order reports by most recent messages)
- * @param {boolean} isUnread
+ * @param {Number[]} [participantAccountIDs]
+ * @param {Number} [millisecondsInThePast] the number of milliseconds in the past for the last message timestamp (to order reports by most recent messages)
+ * @param {boolean} [isUnread]
  * @returns {Object}
  */
 function getFakeReportWithPolicy(participantAccountIDs = [1, 2], millisecondsInThePast = 0, isUnread = false) {
@@ -189,8 +189,8 @@ function getFakeReportWithPolicy(participantAccountIDs = [1, 2], millisecondsInT
 }
 
 /**
- * @param {Number} id
- * @param {String} name the number of milliseconds in the past for the last message timestamp (to order reports by most recent messages)
+ * @param {Number} [id]
+ * @param {String} [name] the number of milliseconds in the past for the last message timestamp (to order reports by most recent messages)
  * @returns {Object}
  */
 function getFakePolicy(id = 1, name = 'Workspace-Test-001') {
@@ -296,9 +296,9 @@ function internalRender(component) {
 }
 
 /**
- * @param {Boolean} shouldShowSubscriptAvatar
- * @param {Object} report
- * @param {Object} reportAction
+ * @param {Boolean} [shouldShowSubscriptAvatar]
+ * @param {Object} [report]
+ * @param {Object} [reportAction]
  */
 function getDefaultRenderedReportActionItemSingle(shouldShowSubscriptAvatar = true, report = null, reportAction = null) {
     const currentReport = report || getFakeReport();


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details

When I user requests money and splits it into a workspace, in workspace chat the split bill avatar displays the default profile sub avatar and on hovering on it, it displays the same user tooltip.

### Fixed Issues

$ https://github.com/Expensify/App/issues/29614
PROPOSAL: https://github.com/Expensify/App/issues/29614#issuecomment-1763214403

### Tests

1. Open the app and login with user A
2. Open the app on another device and login with user B
3. From user A, invite user B to any workspace
4. From user B, click on green plus and click on request money
5. Enter any amount and continue
7. Press the "Split" button beside the workspace name, press "Add to split" and confirm the split summary
8. From user A, open workspace chat was created after inviting user B to a workspace

- [x] From user A, in workspace chat, observe the secondary (small) avatar, ensure that the initial letter is from the workspace name, and when hovering, ensure that the tooltip shows the workspace name.

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

1. Open the app and login with user A
2. Open the app on another device and login with user B
3. From user A, invite user B to any workspace
4. From user B, click on green plus and click on request money
5. Enter any amount and continue
6. Press the "Split" button beside the workspace name, press "Add to split" and confirm the split summary
7. From user A, open workspace chat was created after inviting user B to a workspace
9. Switch to offline mode

- [x] From user A, in workspace chat, observe the secondary (small) avatar, ensure that the initial letter is from the workspace name, and when hovering, ensure that the tooltip shows the workspace name.

### QA Steps

1. Open the app and login with user A
2. Open the app on another device and login with user B
3. From user A, invite user B to any workspace
4. From user B, click on green plus and click on request money
5. Enter any amount and continue
6. Press the "Split" button beside the workspace name, press "Add to split" and confirm the split summary
7. From user A, open workspace chat was created after inviting user B to a workspace

- [x] From user A, in workspace chat, observe the secondary (small) avatar, ensure that the initial letter is from the workspace name, and when hovering, ensure that the tooltip shows the workspace name. 

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] If we are not using the full Onyx data that we loaded, I've added the proper selector in order to ensure the component only re-renders when the data it is using changes
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

https://github.com/Expensify/App/assets/698363/371688ab-7e19-4fbb-93f7-acacc680b317

</details>

<details>
<summary>Android: mWeb Chrome</summary>

https://github.com/Expensify/App/assets/698363/4c6c6d6d-94a3-4c48-ba11-61cbe2c9041b

</details>

<details>
<summary>iOS: Native</summary>

https://github.com/Expensify/App/assets/698363/aab33de4-f4a3-4c10-bb09-9f3a0a71cc04

</details>

<details>
<summary>iOS: mWeb Safari</summary>

https://github.com/Expensify/App/assets/698363/d8ecc1a4-ea1e-46bf-b7ab-4e11433a87c4

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

https://github.com/Expensify/App/assets/698363/33d3bd3c-6bb0-4af7-8079-94c68075984a

Added tests to validate this issue
![image](https://github.com/Expensify/App/assets/698363/36002e03-08f3-48bd-82e4-459b5791da1e)

</details>

<details>
<summary>MacOS: Desktop</summary>

https://github.com/Expensify/App/assets/698363/b3e1f154-036a-4416-959d-78cb25507539

</details>
