### PR TITLE
Revert "feat: migrate KYCWall class component to functional"

### DIFF
--- a/src/components/KYCWall/BaseKYCWall.js
+++ b/src/components/KYCWall/BaseKYCWall.js
@@ -1,5 +1,5 @@
-import React, {useEffect, useState, useRef, useCallback} from 'react';
 import _ from 'underscore';
+import React from 'react';
 import {withOnyx} from 'react-native-onyx';
 import {Dimensions} from 'react-native';
 import lodashGet from 'lodash/get';
@@ -15,114 +15,90 @@ import {propTypes, defaultProps} from './kycWallPropTypes';
 import * as Wallet from '../../libs/actions/Wallet';
 import * as ReportUtils from '../../libs/ReportUtils';
 
-const POPOVER_MENU_ANCHOR_POSITION_HORIZONTAL_OFFSET = 20;
-
 // This component allows us to block various actions by forcing the user to first add a default payment method and successfully make it through our Know Your Customer flow
 // before continuing to take whatever action they originally intended to take. It requires a button as a child and a native event so we can get the coordinates and use it
 // to render the AddPaymentMethodMenu in the correct location.
-function KYCWall({
-    addBankAccountRoute,
-    addDebitCardRoute,
-    anchorAlignment,
-    bankAccountList,
-    chatReportID,
-    children,
-    enablePaymentsRoute,
-    fundList,
-    iouReport,
-    onSelectPaymentMethod,
-    onSuccessfulKYC,
-    reimbursementAccount,
-    shouldIncludeDebitCard,
-    shouldListenForResize,
-    source,
-    userWallet,
-    walletTerms,
-}) {
-    const anchorRef = useRef(null);
-    const transferBalanceButtonRef = useRef(null);
+class KYCWall extends React.Component {
+    constructor(props) {
+        super(props);
 
-    const [shouldShowAddPaymentMenu, setShouldShowAddPaymentMenu] = useState(false);
-    const [anchorPosition, setAnchorPosition] = useState({
-        anchorPositionVertical: 0,
-        anchorPositionHorizontal: 0,
-    });
+        this.continue = this.continue.bind(this);
+        this.setMenuPosition = this.setMenuPosition.bind(this);
+        this.selectPaymentMethod = this.selectPaymentMethod.bind(this);
+        this.anchorRef = React.createRef(null);
+
+        this.state = {
+            shouldShowAddPaymentMenu: false,
+            anchorPositionVertical: 0,
+            anchorPositionHorizontal: 0,
+            transferBalanceButton: null,
+        };
+    }
+
+    componentDidMount() {
+        PaymentMethods.kycWallRef.current = this;
+        if (this.props.shouldListenForResize) {
+            this.dimensionsSubscription = Dimensions.addEventListener('change', this.setMenuPosition);
+        }
+    }
+
+    componentWillUnmount() {
+        if (this.props.shouldListenForResize && this.dimensionsSubscription) {
+            this.dimensionsSubscription.remove();
+        }
+        PaymentMethods.kycWallRef.current = null;
+    }
+
+    setMenuPosition() {
+        if (!this.state.transferBalanceButton) {
+            return;
+        }
+        const buttonPosition = getClickedTargetLocation(this.state.transferBalanceButton);
+        const position = this.getAnchorPosition(buttonPosition);
+        this.setPositionAddPaymentMenu(position);
+    }
 
     /**
      * @param {DOMRect} domRect
      * @returns {Object}
      */
-    const getAnchorPosition = useCallback(
-        (domRect) => {
-            if (anchorAlignment.vertical === CONST.MODAL.ANCHOR_ORIGIN_VERTICAL.TOP) {
-                return {
-                    anchorPositionVertical: domRect.top + domRect.height + CONST.MODAL.POPOVER_MENU_PADDING,
-                    anchorPositionHorizontal: domRect.left + POPOVER_MENU_ANCHOR_POSITION_HORIZONTAL_OFFSET,
-                };
-            }
-
+    getAnchorPosition(domRect) {
+        if (this.props.anchorAlignment.vertical === CONST.MODAL.ANCHOR_ORIGIN_VERTICAL.TOP) {
             return {
-                anchorPositionVertical: domRect.top - CONST.MODAL.POPOVER_MENU_PADDING,
-                anchorPositionHorizontal: domRect.left,
+                anchorPositionVertical: domRect.top + domRect.height + CONST.MODAL.POPOVER_MENU_PADDING,
+                anchorPositionHorizontal: domRect.left + 20,
             };
-        },
-        [anchorAlignment.vertical],
-    );
+        }
+
+        return {
+            anchorPositionVertical: domRect.top - CONST.MODAL.POPOVER_MENU_PADDING,
+            anchorPositionHorizontal: domRect.left,
+        };
+    }
 
     /**
      * Set position of the transfer payment menu
      *
      * @param {Object} position
      */
-    const setPositionAddPaymentMenu = ({anchorPositionVertical, anchorPositionHorizontal}) => {
-        setAnchorPosition({
-            anchorPositionVertical,
-            anchorPositionHorizontal,
+    setPositionAddPaymentMenu(position) {
+        this.setState({
+            anchorPositionVertical: position.anchorPositionVertical,
+            anchorPositionHorizontal: position.anchorPositionHorizontal,
         });
-    };
-
-    const setMenuPosition = useCallback(() => {
-        if (!transferBalanceButtonRef.current) {
-            return;
-        }
-        const buttonPosition = getClickedTargetLocation(transferBalanceButtonRef.current);
-        const position = getAnchorPosition(buttonPosition);
-
-        setPositionAddPaymentMenu(position);
-    }, [getAnchorPosition]);
-
-    useEffect(() => {
-        let dimensionsSubscription = null;
-
-        PaymentMethods.kycWallRef.current = this;
-
-        if (shouldListenForResize) {
-            dimensionsSubscription = Dimensions.addEventListener('change', setMenuPosition);
-        }
-
-        Wallet.setKYCWallSourceChatReportID(chatReportID);
-
-        return () => {
-            if (shouldListenForResize && dimensionsSubscription) {
-                dimensionsSubscription.remove();
-            }
-
-            PaymentMethods.kycWallRef.current = null;
-        };
-    }, [chatReportID, setMenuPosition, shouldListenForResize]);
+    }
 
     /**
      * @param {String} paymentMethod
      */
-    const selectPaymentMethod = (paymentMethod) => {
-        onSelectPaymentMethod(paymentMethod);
-
+    selectPaymentMethod(paymentMethod) {
+        this.props.onSelectPaymentMethod(paymentMethod);
         if (paymentMethod === CONST.PAYMENT_METHODS.BANK_ACCOUNT) {
-            Navigation.navigate(addBankAccountRoute);
+            Navigation.navigate(this.props.addBankAccountRoute);
         } else if (paymentMethod === CONST.PAYMENT_METHODS.DEBIT_CARD) {
-            Navigation.navigate(addDebitCardRoute);
+            Navigation.navigate(this.props.addDebitCardRoute);
         }
-    };
+    }
 
     /**
      * Take the position of the button that calls this method and show the Add Payment method menu when the user has no valid payment method.
@@ -132,86 +108,82 @@ function KYCWall({
      * @param {Event} event
      * @param {String} iouPaymentType
      */
-    const continueAction = (event, iouPaymentType) => {
-        const currentSource = lodashGet(walletTerms, 'source', source);
+    continue(event, iouPaymentType) {
+        const currentSource = lodashGet(this.props.walletTerms, 'source', this.props.source);
 
         /**
          * Set the source, so we can tailor the process according to how we got here.
          * We do not want to set this on mount, as the source can change upon completing the flow, e.g. when upgrading the wallet to Gold.
          */
-        Wallet.setKYCWallSource(source, chatReportID);
+        Wallet.setKYCWallSource(this.props.source, this.props.chatReportID);
 
-        if (shouldShowAddPaymentMenu) {
-            setShouldShowAddPaymentMenu(false);
-
+        if (this.state.shouldShowAddPaymentMenu) {
+            this.setState({shouldShowAddPaymentMenu: false});
             return;
         }
 
         // Use event target as fallback if anchorRef is null for safety
-        const targetElement = anchorRef.current || event.nativeEvent.target;
-
-        transferBalanceButtonRef.current = targetElement;
-        const isExpenseReport = ReportUtils.isExpenseReport(iouReport);
-        const paymentCardList = fundList || {};
+        const targetElement = this.anchorRef.current || event.nativeEvent.target;
+        this.setState({transferBalanceButton: targetElement});
+        const isExpenseReport = ReportUtils.isExpenseReport(this.props.iouReport);
+        const paymentCardList = this.props.fundList || {};
 
         // Check to see if user has a valid payment method on file and display the add payment popover if they don't
         if (
-            (isExpenseReport && lodashGet(reimbursementAccount, 'achData.state', '') !== CONST.BANK_ACCOUNT.STATE.OPEN) ||
-            (!isExpenseReport && !PaymentUtils.hasExpensifyPaymentMethod(paymentCardList, bankAccountList, shouldIncludeDebitCard))
+            (isExpenseReport && lodashGet(this.props.reimbursementAccount, 'achData.state', '') !== CONST.BANK_ACCOUNT.STATE.OPEN) ||
+            (!isExpenseReport && !PaymentUtils.hasExpensifyPaymentMethod(paymentCardList, this.props.bankAccountList, this.props.shouldIncludeDebitCard))
         ) {
             Log.info('[KYC Wallet] User does not have valid payment method');
-            if (!shouldIncludeDebitCard) {
-                selectPaymentMethod(CONST.PAYMENT_METHODS.BANK_ACCOUNT);
+            if (!this.props.shouldIncludeDebitCard) {
+                this.selectPaymentMethod(CONST.PAYMENT_METHODS.BANK_ACCOUNT);
                 return;
             }
-
             const clickedElementLocation = getClickedTargetLocation(targetElement);
-            const position = getAnchorPosition(clickedElementLocation);
-
-            setPositionAddPaymentMenu(position);
-            setShouldShowAddPaymentMenu(true);
-
+            const position = this.getAnchorPosition(clickedElementLocation);
+            this.setPositionAddPaymentMenu(position);
+            this.setState({
+                shouldShowAddPaymentMenu: true,
+            });
             return;
         }
-
         if (!isExpenseReport) {
             // Ask the user to upgrade to a gold wallet as this means they have not yet gone through our Know Your Customer (KYC) checks
-            const hasActivatedWallet = userWallet.tierName && _.contains([CONST.WALLET.TIER_NAME.GOLD, CONST.WALLET.TIER_NAME.PLATINUM], userWallet.tierName);
+            const hasActivatedWallet = this.props.userWallet.tierName && _.contains([CONST.WALLET.TIER_NAME.GOLD, CONST.WALLET.TIER_NAME.PLATINUM], this.props.userWallet.tierName);
             if (!hasActivatedWallet) {
                 Log.info('[KYC Wallet] User does not have active wallet');
-                Navigation.navigate(enablePaymentsRoute);
+                Navigation.navigate(this.props.enablePaymentsRoute);
                 return;
             }
         }
-
         Log.info('[KYC Wallet] User has valid payment method and passed KYC checks or did not need them');
-        onSuccessfulKYC(iouPaymentType, currentSource);
-    };
+        this.props.onSuccessfulKYC(iouPaymentType, currentSource);
+    }
 
-    return (
-        <>
-            <AddPaymentMethodMenu
-                isVisible={shouldShowAddPaymentMenu}
-                onClose={() => setShouldShowAddPaymentMenu(false)}
-                anchorRef={anchorRef}
-                anchorAlignment={anchorAlignment}
-                anchorPosition={{
-                    vertical: anchorPosition.anchorPositionVertical,
-                    horizontal: anchorPosition.anchorPositionHorizontal,
-                }}
-                onItemSelected={(item) => {
-                    setShouldShowAddPaymentMenu(false);
-                    selectPaymentMethod(item);
-                }}
-            />
-            {children(continueAction, anchorRef)}
-        </>
-    );
+    render() {
+        return (
+            <>
+                <AddPaymentMethodMenu
+                    isVisible={this.state.shouldShowAddPaymentMenu}
+                    onClose={() => this.setState({shouldShowAddPaymentMenu: false})}
+                    anchorRef={this.anchorRef}
+                    anchorPosition={{
+                        vertical: this.state.anchorPositionVertical,
+                        horizontal: this.state.anchorPositionHorizontal,
+                    }}
+                    anchorAlignment={this.props.anchorAlignment}
+                    onItemSelected={(item) => {
+                        this.setState({shouldShowAddPaymentMenu: false});
+                        this.selectPaymentMethod(item);
+                    }}
+                />
+                {this.props.children(this.continue, this.anchorRef)}
+            </>
+        );
+    }
 }
 
 KYCWall.propTypes = propTypes;
 KYCWall.defaultProps = defaultProps;
-KYCWall.displayName = 'BaseKYCWall';
 
 export default withOnyx({
     userWallet: {

--- a/src/libs/actions/PaymentMethods.ts
+++ b/src/libs/actions/PaymentMethods.ts
@@ -11,7 +11,7 @@ import {FilterMethodPaymentType} from '../../types/onyx/WalletTransfer';
 import PaymentMethod from '../../types/onyx/PaymentMethod';
 
 type KYCWallRef = {
-    continueAction?: () => void;
+    continue?: () => void;
 };
 
 /**
@@ -23,14 +23,14 @@ const kycWallRef = createRef<KYCWallRef>();
  * When we successfully add a payment method or pass the KYC checks we will continue with our setup action if we have one set.
  */
 function continueSetup(fallbackRoute = ROUTES.HOME) {
-    if (!kycWallRef.current?.continueAction) {
+    if (!kycWallRef.current?.continue) {
         Navigation.goBack(fallbackRoute);
         return;
     }
 
     // Close the screen (Add Debit Card, Add Bank Account, or Enable Payments) on success and continue with setup
     Navigation.goBack(fallbackRoute);
-    kycWallRef.current.continueAction();
+    kycWallRef.current.continue();
 }
 
 function openWalletPage() {


### PR DESCRIPTION
### Fixed issues
$ https://github.com/Expensify/App/issues/30109


Reverts Expensify/App#28798 because it started causing a crash https://expensify.slack.com/archives/C049HHMV9SM/p1697838755135299?thread_ts=1697694190.199399&cid=C049HHMV9SM

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] If we are not using the full Onyx data that we loaded, I've added the proper selector in order to ensure the component only re-renders when the data it is using changes
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.