### PR TITLE
Revert "[Internal QA] Skip rendering content for pay action on non-send money flow"

### DIFF
--- a/src/pages/home/report/ReportActionItem.js
+++ b/src/pages/home/report/ReportActionItem.js
@@ -151,11 +151,6 @@ function ReportActionItem(props) {
 
     const highlightedBackgroundColorIfNeeded = useMemo(() => (isReportActionLinked ? StyleUtils.getBackgroundColorStyle(themeColors.highlightBG) : {}), [isReportActionLinked]);
 
-    const originalMessage = lodashGet(props.action, 'originalMessage', {});
-
-    // IOUDetails only exists when we are sending money
-    const isSendingMoney = originalMessage.type === CONST.IOU.REPORT_ACTION_TYPE.PAY && _.has(originalMessage, 'IOUDetails');
-
     // When active action changes, we need to update the `isContextMenuActive` state
     const isActiveReportActionForMenu = ReportActionContextMenu.isActiveReportAction(props.action.reportActionID);
     useEffect(() => {
@@ -306,6 +301,10 @@ function ReportActionItem(props) {
      */
     const renderItemContent = (hovered = false, isWhisper = false, hasErrors = false) => {
         let children;
+        const originalMessage = lodashGet(props.action, 'originalMessage', {});
+
+        // IOUDetails only exists when we are sending money
+        const isSendingMoney = originalMessage.type === CONST.IOU.REPORT_ACTION_TYPE.PAY && _.has(originalMessage, 'IOUDetails');
 
         // Show the MoneyRequestPreview for when request was created, bill was split or money was sent
         if (
@@ -622,12 +621,6 @@ function ReportActionItem(props) {
                 reportID={props.report.reportID}
             />
         );
-    }
-
-    // For the `pay` IOU action on non-send money flow we don't want to show anything
-    // as the preview action is already shown by the create IOU action above
-    if (props.action.actionName === CONST.REPORT.ACTIONS.TYPE.IOU && originalMessage && originalMessage.type === CONST.IOU.REPORT_ACTION_TYPE.PAY && !isSendingMoney) {
-        return null;
     }
 
     const hasErrors = !_.isEmpty(props.action.errors);


### PR DESCRIPTION
Reverts Expensify/App#30079

From this discussion, this adds a few other side effects that are unintended
https://expensify.slack.com/archives/C07J32337/p1697843073603539
