### PR TITLE
Pasting large text displays text behind loading in search

### DIFF
--- a/src/components/OptionsSelector/BaseOptionsSelector.js
+++ b/src/components/OptionsSelector/BaseOptionsSelector.js
@@ -396,6 +396,9 @@ class BaseOptionsSelector extends Component {
                 spellCheck={false}
                 shouldInterceptSwipe={this.props.shouldTextInputInterceptSwipe}
                 isLoading={this.props.isLoadingNewOptions}
+                autoGrowHeight
+                containerStyles={[styles.autoGrowHeightMultilineInput]}
+                inputStyle={[styles.h4]}
             />
         );
         const optionsList = (

--- a/src/components/OptionsSelector/BaseOptionsSelector.js
+++ b/src/components/OptionsSelector/BaseOptionsSelector.js
@@ -396,9 +396,6 @@ class BaseOptionsSelector extends Component {
                 spellCheck={false}
                 shouldInterceptSwipe={this.props.shouldTextInputInterceptSwipe}
                 isLoading={this.props.isLoadingNewOptions}
-                autoGrowHeight
-                containerStyles={[styles.autoGrowHeightMultilineInput]}
-                inputStyle={[styles.h4]}
             />
         );
         const optionsList = (

--- a/src/components/TextInput/BaseTextInput.js
+++ b/src/components/TextInput/BaseTextInput.js
@@ -15,6 +15,7 @@ import * as Browser from '@libs/Browser';
 import getSecureEntryKeyboardType from '@libs/getSecureEntryKeyboardType';
 import isInputAutoFilled from '@libs/isInputAutoFilled';
 import useNativeDriver from '@libs/useNativeDriver';
+import shouldShowActivityIndicator from '@libs/shouldShowActivityIndicator';
 import styles from '@styles/styles';
 import * as StyleUtils from '@styles/StyleUtils';
 import themeColors from '@styles/themes/default';
@@ -40,6 +41,8 @@ function BaseTextInput(props) {
 
     const input = useRef(null);
     const isLabelActive = useRef(initialActiveLabel);
+
+    const operatingSystem = getOperatingSystem();
 
     // AutoFocus which only works on mount:
     useEffect(() => {
@@ -212,11 +215,6 @@ function BaseTextInput(props) {
         }
     };
 
-    const isNativeOS = () => {
-        const operatingSystem = getOperatingSystem();
-        return ['Android', 'iOS'].includes(operatingSystem);
-    }
-
     // eslint-disable-next-line react/forbid-foreign-prop-types
     const inputProps = _.omit(props, _.keys(baseTextInputPropTypes.propTypes));
     const hasLabel = Boolean(props.label.length);
@@ -370,13 +368,15 @@ function BaseTextInput(props) {
                                 // `dataset.submitOnEnter` is used to indicate that pressing Enter on this input should call the submit callback.
                                 dataSet={{submitOnEnter: isMultiline && props.submitOnEnter}}
                             />
-    
-                            <ActivityIndicator
-                                size="small"
-                                color={themeColors.iconSuccessFill}
-                                style={[styles.mt4, styles.ml1, isNativeOS && !props.isLoading ? styles.dNone : {}]}
-                                animating={props.isLoading}
-                            />
+
+                            {shouldShowActivityIndicator(props.isLoading) && (
+                                <ActivityIndicator
+                                    size="small"
+                                    color={themeColors.iconSuccessFill}
+                                    style={[styles.mt4, styles.ml1]}
+                                    animating={props.isLoading}
+                                />
+                            )}
 
                             {Boolean(props.secureTextEntry) && (
                                 <Checkbox

--- a/src/components/TextInput/BaseTextInput.js
+++ b/src/components/TextInput/BaseTextInput.js
@@ -41,8 +41,6 @@ function BaseTextInput(props) {
     const input = useRef(null);
     const isLabelActive = useRef(initialActiveLabel);
 
-    const operatingSystem = getOperatingSystem();
-
     // AutoFocus which only works on mount:
     useEffect(() => {
         // We are manually managing focus to prevent this issue: https://github.com/Expensify/App/issues/4514
@@ -214,6 +212,11 @@ function BaseTextInput(props) {
         }
     };
 
+    const isNativeOS = () => {
+        const operatingSystem = getOperatingSystem();
+        return ['Android', 'iOS'].includes(operatingSystem);
+    }
+
     // eslint-disable-next-line react/forbid-foreign-prop-types
     const inputProps = _.omit(props, _.keys(baseTextInputPropTypes.propTypes));
     const hasLabel = Boolean(props.label.length);
@@ -367,11 +370,11 @@ function BaseTextInput(props) {
                                 // `dataset.submitOnEnter` is used to indicate that pressing Enter on this input should call the submit callback.
                                 dataSet={{submitOnEnter: isMultiline && props.submitOnEnter}}
                             />
-
+    
                             <ActivityIndicator
                                 size="small"
                                 color={themeColors.iconSuccessFill}
-                                style={[styles.mt4, styles.ml1, ['Android', 'iOS'].includes(operatingSystem) && !props.isLoading ? styles.dNone : {}]}
+                                style={[styles.mt4, styles.ml1, isNativeOS && !props.isLoading ? styles.dNone : {}]}
                                 animating={props.isLoading}
                             />
 

--- a/src/components/TextInput/BaseTextInput.js
+++ b/src/components/TextInput/BaseTextInput.js
@@ -42,8 +42,6 @@ function BaseTextInput(props) {
     const input = useRef(null);
     const isLabelActive = useRef(initialActiveLabel);
 
-    const operatingSystem = getOperatingSystem();
-
     // AutoFocus which only works on mount:
     useEffect(() => {
         // We are manually managing focus to prevent this issue: https://github.com/Expensify/App/issues/4514

--- a/src/components/TextInput/BaseTextInput.js
+++ b/src/components/TextInput/BaseTextInput.js
@@ -295,7 +295,7 @@ function BaseTextInput(props) {
                             </>
                         ) : null}
                         <View
-                            style={[styles.textInputAndIconContainer, isMultiline && hasLabel && styles.textInputMultilineContainer]}
+                            style={[styles.textInputAndIconContainer, isMultiline && hasLabel && styles.textInputMultilineContainer, styles.overflowHidden]}
                             pointerEvents="box-none"
                         >
                             {Boolean(props.prefixCharacter) && (
@@ -346,6 +346,7 @@ function BaseTextInput(props) {
                                     props.autoGrowHeight && StyleUtils.getAutoGrowHeightInputStyle(textInputHeight, maxHeight),
                                     // Add disabled color theme when field is not editable.
                                     props.disabled && styles.textInputDisabled,
+                                    styles.overflowHidden,
                                 ]}
                                 multiline={isMultiline}
                                 maxLength={props.maxLength}
@@ -368,7 +369,7 @@ function BaseTextInput(props) {
                                 <ActivityIndicator
                                     size="small"
                                     color={themeColors.iconSuccessFill}
-                                    style={[styles.mt4, styles.ml1]}
+                                    style={[styles.mt4, styles.ml1, styles.alignSelfEnd]}
                                 />
                             )}
                             {Boolean(props.secureTextEntry) && (

--- a/src/components/TextInput/BaseTextInput.js
+++ b/src/components/TextInput/BaseTextInput.js
@@ -29,6 +29,7 @@ function BaseTextInput(props) {
     const initialActiveLabel = props.forceActiveLabel || initialValue.length > 0 || Boolean(props.prefixCharacter);
 
     const [isFocused, setIsFocused] = useState(false);
+
     const [passwordHidden, setPasswordHidden] = useState(props.secureTextEntry);
     const [textInputWidth, setTextInputWidth] = useState(0);
     const [textInputHeight, setTextInputHeight] = useState(0);
@@ -39,6 +40,8 @@ function BaseTextInput(props) {
 
     const input = useRef(null);
     const isLabelActive = useRef(initialActiveLabel);
+
+    const operatingSystem = getOperatingSystem();
 
     // AutoFocus which only works on mount:
     useEffect(() => {
@@ -295,7 +298,7 @@ function BaseTextInput(props) {
                             </>
                         ) : null}
                         <View
-                            style={[styles.textInputAndIconContainer, isMultiline && hasLabel && styles.textInputMultilineContainer, styles.overflowHidden]}
+                            style={[styles.textInputAndIconContainer, isMultiline && hasLabel && styles.textInputMultilineContainer, styles.justifyContentBetween]}
                             pointerEvents="box-none"
                         >
                             {Boolean(props.prefixCharacter) && (
@@ -346,7 +349,6 @@ function BaseTextInput(props) {
                                     props.autoGrowHeight && StyleUtils.getAutoGrowHeightInputStyle(textInputHeight, maxHeight),
                                     // Add disabled color theme when field is not editable.
                                     props.disabled && styles.textInputDisabled,
-                                    styles.overflowHidden,
                                 ]}
                                 multiline={isMultiline}
                                 maxLength={props.maxLength}
@@ -365,13 +367,14 @@ function BaseTextInput(props) {
                                 // `dataset.submitOnEnter` is used to indicate that pressing Enter on this input should call the submit callback.
                                 dataSet={{submitOnEnter: isMultiline && props.submitOnEnter}}
                             />
-                            {props.isLoading && (
-                                <ActivityIndicator
-                                    size="small"
-                                    color={themeColors.iconSuccessFill}
-                                    style={[styles.mt4, styles.ml1, styles.alignSelfEnd]}
-                                />
-                            )}
+
+                            <ActivityIndicator
+                                size="small"
+                                color={themeColors.iconSuccessFill}
+                                style={[styles.mt4, styles.ml1, ['Android', 'iOS'].includes(operatingSystem) && !props.isLoading ? styles.dNone : {}]}
+                                animating={props.isLoading}
+                            />
+
                             {Boolean(props.secureTextEntry) && (
                                 <Checkbox
                                     style={[styles.flex1, styles.textInputIconContainer]}

--- a/src/libs/shouldShowActivityIndicator/index.native.ts
+++ b/src/libs/shouldShowActivityIndicator/index.native.ts
@@ -1,0 +1,3 @@
+const shouldShowActivityIndicator = (isLoading: Boolean) => isLoading;
+
+export default shouldShowActivityIndicator;

--- a/src/libs/shouldShowActivityIndicator/index.ts
+++ b/src/libs/shouldShowActivityIndicator/index.ts
@@ -1,0 +1,3 @@
+const shouldShowActivityIndicator = (isLoading: Boolean) => typeof isLoading !== 'undefined';
+
+export default shouldShowActivityIndicator;


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
Currently, when a very long text is placed in the search field the spinner is noticeable above the text. Tests were performed and this only occurs in web browsers, not in native applications. For this reason, this change should only apply to those platforms.

The origin of the bug (and this is why there is a space at the end of the input in browsers) is that when we use Flexbox to align an input with any other object, if the input exceeds the maximum size it is not updated until a second iteration with the user even though with the devtool the container is updated, this behavior was verified by disabling JS and testing only the CSS.

Below is a video with more details:
- Please check when we remove the spinner the input continues on the original size even flexbox should do the work of keeping the spinner separated.
- Please check when we are writing (and maintaining any key pressed forcing the spinner to be visible) flexbox do the job, this was tested with javascript disabled and enabled: 

https://github.com/Expensify/App/assets/5216036/0767e6c0-6062-4bec-9949-7aeea3b0caa3

The solution was oriented to maintain the ActivityIndicator as his natural use using the parameter animate to show/hide the spinner, using this way flexbox works as intended for browsers.

### Fixed Issues
$  https://github.com/Expensify/App/issues/30180
PROPOSAL: https://github.com/Expensify/App/issues/30180#issuecomment-1775410569


### Tests
1. Open the app (in Chrome, safari, desktop) and login
2. Click on the search button at the top
3. Paste a long text in the search 
4. Verify the loading is over the text

- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

### QA Steps
Please verify the next in all platforms:
1. Open the app and login
2. Click on the search button at the top
3. Paste a long text in the search 
4. Verify the loading is over the text

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] If we are not using the full Onyx data that we loaded, I've added the proper selector in order to ensure the component only re-renders when the data it is using changes
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

https://github.com/Expensify/App/assets/5216036/6f5a9739-4f47-4438-9834-b08c4bd59f19

</details>

<details>
<summary>Android: mWeb Chrome</summary>


https://github.com/Expensify/App/assets/5216036/6223adcf-e60b-4303-b768-bebeee692453


</details>

<details>
<summary>iOS: Native</summary>

https://github.com/Expensify/App/assets/5216036/851fe72f-a39f-4a23-820f-2f66ac433cec

</details>

<details>
<summary>iOS: mWeb Safari</summary>

https://github.com/Expensify/App/assets/5216036/14e8b25d-36ef-424d-bc2f-ccbbc9446b52

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

https://github.com/Expensify/App/assets/5216036/7d92323a-6d20-4dfd-97ba-c3acbe50e50f

</details>

<details>
<summary>MacOS: Desktop</summary>

https://github.com/Expensify/App/assets/5216036/a28b2f94-8c04-4150-9bb4-3b7d26d94380

</details>
