### PR TITLE
Interactive sub step header component

### DIFF
--- a/src/components/InteractiveStepSubHeader.js
+++ b/src/components/InteractiveStepSubHeader.js
@@ -27,7 +27,7 @@ const MIN_AMOUNT_OF_STEPS = 2;
 
 function InteractiveStepSubHeader({stepNames, startStep, onStepSelected}, ref) {
     if (stepNames.length < MIN_AMOUNT_OF_STEPS) {
-        throw new Error('stepNames prop must have at least 2 elements.');
+        throw new Error('stepNames list must have at least 2 elements.');
     }
 
     const [currentStep, setCurrentStep] = useState(startStep);

--- a/src/components/InteractiveStepSubHeader.js
+++ b/src/components/InteractiveStepSubHeader.js
@@ -1,0 +1,100 @@
+import React, {forwardRef, useState, useImperativeHandle} from 'react';
+import PropTypes from 'prop-types';
+import map from 'lodash/map';
+import {View} from 'react-native';
+
+import CONST from '../CONST';
+import variables from '../styles/variables';
+import styles from '../styles/styles';
+import colors from '../styles/colors';
+import * as Expensicons from './Icon/Expensicons';
+import PressableWithFeedback from './Pressable/PressableWithFeedback';
+import Text from './Text';
+import Icon from './Icon';
+
+const propTypes = {
+    stepNames: PropTypes.arrayOf(PropTypes.string).isRequired,
+    onStepSelected: PropTypes.func.isRequired,
+    startStep: PropTypes.number,
+};
+
+const defaultProps = {
+    startStep: 0,
+};
+
+const MIN_AMOUNT_FOR_EXPANDING = 3;
+const MIN_AMOUNT_OF_STEPS = 2;
+
+function InteractiveStepSubHeader({stepNames, startStep, onStepSelected}, ref) {
+    const [currentStep, setCurrentStep] = useState(startStep);
+    useImperativeHandle(
+        ref,
+        () => ({
+            moveNext: () => {
+                setCurrentStep((actualStep) => actualStep + 1);
+            },
+        }),
+        [],
+    );
+
+    if (stepNames.length < MIN_AMOUNT_OF_STEPS) {
+        console.warn('InteractiveStepSubHeader: stepNames prop must have at least 2 elements');
+        return null;
+    }
+
+    const amountOfUnions = stepNames.length - 1;
+
+    return (
+        <View style={[styles.interactiveStepHeaderContainer, {minWidth: stepNames.length < MIN_AMOUNT_FOR_EXPANDING ? '60%' : '100%'}]}>
+            {map(stepNames, (stepName, index) => {
+                const isCompletedStep = currentStep > index;
+                const isLockedStep = currentStep < index;
+                const isLockedLine = currentStep < index + 1;
+                const hasUnion = index < amountOfUnions;
+
+                const moveToStep = () => {
+                    if (isLockedStep) {
+                        return;
+                    }
+                    setCurrentStep(index);
+                    onStepSelected(stepNames[index]);
+                };
+                return (
+                    <View
+                        style={[styles.interactiveStepHeaderStepContainer, hasUnion && styles.flex1]}
+                        key={stepName}
+                    >
+                        <PressableWithFeedback
+                            style={[
+                                styles.interactiveStepHeaderStepButton,
+                                isLockedStep && styles.interactiveStepHeaderLockedStepButton,
+                                isCompletedStep && styles.interactiveStepHeaderCompletedStepButton,
+                            ]}
+                            disabled={isLockedStep}
+                            onPress={moveToStep}
+                            accessibilityRole={CONST.ACCESSIBILITY_ROLE.BUTTON}
+                        >
+                            {isCompletedStep ? (
+                                <Icon
+                                    src={Expensicons.Checkmark}
+                                    width={variables.iconSizeNormal}
+                                    height={variables.iconSizeNormal}
+                                    fill={colors.white}
+                                />
+                            ) : (
+                                <Text style={styles.interactiveStepHeaderStepText}>{index + 1}</Text>
+                            )}
+                        </PressableWithFeedback>
+                        {hasUnion ? <View style={[styles.interactiveStepHeaderStepLine, isLockedLine && styles.interactiveStepHeaderLockedStepLine]} /> : null}
+                    </View>
+                );
+            })}
+        </View>
+    );
+}
+
+InteractiveStepSubHeader.propTypes = propTypes;
+InteractiveStepSubHeader.defaultProps = defaultProps;
+InteractiveStepSubHeader.displayName = 'InteractiveStepSubHeader';
+
+export default forwardRef(InteractiveStepSubHeader);

--- a/src/components/InteractiveStepSubHeader.js
+++ b/src/components/InteractiveStepSubHeader.js
@@ -25,7 +25,7 @@ const defaultProps = {
 const MIN_AMOUNT_FOR_EXPANDING = 3;
 const MIN_AMOUNT_OF_STEPS = 2;
 
-function InteractiveStepSubHeader({stepNames, startStep, onStepSelected}, ref) {
+const InteractiveStepSubHeader = forwardRef(({stepNames, startStep, onStepSelected}, ref) => {
     if (stepNames.length < MIN_AMOUNT_OF_STEPS) {
         throw new Error(`stepNames list must have at least ${MIN_AMOUNT_OF_STEPS} elements.`);
     }
@@ -90,10 +90,10 @@ function InteractiveStepSubHeader({stepNames, startStep, onStepSelected}, ref) {
             })}
         </View>
     );
-}
+});
 
 InteractiveStepSubHeader.propTypes = propTypes;
 InteractiveStepSubHeader.defaultProps = defaultProps;
 InteractiveStepSubHeader.displayName = 'InteractiveStepSubHeader';
 
-export default forwardRef(InteractiveStepSubHeader);
+export default InteractiveStepSubHeader;

--- a/src/components/InteractiveStepSubHeader.js
+++ b/src/components/InteractiveStepSubHeader.js
@@ -27,7 +27,7 @@ const MIN_AMOUNT_OF_STEPS = 2;
 
 function InteractiveStepSubHeader({stepNames, startStep, onStepSelected}, ref) {
     if (stepNames.length < MIN_AMOUNT_OF_STEPS) {
-        throw new Error('stepNames list must have at least 2 elements.');
+        throw new Error(`stepNames list must have at least ${MIN_AMOUNT_OF_STEPS} elements.`);
     }
 
     const [currentStep, setCurrentStep] = useState(startStep);

--- a/src/components/InteractiveStepSubHeader.js
+++ b/src/components/InteractiveStepSubHeader.js
@@ -26,6 +26,10 @@ const MIN_AMOUNT_FOR_EXPANDING = 3;
 const MIN_AMOUNT_OF_STEPS = 2;
 
 function InteractiveStepSubHeader({stepNames, startStep, onStepSelected}, ref) {
+    if (stepNames.length < MIN_AMOUNT_OF_STEPS) {
+        throw new Error('stepNames prop must have at least 2 elements.');
+    }
+
     const [currentStep, setCurrentStep] = useState(startStep);
     useImperativeHandle(
         ref,
@@ -36,11 +40,6 @@ function InteractiveStepSubHeader({stepNames, startStep, onStepSelected}, ref) {
         }),
         [],
     );
-
-    if (stepNames.length < MIN_AMOUNT_OF_STEPS) {
-        console.warn('InteractiveStepSubHeader: stepNames prop must have at least 2 elements');
-        return null;
-    }
 
     const amountOfUnions = stepNames.length - 1;
 

--- a/src/components/InteractiveStepSubHeader.js
+++ b/src/components/InteractiveStepSubHeader.js
@@ -13,8 +13,13 @@ import Text from './Text';
 import Icon from './Icon';
 
 const propTypes = {
+    /** List of the Route Name to navigate when the step is selected */
     stepNames: PropTypes.arrayOf(PropTypes.string).isRequired,
+
+    /** Function to call when a step is selected */
     onStepSelected: PropTypes.func.isRequired,
+
+    /** The index of the step to start with */
     startStep: PropTypes.number,
 };
 

--- a/src/stories/InteractiveStepSubHeader.stories.js
+++ b/src/stories/InteractiveStepSubHeader.stories.js
@@ -32,7 +32,7 @@ function BaseInteractiveStepSubHeader(props) {
                 ref={ref}
             />
             <Button
-                onPress={ref.current.moveNext}
+                onPress={() => ref.current.moveNext()}
                 title="Next"
             />
         </View>
@@ -42,10 +42,12 @@ function BaseInteractiveStepSubHeader(props) {
 Default.args = {
     stepNames: ['Initial', 'Step 1', 'Step 2', 'Step 3'],
     startStep: 1,
+    onStepSelected: () => {},
 };
 BaseInteractiveStepSubHeader.args = {
     stepNames: ['Initial', 'Step 1', 'Step 2', 'Step 3', 'Confirmation'],
     startStep: 0,
+    onStepSelected: () => {},
 };
 
 export default story;

--- a/src/stories/InteractiveStepSubHeader.stories.js
+++ b/src/stories/InteractiveStepSubHeader.stories.js
@@ -1,0 +1,54 @@
+/* eslint-disable react/jsx-props-no-spreading */
+import React, {useRef} from 'react';
+import {View, Button} from 'react-native';
+
+import InteractiveStepSubHeader from '../components/InteractiveStepSubHeader';
+
+/**
+ * We use the Component Story Format for writing stories. Follow the docs here:
+ *
+ * https://storybook.js.org/docs/react/writing-stories/introduction#component-story-format
+ */
+const story = {
+    title: 'Components/InteractiveStepSubHeader',
+    component: InteractiveStepSubHeader,
+};
+
+function Template(args) {
+    // eslint-disable-next-line react/jsx-props-no-spreading
+    return <InteractiveStepSubHeader {...args} />;
+}
+
+// Arguments can be passed to the component by binding
+// See: https://storybook.js.org/docs/react/writing-stories/introduction#using-args
+const Default = Template.bind({});
+
+function BaseInteractiveStepSubHeader(props) {
+    const ref = useRef(null);
+    return (
+        <View>
+            <InteractiveStepSubHeader
+                {...props}
+                ref={ref}
+            />
+            <Button
+                onPress={() => {
+                    ref.current.moveNext();
+                }}
+                title="Next"
+            />
+        </View>
+    );
+}
+
+Default.args = {
+    stepNames: ['Initial', 'Step 1', 'Step 2', 'Step 3'],
+    startStep: 1,
+};
+BaseInteractiveStepSubHeader.args = {
+    stepNames: ['Initial', 'Step 1', 'Step 2', 'Step 3', 'Confirmation'],
+    startStep: 0,
+};
+
+export default story;
+export {Default, BaseInteractiveStepSubHeader};

--- a/src/stories/InteractiveStepSubHeader.stories.js
+++ b/src/stories/InteractiveStepSubHeader.stories.js
@@ -32,9 +32,7 @@ function BaseInteractiveStepSubHeader(props) {
                 ref={ref}
             />
             <Button
-                onPress={() => {
-                    ref.current.moveNext();
-                }}
+                onPress={ref.current.moveNext}
                 title="Next"
             />
         </View>

--- a/src/styles/styles.ts
+++ b/src/styles/styles.ts
@@ -4035,6 +4035,53 @@ const styles = (theme: ThemeDefault) =>
         singleOptionSelectorCircle: {
             borderColor: theme.icon,
         },
+
+        interactiveStepHeaderContainer: {
+            flex: 1,
+            alignSelf: 'center',
+            flexDirection: 'row',
+            paddingBottom: 24,
+        },
+
+        interactiveStepHeaderStepContainer: {
+            flexDirection: 'row',
+            alignItems: 'center',
+        },
+
+        interactiveStepHeaderStepButton: {
+            width: 40,
+            height: 40,
+            borderWidth: 1,
+            borderRadius: 20,
+            borderColor: colors.green400,
+            justifyContent: 'center',
+            alignItems: 'center',
+            color: colors.white,
+        },
+
+        interactiveStepHeaderLockedStepButton: {
+            borderColor: colors.darkBorders,
+        },
+
+        interactiveStepHeaderStepText: {
+            fontSize: variables.fontSizeLabel,
+            fontFamily: fontFamily.EXP_NEUE_BOLD,
+            fontWeight: fontWeightBold,
+        },
+
+        interactiveStepHeaderCompletedStepButton: {
+            backgroundColor: colors.green400,
+        },
+
+        interactiveStepHeaderStepLine: {
+            height: 1,
+            flexGrow: 1,
+            backgroundColor: colors.green400,
+        },
+
+        interactiveStepHeaderLockedStepLine: {
+            backgroundColor: colors.darkBorders,
+        },
     } satisfies Styles);
 
 // For now we need to export the styles function that takes the theme as an argument


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->
Step header component which is interactive, you can press on the completed ones or move to the next step using the ref

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/30237
PROPOSAL: -


### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

- [x] Verify that no errors appear in the JS console

Use Storybook
- if you have the code: run it in the terminal `npm run storybook`

Default: 
It shows the state of all the steps, completed, current and locked future steps
- Clicking the step 1 (completed)
- Step 2 should change style to locked one
- Step 1 now shows the current step style
- You can't click any of the future steps

Interactive:
You can move to future locked steps when clicking the Next button
- Step 1 should show the current style
- Click on the Next button to move from step 1 to 2
- Step 1 shows the completed style and step 2 shows the current style
- You can keep clicking the Next Button until all the steps are completed
- clicking on a completed step, make the clicked one current and any future step locked
- you can't click on future steps

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] If we are not using the full Onyx data that we loaded, I've added the proper selector in order to ensure the component only re-renders when the data it is using changes
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

Only on Storybook


https://github.com/gedu/App/assets/1676818/64cf724c-6d13-453b-a9c0-3fb5274bfb8f



### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Desktop</summary>

<!-- add screenshots or videos here -->

</details>
