### PR TITLE
change font size for code block in H1

### DIFF
--- a/src/components/HTMLEngineProvider/HTMLRenderers/AnchorRenderer.js
+++ b/src/components/HTMLEngineProvider/HTMLRenderers/AnchorRenderer.js
@@ -70,7 +70,7 @@ function AnchorRenderer(props) {
         Link.openExternalLink(attrHref);
     };
 
-    if (!HTMLEngineUtils.isInsideComment(props.tnode)) {
+    if (!HTMLEngineUtils.isChildOfComment(props.tnode)) {
         // This is not a comment from a chat, the AnchorForCommentsOnly uses a Pressable to create a context menu on right click.
         // We don't have this behaviour in other links in NewDot
         // TODO: We should use TextLink, but I'm leaving it as Text for now because TextLink breaks the alignment in Android.

--- a/src/components/HTMLEngineProvider/HTMLRenderers/CodeRenderer.js
+++ b/src/components/HTMLEngineProvider/HTMLRenderers/CodeRenderer.js
@@ -23,8 +23,7 @@ function CodeRenderer(props) {
     )
     
     const fontSize = StyleUtils.getCodeFontSize(
-        isInsideH1,
-        textStyle
+        isInsideH1
     )
 
     const textStyleOverride = {

--- a/src/components/HTMLEngineProvider/HTMLRenderers/CodeRenderer.js
+++ b/src/components/HTMLEngineProvider/HTMLRenderers/CodeRenderer.js
@@ -17,12 +17,9 @@ function CodeRenderer(props) {
         fontWeight: textStyle.fontWeight,
     });
 
-    // Check if the current element is inside an h1 tag, and set a specific font size if true,
-    // otherwise, use the font size defined in `textStyle`.
     const fontSize = HTMLEngineUtils.isInsideH1(props.tnode) ? 15 : textStyle.fontSize;
 
     const textStyleOverride = {
-        // Override the font family and font size for the rendered HTML element.
         fontSize: fontSize,
         fontFamily: font,
 

--- a/src/components/HTMLEngineProvider/HTMLRenderers/CodeRenderer.js
+++ b/src/components/HTMLEngineProvider/HTMLRenderers/CodeRenderer.js
@@ -17,7 +17,13 @@ function CodeRenderer(props) {
         fontWeight: textStyle.fontWeight,
     });
 
-    const fontSize = HTMLEngineUtils.isInsideH1(props.tnode) ? 15 : textStyle.fontSize;
+    // Determine the font size for the code based on whether it's inside an H1 element.
+    const fontSize = StyleUtils.getCodeFontSize(
+        HTMLEngineUtils.isInsideH1(
+            props.tnode
+        ),
+        textStyle
+    )
 
     const textStyleOverride = {
         fontSize: fontSize,

--- a/src/components/HTMLEngineProvider/HTMLRenderers/CodeRenderer.js
+++ b/src/components/HTMLEngineProvider/HTMLRenderers/CodeRenderer.js
@@ -4,6 +4,7 @@ import _ from 'underscore';
 import InlineCodeBlock from '@components/InlineCodeBlock';
 import * as StyleUtils from '@styles/StyleUtils';
 import htmlRendererPropTypes from './htmlRendererPropTypes';
+import * as HTMLEngineUtils from '@components/HTMLEngineProvider/htmlEngineUtils';
 
 function CodeRenderer(props) {
     // We split wrapper and inner styles
@@ -16,7 +17,13 @@ function CodeRenderer(props) {
         fontWeight: textStyle.fontWeight,
     });
 
+    // Check if the current element is inside an h1 tag, and set a specific font size if true,
+    // otherwise, use the font size defined in `textStyle`.
+    const fontSize = HTMLEngineUtils.isInsideH1(props.tnode) ? 15 : textStyle.fontSize;
+
     const textStyleOverride = {
+        // Override the font family and font size for the rendered HTML element.
+        fontSize: fontSize,
         fontFamily: font,
 
         // We need to override this properties bellow that was defined in `textStyle`

--- a/src/components/HTMLEngineProvider/HTMLRenderers/CodeRenderer.js
+++ b/src/components/HTMLEngineProvider/HTMLRenderers/CodeRenderer.js
@@ -23,7 +23,7 @@ function CodeRenderer(props) {
     const fontSize = StyleUtils.getCodeFontSize(isInsideH1);
 
     const textStyleOverride = {
-        fontSize: fontSize,
+        fontSize,
         fontFamily: font,
 
         // We need to override this properties bellow that was defined in `textStyle`

--- a/src/components/HTMLEngineProvider/HTMLRenderers/CodeRenderer.js
+++ b/src/components/HTMLEngineProvider/HTMLRenderers/CodeRenderer.js
@@ -18,10 +18,12 @@ function CodeRenderer(props) {
     });
 
     // Determine the font size for the code based on whether it's inside an H1 element.
+    const isInsideH1 = HTMLEngineUtils.isInsideH1(
+        props.tnode
+    )
+    
     const fontSize = StyleUtils.getCodeFontSize(
-        HTMLEngineUtils.isInsideH1(
-            props.tnode
-        ),
+        isInsideH1,
         textStyle
     )
 

--- a/src/components/HTMLEngineProvider/HTMLRenderers/CodeRenderer.js
+++ b/src/components/HTMLEngineProvider/HTMLRenderers/CodeRenderer.js
@@ -18,7 +18,7 @@ function CodeRenderer(props) {
     });
 
     // Determine the font size for the code based on whether it's inside an H1 element.
-    const isInsideH1 = HTMLEngineUtils.isInsideH1(props.tnode);
+    const isInsideH1 = HTMLEngineUtils.isChildOfH1(props.tnode);
 
     const fontSize = StyleUtils.getCodeFontSize(isInsideH1);
 

--- a/src/components/HTMLEngineProvider/HTMLRenderers/CodeRenderer.js
+++ b/src/components/HTMLEngineProvider/HTMLRenderers/CodeRenderer.js
@@ -1,10 +1,10 @@
 import React from 'react';
 import {splitBoxModelStyle} from 'react-native-render-html';
 import _ from 'underscore';
+import * as HTMLEngineUtils from '@components/HTMLEngineProvider/htmlEngineUtils';
 import InlineCodeBlock from '@components/InlineCodeBlock';
 import * as StyleUtils from '@styles/StyleUtils';
 import htmlRendererPropTypes from './htmlRendererPropTypes';
-import * as HTMLEngineUtils from '@components/HTMLEngineProvider/htmlEngineUtils';
 
 function CodeRenderer(props) {
     // We split wrapper and inner styles
@@ -18,13 +18,9 @@ function CodeRenderer(props) {
     });
 
     // Determine the font size for the code based on whether it's inside an H1 element.
-    const isInsideH1 = HTMLEngineUtils.isInsideH1(
-        props.tnode
-    )
-    
-    const fontSize = StyleUtils.getCodeFontSize(
-        isInsideH1
-    )
+    const isInsideH1 = HTMLEngineUtils.isInsideH1(props.tnode);
+
+    const fontSize = StyleUtils.getCodeFontSize(isInsideH1);
 
     const textStyleOverride = {
         fontSize: fontSize,

--- a/src/components/HTMLEngineProvider/htmlEngineUtils.js
+++ b/src/components/HTMLEngineProvider/htmlEngineUtils.js
@@ -28,15 +28,16 @@ function isCommentTag(tagName) {
 }
 
 /**
- * Check if there is an ancestor node with name 'comment'.
- * Finding node with name 'comment' flags that we are rendering a comment.
+ * Check if there is an ancestor node for which the predicate returns true.
+ *
  * @param {TNode} tnode
+ * @param {Function} predicate
  * @returns {Boolean}
  */
-function isInsideComment(tnode) {
-    let currentNode = tnode;
-    while (currentNode.parent) {
-        if (isCommentTag(currentNode.domNode.name)) {
+function isChildOfNode(tnode, predicate) {
+    let currentNode = tnode.parent;
+    while (currentNode) {
+        if (predicate(currentNode)) {
             return true;
         }
         currentNode = currentNode.parent;
@@ -45,20 +46,23 @@ function isInsideComment(tnode) {
 }
 
 /**
+ * Check if there is an ancestor node with name 'comment'.
+ * Finding node with name 'comment' flags that we are rendering a comment.
+ * @param {TNode} tnode
+ * @returns {Boolean}
+ */
+function isChildOfComment(tnode) {
+    return isChildOfNode(tnode, (node) => isCommentTag(node.domNode.name));
+}
+
+/**
  * Check if there is an ancestor node with the name 'h1'.
  * Finding a node with the name 'h1' flags that we are rendering inside an h1 element.
  * @param {TNode} tnode
  * @returns {Boolean}
  */
-function isInsideH1(tnode) {
-    let currentNode = tnode.parent;
-    while (currentNode) {
-        if (currentNode.domNode.name === 'h1') {
-            return true;
-        }
-        currentNode = currentNode.parent;
-    }
-    return false;
+function isChildOfH1(tnode) {
+    return isChildOfNode(tnode, (node) => node.domNode.name.toLowerCase() === 'h1');
 }
 
-export {computeEmbeddedMaxWidth, isInsideComment, isCommentTag, isInsideH1};
+export {computeEmbeddedMaxWidth, isChildOfComment, isCommentTag, isChildOfH1};

--- a/src/components/HTMLEngineProvider/htmlEngineUtils.js
+++ b/src/components/HTMLEngineProvider/htmlEngineUtils.js
@@ -51,8 +51,8 @@ function isInsideComment(tnode) {
  * @returns {Boolean}
  */
 function isInsideH1(tnode) {
-    let currentNode = tnode;
-    while (currentNode.parent) {
+    let currentNode = tnode.parent;
+    while (currentNode) {
         if (currentNode.domNode.name === 'h1') {
             return true;
         }

--- a/src/components/HTMLEngineProvider/htmlEngineUtils.js
+++ b/src/components/HTMLEngineProvider/htmlEngineUtils.js
@@ -44,4 +44,21 @@ function isInsideComment(tnode) {
     return false;
 }
 
-export {computeEmbeddedMaxWidth, isInsideComment, isCommentTag};
+/**
+ * Check if there is an ancestor node with the name 'h1'.
+ * Finding a node with the name 'h1' flags that we are rendering inside an h1 element.
+ * @param {TNode} tnode
+ * @returns {Boolean}
+ */
+function isInsideH1(tnode) {
+    let currentNode = tnode;
+    while (currentNode) {
+        if (currentNode.domNode.name === 'h1') {
+            return true;
+        }
+        currentNode = currentNode.parent;
+    }
+    return false;
+}
+
+export {computeEmbeddedMaxWidth, isInsideComment, isCommentTag, isInsideH1};

--- a/src/components/HTMLEngineProvider/htmlEngineUtils.js
+++ b/src/components/HTMLEngineProvider/htmlEngineUtils.js
@@ -52,7 +52,7 @@ function isInsideComment(tnode) {
  */
 function isInsideH1(tnode) {
     let currentNode = tnode;
-    while (currentNode) {
+    while (currentNode.parent) {
         if (currentNode.domNode.name === 'h1') {
             return true;
         }

--- a/src/styles/StyleUtils.ts
+++ b/src/styles/StyleUtils.ts
@@ -606,6 +606,16 @@ function getFontFamilyMonospace({fontStyle, fontWeight}: TextStyle): string {
 
     return italicBold || bold || italic || fontFamily.MONOSPACE;
 }
+/**
+ * Returns the font size for the HTML code tag renderer.
+ */
+function getCodeFontSize(isInsideH1:Boolean, textStyle :TextStyle) {
+    if (isInsideH1) {
+      return 15;
+    } else {
+      return textStyle.fontSize;
+    }
+  }
 
 /**
  * Gives the width for Emoji picker Widget
@@ -1377,6 +1387,7 @@ export {
     getEmptyAvatarStyle,
     getErrorPageContainerStyle,
     getFontFamilyMonospace,
+    getCodeFontSize,
     getFontSizeStyle,
     getGoogleListViewStyle,
     getHeightOfMagicCodeInput,

--- a/src/styles/StyleUtils.ts
+++ b/src/styles/StyleUtils.ts
@@ -609,7 +609,7 @@ function getFontFamilyMonospace({fontStyle, fontWeight}: TextStyle): string {
 /**
  * Returns the font size for the HTML code tag renderer.
  */
-function getCodeFontSize(isInsideH1: Boolean) {
+function getCodeFontSize(isInsideH1: boolean) {
     return isInsideH1 ? 15 : 13;
 }
 

--- a/src/styles/StyleUtils.ts
+++ b/src/styles/StyleUtils.ts
@@ -609,13 +609,13 @@ function getFontFamilyMonospace({fontStyle, fontWeight}: TextStyle): string {
 /**
  * Returns the font size for the HTML code tag renderer.
  */
-function getCodeFontSize(isInsideH1:Boolean) {
+function getCodeFontSize(isInsideH1: Boolean) {
     if (isInsideH1) {
-      return 15;
+        return 15;
     } else {
-      return 13;
+        return 13;
     }
-  }
+}
 
 /**
  * Gives the width for Emoji picker Widget

--- a/src/styles/StyleUtils.ts
+++ b/src/styles/StyleUtils.ts
@@ -610,11 +610,7 @@ function getFontFamilyMonospace({fontStyle, fontWeight}: TextStyle): string {
  * Returns the font size for the HTML code tag renderer.
  */
 function getCodeFontSize(isInsideH1: Boolean) {
-    if (isInsideH1) {
-        return 15;
-    } else {
-        return 13;
-    }
+    return isInsideH1 ? 15 : 13;
 }
 
 /**

--- a/src/styles/StyleUtils.ts
+++ b/src/styles/StyleUtils.ts
@@ -609,11 +609,11 @@ function getFontFamilyMonospace({fontStyle, fontWeight}: TextStyle): string {
 /**
  * Returns the font size for the HTML code tag renderer.
  */
-function getCodeFontSize(isInsideH1:Boolean, textStyle :TextStyle) {
+function getCodeFontSize(isInsideH1:Boolean) {
     if (isInsideH1) {
       return 15;
     } else {
-      return textStyle.fontSize;
+      return 13;
     }
   }
 

--- a/src/styles/styles.ts
+++ b/src/styles/styles.ts
@@ -181,7 +181,7 @@ const webViewStyles = (theme: ThemeDefault) =>
                 paddingLeft: 5,
                 paddingRight: 5,
                 fontFamily: fontFamily.MONOSPACE,
-                fontSize: 13,
+                // Font size is determined by getCodeFontSize function in `StyleUtils.js`
             },
 
             img: {


### PR DESCRIPTION
@s77rt 

### Details
Created a new function to check if there is an ancestor node with the name 'h1' and applied on CodeRenderer.js to change code block font-size if it is inside h1 tag.

### Fixed Issues
$ https://github.com/Expensify/App/issues/30203
PROPOSAL: https://github.com/Expensify/App/issues/30203#issuecomment-1776167351


### Tests

1. Open the app
2. Open any report
3. Send a normal message and observe its font size
4. Send a heading message (add # in beginning)
5. Verify that the font size of the heading message is bigger than that of the normal message
6. Send a normal single backtick code block e.g. `Hello` and observe its font size
7. Send a heading single backtick code block eg: **# `Hello`**
8. Verify that the font size of the heading message is bigger than that of the normal message

- [x] Verify that no errors appear in the JS console

### Offline tests
Not connectivity related.

### QA Steps

1. Open the app
2. Open any report
3. Send a normal message and observe its font size
4. Send a heading message (add # in beginning)
5. Verify that the font size of the heading message is bigger than that of the normal message
6. Send a normal single backtick code block e.g. `Hello` and observe its font size
7. Send a heading single backtick code block eg: **# `Hello`**
8. Verify that the font size of the heading message is bigger than that of the normal message

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] If we are not using the full Onyx data that we loaded, I've added the proper selector in order to ensure the component only re-renders when the data it is using changes
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos

<details>
<summary>Android: Native</summary>

![android-Native](https://github.com/Expensify/App/assets/66640310/2981f0c1-57ba-4b11-91f2-93a564012872)


</details>


<details>
<summary>Android: mWeb Chrome</summary>

![android-mWeb](https://github.com/Expensify/App/assets/66640310/7af8841d-5ced-4333-bfab-5e01112bb333)


</details>


<details>
<summary>iOS: Native</summary>

![ios-native](https://github.com/Expensify/App/assets/66640310/0b6146be-e8ee-4055-a4c5-9f2cca2c46af)

</details>


<details>
<summary>iOS: mWeb Safari</summary>

![ios-mWeb](https://github.com/Expensify/App/assets/66640310/4f1df92a-c7f2-4033-befc-57859546032d)


</details>
<details>
<summary>MacOS: Chrome / Safari</summary>


https://github.com/Expensify/App/assets/66640310/34b2635c-5b59-4c50-ae43-b618eda32e19


</details>


<details>
<summary>MacOS: Desktop</summary>

![MacOS-Desktop](https://github.com/Expensify/App/assets/66640310/2e206cd4-e64b-4b36-ac94-e44a5760175a)



</details>

