### PR TITLE
Handle invisible characters in forms v2

### DIFF
--- a/src/CONST.ts
+++ b/src/CONST.ts
@@ -1366,6 +1366,10 @@ const CONST = {
         ILLEGAL_FILENAME_CHARACTERS: /\/|<|>|\*|"|:|\?|\\|\|/g,
 
         ENCODE_PERCENT_CHARACTER: /%(25)+/g,
+
+        INVISIBLE_CHARACTERS_GROUPS: /[\p{C}\p{Z}]/gu,
+
+        OTHER_INVISIBLE_CHARACTERS: /[\u3164]/g,
     },
 
     PRONOUNS: {

--- a/src/components/Form/FormProvider.js
+++ b/src/components/Form/FormProvider.js
@@ -6,6 +6,7 @@ import _ from 'underscore';
 import networkPropTypes from '@components/networkPropTypes';
 import {withNetwork} from '@components/OnyxProvider';
 import compose from '@libs/compose';
+import * as ValidationUtils from '@libs/ValidationUtils';
 import Visibility from '@libs/Visibility';
 import stylePropTypes from '@styles/stylePropTypes';
 import * as FormActions from '@userActions/FormActions';
@@ -108,14 +109,7 @@ function FormProvider({validate, formID, shouldValidateOnBlur, shouldValidateOnC
 
     const onValidate = useCallback(
         (values, shouldClearServerError = true) => {
-            const trimmedStringValues = {};
-            _.each(values, (inputValue, inputID) => {
-                if (_.isString(inputValue)) {
-                    trimmedStringValues[inputID] = inputValue.trim();
-                } else {
-                    trimmedStringValues[inputID] = inputValue;
-                }
-            });
+            const trimmedStringValues = ValidationUtils.prepareValues(values);
 
             if (shouldClearServerError) {
                 FormActions.setErrors(formID, null);
@@ -186,11 +180,14 @@ function FormProvider({validate, formID, shouldValidateOnBlur, shouldValidateOnC
             return;
         }
 
+        // Prepare values before submitting
+        const trimmedStringValues = ValidationUtils.prepareValues(inputValues);
+
         // Touches all form inputs so we can validate the entire form
         _.each(inputRefs.current, (inputRef, inputID) => (touchedInputs.current[inputID] = true));
 
         // Validate form and return early if any errors are found
-        if (!_.isEmpty(onValidate(inputValues))) {
+        if (!_.isEmpty(onValidate(trimmedStringValues))) {
             return;
         }
 
@@ -199,7 +196,7 @@ function FormProvider({validate, formID, shouldValidateOnBlur, shouldValidateOnC
             return;
         }
 
-        onSubmit(inputValues);
+        onSubmit(trimmedStringValues);
     }, [enabledWhenOffline, formState.isLoading, inputValues, network.isOffline, onSubmit, onValidate]);
 
     const registerInput = useCallback(

--- a/src/libs/StringUtils.ts
+++ b/src/libs/StringUtils.ts
@@ -38,9 +38,16 @@ function removeInvisibleCharacters(value: string): string {
     // - \u2060: word joiner
     result = result.replace(/[\u200B\u00A0\u2060]/g, '');
 
+    // Temporarily replace all newlines with non-breaking spaces
+    // It is necessary because the next step removes all newlines because they are in the (Cc) category
+    result = result.replace(/\n/g, '\u00A0');
+
     // Remove all characters from the 'Other' (C) category except for format characters (Cf)
     // because some of them are used for emojis
     result = result.replace(/[\p{Cc}\p{Cs}\p{Co}\p{Cn}]/gu, '');
+
+    // Replace all non-breaking spaces with newlines
+    result = result.replace(/\u00A0/g, '\n');
 
     // Remove characters from the (Cf) category that are not used for emojis
     result = result.replace(/[\u200E-\u200F]/g, '');

--- a/src/libs/StringUtils.ts
+++ b/src/libs/StringUtils.ts
@@ -10,4 +10,50 @@ function sanitizeString(str: string): string {
     return _.deburr(str).toLowerCase().replaceAll(CONST.REGEX.NON_ALPHABETIC_AND_NON_LATIN_CHARS, '');
 }
 
-export default {sanitizeString};
+/**
+ *  Check if the string would be empty if all invisible characters were removed.
+ */
+function isEmptyString(value: string): boolean {
+    // \p{C} matches all 'Other' characters
+    // \p{Z} matches all separators (spaces etc.)
+    // Source: http://www.unicode.org/reports/tr18/#General_Category_Property
+    let transformed = value.replace(CONST.REGEX.INVISIBLE_CHARACTERS_GROUPS, '');
+
+    // Remove other invisible characters that are not in the above unicode categories
+    transformed = transformed.replace(CONST.REGEX.OTHER_INVISIBLE_CHARACTERS, '');
+
+    // Check if after removing invisible characters the string is empty
+    return transformed === '';
+}
+
+/**
+ *  Remove invisible characters from a string except for spaces and format characters for emoji, and trim it.
+ */
+function removeInvisibleCharacters(value: string): string {
+    let result = value;
+
+    // Remove spaces:
+    // - \u200B: zero-width space
+    // - \u00A0: non-breaking space
+    // - \u2060: word joiner
+    result = result.replace(/[\u200B\u00A0\u2060]/g, '');
+
+    // Remove all characters from the 'Other' (C) category except for format characters (Cf)
+    // because some of them are used for emojis
+    result = result.replace(/[\p{Cc}\p{Cs}\p{Co}\p{Cn}]/gu, '');
+
+    // Remove characters from the (Cf) category that are not used for emojis
+    result = result.replace(/[\u200E-\u200F]/g, '');
+
+    // Remove all characters from the 'Separator' (Z) category except for Space Separator (Zs)
+    result = result.replace(/[\p{Zl}\p{Zp}]/gu, '');
+
+    // If the result consist of only invisible characters, return an empty string
+    if (isEmptyString(result)) {
+        return '';
+    }
+
+    return result.trim();
+}
+
+export default {sanitizeString, isEmptyString, removeInvisibleCharacters};

--- a/src/libs/ValidationUtils.ts
+++ b/src/libs/ValidationUtils.ts
@@ -9,6 +9,7 @@ import {Report} from '@src/types/onyx';
 import * as OnyxCommon from '@src/types/onyx/OnyxCommon';
 import * as CardUtils from './CardUtils';
 import * as LoginUtils from './LoginUtils';
+import StringUtils from './StringUtils';
 
 /**
  * Implements the Luhn Algorithm, a checksum formula used to validate credit card
@@ -73,7 +74,7 @@ function isValidPastDate(date: string | Date): boolean {
  */
 function isRequiredFulfilled(value: string | Date | unknown[] | Record<string, unknown>): boolean {
     if (typeof value === 'string') {
-        return value.trim().length > 0;
+        return !StringUtils.isEmptyString(value);
     }
 
     if (isDate(value)) {
@@ -352,6 +353,25 @@ function isValidAccountRoute(accountID: number): boolean {
     return CONST.REGEX.NUMBER.test(String(accountID)) && accountID > 0;
 }
 
+type ValuesType = Record<string, unknown>;
+
+/**
+ * This function is used to remove invisible characters from strings before validation and submission.
+ */
+function prepareValues(values: ValuesType): ValuesType {
+    const trimmedStringValues: ValuesType = {};
+
+    for (const [inputID, inputValue] of Object.entries(values)) {
+        if (typeof inputValue === 'string') {
+            trimmedStringValues[inputID] = StringUtils.removeInvisibleCharacters(inputValue);
+        } else {
+            trimmedStringValues[inputID] = inputValue;
+        }
+    }
+
+    return trimmedStringValues;
+}
+
 export {
     meetsMinimumAgeRequirement,
     meetsMaximumAgeRequirement,
@@ -385,4 +405,5 @@ export {
     isNumeric,
     isValidAccountRoute,
     isValidRecoveryCode,
+    prepareValues,
 };

--- a/src/pages/workspace/WorkspaceSettingsPage.js
+++ b/src/pages/workspace/WorkspaceSettingsPage.js
@@ -20,6 +20,7 @@ import compose from '@libs/compose';
 import Navigation from '@libs/Navigation/Navigation';
 import * as ReportUtils from '@libs/ReportUtils';
 import * as UserUtils from '@libs/UserUtils';
+import * as ValidationUtils from '@libs/ValidationUtils';
 import styles from '@styles/styles';
 import * as Policy from '@userActions/Policy';
 import CONST from '@src/CONST';
@@ -77,7 +78,7 @@ function WorkspaceSettingsPage({policy, currencyList, windowWidth, route}) {
         const errors = {};
         const name = values.name.trim();
 
-        if (!name || !name.length) {
+        if (!ValidationUtils.isRequiredFulfilled(name)) {
             errors.name = 'workspace.editor.nameIsRequiredError';
         } else if ([...name].length > CONST.WORKSPACE_NAME_CHARACTER_LIMIT) {
             // Uses the spread syntax to count the number of Unicode code points instead of the number of UTF-16

--- a/src/stories/Form.stories.js
+++ b/src/stories/Form.stories.js
@@ -10,6 +10,7 @@ import StatePicker from '@components/StatePicker';
 import Text from '@components/Text';
 import TextInput from '@components/TextInput';
 import NetworkConnection from '@libs/NetworkConnection';
+import * as ValidationUtils from '@libs/ValidationUtils';
 import styles from '@styles/styles';
 import * as FormActions from '@userActions/FormActions';
 import CONST from '@src/CONST';
@@ -177,28 +178,28 @@ const defaultArgs = {
     submitButtonText: 'Submit',
     validate: (values) => {
         const errors = {};
-        if (!values.routingNumber) {
+        if (!ValidationUtils.isRequiredFulfilled(values.routingNumber)) {
             errors.routingNumber = 'Please enter a routing number';
         }
-        if (!values.accountNumber) {
+        if (!ValidationUtils.isRequiredFulfilled(values.accountNumber)) {
             errors.accountNumber = 'Please enter an account number';
         }
-        if (!values.street) {
+        if (!ValidationUtils.isRequiredFulfilled(values.street)) {
             errors.street = 'Please enter an address';
         }
-        if (!values.dob) {
+        if (!ValidationUtils.isRequiredFulfilled(values.dob)) {
             errors.dob = 'Please enter your date of birth';
         }
-        if (!values.pickFruit) {
+        if (!ValidationUtils.isRequiredFulfilled(values.pickFruit)) {
             errors.pickFruit = 'Please select a fruit';
         }
-        if (!values.pickAnotherFruit) {
+        if (!ValidationUtils.isRequiredFulfilled(values.pickAnotherFruit)) {
             errors.pickAnotherFruit = 'Please select a fruit';
         }
-        if (!values.state) {
+        if (!ValidationUtils.isRequiredFulfilled(values.state)) {
             errors.state = 'Please select a state';
         }
-        if (!values.checkbox) {
+        if (!ValidationUtils.isRequiredFulfilled(values.checkbox)) {
             errors.checkbox = 'You must accept the Terms of Service to continue';
         }
         return errors;

--- a/tests/unit/isEmptyString.js
+++ b/tests/unit/isEmptyString.js
@@ -1,0 +1,92 @@
+import _ from 'underscore';
+import enEmojis from '../../assets/emojis/en';
+import StringUtils from '../../src/libs/StringUtils';
+
+describe('libs/StringUtils.isEmptyString', () => {
+    it('basic tests', () => {
+        expect(StringUtils.isEmptyString('test')).toBe(false);
+        expect(StringUtils.isEmptyString('test test')).toBe(false);
+        expect(StringUtils.isEmptyString('test test test')).toBe(false);
+        expect(StringUtils.isEmptyString(' ')).toBe(true);
+    });
+    it('trim spaces', () => {
+        expect(StringUtils.isEmptyString(' test')).toBe(false);
+        expect(StringUtils.isEmptyString('test ')).toBe(false);
+        expect(StringUtils.isEmptyString(' test ')).toBe(false);
+    });
+    it('remove invisible characters', () => {
+        expect(StringUtils.isEmptyString('\u200B')).toBe(true);
+        expect(StringUtils.isEmptyString('\u200B')).toBe(true);
+        expect(StringUtils.isEmptyString('\u200B ')).toBe(true);
+        expect(StringUtils.isEmptyString('\u200B \u200B')).toBe(true);
+        expect(StringUtils.isEmptyString('\u200B \u200B ')).toBe(true);
+    });
+    it('remove invisible characters (Cc)', () => {
+        expect(StringUtils.isEmptyString('\u0000')).toBe(true);
+        expect(StringUtils.isEmptyString('\u0001')).toBe(true);
+        expect(StringUtils.isEmptyString('\u0009')).toBe(true);
+    });
+    it('remove invisible characters (Cf)', () => {
+        expect(StringUtils.isEmptyString('\u200E')).toBe(true);
+        expect(StringUtils.isEmptyString('\u200F')).toBe(true);
+        expect(StringUtils.isEmptyString('\u2060')).toBe(true);
+    });
+    it('remove invisible characters (Cs)', () => {
+        expect(StringUtils.isEmptyString('\uD800')).toBe(true);
+        expect(StringUtils.isEmptyString('\uD801')).toBe(true);
+        expect(StringUtils.isEmptyString('\uD802')).toBe(true);
+    });
+    it('remove invisible characters (Co)', () => {
+        expect(StringUtils.isEmptyString('\uE000')).toBe(true);
+        expect(StringUtils.isEmptyString('\uE001')).toBe(true);
+        expect(StringUtils.isEmptyString('\uE002')).toBe(true);
+    });
+    it('remove invisible characters (Zl)', () => {
+        expect(StringUtils.isEmptyString('\u2028')).toBe(true);
+        expect(StringUtils.isEmptyString('\u2029')).toBe(true);
+        expect(StringUtils.isEmptyString('\u202A')).toBe(true);
+    });
+    it('basic check emojis not removed', () => {
+        expect(StringUtils.isEmptyString('😀')).toBe(false);
+    });
+    it('all emojis not removed', () => {
+        _.keys(enEmojis).forEach((key) => {
+            expect(StringUtils.isEmptyString(key)).toBe(false);
+        });
+    });
+    it('remove invisible characters (editpad)', () => {
+        expect(StringUtils.isEmptyString('\u0020')).toBe(true);
+        expect(StringUtils.isEmptyString('\u00A0')).toBe(true);
+        expect(StringUtils.isEmptyString('\u2000')).toBe(true);
+        expect(StringUtils.isEmptyString('\u2001')).toBe(true);
+        expect(StringUtils.isEmptyString('\u2002')).toBe(true);
+        expect(StringUtils.isEmptyString('\u2003')).toBe(true);
+        expect(StringUtils.isEmptyString('\u2004')).toBe(true);
+        expect(StringUtils.isEmptyString('\u2005')).toBe(true);
+        expect(StringUtils.isEmptyString('\u2006')).toBe(true);
+        expect(StringUtils.isEmptyString('\u2007')).toBe(true);
+        expect(StringUtils.isEmptyString('\u2008')).toBe(true);
+        expect(StringUtils.isEmptyString('\u2009')).toBe(true);
+        expect(StringUtils.isEmptyString('\u200A')).toBe(true);
+        expect(StringUtils.isEmptyString('\u2028')).toBe(true);
+        expect(StringUtils.isEmptyString('\u205F')).toBe(true);
+        expect(StringUtils.isEmptyString('\u3000')).toBe(true);
+        expect(StringUtils.isEmptyString(' ')).toBe(true);
+    });
+    it('other tests', () => {
+        expect(StringUtils.isEmptyString('\u200D')).toBe(true);
+        expect(StringUtils.isEmptyString('\uD83C\uDFF4\uDB40\uDC67\uDB40\uDC62\uDB40\uDC65\uDB40\uDC6E\uDB40\uDC67\uDB40\uDC7F')).toBe(false);
+        expect(StringUtils.isEmptyString('\uD83C')).toBe(true);
+        expect(StringUtils.isEmptyString('\uDFF4')).toBe(true);
+        expect(StringUtils.isEmptyString('\uDB40')).toBe(true);
+        expect(StringUtils.isEmptyString('\uDC67')).toBe(true);
+        expect(StringUtils.isEmptyString('\uDC62')).toBe(true);
+        expect(StringUtils.isEmptyString('\uDC65')).toBe(true);
+        expect(StringUtils.isEmptyString('\uDC6E')).toBe(true);
+        expect(StringUtils.isEmptyString('\uDC67')).toBe(true);
+        expect(StringUtils.isEmptyString('\uDC7F')).toBe(true);
+
+        // A special test, an invisible character from other Unicode categories than format and control
+        expect(StringUtils.isEmptyString('\u3164')).toBe(true);
+    });
+});

--- a/tests/unit/removeInvisibleCharacters.js
+++ b/tests/unit/removeInvisibleCharacters.js
@@ -117,4 +117,14 @@ describe('libs/StringUtils.removeInvisibleCharacters', () => {
         expect(StringUtils.removeInvisibleCharacters('\u200D')).toBe('');
         expect(StringUtils.removeInvisibleCharacters('⁠')).toBe('');
     });
+    it('check multiline', () => {
+        expect(StringUtils.removeInvisibleCharacters('test\ntest')).toBe('test\ntest');
+        expect(StringUtils.removeInvisibleCharacters('test\n')).toBe('test');
+        expect(StringUtils.removeInvisibleCharacters('\ntest')).toBe('test');
+    });
+    it('check markdown styling', () => {
+        expect(StringUtils.removeInvisibleCharacters('# test\n** test **')).toBe('# test\n** test **');
+        expect(StringUtils.removeInvisibleCharacters('# test\n** test **\n')).toBe('# test\n** test **');
+        expect(StringUtils.removeInvisibleCharacters('# test\n**test**\n~~test~~')).toBe('# test\n**test**\n~~test~~');
+    });
 });

--- a/tests/unit/removeInvisibleCharacters.js
+++ b/tests/unit/removeInvisibleCharacters.js
@@ -121,10 +121,32 @@ describe('libs/StringUtils.removeInvisibleCharacters', () => {
         expect(StringUtils.removeInvisibleCharacters('test\ntest')).toBe('test\ntest');
         expect(StringUtils.removeInvisibleCharacters('test\n')).toBe('test');
         expect(StringUtils.removeInvisibleCharacters('\ntest')).toBe('test');
+        expect(StringUtils.removeInvisibleCharacters('\n')).toBe('');
+        expect(StringUtils.removeInvisibleCharacters('\n\n')).toBe('');
+        expect(StringUtils.removeInvisibleCharacters('\n\n\n')).toBe('');
+
+        // multiple newlines
+        expect(StringUtils.removeInvisibleCharacters('test\n\ntest')).toBe('test\n\ntest');
+        expect(StringUtils.removeInvisibleCharacters('test\n\n\ntest')).toBe('test\n\n\ntest');
+        expect(StringUtils.removeInvisibleCharacters('test\n\n\n\ntest')).toBe('test\n\n\n\ntest');
+
+        // multiple newlinest with multiple texts
+        expect(StringUtils.removeInvisibleCharacters('test\ntest\ntest')).toBe('test\ntest\ntest');
+        expect(StringUtils.removeInvisibleCharacters('test\ntest\ntest\ntest')).toBe('test\ntest\ntest\ntest');
+        expect(StringUtils.removeInvisibleCharacters('test\ntest\ntest\ntest\ntest')).toBe('test\ntest\ntest\ntest\ntest');
+
+        // multiple newlines with multiple texts and spaces
+        expect(StringUtils.removeInvisibleCharacters('test\n\ntest\ntest\ntest\ntest')).toBe('test\n\ntest\ntest\ntest\ntest');
+
+        expect(StringUtils.removeInvisibleCharacters('test\n \ntest')).toBe('test\n \ntest');
     });
     it('check markdown styling', () => {
         expect(StringUtils.removeInvisibleCharacters('# test\n** test **')).toBe('# test\n** test **');
         expect(StringUtils.removeInvisibleCharacters('# test\n** test **\n')).toBe('# test\n** test **');
         expect(StringUtils.removeInvisibleCharacters('# test\n**test**\n~~test~~')).toBe('# test\n**test**\n~~test~~');
+
+        // multiple newlines
+        expect(StringUtils.removeInvisibleCharacters('# test\n\n** test **')).toBe('# test\n\n** test **');
+        expect(StringUtils.removeInvisibleCharacters('# test\n\n** test **\n')).toBe('# test\n\n** test **');
     });
 });

--- a/tests/unit/removeInvisibleCharacters.js
+++ b/tests/unit/removeInvisibleCharacters.js
@@ -1,0 +1,120 @@
+import _ from 'underscore';
+import enEmojis from '../../assets/emojis/en';
+import StringUtils from '../../src/libs/StringUtils';
+
+describe('libs/StringUtils.removeInvisibleCharacters', () => {
+    it('basic tests', () => {
+        expect(StringUtils.removeInvisibleCharacters('test')).toBe('test');
+        expect(StringUtils.removeInvisibleCharacters('test test')).toBe('test test');
+        expect(StringUtils.removeInvisibleCharacters('abcdefghijklmnopqrstuvwxyz')).toBe('abcdefghijklmnopqrstuvwxyz');
+        expect(StringUtils.removeInvisibleCharacters('ABCDEFGHIJKLMNOPQRSTUVWXYZ')).toBe('ABCDEFGHIJKLMNOPQRSTUVWXYZ');
+        expect(StringUtils.removeInvisibleCharacters('0123456789')).toBe('0123456789');
+        expect(StringUtils.removeInvisibleCharacters('!@#$%^&*()_+-=[]{}|;:\'",.<>/?`~')).toBe('!@#$%^&*()_+-=[]{}|;:\'",.<>/?`~');
+        expect(StringUtils.removeInvisibleCharacters('')).toBe('');
+        expect(StringUtils.removeInvisibleCharacters(' ')).toBe('');
+    });
+    it('other alphabets, list of all characters', () => {
+        // arabic
+        expect(StringUtils.removeInvisibleCharacters('أبجدية عربية')).toBe('أبجدية عربية');
+        // chinese
+        expect(StringUtils.removeInvisibleCharacters('的一是了我不人在他们')).toBe('的一是了我不人在他们');
+        // cyrillic
+        expect(StringUtils.removeInvisibleCharacters('абвгдезиклмнопр')).toBe('абвгдезиклмнопр');
+        // greek
+        expect(StringUtils.removeInvisibleCharacters('αβγδεζηθικλμνξοπρ')).toBe('αβγδεζηθικλμνξοπρ');
+        // hebrew
+        expect(StringUtils.removeInvisibleCharacters('אבגדהוזחטיכלמנ')).toBe('אבגדהוזחטיכלמנ');
+        // hindi
+        expect(StringUtils.removeInvisibleCharacters('अआइईउऊऋऍऎ')).toBe('अआइईउऊऋऍऎ');
+        // japanese
+        expect(StringUtils.removeInvisibleCharacters('あいうえおかきくけこ')).toBe('あいうえおかきくけこ');
+        // korean
+        expect(StringUtils.removeInvisibleCharacters('가나다라마바사아자')).toBe('가나다라마바사아자');
+        // thai
+        expect(StringUtils.removeInvisibleCharacters('กขคงจฉชซ')).toBe('กขคงจฉชซ');
+    });
+    it('trim spaces', () => {
+        expect(StringUtils.removeInvisibleCharacters(' test')).toBe('test');
+        expect(StringUtils.removeInvisibleCharacters('test ')).toBe('test');
+        expect(StringUtils.removeInvisibleCharacters(' test ')).toBe('test');
+    });
+    it('remove invisible characters', () => {
+        expect(StringUtils.removeInvisibleCharacters('test\u200B')).toBe('test');
+        expect(StringUtils.removeInvisibleCharacters('test\u200Btest')).toBe('testtest');
+        expect(StringUtils.removeInvisibleCharacters('test\u200B test')).toBe('test test');
+        expect(StringUtils.removeInvisibleCharacters('test\u200B test\u200B')).toBe('test test');
+        expect(StringUtils.removeInvisibleCharacters('test\u200B test\u200B test')).toBe('test test test');
+    });
+    it('remove invisible characters (Cc)', () => {
+        expect(StringUtils.removeInvisibleCharacters('test\u0000')).toBe('test');
+        expect(StringUtils.removeInvisibleCharacters('test\u0001')).toBe('test');
+        expect(StringUtils.removeInvisibleCharacters('test\u0009')).toBe('test');
+    });
+    it('remove invisible characters (Cf)', () => {
+        expect(StringUtils.removeInvisibleCharacters('test\u200E')).toBe('test');
+        expect(StringUtils.removeInvisibleCharacters('test\u200F')).toBe('test');
+        expect(StringUtils.removeInvisibleCharacters('test\u2060')).toBe('test');
+    });
+    it('check other visible characters (Cs)', () => {
+        expect(StringUtils.removeInvisibleCharacters('test\uD800')).toBe('test');
+        expect(StringUtils.removeInvisibleCharacters('test\uD801')).toBe('test');
+        expect(StringUtils.removeInvisibleCharacters('test\uD802')).toBe('test');
+    });
+    it('check other visible characters (Co)', () => {
+        expect(StringUtils.removeInvisibleCharacters('test\uE000')).toBe('test');
+        expect(StringUtils.removeInvisibleCharacters('test\uE001')).toBe('test');
+        expect(StringUtils.removeInvisibleCharacters('test\uE002')).toBe('test');
+    });
+    it('remove invisible characters (Cn)', () => {
+        expect(StringUtils.removeInvisibleCharacters('test\uFFF0')).toBe('test');
+        expect(StringUtils.removeInvisibleCharacters('test\uFFF1')).toBe('test');
+        expect(StringUtils.removeInvisibleCharacters('test\uFFF2')).toBe('test');
+    });
+    it('remove invisible characters (Zl)', () => {
+        expect(StringUtils.removeInvisibleCharacters('test\u2028')).toBe('test');
+        expect(StringUtils.removeInvisibleCharacters('test\u2029')).toBe('test');
+    });
+    it('basic check emojis not removed', () => {
+        expect(StringUtils.removeInvisibleCharacters('test😀')).toBe('test😀');
+        expect(StringUtils.removeInvisibleCharacters('test😀😀')).toBe('test😀😀');
+        expect(StringUtils.removeInvisibleCharacters('test😀😀😀')).toBe('test😀😀😀');
+    });
+    it('all emojis not removed', () => {
+        _.keys(enEmojis).forEach((key) => {
+            expect(StringUtils.removeInvisibleCharacters(key)).toBe(key);
+        });
+    });
+    it('remove invisible characters (editpad)', () => {
+        expect(StringUtils.removeInvisibleCharacters('test\u0020')).toBe('test');
+        expect(StringUtils.removeInvisibleCharacters('test\u00A0')).toBe('test');
+        expect(StringUtils.removeInvisibleCharacters('test\u2000')).toBe('test');
+        expect(StringUtils.removeInvisibleCharacters('test\u2001')).toBe('test');
+        expect(StringUtils.removeInvisibleCharacters('test\u2002')).toBe('test');
+        expect(StringUtils.removeInvisibleCharacters('test\u2003')).toBe('test');
+        expect(StringUtils.removeInvisibleCharacters('test\u2004')).toBe('test');
+        expect(StringUtils.removeInvisibleCharacters('test\u2005')).toBe('test');
+        expect(StringUtils.removeInvisibleCharacters('test\u2006')).toBe('test');
+        expect(StringUtils.removeInvisibleCharacters('test\u2007')).toBe('test');
+        expect(StringUtils.removeInvisibleCharacters('test\u2008')).toBe('test');
+        expect(StringUtils.removeInvisibleCharacters('test\u2009')).toBe('test');
+        expect(StringUtils.removeInvisibleCharacters('test\u200A')).toBe('test');
+        expect(StringUtils.removeInvisibleCharacters('test\u2028')).toBe('test');
+        expect(StringUtils.removeInvisibleCharacters('test\u205F')).toBe('test');
+        expect(StringUtils.removeInvisibleCharacters('test\u3000')).toBe('test');
+        expect(StringUtils.removeInvisibleCharacters('test ')).toBe('test');
+    });
+    it('other tests', () => {
+        expect(StringUtils.removeInvisibleCharacters('\uD83D\uDE36\u200D\uD83C\uDF2B\uFE0F')).toBe('😶‍🌫️');
+        expect(StringUtils.removeInvisibleCharacters('⁠test')).toBe('test');
+        expect(StringUtils.removeInvisibleCharacters('test⁠test')).toBe('testtest');
+        expect(StringUtils.removeInvisibleCharacters('  	 ‎ ‏ ⁠        　 ')).toBe('');
+        expect(StringUtils.removeInvisibleCharacters('te	‎‏⁠st')).toBe('test');
+        expect(StringUtils.removeInvisibleCharacters('\uD83C\uDFF4\uDB40\uDC67\uDB40\uDC62\uDB40\uDC65\uDB40\uDC6E\uDB40\uDC67\uDB40\uDC7F')).toBe('🏴󠁧󠁢󠁥󠁮󠁧󠁿');
+    });
+    it('special scenarios', () => {
+        // Normally we do not remove this character, because it is used in Emojis.
+        // But if the String consist of only invisible characters, we can safely remove it.
+        expect(StringUtils.removeInvisibleCharacters('\u200D')).toBe('');
+        expect(StringUtils.removeInvisibleCharacters('⁠')).toBe('');
+    });
+});


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->

It is a fixed version of [this PR](https://github.com/Expensify/App/pull/27414) which was reverted.

This PR handles invisible characters in the required fields, to prevent users from creating an i.g. workspace name with only invisible characters.

We:
- remove all invisible characters, and then check if are there any visible ones left,
- then we remove invisible characters that do not break the emojis (some emojis use helping invisible characters), before sending it to the BE.


### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/23297
PROPOSAL: https://github.com/Expensify/App/issues/23297#issuecomment-1686128116

Updated version fixes a regression related to new lines: 
- https://github.com/Expensify/App/issues/31199
- https://github.com/Expensify/App/issues/31217


### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

- [x] Do the QA tests
- [x] Write unit tests to verify:
  - [x] `isEmptyString` function,
  - [x] `removeInvisibleCharacters` function.
- [x] Verify that [this regression](https://github.com/Expensify/App/issues/31199) is fixed
- [x] Verify that [this regression](https://github.com/Expensify/App/issues/31217) is fixed

‍
### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

N/A

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

- [ ] Verify that no errors appear in the JS console
- [ ] Verify invisible characters. In each field/form below, do the steps from the next point.
  - [ ] Verify workspace names:
    - [ ] Go to Settings -> Workspaces‍
    - [ ] Create a New workspace or use an existing one, select it
    - [ ] With workspace selected go to Settings, type in the `Name` field
  - [ ] Go to Settings -> Profile -> Personal details -> Home address -> Check: Address line, City and other fields
  - [ ] Go to Settings -> Wallet -> Add debit card -> Check: Billing address, and other fields
  - [ ] Try to cover as many forms/fields as possible, especially the ones which are required
- [ ] In each form (field) from above verify:
  - [ ] Try to change input, to a normal one, containing normal characters (e.g. `My workspace 123`)
  - [ ] Try input with only invisible characters:
    - [ ] Try characters from [this site](https://www.editpad.org/tool/invisible-character)
    - [ ] Test [U+3164 HANGUL FILLER](https://invisible-characters.com/3164-HANGUL-FILLER.html).
    - [ ] ‍Try invisible characters used in emojis (e.g.r `\u200D`), you can use [this tool](https://r12a.github.io/app-conversion/) to copy it (paste the character in the *JS/Java/C* section, click *Convert*, and then *Copy* in *Characters* section)
  - [ ] Try input with emojis, especially tricky ones (e.g. 😶‍🌫️, 🏴󠁧󠁢󠁥󠁮󠁧󠁿),‍‍
  - [ ] Try some different characters (i.g. from other alphabets)
- [ ] Verify other forms:
  - [ ] Verify Settings -> Profile -> Display Name (should do both First name and Last name):
    - [ ] Try to set the name to a normal string.
    - [ ] Try to set the name with Emojis.
    - [ ] Try to set the name to empty one.
    - [ ] Try to set the name to one with only invisible characters (e.g. `\u200D`) (should be able to save, but the name will be treated as empty)
  - [ ] Click the "Plus" button -> Assign task -> Title:
    - [ ] Do the same check as above.
  - [ ] Do the same with: Click "Plus" button -> Save the world -> I know a teacher -> All fields
  - [ ] Do the same with: Click "Plus" button -> Save the world -> I am a teacher -> All fields
  - [ ] Do the same with: Settings -> Profile -> Personal details -> Legal Name
  - [ ] Do the same with: Settings -> Profile -> Personal details -> Home address
  - [ ] Enable betas and do the same with: Fab -> Send message -> Room -> Room name
- [ ] Verify all other Forms, if you find any more.
- [ ] Go to Workspace settings -> Notes -> Edit note
- [ ] Double test recently migrated forms (i.g. [this PR](https://github.com/Expensify/App/pull/29098/files))


### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

https://github.com/Expensify/App/assets/104823336/6cdda648-3790-4aa8-9570-607bc86e478e



</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

https://github.com/Expensify/App/assets/104823336/f1064ef8-19a6-4bb5-8629-5ed3169cdb3a



</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

https://github.com/Expensify/App/assets/104823336/b04da081-7631-4a1a-8ab1-eb6ff08c899a

</details>

<details>
<summary>iOS: mWeb Safari</summary>

https://github.com/Expensify/App/assets/104823336/9bb9fe25-2664-4f17-a830-aa06437cf564

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

https://github.com/Expensify/App/assets/104823336/7d361337-439f-4c17-a2dd-a762289c8ebe

</details>

<details>
<summary>MacOS: Desktop</summary>


https://github.com/Expensify/App/assets/104823336/8936493e-a10e-41ee-81e4-9483c9fbea8c


</details>
