### PR TITLE
Remove hacks in web InvertedFlatList

### DIFF
--- a/src/components/InvertedFlatList/BaseInvertedFlatList.js
+++ b/src/components/InvertedFlatList/BaseInvertedFlatList.js
@@ -1,9 +1,6 @@
 import PropTypes from 'prop-types';
-import React, {forwardRef, useCallback, useRef} from 'react';
-import {FlatList as NativeFlatlist, View} from 'react-native';
-import _ from 'underscore';
+import React, {forwardRef} from 'react';
 import FlatList from '@components/FlatList';
-import * as CollectionUtils from '@libs/CollectionUtils';
 
 const AUTOSCROLL_TO_TOP_THRESHOLD = 128;
 
@@ -14,148 +11,28 @@ const propTypes = {
 
     /** Same as FlatList although we wrap it in a measuring helper before passing to the actual FlatList component */
     renderItem: PropTypes.func.isRequired,
-
-    /** This must be set to the minimum size of one of the renderItem rows. Web experiences issues when inaccurate. */
-    initialRowHeight: PropTypes.number.isRequired,
-
-    /** Passed via forwardRef so we can access the FlatList ref */
-    innerRef: PropTypes.oneOfType([PropTypes.func, PropTypes.shape({current: PropTypes.instanceOf(NativeFlatlist)})]).isRequired,
-
-    /** Should we measure these items and call getItemLayout? */
-    shouldMeasureItems: PropTypes.bool,
 };
 
 const defaultProps = {
     data: [],
-    shouldMeasureItems: false,
 };
 
-function BaseInvertedFlatList(props) {
-    const {initialRowHeight, shouldMeasureItems, innerRef, renderItem} = props;
-
-    // Stores each item's computed height after it renders
-    // once and is then referenced for the life of this component.
-    // This is essential to getting FlatList inverted to work on web
-    // and also enables more predictable scrolling on native platforms.
-    const sizeMap = useRef({});
-
-    /**
-     * Return default or previously cached height for
-     * a renderItem row
-     *
-     * @param {*} data
-     * @param {Number} index
-     *
-     * @return {Object}
-     */
-    const getItemLayout = (data, index) => {
-        const size = sizeMap.current[index];
-
-        if (size) {
-            return {
-                length: size.length,
-                offset: size.offset,
-                index,
-            };
-        }
-
-        // If we don't have a size yet means we haven't measured this
-        // item yet. However, we can still calculate the offset by looking
-        // at the last size we have recorded (if any)
-        const lastMeasuredItem = CollectionUtils.lastItem(sizeMap.current);
-
-        return {
-            // We haven't measured this so we must return the minimum row height
-            length: initialRowHeight,
-
-            // Offset will either be based on the lastMeasuredItem or the index +
-            // initialRowHeight since we can only assume that all previous items
-            // have not yet been measured
-            offset: _.isUndefined(lastMeasuredItem) ? initialRowHeight * index : lastMeasuredItem.offset + initialRowHeight,
-            index,
-        };
-    };
-
-    /**
-     * Measure item and cache the returned length (a.k.a. height)
-     *
-     * @param {React.NativeSyntheticEvent} nativeEvent
-     * @param {Number} index
-     */
-    const measureItemLayout = useCallback((nativeEvent, index) => {
-        const computedHeight = nativeEvent.layout.height;
-
-        // We've already measured this item so we don't need to
-        // measure it again.
-        if (sizeMap.current[index]) {
-            return;
-        }
-
-        const previousItem = sizeMap.current[index - 1] || {};
-
-        // If there is no previousItem this can mean we haven't yet measured
-        // the previous item or that we are at index 0 and there is no previousItem
-        const previousLength = previousItem.length || 0;
-        const previousOffset = previousItem.offset || 0;
-        sizeMap.current[index] = {
-            length: computedHeight,
-            offset: previousLength + previousOffset,
-        };
-    }, []);
-
-    /**
-     * Render item method wraps the prop renderItem to render in a
-     * View component so we can attach an onLayout handler and
-     * measure it when it renders.
-     *
-     * @param {Object} params
-     * @param {Object} params.item
-     * @param {Number} params.index
-     *
-     * @return {React.Component}
-     */
-    const renderItemFromProp = useCallback(
-        ({item, index}) => {
-            if (shouldMeasureItems) {
-                return <View onLayout={({nativeEvent}) => measureItemLayout(nativeEvent, index)}>{renderItem({item, index})}</View>;
-            }
-
-            return renderItem({item, index});
-        },
-        [shouldMeasureItems, measureItemLayout, renderItem],
-    );
-
-    return (
-        <FlatList
-            // eslint-disable-next-line react/jsx-props-no-spreading
-            {...props}
-            ref={innerRef}
-            renderItem={renderItemFromProp}
-            // Native platforms do not need to measure items and work fine without this.
-            // Web requires that items be measured or else crazy things happen when scrolling.
-            getItemLayout={shouldMeasureItems ? getItemLayout : undefined}
-            windowSize={15}
-            maintainVisibleContentPosition={{
-                minIndexForVisible: 0,
-                autoscrollToTopThreshold: AUTOSCROLL_TO_TOP_THRESHOLD,
-            }}
-            inverted
-        />
-    );
-}
+const BaseInvertedFlatList = forwardRef((props, ref) => (
+    <FlatList
+        // eslint-disable-next-line react/jsx-props-no-spreading
+        {...props}
+        ref={ref}
+        windowSize={15}
+        maintainVisibleContentPosition={{
+            minIndexForVisible: 0,
+            autoscrollToTopThreshold: AUTOSCROLL_TO_TOP_THRESHOLD,
+        }}
+        inverted
+    />
+));
 
 BaseInvertedFlatList.propTypes = propTypes;
 BaseInvertedFlatList.defaultProps = defaultProps;
 BaseInvertedFlatList.displayName = 'BaseInvertedFlatList';
 
-const BaseInvertedFlatListWithRef = forwardRef((props, ref) => (
-    <BaseInvertedFlatList
-        // eslint-disable-next-line react/jsx-props-no-spreading
-        {...props}
-        innerRef={ref}
-    />
-));
-
-BaseInvertedFlatListWithRef.displayName = 'BaseInvertedFlatListWithRef';
-
-export default BaseInvertedFlatListWithRef;
+export default BaseInvertedFlatList;

--- a/src/components/InvertedFlatList/index.js
+++ b/src/components/InvertedFlatList/index.js
@@ -109,9 +109,6 @@ function InvertedFlatList(props) {
             shouldMeasureItems
             contentContainerStyle={contentContainerStyle}
             onScroll={handleScroll}
-            // We need to keep batch size to one to workaround a bug in react-native-web.
-            // This can be removed once https://github.com/Expensify/App/pull/24482 is merged.
-            maxToRenderPerBatch={1}
         />
     );
 }

--- a/src/components/InvertedFlatList/index.js
+++ b/src/components/InvertedFlatList/index.js
@@ -106,7 +106,6 @@ function InvertedFlatList(props) {
             // eslint-disable-next-line react/jsx-props-no-spreading
             {...props}
             ref={innerRef}
-            shouldMeasureItems
             contentContainerStyle={contentContainerStyle}
             onScroll={handleScroll}
         />

--- a/src/pages/home/report/ReportActionsList.js
+++ b/src/pages/home/report/ReportActionsList.js
@@ -420,7 +420,6 @@ function ReportActionsList({
                     renderItem={renderItem}
                     contentContainerStyle={contentContainerStyle}
                     keyExtractor={keyExtractor}
-                    initialRowHeight={32}
                     initialNumToRender={initialNumToRender}
                     onEndReached={loadOlderChats}
                     onEndReachedThreshold={0.75}


### PR DESCRIPTION
### Details

Now that RN web is updated it should fix a bug that was happening causing us to have to use batchSize = 1 on web. After doing some more testing I noticed it was still buggy and tracked it down to the custom `getItemLayout` implementation. I assume this used to be needed to fix bugs in `FlatList` but it doesn't seem to be needed anymore. `FlatList` already caches cells it measures so it is not needed. After removing the custom `getItemLayout` using the default batch size now works fine. This seems to reduce blanks a lot.

Here you can observe with FlatList debug=true the virtualization window (yellow part) and the viewport (red box).

Before:

https://github.com/Expensify/App/assets/2677334/d3c132d3-087c-43f7-968e-209cc92683da

Virtualization seems broken and the list jumps around for a while.

After:

https://github.com/Expensify/App/assets/2677334/c80b9ec4-1a04-4bcb-aca2-7631c47a6ff3

Virtualization works fine and no more jumping. Also no more blanks with bigger batch size, you can also observe how the viewport never gets close to the end of the render window compared to before where we keep hitting the top.

I also removed the extra component for forwarding ref, we can just use forwardRef directly BaseInvertedFlatList no need for an extra component.

### Fixed Issues

$https://github.com/Expensify/App/issues/30895
PROPOSAL: N/A

### Tests

Tested by scrolling in various chats.

Use the FlatList debug prop to make sure virtualization is working properly.

- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

N/A

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

N/A

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

Chrome

https://github.com/Expensify/App/assets/2677334/0744d95e-cf51-4194-b80e-c4fcf31c20b1

Safari

https://github.com/Expensify/App/assets/2677334/9827f051-f5a5-4863-bed1-4ef18ba8c5cc

</details>

<details>
<summary>MacOS: Desktop</summary>

<!-- add screenshots or videos here -->

</details>
