### PR TITLE
Fix tagList highlight

### DIFF
--- a/src/components/TagPicker/index.js
+++ b/src/components/TagPicker/index.js
@@ -42,7 +42,11 @@ function TagPicker({selectedTag, tag, policyTags, policyRecentlyUsedTags, onSubm
             return policyTagList;
         }
         const selectedNames = _.map(selectedOptions, (s) => s.name);
-        return _.filter(policyTagList, (policyTag) => policyTag.enabled || selectedNames.includes(policyTag.name));
+        return _.chain(policyTagList)
+            .values()
+            .sortBy((policyTag) => policyTag.name)
+            .filter((policyTag) => policyTag.enabled || selectedNames.includes(policyTag.name))
+            .value();
     }, [selectedOptions, policyTagList, shouldShowDisabledAndSelectedOption]);
 
     const initialFocusedIndex = useMemo(() => {

--- a/src/components/TagPicker/index.js
+++ b/src/components/TagPicker/index.js
@@ -37,24 +37,26 @@ function TagPicker({selectedTag, tag, policyTags, policyRecentlyUsedTags, onSubm
         ];
     }, [selectedTag]);
 
-    const enabledTags = useMemo(() => {
-        if (!shouldShowDisabledAndSelectedOption) {
-            return policyTagList;
-        }
-        const selectedNames = _.map(selectedOptions, (s) => s.name);
-        const tags = [...selectedOptions, ..._.filter(policyTagList, (policyTag) => policyTag.enabled && !selectedNames.includes(policyTag.name))];
-        return tags;
-    }, [selectedOptions, policyTagList, shouldShowDisabledAndSelectedOption]);
-
     const initialFocusedIndex = useMemo(() => {
         if (isTagsCountBelowThreshold && selectedOptions.length > 0) {
-            return _.chain(enabledTags)
+            return _.chain(policyTagList)
+                .values()
                 .findIndex((policyTag) => policyTag.name === selectedOptions[0].name, true)
                 .value();
         }
 
         return 0;
-    }, [enabledTags, selectedOptions, isTagsCountBelowThreshold]);
+    }, [policyTagList, selectedOptions, isTagsCountBelowThreshold]);
+
+    const enabledTags = useMemo(() => {
+        if (!shouldShowDisabledAndSelectedOption) {
+            return policyTagList;
+        }
+        const selectedNames = _.map(selectedOptions, (s) => s.name);
+        const tags = _.filter(policyTagList, (policyTag) => policyTag.enabled || selectedNames.includes(policyTag.name));
+        return tags;
+    }, [selectedOptions, policyTagList, shouldShowDisabledAndSelectedOption]);
+
 
     const sections = useMemo(
         () => OptionsListUtils.getFilteredOptions({}, {}, [], searchValue, selectedOptions, [], false, false, false, {}, [], true, enabledTags, policyRecentlyUsedTagsList, false).tagOptions,

--- a/src/components/TagPicker/index.js
+++ b/src/components/TagPicker/index.js
@@ -40,7 +40,6 @@ function TagPicker({selectedTag, tag, policyTags, policyRecentlyUsedTags, onSubm
     const initialFocusedIndex = useMemo(() => {
         if (isTagsCountBelowThreshold && selectedOptions.length > 0) {
             return _.chain(policyTagList)
-                .values()
                 .findIndex((policyTag) => policyTag.name === selectedOptions[0].name, true)
                 .value();
         }
@@ -53,8 +52,7 @@ function TagPicker({selectedTag, tag, policyTags, policyRecentlyUsedTags, onSubm
             return policyTagList;
         }
         const selectedNames = _.map(selectedOptions, (s) => s.name);
-        const tags = _.filter(policyTagList, (policyTag) => policyTag.enabled || selectedNames.includes(policyTag.name));
-        return tags;
+        return _.filter(policyTagList, (policyTag) => policyTag.enabled || selectedNames.includes(policyTag.name));
     }, [selectedOptions, policyTagList, shouldShowDisabledAndSelectedOption]);
 
     const sections = useMemo(

--- a/src/components/TagPicker/index.js
+++ b/src/components/TagPicker/index.js
@@ -37,16 +37,6 @@ function TagPicker({selectedTag, tag, policyTags, policyRecentlyUsedTags, onSubm
         ];
     }, [selectedTag]);
 
-    const initialFocusedIndex = useMemo(() => {
-        if (isTagsCountBelowThreshold && selectedOptions.length > 0) {
-            return _.chain(policyTagList)
-                .findIndex((policyTag) => policyTag.name === selectedOptions[0].name, true)
-                .value();
-        }
-
-        return 0;
-    }, [policyTagList, selectedOptions, isTagsCountBelowThreshold]);
-
     const enabledTags = useMemo(() => {
         if (!shouldShowDisabledAndSelectedOption) {
             return policyTagList;
@@ -54,6 +44,16 @@ function TagPicker({selectedTag, tag, policyTags, policyRecentlyUsedTags, onSubm
         const selectedNames = _.map(selectedOptions, (s) => s.name);
         return _.filter(policyTagList, (policyTag) => policyTag.enabled || selectedNames.includes(policyTag.name));
     }, [selectedOptions, policyTagList, shouldShowDisabledAndSelectedOption]);
+
+    const initialFocusedIndex = useMemo(() => {
+        if (isTagsCountBelowThreshold && selectedOptions.length > 0) {
+            return _.chain(enabledTags)
+                .findIndex((policyTag) => policyTag.name === selectedOptions[0].name, true)
+                .value();
+        }
+
+        return 0;
+    }, [enabledTags, selectedOptions, isTagsCountBelowThreshold]);
 
     const sections = useMemo(
         () => OptionsListUtils.getFilteredOptions({}, {}, [], searchValue, selectedOptions, [], false, false, false, {}, [], true, enabledTags, policyRecentlyUsedTagsList, false).tagOptions,

--- a/src/components/TagPicker/index.js
+++ b/src/components/TagPicker/index.js
@@ -38,13 +38,16 @@ function TagPicker({selectedTag, tag, policyTags, policyRecentlyUsedTags, onSubm
     }, [selectedTag]);
 
     const enabledTags = useMemo(() => {
-        if (!shouldShowDisabledAndSelectedOption) {
-            return policyTagList;
-        }
-        const selectedNames = _.map(selectedOptions, (s) => s.name);
-        return _.chain(policyTagList)
+        const sortedTagList = _.chain(policyTagList)
             .values()
             .sortBy((policyTag) => policyTag.name)
+            .value();
+
+        if (!shouldShowDisabledAndSelectedOption) {
+            return sortedTagList;
+        }
+        const selectedNames = _.map(selectedOptions, (s) => s.name);
+        return _.chain(sortedTagList)
             .filter((policyTag) => policyTag.enabled || selectedNames.includes(policyTag.name))
             .value();
     }, [selectedOptions, policyTagList, shouldShowDisabledAndSelectedOption]);

--- a/src/components/TagPicker/index.js
+++ b/src/components/TagPicker/index.js
@@ -57,7 +57,6 @@ function TagPicker({selectedTag, tag, policyTags, policyRecentlyUsedTags, onSubm
         return tags;
     }, [selectedOptions, policyTagList, shouldShowDisabledAndSelectedOption]);
 
-
     const sections = useMemo(
         () => OptionsListUtils.getFilteredOptions({}, {}, [], searchValue, selectedOptions, [], false, false, false, {}, [], true, enabledTags, policyRecentlyUsedTagsList, false).tagOptions,
         [searchValue, enabledTags, selectedOptions, policyRecentlyUsedTagsList],

--- a/src/components/TagPicker/index.js
+++ b/src/components/TagPicker/index.js
@@ -37,17 +37,6 @@ function TagPicker({selectedTag, tag, policyTags, policyRecentlyUsedTags, onSubm
         ];
     }, [selectedTag]);
 
-    const initialFocusedIndex = useMemo(() => {
-        if (isTagsCountBelowThreshold && selectedOptions.length > 0) {
-            return _.chain(policyTagList)
-                .values()
-                .findIndex((policyTag) => policyTag.name === selectedOptions[0].name, true)
-                .value();
-        }
-
-        return 0;
-    }, [policyTagList, selectedOptions, isTagsCountBelowThreshold]);
-
     const enabledTags = useMemo(() => {
         if (!shouldShowDisabledAndSelectedOption) {
             return policyTagList;
@@ -56,6 +45,16 @@ function TagPicker({selectedTag, tag, policyTags, policyRecentlyUsedTags, onSubm
         const tags = [...selectedOptions, ..._.filter(policyTagList, (policyTag) => policyTag.enabled && !selectedNames.includes(policyTag.name))];
         return tags;
     }, [selectedOptions, policyTagList, shouldShowDisabledAndSelectedOption]);
+    
+    const initialFocusedIndex = useMemo(() => {
+        if (isTagsCountBelowThreshold && selectedOptions.length > 0) {
+            return _.chain(enabledTags)
+            .findIndex((policyTag) => policyTag.name === selectedOptions[0].name, true)
+            .value();
+        }
+        
+        return 0;
+    }, [enabledTags, selectedOptions, isTagsCountBelowThreshold]);
 
     const sections = useMemo(
         () => OptionsListUtils.getFilteredOptions({}, {}, [], searchValue, selectedOptions, [], false, false, false, {}, [], true, enabledTags, policyRecentlyUsedTagsList, false).tagOptions,

--- a/src/components/TagPicker/index.js
+++ b/src/components/TagPicker/index.js
@@ -45,14 +45,14 @@ function TagPicker({selectedTag, tag, policyTags, policyRecentlyUsedTags, onSubm
         const tags = [...selectedOptions, ..._.filter(policyTagList, (policyTag) => policyTag.enabled && !selectedNames.includes(policyTag.name))];
         return tags;
     }, [selectedOptions, policyTagList, shouldShowDisabledAndSelectedOption]);
-    
+
     const initialFocusedIndex = useMemo(() => {
         if (isTagsCountBelowThreshold && selectedOptions.length > 0) {
             return _.chain(enabledTags)
-            .findIndex((policyTag) => policyTag.name === selectedOptions[0].name, true)
-            .value();
+                .findIndex((policyTag) => policyTag.name === selectedOptions[0].name, true)
+                .value();
         }
-        
+
         return 0;
     }, [enabledTags, selectedOptions, isTagsCountBelowThreshold]);
 


### PR DESCRIPTION
cc @robertKozik @srikarparsi @tienifr 

### Details
We started rendering `enabledTags` in [this PR](https://github.com/Expensify/App/pull/30672), but we were still using `policyTagList` to define the `initialFocusedIndex` which threw off the indexes

### Fixed Issues
$ https://github.com/Expensify/App/issues/31578

### Tests
Precondition: enable tags as a workspace's admin following [these instructions](https://github.com/Expensify/App/pull/28151#issuecomment-1736543304)

1. Navigate to NewDot and log in as an employee
2. Click on FAB > Request money
3. Enter amount and select workspace
4. Click on Show more > Tags
5. Select any option
6. Open the tags label again
7. Verify that only the selected tag is highlighted

- [x] Verify that no errors appear in the JS console

### Offline tests
N/A

### QA Steps
Same as tests

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

https://github.com/Expensify/App/assets/22219519/5c06fcb4-7820-49a3-a911-b14c16ce8929


<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Desktop</summary>

<!-- add screenshots or videos here -->

</details>
