### PR TITLE
[TS Migration] Update EnvironmentContext default value

### DIFF
--- a/src/components/EnvironmentBadge.tsx
+++ b/src/components/EnvironmentBadge.tsx
@@ -18,7 +18,7 @@ function EnvironmentBadge() {
     const {environment} = useEnvironment();
 
     // If we are on production, don't show any badge
-    if (environment === CONST.ENVIRONMENT.PRODUCTION || environment === undefined) {
+    if (environment === CONST.ENVIRONMENT.PRODUCTION) {
         return null;
     }
 

--- a/src/components/EnvironmentBadge.tsx
+++ b/src/components/EnvironmentBadge.tsx
@@ -15,10 +15,10 @@ const ENVIRONMENT_SHORT_FORM = {
 
 function EnvironmentBadge() {
     const styles = useThemeStyles();
-    const {environment} = useEnvironment();
+    const {environment, isProduction} = useEnvironment();
 
     // If we are on production, don't show any badge
-    if (environment === CONST.ENVIRONMENT.PRODUCTION) {
+    if (isProduction) {
         return null;
     }
 

--- a/src/components/ExpensifyWordmark.tsx
+++ b/src/components/ExpensifyWordmark.tsx
@@ -30,7 +30,7 @@ function ExpensifyWordmark({isSmallScreenWidth, style}: ExpensifyWordmarkProps) 
     const styles = useThemeStyles();
     const {environment} = useEnvironment();
     // PascalCase is required for React components, so capitalize the const here
-    const LogoComponent = environment ? logoComponents[environment] : AdHocLogo;
+    const LogoComponent = logoComponents[environment];
 
     return (
         <>

--- a/src/components/withEnvironment.tsx
+++ b/src/components/withEnvironment.tsx
@@ -19,7 +19,10 @@ type EnvironmentContextValue = {
     environmentURL: string;
 };
 
-const EnvironmentContext = createContext<EnvironmentContextValue | null>(null);
+const EnvironmentContext = createContext<EnvironmentContextValue>({
+    environment: CONST.ENVIRONMENT.PRODUCTION,
+    environmentURL: CONST.NEW_EXPENSIFY_URL,
+});
 
 function EnvironmentProvider({children}: EnvironmentProviderProps): ReactElement {
     const [environment, setEnvironment] = useState<EnvironmentValue>(CONST.ENVIRONMENT.PRODUCTION);
@@ -47,7 +50,7 @@ export default function withEnvironment<TProps extends EnvironmentContextValue, 
     WrappedComponent: ComponentType<TProps & RefAttributes<TRef>>,
 ): (props: Omit<TProps, keyof EnvironmentContextValue> & React.RefAttributes<TRef>) => ReactElement | null {
     function WithEnvironment(props: Omit<TProps, keyof EnvironmentContextValue>, ref: ForwardedRef<TRef>): ReactElement {
-        const {environment, environmentURL} = useContext(EnvironmentContext) ?? {};
+        const {environment, environmentURL} = useContext(EnvironmentContext);
         return (
             <WrappedComponent
                 // eslint-disable-next-line react/jsx-props-no-spreading

--- a/src/hooks/useEnvironment.ts
+++ b/src/hooks/useEnvironment.ts
@@ -3,13 +3,13 @@ import {EnvironmentContext} from '@components/withEnvironment';
 import type {EnvironmentContextValue} from '@components/withEnvironment';
 import CONST from '@src/CONST';
 
-type UseEnvironment = Partial<EnvironmentContextValue> & {
+type UseEnvironment = EnvironmentContextValue & {
     isProduction: boolean;
     isDevelopment: boolean;
 };
 
 export default function useEnvironment(): UseEnvironment {
-    const {environment, environmentURL} = useContext(EnvironmentContext) ?? {};
+    const {environment, environmentURL} = useContext(EnvironmentContext);
     return {
         environment,
         environmentURL,

--- a/src/styles/StyleUtils.ts
+++ b/src/styles/StyleUtils.ts
@@ -462,7 +462,7 @@ function getBorderColorStyle(borderColor: string): ViewStyle {
 /**
  * Returns the width style for the wordmark logo on the sign in page
  */
-function getSignInWordmarkWidthStyle(isSmallScreenWidth: boolean, environment?: ValueOf<typeof CONST.ENVIRONMENT>): ViewStyle {
+function getSignInWordmarkWidthStyle(isSmallScreenWidth: boolean, environment: ValueOf<typeof CONST.ENVIRONMENT>): ViewStyle {
     if (environment === CONST.ENVIRONMENT.DEV) {
         return isSmallScreenWidth ? {width: variables.signInLogoWidthPill} : {width: variables.signInLogoWidthLargeScreenPill};
     }


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->
With current `EnvironmentContext` default `null` value it makes it possible for environment values to be `undefined`. That turns them into optional on the TS side which doesn't look right.
This PR replace `null` default value with values that are used as default [in the state of EnvironmentProvider](https://github.com/Expensify/App/blob/main/src/components/withEnvironment.tsx#L25).
Related discussion: https://github.com/Expensify/App/pull/31478#discussion_r1400412695

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/25084
PROPOSAL: N/A


### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

- [x] Verify that no errors appear in the JS console

1. Open the app on the Login page.
2. Make sure Expensify wordmark shows your environment.
3. Log into the app.
4. Check if a badge next to the Expensify logo shows your environment.

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

N/A

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

- [x] Verify that no errors appear in the JS console

1. Open the app on the Login page.
2. Make sure Expensify wordmark shows your environment.
3. Log into the app.
4. Check if a badge next to the Expensify logo shows your environment.

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->
![android2](https://github.com/Expensify/App/assets/23176449/54f6b8b8-febe-4d1e-9995-9d337a49c837)
![android1](https://github.com/Expensify/App/assets/23176449/9b75c7ac-c669-47d4-921e-b88bc5e71292)


</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->
![android_web1](https://github.com/Expensify/App/assets/23176449/566bedba-8f02-46ae-9d96-904b502d96b0)
![android_web2](https://github.com/Expensify/App/assets/23176449/1ab778ff-4a62-4df5-9722-1a5af8b29d96)


</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->
![ios2](https://github.com/Expensify/App/assets/23176449/d7fd22cd-f485-4e07-bdc6-3c003c5e2022)
![ios1](https://github.com/Expensify/App/assets/23176449/6625438c-c3c1-459f-9327-64a424e00b77)


</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->
![ios_web2](https://github.com/Expensify/App/assets/23176449/a8042353-fcd0-433b-b059-50d3334b45b6)
![ios_web1](https://github.com/Expensify/App/assets/23176449/02e97351-79dc-4109-b3bf-9ca799626295)


</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->
<img width="1296" alt="web2" src="https://github.com/Expensify/App/assets/23176449/eca7a42d-9455-49b4-b9b5-678bdbadbddc">
<img width="1297" alt="web1" src="https://github.com/Expensify/App/assets/23176449/c3666092-f4ad-47f9-bedc-c14ee797b23c">


</details>

<details>
<summary>MacOS: Desktop</summary>

<!-- add screenshots or videos here -->
![desktop2](https://github.com/Expensify/App/assets/23176449/ce228c06-8985-4340-b128-e67b94d1351d)
![desktop1](https://github.com/Expensify/App/assets/23176449/27f19aeb-1147-4540-b731-e05d4971652c)


</details>
