### PR TITLE
Chat loader flickering

### DIFF
--- a/src/libs/ReportActionsUtils.ts
+++ b/src/libs/ReportActionsUtils.ts
@@ -155,7 +155,7 @@ function isTransactionThread(parentReportAction: OnyxEntry<ReportAction>): boole
  * This gives us a stable order even in the case of multiple reportActions created on the same millisecond
  *
  */
-function getSortedReportActions(reportActions: ReportAction[] | null, shouldSortInDescendingOrder = false, shouldMarkTheFirstItem = false): ReportAction[] {
+function getSortedReportActions(reportActions: ReportAction[] | null, shouldSortInDescendingOrder = false, shouldMarkTheFirstItemAsNewest = false): ReportAction[] {
     if (!Array.isArray(reportActions)) {
         throw new Error(`ReportActionsUtils.getSortedReportActions requires an array, received ${typeof reportActions}`);
     }
@@ -183,8 +183,8 @@ function getSortedReportActions(reportActions: ReportAction[] | null, shouldSort
         return (first.reportActionID < second.reportActionID ? -1 : 1) * invertedMultiplier;
     });
 
-    // If shouldMarkTheFirstItem is true, label the first reportAction as isNewestReportAction
-    if (shouldMarkTheFirstItem && sortedActions?.length > 0) {
+    // If shouldMarkTheFirstItemAsNewest is true, label the first reportAction as isNewestReportAction
+    if (shouldMarkTheFirstItemAsNewest && sortedActions?.length > 0) {
         sortedActions[0] = {
             ...sortedActions[0],
             isNewestReportAction: true,
@@ -453,12 +453,12 @@ function filterOutDeprecatedReportActions(reportActions: ReportActions | null): 
  * to ensure they will always be displayed in the same order (in case multiple actions have the same timestamp).
  * This is all handled with getSortedReportActions() which is used by several other methods to keep the code DRY.
  */
-function getSortedReportActionsForDisplay(reportActions: ReportActions | null): ReportAction[] {
+function getSortedReportActionsForDisplay(reportActions: ReportActions | null, shouldMarkTheFirstItemAsNewest = false): ReportAction[] {
     const filteredReportActions = Object.entries(reportActions ?? {})
         .filter(([key, reportAction]) => shouldReportActionBeVisible(reportAction, key))
         .map((entry) => entry[1]);
     const baseURLAdjustedReportActions = filteredReportActions.map((reportAction) => replaceBaseURL(reportAction));
-    return getSortedReportActions(baseURLAdjustedReportActions, true, true);
+    return getSortedReportActions(baseURLAdjustedReportActions, true, shouldMarkTheFirstItemAsNewest);
 }
 
 /**

--- a/src/libs/ReportActionsUtils.ts
+++ b/src/libs/ReportActionsUtils.ts
@@ -183,7 +183,7 @@ function getSortedReportActions(reportActions: ReportAction[] | null, shouldSort
         return (first.reportActionID < second.reportActionID ? -1 : 1) * invertedMultiplier;
     });
 
-    // Mark the first item if shouldMarkTheFirstItem is true
+    // If shouldMarkTheFirstItem is true, label the first reportAction as isNewestReportAction
     if (shouldMarkTheFirstItem && sortedActions?.length > 0) {
         sortedActions[0] = {
             ...sortedActions[0],

--- a/src/libs/ReportActionsUtils.ts
+++ b/src/libs/ReportActionsUtils.ts
@@ -155,14 +155,14 @@ function isTransactionThread(parentReportAction: OnyxEntry<ReportAction>): boole
  * This gives us a stable order even in the case of multiple reportActions created on the same millisecond
  *
  */
-function getSortedReportActions(reportActions: ReportAction[] | null, shouldSortInDescendingOrder = false): ReportAction[] {
+function getSortedReportActions(reportActions: ReportAction[] | null, shouldSortInDescendingOrder = false, shouldMarkTheFirstItem = false): ReportAction[] {
     if (!Array.isArray(reportActions)) {
         throw new Error(`ReportActionsUtils.getSortedReportActions requires an array, received ${typeof reportActions}`);
     }
 
     const invertedMultiplier = shouldSortInDescendingOrder ? -1 : 1;
 
-    return reportActions?.filter(Boolean).sort((first, second) => {
+    const sortedActions = reportActions?.filter(Boolean).sort((first, second) => {
         // First sort by timestamp
         if (first.created !== second.created) {
             return (first.created < second.created ? -1 : 1) * invertedMultiplier;
@@ -182,6 +182,16 @@ function getSortedReportActions(reportActions: ReportAction[] | null, shouldSort
         // will be consistent across all users and devices
         return (first.reportActionID < second.reportActionID ? -1 : 1) * invertedMultiplier;
     });
+
+    // Mark the first item if shouldMarkTheFirstItem is true
+    if (shouldMarkTheFirstItem && sortedActions?.length > 0) {
+        sortedActions[0] = {
+            ...sortedActions[0],
+            isNewestReportAction: true,
+        };
+    }
+
+    return sortedActions;
 }
 
 /**
@@ -448,7 +458,7 @@ function getSortedReportActionsForDisplay(reportActions: ReportActions | null): 
         .filter(([key, reportAction]) => shouldReportActionBeVisible(reportAction, key))
         .map((entry) => entry[1]);
     const baseURLAdjustedReportActions = filteredReportActions.map((reportAction) => replaceBaseURL(reportAction));
-    return getSortedReportActions(baseURLAdjustedReportActions, true);
+    return getSortedReportActions(baseURLAdjustedReportActions, true, true);
 }
 
 /**

--- a/src/pages/home/ReportScreen.js
+++ b/src/pages/home/ReportScreen.js
@@ -474,7 +474,7 @@ export default compose(
             reportActions: {
                 key: ({route}) => `${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${getReportID(route)}`,
                 canEvict: false,
-                selector: ReportActionsUtils.getSortedReportActionsForDisplay,
+                selector: (reportActions) => ReportActionsUtils.getSortedReportActionsForDisplay(reportActions, true),
             },
             report: {
                 key: ({route}) => `${ONYXKEYS.COLLECTION.REPORT}${getReportID(route)}`,

--- a/src/pages/home/report/ReportActionsView.js
+++ b/src/pages/home/report/ReportActionsView.js
@@ -96,6 +96,7 @@ function ReportActionsView(props) {
 
     const isFocused = useIsFocused();
     const reportID = props.report.reportID;
+    const isNewestReportAction = lodashGet(props.reportActions[0], 'isNewestReportAction');
 
     /**
      * @returns {Boolean}
@@ -199,7 +200,7 @@ function ReportActionsView(props) {
     const loadNewerChats = useMemo(
         () =>
             _.throttle(({distanceFromStart}) => {
-                if (props.isLoadingNewerReportActions || props.isLoadingInitialReportActions) {
+                if (props.isLoadingNewerReportActions || props.isLoadingInitialReportActions || isNewestReportAction) {
                     return;
                 }
 
@@ -221,7 +222,7 @@ function ReportActionsView(props) {
                 const newestReportAction = _.first(props.reportActions);
                 Report.getNewerActions(reportID, newestReportAction.reportActionID);
             }, 500),
-        [props.isLoadingNewerReportActions, props.isLoadingInitialReportActions, props.reportActions, reportID],
+        [props.isLoadingNewerReportActions, props.isLoadingInitialReportActions, props.reportActions, reportID, isNewestReportAction],
     );
 
     /**

--- a/src/pages/home/report/ReportActionsView.js
+++ b/src/pages/home/report/ReportActionsView.js
@@ -96,7 +96,7 @@ function ReportActionsView(props) {
 
     const isFocused = useIsFocused();
     const reportID = props.report.reportID;
-    const isNewestReportAction = lodashGet(props.reportActions[0], 'isNewestReportAction');
+    const hasNewestReportAction = lodashGet(props.reportActions[0], 'isNewestReportAction');
 
     /**
      * @returns {Boolean}
@@ -200,7 +200,7 @@ function ReportActionsView(props) {
     const loadNewerChats = useMemo(
         () =>
             _.throttle(({distanceFromStart}) => {
-                if (props.isLoadingNewerReportActions || props.isLoadingInitialReportActions || isNewestReportAction) {
+                if (props.isLoadingNewerReportActions || props.isLoadingInitialReportActions || hasNewestReportAction) {
                     return;
                 }
 
@@ -222,7 +222,7 @@ function ReportActionsView(props) {
                 const newestReportAction = _.first(props.reportActions);
                 Report.getNewerActions(reportID, newestReportAction.reportActionID);
             }, 500),
-        [props.isLoadingNewerReportActions, props.isLoadingInitialReportActions, props.reportActions, reportID, isNewestReportAction],
+        [props.isLoadingNewerReportActions, props.isLoadingInitialReportActions, props.reportActions, reportID, hasNewestReportAction],
     );
 
     /**

--- a/src/types/onyx/ReportAction.ts
+++ b/src/types/onyx/ReportAction.ts
@@ -50,6 +50,9 @@ type Message = {
 
     /** ID of a task report */
     taskReportID?: string;
+
+    /** We manually add this field while sorting to detect the end of the list */
+    isNewestReportAction?: boolean;
 };
 
 type Person = {

--- a/src/types/onyx/ReportAction.ts
+++ b/src/types/onyx/ReportAction.ts
@@ -50,9 +50,6 @@ type Message = {
 
     /** ID of a task report */
     taskReportID?: string;
-
-    /** We manually add this field while sorting to detect the end of the list */
-    isNewestReportAction?: boolean;
 };
 
 type Person = {
@@ -141,6 +138,9 @@ type ReportActionBase = {
     isAttachment?: boolean;
     childRecentReceiptTransactionIDs?: Record<string, string>;
     reportID?: string;
+
+    /** We manually add this field while sorting to detect the end of the list */
+    isNewestReportAction?: boolean;
 };
 
 type ReportAction = ReportActionBase & OriginalMessage;

--- a/tests/unit/ReportActionsUtilsTest.js
+++ b/tests/unit/ReportActionsUtilsTest.js
@@ -185,9 +185,68 @@ describe('ReportActionsUtils', () => {
                     message: [{html: 'I have changed the task'}],
                 },
             ];
+
             const result = ReportActionsUtils.getSortedReportActionsForDisplay(input);
             input.pop();
             expect(result).toStrictEqual(input);
+        });
+
+    describe('getSortedReportActionsForDisplay with marked the first reportAction', () => {
+        it('should filter out non-whitelisted actions', () => {
+            const input = [
+                {
+                    created: '2022-11-13 22:27:01.825',
+                    reportActionID: '8401445780099176',
+                    actionName: CONST.REPORT.ACTIONS.TYPE.ADDCOMMENT,
+                    message: [{html: 'Hello world'}],
+                },
+                {
+                    created: '2022-11-12 22:27:01.825',
+                    reportActionID: '6401435781022176',
+                    actionName: CONST.REPORT.ACTIONS.TYPE.CREATED,
+                    message: [{html: 'Hello world'}],
+                },
+                {
+                    created: '2022-11-11 22:27:01.825',
+                    reportActionID: '2962390724708756',
+                    actionName: CONST.REPORT.ACTIONS.TYPE.IOU,
+                    message: [{html: 'Hello world'}],
+                },
+                {
+                    created: '2022-11-10 22:27:01.825',
+                    reportActionID: '1609646094152486',
+                    actionName: CONST.REPORT.ACTIONS.TYPE.RENAMED,
+                    message: [{html: 'Hello world'}],
+                },
+                {
+                    created: '2022-11-09 22:27:01.825',
+                    reportActionID: '8049485084562457',
+                    actionName: CONST.REPORT.ACTIONS.TYPE.POLICYCHANGELOG.UPDATE_FIELD,
+                    message: [{html: 'updated the Approval Mode from "Submit and Approve" to "Submit and Close"'}],
+                },
+                {
+                    created: '2022-11-08 22:27:06.825',
+                    reportActionID: '1661970171066216',
+                    actionName: CONST.REPORT.ACTIONS.TYPE.REIMBURSEMENTQUEUED,
+                    message: [{html: 'Waiting for the bank account'}],
+                },
+                {
+                    created: '2022-11-06 22:27:08.825',
+                    reportActionID: '1661970171066220',
+                    actionName: CONST.REPORT.ACTIONS.TYPE.TASKEDITED,
+                    message: [{html: 'I have changed the task'}],
+                },
+            ];
+
+            const resultWithoutNewestFlag = ReportActionsUtils.getSortedReportActionsForDisplay(input);
+            const resultWithNewestFlag = ReportActionsUtils.getSortedReportActionsForDisplay(input, true);
+            input.pop();
+            // Mark the newest report action as the newest report action
+            resultWithoutMark[0] = {
+                ...resultWithoutMark[0],
+                isNewestReportAction: true,
+            };
+            expect(resultWithoutNewestFlag).toStrictEqual(resultWithNewestFlag);
         });
         it('should filter out closed actions', () => {
             const input = [

--- a/tests/unit/ReportActionsUtilsTest.js
+++ b/tests/unit/ReportActionsUtilsTest.js
@@ -191,63 +191,65 @@ describe('ReportActionsUtils', () => {
             expect(result).toStrictEqual(input);
         });
 
-    describe('getSortedReportActionsForDisplay with marked the first reportAction', () => {
-        it('should filter out non-whitelisted actions', () => {
-            const input = [
-                {
-                    created: '2022-11-13 22:27:01.825',
-                    reportActionID: '8401445780099176',
-                    actionName: CONST.REPORT.ACTIONS.TYPE.ADDCOMMENT,
-                    message: [{html: 'Hello world'}],
-                },
-                {
-                    created: '2022-11-12 22:27:01.825',
-                    reportActionID: '6401435781022176',
-                    actionName: CONST.REPORT.ACTIONS.TYPE.CREATED,
-                    message: [{html: 'Hello world'}],
-                },
-                {
-                    created: '2022-11-11 22:27:01.825',
-                    reportActionID: '2962390724708756',
-                    actionName: CONST.REPORT.ACTIONS.TYPE.IOU,
-                    message: [{html: 'Hello world'}],
-                },
-                {
-                    created: '2022-11-10 22:27:01.825',
-                    reportActionID: '1609646094152486',
-                    actionName: CONST.REPORT.ACTIONS.TYPE.RENAMED,
-                    message: [{html: 'Hello world'}],
-                },
-                {
-                    created: '2022-11-09 22:27:01.825',
-                    reportActionID: '8049485084562457',
-                    actionName: CONST.REPORT.ACTIONS.TYPE.POLICYCHANGELOG.UPDATE_FIELD,
-                    message: [{html: 'updated the Approval Mode from "Submit and Approve" to "Submit and Close"'}],
-                },
-                {
-                    created: '2022-11-08 22:27:06.825',
-                    reportActionID: '1661970171066216',
-                    actionName: CONST.REPORT.ACTIONS.TYPE.REIMBURSEMENTQUEUED,
-                    message: [{html: 'Waiting for the bank account'}],
-                },
-                {
-                    created: '2022-11-06 22:27:08.825',
-                    reportActionID: '1661970171066220',
-                    actionName: CONST.REPORT.ACTIONS.TYPE.TASKEDITED,
-                    message: [{html: 'I have changed the task'}],
-                },
-            ];
+        describe('getSortedReportActionsForDisplay with marked the first reportAction', () => {
+            it('should filter out non-whitelisted actions', () => {
+                const input = [
+                    {
+                        created: '2022-11-13 22:27:01.825',
+                        reportActionID: '8401445780099176',
+                        actionName: CONST.REPORT.ACTIONS.TYPE.ADDCOMMENT,
+                        message: [{html: 'Hello world'}],
+                    },
+                    {
+                        created: '2022-11-12 22:27:01.825',
+                        reportActionID: '6401435781022176',
+                        actionName: CONST.REPORT.ACTIONS.TYPE.CREATED,
+                        message: [{html: 'Hello world'}],
+                    },
+                    {
+                        created: '2022-11-11 22:27:01.825',
+                        reportActionID: '2962390724708756',
+                        actionName: CONST.REPORT.ACTIONS.TYPE.IOU,
+                        message: [{html: 'Hello world'}],
+                    },
+                    {
+                        created: '2022-11-10 22:27:01.825',
+                        reportActionID: '1609646094152486',
+                        actionName: CONST.REPORT.ACTIONS.TYPE.RENAMED,
+                        message: [{html: 'Hello world'}],
+                    },
+                    {
+                        created: '2022-11-09 22:27:01.825',
+                        reportActionID: '8049485084562457',
+                        actionName: CONST.REPORT.ACTIONS.TYPE.POLICYCHANGELOG.UPDATE_FIELD,
+                        message: [{html: 'updated the Approval Mode from "Submit and Approve" to "Submit and Close"'}],
+                    },
+                    {
+                        created: '2022-11-08 22:27:06.825',
+                        reportActionID: '1661970171066216',
+                        actionName: CONST.REPORT.ACTIONS.TYPE.REIMBURSEMENTQUEUED,
+                        message: [{html: 'Waiting for the bank account'}],
+                    },
+                    {
+                        created: '2022-11-06 22:27:08.825',
+                        reportActionID: '1661970171066220',
+                        actionName: CONST.REPORT.ACTIONS.TYPE.TASKEDITED,
+                        message: [{html: 'I have changed the task'}],
+                    },
+                ];
 
-            const resultWithoutNewestFlag = ReportActionsUtils.getSortedReportActionsForDisplay(input);
-            const resultWithNewestFlag = ReportActionsUtils.getSortedReportActionsForDisplay(input, true);
-            input.pop();
-            // Mark the newest report action as the newest report action
-            resultWithoutMark[0] = {
-                ...resultWithoutMark[0],
-                isNewestReportAction: true,
-            };
-            expect(resultWithoutNewestFlag).toStrictEqual(resultWithNewestFlag);
+                const resultWithoutNewestFlag = ReportActionsUtils.getSortedReportActionsForDisplay(input);
+                const resultWithNewestFlag = ReportActionsUtils.getSortedReportActionsForDisplay(input, true);
+                input.pop();
+                // Mark the newest report action as the newest report action
+                resultWithoutNewestFlag[0] = {
+                    ...resultWithoutNewestFlag[0],
+                    isNewestReportAction: true,
+                };
+                expect(resultWithoutNewestFlag).toStrictEqual(resultWithNewestFlag);
+            });
         });
+
         it('should filter out closed actions', () => {
             const input = [
                 {


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

Issue: The `onStartReached` function is being triggered more frequently than necessary. It leads to the loader flickering

When onStartReached is Necessary:
1. Navigating to Comments: It's crucial for loading newer report actions when users navigate to comments through links.
2. Returning from Offline Mode: It's important for catching up on messages missed while offline, especially when there's a significant backlog.

Solution:
Introduce `isNewestReportAction` Flag: This flag will be attached to the most recent report actions. It serves as an indicator to decide whether to call `onStartReached`.

Application in Comment Linking: When using comment links, we'll isolate a specific array of reports from Onyx for the user. If the first item (the newest in an inverted list) has the `isNewestReportAction` flag, it signifies that triggering `onStartReached` is not required.
Handling Offline Scenarios: Upon reconnection, the true latest report action is obtained from OpenReport and marked by us with `isNewestReportAction`. This helps determine the necessity of `onStartReached`.

Our goal is to reduce redundant data fetching, thereby improving efficiency and the user experience. This is especially crucial in handling large volumes of messages and in scenarios involving reconnection after being offline.

### Details
<!-- Explanation of the change or anything fishy that is going on -->

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/30729#issuecomment-1827792386
https://github.com/Expensify/App/issues/30495#issuecomment-1827791512
PROPOSAL: 


### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

Open a chat and check the bottom loader, you shouldn't see it.
Scroll to the top and bottom to check if it appears.
Send messages. 

- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

https://github.com/Expensify/App/assets/48593211/b0fba588-c1bd-4f78-945f-fca7e0e14e8d

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

https://github.com/Expensify/App/assets/48593211/003944f3-7cad-4087-8c84-a5a4a1eab982

</details>

<details>
<summary>iOS: mWeb Safari</summary>

https://github.com/Expensify/App/assets/48593211/45a42925-7b61-41b2-8693-d9bf677697d2

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

https://github.com/Expensify/App/assets/48593211/a9a94f9b-ecb7-409f-8215-7c789445b6b0

https://github.com/Expensify/App/assets/48593211/eb1b7ecc-4ed6-45e2-ab45-205cb8adc1e1

</details>

<details>
<summary>MacOS: Desktop</summary>

https://github.com/Expensify/App/assets/48593211/0cc57073-f55c-4c4d-8d3d-e91bce12a188

</details>
