### PR TITLE
Fixed Android - Chat - Message gets displayed from right to left

### DIFF
--- a/src/libs/convertToLTR/index.android.ts
+++ b/src/libs/convertToLTR/index.android.ts
@@ -7,4 +7,26 @@ import ConvertToLTR from './types';
  */
 const convertToLTR: ConvertToLTR = (text) => `${CONST.UNICODE.LTR}${text}`;
 
+/** This is necessary to convert the input to LTR, there is a delay that causes the cursor not to go to the end of the input line when pasting text or typing fast. */
+const moveCursorToEndOfLine = (commentLength: number, setSelection:(value: React.SetStateAction<{
+    start: number;
+    end: number;
+}>)=>void) => {
+    setSelection({
+        start: commentLength + 1,
+        end: commentLength + 1,
+    });
+}
+
+/** We should remove the LTR unicode when the input is empty to prevent: Sending an empty message, bad function of metion suggestions (force option: always remove the unicode), or placeholder issues */
+const removeUnicodeLTRWhenEmpty = (newComment:string, newCommentConverted:string, force?:boolean) => {
+    
+    const removeRegEx = new RegExp(`${CONST.UNICODE.LTR}`,'g')
+
+    const result = newComment.length <= 1 || force ? newCommentConverted.replace(removeRegEx, '') : newCommentConverted;
+    return result;
+}
+
+export {moveCursorToEndOfLine, removeUnicodeLTRWhenEmpty};
+
 export default convertToLTR;

--- a/src/libs/convertToLTR/index.android.ts
+++ b/src/libs/convertToLTR/index.android.ts
@@ -8,24 +8,28 @@ import ConvertToLTR from './types';
 const convertToLTR: ConvertToLTR = (text) => `${CONST.UNICODE.LTR}${text}`;
 
 /** This is necessary to convert the input to LTR, there is a delay that causes the cursor not to go to the end of the input line when pasting text or typing fast. */
-const moveCursorToEndOfLine = (commentLength: number, setSelection:(value: React.SetStateAction<{
-    start: number;
-    end: number;
-}>)=>void) => {
+const moveCursorToEndOfLine = (
+    commentLength: number,
+    setSelection: (
+        value: React.SetStateAction<{
+            start: number;
+            end: number;
+        }>,
+    ) => void,
+) => {
     setSelection({
         start: commentLength + 1,
         end: commentLength + 1,
     });
-}
+};
 
 /** We should remove the LTR unicode when the input is empty to prevent: Sending an empty message, bad function of metion suggestions (force option: always remove the unicode), or placeholder issues */
-const removeUnicodeLTRWhenEmpty = (newComment:string, newCommentConverted:string, force?:boolean) => {
-    
-    const removeRegEx = new RegExp(`${CONST.UNICODE.LTR}`,'g')
+const removeUnicodeLTRWhenEmpty = (newComment: string, newCommentConverted: string, force?: boolean) => {
+    const removeRegEx = new RegExp(`${CONST.UNICODE.LTR}`, 'g');
 
     const result = newComment.length <= 1 || force ? newCommentConverted.replace(removeRegEx, '') : newCommentConverted;
     return result;
-}
+};
 
 export {moveCursorToEndOfLine, removeUnicodeLTRWhenEmpty};
 

--- a/src/libs/convertToLTR/index.android.ts
+++ b/src/libs/convertToLTR/index.android.ts
@@ -8,24 +8,4 @@ import ConvertToLTR from './types';
 
 const convertToLTR: ConvertToLTR = (text) => `${CONST.UNICODE.LTR}${text}`;
 
-/**
- * This is necessary to convert the input to LTR, there is a delay that causes the cursor not to go to the end of the input line when pasting text or typing fast. The delay is caused for the time that takes the input to convert from RTL to LTR and viceversa.
- */
-const moveCursorToEndOfLine = (
-    commentLength: number,
-    setSelection: (
-        value: React.SetStateAction<{
-            start: number;
-            end: number;
-        }>,
-    ) => void,
-) => {
-    setSelection({
-        start: commentLength + 1,
-        end: commentLength + 1,
-    });
-};
-
-export {moveCursorToEndOfLine};
-
 export default convertToLTR;

--- a/src/libs/convertToLTR/index.android.ts
+++ b/src/libs/convertToLTR/index.android.ts
@@ -1,13 +1,16 @@
+/**
+ * Android only - convert RTL text to a LTR text using Unicode controls.
+ *
+ * In React Native, when working with bidirectional text (RTL - Right-to-Left or LTR - Left-to-Right), you may encounter issues related to text rendering, especially on Android devices. These issues arise because Android's default behavior for text direction might not always align with the desired directionality of your app.
+ */
 import CONST from '@src/CONST';
 import ConvertToLTR from './types';
 
-/**
- * Android only - convert RTL text to a LTR text using Unicode controls.
- * https://www.w3.org/International/questions/qa-bidi-unicode-controls
- */
 const convertToLTR: ConvertToLTR = (text) => `${CONST.UNICODE.LTR}${text}`;
 
-/** This is necessary to convert the input to LTR, there is a delay that causes the cursor not to go to the end of the input line when pasting text or typing fast. */
+/**
+ * This is necessary to convert the input to LTR, there is a delay that causes the cursor not to go to the end of the input line when pasting text or typing fast. The delay is caused for the time that takes the input to convert from RTL to LTR and viceversa.
+ */
 const moveCursorToEndOfLine = (
     commentLength: number,
     setSelection: (
@@ -23,14 +26,6 @@ const moveCursorToEndOfLine = (
     });
 };
 
-/** We should remove the LTR unicode when the input is empty to prevent: Sending an empty message, bad function of metion suggestions (force option: always remove the unicode), or placeholder issues */
-const removeUnicodeLTRWhenEmpty = (newComment: string, newCommentConverted: string, force?: boolean) => {
-    const removeRegEx = new RegExp(`${CONST.UNICODE.LTR}`, 'g');
-
-    const result = newComment.length <= 1 || force ? newCommentConverted.replace(removeRegEx, '') : newCommentConverted;
-    return result;
-};
-
-export {moveCursorToEndOfLine, removeUnicodeLTRWhenEmpty};
+export {moveCursorToEndOfLine};
 
 export default convertToLTR;

--- a/src/libs/convertToLTR/index.ts
+++ b/src/libs/convertToLTR/index.ts
@@ -1,3 +1,4 @@
+// The Android platform has to handle switching between LTR and RTL languages a bit differently (https://developer.android.com/training/basics/supporting-devices/languages). For all other platforms, these can simply be no-op functions.
 import ConvertToLTR from './types';
 
 const convertToLTR: ConvertToLTR = (text) => text;
@@ -12,8 +13,6 @@ const moveCursorToEndOfLine = (
     ) => void,
 ) => setSelection;
 
-const removeUnicodeLTRWhenEmpty = (newComment: string) => newComment;
-
-export {moveCursorToEndOfLine, removeUnicodeLTRWhenEmpty};
+export {moveCursorToEndOfLine};
 
 export default convertToLTR;

--- a/src/libs/convertToLTR/index.ts
+++ b/src/libs/convertToLTR/index.ts
@@ -2,4 +2,13 @@ import ConvertToLTR from './types';
 
 const convertToLTR: ConvertToLTR = (text) => text;
 
+const moveCursorToEndOfLine = (commentLength: number, setSelection:(value: React.SetStateAction<{
+    start: number;
+    end: number;
+}>)=>void) => setSelection
+
+const removeUnicodeLTRWhenEmpty = (newComment:string) => newComment;
+
+export {moveCursorToEndOfLine, removeUnicodeLTRWhenEmpty};
+
 export default convertToLTR;

--- a/src/libs/convertToLTR/index.ts
+++ b/src/libs/convertToLTR/index.ts
@@ -2,12 +2,17 @@ import ConvertToLTR from './types';
 
 const convertToLTR: ConvertToLTR = (text) => text;
 
-const moveCursorToEndOfLine = (commentLength: number, setSelection:(value: React.SetStateAction<{
-    start: number;
-    end: number;
-}>)=>void) => setSelection
+const moveCursorToEndOfLine = (
+    commentLength: number,
+    setSelection: (
+        value: React.SetStateAction<{
+            start: number;
+            end: number;
+        }>,
+    ) => void,
+) => setSelection;
 
-const removeUnicodeLTRWhenEmpty = (newComment:string) => newComment;
+const removeUnicodeLTRWhenEmpty = (newComment: string) => newComment;
 
 export {moveCursorToEndOfLine, removeUnicodeLTRWhenEmpty};
 

--- a/src/libs/convertToLTR/index.ts
+++ b/src/libs/convertToLTR/index.ts
@@ -3,16 +3,4 @@ import ConvertToLTR from './types';
 
 const convertToLTR: ConvertToLTR = (text) => text;
 
-const moveCursorToEndOfLine = (
-    commentLength: number,
-    setSelection: (
-        value: React.SetStateAction<{
-            start: number;
-            end: number;
-        }>,
-    ) => void,
-) => setSelection;
-
-export {moveCursorToEndOfLine};
-
 export default convertToLTR;

--- a/src/libs/convertToLTRForComposer/index.android.ts
+++ b/src/libs/convertToLTRForComposer/index.android.ts
@@ -1,8 +1,9 @@
+import CONST from '@src/CONST';
 import ConvertToLTRForComposer from './types';
 
 /**
  * Android only - Do not convert RTL text to a LTR text for input box using Unicode controls.
  * Android does not properly support bidirectional text for mixed content for input box
  */
-const convertToLTRForComposer: ConvertToLTRForComposer = (text) => text;
+const convertToLTRForComposer: ConvertToLTRForComposer = (text, isComposerEmpty) => (isComposerEmpty ? `${CONST.UNICODE.LTR}${text}` : text);
 export default convertToLTRForComposer;

--- a/src/libs/convertToLTRForComposer/index.android.ts
+++ b/src/libs/convertToLTRForComposer/index.android.ts
@@ -7,11 +7,11 @@ import ConvertToLTRForComposer from './types';
  * also to avoid sending empty messages the unicode character with space could enable the send button.
  */
 function canComposerBeConvertedToLTR(text: string): boolean {
-    // This regex handles the case when a user only types spaces into the composer
+    // This regex handles the case when a user only types spaces into the composer.
     const containOnlySpaces = /^\s*$/;
     // This regex handles the case where someone has RTL enabled and they began typing an @mention for someone.
     const startsWithLTRAndAt = new RegExp(`^${CONST.UNICODE.LTR}@$`);
-    // This regex handles the case to avoid sending empty messages when composer is multiline
+    // This regex handles the case where the composer can contain multiple lines of whitespace
     const startsWithLTRAndSpace = new RegExp(`${CONST.UNICODE.LTR}\\s*$`);
     const emptyExpressions = [containOnlySpaces, startsWithLTRAndAt, startsWithLTRAndSpace];
     return emptyExpressions.some((exp) => exp.test(text));
@@ -22,7 +22,9 @@ function canComposerBeConvertedToLTR(text: string): boolean {
  *  Sending an empty message;
  *  Mention suggestions not works if @ or \s (at or space) is the first character;
  *  Placeholder is not displayed if the unicode character is the only character remaining;
- * force: always remove the LTR unicode, going to be used when composer is consider as empty */
+ *
+ * @newComment: the comment written by the user
+ * @force: always remove the LTR unicode, going to be used when composer is consider as empty */
 const resetLTRWhenEmpty = (newComment: string, force?: boolean) => {
     const result = newComment.length <= 1 || force ? newComment.replaceAll(CONST.UNICODE.LTR, '') : newComment;
     return result;

--- a/src/libs/convertToLTRForComposer/index.android.ts
+++ b/src/libs/convertToLTRForComposer/index.android.ts
@@ -1,7 +1,7 @@
 import CONST from '@src/CONST';
 import ConvertToLTRForComposer from './types';
 
-/** Android only - We should remove the LTR unicode when the input is empty to prevent: Sending an empty message, metion suggestions not works if @ is the first character; (force option: always remove the unicode, should be used when the user starts writing with @) or placeholder not shows if unicode character is the only remaining character. */
+/** Android only - We should remove the LTR unicode when the input is empty to prevent: Sending an empty message, metion suggestions not works if @ or \s (at or space) is the first character; (force option: always remove the unicode, should be used when the user starts writing with @) or placeholder not shows if unicode character is the only remaining character. */
 const resetLTRWhenEmpty = (newComment: string, force?: boolean) => {
     const result = newComment.length <= 1 || force ? newComment.replace(CONST.UNICODE.LTR, '') : newComment;
     return result;
@@ -13,7 +13,7 @@ const resetLTRWhenEmpty = (newComment: string, force?: boolean) => {
  */
 const convertToLTRForComposer: ConvertToLTRForComposer = (text, isComposerEmpty) => {
     let newText = resetLTRWhenEmpty(text);
-    if (newText.startsWith(`${CONST.UNICODE.LTR}@`)) {
+    if (newText.startsWith(`${CONST.UNICODE.LTR}@`) || newText.match(/^(\s)*$/)) {
         newText = resetLTRWhenEmpty(newText, true);
         return newText;
     }

--- a/src/libs/convertToLTRForComposer/index.android.ts
+++ b/src/libs/convertToLTRForComposer/index.android.ts
@@ -3,13 +3,15 @@ import ConvertToLTRForComposer from './types';
 
 /**
  * Android only - The composer can be converted to LTR if its content is the LTR character followed by an @ or space
+ * because to mention sugggestion works the @ character must not have any character at the beginning e.g.: \u2066@ doesn't work
+ * also to avoid sending empty messages the unicode character with space could enable the send button.
  */
 function canComposerBeConvertedToLTR(text: string): boolean {
-    // this handle cases when user type only spaces
+    // This regex handles the case when a user only types spaces into the composer
     const containOnlySpaces = /^\s*$/;
-    // this handle the case where someone has RTL enabled and they began typing an @mention for someone.
+    // This regex handles the case where someone has RTL enabled and they began typing an @mention for someone.
     const startsWithLTRAndAt = new RegExp(`^${CONST.UNICODE.LTR}@$`);
-    // this handle cases could send empty messages when composer is multiline
+    // This regex handles the case to avoid sending empty messages when composer is multiline
     const startsWithLTRAndSpace = new RegExp(`${CONST.UNICODE.LTR}\\s*$`);
     const emptyExpressions = [containOnlySpaces, startsWithLTRAndAt, startsWithLTRAndSpace];
     return emptyExpressions.some((exp) => exp.test(text));

--- a/src/libs/convertToLTRForComposer/index.android.ts
+++ b/src/libs/convertToLTRForComposer/index.android.ts
@@ -32,7 +32,6 @@ const resetLTRWhenEmpty = (newComment: string, force?: boolean) => {
  */
 const convertToLTRForComposer: ConvertToLTRForComposer = (text, isComposerEmpty) => {
     const shouldComposerMaintainAsLTR = canComposerBeConvertedToLTR(text);
-    console.log({shouldComposerMaintainAsLTR, isComposerEmpty});
     const newText = resetLTRWhenEmpty(text, shouldComposerMaintainAsLTR);
     if (shouldComposerMaintainAsLTR) {
         return newText;

--- a/src/libs/convertToLTRForComposer/index.android.ts
+++ b/src/libs/convertToLTRForComposer/index.android.ts
@@ -1,9 +1,24 @@
 import CONST from '@src/CONST';
 import ConvertToLTRForComposer from './types';
 
+/** Android only - We should remove the LTR unicode when the input is empty to prevent: Sending an empty message, metion suggestions not works if @ is the first character; (force option: always remove the unicode, should be used when the user starts writing with @) or placeholder not shows if unicode character is the only remaining character. */
+const resetLTRWhenEmpty = (newComment: string, force?: boolean) => {
+    const result = newComment.length <= 1 || force ? newComment.replace(CONST.UNICODE.LTR, '') : newComment;
+    return result;
+};
+
 /**
  * Android only - Do not convert RTL text to a LTR text for input box using Unicode controls.
  * Android does not properly support bidirectional text for mixed content for input box
  */
-const convertToLTRForComposer: ConvertToLTRForComposer = (text, isComposerEmpty) => (isComposerEmpty ? `${CONST.UNICODE.LTR}${text}` : text);
+const convertToLTRForComposer: ConvertToLTRForComposer = (text, isComposerEmpty) => {
+    let newText = resetLTRWhenEmpty(text);
+    if (newText.startsWith(`${CONST.UNICODE.LTR}@`)) {
+        newText = resetLTRWhenEmpty(newText, true);
+        return newText;
+    }
+
+    return isComposerEmpty ? `${CONST.UNICODE.LTR}${newText}` : newText;
+};
+
 export default convertToLTRForComposer;

--- a/src/libs/convertToLTRForComposer/index.android.ts
+++ b/src/libs/convertToLTRForComposer/index.android.ts
@@ -21,4 +21,24 @@ const convertToLTRForComposer: ConvertToLTRForComposer = (text, isComposerEmpty)
     return isComposerEmpty ? `${CONST.UNICODE.LTR}${newText}` : newText;
 };
 
+/**
+ * This is necessary to convert the input to LTR, there is a delay that causes the cursor not to go to the end of the input line when pasting text or typing fast. The delay is caused for the time that takes the input to convert from RTL to LTR and viceversa.
+ */
+const moveCursorToEndOfLine = (
+    commentLength: number,
+    setSelection: (
+        value: React.SetStateAction<{
+            start: number;
+            end: number;
+        }>,
+    ) => void,
+) => {
+    setSelection({
+        start: commentLength + 1,
+        end: commentLength + 1,
+    });
+};
+
+export {moveCursorToEndOfLine};
+
 export default convertToLTRForComposer;

--- a/src/libs/convertToLTRForComposer/index.android.ts
+++ b/src/libs/convertToLTRForComposer/index.android.ts
@@ -2,7 +2,7 @@ import CONST from '@src/CONST';
 import ConvertToLTRForComposer from './types';
 
 /**
- * Android only - The composer is considered "empty" if all it contains is the LTR character followed by an @ or space.
+ * Android only - The composer can be converted to LTR if its content is the LTR character followed by an @ or space
  */
 function canComposerBeConvertedToLTR(text: string): boolean {
     // this handle cases when user type only spaces
@@ -31,9 +31,10 @@ const resetLTRWhenEmpty = (newComment: string, force?: boolean) => {
  * Android does not properly support bidirectional text for mixed content for input box
  */
 const convertToLTRForComposer: ConvertToLTRForComposer = (text, isComposerEmpty) => {
-    const isConsideredAsEmpty = canComposerBeConvertedToLTR(text);
-    const newText = resetLTRWhenEmpty(text, isConsideredAsEmpty);
-    if (isConsideredAsEmpty) {
+    const shouldComposerMaintainAsLTR = canComposerBeConvertedToLTR(text);
+    console.log({shouldComposerMaintainAsLTR, isComposerEmpty});
+    const newText = resetLTRWhenEmpty(text, shouldComposerMaintainAsLTR);
+    if (shouldComposerMaintainAsLTR) {
         return newText;
     }
     return isComposerEmpty ? `${CONST.UNICODE.LTR}${newText}` : newText;

--- a/src/libs/convertToLTRForComposer/index.android.ts
+++ b/src/libs/convertToLTRForComposer/index.android.ts
@@ -23,8 +23,11 @@ function canComposerBeConvertedToLTR(text: string): boolean {
  *  Mention suggestions not works if @ or \s (at or space) is the first character;
  *  Placeholder is not displayed if the unicode character is the only character remaining;
  *
- * @newComment: the comment written by the user
- * @force: always remove the LTR unicode, going to be used when composer is consider as empty */
+ * @param {String} newComment - the comment written by the user
+ * @param {Boolean} force - always remove the LTR unicode, going to be used when composer is consider as empty
+ * @return {String}
+ */
+
 const resetLTRWhenEmpty = (newComment: string, force?: boolean) => {
     const result = newComment.length <= 1 || force ? newComment.replaceAll(CONST.UNICODE.LTR, '') : newComment;
     return result;

--- a/src/libs/convertToLTRForComposer/index.ts
+++ b/src/libs/convertToLTRForComposer/index.ts
@@ -30,4 +30,9 @@ const convertToLTRForComposer: ConvertToLTRForComposer = (text) => {
     // Add the LTR marker to the beginning of the text.
     return `${CONST.UNICODE.LTR}${text}`;
 };
+
+const moveCursorToEndOfLine = (commentLength: number) => commentLength;
+
+export {moveCursorToEndOfLine};
+
 export default convertToLTRForComposer;

--- a/src/libs/convertToLTRForComposer/types.ts
+++ b/src/libs/convertToLTRForComposer/types.ts
@@ -1,3 +1,3 @@
-type ConvertToLTRForComposer = (text: string) => string;
+type ConvertToLTRForComposer = (text: string, isComposerEmpty?: boolean) => string;
 
 export default ConvertToLTRForComposer;

--- a/src/pages/home/report/ReportActionCompose/ComposerWithSuggestions/ComposerWithSuggestions.js
+++ b/src/pages/home/report/ReportActionCompose/ComposerWithSuggestions/ComposerWithSuggestions.js
@@ -14,6 +14,7 @@ import canFocusInputOnScreenFocus from '@libs/canFocusInputOnScreenFocus';
 import compose from '@libs/compose';
 import * as ComposerUtils from '@libs/ComposerUtils';
 import getDraftComment from '@libs/ComposerUtils/getDraftComment';
+import convertToLTR from '@libs/convertToLTR';
 import convertToLTRForComposer from '@libs/convertToLTRForComposer';
 import * as EmojiUtils from '@libs/EmojiUtils';
 import focusComposerWithDelay from '@libs/focusComposerWithDelay';
@@ -524,6 +525,12 @@ function ComposerWithSuggestions({
         }),
         [blur, focus, prepareCommentAndResetComposer, replaceSelectionWithText],
     );
+    // eslint-disable-next-line rulesdir/prefer-early-return
+    useEffect(() => {
+        if (value === '') {
+            setValue(convertToLTR(value));
+        }
+    }, [value]);
 
     return (
         <>

--- a/src/pages/home/report/ReportActionCompose/ComposerWithSuggestions/ComposerWithSuggestions.js
+++ b/src/pages/home/report/ReportActionCompose/ComposerWithSuggestions/ComposerWithSuggestions.js
@@ -525,11 +525,16 @@ function ComposerWithSuggestions({
         }),
         [blur, focus, prepareCommentAndResetComposer, replaceSelectionWithText],
     );
-    // eslint-disable-next-line rulesdir/prefer-early-return
+
     useEffect(() => {
-        if (value === '') {
-            setValue(convertToLTR(value));
-        }
+        const changeInputToLTR = (inputValue) => {
+            if (inputValue === '') {
+                setValue(convertToLTR(inputValue));
+            }
+            return true;
+        };
+
+        return changeInputToLTR(value);
     }, [value]);
 
     return (

--- a/src/pages/home/report/ReportActionCompose/ComposerWithSuggestions/ComposerWithSuggestions.js
+++ b/src/pages/home/report/ReportActionCompose/ComposerWithSuggestions/ComposerWithSuggestions.js
@@ -14,7 +14,7 @@ import canFocusInputOnScreenFocus from '@libs/canFocusInputOnScreenFocus';
 import compose from '@libs/compose';
 import * as ComposerUtils from '@libs/ComposerUtils';
 import getDraftComment from '@libs/ComposerUtils/getDraftComment';
-import {moveCursorToEndOfLine, removeUnicodeLTRWhenEmpty} from '@libs/convertToLTR';
+import {moveCursorToEndOfLine} from '@libs/convertToLTR';
 import convertToLTRForComposer from '@libs/convertToLTRForComposer';
 import * as EmojiUtils from '@libs/EmojiUtils';
 import focusComposerWithDelay from '@libs/focusComposerWithDelay';
@@ -106,7 +106,7 @@ function ComposerWithSuggestions({
     const styles = useThemeStyles();
     const {preferredLocale} = useLocalize();
     const isFocused = useIsFocused();
-    const [composerIsEmpty, setComposerIsEmpty] = useState(true);
+    const composerIsEmpty = useRef(true);
     const navigation = useNavigation();
     const emojisPresentBefore = useRef([]);
     const [value, setValue] = useState(() => {
@@ -228,14 +228,10 @@ function ComposerWithSuggestions({
 
             // This prevent the double execution of setting input value that could affect the place holder and could send an empty message or draft messages in android
             if (prevComment !== newComment) {
-                newCommentConverted = removeUnicodeLTRWhenEmpty(newComment, newCommentConverted);
-                newCommentConverted = convertToLTRForComposer(newCommentConverted, composerIsEmpty);
-                if (['@'].includes(newComment)) {
-                    newCommentConverted = removeUnicodeLTRWhenEmpty(newComment, newCommentConverted, true);
-                }
+                newCommentConverted = convertToLTRForComposer(newCommentConverted, composerIsEmpty.current);
                 setValue(newCommentConverted);
                 moveCursorToEndOfLine(newComment.length, setSelection);
-                setComposerIsEmpty(false);
+                composerIsEmpty.current = false;
             }
 
             const isNewCommentEmpty = !!newCommentConverted.match(/^(\s)*$/);
@@ -245,7 +241,7 @@ function ComposerWithSuggestions({
             if (isNewCommentEmpty !== isPrevCommentEmpty) {
                 setIsCommentEmpty(isNewCommentEmpty);
                 if (isNewCommentEmpty) {
-                    setComposerIsEmpty(true);
+                    composerIsEmpty.current = true;
                 }
             }
 

--- a/src/pages/home/report/ReportActionCompose/ComposerWithSuggestions/ComposerWithSuggestions.js
+++ b/src/pages/home/report/ReportActionCompose/ComposerWithSuggestions/ComposerWithSuggestions.js
@@ -14,8 +14,7 @@ import canFocusInputOnScreenFocus from '@libs/canFocusInputOnScreenFocus';
 import compose from '@libs/compose';
 import * as ComposerUtils from '@libs/ComposerUtils';
 import getDraftComment from '@libs/ComposerUtils/getDraftComment';
-import {moveCursorToEndOfLine} from '@libs/convertToLTR';
-import convertToLTRForComposer from '@libs/convertToLTRForComposer';
+import convertToLTRForComposer, {moveCursorToEndOfLine} from '@libs/convertToLTRForComposer';
 import * as EmojiUtils from '@libs/EmojiUtils';
 import focusComposerWithDelay from '@libs/focusComposerWithDelay';
 import * as KeyDownListener from '@libs/KeyboardShortcut/KeyDownPressListener';
@@ -223,18 +222,18 @@ function ComposerWithSuggestions({
                 }
             }
 
-            let newCommentConverted = newComment;
+            let newCommentConvertedToLTR = newComment;
             const prevComment = commentRef.current;
 
             // This prevent the double execution of setting input value that could affect the place holder and could send an empty message or draft messages in android
             if (prevComment !== newComment) {
-                newCommentConverted = convertToLTRForComposer(newCommentConverted, composerIsEmpty.current);
-                setValue(newCommentConverted);
+                newCommentConvertedToLTR = convertToLTRForComposer(newCommentConvertedToLTR, composerIsEmpty.current);
+                setValue(newCommentConvertedToLTR);
                 moveCursorToEndOfLine(newComment.length, setSelection);
                 composerIsEmpty.current = false;
             }
 
-            const isNewCommentEmpty = !!newCommentConverted.match(/^(\s)*$/);
+            const isNewCommentEmpty = !!newCommentConvertedToLTR.match(/^(\s)*$/);
             const isPrevCommentEmpty = !!prevComment.match(/^(\s)*$/);
 
             /** Only update isCommentEmpty state if it's different from previous one */
@@ -256,22 +255,22 @@ function ComposerWithSuggestions({
             }
 
             // Indicate that draft has been created.
-            if (prevComment.length === 0 && newCommentConverted.length !== 0) {
+            if (prevComment.length === 0 && newCommentConvertedToLTR.length !== 0) {
                 Report.setReportWithDraft(reportID, true);
             }
 
             // The draft has been deleted.
-            if (newCommentConverted.length === 0) {
+            if (newCommentConvertedToLTR.length === 0) {
                 Report.setReportWithDraft(reportID, false);
             }
 
-            commentRef.current = newCommentConverted;
+            commentRef.current = newCommentConvertedToLTR;
             if (shouldDebounceSaveComment) {
-                debouncedSaveReportComment(reportID, newCommentConverted);
+                debouncedSaveReportComment(reportID, newCommentConvertedToLTR);
             } else {
-                Report.saveReportComment(reportID, newCommentConverted || '');
+                Report.saveReportComment(reportID, newCommentConvertedToLTR || '');
             }
-            if (newCommentConverted) {
+            if (newCommentConvertedToLTR) {
                 debouncedBroadcastUserIsTyping(reportID);
             }
         },

--- a/src/pages/home/report/ReportActionCompose/ComposerWithSuggestions/ComposerWithSuggestions.js
+++ b/src/pages/home/report/ReportActionCompose/ComposerWithSuggestions/ComposerWithSuggestions.js
@@ -527,14 +527,10 @@ function ComposerWithSuggestions({
     );
 
     useEffect(() => {
-        const changeInputToLTR = (inputValue) => {
-            if (inputValue === '') {
-                setValue(convertToLTR(inputValue));
-            }
-            return true;
-        };
-
-        return changeInputToLTR(value);
+        if (value !== '') {
+            return;
+        }
+        setValue(convertToLTR(value));
     }, [value]);
 
     return (


### PR DESCRIPTION
### Details
<!-- Explanation of the change or anything fishy that is going on -->

The root cause is that Android only converts RTL text to LTR text using Unicode controls and by default, when you start writing in a language that is written in RTL mode it converts the input text to RTL.

### Fixed Issues
$ https://github.com/Expensify/App/issues/30584
PROPOSAL:  https://github.com/Expensify/App/issues/30584#issuecomment-1785494092


### Tests
1. Launch App
2. Open any chat and paste an RTL text in the compose box, for example " مثال "
3. Continue typing some content

- [x] Verify that no errors appear in the JS console

### Offline tests
N/A

### QA Steps
1. Launch App
2. Open any chat and paste an RTL text in the compose box, for example " مثال "
3. Continue typing some content

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

https://github.com/Expensify/App/assets/5216036/8dbd60b9-d3c2-4887-a8bf-2539811c25b0


</details>

<details>
<summary>Android: mWeb Chrome</summary>

https://github.com/Expensify/App/assets/5216036/88df71ff-8445-4ab3-b3ce-aedeb4013516

</details>

<details>
<summary>iOS: Native</summary>

https://github.com/Expensify/App/assets/5216036/2d00cef0-171a-471a-9afc-d7bed970975e


</details>

<details>
<summary>iOS: mWeb Safari</summary>


https://github.com/Expensify/App/assets/5216036/0227ccf4-78bc-46f8-a830-9ef00d60ddac


</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

https://github.com/Expensify/App/assets/5216036/4ea4afd5-cc9d-42c4-bd97-113f3a476b58


</details>

<details>
<summary>MacOS: Desktop</summary>


https://github.com/Expensify/App/assets/5216036/fb19538c-46b6-409f-bd3d-cb938afd42cc



</details>
