### PR TITLE
[CP Staging] Match bank names for credit card icons

### DIFF
--- a/src/CONST.ts
+++ b/src/CONST.ts
@@ -2873,6 +2873,7 @@ const CONST = {
         FIDELITY: 'fidelity',
         GENERIC_BANK: 'generic bank',
         HUNTINGTON_BANK: 'huntington bank',
+        HUNTINGTON_NATIONAL: 'huntington national',
         NAVY_FEDERAL_CREDIT_UNION: 'navy federal credit union',
         PNC: 'pnc',
         REGIONS_BANK: 'regions bank',

--- a/src/components/Icon/BankIcons.ts
+++ b/src/components/Icon/BankIcons.ts
@@ -62,6 +62,9 @@ function getAssetIcon(bankNameKey: BankNameKey, isCard: boolean): React.FC<SvgPr
         [CONST.BANK_NAMES.HUNTINGTON_BANK]: isCard
             ? (require('@assets/images/cardicons/huntington-bank.svg').default as React.FC<SvgProps>)
             : (require('@assets/images/bankicons/huntington-bank.svg').default as React.FC<SvgProps>),
+        [CONST.BANK_NAMES.HUNTINGTON_NATIONAL]: isCard
+            ? (require('@assets/images/cardicons/huntington-bank.svg').default as React.FC<SvgProps>)
+            : (require('@assets/images/bankicons/huntington-bank.svg').default as React.FC<SvgProps>),
         [CONST.BANK_NAMES.NAVY_FEDERAL_CREDIT_UNION]: isCard
             ? (require('@assets/images/cardicons/navy-federal-credit-union.svg').default as React.FC<SvgProps>)
             : (require('@assets/images/bankicons/navy-federal-credit-union.svg').default as React.FC<SvgProps>),

--- a/src/components/Icon/BankIcons.ts
+++ b/src/components/Icon/BankIcons.ts
@@ -99,9 +99,15 @@ function getAssetIcon(bankNameKey: BankNameKey, isCard: boolean): React.FC<SvgPr
 
 function getBankNameKey(bankName: string): BankNameKey {
     const bank = Object.entries(CONST.BANK_NAMES).find(([, value]) => {
-       const condensedValue = value.replace(/\s/g, '');
-       return bankName === value || bankName.includes(value) || bankName.startsWith(value) ||
-              bankName === condensedValue || bankName.includes(condensedValue) || bankName.startsWith(condensedValue);
+        const condensedValue = value.replace(/\s/g, '');
+        return (
+            bankName === value ||
+            bankName.includes(value) ||
+            bankName.startsWith(value) ||
+            bankName === condensedValue ||
+            bankName.includes(condensedValue) ||
+            bankName.startsWith(condensedValue)
+        );
     });
     return (bank?.[0] as BankNameKey) ?? '';
 }

--- a/src/components/Icon/BankIcons.ts
+++ b/src/components/Icon/BankIcons.ts
@@ -95,7 +95,11 @@ function getAssetIcon(bankNameKey: BankNameKey, isCard: boolean): React.FC<SvgPr
 }
 
 function getBankNameKey(bankName: string): BankNameKey {
-    const bank = Object.entries(CONST.BANK_NAMES).find(([, value]) => value?.toLowerCase() === bankName);
+    const bank = Object.entries(CONST.BANK_NAMES).find(([, value]) => {
+       const condensedValue = value.replace(/\s/g, '');
+       return bankName === value || bankName.includes(value) || bankName.startsWith(value) ||
+              bankName === condensedValue || bankName.includes(condensedValue) || bankName.startsWith(condensedValue);
+    });
     return (bank?.[0] as BankNameKey) ?? '';
 }
 


### PR DESCRIPTION
### Details

More loosely matches a variety of bank names to ensure the credit card icon displays correctly

### Fixed Issues
$ https://github.com/Expensify/App/issues/32392
PROPOSAL: N/A 

### Tests
1. Log into an Expensify account with an Expensify Card
3. Tap on settings icon in the LHN
4. Select the Wallet option
5. Confirm the correct icon is displayed for each credit card

- [x] Verify that no errors appear in the JS console

### Offline tests
N/A 

### QA Steps

1. Navigate to staging.new.expensify.com
2. Log in with [tester@applausecard.expensifail.com](mailto:tester@applausecard.expensifail.com)
3. Tap on the settings icon in LHN
4. Select the Wallet option
5. Confirm the correct icon is displayed for each credit card

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

![Screenshot_1701712582](https://github.com/Expensify/App/assets/16747822/5134e58d-cfc7-4a56-8616-90db3e80739d)

</details>

<details>
<summary>Android: mWeb Chrome</summary>

![Screenshot_1701713871](https://github.com/Expensify/App/assets/16747822/a2659213-322a-498a-a5fa-cb2d8c2a243a)

</details>

<details>
<summary>iOS: Native</summary>

![Simulator Screenshot - iPhone 15 Pro - 2023-12-03 at 00 31 52](https://github.com/Expensify/App/assets/16747822/41f84996-cab8-4c8a-bdc6-03fd99677c2f)

</details>

<details>
<summary>iOS: mWeb Safari</summary>

![Simulator Screenshot - iPhone 15 Pro - 2023-12-03 at 00 41 34](https://github.com/Expensify/App/assets/16747822/dd8a6268-e49c-49e5-895e-341ccbdc4060)

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

![Screenshot 2023-12-03 at 00 01 51](https://github.com/Expensify/App/assets/16747822/0bf071fa-4319-4719-b1c6-de7baf65afc3)

</details>

<details>
<summary>MacOS: Desktop</summary>

<img width="985" alt="image" src="https://github.com/Expensify/App/assets/16747822/f34d178e-ea20-4dca-803a-55d8fc4f12cf">
</details>
