### PR TITLE
[Wave8] Change design of OptionRowLHN

### DIFF
--- a/config/webpack/webpack.dev.js
+++ b/config/webpack/webpack.dev.js
@@ -34,7 +34,6 @@ module.exports = (env = {}) =>
             mode: 'development',
             devtool: 'eval-source-map',
             devServer: {
-                allowedHosts: 'all',
                 static: {
                     directory: path.join(__dirname, '../../dist'),
                 },

--- a/config/webpack/webpack.dev.js
+++ b/config/webpack/webpack.dev.js
@@ -34,6 +34,7 @@ module.exports = (env = {}) =>
             mode: 'development',
             devtool: 'eval-source-map',
             devServer: {
+                allowedHosts: 'all',
                 static: {
                     directory: path.join(__dirname, '../../dist'),
                 },

--- a/src/components/LHNOptionsList/OptionRowLHN.js
+++ b/src/components/LHNOptionsList/OptionRowLHN.js
@@ -197,33 +197,31 @@ function OptionRowLHN(props) {
                         withoutFocusOnSecondaryInteraction
                         activeOpacity={0.8}
                         style={[
-                            styles.sidebarLinkLHN,
+                            styles.flexRow,
+                            styles.alignItemsCenter,
+                            styles.justifyContentBetween,
+                            styles.sidebarLink,
+                            styles.sidebarLinkInnerLHN,
                             StyleUtils.getBackgroundColorStyle(theme.sidebar),
-                            props.isFocused ? styles.sidebarLinkActive : null
+                            props.isFocused ? styles.sidebarLinkActive : null,
+                            (hovered || isContextMenuActive) && !props.isFocused ? props.hoverStyle || styles.sidebarLinkHover : null,
                         ]}
                         role={CONST.ACCESSIBILITY_ROLE.BUTTON}
                         accessibilityLabel={translate('accessibilityHints.navigatesToChat')}
                         needsOffscreenAlphaCompositing={props.optionItem.icons.length >= 2}
                     >
-                        <View style={[
-                            styles.flexRow,
-                            styles.alignItemsCenter,
-                            styles.justifyContentBetween,
-                            styles.sidebarLinkInnerLHN,
-                            (hovered || isContextMenuActive) && !props.isFocused ? props.hoverStyle || styles.sidebarLinkHoverLHN : null,
-                        ]}>
                         <View style={sidebarInnerRowStyle}>
                             <View style={[styles.flexRow, styles.alignItemsCenter]}>
                                 {!_.isEmpty(optionItem.icons) &&
                                     (optionItem.shouldShowSubscript ? (
                                         <SubscriptAvatar
-                                        backgroundColor={props.isFocused ? theme.activeComponentBG : theme.sidebar}
-                                        mainAvatar={optionItem.icons[0]}
-                                        secondaryAvatar={optionItem.icons[1]}
-                                        size={props.viewMode === CONST.OPTION_MODE.COMPACT ? CONST.AVATAR_SIZE.SMALL : defaultSubscriptSize}
+                                            backgroundColor={props.isFocused ? theme.activeComponentBG : theme.sidebar}
+                                            mainAvatar={optionItem.icons[0]}
+                                            secondaryAvatar={optionItem.icons[1]}
+                                            size={props.viewMode === CONST.OPTION_MODE.COMPACT ? CONST.AVATAR_SIZE.SMALL : defaultSubscriptSize}
                                         />
-                                        ) : (
-                                            <MultipleAvatars
+                                    ) : (
+                                        <MultipleAvatars
                                             icons={optionItem.icons}
                                             isFocusMode={props.viewMode === CONST.OPTION_MODE.COMPACT}
                                             size={props.viewMode === CONST.OPTION_MODE.COMPACT ? CONST.AVATAR_SIZE.SMALL : CONST.AVATAR_SIZE.DEFAULT}
@@ -233,8 +231,8 @@ function OptionRowLHN(props) {
                                                 hovered && !props.isFocused ? StyleUtils.getBackgroundAndBorderStyle(hoveredBackgroundColor) : undefined,
                                             ]}
                                             shouldShowTooltip={OptionsListUtils.shouldOptionShowTooltip(optionItem)}
-                                            />
-                                            ))}
+                                        />
+                                    ))}
                                 <View style={contentContainerStyles}>
                                     <View style={[styles.flexRow, styles.alignItemsCenter, styles.mw100, styles.overflowHidden]}>
                                         <DisplayNames
@@ -247,11 +245,11 @@ function OptionRowLHN(props) {
                                             shouldUseFullTitle={
                                                 optionItem.isChatRoom || optionItem.isPolicyExpenseChat || optionItem.isTaskReport || optionItem.isThread || optionItem.isMoneyRequestReport
                                             }
-                                            />
+                                        />
                                         {isStatusVisible && (
                                             <Tooltip
-                                            text={statusContent}
-                                            shiftVertical={-4}
+                                                text={statusContent}
+                                                shiftVertical={-4}
                                             >
                                                 <Text style={styles.ml1}>{emojiCode}</Text>
                                             </Tooltip>
@@ -259,9 +257,9 @@ function OptionRowLHN(props) {
                                     </View>
                                     {optionItem.alternateText ? (
                                         <Text
-                                        style={alternateTextStyle}
-                                        numberOfLines={1}
-                                        accessibilityLabel={translate('accessibilityHints.lastChatMessagePreview')}
+                                            style={alternateTextStyle}
+                                            numberOfLines={1}
+                                            accessibilityLabel={translate('accessibilityHints.lastChatMessagePreview')}
                                         >
                                             {optionItem.alternateText}
                                         </Text>
@@ -277,47 +275,45 @@ function OptionRowLHN(props) {
                                         <Icon
                                             src={Expensicons.DotIndicator}
                                             fill={theme.danger}
-                                            />
+                                        />
                                     </View>
                                 )}
                             </View>
-                        {/* END OF GROUP WITH MESSAGE */}
                         </View>
                         <View
                             style={[styles.flexRow, styles.alignItemsCenter]}
                             accessible={false}
-                            >
+                        >
                             {shouldShowGreenDotIndicator && (
                                 <View style={styles.ml2}>
                                     <Icon
                                         src={Expensicons.DotIndicator}
                                         fill={theme.success}
-                                        />
+                                    />
                                 </View>
                             )}
                             {optionItem.hasDraftComment && optionItem.isAllowedToComment && (
                                 <View
-                                style={styles.ml2}
-                                accessibilityLabel={translate('sidebarScreen.draftedMessage')}
+                                    style={styles.ml2}
+                                    accessibilityLabel={translate('sidebarScreen.draftedMessage')}
                                 >
                                     <Icon src={Expensicons.Pencil} />
                                 </View>
                             )}
                             {!shouldShowGreenDotIndicator && optionItem.isPinned && (
                                 <View
-                                style={styles.ml2}
-                                accessibilityLabel={translate('sidebarScreen.chatPinned')}
+                                    style={styles.ml2}
+                                    accessibilityLabel={translate('sidebarScreen.chatPinned')}
                                 >
                                     <Icon src={Expensicons.Pin} />
                                 </View>
                             )}
                         </View>
-                        </View>
                     </PressableWithSecondaryInteraction>
                 )}
             </Hoverable>
         </OfflineWithFeedback>
-        );
+    );
 }
 
 OptionRowLHN.propTypes = propTypes;

--- a/src/components/LHNOptionsList/OptionRowLHN.js
+++ b/src/components/LHNOptionsList/OptionRowLHN.js
@@ -197,31 +197,33 @@ function OptionRowLHN(props) {
                         withoutFocusOnSecondaryInteraction
                         activeOpacity={0.8}
                         style={[
-                            styles.flexRow,
-                            styles.alignItemsCenter,
-                            styles.justifyContentBetween,
-                            styles.sidebarLink,
-                            styles.sidebarLinkInner,
+                            styles.sidebarLinkLHN,
                             StyleUtils.getBackgroundColorStyle(theme.sidebar),
-                            props.isFocused ? styles.sidebarLinkActive : null,
-                            (hovered || isContextMenuActive) && !props.isFocused ? props.hoverStyle || styles.sidebarLinkHover : null,
+                            props.isFocused ? styles.sidebarLinkActive : null
                         ]}
                         role={CONST.ACCESSIBILITY_ROLE.BUTTON}
                         accessibilityLabel={translate('accessibilityHints.navigatesToChat')}
                         needsOffscreenAlphaCompositing={props.optionItem.icons.length >= 2}
                     >
+                        <View style={[
+                            styles.flexRow,
+                            styles.alignItemsCenter,
+                            styles.justifyContentBetween,
+                            styles.sidebarLinkInnerLHN,
+                            (hovered || isContextMenuActive) && !props.isFocused ? props.hoverStyle || styles.sidebarLinkHoverLHN : null,
+                        ]}>
                         <View style={sidebarInnerRowStyle}>
                             <View style={[styles.flexRow, styles.alignItemsCenter]}>
                                 {!_.isEmpty(optionItem.icons) &&
                                     (optionItem.shouldShowSubscript ? (
                                         <SubscriptAvatar
-                                            backgroundColor={props.isFocused ? theme.activeComponentBG : theme.sidebar}
-                                            mainAvatar={optionItem.icons[0]}
-                                            secondaryAvatar={optionItem.icons[1]}
-                                            size={props.viewMode === CONST.OPTION_MODE.COMPACT ? CONST.AVATAR_SIZE.SMALL : defaultSubscriptSize}
+                                        backgroundColor={props.isFocused ? theme.activeComponentBG : theme.sidebar}
+                                        mainAvatar={optionItem.icons[0]}
+                                        secondaryAvatar={optionItem.icons[1]}
+                                        size={props.viewMode === CONST.OPTION_MODE.COMPACT ? CONST.AVATAR_SIZE.SMALL : defaultSubscriptSize}
                                         />
-                                    ) : (
-                                        <MultipleAvatars
+                                        ) : (
+                                            <MultipleAvatars
                                             icons={optionItem.icons}
                                             isFocusMode={props.viewMode === CONST.OPTION_MODE.COMPACT}
                                             size={props.viewMode === CONST.OPTION_MODE.COMPACT ? CONST.AVATAR_SIZE.SMALL : CONST.AVATAR_SIZE.DEFAULT}
@@ -231,8 +233,8 @@ function OptionRowLHN(props) {
                                                 hovered && !props.isFocused ? StyleUtils.getBackgroundAndBorderStyle(hoveredBackgroundColor) : undefined,
                                             ]}
                                             shouldShowTooltip={OptionsListUtils.shouldOptionShowTooltip(optionItem)}
-                                        />
-                                    ))}
+                                            />
+                                            ))}
                                 <View style={contentContainerStyles}>
                                     <View style={[styles.flexRow, styles.alignItemsCenter, styles.mw100, styles.overflowHidden]}>
                                         <DisplayNames
@@ -245,11 +247,11 @@ function OptionRowLHN(props) {
                                             shouldUseFullTitle={
                                                 optionItem.isChatRoom || optionItem.isPolicyExpenseChat || optionItem.isTaskReport || optionItem.isThread || optionItem.isMoneyRequestReport
                                             }
-                                        />
+                                            />
                                         {isStatusVisible && (
                                             <Tooltip
-                                                text={statusContent}
-                                                shiftVertical={-4}
+                                            text={statusContent}
+                                            shiftVertical={-4}
                                             >
                                                 <Text style={styles.ml1}>{emojiCode}</Text>
                                             </Tooltip>
@@ -257,9 +259,9 @@ function OptionRowLHN(props) {
                                     </View>
                                     {optionItem.alternateText ? (
                                         <Text
-                                            style={alternateTextStyle}
-                                            numberOfLines={1}
-                                            accessibilityLabel={translate('accessibilityHints.lastChatMessagePreview')}
+                                        style={alternateTextStyle}
+                                        numberOfLines={1}
+                                        accessibilityLabel={translate('accessibilityHints.lastChatMessagePreview')}
                                         >
                                             {optionItem.alternateText}
                                         </Text>
@@ -275,45 +277,47 @@ function OptionRowLHN(props) {
                                         <Icon
                                             src={Expensicons.DotIndicator}
                                             fill={theme.danger}
-                                        />
+                                            />
                                     </View>
                                 )}
                             </View>
+                        {/* END OF GROUP WITH MESSAGE */}
                         </View>
                         <View
                             style={[styles.flexRow, styles.alignItemsCenter]}
                             accessible={false}
-                        >
+                            >
                             {shouldShowGreenDotIndicator && (
                                 <View style={styles.ml2}>
                                     <Icon
                                         src={Expensicons.DotIndicator}
                                         fill={theme.success}
-                                    />
+                                        />
                                 </View>
                             )}
                             {optionItem.hasDraftComment && optionItem.isAllowedToComment && (
                                 <View
-                                    style={styles.ml2}
-                                    accessibilityLabel={translate('sidebarScreen.draftedMessage')}
+                                style={styles.ml2}
+                                accessibilityLabel={translate('sidebarScreen.draftedMessage')}
                                 >
                                     <Icon src={Expensicons.Pencil} />
                                 </View>
                             )}
                             {!shouldShowGreenDotIndicator && optionItem.isPinned && (
                                 <View
-                                    style={styles.ml2}
-                                    accessibilityLabel={translate('sidebarScreen.chatPinned')}
+                                style={styles.ml2}
+                                accessibilityLabel={translate('sidebarScreen.chatPinned')}
                                 >
                                     <Icon src={Expensicons.Pin} />
                                 </View>
                             )}
                         </View>
+                        </View>
                     </PressableWithSecondaryInteraction>
                 )}
             </Hoverable>
         </OfflineWithFeedback>
-    );
+        );
 }
 
 OptionRowLHN.propTypes = propTypes;

--- a/src/styles/styles.ts
+++ b/src/styles/styles.ts
@@ -1493,7 +1493,7 @@ const styles = (theme: ThemeColors) =>
             paddingLeft: 8,
             paddingRight: 8,
             marginHorizontal: 12,
-            borderRadius: variables.componentBorderRadiusMedium,
+            borderRadius: variables.componentBorderRadiusNormal,
         },
 
         sidebarLinkText: {

--- a/src/styles/styles.ts
+++ b/src/styles/styles.ts
@@ -1475,9 +1475,7 @@ const styles = (theme: ThemeColors) =>
 
         sidebarLinkLHN: {
             textDecorationLine: 'none',
-            marginLeft: 12,
-            marginRight: 12,
-            borderRadius: 8,
+            paddingHorizontal: 12,
         },
 
         sidebarLinkInner: {
@@ -1488,10 +1486,7 @@ const styles = (theme: ThemeColors) =>
         },
 
         sidebarLinkInnerLHN: {
-            alignItems: 'center',
-            flexDirection: 'row',
-            paddingLeft: 8,
-            paddingRight: 8,
+            paddingHorizontal: 8,
         },
 
         sidebarLinkText: {
@@ -1506,7 +1501,8 @@ const styles = (theme: ThemeColors) =>
         },
 
         sidebarLinkHoverLHN: {
-            backgroundColor: theme.highlightBG,
+            backgroundColor: theme.sidebarHover,
+            borderRadius: variables.componentBorderRadiusMedium,
         },
 
         sidebarLinkActive: {

--- a/src/styles/styles.ts
+++ b/src/styles/styles.ts
@@ -1475,7 +1475,9 @@ const styles = (theme: ThemeColors) =>
 
         sidebarLinkLHN: {
             textDecorationLine: 'none',
-            paddingHorizontal: 12,
+            marginLeft: 12,
+            marginRight: 12,
+            borderRadius: 8,
         },
 
         sidebarLinkInner: {
@@ -1486,7 +1488,12 @@ const styles = (theme: ThemeColors) =>
         },
 
         sidebarLinkInnerLHN: {
-            paddingHorizontal: 8,
+            alignItems: 'center',
+            flexDirection: 'row',
+            paddingLeft: 8,
+            paddingRight: 8,
+            marginHorizontal: 12,
+            borderRadius: variables.componentBorderRadiusMedium,
         },
 
         sidebarLinkText: {
@@ -1501,8 +1508,7 @@ const styles = (theme: ThemeColors) =>
         },
 
         sidebarLinkHoverLHN: {
-            backgroundColor: theme.sidebarHover,
-            borderRadius: variables.componentBorderRadiusMedium,
+            backgroundColor: theme.highlightBG,
         },
 
         sidebarLinkActive: {


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
Instead of changing the color of the whole row,`OptionRowLHN` has a border around it. It is visible when the row is focused or hovered.

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/31766
PROPOSAL: 


### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
4. Verify a modal appears displaying a preview of that image
--->
- [ ] Verify that no errors appear in the JS console

Desktop/browser:
- [ ] Hover the item list (one that is not focused). It should have border visible.
- [ ] Hover over the focused item of the list. The color of the border should remain the same.
- [ ] The border for the hovered item should be visible if and only the cursor is over the area of the border

Mobile devices:
- [ ] Press and hold the item in the list. The border should be visible for a short period of time

### Offline tests
--
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

### QA Steps
Same as tests
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
4. Verify a modal appears displaying a preview of that image
--->

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

[Android app.webm](https://github.com/Expensify/App/assets/60450261/17b4ca64-54de-4695-991b-8b1d87c2774c)


</details>

<details>
<summary>Android: mWeb Chrome</summary>

[Android chrome.webm](https://github.com/Expensify/App/assets/60450261/9947bccd-1420-40c1-8d6e-71912c12393a)


</details>

<details>
<summary>iOS: Native</summary>


https://github.com/Expensify/App/assets/60450261/155019ea-4d3f-4ff6-b950-8dbb09ae5973



</details>

<details>
<summary>iOS: mWeb Safari</summary>


https://github.com/Expensify/App/assets/60450261/20df59d5-c528-4d56-9a86-bffa2aaa8718




</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

https://github.com/Expensify/App/assets/60450261/13452476-2459-4976-b1de-0782222058af

</details>

<details>
<summary>MacOS: Desktop</summary>

https://github.com/Expensify/App/assets/60450261/6912a1f5-676a-483e-afa6-9ea9ba7e07e2

</details>
