### PR TITLE
Truncate long items in the SelectionList

### DIFF
--- a/src/components/SelectionList/BaseListItem.js
+++ b/src/components/SelectionList/BaseListItem.js
@@ -31,20 +31,6 @@ function BaseListItem({
     const isUserItem = lodashGet(item, 'icons.length', 0) > 0;
     const ListItem = isUserItem ? UserListItem : RadioListItem;
 
-    const textStyle = StyleUtils.combineStyles(
-        styles.optionDisplayName,
-        isFocused ? styles.sidebarLinkActiveText : styles.sidebarLinkText,
-        item.isSelected && styles.sidebarLinkTextBold,
-        styles.pre,
-    );
-
-    const alternateTextStyle = StyleUtils.combineStyles(
-        styles.optionAlternateText,
-        styles.textLabelSupporting,
-        isFocused ? styles.sidebarLinkActiveText : styles.sidebarLinkText,
-        styles.pre,
-    );
-
     return (
         <OfflineWithFeedback
             onClose={() => onDismissError(item)}
@@ -97,8 +83,14 @@ function BaseListItem({
                     )}
                     <ListItem
                         item={item}
-                        textStyle={textStyle}
-                        alternateTextStyle={alternateTextStyle}
+                        textStyle={[
+                            styles.optionDisplayName,
+                            isFocused ? styles.sidebarLinkActiveText : styles.sidebarLinkText,
+                            item.isSelected && styles.sidebarLinkTextBold,
+                            isUserItem || item.isSelected ? styles.sidebarLinkTextBold : null,
+                            styles.pre,
+                        ]}
+                        alternateTextStyle={[styles.optionAlternateText, styles.textLabelSupporting, isFocused ? styles.sidebarLinkActiveText : styles.sidebarLinkText, styles.pre]}
                         isFocused={isFocused}
                         isDisabled={isDisabled}
                         onSelectRow={onSelectRow}

--- a/src/components/SelectionList/BaseListItem.js
+++ b/src/components/SelectionList/BaseListItem.js
@@ -31,6 +31,20 @@ function BaseListItem({
     const isUserItem = lodashGet(item, 'icons.length', 0) > 0;
     const ListItem = isUserItem ? UserListItem : RadioListItem;
 
+    const textStyle = StyleUtils.combineStyles(
+        styles.optionDisplayName,
+        isFocused ? styles.sidebarLinkActiveText : styles.sidebarLinkText,
+        item.isSelected && styles.sidebarLinkTextBold,
+        styles.pre,
+    );
+
+    const alternateTextStyle = StyleUtils.combineStyles(
+        styles.optionAlternateText,
+        styles.textLabelSupporting,
+        isFocused ? styles.sidebarLinkActiveText : styles.sidebarLinkText,
+        styles.pre,
+    );
+
     return (
         <OfflineWithFeedback
             onClose={() => onDismissError(item)}
@@ -83,6 +97,8 @@ function BaseListItem({
                     )}
                     <ListItem
                         item={item}
+                        textStyle={textStyle}
+                        alternateTextStyle={alternateTextStyle}
                         isFocused={isFocused}
                         isDisabled={isDisabled}
                         onSelectRow={onSelectRow}

--- a/src/components/SelectionList/BaseListItem.js
+++ b/src/components/SelectionList/BaseListItem.js
@@ -83,14 +83,14 @@ function BaseListItem({
                     )}
                     <ListItem
                         item={item}
-                        textStyle={[
+                        textStyles={[
                             styles.optionDisplayName,
                             isFocused ? styles.sidebarLinkActiveText : styles.sidebarLinkText,
                             item.isSelected && styles.sidebarLinkTextBold,
                             isUserItem || item.isSelected ? styles.sidebarLinkTextBold : null,
                             styles.pre,
                         ]}
-                        alternateTextStyle={[styles.optionAlternateText, styles.textLabelSupporting, isFocused ? styles.sidebarLinkActiveText : styles.sidebarLinkText, styles.pre]}
+                        alternateTextStyles={[styles.optionAlternateText, styles.textLabelSupporting, isFocused ? styles.sidebarLinkActiveText : styles.sidebarLinkText, styles.pre]}
                         isFocused={isFocused}
                         isDisabled={isDisabled}
                         onSelectRow={onSelectRow}

--- a/src/components/SelectionList/BaseListItem.js
+++ b/src/components/SelectionList/BaseListItem.js
@@ -86,8 +86,7 @@ function BaseListItem({
                         textStyles={[
                             styles.optionDisplayName,
                             isFocused ? styles.sidebarLinkActiveText : styles.sidebarLinkText,
-                            item.isSelected && styles.sidebarLinkTextBold,
-                            isUserItem || item.isSelected ? styles.sidebarLinkTextBold : null,
+                            (isUserItem || item.isSelected) && styles.sidebarLinkTextBold,
                             styles.pre,
                         ]}
                         alternateTextStyles={[styles.optionAlternateText, styles.textLabelSupporting, isFocused ? styles.sidebarLinkActiveText : styles.sidebarLinkText, styles.pre]}

--- a/src/components/SelectionList/BaseListItem.js
+++ b/src/components/SelectionList/BaseListItem.js
@@ -90,7 +90,6 @@ function BaseListItem({
                             styles.pre,
                         ]}
                         alternateTextStyles={[styles.optionAlternateText, styles.textLabelSupporting, isFocused ? styles.sidebarLinkActiveText : styles.sidebarLinkText, styles.pre]}
-                        isFocused={isFocused}
                         isDisabled={isDisabled}
                         onSelectRow={onSelectRow}
                         showTooltip={showTooltip}

--- a/src/components/SelectionList/BaseListItem.js
+++ b/src/components/SelectionList/BaseListItem.js
@@ -86,7 +86,7 @@ function BaseListItem({
                         textStyles={[
                             styles.optionDisplayName,
                             isFocused ? styles.sidebarLinkActiveText : styles.sidebarLinkText,
-                            (isUserItem || item.isSelected) && styles.sidebarLinkTextBold,
+                            isUserItem || item.isSelected ? styles.sidebarLinkTextBold : null,
                             styles.pre,
                         ]}
                         alternateTextStyles={[styles.optionAlternateText, styles.textLabelSupporting, isFocused ? styles.sidebarLinkActiveText : styles.sidebarLinkText, styles.pre]}

--- a/src/components/SelectionList/RadioListItem.js
+++ b/src/components/SelectionList/RadioListItem.js
@@ -5,7 +5,7 @@ import Tooltip from '@components/Tooltip';
 import useThemeStyles from '@styles/useThemeStyles';
 import {radioListItemPropTypes} from './selectionListPropTypes';
 
-function RadioListItem({item, showTooltip, textStyle, alternateTextStyle}) {
+function RadioListItem({item, showTooltip, textStyles, alternateTextStyles}) {
     const styles = useThemeStyles();
     return (
         <View style={[styles.flex1, styles.alignItemsStart]}>
@@ -14,7 +14,7 @@ function RadioListItem({item, showTooltip, textStyle, alternateTextStyle}) {
                 text={item.text}
             >
                 <Text
-                    style={textStyle}
+                    style={textStyles}
                     numberOfLines={1}
                 >
                     {item.text}
@@ -27,7 +27,7 @@ function RadioListItem({item, showTooltip, textStyle, alternateTextStyle}) {
                     text={item.alternateText}
                 >
                     <Text
-                        style={alternateTextStyle}
+                        style={alternateTextStyles}
                         numberOfLines={1}
                     >
                         {item.alternateText}

--- a/src/components/SelectionList/RadioListItem.js
+++ b/src/components/SelectionList/RadioListItem.js
@@ -1,27 +1,38 @@
 import React from 'react';
 import {View} from 'react-native';
 import Text from '@components/Text';
+import Tooltip from '@components/Tooltip';
 import useThemeStyles from '@styles/useThemeStyles';
 import {radioListItemPropTypes} from './selectionListPropTypes';
 
-function RadioListItem({item, isFocused = false}) {
+function RadioListItem({item, isFocused = false, showTooltip}) {
     const styles = useThemeStyles();
     return (
         <View style={[styles.flex1, styles.alignItemsStart]}>
-            <Text
-                style={[styles.optionDisplayName, isFocused ? styles.sidebarLinkActiveText : styles.sidebarLinkText, item.isSelected && styles.sidebarLinkTextBold, styles.pre]}
-                numberOfLines={1}
+            <Tooltip
+                shouldRender={showTooltip}
+                text={item.text}
             >
-                {item.text}
-            </Text>
-
-            {Boolean(item.alternateText) && (
                 <Text
-                    style={[isFocused ? styles.sidebarLinkActiveText : styles.sidebarLinkText, styles.optionAlternateText, styles.textLabelSupporting, styles.pre]}
+                    style={[styles.optionDisplayName, isFocused ? styles.sidebarLinkActiveText : styles.sidebarLinkText, item.isSelected && styles.sidebarLinkTextBold, styles.pre]}
                     numberOfLines={1}
                 >
-                    {item.alternateText}
+                    {item.text}
                 </Text>
+            </Tooltip>
+
+            {Boolean(item.alternateText) && (
+                <Tooltip
+                    shouldRender={showTooltip}
+                    text={item.alternateText}
+                >
+                    <Text
+                        style={[isFocused ? styles.sidebarLinkActiveText : styles.sidebarLinkText, styles.optionAlternateText, styles.textLabelSupporting, styles.pre]}
+                        numberOfLines={1}
+                    >
+                        {item.alternateText}
+                    </Text>
+                </Tooltip>
             )}
         </View>
     );

--- a/src/components/SelectionList/RadioListItem.js
+++ b/src/components/SelectionList/RadioListItem.js
@@ -8,10 +8,20 @@ function RadioListItem({item, isFocused = false}) {
     const styles = useThemeStyles();
     return (
         <View style={[styles.flex1, styles.alignItemsStart]}>
-            <Text style={[styles.optionDisplayName, isFocused ? styles.sidebarLinkActiveText : styles.sidebarLinkText, item.isSelected && styles.sidebarLinkTextBold]}>{item.text}</Text>
+            <Text
+                style={[styles.optionDisplayName, isFocused ? styles.sidebarLinkActiveText : styles.sidebarLinkText, item.isSelected && styles.sidebarLinkTextBold, styles.pre]}
+                numberOfLines={1}
+            >
+                {item.text}
+            </Text>
 
             {Boolean(item.alternateText) && (
-                <Text style={[isFocused ? styles.sidebarLinkActiveText : styles.sidebarLinkText, styles.optionAlternateText, styles.textLabelSupporting]}>{item.alternateText}</Text>
+                <Text
+                    style={[isFocused ? styles.sidebarLinkActiveText : styles.sidebarLinkText, styles.optionAlternateText, styles.textLabelSupporting, styles.pre]}
+                    numberOfLines={1}
+                >
+                    {item.alternateText}
+                </Text>
             )}
         </View>
     );

--- a/src/components/SelectionList/RadioListItem.js
+++ b/src/components/SelectionList/RadioListItem.js
@@ -2,10 +2,11 @@ import React from 'react';
 import {View} from 'react-native';
 import Text from '@components/Text';
 import Tooltip from '@components/Tooltip';
+import * as StyleUtils from '@styles/StyleUtils';
 import useThemeStyles from '@styles/useThemeStyles';
 import {radioListItemPropTypes} from './selectionListPropTypes';
 
-function RadioListItem({item, isFocused = false, showTooltip}) {
+function RadioListItem({item, showTooltip, textStyle, alternateTextStyle}) {
     const styles = useThemeStyles();
     return (
         <View style={[styles.flex1, styles.alignItemsStart]}>
@@ -14,7 +15,7 @@ function RadioListItem({item, isFocused = false, showTooltip}) {
                 text={item.text}
             >
                 <Text
-                    style={[styles.optionDisplayName, isFocused ? styles.sidebarLinkActiveText : styles.sidebarLinkText, item.isSelected && styles.sidebarLinkTextBold, styles.pre]}
+                    style={StyleUtils.combineStyles(textStyle, item.isSelected && styles.sidebarLinkTextBold)}
                     numberOfLines={1}
                 >
                     {item.text}
@@ -27,7 +28,7 @@ function RadioListItem({item, isFocused = false, showTooltip}) {
                     text={item.alternateText}
                 >
                     <Text
-                        style={[isFocused ? styles.sidebarLinkActiveText : styles.sidebarLinkText, styles.optionAlternateText, styles.textLabelSupporting, styles.pre]}
+                        style={alternateTextStyle}
                         numberOfLines={1}
                     >
                         {item.alternateText}

--- a/src/components/SelectionList/RadioListItem.js
+++ b/src/components/SelectionList/RadioListItem.js
@@ -2,7 +2,6 @@ import React from 'react';
 import {View} from 'react-native';
 import Text from '@components/Text';
 import Tooltip from '@components/Tooltip';
-import * as StyleUtils from '@styles/StyleUtils';
 import useThemeStyles from '@styles/useThemeStyles';
 import {radioListItemPropTypes} from './selectionListPropTypes';
 
@@ -15,7 +14,7 @@ function RadioListItem({item, showTooltip, textStyle, alternateTextStyle}) {
                 text={item.text}
             >
                 <Text
-                    style={StyleUtils.combineStyles(textStyle, item.isSelected && styles.sidebarLinkTextBold)}
+                    style={textStyle}
                     numberOfLines={1}
                 >
                     {item.text}

--- a/src/components/SelectionList/UserListItem.js
+++ b/src/components/SelectionList/UserListItem.js
@@ -4,10 +4,11 @@ import {View} from 'react-native';
 import SubscriptAvatar from '@components/SubscriptAvatar';
 import Text from '@components/Text';
 import Tooltip from '@components/Tooltip';
+import * as StyleUtils from '@styles/StyleUtils';
 import useThemeStyles from '@styles/useThemeStyles';
 import {userListItemPropTypes} from './selectionListPropTypes';
 
-function UserListItem({item, isFocused = false, showTooltip}) {
+function UserListItem({item, textStyle, alternateTextStyle, showTooltip}) {
     const styles = useThemeStyles();
     return (
         <>
@@ -24,7 +25,7 @@ function UserListItem({item, isFocused = false, showTooltip}) {
                     text={item.text}
                 >
                     <Text
-                        style={[styles.optionDisplayName, isFocused ? styles.sidebarLinkActiveText : styles.sidebarLinkText, styles.sidebarLinkTextBold]}
+                        style={StyleUtils.combineStyles(textStyle, styles.sidebarLinkTextBold)}
                         numberOfLines={1}
                     >
                         {item.text}
@@ -36,7 +37,7 @@ function UserListItem({item, isFocused = false, showTooltip}) {
                         text={item.alternateText}
                     >
                         <Text
-                            style={[isFocused ? styles.sidebarLinkActiveText : styles.sidebarLinkText, styles.optionAlternateText, styles.textLabelSupporting]}
+                            style={alternateTextStyle}
                             numberOfLines={1}
                         >
                             {item.alternateText}

--- a/src/components/SelectionList/UserListItem.js
+++ b/src/components/SelectionList/UserListItem.js
@@ -4,7 +4,6 @@ import {View} from 'react-native';
 import SubscriptAvatar from '@components/SubscriptAvatar';
 import Text from '@components/Text';
 import Tooltip from '@components/Tooltip';
-import * as StyleUtils from '@styles/StyleUtils';
 import useThemeStyles from '@styles/useThemeStyles';
 import {userListItemPropTypes} from './selectionListPropTypes';
 
@@ -25,7 +24,7 @@ function UserListItem({item, textStyle, alternateTextStyle, showTooltip}) {
                     text={item.text}
                 >
                     <Text
-                        style={StyleUtils.combineStyles(textStyle, styles.sidebarLinkTextBold)}
+                        style={textStyle}
                         numberOfLines={1}
                     >
                         {item.text}

--- a/src/components/SelectionList/UserListItem.js
+++ b/src/components/SelectionList/UserListItem.js
@@ -7,7 +7,7 @@ import Tooltip from '@components/Tooltip';
 import useThemeStyles from '@styles/useThemeStyles';
 import {userListItemPropTypes} from './selectionListPropTypes';
 
-function UserListItem({item, textStyle, alternateTextStyle, showTooltip}) {
+function UserListItem({item, textStyles, alternateTextStyles, showTooltip}) {
     const styles = useThemeStyles();
     return (
         <>
@@ -24,7 +24,7 @@ function UserListItem({item, textStyle, alternateTextStyle, showTooltip}) {
                     text={item.text}
                 >
                     <Text
-                        style={textStyle}
+                        style={textStyles}
                         numberOfLines={1}
                     >
                         {item.text}
@@ -36,7 +36,7 @@ function UserListItem({item, textStyle, alternateTextStyle, showTooltip}) {
                         text={item.alternateText}
                     >
                         <Text
-                            style={alternateTextStyle}
+                            style={alternateTextStyles}
                             numberOfLines={1}
                         >
                             {item.alternateText}

--- a/src/components/SelectionList/selectionListPropTypes.js
+++ b/src/components/SelectionList/selectionListPropTypes.js
@@ -6,6 +6,12 @@ const commonListItemPropTypes = {
     /** Whether this item is focused (for arrow key controls) */
     isFocused: PropTypes.bool,
 
+    /** Style to be applied to Text */
+    textStyles: PropTypes.arrayOf(PropTypes.object),
+
+    /** Style to be applied on the alternate text */
+    alternateTextStyles: PropTypes.arrayOf(PropTypes.object),
+
     /** Whether this item is disabled */
     isDisabled: PropTypes.bool,
 


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/32384
PROPOSAL: https://github.com/Expensify/App/issues/32384#issuecomment-1836888387


### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->


- [X] Verify that no errors appear in the JS console

1. Click on Profile -> workspaces -> Create a new workspace and modify the workspace name to be a long one
3. Click + > New chat > Room
4. Click Workspace
5. Verify that the long workspaces names are truncated and ending with `...`

Besides the previous test, All lists using SelectionList should truncate long items.
We can check a few of each type (single selection and multiple selection) to make sure both list items are functioning correctly:

Profile->timezone
Profile -> Pronouns
Workspace -> Members
Workspace -> Members -> Invite
Workspace -> Settings -> currency



### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->


1. Click on Profile -> workspaces -> Create a new workspace and modify the workspace name to be a long one
3. Click + > New chat > Room
4. Click Workspace
5. Verify that the long workspaces names are truncated and ending with `...`


Besides the previous test, All lists using SelectionList should truncate long items.
We can check a few of each type (single selection and multiple selection) to make sure both list items are functioning correctly:

Profile->timezone
Profile -> Pronouns
Workspace -> Members
Workspace -> Members -> Invite
Workspace -> Settings -> currency


### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

- [x] Verify that no errors appear in the JS console


1. Click on Profile -> workspaces -> Create a new workspace and modify the workspace name to be a long one
3. Click + > New chat > Room
4. Click Workspace
5. Verify that the long workspaces names are truncated and ending with `...`

Besides the previous test, All lists using SelectionList should truncate long items.
We can check a few of each type (single selection and multiple selection) to make sure both list items are functioning correctly:

Profile->timezone
Profile -> Pronouns
Workspace -> Members
Workspace -> Members -> Invite
Workspace -> Settings -> currency

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] If we are not using the full Onyx data that we loaded, I've added the proper selector in order to ensure the component only re-renders when the data it is using changes
        - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.


### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<img width="393" alt="Screenshot 2023-12-05 at 11 33 14 PM" src="https://github.com/Expensify/App/assets/59809993/39914ae6-1c97-4685-acfb-0c828ec23eac">

</details>

<details>
<summary>Android: mWeb Chrome</summary>


<img width="395" alt="Screenshot 2023-12-06 at 12 16 44 AM" src="https://github.com/Expensify/App/assets/59809993/ad6bf9c2-578a-42f9-8e65-30e036fdcfbd">

</details>

<details>
<summary>iOS: Native</summary>

<img width="388" alt="Screenshot 2023-12-05 at 11 36 34 PM" src="https://github.com/Expensify/App/assets/59809993/fc301344-0143-458b-a8dc-b3542118c91e">

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<img width="366" alt="Screenshot 2023-12-05 at 11 36 57 PM" src="https://github.com/Expensify/App/assets/59809993/415fe7c9-a8ac-4f27-9ad3-b7ebced5c495">

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<img width="1496" alt="image" src="https://github.com/Expensify/App/assets/59809993/7c08cfbf-b7e1-4b79-ae82-e689b92b12ee">

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Desktop</summary>

<img width="1209" alt="image" src="https://github.com/Expensify/App/assets/59809993/aa5a8e78-da37-4dbf-a84c-0bb6cf5e496a">


<!-- add screenshots or videos here -->

</details>
