### PR TITLE
Migrate QRShare to function component

### DIFF
--- a/src/components/QRShare/QRShareWithDownload/index.native.js
+++ b/src/components/QRShare/QRShareWithDownload/index.native.js
@@ -1,37 +1,46 @@
-import React, {Component} from 'react';
+import React, {forwardRef, useImperativeHandle, useRef} from 'react';
 import ViewShot from 'react-native-view-shot';
-import {withNetwork} from '@components/OnyxProvider';
 import getQrCodeFileName from '@components/QRShare/getQrCodeDownloadFileName';
 import {qrShareDefaultProps, qrSharePropTypes} from '@components/QRShare/propTypes';
+import useNetwork from '@hooks/useNetwork';
 import fileDownload from '@libs/fileDownload';
 import QRShare from '..';
 
-class QRShareWithDownload extends Component {
-    qrCodeScreenshotRef = React.createRef();
+function QRShareWithDownload({innerRef, ...props}) {
+    const {isOffline} = useNetwork();
+    const qrCodeScreenshotRef = useRef(null);
 
-    constructor(props) {
-        super(props);
+    useImperativeHandle(
+        innerRef,
+        () => ({
+            download: () => qrCodeScreenshotRef.current.capture().then((uri) => fileDownload(uri, getQrCodeFileName(props.title))),
+        }),
+        [props.title],
+    );
 
-        this.download = this.download.bind(this);
-    }
-
-    download() {
-        return this.qrCodeScreenshotRef.current.capture().then((uri) => fileDownload(uri, getQrCodeFileName(this.props.title)));
-    }
-
-    render() {
-        return (
-            <ViewShot ref={this.qrCodeScreenshotRef}>
-                <QRShare
-                    // eslint-disable-next-line react/jsx-props-no-spreading
-                    {...this.props}
-                    logo={this.props.network.isOffline ? null : this.props.logo}
-                />
-            </ViewShot>
-        );
-    }
+    return (
+        <ViewShot ref={qrCodeScreenshotRef}>
+            <QRShare
+                // eslint-disable-next-line react/jsx-props-no-spreading
+                {...props}
+                logo={isOffline ? null : props.logo}
+            />
+        </ViewShot>
+    );
 }
+
 QRShareWithDownload.propTypes = qrSharePropTypes;
 QRShareWithDownload.defaultProps = qrShareDefaultProps;
+QRShareWithDownload.displayName = 'QRShareWithDownload';
 
-export default withNetwork()(QRShareWithDownload);
+const QRShareWithDownloadWithRef = forwardRef((props, ref) => (
+    <QRShareWithDownload
+        // eslint-disable-next-line react/jsx-props-no-spreading
+        {...props}
+        innerRef={ref}
+    />
+));
+
+QRShareWithDownloadWithRef.displayName = 'QRShareWithDownloadWithRef';
+
+export default QRShareWithDownloadWithRef;

--- a/src/components/QRShare/index.js
+++ b/src/components/QRShare/index.js
@@ -1,96 +1,91 @@
-import React, {Component} from 'react';
+import React, {forwardRef, useImperativeHandle, useRef, useState} from 'react';
 import {View} from 'react-native';
 import _ from 'underscore';
 import ExpensifyWordmark from '@assets/images/expensify-wordmark.svg';
 import QRCode from '@components/QRCode';
 import Text from '@components/Text';
-import withLocalize, {withLocalizePropTypes} from '@components/withLocalize';
-import withTheme, {withThemePropTypes} from '@components/withTheme';
-import withThemeStyles, {withThemeStylesPropTypes} from '@components/withThemeStyles';
-import withWindowDimensions, {windowDimensionsPropTypes} from '@components/withWindowDimensions';
-import compose from '@libs/compose';
+import useTheme from '@styles/themes/useTheme';
+import useThemeStyles from '@styles/useThemeStyles';
 import variables from '@styles/variables';
 import {qrShareDefaultProps, qrSharePropTypes} from './propTypes';
 
-const propTypes = {
-    ...qrSharePropTypes,
-    ...windowDimensionsPropTypes,
-    ...withLocalizePropTypes,
-    ...withThemeStylesPropTypes,
-    ...withThemePropTypes,
-};
+function QRShare({innerRef, url, title, subtitle, logo, logoRatio, logoMarginRatio}) {
+    const styles = useThemeStyles();
+    const theme = useTheme();
 
-class QRShare extends Component {
-    constructor(props) {
-        super(props);
+    const [qrCodeSize, setQrCodeSize] = useState(1);
+    const svgRef = useRef(null);
 
-        this.state = {
-            qrCodeSize: 1,
-        };
+    useImperativeHandle(
+        innerRef,
+        () => ({
+            getSvg: () => svgRef.current,
+        }),
+        [],
+    );
 
-        this.onLayout = this.onLayout.bind(this);
-        this.getSvg = this.getSvg.bind(this);
-    }
-
-    onLayout(event) {
+    const onLayout = (event) => {
         const containerWidth = event.nativeEvent.layout.width - variables.qrShareHorizontalPadding * 2 || 0;
+        setQrCodeSize(Math.max(1, containerWidth));
+    };
 
-        this.setState({
-            qrCodeSize: Math.max(1, containerWidth),
-        });
-    }
-
-    getSvg() {
-        return this.svg;
-    }
-
-    render() {
-        return (
-            <View
-                style={this.props.themeStyles.shareCodeContainer}
-                onLayout={this.onLayout}
-            >
-                <View style={this.props.themeStyles.expensifyQrLogo}>
-                    <ExpensifyWordmark
-                        fill={this.props.theme.QRLogo}
-                        width="100%"
-                        height="100%"
-                    />
-                </View>
-
-                <QRCode
-                    getRef={(svg) => (this.svg = svg)}
-                    url={this.props.url}
-                    logo={this.props.logo}
-                    size={this.state.qrCodeSize}
-                    logoRatio={this.props.logoRatio}
-                    logoMarginRatio={this.props.logoMarginRatio}
+    return (
+        <View
+            style={styles.shareCodeContainer}
+            onLayout={onLayout}
+        >
+            <View style={styles.expensifyQrLogo}>
+                <ExpensifyWordmark
+                    fill={theme.QRLogo}
+                    width="100%"
+                    height="100%"
                 />
-
-                <Text
-                    family="EXP_NEW_KANSAS_MEDIUM"
-                    fontSize={variables.fontSizeXLarge}
-                    numberOfLines={2}
-                    style={this.props.themeStyles.qrShareTitle}
-                >
-                    {this.props.title}
-                </Text>
-
-                {!_.isEmpty(this.props.subtitle) && (
-                    <Text
-                        fontSize={variables.fontSizeLabel}
-                        numberOfLines={2}
-                        style={[this.props.themeStyles.mt1, this.props.themeStyles.textAlignCenter]}
-                        color={this.props.theme.textSupporting}
-                    >
-                        {this.props.subtitle}
-                    </Text>
-                )}
             </View>
-        );
-    }
-}
-QRShare.propTypes = propTypes;
-QRShare.defaultProps = qrShareDefaultProps;
 
-export default compose(withLocalize, withWindowDimensions, withThemeStyles, withTheme)(QRShare);
+            <QRCode
+                getRef={(svg) => (svgRef.current = svg)}
+                url={url}
+                logo={logo}
+                size={qrCodeSize}
+                logoRatio={logoRatio}
+                logoMarginRatio={logoMarginRatio}
+            />
+
+            <Text
+                family="EXP_NEW_KANSAS_MEDIUM"
+                fontSize={variables.fontSizeXLarge}
+                numberOfLines={2}
+                style={styles.qrShareTitle}
+            >
+                {title}
+            </Text>
+
+            {!_.isEmpty(subtitle) && (
+                <Text
+                    fontSize={variables.fontSizeLabel}
+                    numberOfLines={2}
+                    style={[styles.mt1, styles.textAlignCenter]}
+                    color={theme.textSupporting}
+                >
+                    {subtitle}
+                </Text>
+            )}
+        </View>
+    );
+}
+
+QRShare.propTypes = qrSharePropTypes;
+QRShare.defaultProps = qrShareDefaultProps;
+QRShare.displayName = 'QRShare';
+
+const QRShareWithRef = forwardRef((props, ref) => (
+    <QRShare
+        // eslint-disable-next-line react/jsx-props-no-spreading
+        {...props}
+        innerRef={ref}
+    />
+));
+
+QRShareWithRef.displayName = 'QRShareWithRef';
+
+export default QRShareWithRef;

--- a/src/components/QRShare/propTypes.js
+++ b/src/components/QRShare/propTypes.js
@@ -5,31 +5,41 @@ const qrSharePropTypes = {
      * The QR code URL
      */
     url: PropTypes.string.isRequired,
+
     /**
      * The title that is displayed below the QR Code (usually the user or report name)
      */
     title: PropTypes.string.isRequired,
+
     /**
      * The subtitle which will be shown below the title (usually user email or workspace name)
      * */
     subtitle: PropTypes.string,
+
     /**
      * The logo which will be display in the middle of the QR code
      */
     logo: PropTypes.oneOfType([PropTypes.shape({uri: PropTypes.string}), PropTypes.number, PropTypes.string]),
+
     /**
      * The size ratio of logo to QR code
      */
     logoRatio: PropTypes.number,
+
     /**
      * The size ratio of margin around logo to QR code
      */
     logoMarginRatio: PropTypes.number,
+
+    /**
+     * Forwarded ref
+     */
+    innerRef: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
 };
 
-const defaultProps = {
+const qrShareDefaultProps = {
     subtitle: undefined,
     logo: undefined,
 };
 
-export {qrSharePropTypes, defaultProps as qrShareDefaultProps};
+export {qrSharePropTypes, qrShareDefaultProps};


### PR DESCRIPTION
### Details

This PR will migrate `QRShare` to function component first before proceeding with TS migration.

### Fixed Issues

$ https://github.com/Expensify/App/issues/25124
PROPOSAL: 

### Tests

1. Go to Settings -> Share code.
2. Assert all the functions are working correctly.

- [x] Verify that no errors appear in the JS console

### Offline tests

N/A

### QA Steps

1. Go to Settings -> Share code.
2. Assert all the functions are working correctly.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos

<details>
<summary>Android: Native</summary>

https://github.com/Expensify/App/assets/20051562/2d999ac5-3a4b-4002-9c8b-0a7e199dae69




</details>

<details>
<summary>Android: mWeb Chrome</summary>


https://github.com/Expensify/App/assets/20051562/b70e9473-2ea7-4164-9d4b-66ce06c72cea



</details>

<details>
<summary>iOS: Native</summary>



https://github.com/Expensify/App/assets/20051562/75ccff91-fb47-4da6-9ed7-97ebb5b1bfb7





</details>

<details>
<summary>iOS: mWeb Safari</summary>


https://github.com/Expensify/App/assets/20051562/758026fc-6ed1-4cdc-95a5-8c71a5cb01af



</details>

<details>
<summary>MacOS: Chrome / Safari</summary>


https://github.com/Expensify/App/assets/20051562/a2f1b6cb-cdf3-425a-bcd9-244219d36a38


https://github.com/Expensify/App/assets/20051562/e93da77f-bb00-4ea0-941e-653bb902b7b9



</details>

<details>
<summary>MacOS: Desktop</summary>


https://github.com/Expensify/App/assets/20051562/199793c7-17e7-479f-b2f5-008f3fc18a8c



</details>