### PR TITLE
[Wave8] Create Workspace Switcher

### DIFF
--- a/src/ONYXKEYS.ts
+++ b/src/ONYXKEYS.ts
@@ -21,6 +21,9 @@ const ONYXKEYS = {
      * which tab is the leader, and which ones are the followers */
     ACTIVE_CLIENTS: 'activeClients',
 
+    /** Holds active policyID (if any is active) */
+    ACTIVE_WORKSPACE_ID: 'activeWorkspaceID',
+
     /** A unique ID for the device */
     DEVICE_ID: 'deviceID',
 
@@ -363,6 +366,7 @@ type OnyxValues = {
     [ONYXKEYS.ACCOUNT_MANAGER_REPORT_ID]: string;
     [ONYXKEYS.NVP_IS_FIRST_TIME_NEW_EXPENSIFY_USER]: boolean;
     [ONYXKEYS.ACTIVE_CLIENTS]: string[];
+    [ONYXKEYS.ACTIVE_WORKSPACE_ID]: string | undefined;
     [ONYXKEYS.DEVICE_ID]: string;
     [ONYXKEYS.IS_SIDEBAR_LOADED]: boolean;
     [ONYXKEYS.PERSISTED_REQUESTS]: OnyxTypes.Request[];

--- a/src/ROUTES.ts
+++ b/src/ROUTES.ts
@@ -55,7 +55,7 @@ const ROUTES = {
         route: 'bank-account/:stepToOpen?',
         getRoute: (stepToOpen = '', policyID = '', backTo?: string) => getUrlWithBackToParam(`bank-account/${stepToOpen}?policyID=${policyID}`, backTo),
     },
-
+    WORKSPACE_SELECTOR: 'workspaceSelector',
     SETTINGS: 'settings',
     SETTINGS_PROFILE: 'settings/profile',
     SETTINGS_SHARE_CODE: 'settings/shareCode',

--- a/src/SCREENS.ts
+++ b/src/SCREENS.ts
@@ -79,6 +79,9 @@ const SCREENS = {
     SAVE_THE_WORLD: {
         ROOT: 'SaveTheWorld_Root',
     },
+    WORKSPACE_SELECTOR: {
+        ROOT: 'WorkspaceSelector_Root',
+    },
     RIGHT_MODAL: {
         SETTINGS: 'Settings',
         NEW_CHAT: 'NewChat',
@@ -104,6 +107,7 @@ const SCREENS = {
         ROOM_MEMBERS: 'RoomMembers',
         ROOM_INVITE: 'RoomInvite',
         REFERRAL: 'Referral',
+        WORKSPACE_SELECTOR: 'WorkspaceSelector',
     },
     SIGN_IN_WITH_APPLE_DESKTOP: 'AppleSignInDesktop',
     SIGN_IN_WITH_GOOGLE_DESKTOP: 'GoogleSignInDesktop',

--- a/src/components/EnvironmentBadge.tsx
+++ b/src/components/EnvironmentBadge.tsx
@@ -1,8 +1,10 @@
 import React from 'react';
 import useEnvironment from '@hooks/useEnvironment';
 import * as Environment from '@libs/Environment/Environment';
+import Navigation from '@libs/Navigation/Navigation';
 import useThemeStyles from '@styles/useThemeStyles';
 import CONST from '@src/CONST';
+import ROUTES from '@src/ROUTES';
 import pkg from '../../package.json';
 import Badge from './Badge';
 
@@ -32,6 +34,10 @@ function EnvironmentBadge() {
             badgeStyles={[styles.alignSelfEnd, styles.headerEnvBadge]}
             textStyles={[styles.headerEnvBadgeText]}
             environment={environment}
+            pressable
+            onPress={() => {
+                Navigation.navigate(ROUTES.WORKSPACE_SELECTOR);
+            }}
         />
     );
 }

--- a/src/components/Icon/Expensicons.ts
+++ b/src/components/Icon/Expensicons.ts
@@ -51,6 +51,7 @@ import EReceiptIcon from '@assets/images/eReceiptIcon.svg';
 import Exclamation from '@assets/images/exclamation.svg';
 import Exit from '@assets/images/exit.svg';
 import Expand from '@assets/images/expand.svg';
+import ExpensifyAppIcon from '@assets/images/expensify-app-icon.svg';
 import ExpensifyFooterLogoVertical from '@assets/images/expensify-footer-logo-vertical.svg';
 import ExpensifyFooterLogo from '@assets/images/expensify-footer-logo.svg';
 import ExpensifyWordmark from '@assets/images/expensify-wordmark.svg';
@@ -213,6 +214,7 @@ export {
     Location,
     Lock,
     LoungeAccess,
+    ExpensifyAppIcon,
     Luggage,
     MagnifyingGlass,
     Mail,

--- a/src/components/MultipleAvatars.tsx
+++ b/src/components/MultipleAvatars.tsx
@@ -152,7 +152,7 @@ function MultipleAvatars({
                     <Avatar
                         source={icons[0].source}
                         size={size}
-                        fill={theme.iconSuccessFill}
+                        fill={icons[0].fill ?? theme.iconSuccessFill}
                         name={icons[0].name}
                         type={icons[0].type}
                         fallbackIcon={icons[0].fallbackIcon}

--- a/src/components/OptionRow.js
+++ b/src/components/OptionRow.js
@@ -256,6 +256,14 @@ function OptionRow(props) {
                                         />
                                     </View>
                                 )}
+                                {props.option.brickRoadIndicator === CONST.BRICK_ROAD_INDICATOR_STATUS.INFO && (
+                                    <View style={[styles.alignItemsCenter, styles.justifyContentCenter]}>
+                                        <Icon
+                                            src={Expensicons.DotIndicator}
+                                            fill={theme.iconSuccessFill}
+                                        />
+                                    </View>
+                                )}
                                 {props.showSelectedState && (
                                     <>
                                         {props.shouldShowSelectedStateAsButton && !props.isSelected ? (

--- a/src/components/OptionsList/BaseOptionsList.js
+++ b/src/components/OptionsList/BaseOptionsList.js
@@ -192,6 +192,10 @@ function BaseOptionsList({
                 return true;
             }
 
+            if (option.policyID && option.policyID === item.policyID) {
+                return true;
+            }
+
             if (_.isEmpty(option.name)) {
                 return false;
             }
@@ -201,7 +205,7 @@ function BaseOptionsList({
 
         return (
             <OptionRow
-                option={item}
+                option={{...item, brickRoadIndicator: isSelected ? undefined : item.brickRoadIndicator}}
                 showTitleTooltip={showTitleTooltip}
                 hoverStyle={optionHoveredStyle}
                 optionIsFocused={!disableFocusOptions && !isItemDisabled && focusedIndex === index + section.indexOffset}
@@ -212,7 +216,7 @@ function BaseOptionsList({
                 selectedStateButtonText={multipleOptionSelectorButtonText}
                 onSelectedStatePressed={onAddToSelection}
                 highlightSelected={highlightSelectedOptions}
-                boldStyle={boldStyle}
+                boldStyle={_.isUndefined(item.boldStyle) ? boldStyle : item.boldStyle}
                 isDisabled={isItemDisabled}
                 shouldHaveOptionSeparator={index > 0 && shouldHaveOptionSeparator}
                 shouldDisableRowInnerPadding={shouldDisableRowInnerPadding}

--- a/src/components/OptionsSelector/BaseOptionsSelector.js
+++ b/src/components/OptionsSelector/BaseOptionsSelector.js
@@ -499,6 +499,7 @@ class BaseOptionsSelector extends Component {
                 onSelectRow={this.props.onSelectRow ? this.selectRow : undefined}
                 sections={this.state.sections}
                 focusedIndex={this.state.focusedIndex}
+                disableFocusOptions={this.props.disableFocusOptions}
                 selectedOptions={this.props.selectedOptions}
                 canSelectMultipleOptions={this.props.canSelectMultipleOptions}
                 shouldShowMultipleOptionSelectorAsButton={this.props.shouldShowMultipleOptionSelectorAsButton}

--- a/src/components/OptionsSelector/BaseOptionsSelector.js
+++ b/src/components/OptionsSelector/BaseOptionsSelector.js
@@ -8,7 +8,7 @@ import Button from '@components/Button';
 import FixedFooter from '@components/FixedFooter';
 import FormHelpMessage from '@components/FormHelpMessage';
 import Icon from '@components/Icon';
-import {Info} from '@components/Icon/Expensicons';
+import {Info, MagnifyingGlass} from '@components/Icon/Expensicons';
 import OptionsList from '@components/OptionsList';
 import {PressableWithoutFeedback} from '@components/Pressable';
 import ShowMoreButton from '@components/ShowMoreButton';
@@ -489,6 +489,7 @@ class BaseOptionsSelector extends Component {
                 spellCheck={false}
                 shouldInterceptSwipe={this.props.shouldTextInputInterceptSwipe}
                 isLoading={this.props.isLoadingNewOptions}
+                iconLeft={MagnifyingGlass}
             />
         );
         const optionsList = (

--- a/src/components/OptionsSelector/optionsSelectorPropTypes.js
+++ b/src/components/OptionsSelector/optionsSelectorPropTypes.js
@@ -75,6 +75,9 @@ const propTypes = {
     /** Whether to disable interactivity of option rows */
     isDisabled: PropTypes.bool,
 
+    /** Whether to disable focus options of rows */
+    disableFocusOptions: PropTypes.bool,
+
     /** Display the text of the option in bold font style */
     boldStyle: PropTypes.bool,
 
@@ -166,6 +169,7 @@ const defaultProps = {
     shouldShowOptions: true,
     disableArrowKeysActions: false,
     isDisabled: false,
+    disableFocusOptions: false,
     shouldHaveOptionSeparator: false,
     initiallyFocusedOptionKey: undefined,
     maxLength: CONST.SEARCH_MAX_LENGTH,

--- a/src/components/TextInput/BaseTextInput/index.js
+++ b/src/components/TextInput/BaseTextInput/index.js
@@ -290,6 +290,16 @@ function BaseTextInput(props) {
                             </>
                         ) : null}
                         <View style={[styles.textInputAndIconContainer, isMultiline && hasLabel && styles.textInputMultilineContainer, styles.pointerEventsBoxNone]}>
+                            {!props.secureTextEntry && Boolean(props.iconLeft) && (
+                                <View style={[styles.textInputLeftIconContainer, !isReadOnly ? styles.cursorPointer : styles.pointerEventsNone]}>
+                                    <Icon
+                                        src={props.iconLeft}
+                                        fill={theme.icon}
+                                        height={20}
+                                        widht={20}
+                                    />
+                                </View>
+                            )}
                             {Boolean(props.prefixCharacter) && (
                                 <View style={styles.textInputPrefixWrapper}>
                                     <Text

--- a/src/libs/Navigation/AppNavigator/ModalStackNavigators.tsx
+++ b/src/libs/Navigation/AppNavigator/ModalStackNavigators.tsx
@@ -27,6 +27,7 @@ import type {
     TaskDetailsNavigatorParamList,
     TeachersUniteNavigatorParamList,
     WalletStatementNavigatorParamList,
+    WorkspaceSelectorNavigatorParamList,
 } from '@navigation/types';
 import useThemeStyles from '@styles/useThemeStyles';
 import SCREENS from '@src/SCREENS';
@@ -177,6 +178,10 @@ const NewTeachersUniteNavigator = createModalStackNavigator<TeachersUniteNavigat
     [SCREENS.I_AM_A_TEACHER]: () => require('../../../pages/TeachersUnite/ImTeacherPage').default as React.ComponentType,
 });
 
+const WorkspaceSelectorModalStackNavigator = createModalStackNavigator<WorkspaceSelectorNavigatorParamList>({
+    [SCREENS.WORKSPACE_SELECTOR.ROOT]: () => require('../../../pages/WorkspaceSelectorPage').default as React.ComponentType,
+});
+
 const SettingsModalStackNavigator = createModalStackNavigator<SettingsNavigatorParamList>({
     [SCREENS.SETTINGS.ROOT]: () => require('../../../pages/settings/InitialSettingsPage').default as React.ComponentType,
     [SCREENS.SETTINGS.SHARE_CODE]: () => require('../../../pages/ShareCodePage').default as React.ComponentType,
@@ -304,4 +309,5 @@ export {
     RoomMembersModalStackNavigator,
     RoomInviteModalStackNavigator,
     ReferralModalStackNavigator,
+    WorkspaceSelectorModalStackNavigator,
 };

--- a/src/libs/Navigation/AppNavigator/Navigators/RightModalNavigator.tsx
+++ b/src/libs/Navigation/AppNavigator/Navigators/RightModalNavigator.tsx
@@ -30,6 +30,10 @@ function RightModalNavigator({navigation}: RightModalNavigatorProps) {
                         component={ModalStackNavigators.SettingsModalStackNavigator}
                     />
                     <Stack.Screen
+                        name={SCREENS.RIGHT_MODAL.WORKSPACE_SELECTOR}
+                        component={ModalStackNavigators.WorkspaceSelectorModalStackNavigator}
+                    />
+                    <Stack.Screen
                         name={SCREENS.RIGHT_MODAL.NEW_CHAT}
                         component={ModalStackNavigators.NewChatModalStackNavigator}
                     />

--- a/src/libs/Navigation/linkingConfig.ts
+++ b/src/libs/Navigation/linkingConfig.ts
@@ -266,6 +266,13 @@ const linkingConfig: LinkingOptions<RootStackParamList> = {
                             },
                         },
                     },
+                    [SCREENS.RIGHT_MODAL.WORKSPACE_SELECTOR]: {
+                        screens: {
+                            [SCREENS.WORKSPACE_SELECTOR.ROOT]: {
+                                path: ROUTES.WORKSPACE_SELECTOR,
+                            },
+                        },
+                    },
                     [SCREENS.RIGHT_MODAL.PRIVATE_NOTES]: {
                         screens: {
                             [SCREENS.PRIVATE_NOTES.VIEW]: ROUTES.PRIVATE_NOTES_VIEW.route,

--- a/src/libs/Navigation/types.ts
+++ b/src/libs/Navigation/types.ts
@@ -41,6 +41,10 @@ type CentralPaneNavigatorParamList = {
     };
 };
 
+type WorkspaceSelectorNavigatorParamList = {
+    [SCREENS.WORKSPACE_SELECTOR.ROOT]: undefined;
+};
+
 type SettingsNavigatorParamList = {
     [SCREENS.SETTINGS.ROOT]: undefined;
     [SCREENS.SETTINGS.SHARE_CODE]: undefined;
@@ -357,6 +361,7 @@ type RightModalNavigatorParamList = {
     [SCREENS.RIGHT_MODAL.SIGN_IN]: NavigatorScreenParams<SignInNavigatorParamList>;
     [SCREENS.RIGHT_MODAL.REFERRAL]: NavigatorScreenParams<ReferralDetailsNavigatorParamList>;
     [SCREENS.RIGHT_MODAL.PRIVATE_NOTES]: NavigatorScreenParams<PrivateNotesNavigatorParamList>;
+    [SCREENS.RIGHT_MODAL.WORKSPACE_SELECTOR]: NavigatorScreenParams<WorkspaceSelectorNavigatorParamList>;
 };
 
 type PublicScreensParamList = {
@@ -448,4 +453,5 @@ export type {
     SignInNavigatorParamList,
     ReferralDetailsNavigatorParamList,
     ReimbursementAccountNavigatorParamList,
+    WorkspaceSelectorNavigatorParamList,
 };

--- a/src/libs/actions/Policy.js
+++ b/src/libs/actions/Policy.js
@@ -1511,6 +1511,14 @@ function buildOptimisticPolicyRecentlyUsedTags(policyID, tag) {
 }
 
 /**
+ * This function saves the selected workspace to onyx to filter data depending on this ID
+ * @param {String | undefined} policyID
+ */
+function selectWorkspace(policyID) {
+    Onyx.set(ONYXKEYS.ACTIVE_WORKSPACE_ID, policyID);
+}
+
+/**
  * This flow is used for bottom up flow converting IOU report to an expense report. When user takes this action,
  * we create a Collect type workspace when the person taking the action becomes an owner and an admin, while we
  * add a new member to the workspace as an employee and convert the IOU report passed as a param into an expense report.
@@ -1942,4 +1950,5 @@ export {
     buildOptimisticPolicyRecentlyUsedTags,
     createDraftInitialWorkspace,
     setWorkspaceInviteMessageDraft,
+    selectWorkspace,
 };

--- a/src/pages/WorkspaceSelectorPage.js
+++ b/src/pages/WorkspaceSelectorPage.js
@@ -1,0 +1,222 @@
+import PropTypes from 'prop-types';
+import React, {useCallback, useMemo} from 'react';
+import {View} from 'react-native';
+import {withOnyx} from 'react-native-onyx';
+import _ from 'underscore';
+import HeaderPageLayout from '@components/HeaderPageLayout';
+import * as Expensicons from '@components/Icon/Expensicons';
+import MenuItem from '@components/MenuItem';
+import Text from '@components/Text';
+import useLocalize from '@hooks/useLocalize';
+import useNetwork from '@hooks/useNetwork';
+import * as PolicyUtils from '@libs/PolicyUtils';
+import * as ReportUtils from '@libs/ReportUtils';
+import colors from '@styles/colors';
+import useTheme from '@styles/themes/useTheme';
+import useThemeStyles from '@styles/useThemeStyles';
+import * as Policy from '@userActions/Policy';
+import Icon from '@src/components/Icon';
+import CONST from '@src/CONST';
+import ONYXKEYS from '@src/ONYXKEYS';
+import SCREENS from '@src/SCREENS';
+import PressableWithFeedback from '@components/Pressable/PressableWithFeedback';
+
+const propTypes = {
+    /** The list of this user's policies */
+    policies: PropTypes.objectOf(
+        PropTypes.shape({
+            /** The ID of the policy */
+            id: PropTypes.string,
+
+            /** The name of the policy */
+            name: PropTypes.string,
+
+            /** The type of the policy */
+            type: PropTypes.string,
+
+            /** The user's role in the policy */
+            role: PropTypes.string,
+
+            /** The current action that is waiting to happen on the policy */
+            pendingAction: PropTypes.oneOf(_.values(CONST.RED_BRICK_ROAD_PENDING_ACTION)),
+        }),
+    ),
+    activeWorkspaceID: PropTypes.arrayOf([PropTypes.undefined, PropTypes.string]),
+};
+
+const defaultProps = {
+    policies: {},
+    activeWorkspaceID: undefined,
+};
+
+const INDICATOR_STYLES = {
+    checkmark: {
+        icon: Expensicons.Checkmark,
+        fill: colors.green,
+    },
+    greenIndicator: {
+        icon: Expensicons.DotIndicator,
+        fill: colors.green,
+    },
+    redIndicator: {
+        icon: Expensicons.DotIndicator,
+        fill: colors.red,
+    },
+};
+
+function WorkspacesSelectorPage({policies, activeWorkspaceID}) {
+    const theme = useTheme();
+    const styles = useThemeStyles();
+    const {translate} = useLocalize();
+    const {isOffline} = useNetwork();
+
+    const getIndicatorTypeForPolicy = useCallback(
+        // TO DO: Wait for missing logic to be implemented in other PR
+        (policyId) => {
+            if (policyId === activeWorkspaceID) {
+                return 'checkmark';
+            }
+
+            return undefined;
+        },
+        [activeWorkspaceID],
+    );
+
+    const workspaceStatusComponent = useCallback(
+        (iconType) => {
+            const indicatorStyle = INDICATOR_STYLES[iconType];
+            return (
+                <View style={[styles.alignItemsCenter, styles.justifyContentCenter]}>
+                    <Icon
+                        src={indicatorStyle.icon}
+                        fill={indicatorStyle.fill}
+                        small
+                    />
+                </View>
+            );
+        },
+        [styles.alignItemsCenter, styles.justifyContentCenter],
+    );
+
+    const getMenuItem = useCallback(
+        (item) => {
+            const keyTitle = item.translationKey ? translate(item.translationKey) : item.title;
+
+            const shouldShowRightComponent = _.keys(INDICATOR_STYLES).includes(item.indicatorType);
+            const rightComponent = shouldShowRightComponent ? workspaceStatusComponent(item.indicatorType) : undefined;
+
+            return (
+                <MenuItem
+                    title={keyTitle}
+                    icon={item.icon}
+                    iconType={item.iconType}
+                    onPress={item.action}
+                    iconStyles={item.iconStyles}
+                    iconFill={item.iconFill}
+                    fallbackIcon={item.fallbackIcon}
+                    brickRoadIndicator={item.brickRoadIndicator}
+                    disabled={item.disabled}
+                    rightComponent={rightComponent}
+                    shouldShowRightComponent={shouldShowRightComponent}
+                />
+            );
+        },
+        [translate, workspaceStatusComponent],
+    );
+
+    const usersWorkspaces = useMemo(
+        () =>
+            _.chain(policies)
+                .filter((policy) => PolicyUtils.shouldShowPolicy(policy, isOffline))
+                .map((policy) => ({
+                    title: policy.name,
+                    icon: policy.avatar ? policy.avatar : ReportUtils.getDefaultWorkspaceAvatar(policy.name),
+                    iconType: CONST.ICON_TYPE_WORKSPACE,
+                    action: () => {
+                        Policy.selectWorkspace(policy.id);
+                    },
+                    fallbackIcon: Expensicons.FallbackWorkspaceAvatar,
+                    pendingAction: policy.pendingAction,
+                    errors: policy.errors,
+                    disabled: policy.pendingAction === CONST.RED_BRICK_ROAD_PENDING_ACTION.DELETE,
+                    indicatorType: getIndicatorTypeForPolicy(policy.id),
+                }))
+                .sortBy((policy) => policy.title.toLowerCase())
+                .value(),
+        [policies, isOffline, getIndicatorTypeForPolicy],
+    );
+
+    const allWorkspaces = useMemo(
+        () => [
+            {
+                title: 'Expensify',
+                icon: Expensicons.ExpensifyAppIcon,
+                iconType: CONST.ICON_TYPE_AVATAR,
+                action: () => {
+                    Policy.selectWorkspace(undefined);
+                },
+                indicatorType: getIndicatorTypeForPolicy(undefined),
+            },
+        ],
+        [getIndicatorTypeForPolicy],
+    );
+
+    const getWorkspacesSection = useCallback(
+        (workspaces, section, renderSearchBar, showAddWorkspaceButton) => {
+            const xd = renderSearchBar;
+
+            return (
+                <View>
+                   <View style={[styles.mh4, styles.flexRow, styles.justifyContentBetween, styles.alignItemsCenter, styles.mb3]}>
+                <Text
+                    style={styles.label}
+                    color={theme.textSupporting}
+                >
+                    {section}
+                </Text>
+                {showAddWorkspaceButton && <PressableWithFeedback accessibilityRole={CONST.ACCESSIBILITY_ROLE.BUTTON}>
+                    {({hovered}) => (
+                        <Icon
+                            src={Expensicons.Plus}
+                            width={12}
+                            height={12}
+                            additionalStyles={[styles.highlightBG, styles.borderRadiusNormal, styles.p2, hovered && styles.bordersBG]}
+                        />
+                    )}
+                </PressableWithFeedback>}
+            </View>
+                    <View>
+                        {_.map(workspaces, (item, index) => getMenuItem(item, index))}
+                    </View>
+                </View>
+            );
+        },
+        [getMenuItem, styles.alignItemsCenter, styles.borderRadiusNormal, styles.bordersBG, styles.flexRow, styles.highlightBG, styles.justifyContentBetween, styles.label, styles.mb3, styles.mh4, styles.p2, theme.textSupporting],
+    );
+
+    const allWorkspacesSection = useMemo(() => getWorkspacesSection(allWorkspaces, 'Everything', false, false), [allWorkspaces, getWorkspacesSection]);
+    const usersWorkspacesSection = useMemo(() => getWorkspacesSection(usersWorkspaces, 'Workspaces', true, true), [getWorkspacesSection, usersWorkspaces]);
+
+    return (
+        <HeaderPageLayout
+            title="Choose a workspace"
+            backgroundColor={theme.PAGE_THEMES[SCREENS.WORKSPACE_SELECTOR.ROOT].backgroundColor}
+        >
+            {allWorkspacesSection}
+            {usersWorkspacesSection}
+        </HeaderPageLayout>
+    );
+}
+
+WorkspacesSelectorPage.propTypes = propTypes;
+WorkspacesSelectorPage.defaultProps = defaultProps;
+WorkspacesSelectorPage.displayName = 'WorkspacesSelectorPage';
+
+export default withOnyx({
+    policies: {
+        key: ONYXKEYS.COLLECTION.POLICY,
+    },
+    activeWorkspaceID: {
+        key: ONYXKEYS.ACTIVE_WORKSPACE_ID,
+    },
+})(WorkspacesSelectorPage);

--- a/src/pages/WorkspaceSelectorPage.js
+++ b/src/pages/WorkspaceSelectorPage.js
@@ -1,25 +1,20 @@
 import PropTypes from 'prop-types';
-import React, {useCallback, useMemo} from 'react';
+import React, {useCallback, useEffect, useMemo, useState} from 'react';
 import {View} from 'react-native';
 import {withOnyx} from 'react-native-onyx';
 import _ from 'underscore';
 import HeaderPageLayout from '@components/HeaderPageLayout';
 import * as Expensicons from '@components/Icon/Expensicons';
-import MenuItem from '@components/MenuItem';
 import OptionRow from '@components/OptionRow';
 import OptionsSelector from '@components/OptionsSelector';
-import PressableWithFeedback from '@components/Pressable/PressableWithFeedback';
 import Text from '@components/Text';
 import useAutoFocusInput from '@hooks/useAutoFocusInput';
-import useLocalize from '@hooks/useLocalize';
 import useNetwork from '@hooks/useNetwork';
 import * as PolicyUtils from '@libs/PolicyUtils';
 import * as ReportUtils from '@libs/ReportUtils';
-import colors from '@styles/colors';
 import useTheme from '@styles/themes/useTheme';
 import useThemeStyles from '@styles/useThemeStyles';
 import * as Policy from '@userActions/Policy';
-import Icon from '@src/components/Icon';
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
 import SCREENS from '@src/SCREENS';
@@ -55,180 +50,164 @@ const defaultProps = {
 function WorkspacesSelectorPage({policies, activeWorkspaceID}) {
     const theme = useTheme();
     const styles = useThemeStyles();
-    const {translate} = useLocalize();
     const {isOffline} = useNetwork();
+    const [selectedOption, setSelectedOption] = useState();
+    const [searchTerm, setSearchTerm] = useState('');
 
     const getIndicatorTypeForPolicy = useCallback(
         // TO DO: Wait for missing logic to be implemented in other PR
         // CONST.BRICK_ROAD_INDICATOR_STATUS.INFO or CONST.BRICK_ROAD_INDICATOR_STATUS.ERROR
+        // eslint-disable-next-line no-unused-vars
         (policyId) => undefined,
         [],
     );
 
-    const getMenuItem = useCallback(
-        (item) => {
-            const keyTitle = item.translationKey ? translate(item.translationKey) : item.title;
-
-            const option = {
-                text: keyTitle,
-                brickRoadIndicator: getIndicatorTypeForPolicy(item.policyId),
-                icons: [
-                    {
-                        source: item.icon,
-                        type: item.iconType,
-                        fill: item.iconFill,
-                        name: keyTitle,
-                        fallbackIcon: item.fallbackIcon,
-                    },
-                ],
-            };
-
-            // return (
-            //     <MenuItem
-            //         title={keyTitle}
-            //         icon={item.icon}
-            //         iconType={CONST.ICON_TYPE_WORKSPACE}
-            //         onPress={item.action}
-            //         iconStyles={item.iconStyles}
-            //         iconFill={item.iconFill}
-            //         fallbackIcon={item.fallbackIcon}
-            //         brickRoadIndicator={item.brickRoadIndicator}
-            //         disabled={item.disabled}
-            //         rightComponent={rightComponent}
-            //         shouldShowRightComponent={shouldShowRightComponent}
-            //     />
-            // );
-
-            return (
-                <OptionRow
-                    option={option}
-                    onSelectRow={item.action}
-                    showTitleTooltip={false}
-                    shouldShowSubscript={false}
-                    highlightSelected
-                    isSelected={item.policyId === activeWorkspaceID}
-                />
-            );
-        },
-        [activeWorkspaceID, getIndicatorTypeForPolicy, translate],
+    const hasUnreadData = useCallback(
+        // TO DO: Implement checking if policy has some unread data
+        // eslint-disable-next-line no-unused-vars
+        (policyId) => false, 
+        []
     );
+
+    const selectPolicy = useCallback((option) => {
+        const policyID = option.policyID;
+        Policy.selectWorkspace(policyID);
+
+        if (policyID) {
+            setSelectedOption(option);
+        } else {
+            setSelectedOption(undefined);
+        }
+    }, []);
+
+    const onChangeText = useCallback((newSearchTerm) => {
+        // TO DO: Handle searching logic
+        setSearchTerm(newSearchTerm);
+    }, [])
 
     const usersWorkspaces = useMemo(
         () =>
             _.chain(policies)
                 .filter((policy) => PolicyUtils.shouldShowPolicy(policy, isOffline))
                 .map((policy) => ({
-                    title: policy.name,
-                    policyId: policy.id,
-                    icon: policy.avatar ? policy.avatar : ReportUtils.getDefaultWorkspaceAvatar(policy.name),
-                    iconType: CONST.ICON_TYPE_WORKSPACE,
-                    action: () => {
-                        Policy.selectWorkspace(policy.id);
-                    },
-                    fallbackIcon: Expensicons.FallbackWorkspaceAvatar,
-                    pendingAction: policy.pendingAction,
-                    errors: policy.errors,
-                    disabled: policy.pendingAction === CONST.RED_BRICK_ROAD_PENDING_ACTION.DELETE,
+                    text: policy.name,
+                    policyID: policy.id,
+                    brickRoadIndicator: getIndicatorTypeForPolicy(policy.id),
+                    icons: [
+                        {
+                            source: policy.avatar ? policy.avatar : ReportUtils.getDefaultWorkspaceAvatar(policy.name),
+                            fallbackIcon: Expensicons.FallbackWorkspaceAvatar,
+                            name: policy.name,
+                            type: CONST.ICON_TYPE_WORKSPACE,
+                        },
+                    ],
+                    boldStyle: hasUnreadData(policy.id),
                 }))
-                .sortBy((policy) => policy.title.toLowerCase())
+                .sortBy((policy) => policy.text.toLowerCase())
                 .value(),
-        [policies, isOffline],
+        [policies, isOffline, getIndicatorTypeForPolicy, hasUnreadData],
     );
 
     const usersWorkspacesSectionData = useMemo(
-        () => [
-            {
+        () => ({
                 data: usersWorkspaces,
                 shouldShow: true,
                 indexOffset: 0,
-            },
-        ],
+            }),
         [usersWorkspaces],
     );
 
-    const allWorkspaces = useMemo(
-        () => [
-            {
-                title: 'Expensify',
-                icon: Expensicons.ExpensifyAppIcon,
-                iconType: CONST.ICON_TYPE_AVATAR,
-                action: () => {
-                    Policy.selectWorkspace(undefined);
+    const everythingSection = useMemo(() => {
+        const option = {
+            text: 'Expensify',
+            icons: [
+                {
+                    source: Expensicons.ExpensifyAppIcon,
+                    name: 'Expensify',
+                    type: CONST.ICON_TYPE_AVATAR,
                 },
-                indicatorType: getIndicatorTypeForPolicy(undefined),
-            },
-        ],
-        [getIndicatorTypeForPolicy],
-    );
+            ],
+            brickRoadIndicator: getIndicatorTypeForPolicy(undefined),
+            boldStyle: hasUnreadData(undefined),
+        };
 
-    const getWorkspacesSection = useCallback(
-        (workspaces, section, showAddWorkspaceButton) => (
-            <View>
+        return (
+            <>
                 <View style={[styles.mh4, styles.flexRow, styles.justifyContentBetween, styles.alignItemsCenter, styles.mb3]}>
                     <Text
                         style={styles.label}
                         color={theme.textSupporting}
                     >
-                        {section}
+                        Everything
                     </Text>
-                    {showAddWorkspaceButton && (
-                        <PressableWithFeedback accessibilityRole={CONST.ACCESSIBILITY_ROLE.BUTTON}>
-                            {({hovered}) => (
-                                <Icon
-                                    src={Expensicons.Plus}
-                                    width={12}
-                                    height={12}
-                                    additionalStyles={[styles.highlightBG, styles.borderRadiusNormal, styles.p2, hovered && styles.bordersBG]}
-                                />
-                            )}
-                        </PressableWithFeedback>
-                    )}
                 </View>
-                <View style={{marginBottom: 12}}>{_.map(workspaces, (item, index) => getMenuItem(item, index))}</View>
-            </View>
+                <View>
+                    <OptionRow
+                        option={{...option, brickRoadIndicator: option.policyID === activeWorkspaceID ? undefined : option.brickRoadIndicator}}
+                        onSelectRow={selectPolicy}
+                        showTitleTooltip={false}
+                        shouldShowSubscript={false}
+                        highlightSelected
+                        isSelected={option.policyID === activeWorkspaceID}
+                    />
+                </View>
+            </>
+        );
+    }, [activeWorkspaceID, getIndicatorTypeForPolicy, hasUnreadData, selectPolicy, styles.alignItemsCenter, styles.flexRow, styles.justifyContentBetween, styles.label, styles.mb3, styles.mh4, theme.textSupporting]);
+
+    const inputCallbackRef = useAutoFocusInput();
+    const workspacesSection = useMemo(
+        () => (
+            <>
+            <View style={[styles.mh4, styles.flexRow, styles.justifyContentBetween, styles.alignItemsCenter, styles.mb1]}>
+                    <Text
+                        style={[styles.mt3, styles.label]}
+                        color={theme.textSupporting}
+                    >
+                        Workspaces
+                    </Text>
+                </View>
+            {/* TO DO: Display breadcrumb */}
+            {usersWorkspacesSectionData.data.length === 0 && <View/>}
+            <OptionsSelector
+                ref={inputCallbackRef}
+                sections={[usersWorkspacesSectionData]}
+                value={searchTerm}
+                shouldShowTextInput={usersWorkspacesSectionData.data.length > 8}
+                onChangeText={onChangeText}
+                selectedOptions={selectedOption ? [selectedOption] : []}
+                onSelectRow={selectPolicy}
+                boldStyle
+                shouldPreventDefaultFocusOnSelectRow
+                highlightSelectedOptions
+                shouldShowOptions
+                autoFocus={false}
+                disableFocusOptions
+                canSelectMultipleOptions={false}
+                shouldShowSubscript={false}
+                showTitleTooltip={false}
+                contentContainerStyles={[styles.pt0, styles.mt0]}
+                />
+                </>
         ),
-        [
-            getMenuItem,
-            styles.alignItemsCenter,
-            styles.borderRadiusNormal,
-            styles.bordersBG,
-            styles.flexRow,
-            styles.highlightBG,
-            styles.justifyContentBetween,
-            styles.label,
-            styles.mb3,
-            styles.mh4,
-            styles.p2,
-            theme.textSupporting,
-        ],
+        [inputCallbackRef, onChangeText, searchTerm, selectPolicy, selectedOption, styles.alignItemsCenter, styles.flexRow, styles.justifyContentBetween, styles.label, styles.mb1, styles.mh4, styles.mt0, styles.mt3, styles.pt0, theme.textSupporting, usersWorkspacesSectionData],
     );
 
-    const allWorkspacesSection = useMemo(() => getWorkspacesSection(allWorkspaces, 'Everything', false, false), [allWorkspaces, getWorkspacesSection]);
-    const usersWorkspacesSection = useMemo(() => getWorkspacesSection(usersWorkspaces, 'Workspaces', true, true), [getWorkspacesSection, usersWorkspaces]);
-
-    // const {inputCallbackRef} = useAutoFocusInput();
+    useEffect(() => {
+        if (!activeWorkspaceID) {
+            return;
+        }
+        const optionToSet = _.find(usersWorkspaces, (option) => option.policyID === activeWorkspaceID);
+        setSelectedOption(optionToSet);
+    }, [activeWorkspaceID, usersWorkspaces]);
 
     return (
         <HeaderPageLayout
             title="Choose a workspace"
             backgroundColor={theme.PAGE_THEMES[SCREENS.WORKSPACE_SELECTOR.ROOT].backgroundColor}
         >
-            {allWorkspacesSection}
-            {usersWorkspacesSection}
-            {/* <OptionsSelector
-                            ref={inputCallbackRef}
-                            onAddToSelection={(option) => {}}
-                            sections={usersWorkspacesSectionData}
-                            selectedOptions={[]}
-                            value="Find"
-                            onSelectRow={(option) => {}}
-                            onChangeText
-                            headerMessage
-                            boldStyle
-                            shouldPreventDefaultFocusOnSelectRow
-                            shouldShowOptions
-                            autoFocus={false}
-                        /> */}
+            {everythingSection}
+            {workspacesSection}
         </HeaderPageLayout>
     );
 }

--- a/src/pages/WorkspaceSelectorPage.js
+++ b/src/pages/WorkspaceSelectorPage.js
@@ -6,7 +6,11 @@ import _ from 'underscore';
 import HeaderPageLayout from '@components/HeaderPageLayout';
 import * as Expensicons from '@components/Icon/Expensicons';
 import MenuItem from '@components/MenuItem';
+import OptionRow from '@components/OptionRow';
+import OptionsSelector from '@components/OptionsSelector';
+import PressableWithFeedback from '@components/Pressable/PressableWithFeedback';
 import Text from '@components/Text';
+import useAutoFocusInput from '@hooks/useAutoFocusInput';
 import useLocalize from '@hooks/useLocalize';
 import useNetwork from '@hooks/useNetwork';
 import * as PolicyUtils from '@libs/PolicyUtils';
@@ -19,10 +23,6 @@ import Icon from '@src/components/Icon';
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
 import SCREENS from '@src/SCREENS';
-import PressableWithFeedback from '@components/Pressable/PressableWithFeedback';
-import OptionsSelector from '@components/OptionsSelector';
-import useAutoFocusInput from '@hooks/useAutoFocusInput';
-import OptionRow from '@components/OptionRow';
 
 const propTypes = {
     /** The list of this user's policies */
@@ -69,18 +69,19 @@ function WorkspacesSelectorPage({policies, activeWorkspaceID}) {
         (item) => {
             const keyTitle = item.translationKey ? translate(item.translationKey) : item.title;
 
-
             const option = {
                 text: keyTitle,
                 brickRoadIndicator: getIndicatorTypeForPolicy(item.policyId),
-                icons: [{
-                    source: item.icon,
-                    type: item.iconType,
-                    fill: item.iconFill,
-                    name: keyTitle,
-                    fallbackIcon: item.fallbackIcon,
-                }],
-            }
+                icons: [
+                    {
+                        source: item.icon,
+                        type: item.iconType,
+                        fill: item.iconFill,
+                        name: keyTitle,
+                        fallbackIcon: item.fallbackIcon,
+                    },
+                ],
+            };
 
             // return (
             //     <MenuItem
@@ -108,7 +109,6 @@ function WorkspacesSelectorPage({policies, activeWorkspaceID}) {
                     isSelected={item.policyId === activeWorkspaceID}
                 />
             );
-
         },
         [activeWorkspaceID, getIndicatorTypeForPolicy, translate],
     );
@@ -136,12 +136,13 @@ function WorkspacesSelectorPage({policies, activeWorkspaceID}) {
     );
 
     const usersWorkspacesSectionData = useMemo(
-        () =>
-           [{
+        () => [
+            {
                 data: usersWorkspaces,
                 shouldShow: true,
                 indexOffset: 0,
-            }],
+            },
+        ],
         [usersWorkspaces],
     );
 
@@ -161,42 +162,51 @@ function WorkspacesSelectorPage({policies, activeWorkspaceID}) {
     );
 
     const getWorkspacesSection = useCallback(
-        (workspaces, section, showAddWorkspaceButton) => {
-
-            return (
-                <View>
-                   <View style={[styles.mh4, styles.flexRow, styles.justifyContentBetween, styles.alignItemsCenter, styles.mb3]}>
-                <Text
-                    style={styles.label}
-                    color={theme.textSupporting}
-                >
-                    {section}
-                </Text>
-                {showAddWorkspaceButton && <PressableWithFeedback accessibilityRole={CONST.ACCESSIBILITY_ROLE.BUTTON}>
-                    {({hovered}) => (
-                        <Icon
-                            src={Expensicons.Plus}
-                            width={12}
-                            height={12}
-                            additionalStyles={[styles.highlightBG, styles.borderRadiusNormal, styles.p2, hovered && styles.bordersBG]}
-                        />
+        (workspaces, section, showAddWorkspaceButton) => (
+            <View>
+                <View style={[styles.mh4, styles.flexRow, styles.justifyContentBetween, styles.alignItemsCenter, styles.mb3]}>
+                    <Text
+                        style={styles.label}
+                        color={theme.textSupporting}
+                    >
+                        {section}
+                    </Text>
+                    {showAddWorkspaceButton && (
+                        <PressableWithFeedback accessibilityRole={CONST.ACCESSIBILITY_ROLE.BUTTON}>
+                            {({hovered}) => (
+                                <Icon
+                                    src={Expensicons.Plus}
+                                    width={12}
+                                    height={12}
+                                    additionalStyles={[styles.highlightBG, styles.borderRadiusNormal, styles.p2, hovered && styles.bordersBG]}
+                                />
+                            )}
+                        </PressableWithFeedback>
                     )}
-                </PressableWithFeedback>}
-            </View>
-                    <View style={{marginBottom: 12}}>
-                        {_.map(workspaces, (item, index) => getMenuItem(item, index))}
-                    </View>
                 </View>
-            );
-        },
-        [getMenuItem, styles.alignItemsCenter, styles.borderRadiusNormal, styles.bordersBG, styles.flexRow, styles.highlightBG, styles.justifyContentBetween, styles.label, styles.mb3, styles.mh4, styles.p2, theme.textSupporting],
+                <View style={{marginBottom: 12}}>{_.map(workspaces, (item, index) => getMenuItem(item, index))}</View>
+            </View>
+        ),
+        [
+            getMenuItem,
+            styles.alignItemsCenter,
+            styles.borderRadiusNormal,
+            styles.bordersBG,
+            styles.flexRow,
+            styles.highlightBG,
+            styles.justifyContentBetween,
+            styles.label,
+            styles.mb3,
+            styles.mh4,
+            styles.p2,
+            theme.textSupporting,
+        ],
     );
 
     const allWorkspacesSection = useMemo(() => getWorkspacesSection(allWorkspaces, 'Everything', false, false), [allWorkspaces, getWorkspacesSection]);
     const usersWorkspacesSection = useMemo(() => getWorkspacesSection(usersWorkspaces, 'Workspaces', true, true), [getWorkspacesSection, usersWorkspaces]);
 
     // const {inputCallbackRef} = useAutoFocusInput();
-
 
     return (
         <HeaderPageLayout

--- a/src/pages/WorkspaceSelectorPage.js
+++ b/src/pages/WorkspaceSelectorPage.js
@@ -185,7 +185,7 @@ function WorkspacesSelectorPage({policies, activeWorkspaceID}) {
                     )}
                 </PressableWithFeedback>}
             </View>
-                    <View>
+                    <View style={{marginBottom: 12}}>
                         {_.map(workspaces, (item, index) => getMenuItem(item, index))}
                     </View>
                 </View>

--- a/src/styles/styles.ts
+++ b/src/styles/styles.ts
@@ -1024,6 +1024,11 @@ const styles = (theme: ThemeColors) =>
             margin: 1,
         },
 
+        textInputLeftIconContainer: {
+            justifyContent: "center",
+            paddingRight: 8,
+        },
+
         secureInput: {
             borderTopRightRadius: 0,
             borderBottomRightRadius: 0,

--- a/src/styles/styles.ts
+++ b/src/styles/styles.ts
@@ -1025,7 +1025,7 @@ const styles = (theme: ThemeColors) =>
         },
 
         textInputLeftIconContainer: {
-            justifyContent: "center",
+            justifyContent: 'center',
             paddingRight: 8,
         },
 

--- a/src/styles/themes/default.ts
+++ b/src/styles/themes/default.ts
@@ -127,6 +127,10 @@ const darkTheme = {
             backgroundColor: colors.productDark200,
             statusBarStyle: CONST.STATUS_BAR_STYLE.LIGHT_CONTENT,
         },
+        [SCREENS.WORKSPACE_SELECTOR.ROOT]: {
+            backgroundColor: colors.productDark100,
+            statusBarStyle: CONST.STATUS_BAR_STYLE.LIGHT_CONTENT,
+        },
         [SCREENS.RIGHT_MODAL.REFERRAL]: {
             backgroundColor: colors.pink800,
             statusBarStyle: CONST.STATUS_BAR_STYLE.LIGHT_CONTENT,

--- a/src/styles/themes/light.ts
+++ b/src/styles/themes/light.ts
@@ -127,6 +127,10 @@ const lightTheme = {
             backgroundColor: colors.productLight200,
             statusBarStyle: CONST.STATUS_BAR_STYLE.DARK_CONTENT,
         },
+        [SCREENS.WORKSPACE_SELECTOR.ROOT]: {
+            backgroundColor: colors.productLight100,
+            statusBarStyle: CONST.STATUS_BAR_STYLE.DARK_CONTENT,
+        },
         [SCREENS.RIGHT_MODAL.REFERRAL]: {
             backgroundColor: colors.pink800,
             statusBarStyle: CONST.STATUS_BAR_STYLE.LIGHT_CONTENT,

--- a/src/types/onyx/OnyxCommon.ts
+++ b/src/types/onyx/OnyxCommon.ts
@@ -27,6 +27,9 @@ type Icon = {
 
     /** A fallback avatar icon to display when there is an error on loading avatar from remote URL. */
     fallbackIcon?: AvatarSource;
+
+    /** Fill color of the icon */
+    fill?: string;
 };
 
 export type {Icon, PendingAction, PendingFields, ErrorFields, Errors, AvatarType};


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$
PROPOSAL:


### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

- [ ] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [ ] I linked the correct issue in the `### Fixed Issues` section above
- [ ] I wrote clear testing steps that cover the changes made in this PR
    - [ ] I added steps for local testing in the `Tests` section
    - [ ] I added steps for the expected offline behavior in the `Offline steps` section
    - [ ] I added steps for Staging and/or Production testing in the `QA steps` section
    - [ ] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [ ] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [ ] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [ ] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [ ] I ran the tests on **all platforms** & verified they passed on:
    - [ ] Android: Native
    - [ ] Android: mWeb Chrome
    - [ ] iOS: Native
    - [ ] iOS: mWeb Safari
    - [ ] MacOS: Chrome / Safari
    - [ ] MacOS: Desktop
- [ ] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [ ] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [ ] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [ ] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [ ] I verified that comments were added to code that is not self explanatory
    - [ ] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [ ] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [ ] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [ ] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [ ] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [ ] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [ ] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [ ] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [ ] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [ ] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [ ] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [ ] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [ ] I verified that if a function's arguments changed that all usages have also been updated correctly
- [ ] If any new file was added I verified that:
    - [ ] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [ ] If a new CSS style is added I verified that:
    - [ ] A similar style doesn't already exist
    - [ ] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [ ] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [ ] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [ ] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [ ] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [ ] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [ ] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Desktop</summary>

<!-- add screenshots or videos here -->

</details>
