### PR TITLE
Picker style fix

### DIFF
--- a/src/components/Picker/BasePicker.tsx
+++ b/src/components/Picker/BasePicker.tsx
@@ -179,7 +179,7 @@ function BasePicker<TPickerValue>(
                 <RNPickerSelect
                     onValueChange={onValueChange}
                     // We add a text color to prevent white text on white background dropdown items on Windows
-                    items={items.map((item) => ({...item, color: getItemColor()}))}
+                    items={items.map((item) => ({...item, color: getItemColor}))}
                     style={size === 'normal' ? styles.picker(isDisabled, backgroundColor) : styles.pickerSmall(backgroundColor)}
                     useNativeAndroidPickerStyle={false}
                     placeholder={pickerPlaceholder}

--- a/src/components/Picker/BasePicker.tsx
+++ b/src/components/Picker/BasePicker.tsx
@@ -49,7 +49,7 @@ function BasePicker<TPickerValue>(
 
     // Windows will reuse the text color of the select for each one of the options
     // so we might need to color accordingly so it doesn't blend with the background.
-    const pickerPlaceholder = Object.keys(placeholder).length > 0 ? {...placeholder, color: theme.pickerOptionsTextColor} : {};
+    const pickerPlaceholder = Object.keys(placeholder).length > 0 ? {...placeholder, color: theme.text} : {};
 
     useEffect(() => {
         if (!!value || !items || items.length !== 1 || !onInputChange) {
@@ -146,7 +146,7 @@ function BasePicker<TPickerValue>(
             return theme.textLight;
         }
 
-        return theme.pickerOptionsTextColor;
+        return theme.text;
     }, [theme]);
 
     const hasError = !!errorText;

--- a/src/components/Picker/BasePicker.tsx
+++ b/src/components/Picker/BasePicker.tsx
@@ -143,7 +143,7 @@ function BasePicker<TPickerValue>(
      * so we need to color accordingly so it doesn't blend with the background.
      */
     const itemColor = useMemo(() => {
-        if(getOperatingSystem() === CONST.OS.ANDROID) {
+        if (getOperatingSystem() === CONST.OS.ANDROID) {
             return theme.textLight;
         }
 

--- a/src/components/Picker/BasePicker.tsx
+++ b/src/components/Picker/BasePicker.tsx
@@ -143,7 +143,7 @@ function BasePicker<TPickerValue>(
      * so we need to color accordingly so it doesn't blend with the background.
      */
     const itemColor = useMemo(() => {
-        if (getOperatingSystem() === CONST.OS.WINDOWS) {
+        if (getOperatingSystem() === CONST.OS.WINDOWS || getOperatingSystem() === CONST.OS.IOS) {
             return theme.text;
         }
 

--- a/src/components/Picker/BasePicker.tsx
+++ b/src/components/Picker/BasePicker.tsx
@@ -144,7 +144,7 @@ function BasePicker<TPickerValue>(
      */
     const getItemColor = useMemo(() => {
         if (getOperatingSystem() === CONST.OS.WINDOWS) {
-            return theme.pickerOptionsTextColor;
+            return theme.text;
         }
 
         return theme.textLight;

--- a/src/components/Picker/BasePicker.tsx
+++ b/src/components/Picker/BasePicker.tsx
@@ -138,6 +138,10 @@ function BasePicker<TPickerValue>(
         },
     }));
 
+    /**
+     * Windows will reuse the text color of the select for each one of the options
+     * so we need to color accordingly so it doesn't blend with the background.
+     */
     const getItemColor = useMemo(() => {
         if (getOperatingSystem() == CONST.OS.WINDOWS) {
             return theme.pickerOptionsTextColor;

--- a/src/components/Picker/BasePicker.tsx
+++ b/src/components/Picker/BasePicker.tsx
@@ -10,7 +10,7 @@ import useScrollContext from '@hooks/useScrollContext';
 import useTheme from '@hooks/useTheme';
 import useThemeStyles from '@hooks/useThemeStyles';
 import getOperatingSystem from '@libs/getOperatingSystem';
-import CONST from '@src/CONST'
+import CONST from '@src/CONST';
 import type {BasePickerHandle, BasePickerProps} from './types';
 
 type IconToRender = () => ReactElement;
@@ -146,7 +146,6 @@ function BasePicker<TPickerValue>(
         return theme.textLight;
     }, [theme]);
 
-
     const hasError = !!errorText;
 
     if (isDisabled) {
@@ -165,7 +164,7 @@ function BasePicker<TPickerValue>(
             </View>
         );
     }
-    
+
     return (
         <>
             <View

--- a/src/components/Picker/BasePicker.tsx
+++ b/src/components/Picker/BasePicker.tsx
@@ -139,8 +139,7 @@ function BasePicker<TPickerValue>(
     }));
 
     /**
-     * Windows will reuse the text color of the select for each one of the options
-     * so we need to color accordingly so it doesn't blend with the background.
+     * We pass light text on Android, since Android Native alerts have a dark background in all themes for now.
      */
     const itemColor = useMemo(() => {
         if (getOperatingSystem() === CONST.OS.ANDROID) {

--- a/src/components/Picker/BasePicker.tsx
+++ b/src/components/Picker/BasePicker.tsx
@@ -143,7 +143,7 @@ function BasePicker<TPickerValue>(
      * so we need to color accordingly so it doesn't blend with the background.
      */
     const getItemColor = useMemo(() => {
-        if (getOperatingSystem() == CONST.OS.WINDOWS) {
+        if (getOperatingSystem() === CONST.OS.WINDOWS) {
             return theme.pickerOptionsTextColor;
         }
 

--- a/src/components/Picker/BasePicker.tsx
+++ b/src/components/Picker/BasePicker.tsx
@@ -143,11 +143,11 @@ function BasePicker<TPickerValue>(
      * so we need to color accordingly so it doesn't blend with the background.
      */
     const itemColor = useMemo(() => {
-        if (getOperatingSystem() === CONST.OS.WINDOWS || getOperatingSystem() === CONST.OS.IOS) {
-            return theme.text;
+        if(getOperatingSystem() === CONST.OS.ANDROID) {
+            return theme.textLight;
         }
 
-        return theme.textLight;
+        return theme.pickerOptionsTextColor;
     }, [theme]);
 
     const hasError = !!errorText;

--- a/src/components/Picker/BasePicker.tsx
+++ b/src/components/Picker/BasePicker.tsx
@@ -9,9 +9,9 @@ import Text from '@components/Text';
 import useScrollContext from '@hooks/useScrollContext';
 import useTheme from '@hooks/useTheme';
 import useThemeStyles from '@hooks/useThemeStyles';
-import type {BasePickerHandle, BasePickerProps} from './types';
 import getOperatingSystem from '@libs/getOperatingSystem';
 import CONST from '@src/CONST'
+import type {BasePickerHandle, BasePickerProps} from './types';
 
 type IconToRender = () => ReactElement;
 
@@ -138,6 +138,15 @@ function BasePicker<TPickerValue>(
         },
     }));
 
+    const getItemColor = useMemo(() => {
+        if (getOperatingSystem() == CONST.OS.WINDOWS) {
+            return theme.pickerOptionsTextColor;
+        }
+
+        return theme.textLight;
+    }, [theme]);
+
+
     const hasError = !!errorText;
 
     if (isDisabled) {
@@ -155,14 +164,6 @@ function BasePicker<TPickerValue>(
                 {!!hintText && <Text style={[styles.textLabel, styles.colorMuted, styles.mt2]}>{hintText}</Text>}
             </View>
         );
-    }
-
-    const getItemColor = () => {
-        if (getOperatingSystem() == CONST.OS.WINDOWS) {
-            return theme.pickerOptionsTextColor;
-        }
-
-        return theme.textLight;
     }
     
     return (

--- a/src/components/Picker/BasePicker.tsx
+++ b/src/components/Picker/BasePicker.tsx
@@ -10,6 +10,8 @@ import useScrollContext from '@hooks/useScrollContext';
 import useTheme from '@hooks/useTheme';
 import useThemeStyles from '@hooks/useThemeStyles';
 import type {BasePickerHandle, BasePickerProps} from './types';
+import getOperatingSystem from '@libs/getOperatingSystem';
+import CONST from '@src/CONST'
 
 type IconToRender = () => ReactElement;
 
@@ -155,6 +157,14 @@ function BasePicker<TPickerValue>(
         );
     }
 
+    const getItemColor = () => {
+        if (getOperatingSystem() == CONST.OS.WINDOWS) {
+            return theme.pickerOptionsTextColor;
+        }
+
+        return theme.textLight;
+    }
+    
     return (
         <>
             <View
@@ -165,7 +175,7 @@ function BasePicker<TPickerValue>(
                 <RNPickerSelect
                     onValueChange={onValueChange}
                     // We add a text color to prevent white text on white background dropdown items on Windows
-                    items={items.map((item) => ({...item, color: theme.pickerOptionsTextColor}))}
+                    items={items.map((item) => ({...item, color: getItemColor()}))}
                     style={size === 'normal' ? styles.picker(isDisabled, backgroundColor) : styles.pickerSmall(backgroundColor)}
                     useNativeAndroidPickerStyle={false}
                     placeholder={pickerPlaceholder}

--- a/src/components/Picker/BasePicker.tsx
+++ b/src/components/Picker/BasePicker.tsx
@@ -142,7 +142,7 @@ function BasePicker<TPickerValue>(
      * Windows will reuse the text color of the select for each one of the options
      * so we need to color accordingly so it doesn't blend with the background.
      */
-    const getItemColor = useMemo(() => {
+    const itemColor = useMemo(() => {
         if (getOperatingSystem() === CONST.OS.WINDOWS) {
             return theme.text;
         }
@@ -179,7 +179,7 @@ function BasePicker<TPickerValue>(
                 <RNPickerSelect
                     onValueChange={onValueChange}
                     // We add a text color to prevent white text on white background dropdown items on Windows
-                    items={items.map((item) => ({...item, color: getItemColor}))}
+                    items={items.map((item) => ({...item, color: itemColor}))}
                     style={size === 'normal' ? styles.picker(isDisabled, backgroundColor) : styles.pickerSmall(backgroundColor)}
                     useNativeAndroidPickerStyle={false}
                     placeholder={pickerPlaceholder}

--- a/src/styles/theme/themes/dark.ts
+++ b/src/styles/theme/themes/dark.ts
@@ -65,7 +65,6 @@ const darkTheme = {
     dropUIBG: 'rgba(6,27,9,0.92)',
     receiptDropUIBG: 'rgba(3, 212, 124, 0.84)',
     checkBox: colors.green400,
-    pickerOptionsTextColor: colors.productDark900,
     imageCropBackgroundColor: colors.productDark700,
     fallbackIconColor: colors.green700,
     reactionActiveBackground: colors.green600,

--- a/src/styles/theme/themes/light.ts
+++ b/src/styles/theme/themes/light.ts
@@ -65,7 +65,6 @@ const lightTheme = {
     dropUIBG: 'rgba(252, 251, 249, 0.92)',
     receiptDropUIBG: 'rgba(3, 212, 124, 0.84)',
     checkBox: colors.green400,
-    pickerOptionsTextColor: colors.productLight900,
     imageCropBackgroundColor: colors.productLight700,
     fallbackIconColor: colors.green700,
     reactionActiveBackground: colors.green100,

--- a/src/styles/theme/types.ts
+++ b/src/styles/theme/types.ts
@@ -68,7 +68,6 @@ type ThemeColors = {
     dropUIBG: Color;
     receiptDropUIBG: Color;
     checkBox: Color;
-    pickerOptionsTextColor: Color;
     imageCropBackgroundColor: Color;
     fallbackIconColor: Color;
     reactionActiveBackground: Color;


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
We fix the picker menuItems text color

### Fixed Issues
$ https://github.com/Expensify/App/issues/33136
PROPOSAL: https://github.com/Expensify/App/issues/33136#issuecomment-1857217295


### Tests
1. Open the app
2. Login with any account
3. Go to Settings -> Workspaces -> Open any WS -> Reimbursements -> Track distance
4. Tap on Unit
5. Verify that the inscription in the pop-up window is visible properly

- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->
Same as Tests section.

### QA Steps
Same as Tests section

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<img width="354" alt="android light" src="https://github.com/Expensify/App/assets/64629613/323f0e5b-375f-4a19-a5d5-6c1d79964027">
<img width="350" alt="android dark" src="https://github.com/Expensify/App/assets/64629613/d5136a99-3301-4294-adb7-475393f976db">


</details>

<details>
<summary>Android: mWeb Chrome</summary>


<img width="351" alt="Screenshot 2023-12-16 at 2 33 04 AM" src="https://github.com/Expensify/App/assets/64629613/c7ea2781-eea0-42dd-b163-27317d24abb6">
<img width="351" alt="Screenshot 2023-12-16 at 2 33 26 AM" src="https://github.com/Expensify/App/assets/64629613/ab6d989d-c6b1-4b19-a4c4-1d769551ea49">


</details>

<details>
<summary>iOS: Native</summary>

<img width="454" alt="ios dark" src="https://github.com/Expensify/App/assets/64629613/4e4afdda-4ad7-448a-afce-94c69bf37b17">

<img width="454" alt="ios light" src="https://github.com/Expensify/App/assets/64629613/ff6de870-29cf-4074-9ba2-72a072d0e944">

</details>

<details>
<summary>iOS: mWeb Safari</summary>


<img width="454" alt="Screenshot 2023-12-16 at 2 47 18 AM" src="https://github.com/Expensify/App/assets/64629613/838b0b6d-e9ba-45b7-b11c-d88caed27375">
<img width="454" alt="Screenshot 2023-12-16 at 2 47 38 AM" src="https://github.com/Expensify/App/assets/64629613/b2883a17-5126-4258-aba6-0cce8389f20d">


</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<img width="1428" alt="Screenshot 2023-12-16 at 1 41 53 AM" src="https://github.com/Expensify/App/assets/64629613/4c765e5a-f3ee-4f8c-a164-d1f61badb6d2">
<img width="1428" alt="Screenshot 2023-12-16 at 1 42 15 AM" src="https://github.com/Expensify/App/assets/64629613/ee9322d5-9dd8-4136-aabe-7272d490c467">


</details>

<details>
<summary>MacOS: Desktop</summary>

<img width="1221" alt="desktop light" src="https://github.com/Expensify/App/assets/64629613/72d419ea-da2f-47b3-85f9-4123c26639f7">


<img width="1221" alt="desktop dark" src="https://github.com/Expensify/App/assets/64629613/9df04c1d-10a5-4b3e-9b51-6fd3772c8b75">


</details>
