### PR TITLE
fix older safari launch app issue

### DIFF
--- a/src/libs/UserUtils.ts
+++ b/src/libs/UserUtils.ts
@@ -105,8 +105,8 @@ function getDefaultAvatar(accountID = -1, avatarURL?: string): React.FC<SvgProps
     // But the avatar link still corresponds to the original ID-generated link. So we extract the SVG image number from the backend's link instead of using the user ID directly
     let accountIDHashBucket: AvatarRange;
     if (avatarURL) {
-        const match = avatarURL.match(/(?<=default-avatar_)\d+(?=\.)/);
-        const lastDigit = match && parseInt(match[0], 10);
+        const match = avatarURL.match(/(default-avatar_)(\d+)(?=\.)/);
+        const lastDigit = match && parseInt(match[2], 10);
         accountIDHashBucket = lastDigit as AvatarRange;
     } else {
         accountIDHashBucket = ((accountID % CONST.DEFAULT_AVATAR_COUNT) + 1) as AvatarRange;

--- a/tests/unit/UserUtilsTest.js
+++ b/tests/unit/UserUtilsTest.js
@@ -1,0 +1,9 @@
+import * as UserUtils from '../../src/libs/UserUtils';
+
+describe('UserUtils', () => {
+    it('should return the default avatar from the avatar url', () => {
+        const avatarURL = 'https://d2k5nsl2zxldvw.cloudfront.net/images/avatars/default-avatar_7.png';
+        const defaultAvatar = UserUtils.getDefaultAvatar(1, avatarURL);
+        expect(typeof defaultAvatar).toBe('function');
+    });
+});


### PR DESCRIPTION
@situchan @alitoshmatov @Julesssss 

### Details

This PR uses capture groups instead of lookbehind to support older safari versions (v 16.3) for avatar URL so that the app can launch successfully.

**Declaration**: I could not test on Android Native due to the pending issue as per [slack thread here](https://expensify.slack.com/archives/C01GTK53T8Q/p1702883604941629).
Since this issue has to do with web/mWeb Safari platform, this may not be an issue here.

### Fixed Issues
$ https://github.com/Expensify/App/issues/33215
PROPOSAL: https://github.com/Expensify/App/issues/33215#issuecomment-1860653728

### Tests

**Steps**
Precondition: Safari version: 16.3
1. Reload the App when the user has already signed in

Expected Result: The App should load correctly and the avatars should be displayed.

- [ ] Verify that no errors appear in the JS console

### Offline tests

Same as the Steps for Tests Section.

### QA Steps

Same as the Steps for Tests Section.

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] If we are not using the full Onyx data that we loaded, I've added the proper selector in order to ensure the component only re-renders when the data it is using changes
        - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.


### Screenshots/Videos
<details>
<summary>Web - Safari</summary>

https://github.com/Expensify/App/assets/3004659/175dabd0-21f5-461d-ad9d-a03971b8aefb

</details>

<details>
<summary>Mobile Web - Safari</summary>

https://github.com/Expensify/App/assets/3004659/33cf581a-f701-4033-bb56-bf9abc5becbe

</details>

<details>
<summary>Desktop</summary>

https://github.com/Expensify/App/assets/3004659/1aa94af4-3788-4911-9759-e2778d36378b

</details>

<details>
<summary>iOS</summary>

https://github.com/Expensify/App/assets/3004659/8ead62eb-8de5-4e1d-ba8e-b221a817e8f3

</details>

<details>
<summary>Android</summary>

Not done due to the pending issue as per [slack thread here](https://expensify.slack.com/archives/C01GTK53T8Q/p1702883604941629).
Plus since this issue has to do with web/mWeb Safari platform, this may not be a matter of concern here.

</details>

<details>
<summary>Mobile Web - Chrome</summary>

https://github.com/Expensify/App/assets/3004659/b7f83bed-0999-4a3b-b016-bd39dce8e610

</details>