### PR TITLE
[CP Staging] Disable clearReportNotifications on Android

### DIFF
--- a/src/libs/Notification/PushNotification/index.native.ts
+++ b/src/libs/Notification/PushNotification/index.native.ts
@@ -2,7 +2,6 @@ import Airship, {EventType, PushPayload} from '@ua/react-native-airship';
 import Onyx from 'react-native-onyx';
 import Log from '@libs/Log';
 import * as PushNotificationActions from '@userActions/PushNotification';
-import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
 import ForegroundNotifications from './ForegroundNotifications';
 import NotificationType, {NotificationData} from './NotificationType';
@@ -190,40 +189,6 @@ const clearNotifications: ClearNotifications = () => {
     Airship.push.clearNotifications();
 };
 
-const parseNotificationAndReportIDs = (pushPayload: PushPayload) => {
-    let payload = pushPayload.extras.payload;
-    if (typeof payload === 'string') {
-        payload = JSON.parse(payload);
-    }
-    const data = payload as NotificationData;
-    return {
-        notificationID: pushPayload.notificationId,
-        reportID: String(data.reportID),
-    };
-};
-
-const clearReportNotifications = (reportID: string) => {
-    Log.info('[PushNotification] clearing report notifications', false, {reportID});
-
-    Airship.push
-        .getActiveNotifications()
-        .then((pushPayloads) => {
-            const reportNotificationIDs = pushPayloads.reduce<string[]>((notificationIDs, pushPayload) => {
-                const notification = parseNotificationAndReportIDs(pushPayload);
-                if (notification.notificationID && notification.reportID === reportID) {
-                    notificationIDs.push(notification.notificationID);
-                }
-                return notificationIDs;
-            }, []);
-
-            Log.info(`[PushNotification] found ${reportNotificationIDs.length} notifications to clear`, false, {reportID});
-            reportNotificationIDs.forEach((notificationID) => Airship.push.clearNotification(notificationID));
-        })
-        .catch((error) => {
-            Log.alert(`${CONST.ERROR.ENSURE_BUGBOT} [PushNotification] BrowserNotifications.clearReportNotifications threw an error. This should never happen.`, {reportID, error});
-        });
-};
-
 const PushNotification: PushNotificationType = {
     init,
     register,
@@ -232,7 +197,6 @@ const PushNotification: PushNotificationType = {
     onSelected,
     TYPE: NotificationType,
     clearNotifications,
-    clearReportNotifications,
 };
 
 export default PushNotification;

--- a/src/libs/Notification/PushNotification/index.ts
+++ b/src/libs/Notification/PushNotification/index.ts
@@ -10,7 +10,6 @@ const PushNotification: PushNotificationType = {
     onSelected: () => {},
     TYPE: NotificationType,
     clearNotifications: () => {},
-    clearReportNotifications: () => {},
 };
 
 export default PushNotification;

--- a/src/libs/Notification/PushNotification/types.ts
+++ b/src/libs/Notification/PushNotification/types.ts
@@ -1,5 +1,4 @@
 import {ValueOf} from 'type-fest';
-import ClearReportNotifications from '@libs/Notification/clearReportNotifications/types';
 import NotificationType, {NotificationDataMap} from './NotificationType';
 
 type Init = () => void;
@@ -17,7 +16,6 @@ type PushNotification = {
     onSelected: OnSelected;
     TYPE: typeof NotificationType;
     clearNotifications: ClearNotifications;
-    clearReportNotifications: ClearReportNotifications;
 };
 
 export default PushNotification;

--- a/src/libs/Notification/clearReportNotifications/index.android.ts
+++ b/src/libs/Notification/clearReportNotifications/index.android.ts
@@ -1,0 +1,9 @@
+import ClearReportNotifications from './types';
+
+/**
+ * This is a temporary fix for issues with our Notification Cache not being cleared in Android.
+ * More info here: https://github.com/Expensify/App/issues/33367#issuecomment-1865196381
+ */
+const clearReportNotifications: ClearReportNotifications = () => {};
+
+export default clearReportNotifications;

--- a/src/libs/Notification/clearReportNotifications/index.ios.ts
+++ b/src/libs/Notification/clearReportNotifications/index.ios.ts
@@ -1,0 +1,41 @@
+import Airship, {PushPayload} from '@ua/react-native-airship';
+import Log from '@libs/Log';
+import {NotificationData} from '@libs/Notification/PushNotification/NotificationType';
+import CONST from '@src/CONST';
+import ClearReportNotifications from './types';
+
+const parseNotificationAndReportIDs = (pushPayload: PushPayload) => {
+    let payload = pushPayload.extras.payload;
+    if (typeof payload === 'string') {
+        payload = JSON.parse(payload);
+    }
+    const data = payload as NotificationData;
+    return {
+        notificationID: pushPayload.notificationId,
+        reportID: String(data.reportID),
+    };
+};
+
+const clearReportNotifications: ClearReportNotifications = (reportID: string) => {
+    Log.info('[PushNotification] clearing report notifications', false, {reportID});
+
+    Airship.push
+        .getActiveNotifications()
+        .then((pushPayloads) => {
+            const reportNotificationIDs = pushPayloads.reduce<string[]>((notificationIDs, pushPayload) => {
+                const notification = parseNotificationAndReportIDs(pushPayload);
+                if (notification.notificationID && notification.reportID === reportID) {
+                    notificationIDs.push(notification.notificationID);
+                }
+                return notificationIDs;
+            }, []);
+
+            Log.info(`[PushNotification] found ${reportNotificationIDs.length} notifications to clear`, false, {reportID});
+            reportNotificationIDs.forEach((notificationID) => Airship.push.clearNotification(notificationID));
+        })
+        .catch((error) => {
+            Log.alert(`${CONST.ERROR.ENSURE_BUGBOT} [PushNotification] BrowserNotifications.clearReportNotifications threw an error. This should never happen.`, {reportID, error});
+        });
+};
+
+export default clearReportNotifications;

--- a/src/libs/Notification/clearReportNotifications/index.native.ts
+++ b/src/libs/Notification/clearReportNotifications/index.native.ts
@@ -1,5 +1,0 @@
-import PushNotification from '@libs/Notification/PushNotification';
-import ClearReportNotifications from './types';
-
-const clearReportNotifications: ClearReportNotifications = PushNotification.clearReportNotifications;
-export default clearReportNotifications;


### PR DESCRIPTION
### Details
Temporarily disables clearing report notifications on Android to fix issues with the native [NotificationCache](https://github.com/Expensify/App/blob/main/android/app/src/main/java/com/expensify/chat/customairshipextender/NotificationCache.java) not getting updated

### Fixed Issues
$ https://github.com/Expensify/App/issues/33367

### Tests

_Android only_

1. Log in
2. Accept notification permission
3. Send yourself two messages
4. Verify notifications display and they are threaded into a single notification correctly
5. Open the chat
6. Verify those notifications are NOT cleared
7. Dismiss the notifications manually
8. Go back to the LHN
9. Send yourself two more messages
10. Verify notifications display, the messages are threaded and the original two message do NOT display

### Offline tests
None

### QA Steps
Same as Tests

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

https://github.com/Expensify/App/assets/6833644/959320d5-a077-4ba6-b2c8-1e3915d315aa

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Desktop</summary>

<!-- add screenshots or videos here -->

</details>
