### PR TITLE
Fix incorrect text color in some places

### DIFF
--- a/src/pages/ErrorPage/GenericErrorPage.js
+++ b/src/pages/ErrorPage/GenericErrorPage.js
@@ -85,7 +85,7 @@ function GenericErrorPage({translate}) {
                                 src={LogoWordmark}
                                 height={30}
                                 width={80}
-                                fill={theme.textLight}
+                                fill={theme.text}
                             />
                         </View>
                     </View>

--- a/src/styles/index.ts
+++ b/src/styles/index.ts
@@ -2089,7 +2089,7 @@ const styles = (theme: ThemeColors) =>
         },
 
         avatarInnerTextSmall: {
-            color: theme.textLight,
+            color: theme.text,
             fontSize: variables.fontSizeExtraSmall,
             lineHeight: undefined,
             marginLeft: -2,
@@ -2445,7 +2445,7 @@ const styles = (theme: ThemeColors) =>
         RHPNavigatorContainerNavigatorContainerStyles: (isSmallScreenWidth: boolean) => ({marginLeft: isSmallScreenWidth ? 0 : variables.sideBarWidth, flex: 1} satisfies ViewStyle),
 
         avatarInnerTextChat: {
-            color: theme.textLight,
+            color: theme.text,
             fontSize: variables.fontSizeXLarge,
             fontFamily: fontFamily.EXP_NEW_KANSAS_MEDIUM,
             textAlign: 'center',


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->

Some places in app use wrong text color. Should use `theme.text` instead of `theme.textLight`.

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/33146
PROPOSAL: https://github.com/Expensify/App/issues/33146#issuecomment-1866618659


### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

1. Create more than 4 workspaces (if necessary)
2. Open Settings, verify that the number of workspaces on `Workspaces` menu is dark in light mode and light in dark mode
3. Create a group with more than 4 members
4. Press report header, verify that the number of members on report details header is dark in light mode and light in dark mode
5. Make the app crashed to show error page
6. Verify that the Expensify logo is visible

- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

NA

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
7. Upload an image via copy paste
8. Verify a modal appears displaying a preview of that image
--->

1. Create more than 4 workspaces (if necessary)
2. Open Settings, verify that the number of workspaces on `Workspaces` menu is dark in light mode and light in dark mode
3. Create a group with more than 4 members
4. Press report header, verify that the number of members on report details header is dark in light mode and light in dark mode

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->
![Screenshot_1704215273](https://github.com/Expensify/App/assets/153004152/480bfa42-34ee-4405-99b7-bd55f29c8c0c)
![Screenshot_1704215282](https://github.com/Expensify/App/assets/153004152/50db3d38-dbab-446b-ad9a-6132f866d5ad)
![Screenshot_1704215307](https://github.com/Expensify/App/assets/153004152/f0ffd092-ca92-4dbf-bf97-5ad56e8227b3)
![Screenshot_1704215326](https://github.com/Expensify/App/assets/153004152/78cc2d93-4b7c-4dad-9f71-2fb39de57742)
![Screenshot_1704215338](https://github.com/Expensify/App/assets/153004152/06aeddd2-3be6-484a-9334-53cd60e80d55)
![Screenshot_1704215463](https://github.com/Expensify/App/assets/153004152/1c2622ba-c2ef-4acb-9e7f-f23f75ea6d2e)

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->
![Screenshot_1704204218](https://github.com/Expensify/App/assets/153004152/2be63c46-5d94-4e23-b8c3-0ea805de5df2)
![Screenshot_1704204234](https://github.com/Expensify/App/assets/153004152/e262541b-ffe6-421e-b630-b113e34dae60)
![Screenshot_1704204256](https://github.com/Expensify/App/assets/153004152/4cc977cd-51de-4a61-bfaa-e2c3bec528d0)
![Screenshot_1704204288](https://github.com/Expensify/App/assets/153004152/30020de1-6a50-4db4-a161-0738dffe12e5)
![Screenshot_1704204292](https://github.com/Expensify/App/assets/153004152/30493868-43c1-4690-9887-db2362da550e)
![Screenshot_1704204308](https://github.com/Expensify/App/assets/153004152/5b1e60e8-34d0-4dbb-b82a-d1c5240994d7)

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->
![Simulator Screenshot - iPhone 15 Pro - 2024-01-02 at 20 54 55](https://github.com/Expensify/App/assets/153004152/64238588-377c-491d-a1cb-7778363e344f)
![Simulator Screenshot - iPhone 15 Pro - 2024-01-02 at 20 56 12](https://github.com/Expensify/App/assets/153004152/68ebf7b8-3d40-41ac-9a01-5e582a76389a)
![Simulator Screenshot - iPhone 15 Pro - 2024-01-02 at 20 56 30](https://github.com/Expensify/App/assets/153004152/f11be7ec-c502-4ef2-bbcb-0368676ecd1a)
![Simulator Screenshot - iPhone 15 Pro - 2024-01-02 at 20 56 40](https://github.com/Expensify/App/assets/153004152/b93ee9fd-b946-4979-83a6-d9370366b238)

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->
![Simulator Screenshot - iPhone 15 Pro - 2024-01-02 at 20 47 35](https://github.com/Expensify/App/assets/153004152/c90e95d1-ccd7-44dc-807e-e86d5ad1ab9f)
![Simulator Screenshot - iPhone 15 Pro - 2024-01-02 at 20 48 19](https://github.com/Expensify/App/assets/153004152/86d26ec1-3af8-4539-95fa-8f06474e64aa)
![Simulator Screenshot - iPhone 15 Pro - 2024-01-02 at 20 48 45](https://github.com/Expensify/App/assets/153004152/04ad83cf-b58f-4401-87cf-5bc5e9eae246)
![Simulator Screenshot - iPhone 15 Pro - 2024-01-02 at 20 48 55](https://github.com/Expensify/App/assets/153004152/e3f708a7-5c65-45f4-b7e0-f16c05463f9e)
![Simulator Screenshot - iPhone 15 Pro - 2024-01-02 at 20 50 23](https://github.com/Expensify/App/assets/153004152/a6c222a4-26a9-40f4-a783-c4dcd2551865)
![Simulator Screenshot - iPhone 15 Pro - 2024-01-02 at 20 52 16](https://github.com/Expensify/App/assets/153004152/e3f12583-e85d-4a58-95ec-de4bcea3ff72)


</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->
<img width="500" alt="Screenshot 2024-01-02 at 20 30 28" src="https://github.com/Expensify/App/assets/153004152/767c4197-e370-4c1a-a343-d426d3f1fe66">
<img width="500" alt="Screenshot 2024-01-02 at 20 30 45" src="https://github.com/Expensify/App/assets/153004152/c2f7e295-71fd-48a6-b72a-8a992706b2b1">
<img width="500" alt="Screenshot 2024-01-02 at 20 32 28" src="https://github.com/Expensify/App/assets/153004152/523ceaed-b47f-4b84-b509-d41ffa2984bc">
<img width="500" alt="Screenshot 2024-01-02 at 20 33 16" src="https://github.com/Expensify/App/assets/153004152/b68d9991-1aa8-4823-b6cd-3b91cfd52709">
<img width="500" alt="Screenshot 2024-01-02 at 20 33 30" src="https://github.com/Expensify/App/assets/153004152/c32590b4-4f09-4b04-90f9-dd49fb24815c">
<img width="500" alt="Screenshot 2024-01-02 at 20 34 45" src="https://github.com/Expensify/App/assets/153004152/4c7e6b41-6f78-4a88-84be-1bb3a5ab67e0">

</details>

<details>
<summary>MacOS: Desktop</summary>

<!-- add screenshots or videos here -->
<img width="500" alt="Screenshot 2024-01-02 at 20 38 25" src="https://github.com/Expensify/App/assets/153004152/113b2681-cd2f-47c2-96e6-24e28eb58c1e">
<img width="500" alt="Screenshot 2024-01-02 at 20 38 58" src="https://github.com/Expensify/App/assets/153004152/8ebea015-fa58-43cb-91d9-d8ed345ab166">
<img width="500" alt="Screenshot 2024-01-02 at 20 39 14" src="https://github.com/Expensify/App/assets/153004152/b1d88a23-bab5-4e00-8e51-1bd1cb851ebf">
<img width="500" alt="Screenshot 2024-01-02 at 20 39 29" src="https://github.com/Expensify/App/assets/153004152/3ababbea-c506-4fb8-a7e8-3c3ef1a5da92">
<img width="500" alt="Screenshot 2024-01-02 at 20 40 04" src="https://github.com/Expensify/App/assets/153004152/61477179-71ce-4d2d-ad4f-2d9f8626179a">
<img width="500" alt="Screenshot 2024-01-02 at 20 39 39" src="https://github.com/Expensify/App/assets/153004152/2b79965d-cdc5-4caa-aa1f-a4f05df44c7d">

</details>
