### PR TITLE
fix: Use the full-height ReportActionsSkeletonView in all cases

### DIFF
--- a/src/pages/home/report/ListBoundaryLoader/ListBoundaryLoader.js
+++ b/src/pages/home/report/ListBoundaryLoader/ListBoundaryLoader.js
@@ -39,17 +39,20 @@ function ListBoundaryLoader({type, isLoadingOlderReportActions, isLoadingInitial
     // We use two different loading components for the header and footer
     // to reduce the jumping effect when the user is scrolling to the newer report actions
     if (type === CONST.LIST_COMPONENTS.FOOTER) {
+        // We are actively fetching older report actions from the server – need to show the skeleton view
         if (isLoadingOlderReportActions) {
             return <ReportActionsSkeletonView />;
         }
 
-        // Make sure the report chat is not loaded till the beginning. This is so we do not show the
-        // skeleton view above the "created" action in a newly generated optimistic chat or one with not
-        // that many comments.
-        // Also, if we are offline and the report is not yet loaded till the beginning, we assume there are more actions to load,
-        // therefore show the skeleton view, even though the actions are not loading.
-        if (lastReportActionName !== CONST.REPORT.ACTIONS.TYPE.CREATED && (isLoadingInitialReportActions || isOffline)) {
-            return <ReportActionsSkeletonView possibleVisibleContentItems={3} />;
+        /*
+         Ensure that the report chat is not loaded until the beginning.
+         This is to avoid displaying the skeleton view above the "created" action in a newly generated optimistic chat or one with not that many comments.
+         Additionally, if we are offline and the report is not loaded until the beginning, we assume there are more actions to load;
+         Therefore, show the skeleton view even though the actions are not actually loading.
+        */
+        const isReportLoadedUntilBeginning = lastReportActionName === CONST.REPORT.ACTIONS.TYPE.CREATED;
+        if (!isReportLoadedUntilBeginning && (isLoadingInitialReportActions || isOffline)) {
+            return <ReportActionsSkeletonView />;
         }
     }
     if (type === CONST.LIST_COMPONENTS.HEADER && isLoadingNewerReportActions) {

--- a/src/pages/home/report/ListBoundaryLoader/ListBoundaryLoader.js
+++ b/src/pages/home/report/ListBoundaryLoader/ListBoundaryLoader.js
@@ -39,11 +39,6 @@ function ListBoundaryLoader({type, isLoadingOlderReportActions, isLoadingInitial
     // We use two different loading components for the header and footer
     // to reduce the jumping effect when the user is scrolling to the newer report actions
     if (type === CONST.LIST_COMPONENTS.FOOTER) {
-        // We are actively fetching older report actions from the server – need to show the skeleton view
-        if (isLoadingOlderReportActions) {
-            return <ReportActionsSkeletonView />;
-        }
-
         /*
          Ensure that the report chat is not loaded until the beginning.
          This is to avoid displaying the skeleton view above the "created" action in a newly generated optimistic chat or one with not that many comments.
@@ -51,7 +46,9 @@ function ListBoundaryLoader({type, isLoadingOlderReportActions, isLoadingInitial
          Therefore, show the skeleton view even though the actions are not actually loading.
         */
         const isReportLoadedUntilBeginning = lastReportActionName === CONST.REPORT.ACTIONS.TYPE.CREATED;
-        if (!isReportLoadedUntilBeginning && (isLoadingInitialReportActions || isOffline)) {
+        const mayLoadMoreActions = !isReportLoadedUntilBeginning && (isLoadingInitialReportActions || isOffline);
+
+        if (isLoadingOlderReportActions || mayLoadMoreActions) {
             return <ReportActionsSkeletonView />;
         }
     }


### PR DESCRIPTION
### Details

This PR brings consistency to displaying the ReportActions Skeleton View: makes it take the full-screen height in all scenarios

### Fixed Issues

$ https://github.com/Expensify/App/issues/33659
PROPOSAL: https://github.com/Expensify/App/issues/33659#issuecomment-1871947005


### Tests

Same as QA

### Offline tests

Same as QA

### QA Steps

1. Go offline
2. Open a chat that you have not opened yet
- [ ] Verify a full-height skeleton is displayed
3. While the loading screen is being shown, send any message
- [ ] Verify the message appeared in the chat
- [ ] Verify that the skeleton above the message still takes a full screen height

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

https://github.com/Expensify/App/assets/12595293/d80b60be-6aab-45db-bc20-90cf27f97c42


</details>

<details>
<summary>Android: mWeb Chrome</summary>

https://github.com/Expensify/App/assets/12595293/081423c4-d315-4f91-90e5-03ed46b9113e


</details>

<details>
<summary>iOS: Native</summary>

https://github.com/Expensify/App/assets/12595293/ceb35502-126a-4214-8f00-2ac3bcee3f27


</details>

<details>
<summary>iOS: mWeb Safari</summary>

https://github.com/Expensify/App/assets/12595293/a5ca7bb2-8449-4db3-905a-bc98e3fb1440


</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

https://github.com/Expensify/App/assets/12595293/f05f86e4-8d5c-43a5-8d85-27b2b5a47d70

</details>

<details>
<summary>MacOS: Desktop</summary>

https://github.com/Expensify/App/assets/12595293/bd71919f-9179-4b67-883b-0f0ff197a9f4


</details>