### PR TITLE
[CP Staging] Revert "Add layout=narrow initial param to the ModalStackNavigator"

### DIFF
--- a/src/hooks/useResponsiveLayout.ts
+++ b/src/hooks/useResponsiveLayout.ts
@@ -3,7 +3,7 @@ import {useRoute} from '@react-navigation/native';
 import useWindowDimensions from './useWindowDimensions';
 
 type RouteParams = ParamListBase & {
-    params: {layout?: string};
+    params: {isInRHP?: boolean};
 };
 type ResponsiveLayoutResult = {
     shouldUseNarrowLayout: boolean;
@@ -16,11 +16,10 @@ export default function useResponsiveLayout(): ResponsiveLayoutResult {
     try {
         // eslint-disable-next-line react-hooks/rules-of-hooks
         const {params} = useRoute<RouteProp<RouteParams, 'params'>>();
-        const isNarrowLayout = params?.layout === 'narrow' ?? false;
-        const shouldUseNarrowLayout = isSmallScreenWidth || isNarrowLayout;
-
-        return {shouldUseNarrowLayout};
+        return {shouldUseNarrowLayout: isSmallScreenWidth || (params?.isInRHP ?? false)};
     } catch (error) {
-        return {shouldUseNarrowLayout: isSmallScreenWidth};
+        return {
+            shouldUseNarrowLayout: isSmallScreenWidth,
+        };
     }
 }

--- a/src/libs/Navigation/AppNavigator/ModalStackNavigators.tsx
+++ b/src/libs/Navigation/AppNavigator/ModalStackNavigators.tsx
@@ -62,7 +62,6 @@ function createModalStackNavigator<TStackParams extends ParamListBase>(screens: 
                         key={name}
                         name={name}
                         getComponent={(screens as Required<Screens>)[name as Screen]}
-                        initialParams={{layout: 'narrow'} as TStackParams[string]}
                     />
                 ))}
             </ModalStackNavigator.Navigator>


### PR DESCRIPTION
Reverts Expensify/App#33426

Fixing https://github.com/Expensify/App/issues/34532