### PR TITLE
use announce and admin room report id from policy

### DIFF
--- a/src/pages/workspace/WorkspaceInitialPage.js
+++ b/src/pages/workspace/WorkspaceInitialPage.js
@@ -206,22 +206,22 @@ function WorkspaceInitialPage(props) {
                 onSelected: () => setIsDeleteModalOpen(true),
             },
         ];
-        if (adminsRoom) {
+        if (adminsRoom || policy.chatReportIDAdmins) {
             items.push({
                 icon: Expensicons.Hashtag,
                 text: translate('workspace.common.goToRoom', {roomName: CONST.REPORT.WORKSPACE_CHAT_ROOMS.ADMINS}),
-                onSelected: () => Navigation.dismissModal(adminsRoom.reportID),
+                onSelected: () => Navigation.dismissModal(adminsRoom ? adminsRoom.reportID : policy.chatReportIDAdmins.toString()),
             });
         }
-        if (announceRoom) {
+        if (announceRoom || policy.chatReportIDAnnounce) {
             items.push({
                 icon: Expensicons.Hashtag,
                 text: translate('workspace.common.goToRoom', {roomName: CONST.REPORT.WORKSPACE_CHAT_ROOMS.ANNOUNCE}),
-                onSelected: () => Navigation.dismissModal(announceRoom.reportID),
+                onSelected: () => Navigation.dismissModal(announceRoom ? announceRoom.reportID : policy.chatReportIDAnnounce.toString()),
             });
         }
         return items;
-    }, [adminsRoom, announceRoom, translate]);
+    }, [adminsRoom, announceRoom, translate, policy]);
 
     const prevPolicy = usePrevious(policy);
 

--- a/src/pages/workspace/WorkspaceInitialPage.js
+++ b/src/pages/workspace/WorkspaceInitialPage.js
@@ -206,6 +206,9 @@ function WorkspaceInitialPage(props) {
                 onSelected: () => setIsDeleteModalOpen(true),
             },
         ];
+        // Menu options to navigate to the chat report of #admins and #announce room.
+        // For navigation, the chat report ids may be unavailable due to the missing chat reports in Onyx.
+        // In such cases, let us use the available chat report ids from the policy.
         if (adminsRoom || policy.chatReportIDAdmins) {
             items.push({
                 icon: Expensicons.Hashtag,


### PR DESCRIPTION
@situchan @MariaHCD  

### Details

This PR uses the chat report ids for `announce` room and `admin` room from the `policy` for displaying the respective workspace menu option.

### Fixed Issues
$ https://github.com/Expensify/App/issues/33995
PROPOSAL: https://github.com/Expensify/App/issues/33995#issuecomment-1879657414

### Tests

**Steps**

1. Verify `Go to #announce` room option
	1	Click/Tap Settings -> Workspaces -> Create new workspace
	2	Click/Tap 3Dot Menu -> `Go to #announce` room. Verify that the #announce room report is launched
	3	Log out
	4	Login 
	5	Click/Tap Settings -> Workspaces
	6	Select workspace created in step 2
	7	Click/Tap 3Dot Menu -> `Go to #announce` room.
	8	Verify `Go to #announce` menu option is displayed
	9	Verify navigation to and display of `Announce room` report 

2. Verify `Go to #admin` room option
	1	Click/Tap Settings -> Workspaces -> Create new workspace
	2	Click/Tap 3Dot Menu -> `Go to #admin` room. Verify that the #admin room report is launched
	3	Log out
	4	Login 
	5	Click/Tap Settings -> Workspaces
	6	Select workspace created in step 2
	7	Click/Tap 3Dot Menu.
	8	Verify `Go to #admin` menu option is displayed
	9	Verify navigation to and display of `Announce room` report 
 
- [x] Verify that no errors appear in the JS console

### Offline tests

Same as the Steps for Tests Section.

### QA Steps

Same as the Steps for Tests Section.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] If we are not using the full Onyx data that we loaded, I've added the proper selector in order to ensure the component only re-renders when the data it is using changes
        - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.


### Screenshots/Videos
<details>
<summary>issue</summary>

https://github.com/Expensify/App/assets/3004659/0da19f45-a631-4020-a4db-51514fa4004c

</details>
<details>
<summary>Web - Safari</summary>

https://github.com/Expensify/App/assets/3004659/9b1411f6-afba-4c32-ab0b-4ae1245d3754

</details>

<details>
<summary>Mobile Web - Safari</summary>

https://github.com/Expensify/App/assets/3004659/6e680412-e048-4083-ad1a-0e3478f94874

</details>

<details>
<summary>Desktop</summary>

https://github.com/Expensify/App/assets/3004659/ed3ed7dc-4f6e-445a-a9fe-d3e58543ee9d

</details>

<details>
<summary>iOS</summary>

https://github.com/Expensify/App/assets/3004659/491a581f-e571-4fcc-8f72-db65d1362edb

</details>

<details>
<summary>Android</summary>

https://github.com/Expensify/App/assets/3004659/64daed37-8b4d-49e6-a029-cdbb2d1bc807

</details>

<details>
<summary>Mobile Web - Chrome</summary>

https://github.com/Expensify/App/assets/3004659/94ccd0ed-4b0f-458f-8a62-d14249ed8567

</details>
