### PR TITLE
[TS migration] Migrate 'ReportActionItemImage' component to TypeScript

### DIFF
--- a/src/components/ImageWithSizeCalculation.tsx
+++ b/src/components/ImageWithSizeCalculation.tsx
@@ -19,7 +19,7 @@ type OnLoadNativeEvent = {
 
 type ImageWithSizeCalculationProps = {
     /** Url for image to display */
-    url: string;
+    url: string | number;
 
     /** Any additional styles to apply */
     style?: StyleProp<ViewStyle>;

--- a/src/components/ReportActionItem/ReportActionItemImage.tsx
+++ b/src/components/ReportActionItem/ReportActionItemImage.tsx
@@ -1,47 +1,38 @@
 import Str from 'expensify-common/lib/str';
-import PropTypes from 'prop-types';
 import React from 'react';
+import type {ReactElement} from 'react';
 import {View} from 'react-native';
-import _ from 'underscore';
 import AttachmentModal from '@components/AttachmentModal';
 import EReceiptThumbnail from '@components/EReceiptThumbnail';
 import Image from '@components/Image';
 import PressableWithoutFocus from '@components/Pressable/PressableWithoutFocus';
 import {ShowContextMenuContext} from '@components/ShowContextMenuContext';
 import ThumbnailImage from '@components/ThumbnailImage';
-import transactionPropTypes from '@components/transactionPropTypes';
 import useLocalize from '@hooks/useLocalize';
 import useThemeStyles from '@hooks/useThemeStyles';
 import * as TransactionUtils from '@libs/TransactionUtils';
 import tryResolveUrlFromApiRoot from '@libs/tryResolveUrlFromApiRoot';
 import CONST from '@src/CONST';
+import type {Transaction} from '@src/types/onyx';
 
-const propTypes = {
+type ReportActionItemImageProps = {
     /** thumbnail URI for the image */
-    thumbnail: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+    thumbnail: string | number | null;
 
     /** URI for the image or local numeric reference for the image  */
-    image: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
+    image: string | number;
 
     /** whether or not to enable the image preview modal */
-    enablePreviewModal: PropTypes.bool,
+    enablePreviewModal?: boolean;
 
     /* The transaction associated with this image, if any. Passed for handling eReceipts. */
-    transaction: transactionPropTypes,
+    transaction?: Transaction;
 
     /** whether thumbnail is refer the local file or not */
-    isLocalFile: PropTypes.bool,
+    isLocalFile: boolean;
 
     /** whether the receipt can be replaced */
-    canEditReceipt: PropTypes.bool,
-};
-
-const defaultProps = {
-    thumbnail: null,
-    transaction: {},
-    enablePreviewModal: false,
-    isLocalFile: false,
-    canEditReceipt: false,
+    canEditReceipt?: boolean;
 };
 
 /**
@@ -50,14 +41,14 @@ const defaultProps = {
  * and optional preview modal as well.
  */
 
-function ReportActionItemImage({thumbnail, image, enablePreviewModal, transaction, canEditReceipt, isLocalFile}) {
+function ReportActionItemImage({thumbnail = null, image, enablePreviewModal = false, transaction, canEditReceipt = false, isLocalFile = false}: ReportActionItemImageProps) {
     const styles = useThemeStyles();
     const {translate} = useLocalize();
-    const imageSource = tryResolveUrlFromApiRoot(image || '');
-    const thumbnailSource = tryResolveUrlFromApiRoot(thumbnail || '');
-    const isEReceipt = !_.isEmpty(transaction) && TransactionUtils.hasEReceipt(transaction);
+    const imageSource = tryResolveUrlFromApiRoot(image ?? '');
+    const thumbnailSource = tryResolveUrlFromApiRoot(thumbnail ?? '');
+    const isEReceipt = transaction && TransactionUtils.hasEReceipt(transaction);
 
-    let receiptImageComponent;
+    let receiptImageComponent: ReactElement;
 
     if (isEReceipt) {
         receiptImageComponent = (
@@ -65,7 +56,7 @@ function ReportActionItemImage({thumbnail, image, enablePreviewModal, transactio
                 <EReceiptThumbnail transactionID={transaction.transactionID} />
             </View>
         );
-    } else if (thumbnail && !isLocalFile && !Str.isPDF(imageSource)) {
+    } else if (thumbnail && !isLocalFile && !Str.isPDF(imageSource as string)) {
         receiptImageComponent = (
             <ThumbnailImage
                 previewSourceURL={thumbnailSource}
@@ -77,7 +68,7 @@ function ReportActionItemImage({thumbnail, image, enablePreviewModal, transactio
     } else {
         receiptImageComponent = (
             <Image
-                source={{uri: thumbnail || image}}
+                source={{uri: thumbnail ?? image}}
                 style={[styles.w100, styles.h100]}
             />
         );
@@ -87,6 +78,7 @@ function ReportActionItemImage({thumbnail, image, enablePreviewModal, transactio
         return (
             <ShowContextMenuContext.Consumer>
                 {({report}) => (
+                    // @ts-expect-error TODO: Remove this once AttachmentModal (https://github.com/Expensify/App/issues/25130) is migrated to TypeScript.
                     <AttachmentModal
                         source={imageSource}
                         isAuthTokenRequired={!isLocalFile}
@@ -94,18 +86,22 @@ function ReportActionItemImage({thumbnail, image, enablePreviewModal, transactio
                         isReceiptAttachment
                         canEditReceipt={canEditReceipt}
                         allowToDownload
-                        originalFileName={transaction.filename}
+                        originalFileName={transaction?.filename}
                     >
-                        {({show}) => (
-                            <PressableWithoutFocus
-                                style={[styles.noOutline, styles.w100, styles.h100]}
-                                onPress={show}
-                                accessibilityRole={CONST.ACCESSIBILITY_ROLE.IMAGEBUTTON}
-                                accessibilityLabel={translate('accessibilityHints.viewAttachment')}
-                            >
-                                {receiptImageComponent}
-                            </PressableWithoutFocus>
-                        )}
+                        {
+                            // @ts-expect-error TODO: Remove this once AttachmentModal (https://github.com/Expensify/App/issues/25130) is migrated to TypeScript.
+                            ({show}) => (
+                                <PressableWithoutFocus
+                                    // @ts-expect-error TODO: Remove this once AttachmentModal (https://github.com/Expensify/App/issues/25130) is migrated to TypeScript.
+                                    style={[styles.noOutline, styles.w100, styles.h100]}
+                                    onPress={show}
+                                    accessibilityRole={CONST.ACCESSIBILITY_ROLE.IMAGEBUTTON}
+                                    accessibilityLabel={translate('accessibilityHints.viewAttachment')}
+                                >
+                                    {receiptImageComponent}
+                                </PressableWithoutFocus>
+                            )
+                        }
                     </AttachmentModal>
                 )}
             </ShowContextMenuContext.Consumer>
@@ -115,8 +111,6 @@ function ReportActionItemImage({thumbnail, image, enablePreviewModal, transactio
     return receiptImageComponent;
 }
 
-ReportActionItemImage.propTypes = propTypes;
-ReportActionItemImage.defaultProps = defaultProps;
 ReportActionItemImage.displayName = 'ReportActionItemImage';
 
 export default ReportActionItemImage;

--- a/src/components/ReportActionItem/ReportActionItemImage.tsx
+++ b/src/components/ReportActionItem/ReportActionItemImage.tsx
@@ -17,7 +17,7 @@ import type {Transaction} from '@src/types/onyx';
 
 type ReportActionItemImageProps = {
     /** thumbnail URI for the image */
-    thumbnail: string | number | null;
+    thumbnail?: string | number;
 
     /** URI for the image or local numeric reference for the image  */
     image: string | number;
@@ -41,7 +41,7 @@ type ReportActionItemImageProps = {
  * and optional preview modal as well.
  */
 
-function ReportActionItemImage({thumbnail = null, image, enablePreviewModal = false, transaction, canEditReceipt = false, isLocalFile = false}: ReportActionItemImageProps) {
+function ReportActionItemImage({thumbnail, image, enablePreviewModal = false, transaction, canEditReceipt = false, isLocalFile = false}: ReportActionItemImageProps) {
     const styles = useThemeStyles();
     const {translate} = useLocalize();
     const imageSource = tryResolveUrlFromApiRoot(image ?? '');

--- a/src/components/ReportActionItem/ReportActionItemImage.tsx
+++ b/src/components/ReportActionItem/ReportActionItemImage.tsx
@@ -29,7 +29,7 @@ type ReportActionItemImageProps = {
     transaction?: Transaction;
 
     /** whether thumbnail is refer the local file or not */
-    isLocalFile: boolean;
+    isLocalFile?: boolean;
 
     /** whether the receipt can be replaced */
     canEditReceipt?: boolean;

--- a/src/components/ReportActionItem/ReportActionItemImages.tsx
+++ b/src/components/ReportActionItem/ReportActionItemImages.tsx
@@ -1,44 +1,38 @@
-import PropTypes from 'prop-types';
+/* eslint-disable react/no-array-index-key */
 import React from 'react';
 import {View} from 'react-native';
 import {Polygon, Svg} from 'react-native-svg';
-import _ from 'underscore';
 import Text from '@components/Text';
-import transactionPropTypes from '@components/transactionPropTypes';
 import useStyleUtils from '@hooks/useStyleUtils';
 import useTheme from '@hooks/useTheme';
 import useThemeStyles from '@hooks/useThemeStyles';
 import variables from '@styles/variables';
+import type {Transaction} from '@src/types/onyx';
 import ReportActionItemImage from './ReportActionItemImage';
 
-const propTypes = {
+type Image = {
+    thumbnail: string | number;
+    image: string | number;
+    transaction: Transaction;
+    isLocalFile: boolean;
+};
+
+type ReportActionItemImagesProps = {
     /** array of image and thumbnail URIs */
-    images: PropTypes.arrayOf(
-        PropTypes.shape({
-            thumbnail: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-            image: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-            transaction: transactionPropTypes,
-        }),
-    ).isRequired,
+    images: Image[];
 
     // We're not providing default values for size and total and disabling the ESLint rule
     // because we want them to default to the length of images, but we can't set default props
     // to be computed from another prop
 
     /** max number of images to show in the row if different than images length */
-    // eslint-disable-next-line react/require-default-props
-    size: PropTypes.number,
+    size: number;
 
     /** total number of images if different than images length */
-    // eslint-disable-next-line react/require-default-props
-    total: PropTypes.number,
+    total: number;
 
     /** if the corresponding report action item is hovered */
-    isHovered: PropTypes.bool,
-};
-
-const defaultProps = {
-    isHovered: false,
+    isHovered: boolean;
 };
 
 /**
@@ -50,7 +44,7 @@ const defaultProps = {
  * additional number when subtracted from size.
  */
 
-function ReportActionItemImages({images, size, total, isHovered}) {
+function ReportActionItemImages({images, size, total, isHovered = false}: ReportActionItemImagesProps) {
     const theme = useTheme();
     const styles = useThemeStyles();
     const StyleUtils = useStyleUtils();
@@ -77,7 +71,7 @@ function ReportActionItemImages({images, size, total, isHovered}) {
 
     return (
         <View style={[styles.reportActionItemImages, hoverStyle, heightStyle]}>
-            {_.map(shownImages, ({thumbnail, image, transaction, isLocalFile}, index) => {
+            {shownImages.map(({thumbnail, image, transaction, isLocalFile}, index) => {
                 const isLastImage = index === numberOfShownImages - 1;
 
                 // Show a border to separate multiple images. Shown to the right for each except the last.
@@ -117,8 +111,6 @@ function ReportActionItemImages({images, size, total, isHovered}) {
     );
 }
 
-ReportActionItemImages.propTypes = propTypes;
-ReportActionItemImages.defaultProps = defaultProps;
 ReportActionItemImages.displayName = 'ReportActionItemImages';
 
 export default ReportActionItemImages;

--- a/src/components/ReportActionItem/ReportActionItemImages.tsx
+++ b/src/components/ReportActionItem/ReportActionItemImages.tsx
@@ -26,13 +26,13 @@ type ReportActionItemImagesProps = {
     // to be computed from another prop
 
     /** max number of images to show in the row if different than images length */
-    size: number;
+    size?: number;
 
     /** total number of images if different than images length */
-    total: number;
+    total?: number;
 
     /** if the corresponding report action item is hovered */
-    isHovered: boolean;
+    isHovered?: boolean;
 };
 
 /**
@@ -50,9 +50,9 @@ function ReportActionItemImages({images, size, total, isHovered = false}: Report
     const StyleUtils = useStyleUtils();
     // Calculate the number of images to be shown, limited by the value of 'size' (if defined)
     // or the total number of images.
-    const numberOfShownImages = Math.min(size || images.length, images.length);
+    const numberOfShownImages = Math.min(size ?? images.length, images.length);
     const shownImages = images.slice(0, numberOfShownImages);
-    const remaining = (total || images.length) - size;
+    const remaining = (total ?? images.length) - numberOfShownImages;
     const MAX_REMAINING = 9;
 
     // The height varies depending on the number of images we are displaying.

--- a/src/components/ThumbnailImage.tsx
+++ b/src/components/ThumbnailImage.tsx
@@ -10,7 +10,7 @@ import ImageWithSizeCalculation from './ImageWithSizeCalculation';
 
 type ThumbnailImageProps = {
     /** Source URL for the preview image */
-    previewSourceURL: string;
+    previewSourceURL: string | number;
 
     /** Any additional styles to apply */
     style?: StyleProp<ViewStyle>;

--- a/src/libs/tryResolveUrlFromApiRoot.ts
+++ b/src/libs/tryResolveUrlFromApiRoot.ts
@@ -19,6 +19,7 @@ const ORIGIN_PATTERN = new RegExp(`^(${ORIGINS_TO_REPLACE.join('|')})`);
  */
 function tryResolveUrlFromApiRoot(url: string): string;
 function tryResolveUrlFromApiRoot(url: number): number;
+function tryResolveUrlFromApiRoot(url: string | number): string | number;
 function tryResolveUrlFromApiRoot(url: string | number): string | number {
     // in native, when we import an image asset, it will have a number representation which can be used in `source` of Image
     // in this case we can skip the url resolving


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->
once https://github.com/Expensify/App/issues/25130 is merged we should remove the typescript suppress comment
### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/31969
PROPOSAL: 


### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->
1. open a chat with several receipt money requests and verify the report previews with receipts displays correctly
2. Press on a report preview with receipts and verify it opens the report
3. press on a money request report action in it and verify that the money request is opened
4. In the money request view verify that the receipt is displayed properly press it and check that the attachement modal opens

- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->
same
### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
5. Upload an image via copy paste
6. Verify a modal appears displaying a preview of that image
--->
same
- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

https://github.com/Expensify/App/assets/38649957/8e0d80b8-a915-4840-bfa9-b9a6de2ededf


</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->
https://github.com/Expensify/App/assets/38649957/27e868ee-92d8-4eb4-987b-2bbc80231b1e

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

https://github.com/Expensify/App/assets/38649957/846f8e5c-87c1-47e0-9314-d6b10b6c29ec


</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

https://github.com/Expensify/App/assets/38649957/f2135885-894d-466d-92ba-8b6532e37685


</details>

<details>
<summary>MacOS: Desktop</summary>

<!-- add screenshots or videos here -->

https://github.com/Expensify/App/assets/38649957/088ed734-6a75-4fa9-9c3b-490e8a158bd3


</details>



