### PR TITLE
[TS Migration] Adjustments on KYCWall

### DIFF
--- a/src/components/KYCWall/BaseKYCWall.tsx
+++ b/src/components/KYCWall/BaseKYCWall.tsx
@@ -159,10 +159,8 @@ function KYCWall({
                 return;
             }
 
-
             // Use event target as fallback if anchorRef is null for safety
             const targetElement = anchorRef.current ?? (event?.currentTarget as HTMLElement);
-
 
             transferBalanceButtonRef.current = targetElement;
 

--- a/src/components/KYCWall/BaseKYCWall.tsx
+++ b/src/components/KYCWall/BaseKYCWall.tsx
@@ -1,7 +1,6 @@
 import React, {useCallback, useEffect, useRef, useState} from 'react';
-import type {SyntheticEvent} from 'react';
 import {Dimensions} from 'react-native';
-import type {EmitterSubscription, NativeTouchEvent} from 'react-native';
+import type {EmitterSubscription, GestureResponderEvent} from 'react-native';
 import {withOnyx} from 'react-native-onyx';
 import type {OnyxEntry} from 'react-native-onyx';
 import AddPaymentMethodMenu from '@components/AddPaymentMethodMenu';
@@ -68,8 +67,8 @@ function KYCWall({
     walletTerms,
     shouldShowPersonalBankAccountOption = false,
 }: BaseKYCWallProps) {
-    const anchorRef = useRef<HTMLDivElement>(null);
-    const transferBalanceButtonRef = useRef<HTMLDivElement | null>(null);
+    const anchorRef = useRef<HTMLElement>(null);
+    const transferBalanceButtonRef = useRef<HTMLElement | null>(null);
 
     const [shouldShowAddPaymentMenu, setShouldShowAddPaymentMenu] = useState(false);
 
@@ -146,7 +145,7 @@ function KYCWall({
      *
      */
     const continueAction = useCallback(
-        (event?: SyntheticEvent<NativeTouchEvent>, iouPaymentType?: TransferMethod) => {
+        (event?: GestureResponderEvent | KeyboardEvent | undefined, iouPaymentType?: TransferMethod) => {
             const currentSource = walletTerms?.source ?? source;
 
             /**
@@ -160,8 +159,10 @@ function KYCWall({
                 return;
             }
 
+
             // Use event target as fallback if anchorRef is null for safety
-            const targetElement = anchorRef.current ?? (event?.nativeEvent.target as HTMLDivElement);
+            const targetElement = anchorRef.current ?? (event?.currentTarget as HTMLElement);
+
 
             transferBalanceButtonRef.current = targetElement;
 
@@ -203,7 +204,7 @@ function KYCWall({
 
             Log.info('[KYC Wallet] User has valid payment method and passed KYC checks or did not need them');
 
-            onSuccessfulKYC(currentSource, iouPaymentType);
+            onSuccessfulKYC(iouPaymentType, currentSource);
         },
         [
             bankAccountList,

--- a/src/components/KYCWall/BaseKYCWall.tsx
+++ b/src/components/KYCWall/BaseKYCWall.tsx
@@ -145,7 +145,7 @@ function KYCWall({
      *
      */
     const continueAction = useCallback(
-        (event?: GestureResponderEvent | KeyboardEvent | undefined, iouPaymentType?: TransferMethod) => {
+        (event?: GestureResponderEvent | KeyboardEvent, iouPaymentType?: TransferMethod) => {
             const currentSource = walletTerms?.source ?? source;
 
             /**

--- a/src/components/KYCWall/types.ts
+++ b/src/components/KYCWall/types.ts
@@ -1,5 +1,5 @@
-import type {ForwardedRef, SyntheticEvent} from 'react';
-import type {NativeTouchEvent} from 'react-native';
+import type {ForwardedRef} from 'react';
+import type {GestureResponderEvent} from 'react-native';
 import type {OnyxEntry} from 'react-native-onyx';
 import type {ValueOf} from 'type-fest';
 import type CONST from '@src/CONST';
@@ -64,10 +64,10 @@ type KYCWallProps = {
     shouldShowPersonalBankAccountOption?: boolean;
 
     /** Callback for the end of the onContinue trigger on option selection */
-    onSuccessfulKYC: (currentSource?: Source, iouPaymentType?: TransferMethod) => void;
+    onSuccessfulKYC: (iouPaymentType?: TransferMethod, currentSource?: Source) => void;
 
     /** Children to build the KYC */
-    children: (continueAction: (event: SyntheticEvent<NativeTouchEvent>, method: TransferMethod) => void, anchorRef: ForwardedRef<HTMLElement>) => void;
+    children: (continueAction: (event: GestureResponderEvent | KeyboardEvent | undefined, method: TransferMethod) => void, anchorRef: ForwardedRef<HTMLElement>) => void;
 };
 
 export type {AnchorPosition, KYCWallProps, PaymentMethod, TransferMethod, DomRect};

--- a/src/libs/actions/PaymentMethods.ts
+++ b/src/libs/actions/PaymentMethods.ts
@@ -1,6 +1,6 @@
 import {createRef} from 'react';
-import type {MutableRefObject, SyntheticEvent} from 'react';
-import type {NativeTouchEvent} from 'react-native';
+import type {MutableRefObject} from 'react';
+import type {GestureResponderEvent} from 'react-native';
 import type {OnyxUpdate} from 'react-native-onyx';
 import Onyx from 'react-native-onyx';
 import type {OnyxEntry} from 'react-native-onyx/lib/types';
@@ -17,7 +17,7 @@ import type PaymentMethod from '@src/types/onyx/PaymentMethod';
 import type {FilterMethodPaymentType} from '@src/types/onyx/WalletTransfer';
 
 type KYCWallRef = {
-    continueAction?: (event?: SyntheticEvent<NativeTouchEvent>, iouPaymentType?: TransferMethod) => void;
+    continueAction?: (event?: GestureResponderEvent | KeyboardEvent | undefined, iouPaymentType?: TransferMethod) => void;
 };
 
 /**

--- a/src/libs/actions/PaymentMethods.ts
+++ b/src/libs/actions/PaymentMethods.ts
@@ -17,7 +17,7 @@ import type PaymentMethod from '@src/types/onyx/PaymentMethod';
 import type {FilterMethodPaymentType} from '@src/types/onyx/WalletTransfer';
 
 type KYCWallRef = {
-    continueAction?: (event?: GestureResponderEvent | KeyboardEvent | undefined, iouPaymentType?: TransferMethod) => void;
+    continueAction?: (event?: GestureResponderEvent | KeyboardEvent, iouPaymentType?: TransferMethod) => void;
 };
 
 /**


### PR DESCRIPTION
### Details
[TS migration] Migrate KYCWall component

### Fixed Issues
$ https://github.com/Expensify/App/issues/25126
$ https://github.com/Expensify/App/issues/34904

PROPOSAL: N/A


### Tests

1. log into the app
2. press the FAB and request money from e.g. workspace that you are a part of (to make it easier and not have to jump between accounts)
3. select the said workspace and press on pay with Expensify
4. confirm that the pop up shows in which you can select an option and be navigated to it

- [x] Verify that no errors appear in the JS console

### Offline tests

Same as **Tests** section

### QA Steps

Same as **Tests** section

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<img width="413" alt="android-native" src="https://github.com/Expensify/App/assets/39693995/10f200bb-6e3f-441d-afe9-ab06c73c3966">


</details>

<details>
<summary>Android: mWeb Chrome</summary>

<img width="413" alt="android-web" src="https://github.com/Expensify/App/assets/39693995/b5532c25-ed6e-4b22-909a-fda1a9145e1d">


</details>

<details>
<summary>iOS: Native</summary>

<img width="430" alt="ios-native" src="https://github.com/Expensify/App/assets/39693995/da8c1540-13b8-44a0-8542-2ef4bece7edb">


</details>

<details>
<summary>iOS: mWeb Safari</summary>

<img width="412" alt="ios-web" src="https://github.com/Expensify/App/assets/39693995/b3cfbed3-577c-4eec-8191-a75443537d64">


</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<img width="864" alt="macos-web" src="https://github.com/Expensify/App/assets/39693995/5e41b9e1-4f38-42ca-be4a-c252b046fe76">


</details>

<details>
<summary>MacOS: Desktop</summary>

<img width="1197" alt="macos-desktop" src="https://github.com/Expensify/App/assets/39693995/34753f9c-8cbe-49e5-ab3c-eee92bfdf910">


</details>
