### PR TITLE
fix: Chat - Hover color is not displayed even on move of cursor on window change and back.

### DIFF
--- a/src/components/Hoverable/ActiveHoverable.tsx
+++ b/src/components/Hoverable/ActiveHoverable.tsx
@@ -98,6 +98,9 @@ function ActiveHoverable({onHoverIn, onHoverOut, shouldHandleScroll, children}: 
 
     const hoverAndForwardOnMouseEnter = useCallback(
         (e: MouseEvent) => {
+            if (isVisibiltyHidden.current) {
+                isVisibiltyHidden.current = false;
+            }
             updateIsHovered(true);
             childOnMouseEnter?.(e);
         },
@@ -139,7 +142,7 @@ function ActiveHoverable({onHoverIn, onHoverOut, shouldHandleScroll, children}: 
         onMouseEnter: hoverAndForwardOnMouseEnter,
         onMouseLeave: unhoverAndForwardOnMouseLeave,
         onBlur: unhoverAndForwardOnBlur,
-        ...(isVisibiltyHidden.current && !isHovered ? {onMouseMove: handleAndForwardOnMouseMove} : {}),
+        ...(isVisibiltyHidden.current ? {onMouseMove: handleAndForwardOnMouseMove} : {}),
     });
 }
 

--- a/src/components/Hoverable/ActiveHoverable.tsx
+++ b/src/components/Hoverable/ActiveHoverable.tsx
@@ -75,24 +75,20 @@ function ActiveHoverable({onHoverIn, onHoverOut, shouldHandleScroll, children}: 
         return () => document.removeEventListener('mouseover', unsetHoveredIfOutside);
     }, [isHovered, elementRef]);
 
-    useEffect(
-        () => {
-            const unsetHoveredWhenDocumentIsHidden = () => {
-                if (document.visibilityState !== 'hidden' || !isHovered) {
-                    return;
-                }
+    useEffect(() => {
+        const unsetHoveredWhenDocumentIsHidden = () => {
+            if (document.visibilityState !== 'hidden') {
+                return;
+            }
 
-                isVisibiltyHidden.current = true;
-                setIsHovered(false);
-            };
+            isVisibiltyHidden.current = true;
+            setIsHovered(false);
+        };
 
-            document.addEventListener('visibilitychange', unsetHoveredWhenDocumentIsHidden);
+        document.addEventListener('visibilitychange', unsetHoveredWhenDocumentIsHidden);
 
-            return () => document.removeEventListener('visibilitychange', unsetHoveredWhenDocumentIsHidden);
-        },
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-        [],
-    );
+        return () => document.removeEventListener('visibilitychange', unsetHoveredWhenDocumentIsHidden);
+    }, []);
 
     const child = useMemo(() => getReturnValue(children, !isScrollingRef.current && isHovered), [children, isHovered]);
 

--- a/src/components/Hoverable/ActiveHoverable.tsx
+++ b/src/components/Hoverable/ActiveHoverable.tsx
@@ -73,23 +73,26 @@ function ActiveHoverable({onHoverIn, onHoverOut, shouldHandleScroll, children}: 
         document.addEventListener('mouseover', unsetHoveredIfOutside);
 
         return () => document.removeEventListener('mouseover', unsetHoveredIfOutside);
+    }, [isHovered, elementRef]);
+
+    useEffect(
+        () => {
+            const unsetHoveredWhenDocumentIsHidden = () => {
+                if (document.visibilityState !== 'hidden' || !isHovered) {
+                    return;
+                }
+
+                isVisibiltyHidden.current = true;
+                setIsHovered(false);
+            };
+
+            document.addEventListener('visibilitychange', unsetHoveredWhenDocumentIsHidden);
+
+            return () => document.removeEventListener('visibilitychange', unsetHoveredWhenDocumentIsHidden);
+        },
         // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [elementRef]);
-
-    useEffect(() => {
-        const unsetHoveredWhenDocumentIsHidden = () => {
-            if (document.visibilityState !== 'hidden' || !isHovered) {
-                return;
-            }
-
-            isVisibiltyHidden.current = true;
-            setIsHovered(false);
-        };
-
-        document.addEventListener('visibilitychange', unsetHoveredWhenDocumentIsHidden);
-
-        return () => document.removeEventListener('visibilitychange', unsetHoveredWhenDocumentIsHidden);
-    }, [isHovered]);
+        [],
+    );
 
     const child = useMemo(() => getReturnValue(children, !isScrollingRef.current && isHovered), [children, isHovered]);
 

--- a/src/components/Hoverable/ActiveHoverable.tsx
+++ b/src/components/Hoverable/ActiveHoverable.tsx
@@ -73,7 +73,8 @@ function ActiveHoverable({onHoverIn, onHoverOut, shouldHandleScroll, children}: 
         document.addEventListener('mouseover', unsetHoveredIfOutside);
 
         return () => document.removeEventListener('mouseover', unsetHoveredIfOutside);
-    }, [isHovered, elementRef]);
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [elementRef]);
 
     useEffect(() => {
         const unsetHoveredWhenDocumentIsHidden = () => {
@@ -139,7 +140,7 @@ function ActiveHoverable({onHoverIn, onHoverOut, shouldHandleScroll, children}: 
         onMouseEnter: hoverAndForwardOnMouseEnter,
         onMouseLeave: unhoverAndForwardOnMouseLeave,
         onBlur: unhoverAndForwardOnBlur,
-        ...(isVisibiltyHidden.current && !isHovered ? {onMouseMove: handleAndForwardOnMouseMove} : null),
+        ...(isVisibiltyHidden.current && !isHovered ? {onMouseMove: handleAndForwardOnMouseMove} : {}),
     });
 }
 

--- a/src/components/Hoverable/ActiveHoverable.tsx
+++ b/src/components/Hoverable/ActiveHoverable.tsx
@@ -98,9 +98,7 @@ function ActiveHoverable({onHoverIn, onHoverOut, shouldHandleScroll, children}: 
 
     const hoverAndForwardOnMouseEnter = useCallback(
         (e: MouseEvent) => {
-            if (isVisibiltyHidden.current) {
-                isVisibiltyHidden.current = false;
-            }
+            isVisibiltyHidden.current = false;
             updateIsHovered(true);
             childOnMouseEnter?.(e);
         },

--- a/src/components/Hoverable/ActiveHoverable.tsx
+++ b/src/components/Hoverable/ActiveHoverable.tsx
@@ -14,6 +14,7 @@ function ActiveHoverable({onHoverIn, onHoverOut, shouldHandleScroll, children}: 
     const elementRef = useRef<HTMLElement | null>(null);
     const isScrollingRef = useRef(false);
     const isHoveredRef = useRef(false);
+    const isVisibiltyHidden = useRef(false);
 
     const updateIsHovered = useCallback(
         (hovered: boolean) => {
@@ -75,17 +76,25 @@ function ActiveHoverable({onHoverIn, onHoverOut, shouldHandleScroll, children}: 
     }, [isHovered, elementRef]);
 
     useEffect(() => {
-        const unsetHoveredWhenDocumentIsHidden = () => document.visibilityState === 'hidden' && setIsHovered(false);
+        const unsetHoveredWhenDocumentIsHidden = () => {
+            if (document.visibilityState !== 'hidden' || !isHovered) {
+                return;
+            }
+
+            isVisibiltyHidden.current = true;
+            setIsHovered(false);
+        };
 
         document.addEventListener('visibilitychange', unsetHoveredWhenDocumentIsHidden);
 
         return () => document.removeEventListener('visibilitychange', unsetHoveredWhenDocumentIsHidden);
-    }, []);
+    }, [isHovered]);
 
     const child = useMemo(() => getReturnValue(children, !isScrollingRef.current && isHovered), [children, isHovered]);
 
     const childOnMouseEnter = child.props.onMouseEnter;
     const childOnMouseLeave = child.props.onMouseLeave;
+    const childOnMouseMove = child.props.onMouseMove;
 
     const hoverAndForwardOnMouseEnter = useCallback(
         (e: MouseEvent) => {
@@ -116,11 +125,21 @@ function ActiveHoverable({onHoverIn, onHoverOut, shouldHandleScroll, children}: 
         [child.props],
     );
 
+    const handleAndForwardOnMouseMove = useCallback(
+        (e: MouseEvent) => {
+            isVisibiltyHidden.current = false;
+            updateIsHovered(true);
+            childOnMouseMove?.(e);
+        },
+        [updateIsHovered, childOnMouseMove],
+    );
+
     return cloneElement(child, {
         ref: mergeRefs(elementRef, outerRef, child.ref),
         onMouseEnter: hoverAndForwardOnMouseEnter,
         onMouseLeave: unhoverAndForwardOnMouseLeave,
         onBlur: unhoverAndForwardOnBlur,
+        ...(isVisibiltyHidden.current && !isHovered ? {onMouseMove: handleAndForwardOnMouseMove} : null),
     });
 }
 


### PR DESCRIPTION
…anging windows and back.

<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->

### Fixed Issues
$ https://github.com/Expensify/App/issues/29077
PROPOSAL: https://github.com/Expensify/App/issues/29077#issuecomment-1828850950


### Tests
1. Open the app
2. Open any report
3. Hover on any message
4. Use CMD+TAB to change window and use it again to get back to app
5. Move cursor over the same message and verify that hover color is displayed

- [x] Verify that no errors appear in the JS console

### Offline tests
1. Open the app
2. Open any report
3. Hover on any message
4. Use CMD+TAB to change window and use it again to get back to app
5. Move cursor over the same message and verify that hover color is displayed

### QA Steps
1. Open the app
2. Open any report
3. Hover on any message
4. Use CMD+TAB to change window and use it again to get back to app
5. Move cursor over the same message and verify that hover color is displayed

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

https://github.com/Expensify/App/assets/85894871/7e6c2ee1-40c3-48d7-a8a2-d633cb208db5

</details>

<details>
<summary>Android: mWeb Chrome</summary>

https://github.com/Expensify/App/assets/85894871/6321ff23-a23e-4629-a361-047c587c3519

</details>

<details>
<summary>iOS: Native</summary>

https://github.com/Expensify/App/assets/85894871/d811df3c-98bc-4d2c-998c-9c07582acb15

</details>

<details>
<summary>iOS: mWeb Safari</summary>

https://github.com/Expensify/App/assets/85894871/47db5b67-7fbd-4cbe-a968-4309073505d4

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

https://github.com/Expensify/App/assets/85894871/88b954ae-1e7f-4178-87ab-96669cf8586f

</details>

<details>
<summary>MacOS: Desktop</summary>

https://github.com/Expensify/App/assets/85894871/832f4496-541d-4ccc-9728-f6533886cafa

</details>


