### PR TITLE
Added the ability to paste Google Docs images / charts into the Composer chat for web based platforms

### DIFF
--- a/src/CONST.ts
+++ b/src/CONST.ts
@@ -458,6 +458,8 @@ const CONST = {
     NEW_ZOOM_MEETING_URL: 'https://zoom.us/start/videomeeting',
     NEW_GOOGLE_MEET_MEETING_URL: 'https://meet.google.com/new',
     GOOGLE_MEET_URL_ANDROID: 'https://meet.google.com',
+    GOOGLE_DOC_IMAGE_LINK_MATCH: 'googleusercontent.com',
+    IMAGE_BASE64_MATCH: 'base64',
     DEEPLINK_BASE_URL: 'new-expensify://',
     PDF_VIEWER_URL: '/pdf/web/viewer.html',
     CLOUDFRONT_DOMAIN_REGEX: /^https:\/\/\w+\.cloudfront\.net/i,

--- a/src/components/Composer/index.tsx
+++ b/src/components/Composer/index.tsx
@@ -18,6 +18,7 @@ import useWindowDimensions from '@hooks/useWindowDimensions';
 import * as Browser from '@libs/Browser';
 import * as ComposerUtils from '@libs/ComposerUtils';
 import updateIsFullComposerAvailable from '@libs/ComposerUtils/updateIsFullComposerAvailable';
+import * as FileUtils from '@libs/fileDownload/FileUtils';
 import isEnterWhileComposition from '@libs/KeyboardShortcut/isEnterWhileComposition';
 import ReportActionComposeFocusManager from '@libs/ReportActionComposeFocusManager';
 import CONST from '@src/CONST';
@@ -217,6 +218,9 @@ function Composer(
 
             const TEXT_HTML = 'text/html';
 
+            const clipboardDataHtml = event.clipboardData?.getData(TEXT_HTML) ?? '';
+            const clipboardDataTypesHtml = event.clipboardData?.types.includes(TEXT_HTML) ?? false;
+
             // If paste contains files, then trigger file management
             if (event.clipboardData?.files.length && event.clipboardData.files.length > 0) {
                 // Prevent the default so we do not post the file name into the text box
@@ -224,9 +228,43 @@ function Composer(
                 return;
             }
 
+            // If paste contains base64 image
+            if (clipboardDataHtml?.includes(CONST.IMAGE_BASE64_MATCH)) {
+                const domparser = new DOMParser();
+                const pastedHTML = clipboardDataHtml;
+                const embeddedImages = domparser.parseFromString(pastedHTML, TEXT_HTML)?.images;
+
+                if (embeddedImages.length > 0 && embeddedImages[0].src) {
+                    const src = embeddedImages[0].src;
+                    const file = FileUtils.base64ToFile(src, 'image.png');
+                    onPasteFile(file);
+                    return;
+                }
+            }
+
+            // If paste contains image from Google Workspaces ex: Sheets, Docs, Slide, etc
+            if (clipboardDataHtml?.includes(CONST.GOOGLE_DOC_IMAGE_LINK_MATCH)) {
+                const domparser = new DOMParser();
+                const pastedHTML = clipboardDataHtml;
+                const embeddedImages = domparser.parseFromString(pastedHTML, TEXT_HTML).images;
+
+                if (embeddedImages.length > 0 && embeddedImages[0]?.src) {
+                    const src = embeddedImages[0].src;
+                    if (src.includes(CONST.GOOGLE_DOC_IMAGE_LINK_MATCH)) {
+                        fetch(src)
+                            .then((response) => response.blob())
+                            .then((blob) => {
+                                const file = new File([blob], 'image.jpg', {type: 'image/jpeg'});
+                                onPasteFile(file);
+                            });
+                        return;
+                    }
+                }
+            }
+
             // If paste contains HTML
-            if (event.clipboardData?.types.includes(TEXT_HTML)) {
-                const pastedHTML = event.clipboardData?.getData(TEXT_HTML);
+            if (clipboardDataTypesHtml) {
+                const pastedHTML = clipboardDataHtml;
 
                 const domparser = new DOMParser();
                 const embeddedImages = domparser.parseFromString(pastedHTML, TEXT_HTML).images;


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->

Added the ability to copy objects (not screenshots of objects, just the object itself) from Google Workspace into an Expensify chat, specifically:

- [x]  Google Sheet images / charts
- [x]  Google Doc images
- [x]  Google Slide images

**Note**: The composer objects paste functionality works only on Web, iOS / Android: mWeb and Desktop. On native platforms we never had the object paste functionality, not even for images as we have had on the other platforms already.

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
For https://github.com/Expensify/App/issues/34306
PROPOSAL: https://github.com/Expensify/App/issues/34306#issuecomment-1886364741


### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->
**Web / Desktop steps**:

1. Open app.
2. Open a report chat.
3. Open the following google docs links in a new tab each:
- Google Sheets: https://docs.google.com/spreadsheets/d/1IzOpclhDLrdBxSD3ZdYF6x38tfQIChl-PdPswY38hek (where we have the instructions image and the chart on the right side)
- Google Slides: https://docs.google.com/presentation/d/1Q3lIg1t78ksu4GXYqnavKidgqB5syuDb/edit#slide=id.p10 (where we have an image on slide 10)
- Google Docs: https://docs.google.com/document/d/1GYxBeVGk78yv58Ar1uyciZk7YfO6_2bN (where we have an image on the top right corner)
4. Copy the image / chart from the provided files.
5. Go back to the app and paste it in the composer.
6. The Send attachment modal should open with the pasted image / chart.

**iOS / Android mWeb steps**:

Prerequisite: The Google Sheets / Google Slides / Google Docs apps have to be installed on the device in order to be able to copy images / charts.

1. Open app.
2. Open a report chat.
3. Open the following google docs links in their corresponding apps from (prerequisite step):
- Google Sheets: https://docs.google.com/spreadsheets/d/1IzOpclhDLrdBxSD3ZdYF6x38tfQIChl-PdPswY38hek (where we have the instructions image and the chart on the right side)
- Google Slides: https://docs.google.com/presentation/d/1Q3lIg1t78ksu4GXYqnavKidgqB5syuDb/edit#slide=id.p10 (where we have an image on slide 10)
- Google Docs: https://docs.google.com/document/d/1GYxBeVGk78yv58Ar1uyciZk7YfO6_2bN (where we have an image on the top right corner)
4. Copy the image / chart from the provided files.
5. Go back to the app and paste the object.
6. The Send attachment modal should open with the pasted image / chart.

- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->
**Web / Desktop steps**:

1. Open app.
2. Open a report chat.
3. Open the following google docs links in a new tab each:
- Google Sheets: https://docs.google.com/spreadsheets/d/1IzOpclhDLrdBxSD3ZdYF6x38tfQIChl-PdPswY38hek (where we have the instructions image and the chart on the right side)
- Google Slides: https://docs.google.com/presentation/d/1Q3lIg1t78ksu4GXYqnavKidgqB5syuDb/edit#slide=id.p10 (where we have an image on slide 10)
- Google Docs: https://docs.google.com/document/d/1GYxBeVGk78yv58Ar1uyciZk7YfO6_2bN (where we have an image on the top right corner)
4. Copy the image / chart from the provided files.
5. Go back to the app and paste it in the composer.
6. The Send attachment modal should open with the pasted image / chart.

**iOS / Android mWeb steps**:

Prerequisite: The Google Sheets / Google Slides / Google Docs apps have to be installed on the device in order to be able to copy images / charts.

1. Open app.
2. Open a report chat.
3. Open the following google docs links in their corresponding apps from (prerequisite step):
- Google Sheets: https://docs.google.com/spreadsheets/d/1IzOpclhDLrdBxSD3ZdYF6x38tfQIChl-PdPswY38hek (where we have the instructions image and the chart on the right side)
- Google Slides: https://docs.google.com/presentation/d/1Q3lIg1t78ksu4GXYqnavKidgqB5syuDb/edit#slide=id.p10 (where we have an image on slide 10)
- Google Docs: https://docs.google.com/document/d/1GYxBeVGk78yv58Ar1uyciZk7YfO6_2bN (where we have an image on the top right corner)
4. Copy the image / chart from the provided files.
5. Go back to the app and paste the object.
6. The Send attachment modal should open with the pasted image / chart.

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->
**Web / Desktop steps**:

1. Open app.
2. Open a report chat.
3. Open the following google docs links in a new tab each:
- Google Sheets: https://docs.google.com/spreadsheets/d/1IzOpclhDLrdBxSD3ZdYF6x38tfQIChl-PdPswY38hek (where we have the instructions image and the chart on the right side)
- Google Slides: https://docs.google.com/presentation/d/1Q3lIg1t78ksu4GXYqnavKidgqB5syuDb/edit#slide=id.p10 (where we have an image on slide 10)
- Google Docs: https://docs.google.com/document/d/1GYxBeVGk78yv58Ar1uyciZk7YfO6_2bN (where we have an image on the top right corner)
4. Copy the image / chart from the provided files.
5. Go back to the app and paste it in the composer.
6. The Send attachment modal should open with the pasted image / chart.

**iOS / Android mWeb steps**:

Prerequisite: The Google Sheets / Google Slides / Google Docs apps have to be installed on the device in order to be able to copy images / charts.

1. Open app.
2. Open a report chat.
3. Open the following google docs links in their corresponding apps from (prerequisite step):
- Google Sheets: https://docs.google.com/spreadsheets/d/1IzOpclhDLrdBxSD3ZdYF6x38tfQIChl-PdPswY38hek (where we have the instructions image and the chart on the right side)
- Google Slides: https://docs.google.com/presentation/d/1Q3lIg1t78ksu4GXYqnavKidgqB5syuDb/edit#slide=id.p10 (where we have an image on slide 10)
- Google Docs: https://docs.google.com/document/d/1GYxBeVGk78yv58Ar1uyciZk7YfO6_2bN (where we have an image on the top right corner)
4. Copy the image / chart from the provided files.
5. Go back to the app and paste the object.
6. The Send attachment modal should open with the pasted image / chart.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

https://github.com/Expensify/App/assets/56457735/4edc8c3e-e64b-4cc0-b0a1-da5b9d94c658

</details>

<details>
<summary>Android: mWeb Chrome</summary>

https://github.com/Expensify/App/assets/56457735/00505a34-fa87-4e92-acd9-3e8d6ceabf7d

</details>

<details>
<summary>iOS: Native</summary>

https://github.com/Expensify/App/assets/56457735/0a776cf1-2dd4-461a-8d2e-545bd865a3a1

</details>

<details>
<summary>iOS: mWeb Safari</summary>

https://github.com/Expensify/App/assets/56457735/20de63f3-dc95-4b12-9ddf-e4eec1291bf7

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

https://github.com/Expensify/App/assets/56457735/99f48e84-1002-4db4-9c37-5ef613da6bf6

</details>

<details>
<summary>MacOS: Desktop</summary>

https://github.com/Expensify/App/assets/56457735/ae148963-1fc0-4505-a673-cbbd31d0bea0

</details>