### PR TITLE
Add caret icon next to currency select button

### DIFF
--- a/src/components/CurrencySymbolButton.tsx
+++ b/src/components/CurrencySymbolButton.tsx
@@ -1,13 +1,13 @@
 import React from 'react';
 import useLocalize from '@hooks/useLocalize';
+import useTheme from '@hooks/useTheme';
 import useThemeStyles from '@hooks/useThemeStyles';
 import CONST from '@src/CONST';
-import useTheme from '@hooks/useTheme';
+import Icon from './Icon';
+import * as Expensicons from './Icon/Expensicons';
 import PressableWithoutFeedback from './Pressable/PressableWithoutFeedback';
 import Text from './Text';
 import Tooltip from './Tooltip';
-import Icon from './Icon';
-import * as Expensicons from './Icon/Expensicons';
 
 type CurrencySymbolButtonProps = {
     /** Currency symbol of selected currency */
@@ -17,8 +17,8 @@ type CurrencySymbolButtonProps = {
     onCurrencyButtonPress: () => void;
 };
 
-function CurrencySymbolButton({ onCurrencyButtonPress, currencySymbol }: CurrencySymbolButtonProps) {
-    const { translate } = useLocalize();
+function CurrencySymbolButton({onCurrencyButtonPress, currencySymbol}: CurrencySymbolButtonProps) {
+    const {translate} = useLocalize();
     const styles = useThemeStyles();
     const theme = useTheme();
     return (

--- a/src/components/CurrencySymbolButton.tsx
+++ b/src/components/CurrencySymbolButton.tsx
@@ -3,7 +3,6 @@ import useLocalize from '@hooks/useLocalize';
 import useThemeStyles from '@hooks/useThemeStyles';
 import CONST from '@src/CONST';
 import useTheme from '@hooks/useTheme';
-import { View } from 'react-native';
 import PressableWithoutFeedback from './Pressable/PressableWithoutFeedback';
 import Text from './Text';
 import Tooltip from './Tooltip';

--- a/src/components/CurrencySymbolButton.tsx
+++ b/src/components/CurrencySymbolButton.tsx
@@ -2,9 +2,13 @@ import React from 'react';
 import useLocalize from '@hooks/useLocalize';
 import useThemeStyles from '@hooks/useThemeStyles';
 import CONST from '@src/CONST';
+import useTheme from '@hooks/useTheme';
+import { View } from 'react-native';
 import PressableWithoutFeedback from './Pressable/PressableWithoutFeedback';
 import Text from './Text';
 import Tooltip from './Tooltip';
+import Icon from './Icon';
+import * as Expensicons from './Icon/Expensicons';
 
 type CurrencySymbolButtonProps = {
     /** Currency symbol of selected currency */
@@ -15,8 +19,10 @@ type CurrencySymbolButtonProps = {
 };
 
 function CurrencySymbolButton({onCurrencyButtonPress, currencySymbol}: CurrencySymbolButtonProps) {
+    const { translate } = useLocalize();
     const styles = useThemeStyles();
-    const {translate} = useLocalize();
+    const theme = useTheme();
+
     return (
         <Tooltip text={translate('common.selectCurrency')}>
             <PressableWithoutFeedback
@@ -24,7 +30,14 @@ function CurrencySymbolButton({onCurrencyButtonPress, currencySymbol}: CurrencyS
                 accessibilityLabel={translate('common.selectCurrency')}
                 role={CONST.ROLE.BUTTON}
             >
+                <View style={[styles.flexRow, styles.alignItemsCenter]}>
+                <Icon
+                    small
+                    src={Expensicons.DownArrow}
+                    fill={theme.icon}
+                />
                 <Text style={styles.iouAmountText}>{currencySymbol}</Text>
+                </View>
             </PressableWithoutFeedback>
         </Tooltip>
     );

--- a/src/components/CurrencySymbolButton.tsx
+++ b/src/components/CurrencySymbolButton.tsx
@@ -18,7 +18,7 @@ type CurrencySymbolButtonProps = {
     onCurrencyButtonPress: () => void;
 };
 
-function CurrencySymbolButton({onCurrencyButtonPress, currencySymbol}: CurrencySymbolButtonProps) {
+function CurrencySymbolButton({ onCurrencyButtonPress, currencySymbol }: CurrencySymbolButtonProps) {
     const { translate } = useLocalize();
     const styles = useThemeStyles();
     const theme = useTheme();
@@ -29,15 +29,14 @@ function CurrencySymbolButton({onCurrencyButtonPress, currencySymbol}: CurrencyS
                 onPress={onCurrencyButtonPress}
                 accessibilityLabel={translate('common.selectCurrency')}
                 role={CONST.ROLE.BUTTON}
+                style={[styles.flexRow, styles.alignItemsCenter, styles.gap1]}
             >
-                <View style={[styles.flexRow, styles.alignItemsCenter]}>
                 <Icon
                     small
                     src={Expensicons.DownArrow}
                     fill={theme.icon}
                 />
                 <Text style={styles.iouAmountText}>{currencySymbol}</Text>
-                </View>
             </PressableWithoutFeedback>
         </Tooltip>
     );

--- a/src/components/CurrencySymbolButton.tsx
+++ b/src/components/CurrencySymbolButton.tsx
@@ -21,7 +21,6 @@ function CurrencySymbolButton({ onCurrencyButtonPress, currencySymbol }: Currenc
     const { translate } = useLocalize();
     const styles = useThemeStyles();
     const theme = useTheme();
-
     return (
         <Tooltip text={translate('common.selectCurrency')}>
             <PressableWithoutFeedback


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->
Added caret icon next to currency select button

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/35170
PROPOSAL: https://github.com/Expensify/App/issues/35170#issuecomment-1916148235


### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

Same as QA

- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

Same as QA

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->
1. Click actions
2. Select request money
3. Select manual
4. Confirm caret icon is shown in the correct location next to currency select
5. Change theme and repeat steps
6. Repeat with split bill action

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->
<img width="379" alt="Screenshot 2024-02-02 at 3 51 27 pm" src="https://github.com/Expensify/App/assets/7864862/0a238ea2-3fba-4f16-ab84-572af97463a9">
<img width="377" alt="Screenshot 2024-02-02 at 3 50 47 pm" src="https://github.com/Expensify/App/assets/7864862/a4986855-7447-4bb1-87ce-84cc05cca73d">

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->
<img width="370" alt="Screenshot 2024-02-02 at 4 45 23 pm" src="https://github.com/Expensify/App/assets/7864862/49e33eb2-a154-4445-997a-7ea189b6229d">
<img width="365" alt="Screenshot 2024-02-02 at 4 44 58 pm" src="https://github.com/Expensify/App/assets/7864862/5d3871b3-50c4-48e7-9596-4f064c65f1db">


</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->
<img width="422" alt="Screenshot 2024-02-02 at 2 23 14 pm" src="https://github.com/Expensify/App/assets/7864862/9653951b-fa7d-4095-a085-48d6f15869a8">
<img width="427" alt="Screenshot 2024-02-02 at 2 22 41 pm" src="https://github.com/Expensify/App/assets/7864862/052e8573-b6dc-40d0-b83d-381b3e85b508">


</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->
<img width="422" alt="Screenshot 2024-02-02 at 2 23 14 pm" src="https://github.com/Expensify/App/assets/7864862/23b6bcc5-e096-4398-a78e-eb90653d663e">
<img width="427" alt="Screenshot 2024-02-02 at 2 22 41 pm" src="https://github.com/Expensify/App/assets/7864862/43257df4-967f-4dbf-b957-d0ce6dffd459">

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->
<img width="1153" alt="Screenshot 2024-02-02 at 4 02 00 pm" src="https://github.com/Expensify/App/assets/7864862/7fb48876-3258-4cef-bd0a-b74158d016de">


</details>

<details>
<summary>MacOS: Desktop</summary>

<!-- add screenshots or videos here -->
<img width="1201" alt="Screenshot 2024-02-02 at 4 03 32 pm" src="https://github.com/Expensify/App/assets/7864862/5dcd307d-6081-407e-b077-bb5a741a32ca">

</details>
