### PR TITLE
Simplify native attachment gallery paging context and improve code

### DIFF
--- a/src/components/Attachments/AttachmentCarousel/CarouselItem.js
+++ b/src/components/Attachments/AttachmentCarousel/CarouselItem.js
@@ -37,15 +37,6 @@ const propTypes = {
         transactionID: PropTypes.string,
     }).isRequired,
 
-    /** Whether there is only one element in the attachment carousel */
-    isSingleItem: PropTypes.bool.isRequired,
-
-    /** The index of the carousel item */
-    index: PropTypes.number.isRequired,
-
-    /** The index of the currently active carousel item */
-    activeIndex: PropTypes.number.isRequired,
-
     /** onPress callback */
     onPress: PropTypes.func,
 };
@@ -54,7 +45,7 @@ const defaultProps = {
     onPress: undefined,
 };
 
-function CarouselItem({item, index, activeIndex, isSingleItem, onPress}) {
+function CarouselItem({item, onPress}) {
     const styles = useThemeStyles();
     const {translate} = useLocalize();
     const {isAttachmentHidden} = useContext(ReportAttachmentsContext);
@@ -104,10 +95,6 @@ function CarouselItem({item, index, activeIndex, isSingleItem, onPress}) {
                     source={item.source}
                     file={item.file}
                     isAuthTokenRequired={item.isAuthTokenRequired}
-                    isUsedInCarousel
-                    isSingleCarouselItem={isSingleItem}
-                    carouselItemIndex={index}
-                    carouselActiveItemIndex={activeIndex}
                     onPress={onPress}
                     transactionID={item.transactionID}
                 />

--- a/src/components/Attachments/AttachmentCarousel/Pager/AttachmentCarouselPagerContext.ts
+++ b/src/components/Attachments/AttachmentCarousel/Pager/AttachmentCarouselPagerContext.ts
@@ -3,7 +3,24 @@ import {createContext} from 'react';
 import type PagerView from 'react-native-pager-view';
 import type {SharedValue} from 'react-native-reanimated';
 
+/** The pager items array is used within the pager to render and navigate between the images */
+type AttachmentCarouselPagerItems = {
+    /** The source of the image is used to identify each attachment/page in the pager */
+    source: string;
+
+    /** The index of the pager item determines the order of the images in the pager */
+    index: number;
+
+    /** The active state of the pager item determines whether the image is currently transformable with pinch, pan and tap gestures */
+    isActive: boolean;
+};
+
 type AttachmentCarouselPagerContextValue = {
+    /** The list of items that are shown in the pager */
+    pagerItems: AttachmentCarouselPagerItems[];
+
+    /** The index of the active page */
+    activePage: number;
     pagerRef: ForwardedRef<PagerView>;
     isPagerScrolling: SharedValue<boolean>;
     isScrollEnabled: SharedValue<boolean>;

--- a/src/components/Attachments/AttachmentCarousel/Pager/index.tsx
+++ b/src/components/Attachments/AttachmentCarousel/Pager/index.tsx
@@ -6,6 +6,7 @@ import {createNativeWrapper} from 'react-native-gesture-handler';
 import type {PagerViewProps} from 'react-native-pager-view';
 import PagerView from 'react-native-pager-view';
 import Animated, {useAnimatedProps, useSharedValue} from 'react-native-reanimated';
+import CarouselItem from '@components/Attachments/AttachmentCarousel/CarouselItem';
 import useThemeStyles from '@hooks/useThemeStyles';
 import AttachmentCarouselPagerContext from './AttachmentCarouselPagerContext';
 import usePageScrollHandler from './usePageScrollHandler';
@@ -19,21 +20,31 @@ type AttachmentCarouselPagerHandle = {
     setPage: (selectedPage: number) => void;
 };
 
-type PagerItem = {
-    key: string;
-    url: string;
+type Attachment = {
     source: string;
 };
 
 type AttachmentCarouselPagerProps = {
-    items: PagerItem[];
-    renderItem: (props: {item: PagerItem; index: number; isActive: boolean}) => React.ReactNode;
-    initialIndex: number;
+    /** The attachments to be rendered in the pager. */
+    items: Attachment[];
+
+    /** The source (URL) of the currently active attachment. */
+    activeSource: string;
+
+    /** The index of the initial page to be rendered. */
+    initialPage: number;
+
+    /** A callback to be called when the page is changed. */
     onPageSelected: () => void;
+
+    /**
+     * A callback that can be used to toggle the attachment carousel arrows, when the scale of the image changes.
+     * @param showArrows If set, it will show/hide the arrows. If not set, it will toggle the arrows.
+     */
     onRequestToggleArrows: (showArrows?: boolean) => void;
 };
 
-function AttachmentCarouselPager({items, renderItem, initialIndex, onPageSelected, onRequestToggleArrows}: AttachmentCarouselPagerProps, ref: ForwardedRef<AttachmentCarouselPagerHandle>) {
+function AttachmentCarouselPager({items, activeSource, initialPage, onPageSelected, onRequestToggleArrows}: AttachmentCarouselPagerProps, ref: ForwardedRef<AttachmentCarouselPagerHandle>) {
     const styles = useThemeStyles();
     const pagerRef = useRef<PagerView>(null);
 
@@ -41,8 +52,8 @@ function AttachmentCarouselPager({items, renderItem, initialIndex, onPageSelecte
     const isPagerScrolling = useSharedValue(false);
     const isScrollEnabled = useSharedValue(true);
 
-    const activePage = useSharedValue(initialIndex);
-    const [activePageState, setActivePageState] = useState(initialIndex);
+    const activePage = useSharedValue(initialPage);
+    const [activePageIndex, setActivePageIndex] = useState(initialPage);
 
     const pageScrollHandler = usePageScrollHandler((e) => {
         'worklet';
@@ -52,9 +63,12 @@ function AttachmentCarouselPager({items, renderItem, initialIndex, onPageSelecte
     }, []);
 
     useEffect(() => {
-        setActivePageState(initialIndex);
-        activePage.value = initialIndex;
-    }, [activePage, initialIndex]);
+        setActivePageIndex(initialPage);
+        activePage.value = initialPage;
+    }, [activePage, initialPage]);
+
+    /** The `pagerItems` object that passed down to the context. Later used to detect current page, whether it's a single image gallery etc. */
+    const pagerItems = useMemo(() => items.map((item, index) => ({source: item.source, index, isActive: index === activePageIndex})), [activePageIndex, items]);
 
     /**
      * This callback is passed to the MultiGestureCanvas/Lightbox through the AttachmentCarouselPagerContext.
@@ -94,13 +108,15 @@ function AttachmentCarouselPager({items, renderItem, initialIndex, onPageSelecte
 
     const contextValue = useMemo(
         () => ({
-            pagerRef,
+            pagerItems,
+            activePage: activePageIndex,
             isPagerScrolling,
             isScrollEnabled,
+            pagerRef,
             onTap: handleTap,
             onScaleChanged: handleScaleChange,
         }),
-        [isPagerScrolling, isScrollEnabled, handleTap, handleScaleChange],
+        [pagerItems, activePageIndex, isPagerScrolling, isScrollEnabled, handleTap, handleScaleChange],
     );
 
     const animatedProps = useAnimatedProps(() => ({
@@ -121,6 +137,21 @@ function AttachmentCarouselPager({items, renderItem, initialIndex, onPageSelecte
         [],
     );
 
+    const carouselItems = items.map((item, index) => (
+        <View
+            key={item.source}
+            style={styles.flex1}
+        >
+            <CarouselItem
+                // @ts-expect-error TODO: Remove this once AttachmentView (https://github.com/Expensify/App/issues/25150) is migrated to TypeScript.
+                item={item}
+                isSingleItem={items.length === 1}
+                index={index}
+                isFocused={index === activePageIndex && activeSource === item.source}
+            />
+        </View>
+    ));
+
     return (
         <AttachmentCarouselPagerContext.Provider value={contextValue}>
             <AnimatedPagerView
@@ -128,19 +159,12 @@ function AttachmentCarouselPager({items, renderItem, initialIndex, onPageSelecte
                 offscreenPageLimit={1}
                 onPageScroll={pageScrollHandler}
                 onPageSelected={onPageSelected}
-                ref={pagerRef}
                 style={styles.flex1}
-                initialPage={initialIndex}
+                initialPage={initialPage}
                 animatedProps={animatedProps}
+                ref={pagerRef}
             >
-                {items.map((item, index) => (
-                    <View
-                        key={item.source}
-                        style={styles.flex1}
-                    >
-                        {renderItem({item, index, isActive: index === activePageState})}
-                    </View>
-                ))}
+                {carouselItems}
             </AnimatedPagerView>
         </AttachmentCarouselPagerContext.Provider>
     );

--- a/src/components/Attachments/AttachmentCarousel/index.native.js
+++ b/src/components/Attachments/AttachmentCarousel/index.native.js
@@ -13,7 +13,6 @@ import variables from '@styles/variables';
 import ONYXKEYS from '@src/ONYXKEYS';
 import {defaultProps, propTypes} from './attachmentCarouselPropTypes';
 import CarouselButtons from './CarouselButtons';
-import CarouselItem from './CarouselItem';
 import extractAttachmentsFromReport from './extractAttachmentsFromReport';
 import AttachmentCarouselPager from './Pager';
 import useCarouselArrows from './useCarouselArrows';
@@ -103,24 +102,6 @@ function AttachmentCarousel({report, reportActions, parentReportActions, source,
         [setShouldShowArrows],
     );
 
-    /**
-     * Defines how a single attachment should be rendered
-     * @param {{ reportActionID: String, isAuthTokenRequired: Boolean, source: String, file: { name: String }, hasBeenFlagged: Boolean }} item
-     * @returns {JSX.Element}
-     */
-    const renderItem = useCallback(
-        ({item, index, isActive}) => (
-            <CarouselItem
-                item={item}
-                isSingleItem={attachments.length === 1}
-                index={index}
-                activeIndex={page}
-                isFocused={isActive && activeSource === item.source}
-            />
-        ),
-        [activeSource, attachments.length, page],
-    );
-
     return (
         <View style={[styles.flex1, styles.attachmentCarouselContainer]}>
             {page == null ? (
@@ -148,8 +129,8 @@ function AttachmentCarousel({report, reportActions, parentReportActions, source,
 
                             <AttachmentCarouselPager
                                 items={attachments}
-                                renderItem={renderItem}
-                                initialIndex={page}
+                                initialPage={page}
+                                activeSource={activeSource}
                                 onRequestToggleArrows={toggleArrows}
                                 onPageSelected={({nativeEvent: {position: newPage}}) => updatePage(newPage)}
                                 ref={pagerRef}

--- a/src/components/Attachments/AttachmentView/AttachmentViewImage/index.js
+++ b/src/components/Attachments/AttachmentView/AttachmentViewImage/index.js
@@ -12,21 +12,7 @@ const propTypes = {
     ...withLocalizePropTypes,
 };
 
-function AttachmentViewImage({
-    url,
-    file,
-    isAuthTokenRequired,
-    isUsedInCarousel,
-    isSingleCarouselItem,
-    carouselItemIndex,
-    carouselActiveItemIndex,
-    isFocused,
-    loadComplete,
-    onPress,
-    onError,
-    isImage,
-    translate,
-}) {
+function AttachmentViewImage({url, file, isAuthTokenRequired, isFocused, loadComplete, onPress, onError, isImage, translate}) {
     const styles = useThemeStyles();
     const children = (
         <ImageView
@@ -35,10 +21,6 @@ function AttachmentViewImage({
             fileName={file.name}
             isAuthTokenRequired={isImage && isAuthTokenRequired}
             isFocused={isFocused}
-            isUsedInCarousel={isUsedInCarousel}
-            isSingleCarouselItem={isSingleCarouselItem}
-            carouselItemIndex={carouselItemIndex}
-            carouselActiveItemIndex={carouselActiveItemIndex}
         />
     );
 

--- a/src/components/Attachments/AttachmentView/index.js
+++ b/src/components/Attachments/AttachmentView/index.js
@@ -79,9 +79,6 @@ function AttachmentView({
     translate,
     isFocused,
     isUsedInCarousel,
-    isSingleCarouselItem,
-    carouselItemIndex,
-    carouselActiveItemIndex,
     isUsedInAttachmentModal,
     isWorkspaceAvatar,
     maybeIcon,
@@ -147,8 +144,6 @@ function AttachmentView({
                     isFocused={isFocused}
                     isAuthTokenRequired={isAuthTokenRequired}
                     encryptedSourceUrl={encryptedSourceUrl}
-                    carouselItemIndex={carouselItemIndex}
-                    carouselActiveItemIndex={carouselActiveItemIndex}
                     onPress={onPress}
                     onToggleKeyboard={onToggleKeyboard}
                     onLoadComplete={() => !loadComplete && setLoadComplete(true)}
@@ -177,9 +172,6 @@ function AttachmentView({
                 loadComplete={loadComplete}
                 isFocused={isFocused}
                 isUsedInCarousel={isUsedInCarousel}
-                isSingleCarouselItem={isSingleCarouselItem}
-                carouselItemIndex={carouselItemIndex}
-                carouselActiveItemIndex={carouselActiveItemIndex}
                 isImage={isImage}
                 onPress={onPress}
                 onError={() => {

--- a/src/components/Attachments/AttachmentView/propTypes.js
+++ b/src/components/Attachments/AttachmentView/propTypes.js
@@ -14,18 +14,6 @@ const attachmentViewPropTypes = {
     /** Whether this AttachmentView is shown as part of a AttachmentCarousel */
     isUsedInCarousel: PropTypes.bool,
 
-    /** When "isUsedInCarousel" is set to true, determines whether there is only one item in the carousel */
-    isSingleCarouselItem: PropTypes.bool,
-
-    /** Whether this AttachmentView is shown as part of an AttachmentModal */
-    isUsedInAttachmentModal: PropTypes.bool,
-
-    /** The index of the carousel item */
-    carouselItemIndex: PropTypes.number,
-
-    /** The index of the currently active carousel item */
-    carouselActiveItemIndex: PropTypes.number,
-
     /** Function for handle on press */
     onPress: PropTypes.func,
 
@@ -39,11 +27,8 @@ const attachmentViewDefaultProps = {
         name: '',
     },
     isFocused: false,
-    isUsedInCarousel: false,
-    isSingleCarouselItem: false,
-    carouselItemIndex: 0,
-    carouselActiveItemIndex: 0,
     isSingleElement: false,
+    isUsedInCarousel: false,
     isUsedInAttachmentModal: false,
     onPress: undefined,
     onScaleChanged: () => {},

--- a/src/components/ImageView/index.native.tsx
+++ b/src/components/ImageView/index.native.tsx
@@ -3,28 +3,13 @@ import Lightbox from '@components/Lightbox';
 import {DEFAULT_ZOOM_RANGE} from '@components/MultiGestureCanvas';
 import type {ImageViewProps} from './types';
 
-function ImageView({
-    isAuthTokenRequired = false,
-    url,
-    style,
-    zoomRange = DEFAULT_ZOOM_RANGE,
-    onError,
-    isUsedInCarousel = false,
-    isSingleCarouselItem = false,
-    carouselItemIndex = 0,
-    carouselActiveItemIndex = 0,
-}: ImageViewProps) {
-    const hasSiblingCarouselItems = isUsedInCarousel && !isSingleCarouselItem;
-
+function ImageView({isAuthTokenRequired = false, url, style, zoomRange = DEFAULT_ZOOM_RANGE, onError}: ImageViewProps) {
     return (
         <Lightbox
             uri={url}
             zoomRange={zoomRange}
             isAuthTokenRequired={isAuthTokenRequired}
             onError={onError}
-            index={carouselItemIndex}
-            activeIndex={carouselActiveItemIndex}
-            hasSiblingCarouselItems={hasSiblingCarouselItems}
             style={style}
         />
     );

--- a/src/components/ImageView/types.ts
+++ b/src/components/ImageView/types.ts
@@ -14,18 +14,6 @@ type ImageViewProps = {
     /** Handles errors while displaying the image */
     onError?: () => void;
 
-    /** Whether this AttachmentView is shown as part of a AttachmentCarousel */
-    isUsedInCarousel?: boolean;
-
-    /** When "isUsedInCarousel" is set to true, determines whether there is only one item in the carousel */
-    isSingleCarouselItem?: boolean;
-
-    /** The index of the carousel item */
-    carouselItemIndex?: number;
-
-    /** The index of the currently active carousel item */
-    carouselActiveItemIndex?: number;
-
     /** Additional styles to add to the component */
     style?: StyleProp<ViewStyle>;
 

--- a/src/components/Lightbox/index.tsx
+++ b/src/components/Lightbox/index.tsx
@@ -1,6 +1,8 @@
-import React, {useCallback, useEffect, useMemo, useState} from 'react';
+import React, {useCallback, useContext, useEffect, useMemo, useState} from 'react';
 import type {LayoutChangeEvent, NativeSyntheticEvent, StyleProp, ViewStyle} from 'react-native';
 import {ActivityIndicator, PixelRatio, StyleSheet, View} from 'react-native';
+import {useSharedValue} from 'react-native-reanimated';
+import AttachmentCarouselPagerContext from '@components/Attachments/AttachmentCarousel/Pager/AttachmentCarouselPagerContext';
 import Image from '@components/Image';
 import MultiGestureCanvas, {DEFAULT_ZOOM_RANGE} from '@components/MultiGestureCanvas';
 import type {CanvasSize, ContentSize, OnScaleChangedCallback, ZoomRange} from '@components/MultiGestureCanvas/types';
@@ -31,15 +33,6 @@ type LightboxProps = {
     /** Additional styles to add to the component */
     style?: StyleProp<ViewStyle>;
 
-    /** The index of the carousel item */
-    index?: number;
-
-    /** The index of the currently active carousel item */
-    activeIndex?: number;
-
-    /** Whether the Lightbox is used within a carousel component and there are other sibling elements */
-    hasSiblingCarouselItems?: boolean;
-
     /** Range of zoom that can be applied to the content by pinching or double tapping. */
     zoomRange?: Partial<ZoomRange>;
 };
@@ -47,18 +40,52 @@ type LightboxProps = {
 /**
  * On the native layer, we use a image library to handle zoom functionality
  */
-function Lightbox({
-    isAuthTokenRequired = false,
-    uri,
-    onScaleChanged,
-    onError,
-    style,
-    index = 0,
-    activeIndex = 0,
-    hasSiblingCarouselItems = false,
-    zoomRange = DEFAULT_ZOOM_RANGE,
-}: LightboxProps) {
+function Lightbox({isAuthTokenRequired = false, uri, onScaleChanged: onScaleChangedProp, onError, style, zoomRange = DEFAULT_ZOOM_RANGE}: LightboxProps) {
     const StyleUtils = useStyleUtils();
+
+    /**
+     * React hooks must be used in the render function of the component at top-level and unconditionally.
+     * Therefore, in order to provide a default value for "isPagerScrolling" if the "AttachmentCarouselPagerContext" is not available,
+     * we need to create a shared value that can be used in the render function.
+     */
+    const isPagerScrollingFallback = useSharedValue(false);
+
+    const attachmentCarouselPagerContext = useContext(AttachmentCarouselPagerContext);
+    const {
+        isUsedInCarousel,
+        isSingleCarouselItem,
+        isPagerScrolling,
+        page,
+        activePage,
+        onTap,
+        onScaleChanged: onScaleChangedContext,
+        pagerRef,
+    } = useMemo(() => {
+        if (attachmentCarouselPagerContext === null) {
+            return {
+                isUsedInCarousel: false,
+                isSingleCarouselItem: true,
+                isPagerScrolling: isPagerScrollingFallback,
+                page: 0,
+                activePage: 0,
+                onTap: () => {},
+                onScaleChanged: () => {},
+                pagerRef: undefined,
+            };
+        }
+
+        const foundPage = attachmentCarouselPagerContext.pagerItems.findIndex((item) => item.source === uri);
+        return {
+            ...attachmentCarouselPagerContext,
+            isUsedInCarousel: true,
+            isSingleCarouselItem: attachmentCarouselPagerContext.pagerItems.length === 1,
+            page: foundPage,
+        };
+    }, [attachmentCarouselPagerContext, isPagerScrollingFallback, uri]);
+
+    /** Whether the Lightbox is used within an attachment carousel and there are more than one page in the carousel */
+    const hasSiblingCarouselItems = isUsedInCarousel && !isSingleCarouselItem;
+    const isActive = page === activePage;
 
     const [canvasSize, setCanvasSize] = useState<CanvasSize>();
     const isCanvasLoading = canvasSize === undefined;
@@ -100,9 +127,9 @@ function Lightbox({
         }
 
         const indexCanvasOffset = Math.floor((NUMBER_OF_CONCURRENT_LIGHTBOXES - 1) / 2) || 0;
-        const indexOutOfRange = index > activeIndex + indexCanvasOffset || index < activeIndex - indexCanvasOffset;
+        const indexOutOfRange = page > activePage + indexCanvasOffset || page < activePage - indexCanvasOffset;
         return !indexOutOfRange;
-    }, [activeIndex, hasSiblingCarouselItems, index]);
+    }, [activePage, hasSiblingCarouselItems, page]);
     const [isLightboxImageLoaded, setLightboxImageLoaded] = useState(false);
 
     const [isFallbackVisible, setFallbackVisible] = useState(!isLightboxVisible);
@@ -126,7 +153,6 @@ function Lightbox({
     // because it's only going to be rendered after the fallback image is hidden.
     const shouldShowLightbox = isLightboxImageLoaded && !isFallbackVisible;
 
-    const isActive = index === activeIndex;
     const isFallbackStillLoading = isFallbackVisible && !isFallbackImageLoaded;
     const isLightboxStillLoading = isLightboxVisible && !isLightboxImageLoaded;
     const isLoading = isActive && (isCanvasLoading || isFallbackStillLoading || isLightboxStillLoading);
@@ -160,6 +186,14 @@ function Lightbox({
         }
     }, [hasSiblingCarouselItems, isActive, isFallbackVisible, isLightboxImageLoaded, isLightboxVisible]);
 
+    const scaleChange = useCallback(
+        (scale: number) => {
+            onScaleChangedProp?.(scale);
+            onScaleChangedContext?.(scale);
+        },
+        [onScaleChangedContext, onScaleChangedProp],
+    );
+
     return (
         <View
             style={[StyleSheet.absoluteFill, style]}
@@ -171,10 +205,13 @@ function Lightbox({
                         <View style={[StyleUtils.getFullscreenCenteredContentStyles(), StyleUtils.getOpacityStyle(Number(shouldShowLightbox))]}>
                             <MultiGestureCanvas
                                 isActive={isActive}
-                                onScaleChanged={onScaleChanged}
                                 canvasSize={canvasSize}
                                 contentSize={contentSize}
                                 zoomRange={zoomRange}
+                                pagerRef={pagerRef}
+                                shouldDisableTransformationGestures={isPagerScrolling}
+                                onTap={onTap}
+                                onScaleChanged={scaleChange}
                             >
                                 <Image
                                     source={{uri}}

--- a/src/components/MultiGestureCanvas/index.tsx
+++ b/src/components/MultiGestureCanvas/index.tsx
@@ -1,14 +1,16 @@
-import React, {useCallback, useContext, useEffect, useMemo, useRef} from 'react';
+import type {ForwardedRef} from 'react';
+import React, {useEffect, useMemo, useRef} from 'react';
 import {View} from 'react-native';
 import {Gesture, GestureDetector} from 'react-native-gesture-handler';
 import type {GestureRef} from 'react-native-gesture-handler/lib/typescript/handlers/gestures/gesture';
+import type PagerView from 'react-native-pager-view';
+import type {SharedValue} from 'react-native-reanimated';
 import Animated, {cancelAnimation, runOnUI, useAnimatedStyle, useDerivedValue, useSharedValue, useWorkletCallback, withSpring} from 'react-native-reanimated';
-import AttachmentCarouselPagerContext from '@components/Attachments/AttachmentCarousel/Pager/AttachmentCarouselPagerContext';
 import useStyleUtils from '@hooks/useStyleUtils';
 import useThemeStyles from '@hooks/useThemeStyles';
 import type ChildrenProps from '@src/types/utils/ChildrenProps';
 import {DEFAULT_ZOOM_RANGE, SPRING_CONFIG, ZOOM_RANGE_BOUNCE_FACTORS} from './constants';
-import type {CanvasSize, ContentSize, OnScaleChangedCallback, ZoomRange} from './types';
+import type {CanvasSize, ContentSize, OnScaleChangedCallback, OnTapCallback, ZoomRange} from './types';
 import usePanGesture from './usePanGesture';
 import usePinchGesture from './usePinchGesture';
 import useTapGestures from './useTapGestures';
@@ -34,8 +36,17 @@ type MultiGestureCanvasProps = ChildrenProps & {
     /** Range of zoom that can be applied to the content by pinching or double tapping. */
     zoomRange?: Partial<ZoomRange>;
 
+    /** A shared value of type boolean, that indicates disabled the transformation gestures (pinch, pan, double tap) */
+    shouldDisableTransformationGestures?: SharedValue<boolean>;
+
+    /** If there is a pager wrapping the canvas, we need to disable the pan gesture in case the pager is swiping */
+    pagerRef?: ForwardedRef<PagerView>; // TODO: For TS migration: Exclude<GestureRef, number>
+
     /** Handles scale changed event */
     onScaleChanged?: OnScaleChangedCallback;
+
+    /** Handles scale changed event */
+    onTap?: OnTapCallback;
 };
 
 function MultiGestureCanvas({
@@ -44,41 +55,16 @@ function MultiGestureCanvas({
     zoomRange: zoomRangeProp,
     isActive = true,
     children,
-    onScaleChanged: onScaleChangedProp,
+    pagerRef,
+    shouldDisableTransformationGestures: shouldDisableTransformationGesturesProp,
+    onTap,
+    onScaleChanged,
 }: MultiGestureCanvasProps) {
     const styles = useThemeStyles();
     const StyleUtils = useStyleUtils();
 
-    const isSwipingInPagerFallback = useSharedValue(false);
-
-    // If the MultiGestureCanvas used inside a AttachmentCarouselPager, we need to adapt the behaviour based on the pager state
-    const attachmentCarouselPagerContext = useContext(AttachmentCarouselPagerContext);
-    const {
-        onTap,
-        onScaleChanged: onScaleChangedContext,
-        isPagerScrolling: isPagerSwiping,
-        pagerRef,
-    } = useMemo(
-        () =>
-            attachmentCarouselPagerContext ?? {
-                onTap: () => {},
-                onScaleChanged: () => {},
-                pagerRef: undefined,
-                isPagerScrolling: isSwipingInPagerFallback,
-            },
-        [attachmentCarouselPagerContext, isSwipingInPagerFallback],
-    );
-
-    /**
-     * Calls the onScaleChanged callback from the both props and the pager context
-     */
-    const onScaleChanged = useCallback(
-        (newScale: number) => {
-            onScaleChangedProp?.(newScale);
-            onScaleChangedContext(newScale);
-        },
-        [onScaleChangedContext, onScaleChangedProp],
-    );
+    const shouldDisableTransformationGesturesFallback = useSharedValue(false);
+    const shouldDisableTransformationGestures = shouldDisableTransformationGesturesProp ?? shouldDisableTransformationGesturesFallback;
 
     const zoomRange = useMemo(
         () => ({
@@ -126,8 +112,6 @@ function MultiGestureCanvas({
     const reset = useWorkletCallback((animated: boolean, callback?: () => void) => {
         stopAnimation();
 
-        pinchScale.value = 1;
-
         if (animated) {
             offsetX.value = withSpring(0, SPRING_CONFIG);
             offsetY.value = withSpring(0, SPRING_CONFIG);
@@ -155,7 +139,7 @@ function MultiGestureCanvas({
         callback();
     });
 
-    const {singleTapGesture: basicSingleTapGesture, doubleTapGesture} = useTapGestures({
+    const {singleTapGesture: baseSingleTapGesture, doubleTapGesture} = useTapGestures({
         canvasSize,
         contentSize,
         minContentScale,
@@ -168,8 +152,9 @@ function MultiGestureCanvas({
         stopAnimation,
         onScaleChanged,
         onTap,
+        shouldDisableTransformationGestures,
     });
-    const singleTapGesture = basicSingleTapGesture.requireExternalGestureToFail(doubleTapGesture, panGestureRef);
+    const singleTapGesture = baseSingleTapGesture.requireExternalGestureToFail(doubleTapGesture, panGestureRef);
 
     const panGestureSimultaneousList = useMemo(
         () => (pagerRef === undefined ? [singleTapGesture, doubleTapGesture] : [pagerRef as unknown as Exclude<GestureRef, number>, singleTapGesture, doubleTapGesture]),
@@ -185,8 +170,8 @@ function MultiGestureCanvas({
         offsetY,
         panTranslateX,
         panTranslateY,
-        isPagerSwiping,
         stopAnimation,
+        shouldDisableTransformationGestures,
     })
         .simultaneousWithExternalGesture(...panGestureSimultaneousList)
         .withRef(panGestureRef);
@@ -200,9 +185,9 @@ function MultiGestureCanvas({
         pinchTranslateX,
         pinchTranslateY,
         pinchScale,
-        isPagerSwiping,
         stopAnimation,
         onScaleChanged,
+        shouldDisableTransformationGestures,
     }).simultaneousWithExternalGesture(panGesture, singleTapGesture, doubleTapGesture);
 
     // Trigger a reset when the canvas gets inactive, but only if it was already mounted before

--- a/src/components/MultiGestureCanvas/types.ts
+++ b/src/components/MultiGestureCanvas/types.ts
@@ -31,7 +31,7 @@ type MultiGestureCanvasVariables = {
     zoomRange: ZoomRange;
     minContentScale: number;
     maxContentScale: number;
-    isPagerSwiping: SharedValue<boolean>;
+    shouldDisableTransformationGestures: SharedValue<boolean>;
     zoomScale: SharedValue<number>;
     totalScale: SharedValue<number>;
     pinchScale: SharedValue<number>;
@@ -43,8 +43,8 @@ type MultiGestureCanvasVariables = {
     pinchTranslateY: SharedValue<number>;
     stopAnimation: () => void;
     reset: (animated: boolean, callback: () => void) => void;
-    onTap: OnTapCallback;
+    onTap: OnTapCallback | undefined;
     onScaleChanged: OnScaleChangedCallback | undefined;
 };
 
-export type {CanvasSize, ContentSize, ZoomRange, OnScaleChangedCallback, MultiGestureCanvasVariables};
+export type {CanvasSize, ContentSize, ZoomRange, OnScaleChangedCallback, OnTapCallback, MultiGestureCanvasVariables};

--- a/src/components/MultiGestureCanvas/usePanGesture.ts
+++ b/src/components/MultiGestureCanvas/usePanGesture.ts
@@ -13,10 +13,21 @@ const PAN_DECAY_DECELARATION = 0.9915;
 
 type UsePanGestureProps = Pick<
     MultiGestureCanvasVariables,
-    'canvasSize' | 'contentSize' | 'zoomScale' | 'totalScale' | 'offsetX' | 'offsetY' | 'panTranslateX' | 'panTranslateY' | 'isPagerSwiping' | 'stopAnimation'
+    'canvasSize' | 'contentSize' | 'zoomScale' | 'totalScale' | 'offsetX' | 'offsetY' | 'panTranslateX' | 'panTranslateY' | 'shouldDisableTransformationGestures' | 'stopAnimation'
 >;
 
-const usePanGesture = ({canvasSize, contentSize, zoomScale, totalScale, offsetX, offsetY, panTranslateX, panTranslateY, isPagerSwiping, stopAnimation}: UsePanGestureProps): PanGesture => {
+const usePanGesture = ({
+    canvasSize,
+    contentSize,
+    zoomScale,
+    totalScale,
+    offsetX,
+    offsetY,
+    panTranslateX,
+    panTranslateY,
+    shouldDisableTransformationGestures,
+    stopAnimation,
+}: UsePanGestureProps): PanGesture => {
     // The content size after fitting it to the canvas and zooming
     const zoomedContentWidth = useDerivedValue(() => contentSize.width * totalScale.value, [contentSize.width]);
     const zoomedContentHeight = useDerivedValue(() => contentSize.height * totalScale.value, [contentSize.height]);
@@ -117,7 +128,7 @@ const usePanGesture = ({canvasSize, contentSize, zoomScale, totalScale, offsetX,
         // eslint-disable-next-line @typescript-eslint/naming-convention
         .onTouchesMove((_evt, state) => {
             // We only allow panning when the content is zoomed in
-            if (zoomScale.value <= 1 || isPagerSwiping.value) {
+            if (zoomScale.value <= 1 || shouldDisableTransformationGestures.value) {
                 return;
             }
 
@@ -147,7 +158,7 @@ const usePanGesture = ({canvasSize, contentSize, zoomScale, totalScale, offsetX,
             panTranslateY.value = 0;
 
             // If we are swiping (in the pager), we don't want to return to boundaries
-            if (isPagerSwiping.value) {
+            if (shouldDisableTransformationGestures.value) {
                 return;
             }
 

--- a/src/components/MultiGestureCanvas/usePinchGesture.ts
+++ b/src/components/MultiGestureCanvas/usePinchGesture.ts
@@ -8,7 +8,17 @@ import type {MultiGestureCanvasVariables} from './types';
 
 type UsePinchGestureProps = Pick<
     MultiGestureCanvasVariables,
-    'canvasSize' | 'zoomScale' | 'zoomRange' | 'offsetX' | 'offsetY' | 'pinchTranslateX' | 'pinchTranslateY' | 'pinchScale' | 'isPagerSwiping' | 'stopAnimation' | 'onScaleChanged'
+    | 'canvasSize'
+    | 'zoomScale'
+    | 'zoomRange'
+    | 'offsetX'
+    | 'offsetY'
+    | 'pinchTranslateX'
+    | 'pinchTranslateY'
+    | 'pinchScale'
+    | 'shouldDisableTransformationGestures'
+    | 'stopAnimation'
+    | 'onScaleChanged'
 >;
 
 const usePinchGesture = ({
@@ -20,7 +30,7 @@ const usePinchGesture = ({
     pinchTranslateX: totalPinchTranslateX,
     pinchTranslateY: totalPinchTranslateY,
     pinchScale,
-    isPagerSwiping,
+    shouldDisableTransformationGestures,
     stopAnimation,
     onScaleChanged,
 }: UsePinchGestureProps): PinchGesture => {
@@ -87,10 +97,11 @@ const usePinchGesture = ({
 
     const pinchGesture = Gesture.Pinch()
         .enabled(pinchEnabled)
+        // The first argument is not used, but must be defined
         // eslint-disable-next-line @typescript-eslint/naming-convention
         .onTouchesDown((_evt, state) => {
             // We don't want to activate pinch gesture when we are swiping in the pager
-            if (!isPagerSwiping.value) {
+            if (!shouldDisableTransformationGestures.value) {
                 return;
             }
 

--- a/src/components/MultiGestureCanvas/useTapGestures.ts
+++ b/src/components/MultiGestureCanvas/useTapGestures.ts
@@ -9,7 +9,19 @@ import * as MultiGestureCanvasUtils from './utils';
 
 type UseTapGesturesProps = Pick<
     MultiGestureCanvasVariables,
-    'canvasSize' | 'contentSize' | 'minContentScale' | 'maxContentScale' | 'offsetX' | 'offsetY' | 'pinchScale' | 'zoomScale' | 'reset' | 'stopAnimation' | 'onScaleChanged' | 'onTap'
+    | 'canvasSize'
+    | 'contentSize'
+    | 'minContentScale'
+    | 'maxContentScale'
+    | 'offsetX'
+    | 'offsetY'
+    | 'pinchScale'
+    | 'zoomScale'
+    | 'shouldDisableTransformationGestures'
+    | 'reset'
+    | 'stopAnimation'
+    | 'onScaleChanged'
+    | 'onTap'
 >;
 
 const useTapGestures = ({
@@ -23,6 +35,7 @@ const useTapGestures = ({
     zoomScale,
     reset,
     stopAnimation,
+    shouldDisableTransformationGestures,
     onScaleChanged,
     onTap,
 }: UseTapGesturesProps): {singleTapGesture: TapGesture; doubleTapGesture: TapGesture} => {
@@ -107,6 +120,15 @@ const useTapGestures = ({
     );
 
     const doubleTapGesture = Gesture.Tap()
+        // The first argument is not used, but must be defined
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        .onTouchesDown((_evt, state) => {
+            if (!shouldDisableTransformationGestures.value) {
+                return;
+            }
+
+            state.fail();
+        })
         .numberOfTaps(2)
         .maxDelay(150)
         .maxDistance(20)


### PR DESCRIPTION
maybe @tgolen, @pecanoro

### Details

Based on https://github.com/Expensify/App/pull/33756. Check [this](https://github.com/margelo/expensify-app-fork/compare/%40chrispader/restructure-multi-gesture-canvas...margelo:expensify-app-fork:%40chrispader/simplify-native-attachment-carousel) for actual diff.

This PR removes unnecessary prop-drilling and improves how we use the `AttachmentCarouselPagerContext`.

It also improves many of the components used in the (native) attachment gallery and simplifies some rendering logic.

The` MultiGestureCanvas` component is becoming more generic and can therefore be used in other cases more easily. The `Lightbox` component takes control of the adapted behaviour while in an attachment carousel.

### Fixed Issues

$ https://github.com/Expensify/App/issues/36034
PROPOSAL:

### Tests

- [x] Verify that no errors appear in the JS console

1. Go to a report with attachments
2. Open an (image) attachment
3. Check that the attachment carousel is working
4. Check that image gestures/transformations are working (pinching, panning, double tap, swiping)

### Offline tests

None needed.

### QA Steps

- [ ] Verify that no errors appear in the JS console

Same as in Tests.

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

https://private-user-images.githubusercontent.com/20173411/294859245-a437a23c-78a7-4b5e-a2a8-7a3eacc6bfa6.webm

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

https://private-user-images.githubusercontent.com/20173411/294859270-55266a10-b573-4abe-9ded-0cfe51d0e98a.mp4

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

https://github.com/Expensify/App/assets/22820318/45829646-30ba-4fb8-9dab-14e91b01554c

</details>

<details>
<summary>MacOS: Desktop</summary>

https://github.com/Expensify/App/assets/22820318/24c440d7-5f60-4cf6-ba9f-feb73276877d

</details>
