### PR TITLE
Hide the double offline indicator in bank steps

### DIFF
--- a/src/pages/ReimbursementAccount/BankInfo/substeps/Confirmation.tsx
+++ b/src/pages/ReimbursementAccount/BankInfo/substeps/Confirmation.tsx
@@ -5,7 +5,6 @@ import {withOnyx} from 'react-native-onyx';
 import Button from '@components/Button';
 import DotIndicatorMessage from '@components/DotIndicatorMessage';
 import MenuItemWithTopDescription from '@components/MenuItemWithTopDescription';
-import ScreenWrapper from '@components/ScreenWrapper';
 import Text from '@components/Text';
 import useLocalize from '@hooks/useLocalize';
 import type {SubStepProps} from '@hooks/useSubStep/types';
@@ -46,57 +45,55 @@ function Confirmation({reimbursementAccount, reimbursementAccountDraft, onNext, 
     };
 
     return (
-        <ScreenWrapper
-            testID={Confirmation.displayName}
-            style={[styles.pt0]}
+        <ScrollView
+            style={styles.pt0}
+            contentContainerStyle={styles.flexGrow1}
         >
-            <ScrollView contentContainerStyle={styles.flexGrow1}>
-                <Text style={[styles.textHeadlineLineHeightXXL, styles.ph5]}>{translate('bankAccount.letsDoubleCheck')}</Text>
-                <Text style={[styles.mt3, styles.mb3, styles.ph5, styles.textSupporting]}>{translate('bankAccount.thisBankAccount')}</Text>
-                {setupType === CONST.BANK_ACCOUNT.SUBSTEP.MANUAL && (
-                    <View style={[styles.mb5]}>
-                        <MenuItemWithTopDescription
-                            description={translate('bankAccount.routingNumber')}
-                            title={values[BANK_INFO_STEP_KEYS.ROUTING_NUMBER]}
-                            shouldShowRightIcon={!bankAccountID}
-                            onPress={handleModifyAccountNumbers}
-                        />
-
-                        <MenuItemWithTopDescription
-                            description={translate('bankAccount.accountNumber')}
-                            title={values[BANK_INFO_STEP_KEYS.ACCOUNT_NUMBER]}
-                            shouldShowRightIcon={!bankAccountID}
-                            onPress={handleModifyAccountNumbers}
-                        />
-                    </View>
-                )}
-                {setupType === CONST.BANK_ACCOUNT.SUBSTEP.PLAID && (
+            <Text style={[styles.textHeadlineLineHeightXXL, styles.ph5]}>{translate('bankAccount.letsDoubleCheck')}</Text>
+            <Text style={[styles.mt3, styles.mb3, styles.ph5, styles.textSupporting]}>{translate('bankAccount.thisBankAccount')}</Text>
+            {setupType === CONST.BANK_ACCOUNT.SUBSTEP.MANUAL && (
+                <View style={[styles.mb5]}>
                     <MenuItemWithTopDescription
-                        description={values[BANK_INFO_STEP_KEYS.BANK_NAME]}
-                        title={`${translate('bankAccount.accountEnding')} ${(values[BANK_INFO_STEP_KEYS.ACCOUNT_NUMBER] ?? '').slice(-4)}`}
+                        description={translate('bankAccount.routingNumber')}
+                        title={values[BANK_INFO_STEP_KEYS.ROUTING_NUMBER]}
                         shouldShowRightIcon={!bankAccountID}
                         onPress={handleModifyAccountNumbers}
                     />
-                )}
-                <View style={[styles.ph5, styles.pb5, styles.flexGrow1, styles.justifyContentEnd]}>
-                    {error && error.length > 0 && (
-                        <DotIndicatorMessage
-                            textStyles={[styles.formError]}
-                            type="error"
-                            messages={{error}}
-                        />
-                    )}
-                    <Button
-                        isLoading={isLoading}
-                        isDisabled={isLoading}
-                        success
-                        style={[styles.w100]}
-                        onPress={onNext}
-                        text={translate('common.confirm')}
+
+                    <MenuItemWithTopDescription
+                        description={translate('bankAccount.accountNumber')}
+                        title={values[BANK_INFO_STEP_KEYS.ACCOUNT_NUMBER]}
+                        shouldShowRightIcon={!bankAccountID}
+                        onPress={handleModifyAccountNumbers}
                     />
                 </View>
-            </ScrollView>
-        </ScreenWrapper>
+            )}
+            {setupType === CONST.BANK_ACCOUNT.SUBSTEP.PLAID && (
+                <MenuItemWithTopDescription
+                    description={values[BANK_INFO_STEP_KEYS.BANK_NAME]}
+                    title={`${translate('bankAccount.accountEnding')} ${(values[BANK_INFO_STEP_KEYS.ACCOUNT_NUMBER] ?? '').slice(-4)}`}
+                    shouldShowRightIcon={!bankAccountID}
+                    onPress={handleModifyAccountNumbers}
+                />
+            )}
+            <View style={[styles.ph5, styles.pb5, styles.flexGrow1, styles.justifyContentEnd]}>
+                {error && error.length > 0 && (
+                    <DotIndicatorMessage
+                        textStyles={[styles.formError]}
+                        type="error"
+                        messages={{error}}
+                    />
+                )}
+                <Button
+                    isLoading={isLoading}
+                    isDisabled={isLoading}
+                    success
+                    style={[styles.w100]}
+                    onPress={onNext}
+                    text={translate('common.confirm')}
+                />
+            </View>
+        </ScrollView>
     );
 }
 

--- a/src/pages/ReimbursementAccount/BeneficialOwnerInfo/substeps/BeneficialOwnerDetailsFormSubsteps/ConfirmationUBO.tsx
+++ b/src/pages/ReimbursementAccount/BeneficialOwnerInfo/substeps/BeneficialOwnerDetailsFormSubsteps/ConfirmationUBO.tsx
@@ -5,7 +5,6 @@ import {withOnyx} from 'react-native-onyx';
 import Button from '@components/Button';
 import DotIndicatorMessage from '@components/DotIndicatorMessage';
 import MenuItemWithTopDescription from '@components/MenuItemWithTopDescription';
-import ScreenWrapper from '@components/ScreenWrapper';
 import Text from '@components/Text';
 import TextLink from '@components/TextLink';
 import useLocalize from '@hooks/useLocalize';
@@ -37,85 +36,83 @@ function ConfirmationUBO({reimbursementAccount, reimbursementAccountDraft, onNex
     const error = reimbursementAccount ? ErrorUtils.getLatestErrorMessage(reimbursementAccount) : '';
 
     return (
-        <ScreenWrapper
-            testID={ConfirmationUBO.displayName}
-            style={[styles.pt0]}
+        <ScrollView
+            style={styles.pt0}
+            contentContainerStyle={styles.flexGrow1}
         >
-            <ScrollView contentContainerStyle={styles.flexGrow1}>
-                <Text style={[styles.textHeadlineLineHeightXXL, styles.ph5, styles.mb3]}>{translate('beneficialOwnerInfoStep.letsDoubleCheck')}</Text>
-                <MenuItemWithTopDescription
-                    description={translate('beneficialOwnerInfoStep.legalName')}
-                    title={`${values.firstName} ${values.lastName}`}
-                    shouldShowRightIcon
-                    onPress={() => {
-                        onMove(UBO_STEP_INDEXES.LEGAL_NAME);
-                    }}
-                />
-                <MenuItemWithTopDescription
-                    description={translate('common.dob')}
-                    title={values.dob}
-                    shouldShowRightIcon
-                    onPress={() => {
-                        onMove(UBO_STEP_INDEXES.DATE_OF_BIRTH);
-                    }}
-                />
-                <MenuItemWithTopDescription
-                    description={translate('beneficialOwnerInfoStep.last4SSN')}
-                    title={values.ssnLast4}
-                    shouldShowRightIcon
-                    onPress={() => {
-                        onMove(UBO_STEP_INDEXES.SSN);
-                    }}
-                />
-                <MenuItemWithTopDescription
-                    description={translate('beneficialOwnerInfoStep.address')}
-                    title={`${values.street}, ${values.city}, ${values.state} ${values.zipCode}`}
-                    shouldShowRightIcon
-                    onPress={() => {
-                        onMove(UBO_STEP_INDEXES.ADDRESS);
-                    }}
-                />
+            <Text style={[styles.textHeadlineLineHeightXXL, styles.ph5, styles.mb3]}>{translate('beneficialOwnerInfoStep.letsDoubleCheck')}</Text>
+            <MenuItemWithTopDescription
+                description={translate('beneficialOwnerInfoStep.legalName')}
+                title={`${values.firstName} ${values.lastName}`}
+                shouldShowRightIcon
+                onPress={() => {
+                    onMove(UBO_STEP_INDEXES.LEGAL_NAME);
+                }}
+            />
+            <MenuItemWithTopDescription
+                description={translate('common.dob')}
+                title={values.dob}
+                shouldShowRightIcon
+                onPress={() => {
+                    onMove(UBO_STEP_INDEXES.DATE_OF_BIRTH);
+                }}
+            />
+            <MenuItemWithTopDescription
+                description={translate('beneficialOwnerInfoStep.last4SSN')}
+                title={values.ssnLast4}
+                shouldShowRightIcon
+                onPress={() => {
+                    onMove(UBO_STEP_INDEXES.SSN);
+                }}
+            />
+            <MenuItemWithTopDescription
+                description={translate('beneficialOwnerInfoStep.address')}
+                title={`${values.street}, ${values.city}, ${values.state} ${values.zipCode}`}
+                shouldShowRightIcon
+                onPress={() => {
+                    onMove(UBO_STEP_INDEXES.ADDRESS);
+                }}
+            />
 
-                <Text style={[styles.mt3, styles.ph5, styles.textMicroSupporting]}>
-                    {`${translate('beneficialOwnerInfoStep.byAddingThisBankAccount')} `}
-                    <TextLink
-                        href={CONST.ONFIDO_FACIAL_SCAN_POLICY_URL}
-                        style={[styles.textMicro]}
-                    >
-                        {translate('onfidoStep.facialScan')}
-                    </TextLink>
-                    {', '}
-                    <TextLink
-                        href={CONST.ONFIDO_PRIVACY_POLICY_URL}
-                        style={[styles.textMicro]}
-                    >
-                        {translate('common.privacy')}
-                    </TextLink>
-                    {` ${translate('common.and')} `}
-                    <TextLink
-                        href={CONST.ONFIDO_TERMS_OF_SERVICE_URL}
-                        style={[styles.textMicro]}
-                    >
-                        {translate('common.termsOfService')}
-                    </TextLink>
-                </Text>
-                <View style={[styles.ph5, styles.mtAuto]}>
-                    {error && error.length > 0 && (
-                        <DotIndicatorMessage
-                            textStyles={[styles.formError]}
-                            type="error"
-                            messages={{error}}
-                        />
-                    )}
-                    <Button
-                        success
-                        style={[styles.w100, styles.mt2, styles.pb5]}
-                        onPress={onNext}
-                        text={translate('common.confirm')}
+            <Text style={[styles.mt3, styles.ph5, styles.textMicroSupporting]}>
+                {`${translate('beneficialOwnerInfoStep.byAddingThisBankAccount')} `}
+                <TextLink
+                    href={CONST.ONFIDO_FACIAL_SCAN_POLICY_URL}
+                    style={[styles.textMicro]}
+                >
+                    {translate('onfidoStep.facialScan')}
+                </TextLink>
+                {', '}
+                <TextLink
+                    href={CONST.ONFIDO_PRIVACY_POLICY_URL}
+                    style={[styles.textMicro]}
+                >
+                    {translate('common.privacy')}
+                </TextLink>
+                {` ${translate('common.and')} `}
+                <TextLink
+                    href={CONST.ONFIDO_TERMS_OF_SERVICE_URL}
+                    style={[styles.textMicro]}
+                >
+                    {translate('common.termsOfService')}
+                </TextLink>
+            </Text>
+            <View style={[styles.ph5, styles.mtAuto]}>
+                {error && error.length > 0 && (
+                    <DotIndicatorMessage
+                        textStyles={[styles.formError]}
+                        type="error"
+                        messages={{error}}
                     />
-                </View>
-            </ScrollView>
-        </ScreenWrapper>
+                )}
+                <Button
+                    success
+                    style={[styles.w100, styles.mt2, styles.pb5]}
+                    onPress={onNext}
+                    text={translate('common.confirm')}
+                />
+            </View>
+        </ScrollView>
     );
 }
 

--- a/src/pages/ReimbursementAccount/BeneficialOwnerInfo/substeps/CompanyOwnersListUBO.tsx
+++ b/src/pages/ReimbursementAccount/BeneficialOwnerInfo/substeps/CompanyOwnersListUBO.tsx
@@ -6,7 +6,6 @@ import Button from '@components/Button';
 import DotIndicatorMessage from '@components/DotIndicatorMessage';
 import * as Expensicons from '@components/Icon/Expensicons';
 import MenuItem from '@components/MenuItem';
-import ScreenWrapper from '@components/ScreenWrapper';
 import Text from '@components/Text';
 import useLocalize from '@hooks/useLocalize';
 import useThemeStyles from '@hooks/useThemeStyles';
@@ -101,49 +100,47 @@ function CompanyOwnersListUBO({
         });
 
     return (
-        <ScreenWrapper
-            testID={CompanyOwnersListUBO.displayName}
-            style={[styles.pt0]}
+        <ScrollView
+            style={styles.pt0}
+            contentContainerStyle={[styles.flexGrow1, styles.ph0]}
         >
-            <ScrollView contentContainerStyle={[styles.flexGrow1, styles.ph0]}>
-                <Text style={[styles.textHeadlineLineHeightXXL, styles.ph5]}>{translate('beneficialOwnerInfoStep.letsDoubleCheck')}</Text>
-                <Text style={[styles.p5, styles.textSupporting]}>{translate('beneficialOwnerInfoStep.regulationRequiresUsToVerifyTheIdentity')}</Text>
-                <View>
-                    <Text style={[styles.textSupporting, styles.pv1, styles.ph5]}>{`${translate('beneficialOwnerInfoStep.owners')}:`}</Text>
-                    {isUserUBO && (
-                        <MenuItem
-                            title={`${requestorData.firstName} ${requestorData.lastName}`}
-                            description={`${requestorData.requestorAddressStreet}, ${requestorData.requestorAddressCity}, ${requestorData.requestorAddressState} ${requestorData.requestorAddressZipCode}`}
-                            wrapperStyle={[styles.ph5]}
-                            icon={Expensicons.FallbackAvatar}
-                            iconWidth={40}
-                            iconHeight={40}
-                            interactive={false}
-                            shouldShowRightIcon={false}
-                            displayInDefaultIconColor
-                        />
-                    )}
-                    {extraBeneficialOwners}
-                </View>
+            <Text style={[styles.textHeadlineLineHeightXXL, styles.ph5]}>{translate('beneficialOwnerInfoStep.letsDoubleCheck')}</Text>
+            <Text style={[styles.p5, styles.textSupporting]}>{translate('beneficialOwnerInfoStep.regulationRequiresUsToVerifyTheIdentity')}</Text>
+            <View>
+                <Text style={[styles.textSupporting, styles.pv1, styles.ph5]}>{`${translate('beneficialOwnerInfoStep.owners')}:`}</Text>
+                {isUserUBO && (
+                    <MenuItem
+                        title={`${requestorData.firstName} ${requestorData.lastName}`}
+                        description={`${requestorData.requestorAddressStreet}, ${requestorData.requestorAddressCity}, ${requestorData.requestorAddressState} ${requestorData.requestorAddressZipCode}`}
+                        wrapperStyle={[styles.ph5]}
+                        icon={Expensicons.FallbackAvatar}
+                        iconWidth={40}
+                        iconHeight={40}
+                        interactive={false}
+                        shouldShowRightIcon={false}
+                        displayInDefaultIconColor
+                    />
+                )}
+                {extraBeneficialOwners}
+            </View>
 
-                <View style={[styles.ph5, styles.mtAuto]}>
-                    {error && error.length > 0 && (
-                        <DotIndicatorMessage
-                            textStyles={[styles.formError]}
-                            type="error"
-                            messages={{error}}
-                        />
-                    )}
-                </View>
-                <Button
-                    success
-                    isLoading={isLoading}
-                    style={[styles.w100, styles.mt2, styles.pb5, styles.ph5]}
-                    onPress={handleUBOsConfirmation}
-                    text={translate('common.confirm')}
-                />
-            </ScrollView>
-        </ScreenWrapper>
+            <View style={[styles.ph5, styles.mtAuto]}>
+                {error && error.length > 0 && (
+                    <DotIndicatorMessage
+                        textStyles={[styles.formError]}
+                        type="error"
+                        messages={{error}}
+                    />
+                )}
+            </View>
+            <Button
+                success
+                isLoading={isLoading}
+                style={[styles.w100, styles.mt2, styles.pb5, styles.ph5]}
+                onPress={handleUBOsConfirmation}
+                text={translate('common.confirm')}
+            />
+        </ScrollView>
     );
 }
 

--- a/src/pages/ReimbursementAccount/PersonalInfo/substeps/Confirmation.tsx
+++ b/src/pages/ReimbursementAccount/PersonalInfo/substeps/Confirmation.tsx
@@ -5,7 +5,6 @@ import {withOnyx} from 'react-native-onyx';
 import Button from '@components/Button';
 import DotIndicatorMessage from '@components/DotIndicatorMessage';
 import MenuItemWithTopDescription from '@components/MenuItemWithTopDescription';
-import ScreenWrapper from '@components/ScreenWrapper';
 import Text from '@components/Text';
 import TextLink from '@components/TextLink';
 import useLocalize from '@hooks/useLocalize';
@@ -41,88 +40,86 @@ function Confirmation({reimbursementAccount, reimbursementAccountDraft, onNext, 
     const error = ErrorUtils.getLatestErrorMessage(reimbursementAccount ?? {});
 
     return (
-        <ScreenWrapper
-            testID={Confirmation.displayName}
-            style={[styles.pt0]}
+        <ScrollView
+            style={styles.pt0}
+            contentContainerStyle={styles.flexGrow1}
         >
-            <ScrollView contentContainerStyle={styles.flexGrow1}>
-                <Text style={[styles.textHeadlineLineHeightXXL, styles.ph5, styles.mb3]}>{translate('personalInfoStep.letsDoubleCheck')}</Text>
-                <MenuItemWithTopDescription
-                    description={translate('personalInfoStep.legalName')}
-                    title={`${values[PERSONAL_INFO_STEP_KEYS.FIRST_NAME]} ${values[PERSONAL_INFO_STEP_KEYS.LAST_NAME]}`}
-                    shouldShowRightIcon
-                    onPress={() => {
-                        onMove(PERSONAL_INFO_STEP_INDEXES.LEGAL_NAME);
-                    }}
-                />
-                <MenuItemWithTopDescription
-                    description={translate('common.dob')}
-                    title={values[PERSONAL_INFO_STEP_KEYS.DOB]}
-                    shouldShowRightIcon
-                    onPress={() => {
-                        onMove(PERSONAL_INFO_STEP_INDEXES.DATE_OF_BIRTH);
-                    }}
-                />
-                <MenuItemWithTopDescription
-                    description={translate('personalInfoStep.last4SSN')}
-                    title={values[PERSONAL_INFO_STEP_KEYS.SSN_LAST_4]}
-                    shouldShowRightIcon
-                    onPress={() => {
-                        onMove(PERSONAL_INFO_STEP_INDEXES.SSN);
-                    }}
-                />
-                <MenuItemWithTopDescription
-                    description={translate('personalInfoStep.address')}
-                    title={`${values[PERSONAL_INFO_STEP_KEYS.STREET]}, ${values[PERSONAL_INFO_STEP_KEYS.CITY]}, ${values[PERSONAL_INFO_STEP_KEYS.STATE]} ${
-                        values[PERSONAL_INFO_STEP_KEYS.ZIP_CODE]
-                    }`}
-                    shouldShowRightIcon
-                    onPress={() => {
-                        onMove(PERSONAL_INFO_STEP_INDEXES.ADDRESS);
-                    }}
-                />
+            <Text style={[styles.textHeadlineLineHeightXXL, styles.ph5, styles.mb3]}>{translate('personalInfoStep.letsDoubleCheck')}</Text>
+            <MenuItemWithTopDescription
+                description={translate('personalInfoStep.legalName')}
+                title={`${values[PERSONAL_INFO_STEP_KEYS.FIRST_NAME]} ${values[PERSONAL_INFO_STEP_KEYS.LAST_NAME]}`}
+                shouldShowRightIcon
+                onPress={() => {
+                    onMove(PERSONAL_INFO_STEP_INDEXES.LEGAL_NAME);
+                }}
+            />
+            <MenuItemWithTopDescription
+                description={translate('common.dob')}
+                title={values[PERSONAL_INFO_STEP_KEYS.DOB]}
+                shouldShowRightIcon
+                onPress={() => {
+                    onMove(PERSONAL_INFO_STEP_INDEXES.DATE_OF_BIRTH);
+                }}
+            />
+            <MenuItemWithTopDescription
+                description={translate('personalInfoStep.last4SSN')}
+                title={values[PERSONAL_INFO_STEP_KEYS.SSN_LAST_4]}
+                shouldShowRightIcon
+                onPress={() => {
+                    onMove(PERSONAL_INFO_STEP_INDEXES.SSN);
+                }}
+            />
+            <MenuItemWithTopDescription
+                description={translate('personalInfoStep.address')}
+                title={`${values[PERSONAL_INFO_STEP_KEYS.STREET]}, ${values[PERSONAL_INFO_STEP_KEYS.CITY]}, ${values[PERSONAL_INFO_STEP_KEYS.STATE]} ${
+                    values[PERSONAL_INFO_STEP_KEYS.ZIP_CODE]
+                }`}
+                shouldShowRightIcon
+                onPress={() => {
+                    onMove(PERSONAL_INFO_STEP_INDEXES.ADDRESS);
+                }}
+            />
 
-                <Text style={[styles.mt3, styles.ph5, styles.textMicroSupporting]}>
-                    {`${translate('personalInfoStep.byAddingThisBankAccount')} `}
-                    <TextLink
-                        href={CONST.ONFIDO_FACIAL_SCAN_POLICY_URL}
-                        style={[styles.textMicro]}
-                    >
-                        {translate('onfidoStep.facialScan')}
-                    </TextLink>
-                    {', '}
-                    <TextLink
-                        href={CONST.ONFIDO_PRIVACY_POLICY_URL}
-                        style={[styles.textMicro]}
-                    >
-                        {translate('common.privacy')}
-                    </TextLink>
-                    {` ${translate('common.and')} `}
-                    <TextLink
-                        href={CONST.ONFIDO_TERMS_OF_SERVICE_URL}
-                        style={[styles.textMicro]}
-                    >
-                        {translate('common.termsOfService')}
-                    </TextLink>
-                </Text>
-                <View style={[styles.ph5, styles.pb5, styles.flexGrow1, styles.justifyContentEnd]}>
-                    {error && error.length > 0 && (
-                        <DotIndicatorMessage
-                            textStyles={[styles.formError]}
-                            type="error"
-                            messages={{error}}
-                        />
-                    )}
-                    <Button
-                        success
-                        isLoading={isLoading}
-                        style={[styles.w100]}
-                        onPress={onNext}
-                        text={translate('common.confirm')}
+            <Text style={[styles.mt3, styles.ph5, styles.textMicroSupporting]}>
+                {`${translate('personalInfoStep.byAddingThisBankAccount')} `}
+                <TextLink
+                    href={CONST.ONFIDO_FACIAL_SCAN_POLICY_URL}
+                    style={[styles.textMicro]}
+                >
+                    {translate('onfidoStep.facialScan')}
+                </TextLink>
+                {', '}
+                <TextLink
+                    href={CONST.ONFIDO_PRIVACY_POLICY_URL}
+                    style={[styles.textMicro]}
+                >
+                    {translate('common.privacy')}
+                </TextLink>
+                {` ${translate('common.and')} `}
+                <TextLink
+                    href={CONST.ONFIDO_TERMS_OF_SERVICE_URL}
+                    style={[styles.textMicro]}
+                >
+                    {translate('common.termsOfService')}
+                </TextLink>
+            </Text>
+            <View style={[styles.ph5, styles.pb5, styles.flexGrow1, styles.justifyContentEnd]}>
+                {error && error.length > 0 && (
+                    <DotIndicatorMessage
+                        textStyles={[styles.formError]}
+                        type="error"
+                        messages={{error}}
                     />
-                </View>
-            </ScrollView>
-        </ScreenWrapper>
+                )}
+                <Button
+                    success
+                    isLoading={isLoading}
+                    style={[styles.w100]}
+                    onPress={onNext}
+                    text={translate('common.confirm')}
+                />
+            </View>
+        </ScrollView>
     );
 }
 


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. --> 

### Details
<!-- Explanation of the change or anything fishy that is going on -->

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/33647
$ https://github.com/Expensify/App/issues/33647#issuecomment-1870465517
Do NOT only link the issue number like this: $ #<issueID>
--->

$ https://github.com/Expensify/App/issues/36458
$ https://github.com/Expensify/App/issues/36458#issuecomment-1943002051


### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->


- [X] Verify that no errors appear in the JS console

Pre-requisite: the user must be logged in and have created a workspace.
1. Go to Workspace > Bank account.
2. Initiate the add BA flow until you reach the Personal info double check page.
3. Disable the internet connection.
4. Validate that only one offline indicator is shown



### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

Pre-requisite: the user must be logged in and have created a workspace.
1. Go to Workspace > Bank account.
2. Initiate the add BA flow until you reach the Personal info double check page.
3. Disable the internet connection.
4. Validate that only one offline indicator is shown

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

- [x] Verify that no errors appear in the JS console


Pre-requisite: the user must be logged in and have created a workspace.
1. Go to Workspace > Bank account.
2. Initiate the add BA flow until you reach the Personal info double check page.
3. Disable the internet connection.
4. Validate that only one offline indicator is shown

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] If we are not using the full Onyx data that we loaded, I've added the proper selector in order to ensure the component only re-renders when the data it is using changes
        - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.



### Screenshots/Videos
<details>
<summary>Android: Native</summary>
<img width="757" alt="Screenshot 2024-02-17 at 2 32 01 PM" src="https://github.com/Expensify/App/assets/59809993/d82f99db-04b8-4e09-8834-403759bd3c71">

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->
<img width="742" alt="Screenshot 2024-02-17 at 6 00 00 PM" src="https://github.com/Expensify/App/assets/59809993/7cd5670a-d8c5-481c-af5c-e75ecb427a70">


</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->
<img width="757" alt="Screenshot 2024-02-17 at 2 32 01 PM" src="https://github.com/Expensify/App/assets/59809993/f81efac2-f46f-453c-9a1d-38c06972831b">

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->
<img width="742" alt="Screenshot 2024-02-17 at 6 00 00 PM" src="https://github.com/Expensify/App/assets/59809993/b32f2ea8-1923-48c9-8db4-998e24f9dd37">

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>
<img width="1494" alt="Screenshot 2024-02-16 at 8 09 00 PM" src="https://github.com/Expensify/App/assets/59809993/8d80684b-3b15-441c-a13e-d75029e17d5c">

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Desktop</summary>
<img width="1205" alt="Screenshot 2024-02-17 at 12 09 56 PM" src="https://github.com/Expensify/App/assets/59809993/e411d50c-147a-45ab-b1f8-46e9c369a6ce">

<!-- add screenshots or videos here -->

</details>
