### PR TITLE
[Categories] Add support for long category names

### DIFF
--- a/src/components/CategoryPicker/index.js
+++ b/src/components/CategoryPicker/index.js
@@ -70,6 +70,7 @@ function CategoryPicker({selectedCategory, policyCategories, policyRecentlyUsedC
             onSelectRow={onSubmit}
             ListItem={RadioListItem}
             initiallyFocusedOptionKey={selectedOptionKey}
+            isRowMultilineSupported
         />
     );
 }

--- a/src/components/SelectionList/BaseSelectionList.tsx
+++ b/src/components/SelectionList/BaseSelectionList.tsx
@@ -63,6 +63,7 @@ function BaseSelectionList<TItem extends ListItem>(
         onLayout,
         customListHeader,
         listHeaderWrapperStyle,
+        isRowMultilineSupported = false,
     }: BaseSelectionListProps<TItem>,
     inputRef: ForwardedRef<RNTextInput>,
 ) {

--- a/src/components/SelectionList/BaseSelectionList.tsx
+++ b/src/components/SelectionList/BaseSelectionList.tsx
@@ -294,6 +294,7 @@ function BaseSelectionList<TItem extends ListItem>(
                 shouldPreventDefaultFocusOnSelectRow={shouldPreventDefaultFocusOnSelectRow}
                 rightHandSideComponent={rightHandSideComponent}
                 keyForList={item.keyForList}
+                isMultilineSupported={isRowMultilineSupported}
             />
         );
     };

--- a/src/components/SelectionList/RadioListItem.tsx
+++ b/src/components/SelectionList/RadioListItem.tsx
@@ -16,6 +16,7 @@ function RadioListItem({
     onDismissError,
     shouldPreventDefaultFocusOnSelectRow,
     rightHandSideComponent,
+    isMultilineSupported = false,
 }: RadioListItemProps) {
     const styles = useThemeStyles();
     const StyleUtils = useStyleUtils();

--- a/src/components/SelectionList/RadioListItem.tsx
+++ b/src/components/SelectionList/RadioListItem.tsx
@@ -45,9 +45,10 @@ function RadioListItem({
                             styles.optionDisplayName,
                             isFocused ? styles.sidebarLinkActiveText : styles.sidebarLinkText,
                             styles.sidebarLinkTextBold,
-                            styles.pre,
+                            isMultilineSupported ? styles.preWrap : styles.pre,
                             item.alternateText ? styles.mb1 : null,
                         ]}
+                        numberOfLines={isMultilineSupported ? 2 : 1}
                     />
 
                     {!!item.alternateText && (

--- a/src/components/SelectionList/types.ts
+++ b/src/components/SelectionList/types.ts
@@ -38,7 +38,7 @@ type CommonListItemProps<TItem> = {
     /** Styles for the checkbox wrapper view if select multiple option is on */
     selectMultipleStyle?: StyleProp<ViewStyle>;
 
-    /** Whether to wrap large text up to 2 lines */
+    /** Whether to wrap long text up to 2 lines */
     isMultilineSupported?: boolean;
 };
 

--- a/src/components/SelectionList/types.ts
+++ b/src/components/SelectionList/types.ts
@@ -265,7 +265,7 @@ type BaseSelectionListProps<TItem extends ListItem> = Partial<ChildrenProps> & {
     /** Styles for the list header wrapper */
     listHeaderWrapperStyle?: StyleProp<ViewStyle>;
 
-    /** Whether to wrap large text up to 2 lines */
+    /** Whether to wrap long text up to 2 lines */
     isRowMultilineSupported?: boolean;
 };
 

--- a/src/components/SelectionList/types.ts
+++ b/src/components/SelectionList/types.ts
@@ -87,7 +87,7 @@ type ListItem = {
     /** Whether this option should show subscript */
     shouldShowSubscript?: boolean;
 
-    /** Whether to wrap large text up to 2 lines */
+    /** Whether to wrap long text up to 2 lines */
     isMultilineSupported?: boolean;
 };
 

--- a/src/components/SelectionList/types.ts
+++ b/src/components/SelectionList/types.ts
@@ -258,6 +258,9 @@ type BaseSelectionListProps<TItem extends ListItem> = Partial<ChildrenProps> & {
 
     /** Styles for the list header wrapper */
     listHeaderWrapperStyle?: StyleProp<ViewStyle>;
+
+    /** Whether to wrap large text up to 2 lines */
+    isRowMultilineSupported?: boolean;
 };
 
 type ItemLayout = {

--- a/src/components/SelectionList/types.ts
+++ b/src/components/SelectionList/types.ts
@@ -37,6 +37,9 @@ type CommonListItemProps<TItem> = {
 
     /** Styles for the checkbox wrapper view if select multiple option is on */
     selectMultipleStyle?: StyleProp<ViewStyle>;
+
+    /** Whether to wrap large text up to 2 lines */
+    isMultilineSupported?: boolean;
 };
 
 type ListItem = {
@@ -83,6 +86,9 @@ type ListItem = {
 
     /** Whether this option should show subscript */
     shouldShowSubscript?: boolean;
+
+    /** Whether to wrap large text up to 2 lines */
+    isMultilineSupported?: boolean;
 };
 
 type ListItemProps = CommonListItemProps<ListItem> & {

--- a/src/components/TextWithTooltip/index.native.tsx
+++ b/src/components/TextWithTooltip/index.native.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import Text from '@components/Text';
 import type TextWithTooltipProps from './types';
 
-function TextWithTooltip({text, textStyles, numberOfLines}: TextWithTooltipProps) {
+function TextWithTooltip({text, textStyles, numberOfLines = 1}: TextWithTooltipProps) {
     return (
         <Text
             style={textStyles}

--- a/src/components/TextWithTooltip/index.native.tsx
+++ b/src/components/TextWithTooltip/index.native.tsx
@@ -6,7 +6,7 @@ function TextWithTooltip({text, textStyles, numberOfLines = 1}: TextWithTooltipP
     return (
         <Text
             style={textStyles}
-            numberOfLines={numberOfLines ?? 1}
+            numberOfLines={numberOfLines}
         >
             {text}
         </Text>

--- a/src/components/TextWithTooltip/index.native.tsx
+++ b/src/components/TextWithTooltip/index.native.tsx
@@ -2,11 +2,11 @@ import React from 'react';
 import Text from '@components/Text';
 import type TextWithTooltipProps from './types';
 
-function TextWithTooltip({text, textStyles}: TextWithTooltipProps) {
+function TextWithTooltip({text, textStyles, numberOfLines}: TextWithTooltipProps) {
     return (
         <Text
             style={textStyles}
-            numberOfLines={1}
+            numberOfLines={numberOfLines ?? 1}
         >
             {text}
         </Text>

--- a/src/components/TextWithTooltip/index.tsx
+++ b/src/components/TextWithTooltip/index.tsx
@@ -17,7 +17,7 @@ function TextWithTooltip({text, shouldShowTooltip, textStyles, numberOfLines = 1
         >
             <Text
                 style={textStyles}
-                numberOfLines={numberOfLines ?? 1}
+                numberOfLines={numberOfLines}
                 onLayout={(e) => {
                     const target = (e.nativeEvent as unknown as LayoutChangeEvent).target;
                     if (!shouldShowTooltip) {

--- a/src/components/TextWithTooltip/index.tsx
+++ b/src/components/TextWithTooltip/index.tsx
@@ -7,7 +7,7 @@ type LayoutChangeEvent = {
     target: HTMLElement;
 };
 
-function TextWithTooltip({text, shouldShowTooltip, textStyles, numberOfLines}: TextWithTooltipProps) {
+function TextWithTooltip({text, shouldShowTooltip, textStyles, numberOfLines = 1}: TextWithTooltipProps) {
     const [showTooltip, setShowTooltip] = useState(false);
 
     return (

--- a/src/components/TextWithTooltip/index.tsx
+++ b/src/components/TextWithTooltip/index.tsx
@@ -7,7 +7,7 @@ type LayoutChangeEvent = {
     target: HTMLElement;
 };
 
-function TextWithTooltip({text, shouldShowTooltip, textStyles}: TextWithTooltipProps) {
+function TextWithTooltip({text, shouldShowTooltip, textStyles, numberOfLines}: TextWithTooltipProps) {
     const [showTooltip, setShowTooltip] = useState(false);
 
     return (
@@ -17,7 +17,7 @@ function TextWithTooltip({text, shouldShowTooltip, textStyles}: TextWithTooltipP
         >
             <Text
                 style={textStyles}
-                numberOfLines={1}
+                numberOfLines={numberOfLines ?? 1}
                 onLayout={(e) => {
                     const target = (e.nativeEvent as unknown as LayoutChangeEvent).target;
                     if (!shouldShowTooltip) {

--- a/src/components/TextWithTooltip/types.ts
+++ b/src/components/TextWithTooltip/types.ts
@@ -10,7 +10,7 @@ type TextWithTooltipProps = {
     /** Additional text styles */
     textStyles?: StyleProp<TextStyle>;
 
-    /** Custom number of lines for Text */
+    /** Custom number of lines for text wrapping */
     numberOfLines?: number;
 };
 

--- a/src/components/TextWithTooltip/types.ts
+++ b/src/components/TextWithTooltip/types.ts
@@ -6,7 +6,7 @@ type TextWithTooltipProps = {
 
     /** Whether to show the toolip text */
     shouldShowTooltip: boolean;
-    
+
     /** Additional text styles */
     textStyles?: StyleProp<TextStyle>;
 

--- a/src/components/TextWithTooltip/types.ts
+++ b/src/components/TextWithTooltip/types.ts
@@ -1,8 +1,13 @@
 import type {StyleProp, TextStyle} from 'react-native';
 
 type TextWithTooltipProps = {
+    /** The text to display */
     text: string;
+
+    /** Whether to show the toolip text */
     shouldShowTooltip: boolean;
+    
+    /** Additional text styles */
     textStyles?: StyleProp<TextStyle>;
 
     /** Custom number of lines for Text */

--- a/src/components/TextWithTooltip/types.ts
+++ b/src/components/TextWithTooltip/types.ts
@@ -4,6 +4,9 @@ type TextWithTooltipProps = {
     text: string;
     shouldShowTooltip: boolean;
     textStyles?: StyleProp<TextStyle>;
+
+    /** Custom number of lines for Text */
+    numberOfLines?: number;
 };
 
 export default TextWithTooltipProps;


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/37297
PROPOSAL: https://github.com/Expensify/App/issues/37297#issuecomment-1966680938

### Tests
Precondition:
User is an employee of Collect workspace
The Collect workspace has a long category name

1. Go to expensify
2. Go to workspace chat
3. Open request money page
4. Create manual request and proceed to confirmation page
5. Click Show more > Category

- [x] Verify that no errors appear in the JS console

### Offline tests
Same as Tests step

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->
Same as Tests step


### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>
<img width="403" alt="Screenshot 2024-02-28 at 7 28 26 AM" src="https://github.com/Expensify/App/assets/64629613/691243c3-2d15-4831-a270-df4b00e8ef4c">

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>
<img width="403" alt="Screenshot 2024-02-28 at 7 21 44 AM" src="https://github.com/Expensify/App/assets/64629613/42d32234-8fb8-4bd3-ac6a-9606d2cb188b">

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>
<img width="447" alt="Screenshot 2024-02-28 at 7 34 54 AM" src="https://github.com/Expensify/App/assets/64629613/8962f508-66d5-4828-b26f-418b6383c75d">

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>
<img width="456" alt="Screenshot 2024-02-28 at 7 12 54 AM" src="https://github.com/Expensify/App/assets/64629613/b095be70-43ef-4c31-bd1f-1134dbcd0617">

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>
<img width="1680" alt="Screenshot 2024-02-28 at 7 00 27 AM" src="https://github.com/Expensify/App/assets/64629613/0c2c07fd-9a9e-478d-977a-852e4a683124">

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Desktop</summary>
<img width="1220" alt="Screenshot 2024-02-28 at 7 09 03 AM" src="https://github.com/Expensify/App/assets/64629613/c757a9c0-b802-46e2-8328-7bd0f220a61b">

<!-- add screenshots or videos here -->

</details>
