### PR TITLE
Hover menu is not dismissed after opening emoji picker

### DIFF
--- a/src/components/Reactions/AddReactionBubble.tsx
+++ b/src/components/Reactions/AddReactionBubble.tsx
@@ -43,9 +43,12 @@ type AddReactionBubbleProps = {
      * ReportAction for EmojiPicker.
      */
     reportAction: ReportAction;
+
+    /** Function to update emoji picker state */
+    setIsEmojiPickerActive?: (state: boolean) => void;
 };
 
-function AddReactionBubble({onSelectEmoji, reportAction, onPressOpenPicker, onWillShowPicker = () => {}, isContextMenu = false}: AddReactionBubbleProps) {
+function AddReactionBubble({onSelectEmoji, reportAction, onPressOpenPicker, onWillShowPicker = () => {}, isContextMenu = false, setIsEmojiPickerActive}: AddReactionBubbleProps) {
     const styles = useThemeStyles();
     const StyleUtils = useStyleUtils();
     const ref = useRef<View | HTMLDivElement>(null);
@@ -56,7 +59,9 @@ function AddReactionBubble({onSelectEmoji, reportAction, onPressOpenPicker, onWi
     const onPress = () => {
         const openPicker = (refParam?: PickerRefElement, anchorOrigin?: AnchorOrigin) => {
             EmojiPickerAction.showEmojiPicker(
-                () => {},
+                () => {
+                    setIsEmojiPickerActive?.(false);
+                },
                 (emojiCode, emojiObject) => {
                     onSelectEmoji(emojiObject);
                 },
@@ -68,12 +73,14 @@ function AddReactionBubble({onSelectEmoji, reportAction, onPressOpenPicker, onWi
         };
 
         if (!EmojiPickerAction.emojiPickerRef.current?.isEmojiPickerVisible) {
+            setIsEmojiPickerActive?.(true);
             if (onPressOpenPicker) {
                 onPressOpenPicker(openPicker);
             } else {
                 openPicker();
             }
         } else {
+            setIsEmojiPickerActive?.(false);
             EmojiPickerAction.emojiPickerRef.current.hideEmojiPicker();
         }
     };

--- a/src/components/Reactions/QuickEmojiReactions/BaseQuickEmojiReactions.tsx
+++ b/src/components/Reactions/QuickEmojiReactions/BaseQuickEmojiReactions.tsx
@@ -20,6 +20,7 @@ function BaseQuickEmojiReactions({
     emojiReactions = {},
     onPressOpenPicker = () => {},
     onWillShowPicker = () => {},
+    setIsEmojiPickerActive,
 }: BaseQuickEmojiReactionsProps) {
     const styles = useThemeStyles();
 
@@ -45,6 +46,7 @@ function BaseQuickEmojiReactions({
                 onWillShowPicker={onWillShowPicker}
                 onSelectEmoji={(emoji) => onEmojiSelected(emoji, emojiReactions)}
                 reportAction={reportAction}
+                setIsEmojiPickerActive={setIsEmojiPickerActive}
             />
         </View>
     );

--- a/src/components/Reactions/QuickEmojiReactions/types.ts
+++ b/src/components/Reactions/QuickEmojiReactions/types.ts
@@ -32,6 +32,9 @@ type BaseReactionsProps = {
 
     /** Id of the ReportAction for EmojiPicker. */
     reportActionID: string;
+
+    /** Function to update emoji picker state */
+    setIsEmojiPickerActive?: (state: boolean) => void;
 };
 
 type BaseQuickEmojiReactionsOnyxProps = {
@@ -53,6 +56,8 @@ type QuickEmojiReactionsProps = BaseReactionsProps & {
      * in which this component is rendered.
      */
     closeContextMenu: (callback: CloseContextMenuCallback) => void;
+
+    setIsEmojiPickerActive?: (state: boolean) => void;
 };
 
 export type {BaseQuickEmojiReactionsProps, BaseQuickEmojiReactionsOnyxProps, QuickEmojiReactionsProps, OpenPickerCallback, CloseContextMenuCallback, PickerRefElement};

--- a/src/components/Reactions/ReportActionItemEmojiReactions.tsx
+++ b/src/components/Reactions/ReportActionItemEmojiReactions.tsx
@@ -37,6 +37,9 @@ type ReportActionItemEmojiReactionsProps = WithCurrentUserPersonalDetailsProps &
 
     /** We disable reacting with emojis on report actions that have errors */
     shouldBlockReactions?: boolean;
+
+    /** Function to update emoji picker state */
+    setIsEmojiPickerActive?: (state: boolean) => void;
 };
 
 type PopoverReactionListAnchors = Record<string, ReactionListAnchor>;
@@ -68,6 +71,8 @@ type FormattedReaction = {
 
     /** The type of action that's pending  */
     pendingAction?: PendingAction;
+
+    setIsEmojiPickerActive?: (state: boolean) => void;
 };
 
 function ReportActionItemEmojiReactions({
@@ -77,6 +82,7 @@ function ReportActionItemEmojiReactions({
     emojiReactions = {},
     shouldBlockReactions = false,
     preferredLocale = CONST.LOCALES.DEFAULT,
+    setIsEmojiPickerActive,
 }: ReportActionItemEmojiReactionsProps) {
     const styles = useThemeStyles();
     const reactionListRef = useContext(ReactionListContext);
@@ -166,6 +172,7 @@ function ReportActionItemEmojiReactions({
                     <AddReactionBubble
                         onSelectEmoji={toggleReaction}
                         reportAction={reportAction}
+                        setIsEmojiPickerActive={setIsEmojiPickerActive}
                     />
                 )}
             </View>

--- a/src/pages/home/report/ContextMenu/BaseReportActionContextMenu.tsx
+++ b/src/pages/home/report/ContextMenu/BaseReportActionContextMenu.tsx
@@ -86,6 +86,9 @@ type BaseReportActionContextMenuProps = BaseReportActionContextMenuOnyxProps & {
 
     /** List of disabled actions */
     disabledActions?: ContextMenuAction[];
+
+    /** Function to update emoji picker state */
+    setIsEmojiPickerActive?: (state: boolean) => void;
 };
 
 type MenuItemRefs = Record<string, ContextMenuItemHandle | null>;
@@ -108,6 +111,7 @@ function BaseReportActionContextMenu({
     reportActions,
     checkIfContextMenuActive,
     disabledActions = [],
+    setIsEmojiPickerActive,
 }: BaseReportActionContextMenuProps) {
     const StyleUtils = useStyleUtils();
     const {translate} = useLocalize();
@@ -202,7 +206,10 @@ function BaseReportActionContextMenu({
             originalReportID,
             draftMessage,
             checkIfContextMenuActive,
-            checkIfContextMenuActive,
+            () => {
+                checkIfContextMenuActive?.();
+                setShouldKeepOpen(false);
+            },
             ReportUtils.isArchivedRoom(originalReport),
             ReportUtils.chatIncludesChronos(originalReport),
             undefined,
@@ -229,6 +236,7 @@ function BaseReportActionContextMenu({
                         openContextMenu: () => setShouldKeepOpen(true),
                         interceptAnonymousUser,
                         openOverflowMenu,
+                        setIsEmojiPickerActive,
                     };
 
                     if ('renderContent' in contextAction) {

--- a/src/pages/home/report/ContextMenu/ContextMenuActions.tsx
+++ b/src/pages/home/report/ContextMenu/ContextMenuActions.tsx
@@ -76,6 +76,7 @@ type ContextMenuActionPayload = {
     interceptAnonymousUser: (callback: () => void, isAnonymousAction?: boolean) => void;
     openOverflowMenu: (event: GestureResponderEvent | MouseEvent) => void;
     event?: GestureResponderEvent | MouseEvent | KeyboardEvent;
+    setIsEmojiPickerActive?: (state: boolean) => void;
 };
 
 type OnPress = (closePopover: boolean, payload: ContextMenuActionPayload, selection?: string, reportID?: string, draftMessage?: string) => void;
@@ -108,7 +109,7 @@ const ContextMenuActions: ContextMenuAction[] = [
         isAnonymousAction: false,
         shouldShow: (type, reportAction): reportAction is ReportAction =>
             type === CONST.CONTEXT_MENU_TYPES.REPORT_ACTION && !!reportAction && 'message' in reportAction && !ReportActionsUtils.isMessageDeleted(reportAction),
-        renderContent: (closePopover, {reportID, reportAction, close: closeManually, openContextMenu}) => {
+        renderContent: (closePopover, {reportID, reportAction, close: closeManually, openContextMenu, setIsEmojiPickerActive}) => {
             const isMini = !closePopover;
 
             const closeContextMenu = (onHideCallback?: () => void) => {
@@ -125,6 +126,7 @@ const ContextMenuActions: ContextMenuAction[] = [
             const toggleEmojiAndCloseMenu = (emoji: Emoji, existingReactions: OnyxEntry<ReportActionReactions>) => {
                 Report.toggleEmojiReaction(reportID, reportAction, emoji, existingReactions);
                 closeContextMenu();
+                setIsEmojiPickerActive?.(false);
             };
 
             if (isMini) {
@@ -132,8 +134,14 @@ const ContextMenuActions: ContextMenuAction[] = [
                     <MiniQuickEmojiReactions
                         key="MiniQuickEmojiReactions"
                         onEmojiSelected={toggleEmojiAndCloseMenu}
-                        onPressOpenPicker={openContextMenu}
-                        onEmojiPickerClosed={closeContextMenu}
+                        onPressOpenPicker={() => {
+                            openContextMenu();
+                            setIsEmojiPickerActive?.(true);
+                        }}
+                        onEmojiPickerClosed={() => {
+                            closeContextMenu();
+                            setIsEmojiPickerActive?.(false);
+                        }}
                         reportActionID={reportAction?.reportActionID}
                         reportAction={reportAction}
                     />
@@ -147,6 +155,7 @@ const ContextMenuActions: ContextMenuAction[] = [
                     onEmojiSelected={toggleEmojiAndCloseMenu}
                     reportActionID={reportAction?.reportActionID}
                     reportAction={reportAction}
+                    setIsEmojiPickerActive={setIsEmojiPickerActive}
                 />
             );
         },
@@ -479,8 +488,9 @@ const ContextMenuActions: ContextMenuAction[] = [
         textTranslateKey: 'reportActionContextMenu.menu',
         icon: Expensicons.ThreeDots,
         shouldShow: (type, reportAction, isArchivedRoom, betas, anchor, isChronosReport, reportID, isPinnedChat, isUnreadChat, isOffline, isMini) => isMini,
-        onPress: (closePopover, {openOverflowMenu, event}) => {
+        onPress: (closePopover, {openOverflowMenu, event, openContextMenu}) => {
             openOverflowMenu(event as GestureResponderEvent | MouseEvent);
+            openContextMenu();
         },
         getDescription: () => {},
     },

--- a/src/pages/home/report/ContextMenu/PopoverReportActionContextMenu.tsx
+++ b/src/pages/home/report/ContextMenu/PopoverReportActionContextMenu.tsx
@@ -72,6 +72,7 @@ function PopoverReportActionContextMenu(_props: never, ref: ForwardedRef<ReportA
 
     const onPopoverShow = useRef(() => {});
     const onPopoverHide = useRef(() => {});
+    const onEmojiPickerToggle = useRef<undefined | ((state: boolean) => void)>();
     const onCancelDeleteModal = useRef(() => {});
     const onComfirmDeleteModal = useRef(() => {});
 
@@ -164,6 +165,7 @@ function PopoverReportActionContextMenu(_props: never, ref: ForwardedRef<ReportA
         isUnreadChat = false,
         disabledOptions = [],
         shouldCloseOnTarget = false,
+        setIsEmojiPickerActive = () => {},
     ) => {
         const {pageX = 0, pageY = 0} = extractPointerEvent(event);
         contextMenuAnchorRef.current = contextMenuAnchor;
@@ -177,6 +179,7 @@ function PopoverReportActionContextMenu(_props: never, ref: ForwardedRef<ReportA
 
         onPopoverShow.current = onShow;
         onPopoverHide.current = onHide;
+        onEmojiPickerToggle.current = setIsEmojiPickerActive;
 
         new Promise<void>((resolve) => {
             if (!pageX && !pageY && contextMenuAnchorRef.current) {
@@ -329,6 +332,7 @@ function PopoverReportActionContextMenu(_props: never, ref: ForwardedRef<ReportA
                     contentRef={contentRef}
                     originalReportID={originalReportIDRef.current}
                     disabledActions={disabledActions}
+                    setIsEmojiPickerActive={onEmojiPickerToggle.current}
                 />
             </PopoverWithMeasuredContent>
             <ConfirmModal

--- a/src/pages/home/report/ContextMenu/ReportActionContextMenu.ts
+++ b/src/pages/home/report/ContextMenu/ReportActionContextMenu.ts
@@ -35,6 +35,7 @@ type ShowContextMenu = (
     isUnreadChat?: boolean,
     disabledOptions?: ContextMenuAction[],
     shouldCloseOnTarget?: boolean,
+    setIsEmojiPickerActive?: (state: boolean) => void,
 ) => void;
 
 type ReportActionContextMenu = {
@@ -115,6 +116,7 @@ function showContextMenu(
     isUnreadChat = false,
     disabledActions: ContextMenuAction[] = [],
     shouldCloseOnTarget = false,
+    setIsEmojiPickerActive = () => {},
 ) {
     if (!contextMenuRef.current) {
         return;
@@ -143,6 +145,7 @@ function showContextMenu(
         isUnreadChat,
         disabledActions,
         shouldCloseOnTarget,
+        setIsEmojiPickerActive,
     );
 }
 

--- a/src/pages/home/report/ReportActionItem.js
+++ b/src/pages/home/report/ReportActionItem.js
@@ -144,6 +144,8 @@ function ReportActionItem(props) {
     const StyleUtils = useStyleUtils();
     const personalDetails = usePersonalDetails() || CONST.EMPTY_OBJECT;
     const [isContextMenuActive, setIsContextMenuActive] = useState(() => ReportActionContextMenu.isActiveReportAction(props.action.reportActionID));
+    const [isEmojiPickerActive, setIsEmojiPickerActive] = useState();
+
     const [isHidden, setIsHidden] = useState(false);
     const [moderationDecision, setModerationDecision] = useState(CONST.MODERATION.MODERATOR_DECISION_APPROVED);
     const reactionListRef = useContext(ReactionListContext);
@@ -291,6 +293,11 @@ function ReportActionItem(props) {
                 toggleContextMenuFromActiveReportAction,
                 ReportUtils.isArchivedRoom(originalReport),
                 ReportUtils.chatIncludesChronos(originalReport),
+                false,
+                false,
+                [],
+                false,
+                setIsEmojiPickerActive,
             );
         },
         [props.draftMessage, props.action, props.report.reportID, toggleContextMenuFromActiveReportAction, originalReport, originalReportID],
@@ -569,6 +576,7 @@ function ReportActionItem(props) {
                                     toggleReaction(emoji);
                                 }
                             }}
+                            setIsEmojiPickerActive={setIsEmojiPickerActive}
                         />
                     </View>
                 )}
@@ -597,7 +605,7 @@ function ReportActionItem(props) {
      * @returns {Object} report action item
      */
     const renderReportActionItem = (hovered, isWhisper, hasErrors) => {
-        const content = renderItemContent(hovered || isContextMenuActive, isWhisper, hasErrors);
+        const content = renderItemContent(hovered || isContextMenuActive || isEmojiPickerActive, isWhisper, hasErrors);
 
         if (!_.isUndefined(props.draftMessage)) {
             return <ReportActionItemDraft>{content}</ReportActionItemDraft>;
@@ -785,8 +793,9 @@ function ReportActionItem(props) {
                             draftMessage={props.draftMessage}
                             isChronosReport={ReportUtils.chatIncludesChronos(originalReport)}
                             checkIfContextMenuActive={toggleContextMenuFromActiveReportAction}
+                            setIsEmojiPickerActive={setIsEmojiPickerActive}
                         />
-                        <View style={StyleUtils.getReportActionItemStyle(hovered || isWhisper || isContextMenuActive || !_.isUndefined(props.draftMessage))}>
+                        <View style={StyleUtils.getReportActionItemStyle(hovered || isWhisper || isContextMenuActive || isEmojiPickerActive || !_.isUndefined(props.draftMessage))}>
                             <OfflineWithFeedback
                                 onClose={() => ReportActions.clearReportActionErrors(props.report.reportID, props.action)}
                                 pendingAction={


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/34833
PROPOSAL: https://github.com/Expensify/App/issues/34833#issuecomment-1901846497


### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->
1. Go to any chat
2. Hover over any message (right click on the action or add any reaction)
3. Click Add reaction icon to open the emoji picker
4. Hover away from the message
5. Verify that the background is retain 
6. Verify that mini context menu is open if users open emoji picker from mini context menu
7. Select any emoji or click outside to close the emoji picker 
8. Verify that the background is disappeared and mini context menu is close
9. Click three dot/ menu icon to open popover
10. Hover away from the message
11. Verify that the background is retain and mini context menu is open
12. Click outside to close the popover
13. Verify that the background is disappeared and mini context menu is close

- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

Same as above

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->
1. Go to any chat
2. Hover over any message (right click on the action or add any reaction)
3. Click Add reaction icon to open the emoji picker
4. Hover away from the message
5. Verify that the background is retain
6. Verify that mini context menu is open if users open emoji picker from mini context menu
7. Select any emoji or click outside to close the emoji picker 
8. Verify that the background is disappeared and mini context menu is close
9. Click three dot/ menu icon to open popover
10. Hover away from the message
11. Verify that the background is retain and mini context menu is open
12. Click outside to close the popover
13. Verify that the background is disappeared and mini context menu is close

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

https://github.com/Expensify/App/assets/113963320/0ca730ea-9225-4297-bbd3-921f04447267


</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

https://github.com/Expensify/App/assets/113963320/dc389f76-b820-4faa-9e80-ae5626fa636e


</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->


https://github.com/Expensify/App/assets/113963320/a9d92e8c-1d8d-4854-8061-af65c98ffa3d

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

https://github.com/Expensify/App/assets/113963320/b21319ce-1238-419c-ab51-5eeb1fe2849a


</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->


https://github.com/Expensify/App/assets/113963320/f78e7129-123e-41a2-8729-e754a4d3f436


</details>

<details>
<summary>MacOS: Desktop</summary>

<!-- add screenshots or videos here -->

https://github.com/Expensify/App/assets/113963320/cc83ff53-480e-48ff-9564-16784630f4d7


</details>
