### PR TITLE
Fix/35596: Last message text display incorrectly

### DIFF
--- a/src/components/LHNOptionsList/OptionRowLHN.tsx
+++ b/src/components/LHNOptionsList/OptionRowLHN.tsx
@@ -225,7 +225,7 @@ function OptionRowLHN({reportID, isFocused = false, onSelectRow = () => {}, opti
                                             numberOfLines={1}
                                             accessibilityLabel={translate('accessibilityHints.lastChatMessagePreview')}
                                         >
-                                            {optionItem.alternateText}
+                                            {`${optionItem.alternateText}\u200B`}
                                         </Text>
                                     ) : null}
                                 </View>

--- a/src/libs/OptionsListUtils.ts
+++ b/src/libs/OptionsListUtils.ts
@@ -1,4 +1,5 @@
 /* eslint-disable no-continue */
+import ExpensiMark from 'expensify-common/lib/ExpensiMark';
 import Str from 'expensify-common/lib/str';
 // eslint-disable-next-line you-dont-need-lodash-underscore/get
 import lodashGet from 'lodash/get';
@@ -585,8 +586,13 @@ function getLastMessageTextForReport(report: OnyxEntry<Report>, lastActorDetails
     } else if (ReportActionUtils.isCreatedTaskReportAction(lastReportAction)) {
         lastMessageTextFromReport = TaskUtils.getTaskCreatedMessage(lastReportAction);
     }
-
-    return lastMessageTextFromReport || (report?.lastMessageText ?? '');
+    const parser = new ExpensiMark();
+    return (
+        lastMessageTextFromReport ||
+        (lastActionName === CONST.REPORT.ACTIONS.TYPE.ADDCOMMENT
+            ? ReportUtils.formatReportLastMessageText(parser.htmlToText(report?.lastMessageHtml ?? ''), false, true)
+            : report?.lastMessageText ?? '')
+    );
 }
 
 /**

--- a/src/libs/ReportActionsUtils.ts
+++ b/src/libs/ReportActionsUtils.ts
@@ -502,6 +502,7 @@ function getLastVisibleMessage(reportID: string, actionsToMerge: OnyxCollection<
     }
     return {
         lastMessageText: messageText,
+        lastMessageHtml: message?.html,
     };
 }
 

--- a/src/libs/ReportUtils.ts
+++ b/src/libs/ReportUtils.ts
@@ -1377,9 +1377,15 @@ function canShowReportRecipientLocalTime(personalDetails: OnyxCollection<Persona
 /**
  * Shorten last message text to fixed length and trim spaces.
  */
-function formatReportLastMessageText(lastMessageText: string, isModifiedExpenseMessage = false): string {
+function formatReportLastMessageText(lastMessageText: string, isModifiedExpenseMessage = false, isAddComment = false): string {
     if (isModifiedExpenseMessage) {
         return String(lastMessageText).trim().replace(CONST.REGEX.LINE_BREAK, '').trim();
+    }
+    if (isAddComment) {
+        return String(lastMessageText)
+            .trim()
+            .replace(CONST.REGEX.AFTER_FIRST_LINE_BREAK, ' '.repeat(CONST.REPORT.LAST_MESSAGE_TEXT_MAX_LENGTH))
+            .substring(0, CONST.REPORT.LAST_MESSAGE_TEXT_MAX_LENGTH);
     }
     return String(lastMessageText).trim().replace(CONST.REGEX.LINE_BREAK, ' ').substring(0, CONST.REPORT.LAST_MESSAGE_TEXT_MAX_LENGTH).trim();
 }

--- a/src/libs/ReportUtils.ts
+++ b/src/libs/ReportUtils.ts
@@ -1805,7 +1805,6 @@ function buildOptimisticCancelPaymentReportAction(expenseReportID: string, amoun
 function getLastVisibleMessage(reportID: string | undefined, actionsToMerge: ReportActions = {}): LastVisibleMessage {
     const report = getReport(reportID);
     const lastVisibleAction = ReportActionsUtils.getLastVisibleAction(reportID ?? '', actionsToMerge);
-
     // For Chat Report with deleted parent actions, let us fetch the correct message
     if (ReportActionsUtils.isDeletedParentAction(lastVisibleAction) && !isEmptyObject(report) && isChatReport(report)) {
         const lastMessageText = getDeletedParentActionMessageForChatReport(lastVisibleAction);
@@ -1813,7 +1812,7 @@ function getLastVisibleMessage(reportID: string | undefined, actionsToMerge: Rep
             lastMessageText,
         };
     }
-
+    
     // Fetch the last visible message for report represented by reportID and based on actions to merge.
     return ReportActionsUtils.getLastVisibleMessage(reportID ?? '', actionsToMerge);
 }

--- a/src/libs/ReportUtils.ts
+++ b/src/libs/ReportUtils.ts
@@ -1812,7 +1812,7 @@ function getLastVisibleMessage(reportID: string | undefined, actionsToMerge: Rep
             lastMessageText,
         };
     }
-    
+
     // Fetch the last visible message for report represented by reportID and based on actions to merge.
     return ReportActionsUtils.getLastVisibleMessage(reportID ?? '', actionsToMerge);
 }

--- a/src/libs/ReportUtils.ts
+++ b/src/libs/ReportUtils.ts
@@ -1382,12 +1382,10 @@ function formatReportLastMessageText(lastMessageText: string, isModifiedExpenseM
         return String(lastMessageText).trim().replace(CONST.REGEX.LINE_BREAK, '').trim();
     }
     if (isAddComment) {
-        return (
-            String(lastMessageText)
-                .trim()
-                .replace(CONST.REGEX.AFTER_FIRST_LINE_BREAK, ' '.repeat(CONST.REPORT.LAST_MESSAGE_TEXT_MAX_LENGTH))
-                .substring(0, CONST.REPORT.LAST_MESSAGE_TEXT_MAX_LENGTH) + '\u200B'
-        );
+        return String(lastMessageText)
+            .trim()
+            .replace(CONST.REGEX.AFTER_FIRST_LINE_BREAK, ' '.repeat(CONST.REPORT.LAST_MESSAGE_TEXT_MAX_LENGTH))
+            .substring(0, CONST.REPORT.LAST_MESSAGE_TEXT_MAX_LENGTH);
     }
     return String(lastMessageText).trim().replace(CONST.REGEX.LINE_BREAK, ' ').substring(0, CONST.REPORT.LAST_MESSAGE_TEXT_MAX_LENGTH).trim();
 }

--- a/src/libs/ReportUtils.ts
+++ b/src/libs/ReportUtils.ts
@@ -1382,10 +1382,12 @@ function formatReportLastMessageText(lastMessageText: string, isModifiedExpenseM
         return String(lastMessageText).trim().replace(CONST.REGEX.LINE_BREAK, '').trim();
     }
     if (isAddComment) {
-        return String(lastMessageText)
-            .trim()
-            .replace(CONST.REGEX.AFTER_FIRST_LINE_BREAK, ' '.repeat(CONST.REPORT.LAST_MESSAGE_TEXT_MAX_LENGTH))
-            .substring(0, CONST.REPORT.LAST_MESSAGE_TEXT_MAX_LENGTH);
+        return (
+            String(lastMessageText)
+                .trim()
+                .replace(CONST.REGEX.AFTER_FIRST_LINE_BREAK, ' '.repeat(CONST.REPORT.LAST_MESSAGE_TEXT_MAX_LENGTH))
+                .substring(0, CONST.REPORT.LAST_MESSAGE_TEXT_MAX_LENGTH) + '\u200B'
+        );
     }
     return String(lastMessageText).trim().replace(CONST.REGEX.LINE_BREAK, ' ').substring(0, CONST.REPORT.LAST_MESSAGE_TEXT_MAX_LENGTH).trim();
 }

--- a/src/libs/actions/Report.ts
+++ b/src/libs/actions/Report.ts
@@ -399,13 +399,12 @@ function addActions(reportID: string, text = '', file?: FileObject) {
     const lastAction = attachmentAction ?? reportCommentAction;
     const currentTime = DateUtils.getDBTimeWithSkew();
     const lastComment = lastAction?.message?.[0];
-    const lastCommentText = ReportUtils.formatReportLastMessageText(lastComment?.text ?? '');
 
     const optimisticReport: Partial<Report> = {
         lastVisibleActionCreated: currentTime,
         lastMessageTranslationKey: lastComment?.translationKey ?? '',
-        lastMessageText: lastCommentText,
-        lastMessageHtml: lastCommentText,
+        lastMessageText: text,
+        lastMessageHtml: text,
         lastActorAccountID: currentUserAccountID,
         lastReadTime: currentTime,
     };

--- a/src/libs/actions/Report.ts
+++ b/src/libs/actions/Report.ts
@@ -1169,7 +1169,7 @@ function deleteReportComment(reportID: string, reportAction: ReportAction) {
         lastMessageText: '',
         lastVisibleActionCreated: '',
     };
-    const {lastMessageText = '', lastMessageTranslationKey = ''} = ReportUtils.getLastVisibleMessage(originalReportID, optimisticReportActions as ReportActions);
+    const {lastMessageText = '', lastMessageTranslationKey = '', lastMessageHtml = ''} = ReportUtils.getLastVisibleMessage(originalReportID, optimisticReportActions as ReportActions);
     if (lastMessageText || lastMessageTranslationKey) {
         const lastVisibleAction = ReportActionsUtils.getLastVisibleAction(originalReportID, optimisticReportActions as ReportActions);
         const lastVisibleActionCreated = lastVisibleAction?.created;
@@ -1179,6 +1179,7 @@ function deleteReportComment(reportID: string, reportAction: ReportAction) {
             lastMessageText,
             lastVisibleActionCreated,
             lastActorAccountID,
+            lastMessageHtml
         };
     }
 

--- a/src/libs/actions/Report.ts
+++ b/src/libs/actions/Report.ts
@@ -1179,7 +1179,7 @@ function deleteReportComment(reportID: string, reportAction: ReportAction) {
             lastMessageText,
             lastVisibleActionCreated,
             lastActorAccountID,
-            lastMessageHtml
+            lastMessageHtml,
         };
     }
 

--- a/tests/ui/UnreadIndicatorsTest.js
+++ b/tests/ui/UnreadIndicatorsTest.js
@@ -618,7 +618,7 @@ describe('Unread Indicators', () => {
                     const hintText = Localize.translateLocal('accessibilityHints.lastChatMessagePreview');
                     const alternateText = screen.queryAllByLabelText(hintText);
                     expect(alternateText).toHaveLength(1);
-                    expect(alternateText[0].props.children).toBe('Current User Comment 1');
+                    expect(alternateText[0].props.children).toBe('Current User Comment 1\u200B');
 
                     Report.deleteReportComment(REPORT_ID, lastReportAction);
                     return waitForBatchedUpdates();
@@ -627,7 +627,7 @@ describe('Unread Indicators', () => {
                     const hintText = Localize.translateLocal('accessibilityHints.lastChatMessagePreview');
                     const alternateText = screen.queryAllByLabelText(hintText);
                     expect(alternateText).toHaveLength(1);
-                    expect(alternateText[0].props.children).toBe('Comment 9');
+                    expect(alternateText[0].props.children).toBe('Comment 9\u200B');
                 })
         );
     });


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->
 
### Details
<!-- Explanation of the change or anything fishy that is going on -->

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/35596
PROPOSAL: https://github.com/Expensify/App/issues/35596#issuecomment-1923244586


### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->
1. Open ND
2. Open any report
3. Send a multiple lines message. For example:
```
Line 1
Line 2
```
4. Verify that only the first line of the message should be visible on LHN, and there is the ```...``` at the end
5. Refresh the page
6. Verify that only the first line of the message should be visible on LHN, and there is the ```...``` at the end (similar to step 4)
- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->
1. Open ND and go offline
2. Open any report
3. Send a multiple lines message. For example:
```
Line 1
Line 2
```
4. Verify that only the first line of the message should be visible on LHN, and there is the ```...``` at the end
5. Refresh the page
6. Verify that only the first line of the message should be visible on LHN, and there is the ```...``` at the end (similar to step 4)
### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
7. Verify a modal appears displaying a preview of that image
--->
1. Open ND
2. Open any report
3. Send a multiple lines message. For example:
```
Line 1
Line 2
```
4. Verify that only the first line of the message should be visible on LHN, and there is the ```...``` at the end
5. Refresh the page
6. Verify that only the first line of the message should be visible on LHN, and there is the ```...``` at the end (similar to step 4)
- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->
[Screencast from 03-03-2024 23:26:03.webm](https://github.com/Expensify/App/assets/129500732/92d168b1-18f5-4365-b614-415676687b80)


</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->
[Screencast from 01-03-2024 07:40:57.webm](https://github.com/Expensify/App/assets/129500732/9378356d-028c-4989-8173-6e8c98eaeed8)

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->
[Screencast from 01-03-2024 07:43:02.webm](https://github.com/Expensify/App/assets/129500732/4f200bb2-b722-4690-b56a-f655cfa1ee83)

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->
[Screencast from 01-03-2024 07:34:27.webm](https://github.com/Expensify/App/assets/129500732/dc9b26a8-4b58-4664-a426-4bbe465ac7b9)


</details>

<details>
<summary>MacOS: Desktop</summary>

<!-- add screenshots or videos here -->

</details>
