### PR TITLE
Fix correct redirects from chats to workspaces page

### DIFF
--- a/src/libs/navigateAfterJoinRequest/index.ts
+++ b/src/libs/navigateAfterJoinRequest/index.ts
@@ -4,5 +4,6 @@ import ROUTES from '@src/ROUTES';
 const navigateAfterJoinRequest = () => {
     Navigation.goBack(undefined, false, true);
     Navigation.navigate(ROUTES.ALL_SETTINGS);
+    Navigation.navigate(ROUTES.SETTINGS_WORKSPACES);
 };
 export default navigateAfterJoinRequest;

--- a/src/pages/workspace/WorkspaceJoinUserPage.tsx
+++ b/src/pages/workspace/WorkspaceJoinUserPage.tsx
@@ -36,7 +36,7 @@ function WorkspaceJoinUserPage({route, policies}: WorkspaceJoinUserPageProps) {
         if (!isJoinLinkUsed) {
             return;
         }
-        Navigation.goBack(undefined, false, true);
+        navigateAfterJoinRequest();
     }, []);
 
     useEffect(() => {


### PR DESCRIPTION
### Details
Fix correct redirects from pasted workspace link in chat to all worspaces

### Fixed Issues

$ https://github.com/Expensify/App/issues/37958
$ https://github.com/Expensify/App/issues/37962
PROPOSAL: 


### Tests

1. Has a workspace (new or existing one)
2. Prepare join url link - use WorkspaceID and admin email for that workspace - ex.
3. https://staging.new.expensify.com:8082/workspace/7DE6960B26D79E36/join?email=tenema5675@bizatop.com
4. As the user Paste the link in any chats
5. Click on the link
6. Verify that all workspaces are opened

- [x] Verify that no errors appear in the JS console

### Offline tests

1. Has a workspace (new or existing one)
2. Prepare join url link - use WorkspaceID and admin email for that workspace - ex.
3. https://staging.new.expensify.com:8082/workspace/7DE6960B26D79E36/join?email=tenema5675@bizatop.com
4. As the user Paste the link in any chats
5. Click on the link
6. Verify that all workspaces are opened

### QA Steps

1. Has a workspace (new or existing one)
2. Prepare join url link - use WorkspaceID and admin email for that workspace - ex.
3. https://staging.new.expensify.com:8082/workspace/7DE6960B26D79E36/join?email=tenema5675@bizatop.com
4. As the user Paste the link in any chats
5. Click on the link
6. Verify that all workspaces are opened

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>


https://github.com/Expensify/App/assets/28352309/68234a7d-98ec-44b7-8a83-14eb8c771a93



</details>

<details>
<summary>Android: mWeb Chrome</summary>


https://github.com/Expensify/App/assets/28352309/943be744-22ec-46eb-b75b-6be657740080




</details>

<details>
<summary>iOS: Native</summary>


https://github.com/Expensify/App/assets/28352309/41867584-c3f0-430d-932b-8d104befe074



</details>

<details>
<summary>iOS: mWeb Safari</summary>



https://github.com/Expensify/App/assets/28352309/070b4e70-f6ce-483e-b6bd-82ea41bdc31d



</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

https://github.com/Expensify/App/assets/28352309/2f3c456b-2806-413e-a992-28c72ab95acd




</details>

<details>
<summary>MacOS: Desktop</summary>



https://github.com/Expensify/App/assets/28352309/78b0221a-6c50-4e7f-afdf-1446e40ac8bb




</details>
