### PR TITLE
[CP Staging] Fix icons after regression

### DIFF
--- a/src/components/AvatarCropModal/AvatarCropModal.tsx
+++ b/src/components/AvatarCropModal/AvatarCropModal.tsx
@@ -404,7 +404,6 @@ function AvatarCropModal({imageUri = '', imageName = '', imageType = '', onClose
                                 >
                                     <View>
                                         <Button
-                                            medium
                                             icon={Expensicons.Rotate}
                                             iconFill={theme.inverse}
                                             onPress={rotateImage}

--- a/src/components/AvatarCropModal/AvatarCropModal.tsx
+++ b/src/components/AvatarCropModal/AvatarCropModal.tsx
@@ -405,7 +405,7 @@ function AvatarCropModal({imageUri = '', imageName = '', imageType = '', onClose
                                     <View>
                                         <Button
                                             icon={Expensicons.Rotate}
-                                            iconFill={theme.inverse}
+                                            iconFill={theme.icon}
                                             onPress={rotateImage}
                                         />
                                     </View>

--- a/src/components/Button/index.tsx
+++ b/src/components/Button/index.tsx
@@ -241,6 +241,7 @@ function Button(
                             <View style={[large ? styles.mr2 : styles.mr1, !text && styles.mr0, iconStyles]}>
                                 <Icon
                                     src={icon}
+                                    hasText={!!text}
                                     fill={iconFill ?? (success || danger ? theme.textLight : theme.icon)}
                                     small={small}
                                     medium={medium}

--- a/src/components/ContextMenuItem.tsx
+++ b/src/components/ContextMenuItem.tsx
@@ -101,7 +101,7 @@ function ContextMenuItem(
         >
             {({hovered, pressed}) => (
                 <Icon
-                    small
+                    medium
                     src={itemIcon}
                     fill={StyleUtils.getIconFillColor(getButtonState(hovered, pressed, !isThrottledButtonActive))}
                 />

--- a/src/components/ContextMenuItem.tsx
+++ b/src/components/ContextMenuItem.tsx
@@ -101,7 +101,7 @@ function ContextMenuItem(
         >
             {({hovered, pressed}) => (
                 <Icon
-                    medium
+                    small
                     src={itemIcon}
                     fill={StyleUtils.getIconFillColor(getButtonState(hovered, pressed, !isThrottledButtonActive))}
                 />

--- a/src/components/DistanceRequest/DistanceRequestFooter.tsx
+++ b/src/components/DistanceRequest/DistanceRequestFooter.tsx
@@ -96,7 +96,7 @@ function DistanceRequestFooter({waypoints, transaction, mapboxAccessToken, navig
                         onPress={() => navigateToWaypointEditPage(Object.keys(transaction?.comment?.waypoints ?? {}).length)}
                         text={translate('distance.addStop')}
                         isDisabled={numberOfWaypoints === MAX_WAYPOINTS}
-                        innerStyles={[styles.ph10]}
+                        innerStyles={[styles.pl10, styles.pr10]}
                     />
                 </View>
             )}

--- a/src/components/Icon/index.tsx
+++ b/src/components/Icon/index.tsx
@@ -1,14 +1,13 @@
-import type { ImageContentFit } from 'expo-image';
+import type {ImageContentFit} from 'expo-image';
 import React from 'react';
-import type { StyleProp, ViewStyle } from 'react-native';
-import { View } from 'react-native';
+import type {StyleProp, ViewStyle} from 'react-native';
+import {View} from 'react-native';
 import ImageSVG from '@components/ImageSVG';
 import useStyleUtils from '@hooks/useStyleUtils';
 import useThemeStyles from '@hooks/useThemeStyles';
 import variables from '@styles/variables';
 import type IconAsset from '@src/types/utils/IconAsset';
 import IconWrapperStyles from './IconWrapperStyles';
-
 
 type IconProps = {
     /** The asset to render. */
@@ -60,7 +59,7 @@ function Icon({
     height = variables.iconSizeNormal,
     fill = undefined,
     small = false,
-                  hasText = false,
+    hasText = false,
     large = false,
     medium = false,
     inline = false,

--- a/src/components/Icon/index.tsx
+++ b/src/components/Icon/index.tsx
@@ -1,13 +1,14 @@
-import type {ImageContentFit} from 'expo-image';
+import type { ImageContentFit } from 'expo-image';
 import React from 'react';
-import type {StyleProp, ViewStyle} from 'react-native';
-import {View} from 'react-native';
+import type { StyleProp, ViewStyle } from 'react-native';
+import { View } from 'react-native';
 import ImageSVG from '@components/ImageSVG';
 import useStyleUtils from '@hooks/useStyleUtils';
 import useThemeStyles from '@hooks/useThemeStyles';
 import variables from '@styles/variables';
 import type IconAsset from '@src/types/utils/IconAsset';
 import IconWrapperStyles from './IconWrapperStyles';
+
 
 type IconProps = {
     /** The asset to render. */
@@ -40,6 +41,9 @@ type IconProps = {
     /** Is icon pressed */
     pressed?: boolean;
 
+    /** Is icon will be used with text */
+    hasText?: boolean;
+
     /** Additional styles to add to the Icon */
     additionalStyles?: StyleProp<ViewStyle>;
 
@@ -56,6 +60,7 @@ function Icon({
     height = variables.iconSizeNormal,
     fill = undefined,
     small = false,
+                  hasText = false,
     large = false,
     medium = false,
     inline = false,
@@ -67,7 +72,7 @@ function Icon({
 }: IconProps) {
     const StyleUtils = useStyleUtils();
     const styles = useThemeStyles();
-    const {width: iconWidth, height: iconHeight} = StyleUtils.getIconWidthAndHeightStyle(small, medium, large, width, height);
+    const {width: iconWidth, height: iconHeight} = StyleUtils.getIconWidthAndHeightStyle(small, medium, large, width, height, hasText);
     const iconStyles = [StyleUtils.getWidthAndHeightStyle(width ?? 0, height), IconWrapperStyles, styles.pAbsolute, additionalStyles];
 
     if (inline) {

--- a/src/pages/ReimbursementAccount/BankAccountStep.js
+++ b/src/pages/ReimbursementAccount/BankAccountStep.js
@@ -135,6 +135,7 @@ function BankAccountStep(props) {
                         )}
                         <Button
                             icon={Expensicons.Bank}
+                            iconStyles={[styles.mr5]}
                             text={props.translate('bankAccount.connectOnlineWithPlaid')}
                             onPress={() => {
                                 if (props.isPlaidDisabled || !props.user.validated) {
@@ -148,6 +149,7 @@ function BankAccountStep(props) {
                             shouldShowRightIcon
                             success
                             large
+                            innerStyles={[styles.pr2]}
                         />
                         {Boolean(props.error) && <Text style={[styles.formError, styles.mh5]}>{props.error}</Text>}
                         <View style={[styles.mv3]}>

--- a/src/pages/ReimbursementAccount/BankAccountStep.js
+++ b/src/pages/ReimbursementAccount/BankAccountStep.js
@@ -135,7 +135,7 @@ function BankAccountStep(props) {
                         )}
                         <Button
                             icon={Expensicons.Bank}
-                            iconStyles={[styles.mr5]}
+                            iconStyles={[styles.mr23]}
                             text={props.translate('bankAccount.connectOnlineWithPlaid')}
                             onPress={() => {
                                 if (props.isPlaidDisabled || !props.user.validated) {
@@ -148,8 +148,7 @@ function BankAccountStep(props) {
                             style={[styles.mt4]}
                             shouldShowRightIcon
                             success
-                            large
-                            innerStyles={[styles.pr2]}
+                            innerStyles={[styles.pr2, styles.pl4, styles.h52]}
                         />
                         {Boolean(props.error) && <Text style={[styles.formError, styles.mh5]}>{props.error}</Text>}
                         <View style={[styles.mv3]}>

--- a/src/pages/ReimbursementAccount/BankAccountStep.js
+++ b/src/pages/ReimbursementAccount/BankAccountStep.js
@@ -135,7 +135,7 @@ function BankAccountStep(props) {
                         )}
                         <Button
                             icon={Expensicons.Bank}
-                            iconStyles={[styles.mr23]}
+                            iconStyles={[styles.customMarginButtonWithMenuItem]}
                             text={props.translate('bankAccount.connectOnlineWithPlaid')}
                             onPress={() => {
                                 if (props.isPlaidDisabled || !props.user.validated) {
@@ -148,7 +148,7 @@ function BankAccountStep(props) {
                             style={[styles.mt4]}
                             shouldShowRightIcon
                             success
-                            innerStyles={[styles.pr2, styles.pl4, styles.h52]}
+                            innerStyles={[styles.pr2, styles.pl4, styles.h13]}
                         />
                         {Boolean(props.error) && <Text style={[styles.formError, styles.mh5]}>{props.error}</Text>}
                         <View style={[styles.mv3]}>

--- a/src/pages/ReimbursementAccount/ConnectBankAccount/components/FinishChatCard.tsx
+++ b/src/pages/ReimbursementAccount/ConnectBankAccount/components/FinishChatCard.tsx
@@ -39,12 +39,13 @@ function FinishChatCard({requiresTwoFactorAuth, reimbursementAccount}: FinishCha
             >
                 <Text style={styles.mb6}>{translate('connectBankAccountStep.letsChatText')}</Text>
                 <Button
+                    iconStyles={[styles.mr23]}
                     text={translate('connectBankAccountStep.letsChatCTA')}
                     onPress={handleNavigateToConciergeChat}
                     icon={Expensicons.ChatBubble}
                     shouldShowRightIcon
-                    large
                     success
+                    innerStyles={[styles.pr2, styles.pl4, styles.h52]}
                 />
                 <MenuItem
                     title={translate('workspace.bankAccount.noLetsStartOver')}

--- a/src/pages/ReimbursementAccount/ConnectBankAccount/components/FinishChatCard.tsx
+++ b/src/pages/ReimbursementAccount/ConnectBankAccount/components/FinishChatCard.tsx
@@ -39,13 +39,13 @@ function FinishChatCard({requiresTwoFactorAuth, reimbursementAccount}: FinishCha
             >
                 <Text style={styles.mb6}>{translate('connectBankAccountStep.letsChatText')}</Text>
                 <Button
-                    iconStyles={[styles.mr23]}
+                    iconStyles={[styles.customMarginButtonWithMenuItem]}
                     text={translate('connectBankAccountStep.letsChatCTA')}
                     onPress={handleNavigateToConciergeChat}
                     icon={Expensicons.ChatBubble}
                     shouldShowRightIcon
                     success
-                    innerStyles={[styles.pr2, styles.pl4, styles.h52]}
+                    innerStyles={[styles.pr2, styles.pl4, styles.h13]}
                 />
                 <MenuItem
                     title={translate('workspace.bankAccount.noLetsStartOver')}

--- a/src/pages/workspace/categories/WorkspaceCategoriesPage.tsx
+++ b/src/pages/workspace/categories/WorkspaceCategoriesPage.tsx
@@ -236,7 +236,7 @@ function WorkspaceCategoriesPage({policy, policyCategories, route}: WorkspaceCat
                         onPress={navigateToCreateCategoryPage}
                         icon={Expensicons.Plus}
                         text={translate('workspace.categories.addCategory')}
-                        style={[styles.pr2, isSmallScreenWidth && styles.w50]}
+                        style={[styles.mr3, isSmallScreenWidth && styles.w50]}
                     />
                 )}
                 <Button

--- a/src/pages/workspace/categories/WorkspaceCategoriesPage.tsx
+++ b/src/pages/workspace/categories/WorkspaceCategoriesPage.tsx
@@ -243,7 +243,6 @@ function WorkspaceCategoriesPage({policy, policyCategories, route}: WorkspaceCat
                     medium
                     onPress={navigateToCategoriesSettings}
                     icon={Expensicons.Gear}
-                    iconStyles={[styles.mr2]}
                     text={translate('common.settings')}
                     style={[isSmallScreenWidth && styles.w50]}
                 />

--- a/src/pages/workspace/tags/WorkspaceTagsPage.tsx
+++ b/src/pages/workspace/tags/WorkspaceTagsPage.tsx
@@ -136,7 +136,6 @@ function WorkspaceTagsPage({policyTags, route}: WorkspaceTagsPageProps) {
                     medium
                     onPress={navigateToTagsSettings}
                     icon={Expensicons.Gear}
-                    iconStyles={[styles.mr2]}
                     text={translate('common.settings')}
                     style={[isSmallScreenWidth && styles.w50]}
                 />

--- a/src/pages/workspace/tags/WorkspaceTagsPage.tsx
+++ b/src/pages/workspace/tags/WorkspaceTagsPage.tsx
@@ -129,7 +129,7 @@ function WorkspaceTagsPage({policyTags, route}: WorkspaceTagsPageProps) {
                 onPress={navigateToCreateTagPage}
                 icon={Expensicons.Plus}
                 text={translate('workspace.tags.addTag')}
-                style={[styles.pr2, isSmallScreenWidth && styles.w50]}
+                style={[styles.mr3, isSmallScreenWidth && styles.w50]}
             />
             {policyTags && (
                 <Button

--- a/src/styles/index.ts
+++ b/src/styles/index.ts
@@ -573,6 +573,7 @@ const styles = (theme: ThemeColors) =>
         buttonSmall: {
             borderRadius: variables.buttonBorderRadius,
             minHeight: variables.componentSizeSmall,
+            minWidth: variables.componentSizeSmall,
             paddingHorizontal: 12,
             backgroundColor: theme.buttonDefaultBG,
         },
@@ -580,6 +581,7 @@ const styles = (theme: ThemeColors) =>
         buttonMedium: {
             borderRadius: variables.buttonBorderRadius,
             minHeight: variables.componentSizeNormal,
+            minWidth: variables.componentSizeNormal,
             paddingHorizontal: 16,
             backgroundColor: theme.buttonDefaultBG,
         },
@@ -587,6 +589,7 @@ const styles = (theme: ThemeColors) =>
         buttonLarge: {
             borderRadius: variables.buttonBorderRadius,
             minHeight: variables.componentSizeLarge,
+            minWidth: variables.componentSizeLarge,
             paddingHorizontal: 20,
             backgroundColor: theme.buttonDefaultBG,
         },

--- a/src/styles/index.ts
+++ b/src/styles/index.ts
@@ -2094,6 +2094,10 @@ const styles = (theme: ThemeColors) =>
             alignSelf: 'flex-end',
         },
 
+        customMarginButtonWithMenuItem: {
+            marginRight: variables.bankButtonMargin,
+        },
+
         composerSizeButton: {
             alignSelf: 'center',
             height: 32,

--- a/src/styles/utils/index.ts
+++ b/src/styles/utils/index.ts
@@ -485,6 +485,9 @@ function getButtonStyleWithIcon(
     shouldShowRightIcon?: boolean,
 ): ViewStyle | undefined {
     const useDefaultButtonStyles = Boolean(hasIcon && shouldShowRightIcon) || Boolean(!hasIcon && !shouldShowRightIcon);
+    if (hasIcon && !hasText) {
+        return {...styles.buttonMedium, ...styles.ph0};
+    }
     switch (true) {
         case small: {
             const verticalStyle = hasIcon ? styles.pl2 : styles.pr2;

--- a/src/styles/utils/index.ts
+++ b/src/styles/utils/index.ts
@@ -461,14 +461,14 @@ function getWidthAndHeightStyle(width: number, height?: number): Pick<ViewStyle,
     };
 }
 
-function getIconWidthAndHeightStyle(small: boolean, medium: boolean, large: boolean, width: number, height: number): Pick<ImageSVGProps, 'width' | 'height'> {
+function getIconWidthAndHeightStyle(small: boolean, medium: boolean, large: boolean, width: number, height: number, hasText?: boolean): Pick<ImageSVGProps, 'width' | 'height'> {
     switch (true) {
         case small:
-            return {width: variables.iconSizeExtraSmall, height: variables.iconSizeExtraSmall};
+            return {width: hasText ? variables.iconSizeExtraSmall : variables.iconSizeSmall, height: hasText ? variables.iconSizeExtraSmall : variables?.iconSizeSmall};
         case medium:
-            return {width: variables.iconSizeSmall, height: variables.iconSizeSmall};
+            return {width: hasText ? variables.iconSizeSmall : variables.iconSizeNormal, height: hasText ? variables.iconSizeSmall : variables.iconSizeNormal};
         case large:
-            return {width: variables.iconSizeNormal, height: variables.iconSizeNormal};
+            return {width: hasText ? variables.iconSizeNormal : variables.iconSizeLarge, height: hasText ? variables.iconSizeNormal : variables.iconSizeLarge};
         default: {
             return {width, height};
         }
@@ -485,9 +485,6 @@ function getButtonStyleWithIcon(
     shouldShowRightIcon?: boolean,
 ): ViewStyle | undefined {
     const useDefaultButtonStyles = Boolean(hasIcon && shouldShowRightIcon) || Boolean(!hasIcon && !shouldShowRightIcon);
-    if (hasIcon && !hasText) {
-        return {...styles.buttonMedium, ...styles.ph0};
-    }
     switch (true) {
         case small: {
             const verticalStyle = hasIcon ? styles.pl2 : styles.pr2;
@@ -502,6 +499,10 @@ function getButtonStyleWithIcon(
             return useDefaultButtonStyles ? styles.buttonLarge : {...styles.buttonLarge, ...(hasText ? verticalStyle : styles.ph0)};
         }
         default: {
+            if (hasIcon && !hasText) {
+                return {...styles.buttonMedium, ...styles.ph0};
+            }
+
             return undefined;
         }
     }

--- a/src/styles/utils/sizing.ts
+++ b/src/styles/utils/sizing.ts
@@ -14,7 +14,7 @@ export default {
         height: 272,
     },
 
-    h52: {
+    h13: {
         height: 52,
     },
 

--- a/src/styles/utils/sizing.ts
+++ b/src/styles/utils/sizing.ts
@@ -14,6 +14,10 @@ export default {
         height: 272,
     },
 
+    h52: {
+        height: 52,
+    },
+
     w15: {
         width: '15%',
     },

--- a/src/styles/utils/spacing.ts
+++ b/src/styles/utils/spacing.ts
@@ -119,10 +119,6 @@ export default {
         marginRight: 20,
     },
 
-    mr23: {
-        marginRight: 23,
-    },
-
     mr8: {
         marginRight: 32,
     },

--- a/src/styles/utils/spacing.ts
+++ b/src/styles/utils/spacing.ts
@@ -119,6 +119,10 @@ export default {
         marginRight: 20,
     },
 
+    mr23: {
+        marginRight: 23,
+    },
+
     mr8: {
         marginRight: 32,
     },

--- a/src/styles/utils/spacing.ts
+++ b/src/styles/utils/spacing.ts
@@ -485,6 +485,10 @@ export default {
         paddingRight: 32,
     },
 
+    pr10: {
+        paddingRight: 40,
+    },
+
     pr15: {
         paddingRight: 60,
     },

--- a/src/styles/variables.ts
+++ b/src/styles/variables.ts
@@ -222,4 +222,5 @@ export default {
 
     mushroomTopHatWidth: 138,
     mushroomTopHatHeight: 128,
+    bankButtonMargin: 23,
 } as const;


### PR DESCRIPTION
### Details
Fix button for distance and quick actions for messages

### Fixed Issues

$ https://github.com/Expensify/App/issues/38266
$ https://github.com/Expensify/App/issues/38264
$ https://github.com/Expensify/App/issues/38284
$ https://github.com/Expensify/App/issues/38291
PROPOSAL:


### Tests
Checking quick actions:
1. Go to any chat
2. Send a message
3. Hover over the message for the action menu to appear

Checking distance button:
1. Go to https://staging.new.expensify.com/
2. Tap fab ---Request money--Distance
3. Enter start and stop point
4. Note Add stop button

Checking rotate button:
1. Access staging.new.expensify.com
2. Sign into any account
3. Go to Profile Pic or WS Pic and tap on Upload
4. Observe the rotate button

- [x] Verify that no errors appear in the JS console

### Offline tests
Checking quick actions:
1. Go to any chat
2. Send a message
3. Hover over the message for the action menu to appear

Checking distance button:
1. Go to https://staging.new.expensify.com/
2. Tap fab ---Request money--Distance
3. Enter start and stop point
4. Note Add stop button

Checking rotate button:
1. Access staging.new.expensify.com
2. Sign into any account
3. Go to Profile Pic or WS Pic and tap on Upload
4. Observe the rotate button

### QA Steps
Checking quick actions:
1. Go to any chat
2. Send a message
3. Hover over the message for the action menu to appear

Checking distance button:
1. Go to https://staging.new.expensify.com/
2. Tap fab ---Request money--Distance
3. Enter start and stop point
4. Note Add stop button

Checking rotate button:
1. Access staging.new.expensify.com
2. Sign into any account
3. Go to Profile Pic or WS Pic and tap on Upload
4. Observe the rotate button

- [x] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

![android1](https://github.com/Expensify/App/assets/28352309/60f47495-54c4-4c1c-8922-4029122ad1fb)
![android2](https://github.com/Expensify/App/assets/28352309/c46d1c87-5c39-4d58-8b75-ca571cf34718)
![android](https://github.com/Expensify/App/assets/28352309/bc6e2d01-40c9-4656-b000-337b0cf63ce9)


</details>

<details>
<summary>Android: mWeb Chrome</summary>

![android-web](https://github.com/Expensify/App/assets/28352309/91365bea-e09d-4bb2-a11d-0a16c44f544e)
![android-web2](https://github.com/Expensify/App/assets/28352309/f9d6322f-2dc3-4920-a534-eb7ad8afab1c)
![android-web3](https://github.com/Expensify/App/assets/28352309/709b275e-584d-4297-896c-b94d26a830d6)


</details>

<details>
<summary>iOS: Native</summary>

![ios1](https://github.com/Expensify/App/assets/28352309/1a1fdc45-1c08-4e16-a863-5195d60b8681)
![ios2](https://github.com/Expensify/App/assets/28352309/f0d3b4fd-e125-47d5-8d21-5c7ea6fcf2d4)
![ios4](https://github.com/Expensify/App/assets/28352309/a9ac4d71-8951-49d4-a44e-e59811fbd69c)


</details>

<details>
<summary>iOS: mWeb Safari</summary>

![ios-web1](https://github.com/Expensify/App/assets/28352309/1b1096d7-e0a3-4c0f-ba87-c40787eff651)
![ios-web2](https://github.com/Expensify/App/assets/28352309/6d15c36a-cdd2-4cc9-b350-2519a6791b26)
![ios-web4](https://github.com/Expensify/App/assets/28352309/2a7fc638-0ec6-4f1c-9039-c669066b106e)


</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<img width="378" alt="web1" src="https://github.com/Expensify/App/assets/28352309/4e2dde40-d57f-425b-9fb8-35ee792f9e00">
<img width="1341" alt="web2" src="https://github.com/Expensify/App/assets/28352309/a08a76eb-ed63-4cea-99ed-5439606c9d76">
<img width="390" alt="Screenshot 2024-03-14 at 15 10 39" src="https://github.com/Expensify/App/assets/28352309/7616b137-c720-4015-b756-773611bc4b9b">


</details>

<details>
<summary>MacOS: Desktop</summary>

<img width="818" alt="desktop1" src="https://github.com/Expensify/App/assets/28352309/21db8eb5-4fd4-4edc-bdeb-d61df2a4449b">
<img width="396" alt="desktop2" src="https://github.com/Expensify/App/assets/28352309/a10ca912-2348-41a5-a149-5cd15475ae52">
<img width="390" alt="Screenshot 2024-03-14 at 15 10 39" src="https://github.com/Expensify/App/assets/28352309/7616b137-c720-4015-b756-773611bc4b9b">



</details>
