### PR TITLE
[NoQA] fix: real startup metric

### DIFF
--- a/src/Expensify.tsx
+++ b/src/Expensify.tsx
@@ -22,6 +22,7 @@ import * as Growl from './libs/Growl';
 import Log from './libs/Log';
 import migrateOnyx from './libs/migrateOnyx';
 import Navigation from './libs/Navigation/Navigation';
+import Performance from './libs/Performance';
 import NavigationRoot from './libs/Navigation/NavigationRoot';
 import NetworkConnection from './libs/NetworkConnection';
 import PushNotification from './libs/Notification/PushNotification';
@@ -130,6 +131,7 @@ function Expensify({
 
     const onSplashHide = useCallback(() => {
         setIsSplashHidden(true);
+        Performance.markEnd(CONST.TIMING.SIDEBAR_LOADED);
     }, []);
 
     useLayoutEffect(() => {

--- a/src/Expensify.tsx
+++ b/src/Expensify.tsx
@@ -22,11 +22,11 @@ import * as Growl from './libs/Growl';
 import Log from './libs/Log';
 import migrateOnyx from './libs/migrateOnyx';
 import Navigation from './libs/Navigation/Navigation';
-import Performance from './libs/Performance';
 import NavigationRoot from './libs/Navigation/NavigationRoot';
 import NetworkConnection from './libs/NetworkConnection';
 import PushNotification from './libs/Notification/PushNotification';
 import './libs/Notification/PushNotification/subscribePushNotification';
+import Performance from './libs/Performance';
 import StartupTimer from './libs/StartupTimer';
 // This lib needs to be imported, but it has nothing to export since all it contains is an Onyx connection
 import './libs/UnreadIndicatorUpdater';

--- a/src/libs/actions/App.ts
+++ b/src/libs/actions/App.ts
@@ -131,7 +131,6 @@ function setSidebarLoaded() {
     }
 
     Onyx.set(ONYXKEYS.IS_SIDEBAR_LOADED, true);
-    Performance.markEnd(CONST.TIMING.SIDEBAR_LOADED);
     Performance.markStart(CONST.TIMING.REPORT_INITIAL_RENDER);
 }
 


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details

Changed a place where we capture a metric according to https://github.com/Expensify/App/commit/452595f48ac6bce07a69c7f750b0083e8a799171 but made it cross-platform.

How it affected TTI can be found below (captured in dev mode):

<details>
  <summary>Before</summary>

  ```js
{
    'App start nativeLaunch': [
       863,  919, 1081,  880,
       976,  878,  935, 1000,
      1111, 1032, 1101, 1164,
      1368, 1061, 1010, 1005,
      1080
    ],
    'App start regularAppStart': [
      0.7206630110740662, 0.7102870345115662,
      0.7419430017471313,  4.367106020450592,
      0.7322189807891846, 0.8898509740829468,
      0.9326990246772766, 0.7942700386047363,
      0.9451090097427368, 1.0676679611206055,
      0.7550860047340393, 0.8267410397529602,
      1.0378819704055786, 0.8785799741744995,
      1.0087479948997498, 0.7564700245857239,
      0.7955319881439209
    ],
    'App start runJsBundle': [
      5116, 5623, 5758, 7363,
      6115, 6145, 6820, 6084,
      6862, 7561, 6805, 6834,
      7409, 6988, 7056, 6831,
      5970
    ],
    'App start TTI': [
       11338.93211299181, 12159.524770975113,
       12636.31477600336,  29511.34791201353,
      12840.107114970684, 12998.940169990063,
      13401.366120994091, 13801.768064975739,
       14274.89665299654, 15361.110975980759,
      13998.597352027893, 14445.537382006645,
      15227.997309982777, 14070.840213000774,
      14286.960296988487, 14210.092343986034,
       12750.73859000206
    ],
    'App start jsBundleDownload': [
      1100, 1105, 1135, 1175,
      1174, 1154, 1175, 1176,
      1212, 1179, 1122, 1153,
      1183, 1180, 1162, 1173,
      1158
    ]
  }
}
```
</details>

<details>
  <summary>After</summary>

```js
{
  compareEntries: undefined,
  baselineEntries: {
    'App start nativeLaunch': [
       726,  682, 671,  727,
       753,  891, 936,  839,
       897,  943, 996, 1016,
      1209, 1323, 943,  928,
      1067
    ],
    'App start TTI': [
       9180.628776013851,  9095.821936011314,
       8975.761027991772,  9565.689173996449,
      10251.910939991474, 11852.394060015678,
      12409.389752984047, 12952.296458005905,
      13160.995357990265, 13775.297976970673,
      13346.554168999195, 14187.704729020596,
      14563.292831003666,  15174.43627101183,
      13451.611326992512, 15328.591274023056,
      13972.332086026669
    ],
    'App start runJsBundle': [
      3758, 3803, 3910, 4059,
      4463, 5465, 5688, 5999,
      6099, 6854, 6118, 6779,
      6932, 7374, 6479, 6518,
      6686
    ],
    'App start regularAppStart': [
      0.5345460176467896, 0.5147709846496582,
      0.5024820566177368, 0.5381669998168945,
      0.6133219599723816, 0.6979569792747498,
       1.019327998161316,    0.8785400390625,
      0.9008379578590393, 0.6569010019302368,
      0.7740480303764343, 0.8857830166816711,
      0.8989670276641846, 0.8822020292282104,
      0.8953449726104736, 0.8267419934272766,
      0.8535969853401184
    ],
    'App start jsBundleDownload': [
      1147, 1141, 1163, 1130,
      1185, 1181, 1127, 1145,
      1139, 1166, 1208, 1186,
      1153, 1182, 1160, 1142,
      1136
    ]
  }
}
```
</details>

### Fixed Issues

$ https://github.com/Expensify/App/issues/35234#issuecomment-1911966264
PROPOSAL: https://github.com/Expensify/App/issues/35234#issuecomment-1911966264


### Tests

- run e2e tests;
- be sure that TTI metric still can be collected;

- [ ] Verify that no errors appear in the JS console

### Offline tests

N/A

### QA Steps

- run e2e tests;
- be sure that TTI metric still can be collected;

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

![telegram-cloud-photo-size-2-5201748975563168202-y](https://github.com/Expensify/App/assets/22820318/c042e343-1095-4339-b208-5527c8359a33)

</details>

<details>
<summary>Android: mWeb Chrome</summary>

![telegram-cloud-photo-size-2-5201748975563168210-y](https://github.com/Expensify/App/assets/22820318/f925b71b-9594-4ff8-86ee-e3b7487bf466)

</details>

<details>
<summary>iOS: Native</summary>

![image](https://github.com/Expensify/App/assets/22820318/b0b40f31-7dee-4363-89b0-1c2f7bd31d47)

</details>

<details>
<summary>iOS: mWeb Safari</summary>

![image](https://github.com/Expensify/App/assets/22820318/501b0f8e-80d3-40e8-8426-0f4f9579ef3f)

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<img width="2545" alt="image" src="https://github.com/Expensify/App/assets/22820318/db3fe275-b5f4-4d79-9806-868862704319">

</details>

<details>
<summary>MacOS: Desktop</summary>

<img width="1188" alt="image" src="https://github.com/Expensify/App/assets/22820318/ce48fe00-f205-44d4-b05d-8440b6b33254">

</details>
