### PR TITLE
[NoQA] feat: more startup marks

### DIFF
--- a/android/app/src/main/java/com/expensify/chat/MainActivity.kt
+++ b/android/app/src/main/java/com/expensify/chat/MainActivity.kt
@@ -14,6 +14,8 @@ import com.facebook.react.ReactActivityDelegate
 import com.facebook.react.defaults.DefaultNewArchitectureEntryPoint.fabricEnabled
 import com.facebook.react.defaults.DefaultReactActivityDelegate
 
+import com.oblador.performance.RNPerformance
+
 class MainActivity : ReactActivity() {
     /**
      * Returns the name of the main component registered from JavaScript. This is used to schedule
@@ -81,5 +83,10 @@ class MainActivity : ReactActivity() {
         }
         KeyCommandModule.getInstance().onKeyDownEvent(keyCode, event)
         return super.onKeyUp(keyCode, event)
+    }
+
+    override fun onStart() {
+        super.onStart()
+        RNPerformance.getInstance().mark("appCreationEnd", false);
     }
 }

--- a/android/app/src/main/java/com/expensify/chat/MainApplication.kt
+++ b/android/app/src/main/java/com/expensify/chat/MainApplication.kt
@@ -15,6 +15,7 @@ import com.facebook.react.defaults.DefaultReactNativeHost
 import com.facebook.react.modules.i18nmanager.I18nUtil
 import com.facebook.soloader.SoLoader
 import com.google.firebase.crashlytics.FirebaseCrashlytics
+import com.oblador.performance.RNPerformance
 import expo.modules.ApplicationLifecycleDispatcher
 import expo.modules.ReactNativeHostWrapper
 
@@ -41,6 +42,8 @@ class MainApplication : MultiDexApplication(), ReactApplication {
 
     override fun onCreate() {
         super.onCreate()
+
+        RNPerformance.getInstance().mark("appCreationStart", false);
 
         if (isOnfidoProcess()) {
             return

--- a/src/libs/Performance.tsx
+++ b/src/libs/Performance.tsx
@@ -134,6 +134,13 @@ if (Metrics.canCapturePerformanceMetrics()) {
                 if (entry.name === 'runJsBundleEnd') {
                     Performance.measureFailSafe('runJsBundle', 'runJsBundleStart', 'runJsBundleEnd');
                 }
+                if (entry.name === 'appCreationEnd') {
+                    Performance.measureFailSafe('appCreation', 'appCreationStart', 'appCreationEnd');
+                    Performance.measureFailSafe('nativeLaunchEnd_To_appCreationStart', 'nativeLaunchEnd', 'appCreationStart');
+                }
+                if (entry.name === 'contentAppeared') {
+                    Performance.measureFailSafe('appCreationEnd_To_contentAppeared', 'appCreationEnd', 'contentAppeared');
+                }
 
                 // We don't need to keep the observer past this point
                 if (entry.name === 'runJsBundleEnd' || entry.name === 'downloadEnd') {
@@ -154,6 +161,7 @@ if (Metrics.canCapturePerformanceMetrics()) {
 
                 // Capture any custom measures or metrics below
                 if (mark.name === `${CONST.TIMING.SIDEBAR_LOADED}_end`) {
+                    Performance.measureFailSafe('contentAppeared_To_screenTTI', 'contentAppeared', mark.name);
                     Performance.measureTTI(mark.name);
                 }
             });
@@ -163,6 +171,10 @@ if (Metrics.canCapturePerformanceMetrics()) {
     Performance.getPerformanceMetrics = (): PerformanceEntry[] =>
         [
             ...rnPerformance.getEntriesByName('nativeLaunch'),
+            ...rnPerformance.getEntriesByName('nativeLaunchEnd_To_appCreationStart'),
+            ...rnPerformance.getEntriesByName('appCreation'),
+            ...rnPerformance.getEntriesByName('appCreationEnd_To_contentAppeared'),
+            ...rnPerformance.getEntriesByName('contentAppeared_To_screenTTI'),
             ...rnPerformance.getEntriesByName('runJsBundle'),
             ...rnPerformance.getEntriesByName('jsBundleDownload'),
             ...rnPerformance.getEntriesByName('TTI'),


### PR DESCRIPTION
### Details

Capture new metrics:
- `appCreation`
- `nativeLaunchEnd_To_appCreationStart`
- `appCreationEnd_To_contentAppeared`
- `contentAppeared_To_screenTTI`

A sequence of all events is shown in this diagram (credits to @hurali97)

![image](https://github.com/Expensify/App/assets/22820318/d5ad6ddb-5818-4250-87c7-43ba0e3c2dba)

To verify that metrics are calculated properly we can use next equation:

`TTI = nativeLaunch + nativeLaunchEnd_To_appCreationStart + appCreation + appCreationEnd_To_contentAppeared + contentAppeared_To_screenTTI`

An example of metrics:

<details>
  <summary>Debug</summary>

  ```js
{
    'App start nativeLaunch': [
      614, 605, 620, 601, 632,
      613, 623, 655, 651, 655,
      646, 670, 656, 684, 686,
      730, 691
    ],
    'App start appCreation': [
      226, 200, 226, 189, 212,
      206, 212, 209, 239, 247,
      215, 206, 253, 210, 215,
      233, 257
    ],
    'App start contentAppeared_To_screenTTI': [
      2297.5213369727135, 2147.9439079761505,
      2096.1065099835396, 2204.7391229867935,
       2215.209748983383, 2164.7248899936676,
       2364.765137016773, 2379.7745000123978,
       2363.229461014271, 2377.0611709952354,
      2460.2801690101624, 2350.8586649894714,
       2364.095607995987,  2416.493358016014,
      2559.1686559915543, 2440.7956550121307,
      2477.9847869873047
    ],
    'App start appCreationEnd_To_contentAppeared': [
      4830, 5069, 4998, 4905,
      5014, 4927, 5027, 5273,
      5267, 5159, 5250, 5267,
      5287, 5386, 5674, 5651,
      5597
    ],
    'App start nativeLaunchEnd_To_appCreationStart': [
      155, 156, 138, 155, 162,
      147, 154, 161, 165, 144,
      154, 147, 160, 156, 163,
      159, 150
    ],
    'App start jsBundleDownload': [
      1032, 1106, 1107, 1050,
      1083, 1068, 1119, 1016,
      1063, 1107, 1071, 1115,
      1067, 1044, 1078, 1101,
      1094
    ],
    'App start runJsBundle': [
      3325, 3413, 3306, 3320,
      3390, 3347, 3434, 3617,
      3581, 3498, 3652, 3600,
      3641, 3763, 4030, 3945,
      3896
    ],
    'App start TTI': [
      8122.5213369727135, 8177.9439079761505,
        8078.10650998354, 8054.7391229867935,
       8235.209748983383,  8057.724889993668,
       8380.765137016773,  8677.774500012398,
        8685.22946101427,  8582.061170995235,
       8725.280169010162,  8640.858664989471,
       8720.095607995987,  8852.493358016014,
       9297.168655991554,   9213.79565501213,
       9172.984786987305
    ],
    'App start regularAppStart': [
       0.4095050096511841, 0.46081602573394775,
      0.48258501291275024,  0.3986409902572632,
      0.39428699016571045, 0.40445899963378906,
       0.4330649971961975, 0.46696001291275024,
       0.4245610237121582, 0.43420398235321045,
       0.4852699637413025, 0.45882201194763184,
      0.43571001291275024,  0.4542649984359741,
      0.49698901176452637, 0.45845603942871094,
       0.4975999593734741
    ]
  }
  ```
</details>

<details>
  <summary>Release</summary>

  ```js
{
    'App start nativeLaunch': [
      77, 48, 46, 58,
      49, 51, 49, 49
    ],
    'App start nativeLaunchEnd_To_appCreationStart': [
      51, 95, 47, 62,
      51, 48, 41, 40
    ],
    'App start appCreationEnd_To_contentAppeared': [
      438, 461, 428,
      474, 420, 432,
      447, 509
    ],
    'App start contentAppeared_To_screenTTI': [
      752.8226479887962,
      729.9659600257874,
      886.4854120016098,
      844.554790019989,
      774.1200180053711,
      863.9782549738884,
      860.0640730261803,
      887.7919390201569
    ],
    'App start appCreation': [
      67, 64, 75, 68,
      76, 77, 70, 70
    ],
    'App start runJsBundle': [
      363, 380, 343,
      378, 344, 355,
      371, 422
    ],
    'App start regularAppStart': [
      0.01904296875,
      0.01757800579071045,
      0.01810699701309204,
      0.016071975231170654,
      0.016317009925842285,
      0.018310964107513428,
      0.017089009284973145,
      0.027547001838684082
    ],
    'App start TTI': [
      1385.8226479887962,
      1397.9659600257874,
      1482.4854120016098,
      1506.554790019989,
      1370.120018005371,
      1471.9782549738884,
      1467.0640730261803,
      1555.7919390201569
    ]
  }
  ```
</details>

### Fixed Issues
$ https://github.com/Expensify/App/issues/35234#issuecomment-1911966264
PROPOSAL: https://github.com/Expensify/App/issues/35234#issuecomment-1911966264

### Tests

- run e2e tests and gather metrics;
- be sure that formula in description produces valid output.

- [x] Verify that no errors appear in the JS console

### Offline tests

N/A

### QA Steps

- run e2e tests and gather metrics;
- be sure that formula in description produces valid output.

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

![telegram-cloud-photo-size-2-5201748975563168202-y](https://github.com/Expensify/App/assets/22820318/c042e343-1095-4339-b208-5527c8359a33)

</details>

<details>
<summary>Android: mWeb Chrome</summary>

![telegram-cloud-photo-size-2-5201748975563168210-y](https://github.com/Expensify/App/assets/22820318/f925b71b-9594-4ff8-86ee-e3b7487bf466)

</details>

<details>
<summary>iOS: Native</summary>

![image](https://github.com/Expensify/App/assets/22820318/b0b40f31-7dee-4363-89b0-1c2f7bd31d47)

</details>

<details>
<summary>iOS: mWeb Safari</summary>

![image](https://github.com/Expensify/App/assets/22820318/501b0f8e-80d3-40e8-8426-0f4f9579ef3f)

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<img width="2545" alt="image" src="https://github.com/Expensify/App/assets/22820318/db3fe275-b5f4-4d79-9806-868862704319">

</details>

<details>
<summary>MacOS: Desktop</summary>

<img width="1188" alt="image" src="https://github.com/Expensify/App/assets/22820318/ce48fe00-f205-44d4-b05d-8440b6b33254">

</details>
