### PR TITLE
[CP Staging] Fix Split Scan flow for Group Chats

### DIFF
--- a/src/CONST.ts
+++ b/src/CONST.ts
@@ -59,6 +59,9 @@ const cardActiveStates: number[] = [2, 3, 4, 7];
 const CONST = {
     MERGED_ACCOUNT_PREFIX: 'MERGED_',
     DEFAULT_POLICY_ROOM_CHAT_TYPES: [chatTypes.POLICY_ADMINS, chatTypes.POLICY_ANNOUNCE, chatTypes.DOMAIN_ALL],
+
+    // Note: Group excluded as it is not tied to any Workspace
+    WORKSPACE_ROOM_TYPES: [chatTypes.POLICY_ADMINS, chatTypes.POLICY_ANNOUNCE, chatTypes.DOMAIN_ALL, chatTypes.POLICY_ROOM, chatTypes.POLICY_EXPENSE_CHAT, chatTypes.SELF_DM],
     ANDROID_PACKAGE_NAME,
     ANIMATED_TRANSITION: 300,
     ANIMATED_TRANSITION_FROM_VALUE: 100,

--- a/src/CONST.ts
+++ b/src/CONST.ts
@@ -60,8 +60,8 @@ const CONST = {
     MERGED_ACCOUNT_PREFIX: 'MERGED_',
     DEFAULT_POLICY_ROOM_CHAT_TYPES: [chatTypes.POLICY_ADMINS, chatTypes.POLICY_ANNOUNCE, chatTypes.DOMAIN_ALL],
 
-    // Note: Group excluded as it is not tied to any Workspace
-    WORKSPACE_ROOM_TYPES: [chatTypes.POLICY_ADMINS, chatTypes.POLICY_ANNOUNCE, chatTypes.DOMAIN_ALL, chatTypes.POLICY_ROOM, chatTypes.POLICY_EXPENSE_CHAT, chatTypes.SELF_DM],
+    // Note: Group and Self-DM excluded as these are not tied to a Workspace
+    WORKSPACE_ROOM_TYPES: [chatTypes.POLICY_ADMINS, chatTypes.POLICY_ANNOUNCE, chatTypes.DOMAIN_ALL, chatTypes.POLICY_ROOM, chatTypes.POLICY_EXPENSE_CHAT],
     ANDROID_PACKAGE_NAME,
     ANIMATED_TRANSITION: 300,
     ANIMATED_TRANSITION_FROM_VALUE: 100,

--- a/src/components/RoomHeaderAvatars.tsx
+++ b/src/components/RoomHeaderAvatars.tsx
@@ -13,10 +13,15 @@ import Text from './Text';
 type RoomHeaderAvatarsProps = {
     icons: Icon[];
     reportID: string;
+    isGroupChat?: boolean;
 };
 
-function RoomHeaderAvatars({icons, reportID}: RoomHeaderAvatarsProps) {
+function RoomHeaderAvatars({icons, reportID, isGroupChat}: RoomHeaderAvatarsProps) {
     const navigateToAvatarPage = (icon: Icon) => {
+        if (isGroupChat) {
+            return;
+        }
+
         if (icon.type === CONST.ICON_TYPE_WORKSPACE) {
             Navigation.navigate(ROUTES.REPORT_AVATAR.getRoute(reportID));
             return;

--- a/src/libs/API/parameters/StartSplitBillParams.ts
+++ b/src/libs/API/parameters/StartSplitBillParams.ts
@@ -12,6 +12,7 @@ type StartSplitBillParams = {
     isFromGroupDM: boolean;
     createdReportActionID?: string;
     billable: boolean;
+    chatType?: string;
 };
 
 export default StartSplitBillParams;

--- a/src/libs/ReportUtils.ts
+++ b/src/libs/ReportUtils.ts
@@ -1193,7 +1193,7 @@ function hasOnlyTransactionsWithPendingRoutes(iouReportID: string | undefined): 
  * If the report is a thread and has a chat type set, it is a workspace chat.
  */
 function isWorkspaceThread(report: OnyxEntry<Report>): boolean {
-    return isThread(report) && isChatReport(report) && !isGroupChat(report) && !!getChatType(report);
+    return isThread(report) && isChatReport(report) && CONST.WORKSPACE_ROOM_TYPES.includes(getChatType(report));
 }
 
 /**

--- a/src/libs/ReportUtils.ts
+++ b/src/libs/ReportUtils.ts
@@ -1194,7 +1194,7 @@ function hasOnlyTransactionsWithPendingRoutes(iouReportID: string | undefined): 
  */
 function isWorkspaceThread(report: OnyxEntry<Report>): boolean {
     const chatType = getChatType(report) ?? '';
-    return isThread(report) && isChatReport(report) && CONST.WORKSPACE_ROOM_TYPES.includes(chatType);
+    return isThread(report) && isChatReport(report) && typeof chatType === 'string' && CONST.WORKSPACE_ROOM_TYPES.includes(chatType);
 }
 
 /**

--- a/src/libs/ReportUtils.ts
+++ b/src/libs/ReportUtils.ts
@@ -1193,7 +1193,7 @@ function hasOnlyTransactionsWithPendingRoutes(iouReportID: string | undefined): 
  * If the report is a thread and has a chat type set, it is a workspace chat.
  */
 function isWorkspaceThread(report: OnyxEntry<Report>): boolean {
-    return isThread(report) && isChatReport(report) && !!getChatType(report);
+    return isThread(report) && isChatReport(report) && !isGroupChat(report) && !!getChatType(report);
 }
 
 /**

--- a/src/libs/ReportUtils.ts
+++ b/src/libs/ReportUtils.ts
@@ -1193,8 +1193,8 @@ function hasOnlyTransactionsWithPendingRoutes(iouReportID: string | undefined): 
  * If the report is a thread and has a chat type set, it is a workspace chat.
  */
 function isWorkspaceThread(report: OnyxEntry<Report>): boolean {
-    const chatType = getChatType(report) ?? '';
-    return isThread(report) && isChatReport(report) && CONST.WORKSPACE_ROOM_TYPES.some(type => chatType === type);
+    const chatType = getChatType(report);
+    return isThread(report) && isChatReport(report) && CONST.WORKSPACE_ROOM_TYPES.some((type) => chatType === type);
 }
 
 /**

--- a/src/libs/ReportUtils.ts
+++ b/src/libs/ReportUtils.ts
@@ -1194,7 +1194,7 @@ function hasOnlyTransactionsWithPendingRoutes(iouReportID: string | undefined): 
  */
 function isWorkspaceThread(report: OnyxEntry<Report>): boolean {
     const chatType = getChatType(report) ?? '';
-    return isThread(report) && isChatReport(report) && typeof chatType === 'string' && CONST.WORKSPACE_ROOM_TYPES.includes(chatType);
+    return isThread(report) && isChatReport(report) && CONST.WORKSPACE_ROOM_TYPES.some(type => chatType === type);
 }
 
 /**

--- a/src/libs/ReportUtils.ts
+++ b/src/libs/ReportUtils.ts
@@ -1193,7 +1193,8 @@ function hasOnlyTransactionsWithPendingRoutes(iouReportID: string | undefined): 
  * If the report is a thread and has a chat type set, it is a workspace chat.
  */
 function isWorkspaceThread(report: OnyxEntry<Report>): boolean {
-    return isThread(report) && isChatReport(report) && CONST.WORKSPACE_ROOM_TYPES.includes(getChatType(report));
+    const chatType = getChatType(report) ?? '';
+    return isThread(report) && isChatReport(report) && CONST.WORKSPACE_ROOM_TYPES.includes(chatType);
 }
 
 /**

--- a/src/libs/actions/IOU.ts
+++ b/src/libs/actions/IOU.ts
@@ -3047,6 +3047,7 @@ function startSplitBill(
         isFromGroupDM: !existingSplitChatReport,
         billable,
         ...(existingSplitChatReport ? {} : {createdReportActionID: splitChatCreatedReportAction.reportActionID}),
+        chatType: splitChatReport?.chatType,
     };
 
     API.write(WRITE_COMMANDS.START_SPLIT_BILL, parameters, {optimisticData, successData, failureData});

--- a/src/libs/actions/IOU.ts
+++ b/src/libs/actions/IOU.ts
@@ -2642,14 +2642,14 @@ function getOrCreateSplitChatReport(existingSplitChatReportID: string, participa
             undefined,
             undefined,
             undefined,
-            CONST.REPORT.NOTIFICATION_PREFERENCE.HIDDEN
+            CONST.REPORT.NOTIFICATION_PREFERENCE.HIDDEN,
         );
     }
     if (isEmptyObject(newChat)) {
         newChat = ReportUtils.buildOptimisticChatReport(allParticipantsAccountIDs);
     }
     const splitChatReport = existingSplitChatReport ?? newChat;
-    return { splitChatReport, existingSplitChatReport };
+    return {splitChatReport, existingSplitChatReport};
 }
 
 /**

--- a/src/libs/actions/IOU.ts
+++ b/src/libs/actions/IOU.ts
@@ -2280,7 +2280,7 @@ function createSplitsAndOnyxData(
     const currentUserEmailForIOUSplit = PhoneNumber.addSMSDomainIfPhoneNumber(currentUserLogin);
     const participantAccountIDs = participants.map((participant) => Number(participant.accountID));
 
-    const {splitChatReport, existingSplitChatReport} = getOrCreateSplitChatReport(existingSplitChatReportID, participants, participantAccountIDs, currentUserAccountID);
+    const {splitChatReport, existingSplitChatReport} = getOrCreateOptimisticSplitChatReport(existingSplitChatReportID, participants, participantAccountIDs, currentUserAccountID);
     const isOwnPolicyExpenseChat = !!splitChatReport.isOwnPolicyExpenseChat;
 
     const splitTransaction = TransactionUtils.buildOptimisticTransaction(
@@ -2623,7 +2623,7 @@ function createSplitsAndOnyxData(
     };
 }
 
-function getOrCreateSplitChatReport(existingSplitChatReportID: string, participants: Participant[], participantAccountIDs: number[], currentUserAccountID: number) {
+function getOrCreateOptimisticSplitChatReport(existingSplitChatReportID: string, participants: Participant[], participantAccountIDs: number[], currentUserAccountID: number) {
     const existingChatReportID = existingSplitChatReportID || participants[0].reportID;
     let existingSplitChatReport = allReports?.[`${ONYXKEYS.COLLECTION.REPORT}${existingChatReportID}`];
     if (!existingSplitChatReport) {
@@ -2790,7 +2790,7 @@ function startSplitBill(
 ) {
     const currentUserEmailForIOUSplit = PhoneNumber.addSMSDomainIfPhoneNumber(currentUserLogin);
     const participantAccountIDs = participants.map((participant) => Number(participant.accountID));
-    const {splitChatReport, existingSplitChatReport} = getOrCreateSplitChatReport(existingSplitChatReportID, participants, participantAccountIDs, currentUserAccountID);
+    const {splitChatReport, existingSplitChatReport} = getOrCreateOptimisticSplitChatReport(existingSplitChatReportID, participants, participantAccountIDs, currentUserAccountID);
     const isOwnPolicyExpenseChat = !!splitChatReport.isOwnPolicyExpenseChat;
 
     const {name: filename, source, state = CONST.IOU.RECEIPT_STATE.SCANREADY} = receipt;

--- a/src/pages/ReportDetailsPage.tsx
+++ b/src/pages/ReportDetailsPage.tsx
@@ -218,6 +218,7 @@ function ReportDetailsPage({policies, report, session, personalDetails}: ReportD
                                 <RoomHeaderAvatars
                                     icons={icons}
                                     reportID={report?.reportID}
+                                    isGroupChat={ReportUtils.isGroupChat(report)}
                                 />
                             )}
                         </View>


### PR DESCRIPTION
### Details

@waterim @s77rt we missed a couple things. Split with a receipt should work now 🤞 

### Fixed Issues
$ https://github.com/Expensify/App/issues/39254
$ https://github.com/Expensify/App/issues/39249
$ https://github.com/Expensify/App/issues/39247

### Tests

**Split scan with Group Chats**

1. Go to FAB > Request money > Manual
2. Create a split **SCAN** request with two users with no chat history
3. Verify: The group chat avatar from the group with split scan will follow the same style as group from manual split

**Group chat avatar does not lead to "not found" page**
1. Create Group Chat
2. Tap avatar in header
3. Tap avatar on Details page
4. Confirm no navigation happens

**Confirm workspace avatar does not show for Group Chat**
1. Create Group Chat
2. Create thread
3. Navigate to thread
4. Verify avatars in header do not show "Unavailable workspace" icon

- [ ] Verify that no errors appear in the JS console

### Offline tests

Repeat steps offline - verify same

![2024-03-29_07-59-57](https://github.com/Expensify/App/assets/32969087/fb10b88e-4d46-4a2e-a0d2-1c71b2d3855b)

### QA Steps

Same as tests

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist
- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

![2024-03-29_15-03-07](https://github.com/Expensify/App/assets/32969087/0b8dadc6-f3cf-4c58-ba96-fe516323f63e)

</details>

<details>
<summary>Android: mWeb Chrome</summary>

![2024-03-29_15-13-11](https://github.com/Expensify/App/assets/32969087/0ba09621-42c5-4000-809f-99397dd78f99)

</details>

<details>
<summary>iOS: Native</summary>

![2024-03-29_13-33-56](https://github.com/Expensify/App/assets/32969087/2c3ef4b6-98b1-4bc2-8f15-ff4434dda533)

</details>

<details>
<summary>iOS: mWeb Safari</summary>

![2024-03-29_13-34-02](https://github.com/Expensify/App/assets/32969087/c04fa549-d087-47b2-a8c7-f3f130b14070)

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

![2024-03-29_07-59-57](https://github.com/Expensify/App/assets/32969087/04e28ccb-3279-4c01-b301-635c8c6c9713)

![2024-03-29_07-59-57](https://github.com/Expensify/App/assets/32969087/c2903f63-06b8-43ee-9de5-a3a9ecb8bbbc)

</details>

<details>
<summary>MacOS: Desktop</summary>

![2024-03-29_15-18-20](https://github.com/Expensify/App/assets/32969087/89a6f784-3862-4e1e-ae09-f14b87ac7ff8)

</details>
