### PR TITLE
[NoQA] feat: chat TTI

### DIFF
--- a/src/CONST.ts
+++ b/src/CONST.ts
@@ -849,6 +849,7 @@ const CONST = {
         CALCULATE_MOST_RECENT_LAST_MODIFIED_ACTION: 'calc_most_recent_last_modified_action',
         SEARCH_RENDER: 'search_render',
         CHAT_RENDER: 'chat_render',
+        OPEN_REPORT: 'open_report',
         HOMEPAGE_INITIAL_RENDER: 'homepage_initial_render',
         REPORT_INITIAL_RENDER: 'report_initial_render',
         SWITCH_REPORT: 'switch_report',

--- a/src/components/LHNOptionsList/OptionRowLHN.tsx
+++ b/src/components/LHNOptionsList/OptionRowLHN.tsx
@@ -21,6 +21,7 @@ import DateUtils from '@libs/DateUtils';
 import DomUtils from '@libs/DomUtils';
 import {getGroupChatName} from '@libs/GroupChatUtils';
 import * as OptionsListUtils from '@libs/OptionsListUtils';
+import Performance from '@libs/Performance';
 import ReportActionComposeFocusManager from '@libs/ReportActionComposeFocusManager';
 import * as ReportUtils from '@libs/ReportUtils';
 import * as ReportActionContextMenu from '@pages/home/report/ContextMenu/ReportActionContextMenu';
@@ -123,6 +124,8 @@ function OptionRowLHN({reportID, isFocused = false, onSelectRow = () => {}, opti
                     <PressableWithSecondaryInteraction
                         ref={popoverAnchor}
                         onPress={(event) => {
+                            Performance.markStart(CONST.TIMING.OPEN_REPORT);
+
                             event?.preventDefault();
                             // Enable Composer to focus on clicking the same chat after opening the context menu.
                             ReportActionComposeFocusManager.focus();

--- a/src/libs/E2E/tests/chatOpeningTest.e2e.ts
+++ b/src/libs/E2E/tests/chatOpeningTest.e2e.ts
@@ -1,3 +1,4 @@
+import Config from 'react-native-config';
 import type {NativeConfig} from 'react-native-config';
 import E2ELogin from '@libs/E2E/actions/e2eLogin';
 import waitForAppLoaded from '@libs/E2E/actions/waitForAppLoaded';
@@ -7,6 +8,16 @@ import Navigation from '@libs/Navigation/Navigation';
 import Performance from '@libs/Performance';
 import CONST from '@src/CONST';
 import ROUTES from '@src/ROUTES';
+
+function getPromiseWithResolve<T>(): [Promise<T | undefined>, (value?: T) => void] {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    let resolveFn = (_value?: T) => {};
+    const promise = new Promise<T | undefined>((resolve) => {
+        resolveFn = resolve;
+    });
+
+    return [promise, resolveFn];
+}
 
 const test = (config: NativeConfig) => {
     // check for login (if already logged in the action will simply resolve)
@@ -23,29 +34,55 @@ const test = (config: NativeConfig) => {
         }
 
         console.debug('[E2E] Logged in, getting chat opening metrics and submitting them…');
+
+        const [renderChatPromise, renderChatResolve] = getPromiseWithResolve();
+        const [chatTTIPromise, chatTTIResolve] = getPromiseWithResolve();
+
+        Promise.all([renderChatPromise, chatTTIPromise]).then(() => {
+            console.debug(`[E2E] Submitting!`);
+
+            E2EClient.submitTestDone();
+        });
+
         Performance.subscribeToMeasurements((entry) => {
             if (entry.name === CONST.TIMING.SIDEBAR_LOADED) {
                 console.debug(`[E2E] Sidebar loaded, navigating to report…`);
+                Performance.markStart(CONST.TIMING.OPEN_REPORT);
                 Navigation.navigate(ROUTES.REPORT_WITH_ID.getRoute(reportID));
                 return;
             }
+
             console.debug(`[E2E] Entry: ${JSON.stringify(entry)}`);
-            if (entry.name !== CONST.TIMING.CHAT_RENDER) {
-                return;
+
+            if (entry.name === CONST.TIMING.CHAT_RENDER) {
+                E2EClient.submitTestResults({
+                    branch: Config.E2E_BRANCH,
+                    name: 'Chat opening',
+                    duration: entry.duration,
+                })
+                    .then(() => {
+                        console.debug('[E2E] Done with chat opening, exiting…');
+                        renderChatResolve();
+                    })
+                    .catch((err) => {
+                        console.debug('[E2E] Error while submitting test results:', err);
+                    });
             }
 
-            console.debug(`[E2E] Submitting!`);
-            E2EClient.submitTestResults({
-                name: 'Chat opening',
-                duration: entry.duration,
-            })
-                .then(() => {
-                    console.debug('[E2E] Done with chat opening, exiting…');
-                    E2EClient.submitTestDone();
+            if (entry.name === CONST.TIMING.OPEN_REPORT) {
+                E2EClient.submitTestResults({
+                    branch: Config.E2E_BRANCH,
+                    name: 'Chat TTI',
+                    duration: entry.duration,
                 })
-                .catch((err) => {
-                    console.debug('[E2E] Error while submitting test results:', err);
-                });
+                    .then(() => {
+                        console.debug('[E2E] Done with chat TTI tracking, exiting…');
+                        chatTTIResolve();
+                    })
+                    .catch((err) => {
+                        console.debug('[E2E] Error while submitting test results:', err);
+                    });
+            }
         });
     });
 };

--- a/src/libs/E2E/tests/chatOpeningTest.e2e.ts
+++ b/src/libs/E2E/tests/chatOpeningTest.e2e.ts
@@ -4,20 +4,11 @@ import E2ELogin from '@libs/E2E/actions/e2eLogin';
 import waitForAppLoaded from '@libs/E2E/actions/waitForAppLoaded';
 import E2EClient from '@libs/E2E/client';
 import getConfigValueOrThrow from '@libs/E2E/utils/getConfigValueOrThrow';
+import getPromiseWithResolve from '@libs/E2E/utils/getPromiseWithResolve';
 import Navigation from '@libs/Navigation/Navigation';
 import Performance from '@libs/Performance';
 import CONST from '@src/CONST';
 import ROUTES from '@src/ROUTES';
-
-function getPromiseWithResolve<T>(): [Promise<T | undefined>, (value?: T) => void] {
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    let resolveFn = (_value?: T) => {};
-    const promise = new Promise<T | undefined>((resolve) => {
-        resolveFn = resolve;
-    });
-
-    return [promise, resolveFn];
-}
 
 const test = (config: NativeConfig) => {
     // check for login (if already logged in the action will simply resolve)

--- a/src/libs/E2E/utils/getPromiseWithResolve.ts
+++ b/src/libs/E2E/utils/getPromiseWithResolve.ts
@@ -1,0 +1,9 @@
+export default function getPromiseWithResolve<T>(): [Promise<T | undefined>, (value?: T) => void] {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    let resolveFn = (_value?: T) => {};
+    const promise = new Promise<T | undefined>((resolve) => {
+        resolveFn = resolve;
+    });
+
+    return [promise, resolveFn];
+}

--- a/src/pages/home/report/ReportActionsView.tsx
+++ b/src/pages/home/report/ReportActionsView.tsx
@@ -346,6 +346,7 @@ function ReportActionsView({
         didLayout.current = true;
         // Capture the init measurement only once not per each chat switch as the value gets overwritten
         if (!ReportActionsView.initMeasured) {
+            Performance.markEnd(CONST.TIMING.OPEN_REPORT);
             Performance.markEnd(CONST.TIMING.REPORT_INITIAL_RENDER);
             Timing.end(CONST.TIMING.REPORT_INITIAL_RENDER);
             ReportActionsView.initMeasured = true;


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details

Added `Chat TTI` metric:

```js
{
    'Chat opening': [
      364.42500799894333,  971.0976159870625,
      1022.3185229897499,  982.3613690137863,
       999.4865730106831,   887.573323994875,
       979.0697430074215, 1010.2117110192776,
      1032.6744799911976,  921.7213949859142,
       981.4588629901409, 1158.6486819982529,
       945.6628830134869, 1176.0617680251598,
      1052.8429770171642, 1118.5135499835014,
      1033.7156990170479
    ],
    'Chat TTI': [
        5074.55298101902, 1790.0745859742165,
      2051.2563489973545, 2005.0043540000916,
      1998.7331549823284, 1866.3199880123138,
      1889.6545830070972, 2032.6024180054665,
      2021.3704849779606, 1968.0362559854984,
       1953.295248001814, 2143.3363049924374,
      1900.3940030038357, 2204.9531259834766,
      2105.7273360192776, 2345.3342700004578,
       2110.460002988577
    ]
  }
```

And running a test:

```bash
➡️  Meaningless changes to duration
 - Chat opening: 1017.089 ms → 1017.089 ms 
 - Chat TTI: 2024.160 ms → 2024.160 ms 
```

### Fixed Issues

$ https://github.com/Expensify/App/issues/34494
PROPOSAL: N/A

### Tests

- run ChatOpening tests
- check that new metric is present and has valid values

- [x] Verify that no errors appear in the JS console

### Offline tests

N/A

### QA Steps

- run ChatOpening tests
- check that new metric is present and has valid values

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos

<details>
<summary>Android: Native</summary>

![telegram-cloud-photo-size-2-5201748975563168202-y](https://github.com/Expensify/App/assets/22820318/c042e343-1095-4339-b208-5527c8359a33)

</details>

<details>
<summary>Android: mWeb Chrome</summary>

![telegram-cloud-photo-size-2-5201748975563168210-y](https://github.com/Expensify/App/assets/22820318/f925b71b-9594-4ff8-86ee-e3b7487bf466)

</details>

<details>
<summary>iOS: Native</summary>

![image](https://github.com/Expensify/App/assets/22820318/b0b40f31-7dee-4363-89b0-1c2f7bd31d47)

</details>

<details>
<summary>iOS: mWeb Safari</summary>

![image](https://github.com/Expensify/App/assets/22820318/501b0f8e-80d3-40e8-8426-0f4f9579ef3f)

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<img width="2545" alt="image" src="https://github.com/Expensify/App/assets/22820318/db3fe275-b5f4-4d79-9806-868862704319">

</details>

<details>
<summary>MacOS: Desktop</summary>

<img width="1188" alt="image" src="https://github.com/Expensify/App/assets/22820318/ce48fe00-f205-44d4-b05d-8440b6b33254">

</details>
