### PR TITLE
Support markdown for description preview

### DIFF
--- a/src/components/HTMLEngineProvider/BaseHTMLEngineProvider.tsx
+++ b/src/components/HTMLEngineProvider/BaseHTMLEngineProvider.tsx
@@ -42,6 +42,11 @@ function BaseHTMLEngineProvider({textSelectable = false, children, enableExperim
                 mixedUAStyles: {...styles.colorMuted, ...styles.mb0},
                 contentModel: HTMLContentModel.block,
             }),
+            'supporting-text': HTMLElementModel.fromCustomModel({
+                tagName: 'supporting-text',
+                mixedUAStyles: {...styles.textLabelSupporting, ...styles.textNormal, ...styles.lh20},
+                contentModel: HTMLContentModel.block,
+            }),
             comment: HTMLElementModel.fromCustomModel({
                 tagName: 'comment',
                 mixedUAStyles: {whiteSpace: 'pre'},

--- a/src/components/HTMLEngineProvider/BaseHTMLEngineProvider.tsx
+++ b/src/components/HTMLEngineProvider/BaseHTMLEngineProvider.tsx
@@ -42,11 +42,6 @@ function BaseHTMLEngineProvider({textSelectable = false, children, enableExperim
                 mixedUAStyles: {...styles.colorMuted, ...styles.mb0},
                 contentModel: HTMLContentModel.block,
             }),
-            'supporting-text': HTMLElementModel.fromCustomModel({
-                tagName: 'supporting-text',
-                mixedUAStyles: {...styles.textLabelSupporting, ...styles.textNormal, ...styles.lh20},
-                contentModel: HTMLContentModel.block,
-            }),
             comment: HTMLElementModel.fromCustomModel({
                 tagName: 'comment',
                 mixedUAStyles: {whiteSpace: 'pre'},

--- a/src/components/MenuItem.tsx
+++ b/src/components/MenuItem.tsx
@@ -325,8 +325,6 @@ function MenuItem(
     const StyleUtils = useStyleUtils();
     const combinedStyle = [style, styles.popoverMenuItem];
     const {isSmallScreenWidth} = useWindowDimensions();
-    const [html, setHtml] = useState('');
-    const titleRef = useRef('');
     const {isExecuting, singleExecution, waitForNavigate} = useContext(MenuItemGroupContext) ?? {};
 
     const isDeleted = style && Array.isArray(style) ? style.includes(styles.offlineFeedback.deleted) : false;
@@ -354,26 +352,25 @@ function MenuItem(
         isDeleted ? styles.offlineFeedback.deleted : {},
     ]);
 
-    useEffect(() => {
-        if (!title || (titleRef.current.length && titleRef.current === title) || !shouldParseTitle) {
-            return;
+    const html = useMemo(() => {
+        if (!title || !shouldParseTitle) {
+            return '';
         }
         const parser = new ExpensiMark();
-        setHtml(parser.replace(title));
-        titleRef.current = title;
+        return parser.replace(title);
     }, [title, shouldParseTitle]);
 
-    const getProcessedTitle = useMemo(() => {
-        let processedTitle = '';
+    const processedTitle = useMemo(() => {
+        let titleToWrap = '';
         if (shouldRenderAsHTML) {
-            processedTitle = title ? convertToLTR(title) : '';
+            titleToWrap = title ? convertToLTR(title) : '';
         }
 
         if (shouldParseTitle) {
-            processedTitle = html;
+            titleToWrap = html;
         }
 
-        return processedTitle ? `<comment>${processedTitle}</comment>` : '';
+        return titleToWrap ? `<comment>${titleToWrap}</comment>` : '';
     }, [title, shouldRenderAsHTML, shouldParseTitle, html]);
 
     const hasPressableRightComponent = iconRight || (shouldShowRightComponent && rightComponent);
@@ -536,7 +533,7 @@ function MenuItem(
                                             <View style={[styles.flexRow, styles.alignItemsCenter]}>
                                                 {!!title && (shouldRenderAsHTML || (shouldParseTitle && !!html.length)) && (
                                                     <View style={styles.renderHTMLTitle}>
-                                                        <RenderHTML html={getProcessedTitle} />
+                                                        <RenderHTML html={processedTitle} />
                                                     </View>
                                                 )}
                                                 {!shouldRenderAsHTML && !shouldParseTitle && !!title && (

--- a/src/components/MenuItem.tsx
+++ b/src/components/MenuItem.tsx
@@ -1,7 +1,7 @@
 import ExpensiMark from 'expensify-common/lib/ExpensiMark';
 import type {ImageContentFit} from 'expo-image';
 import type {ForwardedRef, ReactNode} from 'react';
-import React, {forwardRef, useContext, useEffect, useMemo, useRef, useState} from 'react';
+import React, {forwardRef, useContext, useMemo} from 'react';
 import type {GestureResponderEvent, StyleProp, TextStyle, ViewStyle} from 'react-native';
 import {View} from 'react-native';
 import type {AnimatedStyle} from 'react-native-reanimated';

--- a/src/components/ReportActionItem/ReportPreview.tsx
+++ b/src/components/ReportActionItem/ReportPreview.tsx
@@ -242,7 +242,7 @@ function ReportPreview({
             return '';
         }
         const parsedSubtitle = new ExpensiMark().replace(subtitle);
-        return parsedSubtitle ? `<supporting-text>${parsedSubtitle}</supporting-text>` : '';
+        return parsedSubtitle ? `<muted-text>${parsedSubtitle}</muted-text>` : '';
     }, [subtitle, shouldShowSubtitle]);
 
     return (

--- a/src/components/ReportActionItem/ReportPreview.tsx
+++ b/src/components/ReportActionItem/ReportPreview.tsx
@@ -8,6 +8,7 @@ import Icon from '@components/Icon';
 import * as Expensicons from '@components/Icon/Expensicons';
 import OfflineWithFeedback from '@components/OfflineWithFeedback';
 import PressableWithoutFeedback from '@components/Pressable/PressableWithoutFeedback';
+import RenderHTML from '@components/RenderHTML';
 import SettlementButton from '@components/SettlementButton';
 import {showContextMenuForReport} from '@components/ShowContextMenuContext';
 import Text from '@components/Text';
@@ -32,6 +33,7 @@ import ROUTES from '@src/ROUTES';
 import type {Policy, Report, ReportAction, Transaction, TransactionViolations, UserWallet} from '@src/types/onyx';
 import type {PaymentMethodType} from '@src/types/onyx/OriginalMessage';
 import ReportActionItemImages from './ReportActionItemImages';
+import ExpensiMark from 'expensify-common/lib/ExpensiMark';
 
 type ReportPreviewOnyxProps = {
     /** The policy tied to the money request report */
@@ -234,6 +236,15 @@ function ReportPreview({
         numberOfRequests === 1 && (!!formattedMerchant || !!formattedDescription) && !(hasOnlyTransactionsWithPendingRoutes && !totalDisplaySpend);
     const shouldShowSubtitle = !isScanning && (shouldShowSingleRequestMerchantOrDescription || numberOfRequests > 1);
 
+    const subtitle = previewSubtitle || moneyRequestComment;
+    const htmlSubtitle = useMemo(() => {
+        if (!subtitle || !shouldShowSubtitle) {
+            return '';
+        }
+        const parsedSubtitle = new ExpensiMark().replace(subtitle);
+        return parsedSubtitle ? `<supporting-text>${parsedSubtitle}</supporting-text>` : '';
+    }, [subtitle, shouldShowSubtitle]);
+
     return (
         <OfflineWithFeedback
             pendingAction={iouReport?.pendingFields?.preview}
@@ -296,10 +307,10 @@ function ReportPreview({
                                                 )}
                                             </View>
                                         </View>
-                                        {shouldShowSubtitle && (
+                                        {shouldShowSubtitle && htmlSubtitle && (
                                             <View style={styles.flexRow}>
-                                                <View style={[styles.flex1, styles.flexRow, styles.alignItemsCenter]}>
-                                                    <Text style={[styles.textLabelSupporting, styles.textNormal, styles.lh20]}>{previewSubtitle || moneyRequestComment}</Text>
+                                                <View style={[styles.flex1, styles.flexRow, styles.alignItemsCenter, styles.textLabelSupporting, styles.textNormal, styles.lh20]}>
+                                                    <RenderHTML html={htmlSubtitle} />
                                                 </View>
                                             </View>
                                         )}

--- a/src/components/ReportActionItem/ReportPreview.tsx
+++ b/src/components/ReportActionItem/ReportPreview.tsx
@@ -1,3 +1,4 @@
+import ExpensiMark from 'expensify-common/lib/ExpensiMark';
 import React, {useMemo} from 'react';
 import type {StyleProp, ViewStyle} from 'react-native';
 import {View} from 'react-native';
@@ -33,7 +34,6 @@ import ROUTES from '@src/ROUTES';
 import type {Policy, Report, ReportAction, Transaction, TransactionViolations, UserWallet} from '@src/types/onyx';
 import type {PaymentMethodType} from '@src/types/onyx/OriginalMessage';
 import ReportActionItemImages from './ReportActionItemImages';
-import ExpensiMark from 'expensify-common/lib/ExpensiMark';
 
 type ReportPreviewOnyxProps = {
     /** The policy tied to the money request report */


### PR DESCRIPTION
### Details

- ~Add new custom html tag `<supporting-text>` to handle passing the styles we use for supporting text~
- Use `RenderHTML` along with `<muted-text>` instead of `<Text>` to handle the html derived from the markdown
- Replace `useState` + `useRef` by `useMemo`

Update: changed it to use the existing `muted-text` since it looks the same

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/39451
PROPOSAL:


### Tests

1. Open a new DM chat with someone you haven't chatted before
2. Create a money request and set as description `~test~`
3. Verify that the money request preview shows ~test~ as the description (markdown rendered correctly)
    <img width="574" alt="image" src="https://github.com/Expensify/App/assets/87341702/50fc198b-9dcf-477b-b741-ba51585f3d49">
5. Create another money request in the same chat
6. Verify that now it shows "2 requests"
    <img width="564" alt="image" src="https://github.com/Expensify/App/assets/87341702/7bb5d2f0-191a-43b7-8b36-3cf784b7a566">
7. Click on the preview and go inside the IOU report
8. Verify that both transactions show the description correctly:
    <img width="540" alt="image" src="https://github.com/Expensify/App/assets/87341702/405d80a8-a9c2-4933-a475-89f6727ed66b">
9. Click the transaction with description ~test~
10. Verify that the "Description" shows strikethrough in the detailed view
    <img width="384" alt="image" src="https://github.com/Expensify/App/assets/87341702/3943d3e3-bea2-4fac-8a33-6060307e546b">
11. Delete the second request so you only have one again
12. Edit the only transaction left with Merchant: `~merchant~`
13. Verify that the input shows `~merchant~` and not ~`merchant`~
    <img width="395" alt="image" src="https://github.com/Expensify/App/assets/87341702/39781d15-311d-433d-bcb2-5b11fad675e7">
14. Go to the DM chat and verify that the preview shows `~merchant~` and not ~`merchant`~
    <img width="573" alt="image" src="https://github.com/Expensify/App/assets/87341702/3d50d063-5813-4367-b9de-92052b7e8151">




- [x] Verify that no errors appear in the JS console

### Offline tests
N/A

### QA Steps



1. Open a new DM chat with someone you haven't chatted before
2. Create a money request and set as description `~test~`
3. Verify that the money request preview shows ~test~ as the description (markdown rendered correctly)
    <img width="574" alt="image" src="https://github.com/Expensify/App/assets/87341702/50fc198b-9dcf-477b-b741-ba51585f3d49">
5. Create another money request in the same chat
6. Verify that now it shows "2 requests"
    <img width="564" alt="image" src="https://github.com/Expensify/App/assets/87341702/7bb5d2f0-191a-43b7-8b36-3cf784b7a566">
7. Click on the preview and go inside the IOU report
8. Verify that both transactions show the description correctly:
    <img width="540" alt="image" src="https://github.com/Expensify/App/assets/87341702/405d80a8-a9c2-4933-a475-89f6727ed66b">
9. Click the transaction with description ~test~
10. Verify that the "Description" shows strikethrough in the detailed view
    <img width="384" alt="image" src="https://github.com/Expensify/App/assets/87341702/3943d3e3-bea2-4fac-8a33-6060307e546b">
11. Delete the second request so you only have one again
12. Edit the only transaction left with Merchant: `~merchant~`
13. Verify that the input shows `~merchant~` and not ~`merchant`~
    <img width="395" alt="image" src="https://github.com/Expensify/App/assets/87341702/39781d15-311d-433d-bcb2-5b11fad675e7">
14. Go to the DM chat and verify that the preview shows `~merchant~` and not ~`merchant`~
    <img width="573" alt="image" src="https://github.com/Expensify/App/assets/87341702/3d50d063-5813-4367-b9de-92052b7e8151">


- [ ] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<img width="571" alt="image" src="https://github.com/Expensify/App/assets/87341702/41c39d5c-1c73-40d1-a561-e9ccf1591ddd">


</details>

<details>
<summary>MacOS: Desktop</summary>

<!-- add screenshots or videos here -->

</details>
