### PR TITLE
Refactor layout of WorkspaceListRow

### DIFF
--- a/src/pages/workspace/WorkspacesListRow.tsx
+++ b/src/pages/workspace/WorkspacesListRow.tsx
@@ -15,13 +15,13 @@ import withCurrentUserPersonalDetails from '@components/withCurrentUserPersonalD
 import useLocalize from '@hooks/useLocalize';
 import useTheme from '@hooks/useTheme';
 import useThemeStyles from '@hooks/useThemeStyles';
+import useWindowDimensions from '@hooks/useWindowDimensions';
 import * as PersonalDetailsUtils from '@libs/PersonalDetailsUtils';
 import type {AvatarSource} from '@libs/UserUtils';
 import type {AnchorPosition} from '@styles/index';
 import variables from '@styles/variables';
 import CONST from '@src/CONST';
 import type IconAsset from '@src/types/utils/IconAsset';
-import useWindowDimensions from '@hooks/useWindowDimensions';
 
 type WorkspacesListRowProps = WithCurrentUserPersonalDetailsProps & {
     /** Name of the workspace */

--- a/src/pages/workspace/WorkspacesListRow.tsx
+++ b/src/pages/workspace/WorkspacesListRow.tsx
@@ -21,6 +21,7 @@ import type {AnchorPosition} from '@styles/index';
 import variables from '@styles/variables';
 import CONST from '@src/CONST';
 import type IconAsset from '@src/types/utils/IconAsset';
+import useWindowDimensions from '@hooks/useWindowDimensions';
 
 type WorkspacesListRowProps = WithCurrentUserPersonalDetailsProps & {
     /** Name of the workspace */
@@ -108,6 +109,7 @@ function WorkspacesListRow({
     const {translate} = useLocalize();
     const [threeDotsMenuPosition, setThreeDotsMenuPosition] = useState<AnchorPosition>({horizontal: 0, vertical: 0});
     const threeDotsMenuContainerRef = useRef<View>(null);
+    const {isSmallScreenWidth} = useWindowDimensions();
 
     const ownerDetails = ownerAccountID && PersonalDetailsUtils.getPersonalDetailsByIDs([ownerAccountID], currentUserPersonalDetails.accountID)[0];
 
@@ -136,124 +138,111 @@ function WorkspacesListRow({
     const isDeleted = style && Array.isArray(style) ? style.includes(styles.offlineFeedback.deleted) : false;
 
     return (
-        <View style={[isWide ? styles.flexRow : styles.flexColumn, isWide && styles.gap5, styles.highlightBG, styles.br3, styles.pv5, styles.pl5, rowStyles, style]}>
-            <View style={[styles.flexRow, isWide && styles.flex1, styles.gap3, isNarrow && [styles.mb3, styles.mr5], styles.alignItemsCenter]}>
-                <Avatar
-                    imageStyles={[styles.alignSelfCenter]}
-                    size={CONST.AVATAR_SIZE.DEFAULT}
-                    source={workspaceIcon}
-                    fallbackIcon={fallbackWorkspaceIcon}
-                    name={title}
-                    type={CONST.ICON_TYPE_WORKSPACE}
-                />
-                <Text
-                    numberOfLines={1}
-                    style={[styles.flex1, styles.flexGrow1, styles.textStrong, isDeleted ? styles.offlineFeedback.deleted : {}]}
-                >
-                    {title}
-                </Text>
-                {isNarrow &&
-                    (!isJoinRequestPending ? (
+        <View style={[styles.flexRow, styles.highlightBG, rowStyles, style, isWide && styles.gap5, styles.br3, styles.pv5, styles.pl5]}>
+            <View style={[isWide ? styles.flexRow : styles.flexColumn, styles.flex1, isWide && styles.gap5]}>
+                <View style={[styles.flexRow, isWide && styles.flex1, styles.gap3, isNarrow && styles.mb3, styles.alignItemsCenter]}>
+                    <Avatar
+                        imageStyles={[styles.alignSelfCenter]}
+                        size={CONST.AVATAR_SIZE.DEFAULT}
+                        source={workspaceIcon}
+                        fallbackIcon={fallbackWorkspaceIcon}
+                        name={title}
+                        type={CONST.ICON_TYPE_WORKSPACE}
+                    />
+                    <Text
+                        numberOfLines={1}
+                        style={[styles.flex1, styles.flexGrow1, styles.textStrong, isDeleted ? styles.offlineFeedback.deleted : {}]}
+                    >
+                        {title}
+                    </Text>
+                </View>
+                <View style={[styles.flexRow, isWide && styles.flex1, styles.gap2, isNarrow && styles.mr5, styles.alignItemsCenter]}>
+                    {!!ownerDetails && (
                         <>
-                            <BrickRoadIndicatorIcon brickRoadIndicator={brickRoadIndicator} />
-                            <ThreeDotsMenu
-                                menuItems={menuItems}
-                                anchorPosition={{horizontal: 0, vertical: 0}}
-                                disabled={shouldDisableThreeDotsMenu}
+                            <Avatar
+                                source={ownerDetails.avatar}
+                                size={CONST.AVATAR_SIZE.SMALL}
+                                containerStyles={styles.workspaceOwnerAvatarWrapper}
                             />
+                            <View style={styles.flex1}>
+                                <Text
+                                    numberOfLines={1}
+                                    style={[styles.labelStrong, isDeleted ? styles.offlineFeedback.deleted : {}]}
+                                >
+                                    {PersonalDetailsUtils.getDisplayNameOrDefault(ownerDetails)}
+                                </Text>
+                                <Text
+                                    numberOfLines={1}
+                                    style={[styles.textMicro, styles.textSupporting, isDeleted ? styles.offlineFeedback.deleted : {}]}
+                                >
+                                    {ownerDetails.login}
+                                </Text>
+                            </View>
                         </>
-                    ) : (
+                    )}
+                </View>
+                <View style={[styles.flexRow, isWide && !isJoinRequestPending && styles.flex1, styles.gap2, isNarrow && styles.mr5, styles.alignItemsCenter]}>
+                    <Icon
+                        src={workspaceTypeIcon(workspaceType)}
+                        width={variables.workspaceTypeIconWidth}
+                        height={variables.workspaceTypeIconWidth}
+                        additionalStyles={styles.workspaceTypeWrapper}
+                    />
+                    <View>
+                        <Text
+                            numberOfLines={1}
+                            style={[styles.labelStrong, isDeleted ? styles.offlineFeedback.deleted : {}]}
+                        >
+                            {userFriendlyWorkspaceType}
+                        </Text>
+                        <Text
+                            numberOfLines={1}
+                            style={[styles.textMicro, styles.textSupporting, isDeleted ? styles.offlineFeedback.deleted : {}]}
+                        >
+                            {translate('workspace.common.plan')}
+                        </Text>
+                    </View>
+                </View>
+            </View>
+            <View style={[isNarrow && styles.mr5]}>
+                {isJoinRequestPending && (
+                    <View style={[styles.flexRow, styles.gap2, styles.alignItemsCenter, styles.flex1, styles.justifyContentEnd, styles.mln6, styles.pr4]}>
                         <Badge
                             text={translate('workspace.common.requested')}
                             textStyles={styles.textStrong}
                             badgeStyles={[styles.alignSelfCenter, styles.badgeBordered]}
                             icon={Expensicons.Hourglass}
                         />
-                    ))}
-            </View>
-            <View style={[styles.flexRow, isWide && styles.flex1, styles.gap2, isNarrow && styles.mr5, styles.alignItemsCenter]}>
-                {!!ownerDetails && (
+                    </View>
+                )}
+                {!isJoinRequestPending && (
                     <>
-                        <Avatar
-                            source={ownerDetails.avatar}
-                            size={CONST.AVATAR_SIZE.SMALL}
-                            containerStyles={styles.workspaceOwnerAvatarWrapper}
-                        />
-                        <View style={styles.flex1}>
-                            <Text
-                                numberOfLines={1}
-                                style={[styles.labelStrong, isDeleted ? styles.offlineFeedback.deleted : {}]}
-                            >
-                                {PersonalDetailsUtils.getDisplayNameOrDefault(ownerDetails)}
-                            </Text>
-                            <Text
-                                numberOfLines={1}
-                                style={[styles.textMicro, styles.textSupporting, isDeleted ? styles.offlineFeedback.deleted : {}]}
-                            >
-                                {ownerDetails.login}
-                            </Text>
+                        <View style={[styles.flexRow, styles.flex0, styles.gap2, isNarrow && styles.mr5, styles.alignItemsCenter]}>
+                            <BrickRoadIndicatorIcon brickRoadIndicator={brickRoadIndicator} />
+                        </View>
+                        <View ref={threeDotsMenuContainerRef}>
+                            <ThreeDotsMenu
+                                onIconPress={() => {
+                                    if (isSmallScreenWidth) {
+                                        return;
+                                    }
+                                    threeDotsMenuContainerRef.current?.measureInWindow((x, y, width, height) => {
+                                        setThreeDotsMenuPosition({
+                                            horizontal: x + width,
+                                            vertical: y + height,
+                                        });
+                                    });
+                                }}
+                                menuItems={menuItems}
+                                anchorPosition={threeDotsMenuPosition}
+                                anchorAlignment={{horizontal: CONST.MODAL.ANCHOR_ORIGIN_HORIZONTAL.RIGHT, vertical: CONST.MODAL.ANCHOR_ORIGIN_VERTICAL.TOP}}
+                                shouldOverlay
+                                disabled={shouldDisableThreeDotsMenu}
+                            />
                         </View>
                     </>
                 )}
             </View>
-            <View style={[styles.flexRow, isWide && !isJoinRequestPending && styles.flex1, styles.gap2, isNarrow && styles.mr5, styles.alignItemsCenter]}>
-                <Icon
-                    src={workspaceTypeIcon(workspaceType)}
-                    width={variables.workspaceTypeIconWidth}
-                    height={variables.workspaceTypeIconWidth}
-                    additionalStyles={styles.workspaceTypeWrapper}
-                />
-                <View>
-                    <Text
-                        numberOfLines={1}
-                        style={[styles.labelStrong, isDeleted ? styles.offlineFeedback.deleted : {}]}
-                    >
-                        {userFriendlyWorkspaceType}
-                    </Text>
-                    <Text
-                        numberOfLines={1}
-                        style={[styles.textMicro, styles.textSupporting, isDeleted ? styles.offlineFeedback.deleted : {}]}
-                    >
-                        {translate('workspace.common.plan')}
-                    </Text>
-                </View>
-            </View>
-            {isJoinRequestPending && !isNarrow && (
-                <View style={[styles.flexRow, styles.gap2, styles.alignItemsCenter, styles.flex1, styles.justifyContentEnd, styles.mln6, styles.pr4]}>
-                    <Badge
-                        text={translate('workspace.common.requested')}
-                        textStyles={styles.textStrong}
-                        badgeStyles={[styles.alignSelfCenter, styles.badgeBordered]}
-                        icon={Expensicons.Hourglass}
-                    />
-                </View>
-            )}
-
-            {isWide && !isJoinRequestPending && (
-                <>
-                    <View style={[styles.flexRow, styles.flex0, styles.gap2, isNarrow && styles.mr5, styles.alignItemsCenter]}>
-                        <BrickRoadIndicatorIcon brickRoadIndicator={brickRoadIndicator} />
-                    </View>
-                    <View ref={threeDotsMenuContainerRef}>
-                        <ThreeDotsMenu
-                            onIconPress={() => {
-                                threeDotsMenuContainerRef.current?.measureInWindow((x, y, width, height) => {
-                                    setThreeDotsMenuPosition({
-                                        horizontal: x + width,
-                                        vertical: y + height,
-                                    });
-                                });
-                            }}
-                            menuItems={menuItems}
-                            anchorPosition={threeDotsMenuPosition}
-                            anchorAlignment={{horizontal: CONST.MODAL.ANCHOR_ORIGIN_HORIZONTAL.RIGHT, vertical: CONST.MODAL.ANCHOR_ORIGIN_VERTICAL.TOP}}
-                            iconStyles={[styles.mr2]}
-                            shouldOverlay
-                            disabled={shouldDisableThreeDotsMenu}
-                        />
-                    </View>
-                </>
-            )}
         </View>
     );
 }


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->
Refactor layout of WorkspaceListRow
### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/39015
PROPOSAL: https://github.com/Expensify/App/issues/39015#issuecomment-2024640520


### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->
For Web/Desktop:
1. Go to Settings > Workspace
2. Resize window to medium screen
3. Click on three-dot icon
4. Verify that the three-dot menu is displayed below the icon

For other platforms:
1. Go to Settings > Workspace
2. Click on three-dot icon
3. Verify that the three-dot menu is displayed at the bottom of the screen

- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->
Same as above
### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
5. Upload an image via copy paste
6. Verify a modal appears displaying a preview of that image
--->
For Web/Desktop:
1. Go to Settings > Workspace
2. Resize window to medium screen
3. Click on three-dot icon
4. Verify that the three-dot menu is displayed below the icon

For other platforms:
1. Go to Settings > Workspace
2. Click on three-dot icon
3. Verify that the three-dot menu is displayed at the bottom of the screen
- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>


https://github.com/Expensify/App/assets/161821005/dd3daa26-d4a9-49fc-82a3-ec340589a06e


<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

https://github.com/Expensify/App/assets/161821005/763439db-0ee1-422c-9ef6-37463c091bcb

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>


https://github.com/Expensify/App/assets/161821005/684a6372-c9e8-486c-b583-84e785910081


<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

https://github.com/Expensify/App/assets/161821005/b129d6a8-e825-4c9a-af44-15a7196a3ce2


<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>


https://github.com/Expensify/App/assets/161821005/03366a1c-82a5-485b-827a-ea32355d0dc2


<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Desktop</summary>


https://github.com/Expensify/App/assets/161821005/91605bc2-6267-42a9-92b3-0fc14b859c7f


<!-- add screenshots or videos here -->

</details>




