### PR TITLE
[HOLD another deploy] [No QA] Remove debug logs from awaitStagingDeploys.ts and promiseWhile.ts

### DIFF
--- a/.github/actions/javascript/awaitStagingDeploys/awaitStagingDeploys.ts
+++ b/.github/actions/javascript/awaitStagingDeploys/awaitStagingDeploys.ts
@@ -8,17 +8,9 @@ import {promiseDoWhile} from '@github/libs/promiseWhile';
 type CurrentStagingDeploys = Awaited<ReturnType<typeof GitHubUtils.octokit.actions.listWorkflowRuns>>['data']['workflow_runs'];
 
 function run() {
-    console.info('[awaitStagingDeploys] run()');
-    console.info('[awaitStagingDeploys] getStringInput', getStringInput);
-    console.info('[awaitStagingDeploys] GitHubUtils', GitHubUtils);
-    console.info('[awaitStagingDeploys] promiseDoWhile', promiseDoWhile);
-
     const tag = getStringInput('TAG', {required: false});
-    console.info('[awaitStagingDeploys] run() tag', tag);
 
     let currentStagingDeploys: CurrentStagingDeploys = [];
-
-    console.info('[awaitStagingDeploys] run()  _.throttle', lodashThrottle);
 
     const throttleFunc = () =>
         Promise.all([
@@ -41,24 +33,21 @@ function run() {
                 }),
         ])
             .then((responses) => {
-                console.info('[awaitStagingDeploys] listWorkflowRuns responses', responses);
                 const workflowRuns = responses[0].data.workflow_runs;
                 if (!tag && typeof responses[1] === 'object') {
                     workflowRuns.push(...responses[1].data.workflow_runs);
                 }
-                console.info('[awaitStagingDeploys] workflowRuns', workflowRuns);
+
                 return workflowRuns;
             })
             .then((workflowRuns) => (currentStagingDeploys = workflowRuns.filter((workflowRun) => workflowRun.status !== 'completed')))
             .then(() => {
-                console.info('[awaitStagingDeploys] currentStagingDeploys', currentStagingDeploys);
                 console.log(
                     !currentStagingDeploys.length
                         ? 'No current staging deploys found'
                         : `Found ${currentStagingDeploys.length} staging deploy${currentStagingDeploys.length > 1 ? 's' : ''} still running...`,
                 );
             });
-    console.info('[awaitStagingDeploys] run() throttleFunc', throttleFunc);
 
     return promiseDoWhile(
         () => !!currentStagingDeploys.length,

--- a/.github/actions/javascript/awaitStagingDeploys/index.js
+++ b/.github/actions/javascript/awaitStagingDeploys/index.js
@@ -12131,14 +12131,8 @@ const CONST_1 = __importDefault(__nccwpck_require__(9873));
 const GithubUtils_1 = __importDefault(__nccwpck_require__(9296));
 const promiseWhile_1 = __nccwpck_require__(9438);
 function run() {
-    console.info('[awaitStagingDeploys] run()');
-    console.info('[awaitStagingDeploys] getStringInput', ActionUtils_1.getStringInput);
-    console.info('[awaitStagingDeploys] GitHubUtils', GithubUtils_1.default);
-    console.info('[awaitStagingDeploys] promiseDoWhile', promiseWhile_1.promiseDoWhile);
     const tag = (0, ActionUtils_1.getStringInput)('TAG', { required: false });
-    console.info('[awaitStagingDeploys] run() tag', tag);
     let currentStagingDeploys = [];
-    console.info('[awaitStagingDeploys] run()  _.throttle', throttle_1.default);
     const throttleFunc = () => Promise.all([
         // These are active deploys
         GithubUtils_1.default.octokit.actions.listWorkflowRuns({
@@ -12158,22 +12152,18 @@ function run() {
             }),
     ])
         .then((responses) => {
-        console.info('[awaitStagingDeploys] listWorkflowRuns responses', responses);
         const workflowRuns = responses[0].data.workflow_runs;
         if (!tag && typeof responses[1] === 'object') {
             workflowRuns.push(...responses[1].data.workflow_runs);
         }
-        console.info('[awaitStagingDeploys] workflowRuns', workflowRuns);
         return workflowRuns;
     })
         .then((workflowRuns) => (currentStagingDeploys = workflowRuns.filter((workflowRun) => workflowRun.status !== 'completed')))
         .then(() => {
-        console.info('[awaitStagingDeploys] currentStagingDeploys', currentStagingDeploys);
         console.log(!currentStagingDeploys.length
             ? 'No current staging deploys found'
             : `Found ${currentStagingDeploys.length} staging deploy${currentStagingDeploys.length > 1 ? 's' : ''} still running...`);
     });
-    console.info('[awaitStagingDeploys] run() throttleFunc', throttleFunc);
     return (0, promiseWhile_1.promiseDoWhile)(() => !!currentStagingDeploys.length, (0, throttle_1.default)(throttleFunc, 
     // Poll every 60 seconds instead of every 10 seconds
     CONST_1.default.POLL_RATE * 6));
@@ -12729,7 +12719,6 @@ exports.promiseDoWhile = exports.promiseWhile = void 0;
  * Simulates a while loop where the condition is determined by the result of a Promise.
  */
 function promiseWhile(condition, action) {
-    console.info('[promiseWhile] promiseWhile()');
     return new Promise((resolve, reject) => {
         const loop = function () {
             if (!condition()) {
@@ -12737,7 +12726,6 @@ function promiseWhile(condition, action) {
             }
             else {
                 const actionResult = action?.();
-                console.info('[promiseWhile] promiseWhile() actionResult', actionResult);
                 if (!actionResult) {
                     resolve();
                     return;
@@ -12753,11 +12741,8 @@ exports.promiseWhile = promiseWhile;
  * Simulates a do-while loop where the condition is determined by the result of a Promise.
  */
 function promiseDoWhile(condition, action) {
-    console.info('[promiseWhile] promiseDoWhile()');
     return new Promise((resolve, reject) => {
-        console.info('[promiseWhile] promiseDoWhile() condition', condition);
         const actionResult = action?.();
-        console.info('[promiseWhile] promiseDoWhile() actionResult', actionResult);
         if (!actionResult) {
             resolve();
             return;

--- a/.github/libs/promiseWhile.ts
+++ b/.github/libs/promiseWhile.ts
@@ -4,15 +4,12 @@ import type {DebouncedFunc} from 'lodash';
  * Simulates a while loop where the condition is determined by the result of a Promise.
  */
 function promiseWhile(condition: () => boolean, action: (() => Promise<void>) | DebouncedFunc<() => Promise<void>> | undefined): Promise<void> {
-    console.info('[promiseWhile] promiseWhile()');
-
     return new Promise((resolve, reject) => {
         const loop = function () {
             if (!condition()) {
                 resolve();
             } else {
                 const actionResult = action?.();
-                console.info('[promiseWhile] promiseWhile() actionResult', actionResult);
 
                 if (!actionResult) {
                     resolve();
@@ -30,12 +27,8 @@ function promiseWhile(condition: () => boolean, action: (() => Promise<void>) | 
  * Simulates a do-while loop where the condition is determined by the result of a Promise.
  */
 function promiseDoWhile(condition: () => boolean, action: (() => Promise<void>) | DebouncedFunc<() => Promise<void>> | undefined): Promise<void> {
-    console.info('[promiseWhile] promiseDoWhile()');
-
     return new Promise((resolve, reject) => {
-        console.info('[promiseWhile] promiseDoWhile() condition', condition);
         const actionResult = action?.();
-        console.info('[promiseWhile] promiseDoWhile() actionResult', actionResult);
         if (!actionResult) {
             resolve();
             return;


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->

As https://github.com/Expensify/App/issues/39066 has been resolved in https://github.com/Expensify/App/pull/40104 we can now get rid of debug logs.

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/39066
PROPOSAL: N/A


### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
