### PR TITLE
Swap from withPolicy to withPolicyConnections for Export Quickbooks pages

### DIFF
--- a/src/pages/workspace/accounting/qbo/export/QuickbooksCompanyCardExpenseAccountSelectPage.tsx
+++ b/src/pages/workspace/accounting/qbo/export/QuickbooksCompanyCardExpenseAccountSelectPage.tsx
@@ -13,8 +13,8 @@ import * as Connections from '@libs/actions/connections';
 import Navigation from '@navigation/Navigation';
 import AdminPolicyAccessOrNotFoundWrapper from '@pages/workspace/AdminPolicyAccessOrNotFoundWrapper';
 import FeatureEnabledAccessOrNotFoundWrapper from '@pages/workspace/FeatureEnabledAccessOrNotFoundWrapper';
-import withPolicy from '@pages/workspace/withPolicy';
 import type {WithPolicyProps} from '@pages/workspace/withPolicy';
+import withPolicyConnections from '@pages/workspace/withPolicyConnections';
 import CONST from '@src/CONST';
 import ROUTES from '@src/ROUTES';
 
@@ -106,4 +106,4 @@ function QuickbooksCompanyCardExpenseAccountSelectPage({policy}: WithPolicyProps
 
 QuickbooksCompanyCardExpenseAccountSelectPage.displayName = 'QuickbooksCompanyCardExpenseAccountSelectPage';
 
-export default withPolicy(QuickbooksCompanyCardExpenseAccountSelectPage);
+export default withPolicyConnections(QuickbooksCompanyCardExpenseAccountSelectPage);

--- a/src/pages/workspace/accounting/qbo/export/QuickbooksCompanyCardExpenseAccountSelectPage.tsx
+++ b/src/pages/workspace/accounting/qbo/export/QuickbooksCompanyCardExpenseAccountSelectPage.tsx
@@ -27,8 +27,6 @@ type Card = {name: string};
 function QuickbooksCompanyCardExpenseAccountSelectPage({policy}: WithPolicyProps) {
     const {translate} = useLocalize();
     const styles = useThemeStyles();
-    const {creditCards} = policy?.connections?.quickbooksOnline?.data ?? {};
-
     const {exportCompanyCard, syncLocations} = policy?.connections?.quickbooksOnline?.config ?? {};
     const isLocationEnabled = Boolean(syncLocations && syncLocations !== CONST.INTEGRATION_ENTITY_MAP_TYPES.NONE);
 
@@ -46,12 +44,7 @@ function QuickbooksCompanyCardExpenseAccountSelectPage({policy}: WithPolicyProps
         ],
         [translate],
     );
-    const cards = useMemo<Card[]>(() => {
-        if (creditCards?.length) {
-            return creditCards;
-        }
-        return isLocationEnabled ? defaultCards.slice(0, -1) : defaultCards;
-    }, [creditCards, isLocationEnabled, defaultCards]);
+    const cards = useMemo<Card[]>(() => (isLocationEnabled ? defaultCards.slice(0, -1) : defaultCards), [isLocationEnabled, defaultCards]);
 
     const data = useMemo<CardListItem[]>(
         () =>

--- a/src/pages/workspace/accounting/qbo/export/QuickbooksExportConfigurationPage.tsx
+++ b/src/pages/workspace/accounting/qbo/export/QuickbooksExportConfigurationPage.tsx
@@ -13,8 +13,8 @@ import useThemeStyles from '@hooks/useThemeStyles';
 import Navigation from '@navigation/Navigation';
 import AdminPolicyAccessOrNotFoundWrapper from '@pages/workspace/AdminPolicyAccessOrNotFoundWrapper';
 import FeatureEnabledAccessOrNotFoundWrapper from '@pages/workspace/FeatureEnabledAccessOrNotFoundWrapper';
-import withPolicy from '@pages/workspace/withPolicy';
 import type {WithPolicyProps} from '@pages/workspace/withPolicy';
+import withPolicyConnections from '@pages/workspace/withPolicyConnections';
 import * as Link from '@userActions/Link';
 import CONST from '@src/CONST';
 import ROUTES from '@src/ROUTES';
@@ -125,4 +125,4 @@ function QuickbooksExportConfigurationPage({policy}: WithPolicyProps) {
 
 QuickbooksExportConfigurationPage.displayName = 'QuickbooksExportConfigurationPage';
 
-export default withPolicy(QuickbooksExportConfigurationPage);
+export default withPolicyConnections(QuickbooksExportConfigurationPage);

--- a/src/pages/workspace/accounting/qbo/export/QuickbooksExportDateSelectPage.tsx
+++ b/src/pages/workspace/accounting/qbo/export/QuickbooksExportDateSelectPage.tsx
@@ -12,8 +12,8 @@ import * as Connections from '@libs/actions/connections';
 import Navigation from '@navigation/Navigation';
 import AdminPolicyAccessOrNotFoundWrapper from '@pages/workspace/AdminPolicyAccessOrNotFoundWrapper';
 import FeatureEnabledAccessOrNotFoundWrapper from '@pages/workspace/FeatureEnabledAccessOrNotFoundWrapper';
-import withPolicy from '@pages/workspace/withPolicy';
 import type {WithPolicyProps} from '@pages/workspace/withPolicy';
+import withPolicyConnections from '@pages/workspace/withPolicyConnections';
 import CONST from '@src/CONST';
 import ROUTES from '@src/ROUTES';
 
@@ -69,4 +69,4 @@ function QuickbooksExportDateSelectPage({policy}: WithPolicyProps) {
 
 QuickbooksExportDateSelectPage.displayName = 'QuickbooksExportDateSelectPage';
 
-export default withPolicy(QuickbooksExportDateSelectPage);
+export default withPolicyConnections(QuickbooksExportDateSelectPage);

--- a/src/pages/workspace/accounting/qbo/export/QuickbooksExportInvoiceAccountSelectPage.tsx
+++ b/src/pages/workspace/accounting/qbo/export/QuickbooksExportInvoiceAccountSelectPage.tsx
@@ -25,27 +25,17 @@ function QuickbooksExportInvoiceAccountSelectPage({policy}: WithPolicyProps) {
     const styles = useThemeStyles();
     const {accountsReceivable} = policy?.connections?.quickbooksOnline?.data ?? {};
     const {exportInvoice} = policy?.connections?.quickbooksOnline?.config ?? {};
-    // TODO - should be removed after API fully working
-    const draft = [
-        {
-            name: translate(`workspace.qbo.receivable`),
-        },
-        {
-            name: translate(`workspace.qbo.archive`),
-        },
-    ];
-    const result = accountsReceivable?.length ? accountsReceivable : draft;
 
     const policyID = policy?.id ?? '';
     const data: CardListItem[] = useMemo(
         () =>
-            result?.map((account) => ({
+            accountsReceivable?.map((account) => ({
                 value: account.name,
                 text: account.name,
                 keyForList: account.name,
                 isSelected: account.name === exportInvoice,
-            })),
-        [exportInvoice, result],
+            })) ?? [],
+        [exportInvoice, accountsReceivable],
     );
 
     const onSelectRow = useCallback(

--- a/src/pages/workspace/accounting/qbo/export/QuickbooksExportInvoiceAccountSelectPage.tsx
+++ b/src/pages/workspace/accounting/qbo/export/QuickbooksExportInvoiceAccountSelectPage.tsx
@@ -11,8 +11,8 @@ import * as Connections from '@libs/actions/connections';
 import Navigation from '@navigation/Navigation';
 import AdminPolicyAccessOrNotFoundWrapper from '@pages/workspace/AdminPolicyAccessOrNotFoundWrapper';
 import FeatureEnabledAccessOrNotFoundWrapper from '@pages/workspace/FeatureEnabledAccessOrNotFoundWrapper';
-import withPolicy from '@pages/workspace/withPolicy';
 import type {WithPolicyProps} from '@pages/workspace/withPolicy';
+import withPolicyConnections from '@pages/workspace/withPolicyConnections';
 import CONST from '@src/CONST';
 import ROUTES from '@src/ROUTES';
 
@@ -81,4 +81,4 @@ function QuickbooksExportInvoiceAccountSelectPage({policy}: WithPolicyProps) {
 
 QuickbooksExportInvoiceAccountSelectPage.displayName = 'QuickbooksExportInvoiceAccountSelectPage';
 
-export default withPolicy(QuickbooksExportInvoiceAccountSelectPage);
+export default withPolicyConnections(QuickbooksExportInvoiceAccountSelectPage);

--- a/src/pages/workspace/accounting/qbo/export/QuickbooksOutOfPocketExpenseAccountSelectPage.tsx
+++ b/src/pages/workspace/accounting/qbo/export/QuickbooksOutOfPocketExpenseAccountSelectPage.tsx
@@ -15,16 +15,7 @@ import type {WithPolicyProps} from '@pages/workspace/withPolicy';
 import withPolicyConnections from '@pages/workspace/withPolicyConnections';
 import CONST from '@src/CONST';
 import ROUTES from '@src/ROUTES';
-
-// TODO - should be removed after API fully working
-const draft = [
-    {
-        name: 'Accounts Payable (A/P)',
-    },
-    {
-        name: 'Payroll Accounts',
-    },
-];
+import type {Account} from '@src/types/onyx/Policy';
 
 type CardListItem = ListItem & {
     value: string;
@@ -38,7 +29,7 @@ function QuickbooksOutOfPocketExpenseAccountSelectPage({policy}: WithPolicyProps
     const {exportEntity, exportAccount} = policy?.connections?.quickbooksOnline?.config ?? {};
 
     const data: CardListItem[] = useMemo(() => {
-        let result;
+        let result: Account[] | [];
         switch (exportEntity) {
             case CONST.QUICKBOOKS_EXPORT_ENTITY.CHECK:
                 result = bankAccounts ?? [];
@@ -50,10 +41,10 @@ function QuickbooksOutOfPocketExpenseAccountSelectPage({policy}: WithPolicyProps
                 result = journalEntryAccounts ?? [];
                 break;
             default:
-                result = draft;
+                result = [];
         }
 
-        return (draft ?? result)?.map((card) => ({
+        return result?.map((card) => ({
             value: card.name,
             text: card.name,
             keyForList: card.name,

--- a/src/pages/workspace/accounting/qbo/export/QuickbooksOutOfPocketExpenseAccountSelectPage.tsx
+++ b/src/pages/workspace/accounting/qbo/export/QuickbooksOutOfPocketExpenseAccountSelectPage.tsx
@@ -11,8 +11,8 @@ import * as Connections from '@libs/actions/connections';
 import Navigation from '@navigation/Navigation';
 import AdminPolicyAccessOrNotFoundWrapper from '@pages/workspace/AdminPolicyAccessOrNotFoundWrapper';
 import FeatureEnabledAccessOrNotFoundWrapper from '@pages/workspace/FeatureEnabledAccessOrNotFoundWrapper';
-import withPolicy from '@pages/workspace/withPolicy';
 import type {WithPolicyProps} from '@pages/workspace/withPolicy';
+import withPolicyConnections from '@pages/workspace/withPolicyConnections';
 import CONST from '@src/CONST';
 import ROUTES from '@src/ROUTES';
 
@@ -96,4 +96,4 @@ function QuickbooksOutOfPocketExpenseAccountSelectPage({policy}: WithPolicyProps
 
 QuickbooksOutOfPocketExpenseAccountSelectPage.displayName = 'QuickbooksOutOfPocketExpenseAccountSelectPage';
 
-export default withPolicy(QuickbooksOutOfPocketExpenseAccountSelectPage);
+export default withPolicyConnections(QuickbooksOutOfPocketExpenseAccountSelectPage);

--- a/src/pages/workspace/accounting/qbo/export/QuickbooksOutOfPocketExpenseAccountSelectPage.tsx
+++ b/src/pages/workspace/accounting/qbo/export/QuickbooksOutOfPocketExpenseAccountSelectPage.tsx
@@ -29,22 +29,22 @@ function QuickbooksOutOfPocketExpenseAccountSelectPage({policy}: WithPolicyProps
     const {exportEntity, exportAccount} = policy?.connections?.quickbooksOnline?.config ?? {};
 
     const data: CardListItem[] = useMemo(() => {
-        let result: Account[] | [];
+        let accounts: Account[];
         switch (exportEntity) {
             case CONST.QUICKBOOKS_EXPORT_ENTITY.CHECK:
-                result = bankAccounts ?? [];
+                accounts = bankAccounts ?? [];
                 break;
             case CONST.QUICKBOOKS_EXPORT_ENTITY.VENDOR_BILL:
-                result = accountsPayable ?? [];
+                accounts = accountsPayable ?? [];
                 break;
             case CONST.QUICKBOOKS_EXPORT_ENTITY.JOURNAL_ENTRY:
-                result = journalEntryAccounts ?? [];
+                accounts = journalEntryAccounts ?? [];
                 break;
             default:
-                result = [];
+                accounts = [];
         }
 
-        return result?.map((card) => ({
+        return accounts.map((card) => ({
             value: card.name,
             text: card.name,
             keyForList: card.name,

--- a/src/pages/workspace/accounting/qbo/export/QuickbooksOutOfPocketExpenseConfigurationPage.tsx
+++ b/src/pages/workspace/accounting/qbo/export/QuickbooksOutOfPocketExpenseConfigurationPage.tsx
@@ -10,8 +10,8 @@ import useThemeStyles from '@hooks/useThemeStyles';
 import Navigation from '@navigation/Navigation';
 import AdminPolicyAccessOrNotFoundWrapper from '@pages/workspace/AdminPolicyAccessOrNotFoundWrapper';
 import FeatureEnabledAccessOrNotFoundWrapper from '@pages/workspace/FeatureEnabledAccessOrNotFoundWrapper';
-import withPolicy from '@pages/workspace/withPolicy';
 import type {WithPolicyProps} from '@pages/workspace/withPolicy';
+import withPolicyConnections from '@pages/workspace/withPolicyConnections';
 import CONST from '@src/CONST';
 import ROUTES from '@src/ROUTES';
 
@@ -76,4 +76,4 @@ function QuickbooksOutOfPocketExpenseConfigurationPage({policy}: WithPolicyProps
 
 QuickbooksOutOfPocketExpenseConfigurationPage.displayName = 'QuickbooksExportOutOfPocketExpensesPage';
 
-export default withPolicy(QuickbooksOutOfPocketExpenseConfigurationPage);
+export default withPolicyConnections(QuickbooksOutOfPocketExpenseConfigurationPage);

--- a/src/pages/workspace/accounting/qbo/export/QuickbooksOutOfPocketExpenseEntitySelectPage.tsx
+++ b/src/pages/workspace/accounting/qbo/export/QuickbooksOutOfPocketExpenseEntitySelectPage.tsx
@@ -14,8 +14,8 @@ import * as Connections from '@libs/actions/connections';
 import Navigation from '@navigation/Navigation';
 import AdminPolicyAccessOrNotFoundWrapper from '@pages/workspace/AdminPolicyAccessOrNotFoundWrapper';
 import FeatureEnabledAccessOrNotFoundWrapper from '@pages/workspace/FeatureEnabledAccessOrNotFoundWrapper';
-import withPolicy from '@pages/workspace/withPolicy';
 import type {WithPolicyProps} from '@pages/workspace/withPolicy';
+import withPolicyConnections from '@pages/workspace/withPolicyConnections';
 import CONST from '@src/CONST';
 import ROUTES from '@src/ROUTES';
 
@@ -111,4 +111,4 @@ function QuickbooksOutOfPocketExpenseEntitySelectPage({policy}: WithPolicyProps)
 
 QuickbooksOutOfPocketExpenseEntitySelectPage.displayName = 'QuickbooksOutOfPocketExpenseEntitySelectPage';
 
-export default withPolicy(QuickbooksOutOfPocketExpenseEntitySelectPage);
+export default withPolicyConnections(QuickbooksOutOfPocketExpenseEntitySelectPage);

--- a/src/pages/workspace/accounting/qbo/export/QuickbooksPreferredExporterConfigurationPage.tsx
+++ b/src/pages/workspace/accounting/qbo/export/QuickbooksPreferredExporterConfigurationPage.tsx
@@ -12,8 +12,8 @@ import {getAdminEmployees} from '@libs/PolicyUtils';
 import Navigation from '@navigation/Navigation';
 import AdminPolicyAccessOrNotFoundWrapper from '@pages/workspace/AdminPolicyAccessOrNotFoundWrapper';
 import FeatureEnabledAccessOrNotFoundWrapper from '@pages/workspace/FeatureEnabledAccessOrNotFoundWrapper';
-import withPolicy from '@pages/workspace/withPolicy';
 import type {WithPolicyProps} from '@pages/workspace/withPolicy';
+import withPolicyConnections from '@pages/workspace/withPolicyConnections';
 import CONST from '@src/CONST';
 import ROUTES from '@src/ROUTES';
 
@@ -92,4 +92,4 @@ function QuickBooksExportPreferredExporterPage({policy}: WithPolicyProps) {
 
 QuickBooksExportPreferredExporterPage.displayName = 'QuickBooksExportPreferredExporterPage';
 
-export default withPolicy(QuickBooksExportPreferredExporterPage);
+export default withPolicyConnections(QuickBooksExportPreferredExporterPage);

--- a/src/pages/workspace/accounting/qbo/export/QuickbooksPreferredExporterConfigurationPage.tsx
+++ b/src/pages/workspace/accounting/qbo/export/QuickbooksPreferredExporterConfigurationPage.tsx
@@ -17,15 +17,6 @@ import withPolicyConnections from '@pages/workspace/withPolicyConnections';
 import CONST from '@src/CONST';
 import ROUTES from '@src/ROUTES';
 
-// TODO - should be removed after API fully working
-const draft = [
-    {name: '+14153166423@expensify.sms', currency: 'USD', id: '94', email: '+14153166423@expensify.sms'},
-    {name: 'Account Maintenance Fee', currency: 'USD', id: '141', email: 'alberto@expensify213.com'},
-    {name: 'Admin Test', currency: 'USD', id: '119', email: 'admin@qbocard.com'},
-    {name: 'Alberto Gonzalez-Cela', currency: 'USD', id: '104', email: 'alberto@expensify.com'},
-    {name: 'Aldo test QBO2 QBO2 Last name', currency: 'USD', id: '140', email: 'admin@qbo.com'},
-];
-
 type CardListItem = ListItem & {
     value: string;
 };
@@ -35,12 +26,11 @@ function QuickBooksExportPreferredExporterPage({policy}: WithPolicyProps) {
     const styles = useThemeStyles();
     const {exporter} = policy?.connections?.quickbooksOnline?.config ?? {};
     const exporters = getAdminEmployees(policy);
-    const result = exporters?.length ? exporters : draft;
 
     const policyID = policy?.id ?? '';
     const data: CardListItem[] = useMemo(
         () =>
-            result.reduce<CardListItem[]>((vendors, vendor) => {
+            exporters?.reduce<CardListItem[]>((vendors, vendor) => {
                 if (vendor.email) {
                     vendors.push({
                         value: vendor.email,
@@ -51,7 +41,7 @@ function QuickBooksExportPreferredExporterPage({policy}: WithPolicyProps) {
                 }
                 return vendors;
             }, []),
-        [result, exporter],
+        [exporter, exporters],
     );
 
     const onSelectRow = useCallback(

--- a/src/types/onyx/Policy.ts
+++ b/src/types/onyx/Policy.ts
@@ -475,4 +475,5 @@ export type {
     PolicyConnectionSyncProgress,
     Connections,
     ConnectionName,
+    Account,
 };


### PR DESCRIPTION
### Details
Follow up integration withPolicyConnection inside Export pages

### Fixed Issues

$ https://github.com/Expensify/App/issues/39108
PROPOSAL:


### Tests / QA Steps
_Applause team: Please don't add deploy blocker to the issue that you create if you find any issues with the following QA steps. This is behind beta, and we don't have to block deploy on this. Please just create GH issues without the deploy blocker label_
1. Log into the QA QBO account
2. Menu -> Transactions -> Chart of Accounts
3. Keep open the Chart of Accounts page for reference.
4. Log into New Expensify with an account that is on the accounting beta
5. Enable Accounting feature on the More Features page
6. Go to the Accounting screen and connect to QBO
7. After the connection is established, click Export
8. Click "Export out-of-pocket expenses as". Click "Export as".
9. Select "Journal Entry", go back and click the menu item below "Export as".
10. Check that you see the list of accounts from QBO whose types are `Accounts Payable`, `Other Current Assets`, and `Other Current Liabilities`
11. Go back, click "Export as" and Select "Check", go back and click the menu item below "Export as".
12. Check that you see the list of accounts from QBO whose types is `Bank`.
13. Go back, click "Export as" and Select "Vendor Bill", go back and click the menu item below "Export as".
14. Check that you see the list of accounts from QBO whose types is `Accounts Payable`.
15. Bo back two levels and click "Export invoices to". Check  that you see the list of accounts from QBO whose types is `Accounts Receivable`.
16. Go back and click "Export company cards as".
17. Click "Export as" and Select "Credit card", go back and click "Account".
18. Check that you see the list of accounts from QBO whose types is `Credit Card`.
19. Go back, click "Export as" and select "Debit card", go back and click "Account".
20. Check that you see the list of accounts from QBO whose types is `Bank`.
21. Go back, click "Export as" and select "Vendor bill", go back and click "Account payable".
22. Check that you see the list of accounts from QBO whose types is `Accounts Payable`.
23. Go back and confirm that you see a toggle button for "Default vendor". Toggle the option on.
24. Click "Vendor". Confirm that you see the list of vendors from QBO. To see the list of vendors on QBO, go to Expenses -> Vendors.

### Offline tests
N/A

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Desktop</summary>

<!-- add screenshots or videos here -->

</details>
