### PR TITLE
Format ISO string correctly when missing reportAction to find `mostRecentReportActionLastModified`

### DIFF
--- a/src/libs/ReportActionsUtils.ts
+++ b/src/libs/ReportActionsUtils.ts
@@ -27,6 +27,7 @@ import Log from './Log';
 import type {MessageElementBase, MessageTextElement} from './MessageElement';
 import * as PersonalDetailsUtils from './PersonalDetailsUtils';
 import type {OptimisticIOUReportAction} from './ReportUtils';
+import * as DateUtils from './DateUtils';
 
 type LastVisibleMessage = {
     lastMessageTranslationKey?: string;
@@ -726,7 +727,7 @@ function getReportAction(reportID: string, reportActionID: string): OnyxEntry<Re
 
 function getMostRecentReportActionLastModified(): string {
     // Start with the oldest date possible
-    let mostRecentReportActionLastModified = new Date(0).toISOString();
+    let mostRecentReportActionLastModified = DateUtils.getDBTimeFromDate(new Date(0));
 
     // Flatten all the actions
     // Loop over them all to find the one that is the most recent

--- a/src/libs/ReportActionsUtils.ts
+++ b/src/libs/ReportActionsUtils.ts
@@ -27,7 +27,7 @@ import Log from './Log';
 import type {MessageElementBase, MessageTextElement} from './MessageElement';
 import * as PersonalDetailsUtils from './PersonalDetailsUtils';
 import type {OptimisticIOUReportAction} from './ReportUtils';
-import * as DateUtils from './DateUtils';
+import DateUtils from './DateUtils';
 
 type LastVisibleMessage = {
     lastMessageTranslationKey?: string;
@@ -727,7 +727,7 @@ function getReportAction(reportID: string, reportActionID: string): OnyxEntry<Re
 
 function getMostRecentReportActionLastModified(): string {
     // Start with the oldest date possible
-    let mostRecentReportActionLastModified = DateUtils.getDBTimeFromDate(new Date(0));
+    let mostRecentReportActionLastModified = DateUtils.getDBTime(0);
 
     // Flatten all the actions
     // Loop over them all to find the one that is the most recent

--- a/src/libs/ReportActionsUtils.ts
+++ b/src/libs/ReportActionsUtils.ts
@@ -20,6 +20,7 @@ import type {Message, ReportActionBase, ReportActions} from '@src/types/onyx/Rep
 import type ReportAction from '@src/types/onyx/ReportAction';
 import type {EmptyObject} from '@src/types/utils/EmptyObject';
 import {isEmptyObject} from '@src/types/utils/EmptyObject';
+import DateUtils from './DateUtils';
 import * as Environment from './Environment/Environment';
 import isReportMessageAttachment from './isReportMessageAttachment';
 import * as Localize from './Localize';
@@ -27,7 +28,6 @@ import Log from './Log';
 import type {MessageElementBase, MessageTextElement} from './MessageElement';
 import * as PersonalDetailsUtils from './PersonalDetailsUtils';
 import type {OptimisticIOUReportAction} from './ReportUtils';
-import DateUtils from './DateUtils';
 
 type LastVisibleMessage = {
     lastMessageTranslationKey?: string;


### PR DESCRIPTION
cc @pecanoro as this came up in https://github.com/Expensify/App/issues/39455, but not sure if causing the problem

### Details

waf is tossing values when they are not formatted correctly. we initialize the `mostRecentReportActionLastModified` with `new Date(0).toISOString()`, but need to get rid of the `T` and `Z` for it to pass the regex validation we use.

### Fixed Issues

Not really any specific issue.

### Tests

Take this test with a grain of salt as I am not entirely sure how someone could end up in a situation where they do not have any `reportActions`. But to confirm the changes are valid I:

1. Apply this diff to confirm the value of our initial `mostRecentReportActionLastModified`
```diff
diff --git a/src/libs/ReportActionsUtils.ts b/src/libs/ReportActionsUtils.ts
index 0eeba0b080..b76133dbde 100644
--- a/src/libs/ReportActionsUtils.ts
+++ b/src/libs/ReportActionsUtils.ts
@@ -727,7 +727,8 @@ function getReportAction(reportID: string, reportActionID: string): OnyxEntry<Re

 function getMostRecentReportActionLastModified(): string {
     // Start with the oldest date possible
-    let mostRecentReportActionLastModified = DateUtils.getDBTime(0);
+    let mostRecentReportActionLastModified = DateUtils.getDBTimeFromDate(new Date(0));
+    console.log('~ before', {mostRecentReportActionLastModified});

     // Flatten all the actions
     // Loop over them all to find the one that is the most recent
@@ -761,6 +762,7 @@ function getMostRecentReportActionLastModified(): string {
         mostRecentReportActionLastModified = reportLastVisibleActionLastModified;
     });

+    console.log('~ after', {mostRecentReportActionLastModified});
     return mostRecentReportActionLastModified;
 }
```
2. Go offline
3. Come back online which should trigger a call to `ReconnectApp`
4. We should see that the "before" value is a correct ISO formatted string and the "after" has a value (related to some report action). And verify that there is no `T` indicating the "time separator" or `Z` (indicating utc) at the end of the timestamp
![2024-04-22_14-32-25](https://github.com/Expensify/App/assets/32969087/23c38861-ff32-473b-83f2-60e2b5bbc84e)

6. Verify we do not see any logs like (which might be hard since you probably have some valid report actions):
```
Malformed REQUEST: 'mostRecentReportActionLastModified' = '1970-01-01T00:00:00.000Z', ignoring (should match '\d{4}-\d{2}-\d{2}( \d{2}:\d{2}:\d{2}(\.\d{3})?)?').
```

- [ ] Verify that no errors appear in the JS console

### Offline tests

❌ 

### QA Steps

No specific QA for this. It's not an easily reproducible situation AFAICT.

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

Skipped because the change is very small and no UI.

</details>

<details>
<summary>Android: mWeb Chrome</summary>

Skipped because the change is very small and no UI.

</details>

<details>
<summary>iOS: Native</summary>

Skipped because the change is very small and no UI.

</details>

<details>
<summary>iOS: mWeb Safari</summary>

Skipped because the change is very small and no UI.

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

![2024-04-22_14-32-25](https://github.com/Expensify/App/assets/32969087/a14308d6-fd80-4338-9aa6-9031e88a27ff)

</details>

<details>
<summary>MacOS: Desktop</summary>

Skipped because the change is very small and no UI.

</details>
