### PR TITLE
[CP Staging] Revert "Fix here is your magic code shows briefly when login with magic link"

### DIFF
--- a/src/pages/ValidateLoginPage/index.website.tsx
+++ b/src/pages/ValidateLoginPage/index.website.tsx
@@ -24,11 +24,9 @@ function ValidateLoginPage({
     const isSignedIn = !!session?.authToken && session?.authTokenType !== CONST.AUTH_TOKEN_TYPES.ANONYMOUS;
     const is2FARequired = !!account?.requiresTwoFactorAuth;
     const cachedAccountID = credentials?.accountID;
-    const isUserClickedSignIn = !login && isSignedIn && (autoAuthState === CONST.AUTO_AUTH_STATE.SIGNING_IN || autoAuthState === CONST.AUTO_AUTH_STATE.JUST_SIGNED_IN);
-    const shouldStartSignInWithValidateCode = !isUserClickedSignIn && !isSignedIn && (!!login || !!exitTo);
 
     useEffect(() => {
-        if (isUserClickedSignIn) {
+        if (!login && isSignedIn && (autoAuthState === CONST.AUTO_AUTH_STATE.SIGNING_IN || autoAuthState === CONST.AUTO_AUTH_STATE.JUST_SIGNED_IN)) {
             // The user clicked the option to sign in the current tab
             Navigation.isNavigationReady().then(() => {
                 Navigation.goBack();
@@ -37,7 +35,7 @@ function ValidateLoginPage({
         }
         Session.initAutoAuthState(autoAuthState);
 
-        if (!shouldStartSignInWithValidateCode) {
+        if (isSignedIn || (!login && !exitTo)) {
             if (exitTo) {
                 Session.handleExitToNavigation(exitTo);
             }
@@ -73,13 +71,13 @@ function ValidateLoginPage({
             {autoAuthState === CONST.AUTO_AUTH_STATE.FAILED && <ExpiredValidateCodeModal />}
             {autoAuthState === CONST.AUTO_AUTH_STATE.JUST_SIGNED_IN && is2FARequired && !isSignedIn && <JustSignedInModal is2FARequired />}
             {autoAuthState === CONST.AUTO_AUTH_STATE.JUST_SIGNED_IN && isSignedIn && !exitTo && <JustSignedInModal is2FARequired={false} />}
-            {autoAuthState === CONST.AUTO_AUTH_STATE.NOT_STARTED && !exitTo && !shouldStartSignInWithValidateCode && (
+            {autoAuthState === CONST.AUTO_AUTH_STATE.NOT_STARTED && !exitTo && (
                 <ValidateCodeModal
                     accountID={Number(accountID)}
                     code={validateCode}
                 />
             )}
-            {(autoAuthState === CONST.AUTO_AUTH_STATE.SIGNING_IN || shouldStartSignInWithValidateCode) && <FullScreenLoadingIndicator />}
+            {autoAuthState === CONST.AUTO_AUTH_STATE.SIGNING_IN && <FullScreenLoadingIndicator />}
         </>
     );
 }


### PR DESCRIPTION
Reverts Expensify/App#40177

Fixes a deploy blocker https://github.com/Expensify/App/issues/40742


1. Go to New dot and enter expensifail account with 2FA enabled
2. Navigate to email and locate the magic link - change to staging
3. Open an new tab and navigate to the staging link or build link
4. 2FA required page should be displayed without infinite loader