### PR TITLE
[CP Staging] Revert "Fix unread issue in combine report"

### DIFF
--- a/src/components/LHNOptionsList/LHNOptionsList.tsx
+++ b/src/components/LHNOptionsList/LHNOptionsList.tsx
@@ -116,8 +116,6 @@ function LHNOptionsList({
             const hasDraftComment = DraftCommentUtils.isValidDraftComment(draftComments?.[`${ONYXKEYS.COLLECTION.REPORT_DRAFT_COMMENT}${reportID}`]);
             const sortedReportActions = ReportActionsUtils.getSortedReportActionsForDisplay(itemReportActions);
             const lastReportAction = sortedReportActions[0];
-            const transactionThreadReportID = ReportActionsUtils.getOneTransactionThreadReportID(reportID, itemReportActions);
-            const transactionThreadReport = reports?.[`${ONYXKEYS.COLLECTION.REPORT}${transactionThreadReportID}`] ?? null;
 
             // Get the transaction for the last report action
             let lastReportActionTransactionID = '';
@@ -131,7 +129,6 @@ function LHNOptionsList({
                 <OptionRowLHNData
                     reportID={reportID}
                     fullReport={itemFullReport}
-                    transactionThreadReport={transactionThreadReport}
                     reportActions={itemReportActions}
                     parentReportAction={itemParentReportAction}
                     policy={itemPolicy}

--- a/src/components/LHNOptionsList/OptionRowLHN.tsx
+++ b/src/components/LHNOptionsList/OptionRowLHN.tsx
@@ -96,11 +96,6 @@ function OptionRowLHN({reportID, isFocused = false, onSelectRow = () => {}, opti
             false,
             optionItem.isPinned,
             !!optionItem.isUnread,
-            [],
-            false,
-            () => {},
-            false,
-            optionItem.transactionThreadReportID,
         );
     };
 

--- a/src/components/LHNOptionsList/OptionRowLHNData.tsx
+++ b/src/components/LHNOptionsList/OptionRowLHNData.tsx
@@ -27,7 +27,6 @@ function OptionRowLHNData({
     lastReportActionTransaction = {},
     transactionViolations,
     canUseViolations,
-    transactionThreadReport,
     ...propsToForward
 }: OptionRowLHNDataProps) {
     const reportID = propsToForward.reportID;
@@ -48,7 +47,6 @@ function OptionRowLHNData({
             policy,
             parentReportAction,
             hasViolations: !!shouldDisplayViolations,
-            transactionThreadReport,
         });
         if (deepEqual(item, optionItemRef.current)) {
             return optionItemRef.current;
@@ -72,7 +70,6 @@ function OptionRowLHNData({
         transactionViolations,
         canUseViolations,
         receiptTransactions,
-        transactionThreadReport,
     ]);
 
     return (

--- a/src/components/LHNOptionsList/types.ts
+++ b/src/components/LHNOptionsList/types.ts
@@ -74,9 +74,6 @@ type OptionRowLHNDataProps = {
     /** The full data of the report */
     fullReport: OnyxEntry<Report>;
 
-    /** The transaction thread report associated with the current report – applicable only for one-transaction money reports */
-    transactionThreadReport: OnyxEntry<Report>;
-
     /** The policy which the user has access to and which the report could be tied to */
     policy?: OnyxEntry<Policy>;
 

--- a/src/libs/ReportUtils.ts
+++ b/src/libs/ReportUtils.ts
@@ -441,7 +441,6 @@ type OptionData = {
     reportID?: string;
     enabled?: boolean;
     data?: Partial<TaxRate>;
-    transactionThreadReportID?: string | null;
 } & Report;
 
 type OnyxDataTaskAssigneeChat = {

--- a/src/libs/SidebarUtils.ts
+++ b/src/libs/SidebarUtils.ts
@@ -190,7 +190,6 @@ function getOptionData({
     policy,
     parentReportAction,
     hasViolations,
-    transactionThreadReport,
 }: {
     report: OnyxEntry<Report>;
     reportActions: OnyxEntry<ReportActions>;
@@ -199,7 +198,6 @@ function getOptionData({
     policy: OnyxEntry<Policy> | undefined;
     parentReportAction: OnyxEntry<ReportAction> | undefined;
     hasViolations: boolean;
-    transactionThreadReport: OnyxEntry<Report>;
 }): ReportUtils.OptionData | undefined {
     // When a user signs out, Onyx is cleared. Due to the lazy rendering with a virtual list, it's possible for
     // this method to be called after the Onyx data has been cleared out. In that case, it's fine to do
@@ -236,7 +234,6 @@ function getOptionData({
         isWaitingOnBankAccount: false,
         isAllowedToComment: true,
         isDeletedParentAction: false,
-        transactionThreadReportID: transactionThreadReport?.reportID,
     };
 
     let participantAccountIDs = report.participantAccountIDs ?? [];
@@ -269,7 +266,7 @@ function getOptionData({
     result.statusNum = report.statusNum;
     // When the only message of a report is deleted lastVisibileActionCreated is not reset leading to wrongly
     // setting it Unread so we add additional condition here to avoid empty chat LHN from being bold.
-    result.isUnread = (ReportUtils.isUnread(report) && !!report.lastActorAccountID) || (ReportUtils.isUnread(transactionThreadReport) && !!transactionThreadReport?.lastActorAccountID);
+    result.isUnread = ReportUtils.isUnread(report) && !!report.lastActorAccountID;
     result.isUnreadWithMention = ReportUtils.isUnreadWithMention(report);
     result.isPinned = report.isPinned;
     result.iouReportID = report.iouReportID;

--- a/src/pages/home/report/ContextMenu/BaseReportActionContextMenu.tsx
+++ b/src/pages/home/report/ContextMenu/BaseReportActionContextMenu.tsx
@@ -49,9 +49,6 @@ type BaseReportActionContextMenuProps = BaseReportActionContextMenuOnyxProps & {
     // eslint-disable-next-line react/no-unused-prop-types
     originalReportID: string;
 
-    /** The ID of transaction thread report associated with the current report, if any */
-    transactionThreadReportID: string;
-
     /**
      * If true, this component will be a small, row-oriented menu that displays icons but not text.
      * If false, this component will be a larger, column-oriented menu that displays icons alongside text in each row.
@@ -120,7 +117,6 @@ function BaseReportActionContextMenu({
     checkIfContextMenuActive,
     disabledActions = [],
     setIsEmojiPickerActive,
-    transactionThreadReportID,
 }: BaseReportActionContextMenuProps) {
     const StyleUtils = useStyleUtils();
     const {translate} = useLocalize();
@@ -249,7 +245,6 @@ function BaseReportActionContextMenu({
                         interceptAnonymousUser,
                         openOverflowMenu,
                         setIsEmojiPickerActive,
-                        transactionThreadReportID,
                     };
 
                     if ('renderContent' in contextAction) {

--- a/src/pages/home/report/ContextMenu/ContextMenuActions.tsx
+++ b/src/pages/home/report/ContextMenu/ContextMenuActions.tsx
@@ -79,7 +79,6 @@ type ContextMenuActionPayload = {
     event?: GestureResponderEvent | MouseEvent | KeyboardEvent;
     setIsEmojiPickerActive?: (state: boolean) => void;
     anchorRef?: MutableRefObject<View | null>;
-    transactionThreadReportID?: string;
 };
 
 type OnPress = (closePopover: boolean, payload: ContextMenuActionPayload, selection?: string, reportID?: string, draftMessage?: string) => void;
@@ -214,11 +213,8 @@ const ContextMenuActions: ContextMenuAction[] = [
         successIcon: Expensicons.Checkmark,
         shouldShow: (type, reportAction, isArchivedRoom, betas, menuTarget, isChronosReport, reportID, isPinnedChat, isUnreadChat) =>
             type === CONST.CONTEXT_MENU_TYPES.REPORT && isUnreadChat,
-        onPress: (closePopover, {reportID, transactionThreadReportID}) => {
+        onPress: (closePopover, {reportID}) => {
             Report.readNewestAction(reportID);
-            if (transactionThreadReportID && transactionThreadReportID !== '0') {
-                Report.readNewestAction(transactionThreadReportID);
-            }
             if (closePopover) {
                 hideContextMenu(true, ReportActionComposeFocusManager.focus);
             }

--- a/src/pages/home/report/ContextMenu/PopoverReportActionContextMenu.tsx
+++ b/src/pages/home/report/ContextMenu/PopoverReportActionContextMenu.tsx
@@ -37,7 +37,6 @@ function PopoverReportActionContextMenu(_props: unknown, ref: ForwardedRef<Repor
     const reportActionRef = useRef<OnyxEntry<ReportAction>>(null);
     const reportActionIDRef = useRef('0');
     const originalReportIDRef = useRef('0');
-    const transactionThreadReportIDRef = useRef('0');
     const selectionRef = useRef('');
     const reportActionDraftMessageRef = useRef<string>();
 
@@ -172,7 +171,6 @@ function PopoverReportActionContextMenu(_props: unknown, ref: ForwardedRef<Repor
         shouldCloseOnTarget = false,
         setIsEmojiPickerActive = () => {},
         isOverflowMenu = false,
-        transactionThreadReportID = undefined,
     ) => {
         const {pageX = 0, pageY = 0} = extractPointerEvent(event);
         contextMenuAnchorRef.current = contextMenuAnchor;
@@ -214,7 +212,6 @@ function PopoverReportActionContextMenu(_props: unknown, ref: ForwardedRef<Repor
             reportIDRef.current = reportID ?? '0';
             reportActionIDRef.current = reportActionID ?? '0';
             originalReportIDRef.current = originalReportID ?? '0';
-            transactionThreadReportIDRef.current = transactionThreadReportID ?? '0';
             selectionRef.current = selection;
             setIsPopoverVisible(true);
             reportActionDraftMessageRef.current = draftMessage;
@@ -340,7 +337,6 @@ function PopoverReportActionContextMenu(_props: unknown, ref: ForwardedRef<Repor
                     type={typeRef.current}
                     reportID={reportIDRef.current}
                     reportActionID={reportActionIDRef.current}
-                    transactionThreadReportID={transactionThreadReportIDRef.current}
                     draftMessage={reportActionDraftMessageRef.current}
                     selection={selectionRef.current}
                     isArchivedRoom={isRoomArchived}

--- a/src/pages/home/report/ContextMenu/ReportActionContextMenu.ts
+++ b/src/pages/home/report/ContextMenu/ReportActionContextMenu.ts
@@ -37,7 +37,6 @@ type ShowContextMenu = (
     shouldCloseOnTarget?: boolean,
     setIsEmojiPickerActive?: (state: boolean) => void,
     isOverflowMenu?: boolean,
-    transactionThreadReportID?: string,
 ) => void;
 
 type ReportActionContextMenu = {
@@ -120,7 +119,6 @@ function showContextMenu(
     shouldCloseOnTarget = false,
     setIsEmojiPickerActive = () => {},
     isOverflowMenu = false,
-    transactionThreadReportID = '0',
 ) {
     if (!contextMenuRef.current) {
         return;
@@ -151,7 +149,6 @@ function showContextMenu(
         shouldCloseOnTarget,
         setIsEmojiPickerActive,
         isOverflowMenu,
-        transactionThreadReportID,
     );
 }
 

--- a/src/pages/home/report/ReportActionItem.tsx
+++ b/src/pages/home/report/ReportActionItem.tsx
@@ -919,7 +919,6 @@ function ReportActionItem({
                             isChronosReport={ReportUtils.chatIncludesChronos(originalReport)}
                             checkIfContextMenuActive={toggleContextMenuFromActiveReportAction}
                             setIsEmojiPickerActive={setIsEmojiPickerActive}
-                            transactionThreadReportID={transactionThreadReport?.reportID ?? '0'}
                         />
                         <View style={StyleUtils.getReportActionItemStyle(hovered || isWhisper || isContextMenuActive || !!isEmojiPickerActive || draftMessage !== undefined, !!onPress)}>
                             <OfflineWithFeedback

--- a/tests/perf-test/SidebarUtils.perf-test.ts
+++ b/tests/perf-test/SidebarUtils.perf-test.ts
@@ -107,7 +107,6 @@ describe('SidebarUtils', () => {
                 policy,
                 parentReportAction,
                 hasViolations: false,
-                transactionThreadReport: null,
             }),
         );
     });


### PR DESCRIPTION
Reverts Expensify/App#40676

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/41088
PROPOSAL: 


### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

1. Go to staging.new.expensify.com
2. Go to workspace chat with no unsettled expense.
3. Create an expense. (this could be in DM too)
4. Go to combined report.
4. Pin the report to LHN.
5. Note that the report in LHN is not bolded.
6. Go to combined report and modifying any field.
7. Verify the LHN is not bold
8. Go back and forth between other chat and the combined report.
9. Verify the combined report is not bold in the LHN

<img width="1207" alt="image" src="https://github.com/Expensify/App/assets/36083550/ef716c20-0a9f-45e2-9e01-69e1bd331a5c">
