### PR TITLE
[Video] The controls bar flickers when video's popover menu is closed

### DIFF
--- a/src/components/Hoverable/ActiveHoverable.tsx
+++ b/src/components/Hoverable/ActiveHoverable.tsx
@@ -8,7 +8,7 @@ import type HoverableProps from './types';
 
 type ActiveHoverableProps = Omit<HoverableProps, 'disabled'>;
 
-function ActiveHoverable({onHoverIn, onHoverOut, shouldHandleScroll, children}: ActiveHoverableProps, outerRef: Ref<HTMLElement>) {
+function ActiveHoverable({onHoverIn, onHoverOut, shouldHandleScroll, shouldFreezeCapture, children}: ActiveHoverableProps, outerRef: Ref<HTMLElement>) {
     const [isHovered, setIsHovered] = useState(false);
 
     const elementRef = useRef<HTMLElement | null>(null);
@@ -19,12 +19,16 @@ function ActiveHoverable({onHoverIn, onHoverOut, shouldHandleScroll, children}: 
     const updateIsHovered = useCallback(
         (hovered: boolean) => {
             isHoveredRef.current = hovered;
-            if (shouldHandleScroll && isScrollingRef.current) {
+            // Nullish coalescing operator (`??`) wouldn't be appropriate here because
+            // it's not a matter of providing a default when encountering `null` or `undefined`
+            // but rather making a decision based on the truthy nature of the complete expressions.
+            // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+            if ((shouldHandleScroll && isScrollingRef.current) || shouldFreezeCapture) {
                 return;
             }
             setIsHovered(hovered);
         },
-        [shouldHandleScroll],
+        [shouldHandleScroll, shouldFreezeCapture],
     );
 
     useEffect(() => {
@@ -63,7 +67,9 @@ function ActiveHoverable({onHoverIn, onHoverOut, shouldHandleScroll, children}: 
          * @param event The hover event object.
          */
         const unsetHoveredIfOutside = (event: MouseEvent) => {
-            if (!elementRef.current || elementRef.current.contains(event.target as Node)) {
+            // We're also returning early if shouldFreezeCapture is true because
+            // in order to not update the hover state but keep it frozen.
+            if (!elementRef.current || elementRef.current.contains(event.target as Node) || shouldFreezeCapture) {
                 return;
             }
 
@@ -73,7 +79,7 @@ function ActiveHoverable({onHoverIn, onHoverOut, shouldHandleScroll, children}: 
         document.addEventListener('mouseover', unsetHoveredIfOutside);
 
         return () => document.removeEventListener('mouseover', unsetHoveredIfOutside);
-    }, [isHovered, elementRef]);
+    }, [isHovered, elementRef, shouldFreezeCapture]);
 
     useEffect(() => {
         const unsetHoveredWhenDocumentIsHidden = () => {

--- a/src/components/Hoverable/ActiveHoverable.tsx
+++ b/src/components/Hoverable/ActiveHoverable.tsx
@@ -67,8 +67,8 @@ function ActiveHoverable({onHoverIn, onHoverOut, shouldHandleScroll, shouldFreez
          * @param event The hover event object.
          */
         const unsetHoveredIfOutside = (event: MouseEvent) => {
-            // We're also returning early if shouldFreezeCapture is true because
-            // in order to not update the hover state but keep it frozen.
+            // We're also returning early if shouldFreezeCapture is true in order
+            // to not update the hover state but keep it frozen.
             if (!elementRef.current || elementRef.current.contains(event.target as Node) || shouldFreezeCapture) {
                 return;
             }

--- a/src/components/Hoverable/types.ts
+++ b/src/components/Hoverable/types.ts
@@ -18,6 +18,9 @@ type HoverableProps = {
 
     /** Decides whether to handle the scroll behaviour to show hover once the scroll ends */
     shouldHandleScroll?: boolean;
+
+    /** Decides whether to freeze the capture of the hover event */
+    shouldFreezeCapture?: boolean;
 };
 
 export default HoverableProps;

--- a/src/components/VideoPlayer/BaseVideoPlayer.tsx
+++ b/src/components/VideoPlayer/BaseVideoPlayer.tsx
@@ -285,7 +285,7 @@ function BaseVideoPlayer({
                 accessible={false}
                 style={[styles.cursorDefault, style]}
             >
-                <Hoverable>
+                <Hoverable shouldFreezeCapture={isPopoverVisible}>
                     {(isHovered) => (
                         <View style={[styles.w100, styles.h100]}>
                             <PressableWithoutFeedback


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->

Because within our [VideoPopoverMenu](https://github.com/Expensify/App/blob/f1502291a14d4e15e04249b241109f146bdb512f/src/components/VideoPlayer/BaseVideoPlayer.tsx#L326-L330) component we're using a [portal](https://github.com/Expensify/App/blob/f1502291a14d4e15e04249b241109f146bdb512f/src/components/Popover/index.tsx#L58-L75), when this is **open** it comes on top of the `BaseVideoPlayer` Hoverable surface of the video. These are the events that occur which lead to our issue:

- The video player controls 3-dot menu (More) is clicked -> Popover opens -> isHovered state is set to false.
- User clicks outside of the Popover -> Popover closes -> isHovered state is set to false again.
- Right after the Popover is gone, the Hoverable surface re-captures the mouse event -> isHovered state is set to true.

Our issue occurs between (2.) and (3.) in very quick succession which causes the flicker of the video player controls bar because of this condition [here](https://github.com/Expensify/App/blob/f1502291a14d4e15e04249b241109f146bdb512f/src/components/VideoPlayer/BaseVideoPlayer.tsx#L308), specifically the isHovered state variable coming from the Hoverable component which wraps the video container, toggling false/true in quick succession right after the isPopoverVisible becomes false.

This PR introduces a new boolean prop to the `Hoverable` component, named `shouldFreezeCapture` which will be used within the `ActiveHoverable` component to prevent setting the isHovered state to false the second time (unnecessarily) when an open portal (popover / modal) is being closed, essentially freezing the capture of the hover event.

> [!note]
> This behaviour and fix can observed only on large layout devices where hover event is available.

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/39598
PROPOSAL: https://github.com/Expensify/App/issues/39598#issuecomment-2041187706


### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

> [!tip]
> 1. Go to any chat.
> 2. Add a video attachment (you don't need to upload it).
> 3. Click on the 3-dot (`More`) button to open the Popover (you should see the `Playback speed` option).
> 4. Click outside of the Popover in order to close it.
> 5. Notice:
> - if the click outside the popover was applied **within** the video view -> the video controls bar remains **visible** and does not flicker when the popover menu is closed;
> - if the click outside the popover was applied **outside** of the video view -> the video controls bar **disappears** without flickering

- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

**TLDR:** same as **Tests**.

> [!tip]
> 1. Go to any chat.
> 2. Add a video attachment (you don't need to upload it).
> 3. Click on the 3-dot (`More`) button to open the Popover (you should see the `Playback speed` option).
> 4. Click outside of the Popover in order to close it.
> 5. Notice:
> - if the click outside the popover was applied **within** the video view -> the video controls bar remains **visible** and does not flicker when the popover menu is closed;
> - if the click outside the popover was applied **outside** of the video view -> the video controls bar **disappears** without flickering

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

**TLDR:** same as **Tests**.

> [!tip]
> 1. Go to any chat.
> 2. Add a video attachment (you don't need to upload it).
> 3. Click on the 3-dot (`More`) button to open the Popover (you should see the `Playback speed` option).
> 4. Click outside of the Popover in order to close it.
> 5. Notice:
> - if the click outside the popover was applied **within** the video view -> the video controls bar remains **visible** and does not flicker when the popover menu is closed;
> - if the click outside the popover was applied **outside** of the video view -> the video controls bar **disappears** without flickering

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

https://github.com/Expensify/App/assets/56457735/839d5338-8c91-4d47-b511-d1c556e73af1

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

https://github.com/Expensify/App/assets/56457735/1301d581-1ea4-4ed7-a87b-684afb7afe2e

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

https://github.com/Expensify/App/assets/56457735/95691ba4-1a68-4328-b26c-eabb0dfee80f

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

https://github.com/Expensify/App/assets/56457735/8093d22a-f30e-4b9a-af23-a9b868ae1d1d

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

https://github.com/Expensify/App/assets/56457735/52792167-991c-47b6-8334-df47971b6ccb

</details>

<details>
<summary>MacOS: Desktop</summary>

<!-- add screenshots or videos here -->

https://github.com/Expensify/App/assets/56457735/2a47ddbb-db73-44e9-80f9-2111e75ff25e



</details>
