### PR TITLE
fix: customize size behavior of image component

### DIFF
--- a/src/components/Image/ImageBehaviorContextProvider.tsx
+++ b/src/components/Image/ImageBehaviorContextProvider.tsx
@@ -11,8 +11,8 @@ const ImageBehaviorContext = createContext<ImageBehaviorContextValue>({
     doNotSetAspectRatio: false,
 });
 
-const ImageBehaviorContextProvider = ({children, ...value}: {children: React.ReactNode} & ImageBehaviorContextValue) => {
+function ImageBehaviorContextProvider({children, ...value}: {children: React.ReactNode} & ImageBehaviorContextValue) {
     return <ImageBehaviorContext.Provider value={value}>{children}</ImageBehaviorContext.Provider>;
-};
+}
 
 export {ImageBehaviorContext, ImageBehaviorContextProvider};

--- a/src/components/Image/ImageBehaviorContextProvider.tsx
+++ b/src/components/Image/ImageBehaviorContextProvider.tsx
@@ -4,11 +4,11 @@ type ImageBehaviorContextValue = {
     /**
      * Disable the logic to set aspect ratio of the container div based on the image aspect ratio.
      */
-    doNotSetAspectRatio: boolean;
+    doNotSetAspectRatioInStyle: boolean;
 };
 
 const ImageBehaviorContext = createContext<ImageBehaviorContextValue>({
-    doNotSetAspectRatio: false,
+    doNotSetAspectRatioInStyle: false,
 });
 
 function ImageBehaviorContextProvider({children, ...value}: {children: React.ReactNode} & ImageBehaviorContextValue) {

--- a/src/components/Image/ImageBehaviorContextProvider.tsx
+++ b/src/components/Image/ImageBehaviorContextProvider.tsx
@@ -4,11 +4,11 @@ type ImageBehaviorContextValue = {
     /**
      * Disable the logic to set aspect ratio of the container div based on the image aspect ratio.
      */
-    doNotSetAspectRatioInStyle: boolean;
+    shouldSetAspectRatioInStyle: boolean;
 };
 
 const ImageBehaviorContext = createContext<ImageBehaviorContextValue>({
-    doNotSetAspectRatioInStyle: false,
+    shouldSetAspectRatioInStyle: true,
 });
 
 function ImageBehaviorContextProvider({children, ...value}: {children: React.ReactNode} & ImageBehaviorContextValue) {

--- a/src/components/Image/ImageBehaviorContextProvider.tsx
+++ b/src/components/Image/ImageBehaviorContextProvider.tsx
@@ -2,7 +2,7 @@ import React, {createContext} from 'react';
 
 type ImageBehaviorContextValue = {
     /**
-     * Disable the logic to set aspect ratio of the container div based on the image aspect ratio.
+     * Determine whether or not to set the aspect ratio of the container div based on the image's aspect ratio.
      */
     shouldSetAspectRatioInStyle: boolean;
 };

--- a/src/components/Image/ImageBehaviorContextProvider.tsx
+++ b/src/components/Image/ImageBehaviorContextProvider.tsx
@@ -1,0 +1,18 @@
+import React, {createContext} from 'react';
+
+type ImageBehaviorContextValue = {
+    /**
+     * Disable the logic to set aspect ratio of the container div based on the image aspect ratio.
+     */
+    doNotSetAspectRatio: boolean;
+};
+
+const ImageBehaviorContext = createContext<ImageBehaviorContextValue>({
+    doNotSetAspectRatio: false,
+});
+
+const ImageBehaviorContextProvider = ({children, ...value}: {children: React.ReactNode} & ImageBehaviorContextValue) => {
+    return <ImageBehaviorContext.Provider value={value}>{children}</ImageBehaviorContext.Provider>;
+};
+
+export {ImageBehaviorContext, ImageBehaviorContextProvider};

--- a/src/components/Image/index.tsx
+++ b/src/components/Image/index.tsx
@@ -10,7 +10,7 @@ function Image({source: propsSource, isAuthTokenRequired = false, session, onLoa
     const [aspectRatio, setAspectRatio] = useState<string | number | null>(null);
     const isObjectPositionTop = objectPosition === CONST.IMAGE_OBJECT_POSITION.TOP;
 
-    const {doNotSetAspectRatioInStyle} = useContext(ImageBehaviorContext);
+    const {shouldSetAspectRatioInStyle} = useContext(ImageBehaviorContext);
 
     const updateAspectRatio = useCallback(
         (width: number, height: number) => {
@@ -61,6 +61,9 @@ function Image({source: propsSource, isAuthTokenRequired = false, session, onLoa
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [propsSource, isAuthTokenRequired]);
 
+    /**
+     * If the image fails to load and the object position is top, we should hide the image by setting the opacity to 0.
+     */
     const shouldOpacityBeZero = isObjectPositionTop && !aspectRatio;
 
     return (
@@ -68,7 +71,7 @@ function Image({source: propsSource, isAuthTokenRequired = false, session, onLoa
             // eslint-disable-next-line react/jsx-props-no-spreading
             {...forwardedProps}
             onLoad={handleLoad}
-            style={[style, !doNotSetAspectRatioInStyle && aspectRatio ? {aspectRatio, height: 'auto'} : {}, shouldOpacityBeZero && {opacity: 0}]}
+            style={[style, shouldSetAspectRatioInStyle && aspectRatio ? {aspectRatio, height: 'auto'} : {}, shouldOpacityBeZero && {opacity: 0}]}
             source={source}
         />
     );

--- a/src/components/Image/index.tsx
+++ b/src/components/Image/index.tsx
@@ -63,12 +63,14 @@ function Image({source: propsSource, isAuthTokenRequired = false, session, onLoa
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [propsSource, isAuthTokenRequired]);
 
+    const shouldOpacityBeZero = isObjectPositionTop && !doNotSetAspectRatio && !aspectRatio;
+
     return (
         <BaseImage
             // eslint-disable-next-line react/jsx-props-no-spreading
             {...forwardedProps}
             onLoad={handleLoad}
-            style={[style, aspectRatio ? {aspectRatio, height: 'auto'} : {}, isObjectPositionTop && !aspectRatio && {opacity: 0}]}
+            style={[style, aspectRatio ? {aspectRatio, height: 'auto'} : {}, shouldOpacityBeZero && {opacity: 0}]}
             source={source}
         />
     );

--- a/src/components/Image/index.tsx
+++ b/src/components/Image/index.tsx
@@ -1,13 +1,16 @@
-import React, {useCallback, useMemo, useState} from 'react';
+import React, {useCallback, useContext, useMemo, useState} from 'react';
 import {withOnyx} from 'react-native-onyx';
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
 import BaseImage from './BaseImage';
+import {ImageBehaviorContext} from './ImageBehaviorContextProvider';
 import type {ImageOnLoadEvent, ImageOnyxProps, ImageOwnProps, ImageProps} from './types';
 
 function Image({source: propsSource, isAuthTokenRequired = false, session, onLoad, objectPosition = CONST.IMAGE_OBJECT_POSITION.INITIAL, style, ...forwardedProps}: ImageProps) {
     const [aspectRatio, setAspectRatio] = useState<string | number | null>(null);
     const isObjectPositionTop = objectPosition === CONST.IMAGE_OBJECT_POSITION.TOP;
+
+    const {doNotSetAspectRatio} = useContext(ImageBehaviorContext);
 
     const updateAspectRatio = useCallback(
         (width: number, height: number) => {
@@ -30,10 +33,11 @@ function Image({source: propsSource, isAuthTokenRequired = false, session, onLoa
             const {width, height} = event.nativeEvent;
 
             onLoad?.(event);
-
-            updateAspectRatio(width, height);
+            if (!doNotSetAspectRatio) {
+                updateAspectRatio(width, height);
+            }
         },
-        [onLoad, updateAspectRatio],
+        [onLoad, updateAspectRatio, doNotSetAspectRatio],
     );
     /**
      * Check if the image source is a URL - if so the `encryptedAuthToken` is appended

--- a/src/components/Image/index.tsx
+++ b/src/components/Image/index.tsx
@@ -10,7 +10,7 @@ function Image({source: propsSource, isAuthTokenRequired = false, session, onLoa
     const [aspectRatio, setAspectRatio] = useState<string | number | null>(null);
     const isObjectPositionTop = objectPosition === CONST.IMAGE_OBJECT_POSITION.TOP;
 
-    const {doNotSetAspectRatio} = useContext(ImageBehaviorContext);
+    const {doNotSetAspectRatioInStyle} = useContext(ImageBehaviorContext);
 
     const updateAspectRatio = useCallback(
         (width: number, height: number) => {
@@ -33,11 +33,9 @@ function Image({source: propsSource, isAuthTokenRequired = false, session, onLoa
             const {width, height} = event.nativeEvent;
 
             onLoad?.(event);
-            if (!doNotSetAspectRatio) {
-                updateAspectRatio(width, height);
-            }
+            updateAspectRatio(width, height);
         },
-        [onLoad, updateAspectRatio, doNotSetAspectRatio],
+        [onLoad, updateAspectRatio],
     );
     /**
      * Check if the image source is a URL - if so the `encryptedAuthToken` is appended
@@ -63,14 +61,14 @@ function Image({source: propsSource, isAuthTokenRequired = false, session, onLoa
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [propsSource, isAuthTokenRequired]);
 
-    const shouldOpacityBeZero = isObjectPositionTop && !doNotSetAspectRatio && !aspectRatio;
+    const shouldOpacityBeZero = isObjectPositionTop && !aspectRatio;
 
     return (
         <BaseImage
             // eslint-disable-next-line react/jsx-props-no-spreading
             {...forwardedProps}
             onLoad={handleLoad}
-            style={[style, aspectRatio ? {aspectRatio, height: 'auto'} : {}, shouldOpacityBeZero && {opacity: 0}]}
+            style={[style, !doNotSetAspectRatioInStyle && aspectRatio ? {aspectRatio, height: 'auto'} : {}, shouldOpacityBeZero && {opacity: 0}]}
             source={source}
         />
     );

--- a/src/components/ReportActionItem/ReportActionItemImage.tsx
+++ b/src/components/ReportActionItem/ReportActionItemImage.tsx
@@ -46,9 +46,6 @@ type ReportActionItemImageProps = {
 
     /** Whether there are other images displayed in the same parent container */
     isSingleImage?: boolean;
-
-    /** Whether there are other images displayed in the same parent container */
-    doNotSetAspectRatio?: boolean;
 };
 
 /**

--- a/src/components/ReportActionItem/ReportActionItemImage.tsx
+++ b/src/components/ReportActionItem/ReportActionItemImage.tsx
@@ -46,6 +46,9 @@ type ReportActionItemImageProps = {
 
     /** Whether there are other images displayed in the same parent container */
     isSingleImage?: boolean;
+
+    /** Whether there are other images displayed in the same parent container */
+    doNotSetAspectRatio?: boolean;
 };
 
 /**

--- a/src/components/ReportActionItem/ReportActionItemImages.tsx
+++ b/src/components/ReportActionItem/ReportActionItemImages.tsx
@@ -2,6 +2,7 @@
 import React from 'react';
 import {View} from 'react-native';
 import {Polygon, Svg} from 'react-native-svg';
+import {ImageBehaviorContextProvider} from '@components/Image/ImageBehaviorContextProvider';
 import Text from '@components/Text';
 import useStyleUtils from '@hooks/useStyleUtils';
 import useTheme from '@hooks/useTheme';
@@ -65,28 +66,30 @@ function ReportActionItemImages({images, size, total, isHovered = false}: Report
     return (
         <View style={styles.reportActionItemImagesContainer}>
             <View style={[styles.reportActionItemImages, hoverStyle, heightStyle]}>
-                {shownImages.map(({thumbnail, isThumbnail, image, transaction, isLocalFile, fileExtension, filename}, index) => {
-                    // Show a border to separate multiple images. Shown to the right for each except the last.
-                    const shouldShowBorder = shownImages.length > 1 && index < shownImages.length - 1;
-                    const borderStyle = shouldShowBorder ? styles.reportActionItemImageBorder : {};
-                    return (
-                        <View
-                            key={`${index}-${image}`}
-                            style={[styles.reportActionItemImage, borderStyle, hoverStyle]}
-                        >
-                            <ReportActionItemImage
-                                thumbnail={thumbnail}
-                                fileExtension={fileExtension}
-                                image={image}
-                                isLocalFile={isLocalFile}
-                                filename={filename}
-                                transaction={transaction}
-                                isThumbnail={isThumbnail}
-                                isSingleImage={numberOfShownImages === 1}
-                            />
-                        </View>
-                    );
-                })}
+                <ImageBehaviorContextProvider doNotSetAspectRatio={true}>
+                    {shownImages.map(({thumbnail, isThumbnail, image, transaction, isLocalFile, fileExtension, filename}, index) => {
+                        // Show a border to separate multiple images. Shown to the right for each except the last.
+                        const shouldShowBorder = shownImages.length > 1 && index < shownImages.length - 1;
+                        const borderStyle = shouldShowBorder ? styles.reportActionItemImageBorder : {};
+                        return (
+                            <View
+                                key={`${index}-${image}`}
+                                style={[styles.reportActionItemImage, borderStyle, hoverStyle]}
+                            >
+                                <ReportActionItemImage
+                                    thumbnail={thumbnail}
+                                    fileExtension={fileExtension}
+                                    image={image}
+                                    isLocalFile={isLocalFile}
+                                    filename={filename}
+                                    transaction={transaction}
+                                    isThumbnail={isThumbnail}
+                                    isSingleImage={numberOfShownImages === 1}
+                                />
+                            </View>
+                        );
+                    })}
+                </ImageBehaviorContextProvider>
             </View>
             {remaining > 0 && (
                 <View style={[styles.reportActionItemImagesMoreContainer]}>

--- a/src/components/ReportActionItem/ReportActionItemImages.tsx
+++ b/src/components/ReportActionItem/ReportActionItemImages.tsx
@@ -66,7 +66,7 @@ function ReportActionItemImages({images, size, total, isHovered = false}: Report
     return (
         <View style={styles.reportActionItemImagesContainer}>
             <View style={[styles.reportActionItemImages, hoverStyle, heightStyle]}>
-                <ImageBehaviorContextProvider doNotSetAspectRatio>
+                <ImageBehaviorContextProvider doNotSetAspectRatioInStyle>
                     {shownImages.map(({thumbnail, isThumbnail, image, transaction, isLocalFile, fileExtension, filename}, index) => {
                         // Show a border to separate multiple images. Shown to the right for each except the last.
                         const shouldShowBorder = shownImages.length > 1 && index < shownImages.length - 1;

--- a/src/components/ReportActionItem/ReportActionItemImages.tsx
+++ b/src/components/ReportActionItem/ReportActionItemImages.tsx
@@ -66,7 +66,7 @@ function ReportActionItemImages({images, size, total, isHovered = false}: Report
     return (
         <View style={styles.reportActionItemImagesContainer}>
             <View style={[styles.reportActionItemImages, hoverStyle, heightStyle]}>
-                <ImageBehaviorContextProvider doNotSetAspectRatio={true}>
+                <ImageBehaviorContextProvider doNotSetAspectRatio>
                     {shownImages.map(({thumbnail, isThumbnail, image, transaction, isLocalFile, fileExtension, filename}, index) => {
                         // Show a border to separate multiple images. Shown to the right for each except the last.
                         const shouldShowBorder = shownImages.length > 1 && index < shownImages.length - 1;

--- a/src/components/ReportActionItem/ReportActionItemImages.tsx
+++ b/src/components/ReportActionItem/ReportActionItemImages.tsx
@@ -66,7 +66,7 @@ function ReportActionItemImages({images, size, total, isHovered = false}: Report
     return (
         <View style={styles.reportActionItemImagesContainer}>
             <View style={[styles.reportActionItemImages, hoverStyle, heightStyle]}>
-                <ImageBehaviorContextProvider doNotSetAspectRatioInStyle>
+                <ImageBehaviorContextProvider shouldSetAspectRatioInStyle={false}>
                     {shownImages.map(({thumbnail, isThumbnail, image, transaction, isLocalFile, fileExtension, filename}, index) => {
                         // Show a border to separate multiple images. Shown to the right for each except the last.
                         const shouldShowBorder = shownImages.length > 1 && index < shownImages.length - 1;


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->
Customize size behavior of image component: Do not set aspect ratio for all images in report preview to avoid inconsistent heights
### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/40751
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/40751
PROPOSAL: https://github.com/Expensify/App/issues/40751#issuecomment-2094010717


### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

- Submit a new expense with 3 following files to scan

<details><summary>3 files (2 images and 1 pdf)</summary>

![receipt-2](https://github.com/Expensify/App/assets/165644294/5123b512-57e6-42f7-8227-f431c77d1206)
![receipt-3](https://github.com/Expensify/App/assets/165644294/3bdc9cf6-d0ce-4617-8a98-e8abda81fb34)
[receipt-4.pdf](https://github.com/Expensify/App/files/15402860/receipt-4.pdf)

</details> 

- Reduce the screen size or use mobile browser, visit the report preview of the submitted expense
- Verify that all 3 preview images are aligned (same height)

- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->
![image](https://github.com/Expensify/App/assets/165644294/0e995c13-d591-49b6-8bc0-7b4412efc511)

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->
![Screenshot_1716399437](https://github.com/Expensify/App/assets/165644294/b00791cb-5b0b-4a41-a608-5889efd42f5c)


</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->
![Simulator Screenshot - iPhone 15 Pro Max - 2024-05-23 at 00 57 57](https://github.com/Expensify/App/assets/165644294/413694ae-3c16-47a6-98b8-5a7632d7e46f)

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->
![Simulator Screenshot - iPhone SE (3rd generation) - 2024-05-23 at 00 32 12](https://github.com/Expensify/App/assets/165644294/7c9bdeee-5f43-44e3-b880-4139c457549d)

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->
<img width="1322" alt="image" src="https://github.com/Expensify/App/assets/165644294/52ed0f17-1db3-43bc-9a58-b2f9b1cb285c">

</details>

<details>
<summary>MacOS: Desktop</summary>

<!-- add screenshots or videos here -->
<img width="821" alt="image" src="https://github.com/Expensify/App/assets/165644294/a2d3a207-e01d-4418-9e4c-7c5df90e71ea">

</details>
