### PR TITLE
fix: Taxes - App allows deleted tax rate to be selected as currency default in offline mode.

### DIFF
--- a/src/components/SelectionList/RadioListItem.tsx
+++ b/src/components/SelectionList/RadioListItem.tsx
@@ -40,6 +40,7 @@ function RadioListItem<TItem extends ListItem>({
             keyForList={item.keyForList}
             onFocus={onFocus}
             shouldSyncFocus={shouldSyncFocus}
+            pendingAction={item.pendingAction}
         >
             <>
                 <View style={[styles.flex1, styles.alignItemsStart]}>

--- a/src/components/TagPicker/index.tsx
+++ b/src/components/TagPicker/index.tsx
@@ -11,12 +11,14 @@ import type * as ReportUtils from '@libs/ReportUtils';
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
 import type {PolicyTag, PolicyTagList, PolicyTags, RecentlyUsedTags} from '@src/types/onyx';
+import type {PendingAction} from '@src/types/onyx/OnyxCommon';
 
 type SelectedTagOption = {
     name: string;
     enabled: boolean;
     isSelected?: boolean;
     accountID: number | undefined;
+    pendingAction?: PendingAction;
 };
 
 type TagPickerOnyxProps = {

--- a/src/libs/OptionsListUtils.ts
+++ b/src/libs/OptionsListUtils.ts
@@ -1144,7 +1144,10 @@ function getCategoryListSections(
     }
 
     const filteredRecentlyUsedCategories = recentlyUsedCategories
-        .filter((categoryName) => !selectedOptionNames.includes(categoryName) && categories[categoryName]?.enabled)
+        .filter(
+            (categoryName) =>
+                !selectedOptionNames.includes(categoryName) && categories[categoryName]?.enabled && categories[categoryName]?.pendingAction !== CONST.RED_BRICK_ROAD_PENDING_ACTION.DELETE,
+        )
         .map((categoryName) => ({
             name: categoryName,
             enabled: categories[categoryName].enabled ?? false,
@@ -1264,7 +1267,7 @@ function getTagListSections(
     const filteredRecentlyUsedTags = recentlyUsedTags
         .filter((recentlyUsedTag) => {
             const tagObject = tags.find((tag) => tag.name === recentlyUsedTag);
-            return !!tagObject?.enabled && !selectedOptionNames.includes(recentlyUsedTag);
+            return !!tagObject?.enabled && !selectedOptionNames.includes(recentlyUsedTag) && tagObject?.pendingAction !== CONST.RED_BRICK_ROAD_PENDING_ACTION.DELETE;
         })
         .map((tag) => ({name: tag, enabled: true}));
 

--- a/tests/unit/OptionsListUtilsTest.ts
+++ b/tests/unit/OptionsListUtilsTest.ts
@@ -7,6 +7,7 @@ import * as OptionsListUtils from '@src/libs/OptionsListUtils';
 import * as ReportUtils from '@src/libs/ReportUtils';
 import ONYXKEYS from '@src/ONYXKEYS';
 import type {PersonalDetails, Policy, PolicyCategories, Report, TaxRatesWithDefault, Transaction} from '@src/types/onyx';
+import type {PendingAction} from '@src/types/onyx/OnyxCommon';
 import waitForBatchedUpdates from '../utils/waitForBatchedUpdates';
 
 type PersonalDetailsList = Record<string, PersonalDetails & ReportUtils.OptionData>;
@@ -817,6 +818,7 @@ describe('OptionsListUtils', () => {
                 'GL Code': '',
                 externalID: '',
                 origin: '',
+                pendingAction: undefined,
             },
             Restaurant: {
                 enabled: true,
@@ -826,6 +828,7 @@ describe('OptionsListUtils', () => {
                 'GL Code': '',
                 externalID: '',
                 origin: '',
+                pendingAction: 'delete',
             },
             Food: {
                 enabled: true,
@@ -835,6 +838,7 @@ describe('OptionsListUtils', () => {
                 'GL Code': '',
                 externalID: '',
                 origin: '',
+                pendingAction: undefined,
             },
             'Food: Meat': {
                 enabled: true,
@@ -844,6 +848,7 @@ describe('OptionsListUtils', () => {
                 'GL Code': '',
                 externalID: '',
                 origin: '',
+                pendingAction: undefined,
             },
         };
         const smallResultList: OptionsListUtils.CategoryTreeSection[] = [
@@ -858,6 +863,7 @@ describe('OptionsListUtils', () => {
                         tooltipText: 'Food',
                         isDisabled: false,
                         isSelected: false,
+                        pendingAction: undefined,
                     },
                     {
                         text: '    Meat',
@@ -866,14 +872,16 @@ describe('OptionsListUtils', () => {
                         tooltipText: 'Meat',
                         isDisabled: false,
                         isSelected: false,
+                        pendingAction: undefined,
                     },
                     {
                         text: 'Restaurant',
                         keyForList: 'Restaurant',
                         searchText: 'Restaurant',
                         tooltipText: 'Restaurant',
-                        isDisabled: false,
+                        isDisabled: true,
                         isSelected: false,
+                        pendingAction: 'delete',
                     },
                 ],
                 indexOffset: 3,
@@ -892,6 +900,7 @@ describe('OptionsListUtils', () => {
                         tooltipText: 'Food',
                         isDisabled: false,
                         isSelected: false,
+                        pendingAction: undefined,
                     },
                     {
                         text: 'Food: Meat',
@@ -900,6 +909,7 @@ describe('OptionsListUtils', () => {
                         tooltipText: 'Food: Meat',
                         isDisabled: false,
                         isSelected: false,
+                        pendingAction: undefined,
                     },
                 ],
             },
@@ -1053,6 +1063,7 @@ describe('OptionsListUtils', () => {
                         tooltipText: 'Medical',
                         isDisabled: true,
                         isSelected: true,
+                        pendingAction: undefined,
                     },
                 ],
             },
@@ -1068,6 +1079,7 @@ describe('OptionsListUtils', () => {
                         tooltipText: 'Restaurant',
                         isDisabled: false,
                         isSelected: false,
+                        pendingAction: undefined,
                     },
                 ],
             },
@@ -1083,6 +1095,7 @@ describe('OptionsListUtils', () => {
                         tooltipText: 'Cars',
                         isDisabled: true,
                         isSelected: false,
+                        pendingAction: undefined,
                     },
                     {
                         text: '    Audi',
@@ -1091,6 +1104,7 @@ describe('OptionsListUtils', () => {
                         tooltipText: 'Audi',
                         isDisabled: false,
                         isSelected: false,
+                        pendingAction: undefined,
                     },
                     {
                         text: '    Mercedes-Benz',
@@ -1099,6 +1113,7 @@ describe('OptionsListUtils', () => {
                         tooltipText: 'Mercedes-Benz',
                         isDisabled: false,
                         isSelected: false,
+                        pendingAction: undefined,
                     },
                     {
                         text: 'Food',
@@ -1107,6 +1122,7 @@ describe('OptionsListUtils', () => {
                         tooltipText: 'Food',
                         isDisabled: false,
                         isSelected: false,
+                        pendingAction: undefined,
                     },
                     {
                         text: '    Meat',
@@ -1115,6 +1131,7 @@ describe('OptionsListUtils', () => {
                         tooltipText: 'Meat',
                         isDisabled: false,
                         isSelected: false,
+                        pendingAction: undefined,
                     },
                     {
                         text: '    Milk',
@@ -1123,6 +1140,7 @@ describe('OptionsListUtils', () => {
                         tooltipText: 'Milk',
                         isDisabled: false,
                         isSelected: false,
+                        pendingAction: undefined,
                     },
                     {
                         text: 'Restaurant',
@@ -1131,6 +1149,7 @@ describe('OptionsListUtils', () => {
                         tooltipText: 'Restaurant',
                         isDisabled: false,
                         isSelected: false,
+                        pendingAction: undefined,
                     },
                     {
                         text: 'Travel',
@@ -1139,6 +1158,7 @@ describe('OptionsListUtils', () => {
                         tooltipText: 'Travel',
                         isDisabled: true,
                         isSelected: false,
+                        pendingAction: undefined,
                     },
                     {
                         text: '    Meals',
@@ -1147,6 +1167,7 @@ describe('OptionsListUtils', () => {
                         tooltipText: 'Meals',
                         isDisabled: false,
                         isSelected: false,
+                        pendingAction: undefined,
                     },
                     {
                         text: '        Breakfast',
@@ -1155,6 +1176,7 @@ describe('OptionsListUtils', () => {
                         tooltipText: 'Breakfast',
                         isDisabled: false,
                         isSelected: false,
+                        pendingAction: undefined,
                     },
                     {
                         text: '        Lunch',
@@ -1163,6 +1185,7 @@ describe('OptionsListUtils', () => {
                         tooltipText: 'Lunch',
                         isDisabled: false,
                         isSelected: false,
+                        pendingAction: undefined,
                     },
                 ],
             },
@@ -1180,6 +1203,7 @@ describe('OptionsListUtils', () => {
                         tooltipText: 'Food',
                         isDisabled: false,
                         isSelected: false,
+                        pendingAction: undefined,
                     },
                     {
                         text: 'Food: Meat',
@@ -1188,6 +1212,7 @@ describe('OptionsListUtils', () => {
                         tooltipText: 'Food: Meat',
                         isDisabled: false,
                         isSelected: false,
+                        pendingAction: undefined,
                     },
                     {
                         text: 'Food: Milk',
@@ -1196,6 +1221,7 @@ describe('OptionsListUtils', () => {
                         tooltipText: 'Food: Milk',
                         isDisabled: false,
                         isSelected: false,
+                        pendingAction: undefined,
                     },
                 ],
             },
@@ -1222,6 +1248,7 @@ describe('OptionsListUtils', () => {
                         tooltipText: 'Medical',
                         isDisabled: true,
                         isSelected: true,
+                        pendingAction: undefined,
                     },
                 ],
             },
@@ -1316,6 +1343,7 @@ describe('OptionsListUtils', () => {
                 enabled: true,
                 name: 'HR',
                 accountID: undefined,
+                pendingAction: 'delete',
             },
         };
         const smallResultList: OptionsListUtils.CategorySection[] = [
@@ -1331,14 +1359,16 @@ describe('OptionsListUtils', () => {
                         tooltipText: 'Accounting',
                         isDisabled: false,
                         isSelected: false,
+                        pendingAction: undefined,
                     },
                     {
                         text: 'HR',
                         keyForList: 'HR',
                         searchText: 'HR',
                         tooltipText: 'HR',
-                        isDisabled: false,
+                        isDisabled: true,
                         isSelected: false,
+                        pendingAction: 'delete',
                     },
                     {
                         text: 'Medical',
@@ -1347,6 +1377,7 @@ describe('OptionsListUtils', () => {
                         tooltipText: 'Medical',
                         isDisabled: false,
                         isSelected: false,
+                        pendingAction: undefined,
                     },
                 ],
             },
@@ -1363,6 +1394,7 @@ describe('OptionsListUtils', () => {
                         tooltipText: 'Accounting',
                         isDisabled: false,
                         isSelected: false,
+                        pendingAction: undefined,
                     },
                 ],
             },
@@ -1424,6 +1456,7 @@ describe('OptionsListUtils', () => {
                 enabled: true,
                 name: 'Taxes',
                 accountID: undefined,
+                pendingAction: 'delete',
             },
             Benefits: {
                 enabled: true,
@@ -1443,6 +1476,7 @@ describe('OptionsListUtils', () => {
                         tooltipText: 'Medical',
                         isDisabled: false,
                         isSelected: true,
+                        pendingAction: undefined,
                     },
                 ],
             },
@@ -1457,6 +1491,7 @@ describe('OptionsListUtils', () => {
                         tooltipText: 'HR',
                         isDisabled: false,
                         isSelected: false,
+                        pendingAction: undefined,
                     },
                 ],
             },
@@ -1472,6 +1507,7 @@ describe('OptionsListUtils', () => {
                         tooltipText: 'Accounting',
                         isDisabled: false,
                         isSelected: false,
+                        pendingAction: undefined,
                     },
                     {
                         text: 'Benefits',
@@ -1480,6 +1516,7 @@ describe('OptionsListUtils', () => {
                         tooltipText: 'Benefits',
                         isDisabled: false,
                         isSelected: false,
+                        pendingAction: undefined,
                     },
                     {
                         text: 'Cleaning',
@@ -1488,6 +1525,7 @@ describe('OptionsListUtils', () => {
                         tooltipText: 'Cleaning',
                         isDisabled: false,
                         isSelected: false,
+                        pendingAction: undefined,
                     },
                     {
                         text: 'Food',
@@ -1496,6 +1534,7 @@ describe('OptionsListUtils', () => {
                         tooltipText: 'Food',
                         isDisabled: false,
                         isSelected: false,
+                        pendingAction: undefined,
                     },
                     {
                         text: 'HR',
@@ -1504,6 +1543,7 @@ describe('OptionsListUtils', () => {
                         tooltipText: 'HR',
                         isDisabled: false,
                         isSelected: false,
+                        pendingAction: undefined,
                     },
                     {
                         text: 'Software',
@@ -1512,14 +1552,16 @@ describe('OptionsListUtils', () => {
                         tooltipText: 'Software',
                         isDisabled: false,
                         isSelected: false,
+                        pendingAction: undefined,
                     },
                     {
                         text: 'Taxes',
                         keyForList: 'Taxes',
                         searchText: 'Taxes',
                         tooltipText: 'Taxes',
-                        isDisabled: false,
+                        isDisabled: true,
                         isSelected: false,
+                        pendingAction: 'delete',
                     },
                 ],
             },
@@ -1536,6 +1578,7 @@ describe('OptionsListUtils', () => {
                         tooltipText: 'Accounting',
                         isDisabled: false,
                         isSelected: false,
+                        pendingAction: undefined,
                     },
                     {
                         text: 'Cleaning',
@@ -1544,6 +1587,7 @@ describe('OptionsListUtils', () => {
                         tooltipText: 'Cleaning',
                         isDisabled: false,
                         isSelected: false,
+                        pendingAction: undefined,
                     },
                 ],
             },
@@ -1705,6 +1749,7 @@ describe('OptionsListUtils', () => {
                 tooltipText: 'Meals',
                 isDisabled: false,
                 isSelected: false,
+                pendingAction: undefined,
             },
             {
                 text: 'Restaurant',
@@ -1713,6 +1758,7 @@ describe('OptionsListUtils', () => {
                 tooltipText: 'Restaurant',
                 isDisabled: false,
                 isSelected: false,
+                pendingAction: undefined,
             },
             {
                 text: 'Food',
@@ -1721,6 +1767,7 @@ describe('OptionsListUtils', () => {
                 tooltipText: 'Food',
                 isDisabled: false,
                 isSelected: false,
+                pendingAction: undefined,
             },
             {
                 text: '    Meat',
@@ -1729,6 +1776,7 @@ describe('OptionsListUtils', () => {
                 tooltipText: 'Meat',
                 isDisabled: false,
                 isSelected: false,
+                pendingAction: undefined,
             },
             {
                 text: '    Milk',
@@ -1737,6 +1785,7 @@ describe('OptionsListUtils', () => {
                 tooltipText: 'Milk',
                 isDisabled: false,
                 isSelected: false,
+                pendingAction: undefined,
             },
             {
                 text: 'Cars',
@@ -1745,6 +1794,7 @@ describe('OptionsListUtils', () => {
                 tooltipText: 'Cars',
                 isDisabled: true,
                 isSelected: false,
+                pendingAction: undefined,
             },
             {
                 text: '    Audi',
@@ -1753,6 +1803,7 @@ describe('OptionsListUtils', () => {
                 tooltipText: 'Audi',
                 isDisabled: false,
                 isSelected: false,
+                pendingAction: undefined,
             },
             {
                 text: '    Mercedes-Benz',
@@ -1761,6 +1812,7 @@ describe('OptionsListUtils', () => {
                 tooltipText: 'Mercedes-Benz',
                 isDisabled: false,
                 isSelected: false,
+                pendingAction: undefined,
             },
             {
                 text: 'Travel',
@@ -1769,6 +1821,7 @@ describe('OptionsListUtils', () => {
                 tooltipText: 'Travel',
                 isDisabled: true,
                 isSelected: false,
+                pendingAction: undefined,
             },
             {
                 text: '    Meals',
@@ -1777,6 +1830,7 @@ describe('OptionsListUtils', () => {
                 tooltipText: 'Meals',
                 isDisabled: false,
                 isSelected: false,
+                pendingAction: undefined,
             },
             {
                 text: '        Breakfast',
@@ -1785,6 +1839,7 @@ describe('OptionsListUtils', () => {
                 tooltipText: 'Breakfast',
                 isDisabled: false,
                 isSelected: false,
+                pendingAction: undefined,
             },
             {
                 text: '        Lunch',
@@ -1793,6 +1848,7 @@ describe('OptionsListUtils', () => {
                 tooltipText: 'Lunch',
                 isDisabled: false,
                 isSelected: false,
+                pendingAction: undefined,
             },
             {
                 text: 'Plain',
@@ -1801,6 +1857,7 @@ describe('OptionsListUtils', () => {
                 tooltipText: 'Plain',
                 isDisabled: false,
                 isSelected: false,
+                pendingAction: undefined,
             },
             {
                 text: 'Audi',
@@ -1809,6 +1866,7 @@ describe('OptionsListUtils', () => {
                 tooltipText: 'Audi',
                 isDisabled: false,
                 isSelected: false,
+                pendingAction: undefined,
             },
             {
                 text: 'Health',
@@ -1817,6 +1875,7 @@ describe('OptionsListUtils', () => {
                 tooltipText: 'Health',
                 isDisabled: false,
                 isSelected: false,
+                pendingAction: undefined,
             },
             {
                 text: 'A',
@@ -1825,6 +1884,7 @@ describe('OptionsListUtils', () => {
                 tooltipText: 'A',
                 isDisabled: true,
                 isSelected: false,
+                pendingAction: undefined,
             },
             {
                 text: '    B',
@@ -1833,6 +1893,7 @@ describe('OptionsListUtils', () => {
                 tooltipText: 'B',
                 isDisabled: true,
                 isSelected: false,
+                pendingAction: undefined,
             },
             {
                 text: '        C',
@@ -1841,6 +1902,7 @@ describe('OptionsListUtils', () => {
                 tooltipText: 'C',
                 isDisabled: false,
                 isSelected: false,
+                pendingAction: undefined,
             },
             {
                 text: '            D',
@@ -1849,6 +1911,7 @@ describe('OptionsListUtils', () => {
                 tooltipText: 'D',
                 isDisabled: true,
                 isSelected: false,
+                pendingAction: undefined,
             },
             {
                 text: '                E',
@@ -1857,6 +1920,7 @@ describe('OptionsListUtils', () => {
                 tooltipText: 'E',
                 isDisabled: false,
                 isSelected: false,
+                pendingAction: undefined,
             },
         ];
         const resultOneLine = [
@@ -1867,6 +1931,7 @@ describe('OptionsListUtils', () => {
                 tooltipText: 'Meals',
                 isDisabled: false,
                 isSelected: false,
+                pendingAction: undefined,
             },
             {
                 text: 'Restaurant',
@@ -1875,6 +1940,7 @@ describe('OptionsListUtils', () => {
                 tooltipText: 'Restaurant',
                 isDisabled: false,
                 isSelected: false,
+                pendingAction: undefined,
             },
             {
                 text: 'Food',
@@ -1883,6 +1949,7 @@ describe('OptionsListUtils', () => {
                 tooltipText: 'Food',
                 isDisabled: false,
                 isSelected: false,
+                pendingAction: undefined,
             },
             {
                 text: 'Food: Meat',
@@ -1891,6 +1958,7 @@ describe('OptionsListUtils', () => {
                 tooltipText: 'Food: Meat',
                 isDisabled: false,
                 isSelected: false,
+                pendingAction: undefined,
             },
             {
                 text: 'Food: Milk',
@@ -1899,6 +1967,7 @@ describe('OptionsListUtils', () => {
                 tooltipText: 'Food: Milk',
                 isDisabled: false,
                 isSelected: false,
+                pendingAction: undefined,
             },
             {
                 text: 'Cars: Audi',
@@ -1907,6 +1976,7 @@ describe('OptionsListUtils', () => {
                 tooltipText: 'Cars: Audi',
                 isDisabled: false,
                 isSelected: false,
+                pendingAction: undefined,
             },
             {
                 text: 'Cars: Mercedes-Benz',
@@ -1915,6 +1985,7 @@ describe('OptionsListUtils', () => {
                 tooltipText: 'Cars: Mercedes-Benz',
                 isDisabled: false,
                 isSelected: false,
+                pendingAction: undefined,
             },
             {
                 text: 'Travel: Meals',
@@ -1923,6 +1994,7 @@ describe('OptionsListUtils', () => {
                 tooltipText: 'Travel: Meals',
                 isDisabled: false,
                 isSelected: false,
+                pendingAction: undefined,
             },
             {
                 text: 'Travel: Meals: Breakfast',
@@ -1931,6 +2003,7 @@ describe('OptionsListUtils', () => {
                 tooltipText: 'Travel: Meals: Breakfast',
                 isDisabled: false,
                 isSelected: false,
+                pendingAction: undefined,
             },
             {
                 text: 'Travel: Meals: Lunch',
@@ -1939,6 +2012,7 @@ describe('OptionsListUtils', () => {
                 tooltipText: 'Travel: Meals: Lunch',
                 isDisabled: false,
                 isSelected: false,
+                pendingAction: undefined,
             },
             {
                 text: 'Plain',
@@ -1947,6 +2021,7 @@ describe('OptionsListUtils', () => {
                 tooltipText: 'Plain',
                 isDisabled: false,
                 isSelected: false,
+                pendingAction: undefined,
             },
             {
                 text: 'Audi',
@@ -1955,6 +2030,7 @@ describe('OptionsListUtils', () => {
                 tooltipText: 'Audi',
                 isDisabled: false,
                 isSelected: false,
+                pendingAction: undefined,
             },
             {
                 text: 'Health',
@@ -1963,6 +2039,7 @@ describe('OptionsListUtils', () => {
                 tooltipText: 'Health',
                 isDisabled: false,
                 isSelected: false,
+                pendingAction: undefined,
             },
             {
                 text: 'A: B: C',
@@ -1971,6 +2048,7 @@ describe('OptionsListUtils', () => {
                 tooltipText: 'A: B: C',
                 isDisabled: false,
                 isSelected: false,
+                pendingAction: undefined,
             },
             {
                 text: 'A: B: C: D: E',
@@ -1979,6 +2057,7 @@ describe('OptionsListUtils', () => {
                 tooltipText: 'A: B: C: D: E',
                 isDisabled: false,
                 isSelected: false,
+                pendingAction: undefined,
             },
         ];
 
@@ -2007,6 +2086,7 @@ describe('OptionsListUtils', () => {
             Test: {
                 name: 'Test',
                 enabled: true,
+                pendingAction: 'delete' as PendingAction,
             },
             Test1: {
                 name: 'Test1',
@@ -2061,70 +2141,87 @@ describe('OptionsListUtils', () => {
             {
                 name: 'Taxes',
                 enabled: true,
+                pendingAction: undefined,
             },
             {
                 name: 'Taxi',
                 enabled: false,
+                pendingAction: undefined,
             },
             {
                 name: 'Test',
                 enabled: true,
+                pendingAction: 'delete',
             },
             {
                 name: 'Test: Test1',
                 enabled: true,
+                pendingAction: undefined,
             },
             {
                 name: 'Test: Test1: Subtest1',
                 enabled: true,
+                pendingAction: undefined,
             },
             {
                 name: 'Test: Test1: Subtest2',
                 enabled: true,
+                pendingAction: undefined,
             },
             {
                 name: 'Test: Test1: Subtest3',
                 enabled: false,
+                pendingAction: undefined,
             },
             {
                 name: 'Test: Test1: Subtest4',
                 enabled: true,
+                pendingAction: undefined,
             },
             {
                 name: 'Test: Test2',
                 enabled: true,
+                pendingAction: undefined,
             },
             {
                 name: 'Test: Test3: Subtest1',
                 enabled: true,
+                pendingAction: undefined,
             },
             {
                 name: 'Test1',
                 enabled: true,
+                pendingAction: undefined,
             },
             {
                 name: 'Test1: Subtest1',
                 enabled: true,
+                pendingAction: undefined,
             },
             {
                 name: 'Test1: Subtest2',
                 enabled: true,
+                pendingAction: undefined,
             },
             {
                 name: 'Test1: Subtest3',
                 enabled: true,
+                pendingAction: undefined,
             },
             {
                 name: 'Travel',
                 enabled: true,
+                pendingAction: undefined,
             },
             {
                 name: 'Travel: Nested-Travel',
                 enabled: true,
+                pendingAction: undefined,
             },
             {
                 name: 'Utilities',
                 enabled: true,
+                pendingAction: undefined,
             },
         ];
         const categoriesIncorrectOrdering2 = {
@@ -2189,58 +2286,72 @@ describe('OptionsListUtils', () => {
             {
                 enabled: true,
                 name: 'Cars: Audi',
+                pendingAction: undefined,
             },
             {
                 enabled: false,
                 name: 'Cars: BMW',
+                pendingAction: undefined,
             },
             {
                 enabled: true,
                 name: 'Cars: Mercedes-Benz',
+                pendingAction: undefined,
             },
             {
                 enabled: true,
                 name: 'Food',
+                pendingAction: undefined,
             },
             {
                 enabled: true,
                 name: 'Food: Meat',
+                pendingAction: undefined,
             },
             {
                 enabled: true,
                 name: 'Food: Milk',
+                pendingAction: undefined,
             },
             {
                 enabled: false,
                 name: 'Food: Vegetables',
+                pendingAction: undefined,
             },
             {
                 enabled: false,
                 name: 'Medical',
+                pendingAction: undefined,
             },
             {
                 enabled: true,
                 name: 'Restaurant',
+                pendingAction: undefined,
             },
             {
                 enabled: false,
                 name: 'Taxi',
+                pendingAction: undefined,
             },
             {
                 enabled: true,
                 name: 'Travel: Meals',
+                pendingAction: undefined,
             },
             {
                 enabled: true,
                 name: 'Travel: Meals: Breakfast',
+                pendingAction: undefined,
             },
             {
                 enabled: false,
                 name: 'Travel: Meals: Dinner',
+                pendingAction: undefined,
             },
             {
                 enabled: true,
                 name: 'Travel: Meals: Lunch',
+                pendingAction: undefined,
             },
         ];
         const categoriesIncorrectOrdering3 = {
@@ -2273,26 +2384,32 @@ describe('OptionsListUtils', () => {
             {
                 enabled: true,
                 name: 'Dr. House',
+                pendingAction: undefined,
             },
             {
                 enabled: true,
                 name: 'House, M.D.',
+                pendingAction: undefined,
             },
             {
                 enabled: true,
                 name: 'Many.dots.on.the.way.',
+                pendingAction: undefined,
             },
             {
                 enabled: false,
                 name: 'More.Many.dots.on.the.way.',
+                pendingAction: undefined,
             },
             {
                 enabled: true,
                 name: 'Movies',
+                pendingAction: undefined,
             },
             {
                 enabled: true,
                 name: 'Movies: Mr. Nobody',
+                pendingAction: undefined,
             },
         ];
 
@@ -2541,18 +2658,21 @@ describe('OptionsListUtils', () => {
                     value: '3%',
                     code: 'CODE2',
                     modifiedName: 'Tax rate 2 (3%)',
+                    pendingAction: 'delete',
                 },
                 CODE3: {
                     name: 'Tax option 3',
                     value: '5%',
                     code: 'CODE3',
                     modifiedName: 'Tax option 3 (5%)',
+                    pendingAction: undefined,
                 },
                 CODE1: {
                     name: 'Tax exempt 1',
                     value: '0%',
                     code: 'CODE1',
                     modifiedName: 'Tax exempt 1 (0%) • Default',
+                    pendingAction: undefined,
                 },
             },
         };
@@ -2569,30 +2689,33 @@ describe('OptionsListUtils', () => {
                 data: [
                     {
                         code: 'CODE1',
-                        isDisabled: undefined,
+                        isDisabled: false,
                         isSelected: undefined,
                         keyForList: 'Tax exempt 1 (0%) • Default',
                         searchText: 'Tax exempt 1 (0%) • Default',
                         text: 'Tax exempt 1 (0%) • Default',
                         tooltipText: 'Tax exempt 1 (0%) • Default',
+                        pendingAction: undefined,
                     },
                     {
                         code: 'CODE3',
-                        isDisabled: undefined,
+                        isDisabled: false,
                         isSelected: undefined,
                         keyForList: 'Tax option 3 (5%)',
                         searchText: 'Tax option 3 (5%)',
                         text: 'Tax option 3 (5%)',
                         tooltipText: 'Tax option 3 (5%)',
+                        pendingAction: undefined,
                     },
                     {
                         code: 'CODE2',
-                        isDisabled: undefined,
+                        isDisabled: true,
                         isSelected: undefined,
                         keyForList: 'Tax rate 2 (3%)',
                         searchText: 'Tax rate 2 (3%)',
                         text: 'Tax rate 2 (3%)',
                         tooltipText: 'Tax rate 2 (3%)',
+                        pendingAction: 'delete',
                     },
                 ],
                 shouldShow: false,
@@ -2605,12 +2728,13 @@ describe('OptionsListUtils', () => {
                 data: [
                     {
                         code: 'CODE2',
-                        isDisabled: undefined,
+                        isDisabled: true,
                         isSelected: undefined,
                         keyForList: 'Tax rate 2 (3%)',
                         searchText: 'Tax rate 2 (3%)',
                         text: 'Tax rate 2 (3%)',
                         tooltipText: 'Tax rate 2 (3%)',
+                        pendingAction: 'delete',
                     },
                 ],
                 shouldShow: true,


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->

### Fixed Issues
$ https://github.com/Expensify/App/issues/41066
PROPOSAL: https://github.com/Expensify/App/issues/41066#issuecomment-2079243609


### Tests 

- Test 1
1. Go to Account settings > Workspaces > any workspace.
2. Go to Taxes.
3. Go offline.
4. Delete one of the tax rate which is not the default tax rate.
5. Go to Settings > Workspace currency default.
6. Verify deleted tax rate can't be selected and is styled correctly with line-through
 
- Test 2
1. Go to Account settings > Workspaces > any workspace.
2. Go to Taxes.
3. Go offline.
4. Delete any tax.
5. Go back > Submit expense > Enter amount > Select the workspace with deleted tax 
6. Open tax picker > verify the deleted tax is can't be selected and is styled correctly with line-through
7. Repeat step 1 to 6 for category and tags also


- [x] Verify that no errors appear in the JS console

### Offline tests

- Test 1
1. Go to Account settings > Workspaces > any workspace.
2. Go to Taxes.
3. Go offline.
4. Delete one of the tax rate which is not the default tax rate.
5. Go to Settings > Workspace currency default.
6. Verify deleted tax rate can't be selected and is styled correctly with line-through
 
- Test 2
1. Go to Account settings > Workspaces > any workspace.
2. Go to Taxes.
3. Go offline.
4. Delete any tax.
5. Go back > Submit expense > Enter amount > Select the workspace with deleted tax 
6. Open tax picker > verify the deleted tax is can't be selected and is styled correctly with line-through
7. Repeat step 1 to 6 for category and tags also


### QA Steps

- Test 1
1. Go to Account settings > Workspaces > any workspace.
2. Go to Taxes.
3. Go offline.
4. Delete one of the tax rate which is not the default tax rate.
5. Go to Settings > Workspace currency default.
6. Verify deleted tax rate can't be selected and is styled correctly with line-through
 
- Test 2
1. Go to Account settings > Workspaces > any workspace.
2. Go to Taxes.
3. Go offline.
4. Delete any tax.
5. Go back > Submit expense > Enter amount > Select the workspace with deleted tax 
6. Open tax picker > verify the deleted tax is can't be selected and is styled correctly with line-through
7. Repeat step 1 to 6 for category and tags also


- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

https://github.com/Expensify/App/assets/85894871/69104b43-f7cf-45e3-bddc-d85577029527

</details>

<details>
<summary>Android: mWeb Chrome</summary>

https://github.com/Expensify/App/assets/85894871/4334491c-1973-4530-bf7e-a318ff998eb7

</details>

<details>
<summary>iOS: Native</summary>

https://github.com/Expensify/App/assets/85894871/eddd032d-ccb3-4828-ac56-0cbeb6275c48

</details>

<details>
<summary>iOS: mWeb Safari</summary>

https://github.com/Expensify/App/assets/85894871/f6d83812-7127-4a9e-9d74-41350af55f38

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

https://github.com/Expensify/App/assets/85894871/d17cc86a-a1d6-4332-99d5-5d476ebb0346

</details>

<details>
<summary>MacOS: Desktop</summary>

https://github.com/Expensify/App/assets/85894871/5dcae27e-38d1-4ba2-bc0d-767215329698

</details>
