### PR TITLE
Fix linked message visibility in offline mode

### DIFF
--- a/src/libs/actions/Report.ts
+++ b/src/libs/actions/Report.ts
@@ -3579,6 +3579,13 @@ function updateLastVisitTime(reportID: string) {
     Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT_METADATA}${reportID}`, {lastVisitTime: DateUtils.getDBTime()});
 }
 
+function updateLoadingInitialReportAction(reportID: string) {
+    if (!ReportUtils.isValidReportIDFromPath(reportID)) {
+        return;
+    }
+    Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT_METADATA}${reportID}`, {isLoadingInitialReportActions: false});
+}
+
 function clearNewRoomFormError() {
     Onyx.set(ONYXKEYS.FORMS.NEW_ROOM_FORM, {
         isLoading: false,
@@ -3819,6 +3826,7 @@ export {
     leaveGroupChat,
     removeFromGroupChat,
     updateGroupChatMemberRoles,
+    updateLoadingInitialReportAction,
     clearAddRoomMemberError,
     clearAvatarErrors,
 };

--- a/src/pages/home/report/ReportActionsView.tsx
+++ b/src/pages/home/report/ReportActionsView.tsx
@@ -104,6 +104,7 @@ function ReportActionsView({
     const didLayout = useRef(false);
     const didLoadOlderChats = useRef(false);
     const didLoadNewerChats = useRef(false);
+    const {isOffline} = useNetwork();
 
     // triggerListID is used when navigating to a chat with messages loaded from LHN. Typically, these include thread actions, task actions, etc. Since these messages aren't the latest,we don't maintain their position and instead trigger a recalculation of their positioning in the list.
     // we don't set currentReportActionID on initial render as linkedID as it should trigger visibleReportActions after linked message was positioned
@@ -127,6 +128,14 @@ function ReportActionsView({
 
         Report.openReport(reportID, reportActionID);
     };
+
+    useEffect(() => {
+        // When we linked to message - we do not need to wait for initial actions - they already exists
+        if (!(isNavigatingToLinkedMessage && isOffline)) {
+            return;
+        }
+        Report.updateLoadingInitialReportAction(report.reportID);
+    }, [isNavigatingToLinkedMessage, isOffline, report.reportID]);
 
     useLayoutEffect(() => {
         setCurrentReportActionID('');
@@ -348,7 +357,6 @@ function ReportActionsView({
                     // If there was an error only try again once on initial mount. We should also still load
                     // more in case we have cached messages.
                     (!hasMoreCached && didLoadNewerChats.current && hasLoadingNewerReportActionsError) ||
-                    network.isOffline ||
                     newestReportAction.pendingAction === CONST.RED_BRICK_ROAD_PENDING_ACTION.DELETE)
             ) {
                 return;

--- a/src/pages/home/report/ReportActionsView.tsx
+++ b/src/pages/home/report/ReportActionsView.tsx
@@ -208,7 +208,7 @@ function ReportActionsView({
      */
     const fetchNewerAction = useCallback(
         (newestReportAction: OnyxTypes.ReportAction) => {
-            if (isLoadingNewerReportActions || isLoadingInitialReportActions) {
+            if (isLoadingNewerReportActions || isLoadingInitialReportActions || (!!reportActionID && isOffline)) {
                 return;
             }
 
@@ -225,7 +225,7 @@ function ReportActionsView({
                 Report.getNewerActions(reportID, newestReportAction.reportActionID);
             }
         },
-        [isLoadingNewerReportActions, isLoadingInitialReportActions, reportID, transactionThreadReport, reportActionIDMap],
+        [isLoadingNewerReportActions, isLoadingInitialReportActions, reportActionID, isOffline, transactionThreadReport, reportActionIDMap, reportID],
     );
 
     const hasMoreCached = reportActions.length < combinedReportActions.length;

--- a/src/pages/home/report/ReportActionsView.tsx
+++ b/src/pages/home/report/ReportActionsView.tsx
@@ -131,11 +131,11 @@ function ReportActionsView({
 
     useEffect(() => {
         // When we linked to message - we do not need to wait for initial actions - they already exists
-        if (!(isNavigatingToLinkedMessage && isOffline)) {
+        if (!reportActionID || !isOffline) {
             return;
         }
         Report.updateLoadingInitialReportAction(report.reportID);
-    }, [isNavigatingToLinkedMessage, isOffline, report.reportID]);
+    }, [isOffline, report.reportID, reportActionID]);
 
     useLayoutEffect(() => {
         setCurrentReportActionID('');

--- a/src/pages/home/report/ReportActionsView.tsx
+++ b/src/pages/home/report/ReportActionsView.tsx
@@ -208,7 +208,7 @@ function ReportActionsView({
      */
     const fetchNewerAction = useCallback(
         (newestReportAction: OnyxTypes.ReportAction) => {
-            if (isLoadingNewerReportActions || isLoadingInitialReportActions || (!!reportActionID && isOffline)) {
+            if (isLoadingNewerReportActions || isLoadingInitialReportActions || (reportActionID && isOffline)) {
                 return;
             }
 

--- a/src/pages/home/report/ReportActionsView.tsx
+++ b/src/pages/home/report/ReportActionsView.tsx
@@ -375,7 +375,6 @@ function ReportActionsView({
             reportActionID,
             indexOfLinkedAction,
             handleReportActionPagination,
-            network.isOffline,
             reportActions.length,
             newestReportAction,
             isFocused,


### PR DESCRIPTION
### Details
Linked message in report is not showing in offline mode and user stuck in the same screen without option to go back

### Fixed Issues

$ https://github.com/Expensify/App/issues/41063
PROPOSAL:


### Tests
1. Launch New Expensify app.
2. Go offline.
3. Submit two expenses to a user.
4. Go to expense report.
5. Right click on any expense preview > Copy link.
6. Paste the link and send it.
7. Click on the same link
8. Verify that you can see messages - and linked message will be highlighted
9. Verify that user can go back and not stuck on the same screen (actual result in linked issue)


- [x] Verify that no errors appear in the JS console

### Offline tests
1. Launch New Expensify app.
2. Go offline.
3. Submit two expenses to a user.
4. Go to expense report.
5. Right click on any expense preview > Copy link.
6. Paste the link and send it.
7. Click on the same link
8. Verify that you can see messages - and linked message will be highlighted
9. Verify that user can go back and not stuck on the same screen (actual result in linked issue)

### QA Steps
1. Launch New Expensify app.
2. Go offline.
3. Submit two expenses to a user.
4. Go to expense report.
5. Right click on any expense preview > Copy link.
6. Paste the link and send it.
7. Click on the same link
8. Verify that you can see messages - and linked message will be highlighted
9. Verify that user can go back and not stuck on the same screen (actual result in linked issue)

- [x] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>


https://github.com/Expensify/App/assets/28352309/a467b46c-7c26-4def-b83f-80f205f0b0f3


</details>

<details>
<summary>Android: mWeb Chrome</summary>


https://github.com/Expensify/App/assets/28352309/d4348227-8c5f-4960-9c3e-154aa456493e


</details>

<details>
<summary>iOS: Native</summary>


https://github.com/Expensify/App/assets/28352309/860533b2-5153-4924-a05f-ac73bf9ce742


</details>

<details>
<summary>iOS: mWeb Safari</summary>


https://github.com/Expensify/App/assets/28352309/0db6891d-f390-4e0a-9444-050b486dfdf5


</details>

<details>
<summary>MacOS: Chrome / Safari</summary>



https://github.com/Expensify/App/assets/28352309/f6411469-1793-42c3-8268-6fbd665b0b8b



</details>

<details>
<summary>MacOS: Desktop</summary>


https://github.com/Expensify/App/assets/28352309/1b1f092c-599e-4193-aa6b-ddf0dcaa4102


</details>
