### PR TITLE
Fix issue of some views not being clickable due to flex1 on button

### DIFF
--- a/src/components/Form/FormProvider.tsx
+++ b/src/components/Form/FormProvider.tsx
@@ -72,9 +72,6 @@ type FormProviderProps<TFormID extends OnyxFormKey = OnyxFormKey> = FormProvider
         /** Styles that will be applied to the submit button only */
         submitButtonStyles?: StyleProp<ViewStyle>;
 
-        /** Whether to apply flex to the submit button */
-        submitFlexEnabled?: boolean;
-
         /** Whether the form container should grow or adapt to the viewable available space */
         shouldContainerGrow?: boolean;
     };

--- a/src/components/Form/FormWrapper.tsx
+++ b/src/components/Form/FormWrapper.tsx
@@ -29,9 +29,6 @@ type FormWrapperProps = ChildrenProps &
         /** Submit button styles */
         submitButtonStyles?: StyleProp<ViewStyle>;
 
-        /** Whether to apply flex to the submit button */
-        submitFlexEnabled?: boolean;
-
         /** Whether the form container should grow or adapt to the viewable available space */
         shouldContainerGrow?: boolean;
 
@@ -56,7 +53,6 @@ function FormWrapper({
     isSubmitButtonVisible = true,
     style,
     submitButtonStyles,
-    submitFlexEnabled = true,
     enabledWhenOffline,
     isSubmitActionDangerous = false,
     formID,
@@ -118,7 +114,7 @@ function FormWrapper({
                         onSubmit={onSubmit}
                         footerContent={footerContent}
                         onFixTheErrorsLinkPressed={onFixTheErrorsLinkPressed}
-                        containerStyles={[styles.mh0, styles.mt5, submitFlexEnabled ? styles.flex1 : {}, submitButtonStyles]}
+                        containerStyles={[styles.mh0, styles.mt5, submitButtonStyles]}
                         enabledWhenOffline={enabledWhenOffline}
                         isSubmitActionDangerous={isSubmitActionDangerous}
                         disablePressOnEnter={disablePressOnEnter}
@@ -145,7 +141,6 @@ function FormWrapper({
             onSubmit,
             footerContent,
             onFixTheErrorsLinkPressed,
-            submitFlexEnabled,
             submitButtonStyles,
             enabledWhenOffline,
             isSubmitActionDangerous,

--- a/src/pages/OnboardingPersonalDetails/BaseOnboardingPersonalDetails.tsx
+++ b/src/pages/OnboardingPersonalDetails/BaseOnboardingPersonalDetails.tsx
@@ -136,7 +136,7 @@ function BaseOnboardingPersonalDetails({currentUserPersonalDetails, shouldUseNat
                     onSubmit={completeEngagement}
                     submitButtonText={translate('common.continue')}
                     enabledWhenOffline
-                    submitFlexEnabled
+                    submitButtonStyles={[styles.flex1]}
                     shouldValidateOnBlur={false}
                     shouldValidateOnChange={shouldValidateOnChange}
                     shouldTrimValues={false}

--- a/src/pages/OnboardingWork/BaseOnboardingWork.tsx
+++ b/src/pages/OnboardingWork/BaseOnboardingWork.tsx
@@ -90,7 +90,7 @@ function BaseOnboardingWork({shouldUseNativeStyles, onboardingPurposeSelected, o
                     onSubmit={completeEngagement}
                     submitButtonText={translate('common.continue')}
                     enabledWhenOffline
-                    submitFlexEnabled
+                    submitButtonStyles={[styles.flex1]}
                     shouldValidateOnBlur
                     shouldValidateOnChange
                     shouldTrimValues={false}

--- a/src/pages/iou/request/step/IOURequestStepWaypoint.tsx
+++ b/src/pages/iou/request/step/IOURequestStepWaypoint.tsx
@@ -195,7 +195,6 @@ function IOURequestStepWaypoint({
                     enabledWhenOffline
                     validate={validate}
                     onSubmit={submit}
-                    submitFlexEnabled={false}
                     shouldContainerGrow={false}
                     shouldValidateOnChange={false}
                     shouldValidateOnBlur={false}

--- a/src/pages/workspace/distanceRates/CreateDistanceRatePage.tsx
+++ b/src/pages/workspace/distanceRates/CreateDistanceRatePage.tsx
@@ -78,7 +78,6 @@ function CreateDistanceRatePage({policy, route}: CreateDistanceRatePageProps) {
                     enabledWhenOffline
                     style={[styles.flexGrow1]}
                     shouldHideFixErrorsAlert
-                    submitFlexEnabled={false}
                     submitButtonStyles={[styles.mh5, styles.mt0]}
                     disablePressOnEnter={false}
                 >

--- a/src/pages/workspace/distanceRates/PolicyDistanceRateEditPage.tsx
+++ b/src/pages/workspace/distanceRates/PolicyDistanceRateEditPage.tsx
@@ -84,7 +84,6 @@ function PolicyDistanceRateEditPage({policy, route}: PolicyDistanceRateEditPageP
                     enabledWhenOffline
                     style={[styles.flexGrow1]}
                     shouldHideFixErrorsAlert
-                    submitFlexEnabled={false}
                     submitButtonStyles={[styles.mh5, styles.mt0]}
                     disablePressOnEnter={false}
                 >

--- a/src/pages/workspace/reimburse/WorkspaceRateAndUnitPage/RatePage.tsx
+++ b/src/pages/workspace/reimburse/WorkspaceRateAndUnitPage/RatePage.tsx
@@ -77,7 +77,6 @@ function WorkspaceRatePage(props: WorkspaceRatePageProps) {
                     enabledWhenOffline
                     style={[styles.flexGrow1]}
                     shouldHideFixErrorsAlert
-                    submitFlexEnabled={false}
                     submitButtonStyles={[styles.mh5, styles.mt0]}
                     disablePressOnEnter={false}
                 >

--- a/src/pages/workspace/taxes/ValuePage.tsx
+++ b/src/pages/workspace/taxes/ValuePage.tsx
@@ -78,7 +78,6 @@ function ValuePage({
                     enabledWhenOffline
                     disablePressOnEnter={false}
                     shouldHideFixErrorsAlert
-                    submitFlexEnabled={false}
                     submitButtonStyles={[styles.mh5, styles.mt0]}
                 >
                     <InputWrapper


### PR DESCRIPTION
### Details
Fix issue of some views not being clickable due to flex1 on button.

### Fixed Issues

$ https://github.com/Expensify/App/issues/42767
PROPOSAL: https://github.com/Expensify/App/issues/42767#issuecomment-2137800332

### Tests
1. Navigate to Settings > Wallet.
2. Click on "Add payment method".
3. Click on the "Debit Card" option.
4. I accept the Expensify Terms of Service checkbox and state field should be clickable.

### QA Steps
1. Navigate to Settings > Wallet.
2. Click on "Add payment method".
3. Click on the "Debit Card" option.
4. I accept the Expensify Terms of Service checkbox and state field should be clickable.

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>


</details>

<details>
<summary>Android: mWeb Chrome</summary>


</details>

<details>
<summary>iOS: Native</summary>




</details>

<details>
<summary>iOS: mWeb Safari</summary>


</details>

<details>
<summary>MacOS: Chrome / Safari</summary>


</details>

<details>
<summary>MacOS: Desktop</summary>


</details>