### PR TITLE
[CP Staging] Use modal context provider to fix useResponsiveLayout

### DIFF
--- a/src/components/ConfirmModal.tsx
+++ b/src/components/ConfirmModal.tsx
@@ -99,7 +99,7 @@ function ConfirmModal({
     image,
     shouldEnableNewFocusManagement,
 }: ConfirmModalProps) {
-    const {shouldUseNarrowLayout} = useResponsiveLayout();
+    const {isSmallScreenWidth} = useResponsiveLayout();
     const styles = useThemeStyles();
 
     return (
@@ -109,7 +109,7 @@ function ConfirmModal({
             isVisible={isVisible}
             shouldSetModalVisibility={shouldSetModalVisibility}
             onModalHide={onModalHide}
-            type={shouldUseNarrowLayout ? CONST.MODAL.MODAL_TYPE.BOTTOM_DOCKED : CONST.MODAL.MODAL_TYPE.CONFIRM}
+            type={isSmallScreenWidth ? CONST.MODAL.MODAL_TYPE.BOTTOM_DOCKED : CONST.MODAL.MODAL_TYPE.CONFIRM}
             innerContainerStyle={image ? styles.pt0 : {}}
             shouldEnableNewFocusManagement={shouldEnableNewFocusManagement}
         >

--- a/src/components/Modal/BaseModal.tsx
+++ b/src/components/Modal/BaseModal.tsx
@@ -56,8 +56,7 @@ function BaseModal(
     const theme = useTheme();
     const styles = useThemeStyles();
     const StyleUtils = useStyleUtils();
-    const {windowWidth, windowHeight} = useWindowDimensions();
-    const {shouldUseNarrowLayout} = useResponsiveLayout();
+    const {isSmallScreenWidth, windowWidth, windowHeight} = useWindowDimensions();
     const keyboardStateContextValue = useKeyboardState();
 
     const safeAreaInsets = useSafeAreaInsets();
@@ -164,13 +163,13 @@ function BaseModal(
                 {
                     windowWidth,
                     windowHeight,
-                    isSmallScreenWidth: shouldUseNarrowLayout,
+                    isSmallScreenWidth,
                 },
                 popoverAnchorPosition,
                 innerContainerStyle,
                 outerStyle,
             ),
-        [StyleUtils, type, windowWidth, windowHeight, shouldUseNarrowLayout, popoverAnchorPosition, innerContainerStyle, outerStyle],
+        [StyleUtils, type, windowWidth, windowHeight, isSmallScreenWidth, popoverAnchorPosition, innerContainerStyle, outerStyle],
     );
 
     const {

--- a/src/components/Modal/BaseModal.tsx
+++ b/src/components/Modal/BaseModal.tsx
@@ -17,6 +17,7 @@ import variables from '@styles/variables';
 import * as Modal from '@userActions/Modal';
 import CONST from '@src/CONST';
 import ModalContent from './ModalContent';
+import ModalContext from './ModalContext';
 import type BaseModalProps from './types';
 
 function BaseModal(
@@ -200,60 +201,69 @@ function BaseModal(
               paddingRight: safeAreaPaddingRight ?? 0,
           };
 
+    const modalContextValue = useMemo(
+        () => ({
+            activeModalType: isVisible ? type : undefined,
+        }),
+        [isVisible, type],
+    );
+
     return (
-        // this is a workaround for modal not being visible on the new arch in some cases
-        // it's necessary to have a non-collapseable view as a parent of the modal to prevent
-        // a conflict between RN core and Reanimated shadow tree operations
-        // position absolute is needed to prevent the view from interfering with flex layout
-        <View
-            collapsable={false}
-            style={[styles.pAbsolute]}
-        >
-            <ReactNativeModal
-                // Prevent the parent element to capture a click. This is useful when the modal component is put inside a pressable.
-                onClick={(e) => e.stopPropagation()}
-                onBackdropPress={handleBackdropPress}
-                // Note: Escape key on web/desktop will trigger onBackButtonPress callback
-                // eslint-disable-next-line react/jsx-props-no-multi-spaces
-                onBackButtonPress={Modal.closeTop}
-                onModalShow={handleShowModal}
-                propagateSwipe={propagateSwipe}
-                onModalHide={hideModal}
-                onModalWillShow={saveFocusState}
-                onDismiss={handleDismissModal}
-                onSwipeComplete={() => onClose?.()}
-                swipeDirection={swipeDirection}
-                isVisible={isVisible}
-                backdropColor={theme.overlay}
-                backdropOpacity={!shouldUseCustomBackdrop && hideBackdrop ? 0 : variables.overlayOpacity}
-                backdropTransitionOutTiming={0}
-                hasBackdrop={fullscreen}
-                coverScreen={fullscreen}
-                style={modalStyle}
-                deviceHeight={windowHeight}
-                deviceWidth={windowWidth}
-                animationIn={animationIn ?? modalStyleAnimationIn}
-                animationOut={animationOut ?? modalStyleAnimationOut}
-                useNativeDriver={useNativeDriverProp && useNativeDriver}
-                useNativeDriverForBackdrop={useNativeDriverForBackdrop && useNativeDriver}
-                hideModalContentWhileAnimating={hideModalContentWhileAnimating}
-                animationInTiming={animationInTiming}
-                animationOutTiming={animationOutTiming}
-                statusBarTranslucent={statusBarTranslucent}
-                onLayout={onLayout}
-                avoidKeyboard={avoidKeyboard}
-                customBackdrop={shouldUseCustomBackdrop ? <Overlay onPress={handleBackdropPress} /> : undefined}
+        <ModalContext.Provider value={modalContextValue}>
+            <View
+                // this is a workaround for modal not being visible on the new arch in some cases
+                // it's necessary to have a non-collapseable view as a parent of the modal to prevent
+                // a conflict between RN core and Reanimated shadow tree operations
+                // position absolute is needed to prevent the view from interfering with flex layout
+                collapsable={false}
+                style={[styles.pAbsolute]}
             >
-                <ModalContent onDismiss={handleDismissModal}>
-                    <View
-                        style={[styles.defaultModalContainer, modalPaddingStyles, modalContainerStyle, !isVisible && styles.pointerEventsNone]}
-                        ref={ref}
-                    >
-                        <ColorSchemeWrapper>{children}</ColorSchemeWrapper>
-                    </View>
-                </ModalContent>
-            </ReactNativeModal>
-        </View>
+                <ReactNativeModal
+                    // Prevent the parent element to capture a click. This is useful when the modal component is put inside a pressable.
+                    onClick={(e) => e.stopPropagation()}
+                    onBackdropPress={handleBackdropPress}
+                    // Note: Escape key on web/desktop will trigger onBackButtonPress callback
+                    // eslint-disable-next-line react/jsx-props-no-multi-spaces
+                    onBackButtonPress={Modal.closeTop}
+                    onModalShow={handleShowModal}
+                    propagateSwipe={propagateSwipe}
+                    onModalHide={hideModal}
+                    onModalWillShow={saveFocusState}
+                    onDismiss={handleDismissModal}
+                    onSwipeComplete={() => onClose?.()}
+                    swipeDirection={swipeDirection}
+                    isVisible={isVisible}
+                    backdropColor={theme.overlay}
+                    backdropOpacity={!shouldUseCustomBackdrop && hideBackdrop ? 0 : variables.overlayOpacity}
+                    backdropTransitionOutTiming={0}
+                    hasBackdrop={fullscreen}
+                    coverScreen={fullscreen}
+                    style={modalStyle}
+                    deviceHeight={windowHeight}
+                    deviceWidth={windowWidth}
+                    animationIn={animationIn ?? modalStyleAnimationIn}
+                    animationOut={animationOut ?? modalStyleAnimationOut}
+                    useNativeDriver={useNativeDriverProp && useNativeDriver}
+                    useNativeDriverForBackdrop={useNativeDriverForBackdrop && useNativeDriver}
+                    hideModalContentWhileAnimating={hideModalContentWhileAnimating}
+                    animationInTiming={animationInTiming}
+                    animationOutTiming={animationOutTiming}
+                    statusBarTranslucent={statusBarTranslucent}
+                    onLayout={onLayout}
+                    avoidKeyboard={avoidKeyboard}
+                    customBackdrop={shouldUseCustomBackdrop ? <Overlay onPress={handleBackdropPress} /> : undefined}
+                >
+                    <ModalContent onDismiss={handleDismissModal}>
+                        <View
+                            style={[styles.defaultModalContainer, modalPaddingStyles, modalContainerStyle, !isVisible && styles.pointerEventsNone]}
+                            ref={ref}
+                        >
+                            <ColorSchemeWrapper>{children}</ColorSchemeWrapper>
+                        </View>
+                    </ModalContent>
+                </ReactNativeModal>
+            </View>
+        </ModalContext.Provider>
     );
 }
 

--- a/src/components/Modal/BaseModal.tsx
+++ b/src/components/Modal/BaseModal.tsx
@@ -4,7 +4,6 @@ import ReactNativeModal from 'react-native-modal';
 import ColorSchemeWrapper from '@components/ColorSchemeWrapper';
 import useKeyboardState from '@hooks/useKeyboardState';
 import usePrevious from '@hooks/usePrevious';
-import useResponsiveLayout from '@hooks/useResponsiveLayout';
 import useSafeAreaInsets from '@hooks/useSafeAreaInsets';
 import useStyleUtils from '@hooks/useStyleUtils';
 import useTheme from '@hooks/useTheme';

--- a/src/components/Modal/ModalContext.ts
+++ b/src/components/Modal/ModalContext.ts
@@ -1,0 +1,15 @@
+import {createContext} from 'react';
+import type ModalType from '@src/types/utils/ModalType';
+
+type ModalContextType = {
+    // The type of the currently displayed modal, or undefined if there is no currently displayed modal.
+    // Note that React Native can only display one modal at a time.
+    activeModalType?: ModalType;
+};
+
+// This context is meant to inform modal children that they are rendering in a modal (and what type of modal they are rendering in)
+// Note that this is different than ONYXKEYS.MODAL.isVisible data point in that that is a global variable for whether a modal is visible or not,
+// whereas this context is provided by the BaseModal component, and thus is only available to components rendered inside a modal.
+const ModalContext = createContext<ModalContextType>({});
+
+export default ModalContext;

--- a/src/components/Popover/index.tsx
+++ b/src/components/Popover/index.tsx
@@ -28,7 +28,7 @@ function Popover(props: PopoverProps) {
         animationOut = 'fadeOut',
     } = props;
 
-    const {shouldUseNarrowLayout} = useResponsiveLayout();
+    const {isSmallScreenWidth} = useResponsiveLayout();
     const withoutOverlayRef = useRef(null);
     const {close, popover} = React.useContext(PopoverContext);
 
@@ -55,7 +55,7 @@ function Popover(props: PopoverProps) {
         onClose();
     };
 
-    if (!fullscreen && !shouldUseNarrowLayout) {
+    if (!fullscreen && !isSmallScreenWidth) {
         return createPortal(
             <Modal
                 // eslint-disable-next-line react/jsx-props-no-spreading
@@ -74,7 +74,7 @@ function Popover(props: PopoverProps) {
         );
     }
 
-    if (withoutOverlay && !shouldUseNarrowLayout) {
+    if (withoutOverlay && !isSmallScreenWidth) {
         return createPortal(
             <PopoverWithoutOverlay
                 // eslint-disable-next-line react/jsx-props-no-spreading
@@ -93,11 +93,11 @@ function Popover(props: PopoverProps) {
             {...props}
             onClose={onCloseWithPopoverContext}
             shouldHandleNavigationBack={props.shouldHandleNavigationBack}
-            type={shouldUseNarrowLayout ? CONST.MODAL.MODAL_TYPE.BOTTOM_DOCKED : CONST.MODAL.MODAL_TYPE.POPOVER}
-            popoverAnchorPosition={shouldUseNarrowLayout ? undefined : anchorPosition}
-            fullscreen={shouldUseNarrowLayout ? true : fullscreen}
-            animationInTiming={disableAnimation && !shouldUseNarrowLayout ? 1 : animationInTiming}
-            animationOutTiming={disableAnimation && !shouldUseNarrowLayout ? 1 : animationOutTiming}
+            type={isSmallScreenWidth ? CONST.MODAL.MODAL_TYPE.BOTTOM_DOCKED : CONST.MODAL.MODAL_TYPE.POPOVER}
+            popoverAnchorPosition={isSmallScreenWidth ? undefined : anchorPosition}
+            fullscreen={isSmallScreenWidth ? true : fullscreen}
+            animationInTiming={disableAnimation && !isSmallScreenWidth ? 1 : animationInTiming}
+            animationOutTiming={disableAnimation && !isSmallScreenWidth ? 1 : animationOutTiming}
             onLayout={onLayout}
             animationIn={animationIn}
             animationOut={animationOut}

--- a/src/components/PopoverMenu.tsx
+++ b/src/components/PopoverMenu.tsx
@@ -98,7 +98,7 @@ function PopoverMenu({
     shouldEnableNewFocusManagement,
 }: PopoverMenuProps) {
     const styles = useThemeStyles();
-    const {shouldUseNarrowLayout} = useResponsiveLayout();
+    const {isSmallScreenWidth} = useResponsiveLayout();
     const selectedItemIndex = useRef<number | null>(null);
 
     const [currentMenuItems, setCurrentMenuItems] = useState(menuItems);
@@ -198,7 +198,7 @@ function PopoverMenu({
             shouldSetModalVisibility={shouldSetModalVisibility}
             shouldEnableNewFocusManagement={shouldEnableNewFocusManagement}
         >
-            <View style={shouldUseNarrowLayout ? {} : styles.createMenuContainer}>
+            <View style={isSmallScreenWidth ? {} : styles.createMenuContainer}>
                 {!!headerText && <Text style={[styles.createMenuHeaderText, styles.ml3]}>{headerText}</Text>}
                 {enteredSubMenuIndexes.length > 0 && renderBackButtonItem()}
                 {currentMenuItems.map((item, menuIndex) => (

--- a/src/hooks/useResponsiveLayout.ts
+++ b/src/hooks/useResponsiveLayout.ts
@@ -1,15 +1,14 @@
-import {useEffect, useRef, useState} from 'react';
-import type {OnyxEntry} from 'react-native-onyx';
-import {useOnyx} from 'react-native-onyx';
-import Navigation, {navigationRef} from '@libs/Navigation/Navigation';
-import ONYXKEYS from '@src/ONYXKEYS';
-import type {Modal} from '@src/types/onyx';
+import {useContext} from 'react';
+import ModalContext from '@components/Modal/ModalContext';
+import Navigation from '@libs/Navigation/Navigation';
+import CONST from '@src/CONST';
+import useRootNavigationState from './useRootNavigationState';
 import useWindowDimensions from './useWindowDimensions';
 
 type ResponsiveLayoutResult = {
     shouldUseNarrowLayout: boolean;
     isSmallScreenWidth: boolean;
-    isInModal: boolean;
+    isInNarrowPaneModal: boolean;
     isExtraSmallScreenHeight: boolean;
     isMediumScreenWidth: boolean;
     isLargeScreenWidth: boolean;
@@ -19,39 +18,47 @@ type ResponsiveLayoutResult = {
 
 /**
  * Hook to determine if we are on mobile devices or in the Modal Navigator.
- * Use "shouldUseNarrowLayout" for "on mobile or in RHP/LHP", "isSmallScreenWidth" for "on mobile", "isInModal" for "in RHP/LHP".
+ * Use "shouldUseNarrowLayout" for "on mobile or in RHP/LHP", "isSmallScreenWidth" for "on mobile", "isInNarrowPaneModal" for "in RHP/LHP".
+ *
+ * There are two kinds of modals in this app:
+ *     1. Modal stack navigators from react-navigation
+ *     2. Modal components that use react-native-modal
+ *
+ * This hook is designed to handle both. `shouldUseNarrowLayout` will return `true` if any of the following are true:
+ *     1. The device screen width is narrow
+ *     2. The consuming component is the child of a "right docked" react-native-modal component
+ *     3. The consuming component is a screen in a modal stack navigator and not a child of a "non-right-docked" react-native-modal component.
+ *
+ * For more details on the various modal types we've defined for this app and implemented using react-native-modal, see `ModalType`.
  */
 export default function useResponsiveLayout(): ResponsiveLayoutResult {
     const {isSmallScreenWidth, isExtraSmallScreenHeight, isExtraSmallScreenWidth, isMediumScreenWidth, isLargeScreenWidth, isSmallScreen} = useWindowDimensions();
 
-    const [willAlertModalBecomeVisible] = useOnyx(ONYXKEYS.MODAL, {selector: (value: OnyxEntry<Modal>) => value?.willAlertModalBecomeVisible ?? false});
+    // Note: activeModalType refers to our react-native-modal component wrapper, not react-navigation's modal stack navigators.
+    // This means it will only be defined if the component calling this hook is a child of a modal component. See BaseModal for the provider.
+    const {activeModalType} = useContext(ModalContext);
 
-    const [isInModal, setIsInModal] = useState(false);
-    const hasSetIsInModal = useRef(false);
-    const updateModalStatus = () => {
-        if (hasSetIsInModal.current) {
-            return;
-        }
-        const isDisplayedInModal = Navigation.isDisplayedInModal();
-        if (isInModal !== isDisplayedInModal) {
-            setIsInModal(isDisplayedInModal);
-        }
-        hasSetIsInModal.current = true;
+    // This refers to the state of the root navigator, and is true if and only if the topmost navigator is the "left modal navigator" or the "right modal navigator"
+    const isDisplayedInModalNavigator = !!useRootNavigationState(Navigation.isModalNavigatorActive);
+
+    // The component calling this hook is in a "narrow pane modal" if:
+    const isInNarrowPaneModal =
+        // it's a child of the right-docked modal
+        activeModalType === CONST.MODAL.MODAL_TYPE.RIGHT_DOCKED ||
+        // or there's a "right modal navigator" or "left modal navigator" on the top of the root navigation stack
+        // and the component calling this hook is not the child of another modal type, such as a confirm modal
+        (isDisplayedInModalNavigator && !activeModalType);
+
+    const shouldUseNarrowLayout = isSmallScreenWidth || isInNarrowPaneModal;
+
+    return {
+        shouldUseNarrowLayout,
+        isSmallScreenWidth,
+        isInNarrowPaneModal,
+        isExtraSmallScreenHeight,
+        isExtraSmallScreenWidth,
+        isMediumScreenWidth,
+        isLargeScreenWidth,
+        isSmallScreen,
     };
-
-    useEffect(() => {
-        const unsubscribe = navigationRef?.current?.addListener('state', updateModalStatus);
-
-        if (navigationRef?.current?.isReady()) {
-            updateModalStatus();
-        }
-
-        return () => {
-            unsubscribe?.();
-        };
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, []);
-
-    const shouldUseNarrowLayout = willAlertModalBecomeVisible ? isSmallScreenWidth : isSmallScreenWidth || isInModal;
-    return {shouldUseNarrowLayout, isSmallScreenWidth, isInModal, isExtraSmallScreenHeight, isExtraSmallScreenWidth, isMediumScreenWidth, isLargeScreenWidth, isSmallScreen};
 }

--- a/src/hooks/useRootNavigationState.ts
+++ b/src/hooks/useRootNavigationState.ts
@@ -1,0 +1,30 @@
+import type {EventListenerCallback, NavigationContainerEventMap} from '@react-navigation/native';
+import type {NavigationState} from '@react-navigation/routers';
+import {useCallback, useSyncExternalStore} from 'react';
+import {navigationRef} from '@libs/Navigation/Navigation';
+
+/**
+ * This hook is a replacement for `useNavigationState` for nested navigators.
+ * If `useNavigationState` is used within a nested navigator then the state that's returned is the state of the nearest parent navigator,
+ * not the root navigator state representing the whole app's navigation tree.
+ *
+ * Use with caution, because re-rendering any component every time the root navigation state changes can be very costly for performance.
+ * That's why the selector is mandatory.
+ */
+function useRootNavigationState(selector: (state: NavigationState) => unknown) {
+    const getSnapshot = useCallback(() => {
+        if (!navigationRef.current) {
+            return;
+        }
+        return selector(navigationRef.current.getRootState());
+    }, [selector]);
+
+    const subscribeToRootState = useCallback((callback: EventListenerCallback<NavigationContainerEventMap, 'state'>) => {
+        const unsubscribe = navigationRef?.current?.addListener('state', callback);
+        return () => unsubscribe?.();
+    }, []);
+
+    return useSyncExternalStore(subscribeToRootState, getSnapshot);
+}
+
+export default useRootNavigationState;

--- a/src/hooks/useRootNavigationState.ts
+++ b/src/hooks/useRootNavigationState.ts
@@ -11,7 +11,7 @@ import {navigationRef} from '@libs/Navigation/Navigation';
  * Use with caution, because re-rendering any component every time the root navigation state changes can be very costly for performance.
  * That's why the selector is mandatory.
  */
-function useRootNavigationState(selector: (state: NavigationState) => unknown) {
+function useRootNavigationState<T>(selector: (state: NavigationState) => T): T | undefined {
     const getSnapshot = useCallback(() => {
         if (!navigationRef.current) {
             return;

--- a/src/hooks/useRootNavigationState.ts
+++ b/src/hooks/useRootNavigationState.ts
@@ -13,7 +13,7 @@ import {navigationRef} from '@libs/Navigation/Navigation';
  */
 function useRootNavigationState<T>(selector: (state: NavigationState) => T): T | undefined {
     const getSnapshot = useCallback(() => {
-        if (!navigationRef.current) {
+        if (!navigationRef?.current) {
             return;
         }
         return selector(navigationRef.current.getRootState());

--- a/src/libs/Navigation/Navigation.ts
+++ b/src/libs/Navigation/Navigation.ts
@@ -1,5 +1,5 @@
 import {findFocusedRoute} from '@react-navigation/core';
-import type {EventArg, NavigationContainerEventMap} from '@react-navigation/native';
+import type {EventArg, NavigationContainerEventMap, NavigationState} from '@react-navigation/native';
 import {CommonActions, getPathFromState, StackActions} from '@react-navigation/native';
 import Log from '@libs/Log';
 import * as ReportUtils from '@libs/ReportUtils';
@@ -356,9 +356,12 @@ function navigateWithSwitchPolicyID(params: SwitchPolicyIDParams) {
     return switchPolicyID(navigationRef.current, params);
 }
 
-/** Check if the modal is being displayed */
-function isDisplayedInModal() {
-    const state = navigationRef?.current?.getRootState();
+/**
+ * Check if the modal is being displayed.
+ *
+ * @param state - MUST be the state of the root navigator for this to work. Do not use a child navigator state.
+ */
+function isModalNavigatorActive(state: NavigationState) {
     const lastRoute = state?.routes?.at(-1);
     const lastRouteName = lastRoute?.name;
     return lastRouteName === NAVIGATORS.LEFT_MODAL_NAVIGATOR || lastRouteName === NAVIGATORS.RIGHT_MODAL_NAVIGATOR;
@@ -383,7 +386,7 @@ export default {
     parseHybridAppUrl,
     navigateWithSwitchPolicyID,
     resetToHome,
-    isDisplayedInModal,
+    isModalNavigatorActive,
     closeRHPFlow,
     setNavigationActionToMicrotaskQueue,
 };

--- a/src/pages/signin/LoginForm/BaseLoginForm.tsx
+++ b/src/pages/signin/LoginForm/BaseLoginForm.tsx
@@ -64,7 +64,7 @@ function BaseLoginForm({account, credentials, closeAccount, blurOnSubmit = false
     const firstBlurred = useRef(false);
     const isFocused = useIsFocused();
     const isLoading = useRef(false);
-    const {shouldUseNarrowLayout, isInModal} = useResponsiveLayout();
+    const {shouldUseNarrowLayout, isInNarrowPaneModal} = useResponsiveLayout();
 
     /**
      * Validate the input value and set the error for formError
@@ -167,7 +167,7 @@ function BaseLoginForm({account, credentials, closeAccount, blurOnSubmit = false
             return;
         }
         let focusTimeout: NodeJS.Timeout;
-        if (isInModal) {
+        if (isInNarrowPaneModal) {
             focusTimeout = setTimeout(() => input.current?.focus(), CONST.ANIMATED_TRANSITION);
         } else {
             input.current.focus();

--- a/src/pages/signin/SignInPage.tsx
+++ b/src/pages/signin/SignInPage.tsx
@@ -130,7 +130,7 @@ function SignInPageInner({credentials, account, activeClients = [], preferredLoc
     const styles = useThemeStyles();
     const StyleUtils = useStyleUtils();
     const {translate, formatPhoneNumber} = useLocalize();
-    const {shouldUseNarrowLayout, isInModal} = useResponsiveLayout();
+    const {shouldUseNarrowLayout, isInNarrowPaneModal} = useResponsiveLayout();
     const safeAreaInsets = useSafeAreaInsets();
     const signInPageLayoutRef = useRef<SignInPageLayoutRef>(null);
     const loginFormRef = useRef<InputHandle>(null);
@@ -250,7 +250,7 @@ function SignInPageInner({credentials, account, activeClients = [], preferredLoc
         <ScreenWrapper
             shouldShowOfflineIndicator={false}
             shouldEnableMaxHeight={shouldEnableMaxHeight}
-            style={[styles.signInPage, StyleUtils.getSafeAreaPadding({...safeAreaInsets, bottom: 0, top: isInModal ? 0 : safeAreaInsets.top}, 1)]}
+            style={[styles.signInPage, StyleUtils.getSafeAreaPadding({...safeAreaInsets, bottom: 0, top: isInNarrowPaneModal ? 0 : safeAreaInsets.top}, 1)]}
             testID={SignInPageInner.displayName}
         >
             <SignInPageLayout


### PR DESCRIPTION
### Details
Tried to add lots of detailed code comments. The idea is that `shouldUseNarrowLayout` should be true if and only if:

- The screen is narrow, OR
- The component is a child of a right-docked modal
- The component is a child of a "left hand pane" or "right hand pane" modal stack navigator and is not a child of another modal type, such as a popover or confirm modal.

cc @rayane-djouah @getusha

### Fixed Issues
$ https://github.com/Expensify/App/issues/42910
$ https://github.com/Expensify/App/issues/42911
$ https://github.com/Expensify/App/issues/42912
PROPOSAL: https://github.com/Expensify/App/issues/42911#issuecomment-2145856344

### Tests / QA Steps
1. FAB > Start Chat
1. Add Members > Click Next
1. Click on the Group Avatar
1. Verify that the `Upload Photo` popover does not jitter.
1. Right-click / longPress on a message. Verify that the popover appears in the correct place without jittering. On mobile, verify that the bottom-docked modal appears.
1. Upload an attachment to a chat, make sure the attachment preview looks as expected.
1. Open the search page, page sure it looks as expected.
1. Sign in with a new account. Verify the welcome modal appears as expected.
1. (web) Go to any chat.
1. (web) Click on the chat header.
1. (web) Refresh the page while RHP is open.
1. (web) Click outside the RHP to dismiss it.
1. (web) Click + button next to the composer.
1. (web) Click FAB button. Verify it opens as normal.
1. Go to workspace chat that has other members than yourself.
1. Click on the chat header.
1. Go to Members.
1. Select one user.
1. Click Remove. Verify the confirm modal appears as expected (centered confirm modal on wide screens, bottom-docked on mobile).
1. Create a new group.
1. Click on the group header.
1. Select one or more participants.
1. Click on the drop-down button. Verify that the popover appears as expected (near the button on wide screens, bottom-docked on mobile)
1. Click on remove
1. Verify that the confirm modal appears as expected.
1. Press cancel.
1. Click on the group avatar.
1. Verify the `Upload photo` popover appears as expected (near the button on wide screens, bottom-docked on narrow).
1. Click on any user's profile photo.
1. Verify that the attachment modal for their profile photo appears centered on wide screens and full-screen on narrow screens.
1. Close the attachment modal. Verify that on wide screens it fades out and on narrow screens it slides out to the right.

- [ ] Verify that no errors appear in the JS console

### Offline tests
n/a

### PR Author Checklist
- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

https://github.com/Expensify/App/assets/47436092/8ab2b0b4-4ffc-44f1-b4d6-35bdc2a81b81

<img width="1510" alt="image" src="https://github.com/Expensify/App/assets/47436092/46df923f-da87-4c16-8bf0-5125845328b9">

<img width="1469" alt="image" src="https://github.com/Expensify/App/assets/47436092/59320b1c-c699-444d-8ee1-1f7da991445f">

<img width="848" alt="image" src="https://github.com/Expensify/App/assets/47436092/7b6cc5b8-0787-496a-8289-00c2b7af9572">

<img width="1492" alt="image" src="https://github.com/Expensify/App/assets/47436092/e0b67824-fa1d-4eb6-a140-c3b93137486d">

<img width="1512" alt="image" src="https://github.com/Expensify/App/assets/47436092/39a03448-77be-4e1b-83f4-3ac4f50654f9">

<img width="1512" alt="image" src="https://github.com/Expensify/App/assets/47436092/92548bbc-cc2f-498d-9607-f5e493e62d6c">

<img width="1512" alt="image" src="https://github.com/Expensify/App/assets/47436092/40da2462-7381-4f10-a485-ba6afa27ad00">

https://github.com/Expensify/App/assets/47436092/ee6fd96d-e51e-4542-86d9-758b3b28228e

https://github.com/Expensify/App/assets/47436092/f7a2cc9c-97a8-4baa-9e0d-c2e59b3dc501

<img width="1512" alt="image" src="https://github.com/Expensify/App/assets/47436092/6d8981a3-2f33-4623-a627-9b1d6b65b6c5">

<img width="650" alt="image" src="https://github.com/Expensify/App/assets/47436092/a13e586f-2623-45a9-b2a0-4fc28b0bf5f2">

https://github.com/Expensify/App/assets/47436092/c53a917a-b469-4c28-9dc3-934a74857d21

</details>

<details>
<summary>MacOS: Desktop</summary>

<!-- add screenshots or videos here -->

</details>
