### PR TITLE
[No QA] Temporarily disable queries that are not implemented yet

### DIFF
--- a/src/pages/Search/SearchFilters.tsx
+++ b/src/pages/Search/SearchFilters.tsx
@@ -44,18 +44,6 @@ function SearchFilters({query}: SearchFiltersProps) {
             icon: Expensicons.Send,
             route: ROUTES.SEARCH.getRoute(CONST.TAB_SEARCH.SHARED),
         },
-        // {
-        //     title: translate('common.drafts'),
-        //     query: CONST.TAB_SEARCH.DRAFTS,
-        //     icon: Expensicons.Pencil,
-        //     route: ROUTES.SEARCH.getRoute(CONST.TAB_SEARCH.DRAFTS),
-        // },
-        // {
-        //     title: translate('common.finished'),
-        //     query: CONST.TAB_SEARCH.FINISHED,
-        //     icon: Expensicons.CheckCircle,
-        //     route: ROUTES.SEARCH.getRoute(CONST.TAB_SEARCH.FINISHED),
-        // },
     ];
     const activeItemIndex = filterItems.findIndex((item) => item.query === query);
 

--- a/src/pages/Search/SearchFilters.tsx
+++ b/src/pages/Search/SearchFilters.tsx
@@ -44,18 +44,18 @@ function SearchFilters({query}: SearchFiltersProps) {
             icon: Expensicons.Send,
             route: ROUTES.SEARCH.getRoute(CONST.TAB_SEARCH.SHARED),
         },
-        {
-            title: translate('common.drafts'),
-            query: CONST.TAB_SEARCH.DRAFTS,
-            icon: Expensicons.Pencil,
-            route: ROUTES.SEARCH.getRoute(CONST.TAB_SEARCH.DRAFTS),
-        },
-        {
-            title: translate('common.finished'),
-            query: CONST.TAB_SEARCH.FINISHED,
-            icon: Expensicons.CheckCircle,
-            route: ROUTES.SEARCH.getRoute(CONST.TAB_SEARCH.FINISHED),
-        },
+        // {
+        //     title: translate('common.drafts'),
+        //     query: CONST.TAB_SEARCH.DRAFTS,
+        //     icon: Expensicons.Pencil,
+        //     route: ROUTES.SEARCH.getRoute(CONST.TAB_SEARCH.DRAFTS),
+        // },
+        // {
+        //     title: translate('common.finished'),
+        //     query: CONST.TAB_SEARCH.FINISHED,
+        //     icon: Expensicons.CheckCircle,
+        //     route: ROUTES.SEARCH.getRoute(CONST.TAB_SEARCH.FINISHED),
+        // },
     ];
     const activeItemIndex = filterItems.findIndex((item) => item.query === query);
 


### PR DESCRIPTION
### Details
I merged this PR to help testing the hybrid report view in the new search pages, but a couple of the queries are not implemented yet, so I'm commenting those options out for now.

### Fixed Issues
https://github.com/Expensify/App/issues/41625

### Tests
1. Navigate to the search page, `Profile > Troubleshoot > New search page`
2. Verify that you cannot see the `Drafts` and `Finished` options

- [x] Verify that no errors appear in the JS console

### Offline tests
N/A

### QA Steps
N/A

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos

![Screenshot 2024-06-03 at 5 42 51 PM](https://github.com/Expensify/App/assets/22219519/41d129a4-470c-4c95-a035-45b02cfda625)
<details>


<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Desktop</summary>

<!-- add screenshots or videos here -->

</details>
