### PR TITLE
Fix applying onyx updates from push notifications

### DIFF
--- a/src/libs/Notification/PushNotification/subscribePushNotification/index.ts
+++ b/src/libs/Notification/PushNotification/subscribePushNotification/index.ts
@@ -56,7 +56,7 @@ function applyOnyxData({reportID, reportActionID, onyxData, lastUpdateID, previo
         previousUpdateID,
         updates: [
             {
-                eventType: 'eventType',
+                eventType: '', // This is only needed for Pusher events
                 data: onyxData,
             },
         ],

--- a/src/libs/PusherUtils.ts
+++ b/src/libs/PusherUtils.ts
@@ -17,6 +17,7 @@ function subscribeToMultiEvent(eventType: string, callback: Callback) {
 
 function triggerMultiEventHandler(eventType: string, data: OnyxUpdate[]): Promise<void> {
     if (!multiEventCallbackMapping[eventType]) {
+        Log.warn('[PusherUtils] Received unexpected multi-event', {eventType});
         return Promise.resolve();
     }
     return multiEventCallbackMapping[eventType](data);

--- a/tests/unit/OnyxUpdatesTest.ts
+++ b/tests/unit/OnyxUpdatesTest.ts
@@ -1,0 +1,79 @@
+import type {KeyValueMapping, OnyxEntry, OnyxKey} from 'react-native-onyx';
+import Onyx from 'react-native-onyx';
+import CONST from '@src/CONST';
+import * as OnyxUpdates from '@src/libs/actions/OnyxUpdates';
+import DateUtils from '@src/libs/DateUtils';
+import * as NumberUtils from '@src/libs/NumberUtils';
+import ONYXKEYS from '@src/ONYXKEYS';
+import type {OnyxUpdatesFromServer} from '@src/types/onyx';
+import waitForBatchedUpdates from '../utils/waitForBatchedUpdates';
+
+describe('OnyxUpdatesTest', () => {
+    beforeAll(() => {
+        Onyx.init({
+            keys: ONYXKEYS,
+        });
+    });
+
+    beforeEach(() => Onyx.clear().then(waitForBatchedUpdates));
+
+    it('applies Airship Onyx updates correctly', () => {
+        const reportID = NumberUtils.rand64();
+        const reportActionID = NumberUtils.rand64();
+        const created = DateUtils.getDBTime();
+
+        const reportValue = {reportID};
+        const reportActionValue = {
+            [reportActionID]: {
+                reportActionID,
+                created,
+            },
+        };
+
+        // Given an onyx update from an Airship push notification
+        const airshipUpdates: OnyxUpdatesFromServer = {
+            type: CONST.ONYX_UPDATE_TYPES.AIRSHIP,
+            previousUpdateID: 0,
+            lastUpdateID: 1,
+            updates: [
+                {
+                    eventType: '',
+                    data: [
+                        {
+                            onyxMethod: 'merge',
+                            key: `${ONYXKEYS.COLLECTION.REPORT}${reportID}`,
+                            value: reportValue,
+                        },
+                        {
+                            onyxMethod: 'merge',
+                            key: `${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${reportID}`,
+                            value: reportActionValue,
+                            shouldShowPushNotification: true,
+                        },
+                    ],
+                },
+            ],
+        };
+
+        // When we apply the updates, then their values are updated correctly
+        return OnyxUpdates.apply(airshipUpdates)
+            .then(() => getOnyxValues(`${ONYXKEYS.COLLECTION.REPORT}${reportID}`, `${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${reportID}`))
+            .then(([report, reportAction]) => {
+                expect(report).toStrictEqual(reportValue);
+                expect(reportAction).toStrictEqual(reportActionValue);
+            });
+    });
+});
+
+function getOnyxValues<TKey extends OnyxKey>(...keys: TKey[]) {
+    return Promise.all(keys.map((key) => getOnyxValue(key)));
+}
+
+function getOnyxValue<TKey extends OnyxKey>(key: TKey): Promise<OnyxEntry<KeyValueMapping[TKey]>> {
+    return new Promise((resolve) => {
+        Onyx.connect({
+            key,
+            callback: (value) => resolve(value),
+        });
+    });
+}


### PR DESCRIPTION
### Details
Adds a separate flow for applying onyx updates from push notifications. This fixes an issue where we try to apply them using event handlers for Pusher with an invalid `eventType` which results in a no-op.

### Fixed Issues
$ https://github.com/Expensify/App/issues/43047

### Tests

**Android**
1. Log in
2. Accept push notification prompt
3. Kill the app
4. Send yourself a message
5. Verify a push notification appears
6. View logs and verify an update is applied in the background (may take a minute)

```
 [PushNotification] Callback triggered for com.airship.push_received - ""
 [PushNotification] Applying onyx data in the background - {"reportID":624968496832156,"reportActionID":"4653738563044339674"}
 [PushNotification] reliable onyx update received - {"lastUpdateID":7288,"previousUpdateID":7287,"onyxDataCount":2}
 [OnyxUpdateManager] Applying update type: airship with lastUpdateID: 7288 - {}
 [Onyx] merge called for key: OnyxUpdatesLastUpdateIDAppliedToClient hasChanged: true - ""
 [OnyxUpdateManager] Applying Airship updates
 [Onyx] merge called for key: report_624968496832156 properties: lastActorAccountID,lastMessageText,lastVisibleActionCreated,reportID hasChanged: true - ""
 [Onyx] merge called for key: reportActions_624968496832156 properties: 4653738563044339674 hasChanged: true - ""
 [OnyxUpdateManager] Done applying Airship updates
```
9. Enable airplane mode
10. Click the push notification
11. Verify the app opens, you're navigated to the chat and the message displays

**iOS**
1. Log in
2. Accept push notification prompt
3. Kill the app
4. Send yourself a message
5. Verify a push notification appears
10. Click the push notification
11. Verify the app opens, you're navigated to the chat and the message displays
12. View logs and verify an update is applied
```
 [PushNotification] Callback triggered for com.airship.push_received - ""
 [PushNotification] Applying onyx data in the background - {"reportID":624968496832156,"reportActionID":"4653738563044339674"}
 [PushNotification] reliable onyx update received - {"lastUpdateID":7288,"previousUpdateID":7287,"onyxDataCount":2}
 [OnyxUpdateManager] Applying update type: airship with lastUpdateID: 7288 - {}
 [Onyx] merge called for key: OnyxUpdatesLastUpdateIDAppliedToClient hasChanged: true - ""
 [OnyxUpdateManager] Applying Airship updates
 [Onyx] merge called for key: report_624968496832156 properties: lastActorAccountID,lastMessageText,lastVisibleActionCreated,reportID hasChanged: true - ""
 [Onyx] merge called for key: reportActions_624968496832156 properties: 4653738563044339674 hasChanged: true - ""
 [OnyxUpdateManager] Done applying Airship updates
```

### Offline tests
None

### QA Steps
None

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

https://github.com/Expensify/App/assets/6833644/46c11b8e-3f24-4b4f-ba99-7c7f678456b7

</details>

<details>
<summary>iOS: Native</summary>

https://github.com/Expensify/App/assets/6833644/08bfaff7-5723-474b-801f-098560811a0d

</details>
