### PR TITLE
Move `name` field out of `Settings` and into `ReportDetailsPage`

### DIFF
--- a/src/components/MenuItem.tsx
+++ b/src/components/MenuItem.tsx
@@ -286,6 +286,9 @@ type MenuItemBaseProps = {
 
     /** Optional account id if it's user avatar or policy id if it's workspace avatar */
     avatarID?: number | string;
+
+    /** Should we center all text or not */
+    shouldCenter?: boolean;
 };
 
 type MenuItemProps = (IconProps | AvatarProps | NoIcon) & MenuItemBaseProps;
@@ -370,6 +373,7 @@ function MenuItem(
         onFocus,
         onBlur,
         avatarID,
+        shouldCenter = false,
     }: MenuItemProps,
     ref: PressableRef,
 ) {
@@ -387,6 +391,7 @@ function MenuItem(
         [
             styles.flexShrink1,
             styles.popoverMenuText,
+            shouldCenter ? styles.textAlignCenter : {},
             // eslint-disable-next-line no-nested-ternary
             shouldPutLeftPaddingWhenNoIcon || (icon && !Array.isArray(icon)) ? (avatarSize === CONST.AVATAR_SIZE.SMALL ? styles.ml2 : styles.ml3) : {},
             shouldShowBasicTitle ? {} : styles.textStrong,
@@ -595,7 +600,7 @@ function MenuItem(
                                                     </Text>
                                                 )}
                                                 {(!!title || !!shouldShowTitleIcon) && (
-                                                    <View style={[styles.flexRow, styles.alignItemsCenter]}>
+                                                    <View style={[!shouldCenter && styles.flexRow, styles.alignItemsCenter]}>
                                                         {!!title && (shouldRenderAsHTML || (shouldParseTitle && !!html.length)) && (
                                                             <View style={styles.renderHTMLTitle}>
                                                                 <RenderHTML html={processedTitle} />
@@ -629,7 +634,7 @@ function MenuItem(
                                                     </Text>
                                                 )}
                                                 {!!furtherDetails && (
-                                                    <View style={[styles.flexRow, styles.mt1, styles.alignItemsCenter]}>
+                                                    <View style={[!shouldCenter && styles.flexRow, styles.mt1, styles.alignItemsCenter]}>
                                                         {!!furtherDetailsIcon && (
                                                             <Icon
                                                                 src={furtherDetailsIcon}
@@ -639,7 +644,10 @@ function MenuItem(
                                                             />
                                                         )}
                                                         <Text
-                                                            style={furtherDetailsIcon ? [styles.furtherDetailsText, styles.ph2, styles.pt1] : styles.textLabelSupporting}
+                                                            style={[
+                                                                furtherDetailsIcon ? [styles.furtherDetailsText, styles.ph2, styles.pt1] : styles.textLabelSupporting,
+                                                                shouldCenter && styles.textAlignCenter,
+                                                            ]}
                                                             numberOfLines={2}
                                                         >
                                                             {furtherDetails}

--- a/src/components/MenuItem.tsx
+++ b/src/components/MenuItem.tsx
@@ -639,7 +639,7 @@ function MenuItem(
                                                             />
                                                         )}
                                                         <Text
-                                                            style={[furtherDetailsIcon ? [styles.furtherDetailsText, styles.ph2, styles.pt1] : styles.textLabelSupporting]}
+                                                            style={furtherDetailsIcon ? [styles.furtherDetailsText, styles.ph2, styles.pt1] : styles.textLabelSupporting}
                                                             numberOfLines={2}
                                                         >
                                                             {furtherDetails}

--- a/src/components/MenuItem.tsx
+++ b/src/components/MenuItem.tsx
@@ -286,9 +286,6 @@ type MenuItemBaseProps = {
 
     /** Optional account id if it's user avatar or policy id if it's workspace avatar */
     avatarID?: number | string;
-
-    /** Should we center all text or not */
-    shouldCenter?: boolean;
 };
 
 type MenuItemProps = (IconProps | AvatarProps | NoIcon) & MenuItemBaseProps;
@@ -373,7 +370,6 @@ function MenuItem(
         onFocus,
         onBlur,
         avatarID,
-        shouldCenter = false,
     }: MenuItemProps,
     ref: PressableRef,
 ) {
@@ -391,7 +387,6 @@ function MenuItem(
         [
             styles.flexShrink1,
             styles.popoverMenuText,
-            shouldCenter ? styles.textAlignCenter : {},
             // eslint-disable-next-line no-nested-ternary
             shouldPutLeftPaddingWhenNoIcon || (icon && !Array.isArray(icon)) ? (avatarSize === CONST.AVATAR_SIZE.SMALL ? styles.ml2 : styles.ml3) : {},
             shouldShowBasicTitle ? {} : styles.textStrong,
@@ -600,7 +595,7 @@ function MenuItem(
                                                     </Text>
                                                 )}
                                                 {(!!title || !!shouldShowTitleIcon) && (
-                                                    <View style={[!shouldCenter && styles.flexRow, styles.alignItemsCenter]}>
+                                                    <View style={[styles.flexRow, styles.alignItemsCenter]}>
                                                         {!!title && (shouldRenderAsHTML || (shouldParseTitle && !!html.length)) && (
                                                             <View style={styles.renderHTMLTitle}>
                                                                 <RenderHTML html={processedTitle} />
@@ -634,7 +629,7 @@ function MenuItem(
                                                     </Text>
                                                 )}
                                                 {!!furtherDetails && (
-                                                    <View style={[!shouldCenter && styles.flexRow, styles.mt1, styles.alignItemsCenter]}>
+                                                    <View style={[styles.flexRow, styles.mt1, styles.alignItemsCenter]}>
                                                         {!!furtherDetailsIcon && (
                                                             <Icon
                                                                 src={furtherDetailsIcon}
@@ -644,10 +639,7 @@ function MenuItem(
                                                             />
                                                         )}
                                                         <Text
-                                                            style={[
-                                                                furtherDetailsIcon ? [styles.furtherDetailsText, styles.ph2, styles.pt1] : styles.textLabelSupporting,
-                                                                shouldCenter && styles.textAlignCenter,
-                                                            ]}
+                                                            style={[furtherDetailsIcon ? [styles.furtherDetailsText, styles.ph2, styles.pt1] : styles.textLabelSupporting]}
                                                             numberOfLines={2}
                                                         >
                                                             {furtherDetails}

--- a/src/libs/ReportUtils.ts
+++ b/src/libs/ReportUtils.ts
@@ -6101,9 +6101,18 @@ function getAllWorkspaceReports(policyID: string): Array<OnyxEntry<Report>> {
     return Object.values(allReports ?? {}).filter((report) => (report?.policyID ?? '') === policyID);
 }
 
-
-function shouldDisableRename(report: OnyxEntry<Report>, policy?: OnyxEntry<Policy>): boolean {
-    if (isDefaultRoom(report) || isArchivedRoom(report) || isThread(report) || isMoneyRequest(report) || isMoneyRequestReport(report) || isPolicyExpenseChat(report) || isInvoiceRoom(report) || isInvoiceReport(report)) {
+function shouldDisableRename(report: OnyxEntry<Report>): boolean {
+    if (
+        isDefaultRoom(report) ||
+        isArchivedRoom(report) ||
+        isPublicRoom(report) ||
+        isThread(report) ||
+        isMoneyRequest(report) ||
+        isMoneyRequestReport(report) ||
+        isPolicyExpenseChat(report) ||
+        isInvoiceRoom(report) ||
+        isInvoiceReport(report)
+    ) {
         return true;
     }
 
@@ -6112,12 +6121,6 @@ function shouldDisableRename(report: OnyxEntry<Report>, policy?: OnyxEntry<Polic
     }
 
     if (isDeprecatedGroupDM(report) || isTaskReport(report)) {
-        return true;
-    }
-
-    // if the linked workspace is null, that means the person isn't a member of the workspace the report is in
-    // which means this has to be a public room we want to disable renaming for
-    if (isChatRoom(report) && !policy) {
         return true;
     }
 

--- a/src/libs/ReportUtils.ts
+++ b/src/libs/ReportUtils.ts
@@ -6101,11 +6101,9 @@ function getAllWorkspaceReports(policyID: string): Array<OnyxEntry<Report>> {
     return Object.values(allReports ?? {}).filter((report) => (report?.policyID ?? '') === policyID);
 }
 
-/**
- * @param policy - the workspace the report is on, null if the user isn't a member of the workspace
- */
-function shouldDisableRename(report: OnyxEntry<Report>, policy: OnyxEntry<Policy>): boolean {
-    if (isDefaultRoom(report) || isArchivedRoom(report) || isThread(report) || isMoneyRequestReport(report) || isPolicyExpenseChat(report)) {
+
+function shouldDisableRename(report: OnyxEntry<Report>, policy?: OnyxEntry<Policy>): boolean {
+    if (isDefaultRoom(report) || isArchivedRoom(report) || isThread(report) || isMoneyRequest(report) || isMoneyRequestReport(report) || isPolicyExpenseChat(report) || isInvoiceRoom(report) || isInvoiceReport(report)) {
         return true;
     }
 
@@ -6113,13 +6111,16 @@ function shouldDisableRename(report: OnyxEntry<Report>, policy: OnyxEntry<Policy
         return false;
     }
 
-    // if the linked workspace is null, that means the person isn't a member of the workspace the report is in
-    // which means this has to be a public room we want to disable renaming for
-    if (!policy) {
+    if (isDeprecatedGroupDM(report) || isTaskReport(report)) {
         return true;
     }
 
-    // If there is a linked workspace, that means the user is a member of the workspace the report is in and is allowed to rename.
+    // if the linked workspace is null, that means the person isn't a member of the workspace the report is in
+    // which means this has to be a public room we want to disable renaming for
+    if (isChatRoom(report) && !policy) {
+        return true;
+    }
+
     return false;
 }
 

--- a/src/pages/ReportDetailsPage.tsx
+++ b/src/pages/ReportDetailsPage.tsx
@@ -86,16 +86,7 @@ function ReportDetailsPage({policies, report, session, personalDetails}: ReportD
     const shouldShowReportDescription = isChatRoom && (canEditReportDescription || report.description !== '');
     const linkedWorkspace = useMemo(() => Object.values(policies ?? {}).find((linkedPolicy) => linkedPolicy && linkedPolicy.id === report?.policyID), [policies, report?.policyID]);
     const shouldDisableRename = useMemo(() => ReportUtils.shouldDisableRename(report, linkedWorkspace), [report, linkedWorkspace]);
-    const isDeprecatedGroupDM = useMemo(() => ReportUtils.isDeprecatedGroupDM(report), [report]);
     const parentNavigationSubtitleData = ReportUtils.getParentNavigationSubtitle(report);
-    const shouldShowRoomName =
-        !ReportUtils.isChatThread(report) &&
-        !isDeprecatedGroupDM &&
-        !isPolicyExpenseChat &&
-        !isTaskReport &&
-        !isMoneyRequestReport &&
-        !isInvoiceRoom &&
-        !(isMoneyRequestReport || isInvoiceReport || isMoneyRequest);
     // eslint-disable-next-line react-hooks/exhaustive-deps -- policy is a dependency because `getChatRoomSubtitle` calls `getPolicyName` which in turn retrieves the value from the `policy` value stored in Onyx
     const chatRoomSubtitle = useMemo(() => ReportUtils.getChatRoomSubtitle(report), [report, policy]);
     const isSystemChat = useMemo(() => ReportUtils.isSystemChat(report), [report]);
@@ -200,7 +191,7 @@ function ReportDetailsPage({policies, report, session, personalDetails}: ReportD
         });
 
         // Prevent displaying private notes option for threads and task reports
-        if (!isChatThread && !isMoneyRequestReport && !isInvoiceReport && !ReportUtils.isTaskReport(report)) {
+        if (!isChatThread && !isMoneyRequestReport && !isInvoiceReport && !isTaskReport) {
             items.push({
                 key: CONST.REPORT_DETAILS_MENU_ITEM.PRIVATE_NOTES,
                 translationKey: 'privateNotes.title',
@@ -340,10 +331,10 @@ function ReportDetailsPage({policies, report, session, personalDetails}: ReportD
             <FullPageNotFoundView shouldShow={isEmptyObject(report)}>
                 <HeaderWithBackButton title={translate('common.details')} />
                 <ScrollView style={[styles.flex1]}>
-                    <View style={[styles.reportDetailsTitleContainer, !shouldShowRoomName && styles.mb5]}>
+                    <View style={[styles.reportDetailsTitleContainer, shouldDisableRename && styles.mb5]}>
                         {renderedAvatar}
                         <View style={[styles.reportDetailsRoomInfo, styles.mw100]}>
-                            {!shouldShowRoomName && (
+                            {shouldDisableRename && (
                                 <>
                                     <View style={[styles.alignSelfCenter, styles.w100, styles.mt1]}>
                                         <DisplayNames
@@ -383,7 +374,7 @@ function ReportDetailsPage({policies, report, session, personalDetails}: ReportD
                             )}
                         </View>
                     </View>
-                    {shouldShowRoomName && (
+                    {!shouldDisableRename && (
                         <OfflineWithFeedback
                             pendingAction={report?.pendingFields?.reportName}
                             errors={report?.errorFields?.reportName}

--- a/src/pages/ReportDetailsPage.tsx
+++ b/src/pages/ReportDetailsPage.tsx
@@ -84,8 +84,7 @@ function ReportDetailsPage({policies, report, session, personalDetails}: ReportD
     const isInvoiceRoom = useMemo(() => ReportUtils.isInvoiceRoom(report), [report]);
     const canEditReportDescription = useMemo(() => ReportUtils.canEditReportDescription(report, policy), [report, policy]);
     const shouldShowReportDescription = isChatRoom && (canEditReportDescription || report.description !== '');
-    const linkedWorkspace = useMemo(() => Object.values(policies ?? {}).find((linkedPolicy) => linkedPolicy && linkedPolicy.id === report?.policyID), [policies, report?.policyID]);
-    const shouldDisableRename = useMemo(() => ReportUtils.shouldDisableRename(report, linkedWorkspace), [report, linkedWorkspace]);
+    const shouldDisableRename = useMemo(() => ReportUtils.shouldDisableRename(report), [report]);
     const parentNavigationSubtitleData = ReportUtils.getParentNavigationSubtitle(report);
     // eslint-disable-next-line react-hooks/exhaustive-deps -- policy is a dependency because `getChatRoomSubtitle` calls `getPolicyName` which in turn retrieves the value from the `policy` value stored in Onyx
     const chatRoomSubtitle = useMemo(() => ReportUtils.getChatRoomSubtitle(report), [report, policy]);
@@ -235,6 +234,7 @@ function ReportDetailsPage({policies, report, session, personalDetails}: ReportD
         report,
         isMoneyRequestReport,
         isInvoiceReport,
+        isTaskReport,
         isChatRoom,
         policy,
         activeChatMembers.length,
@@ -315,7 +315,8 @@ function ReportDetailsPage({policies, report, session, personalDetails}: ReportD
             ? chatRoomSubtitle
             : `${translate('threads.in')} ${chatRoomSubtitle}`;
 
-    const roomTitle = isPolicyExpenseChat || isGroupChat ? reportName : report?.reportName ?? reportName;
+    // const roomTitle = isPolicyExpenseChat || isGroupChat ? reportName : report?.reportName ?? reportName;
+    // const roomTitle = reportName;
 
     let roomDescription;
     if (isInvoiceRoom || isPolicyExpenseChat) {
@@ -385,13 +386,12 @@ function ReportDetailsPage({policies, report, session, personalDetails}: ReportD
                                 <MenuItemWithTopDescription
                                     shouldShowRightIcon={!shouldDisableRename}
                                     interactive={!shouldDisableRename}
-                                    title={roomTitle}
+                                    title={reportName}
                                     titleStyle={styles.newKansasLarge}
                                     shouldCheckActionAllowedOnPress={false}
                                     description={!shouldDisableRename ? roomDescription : ''}
                                     furtherDetails={chatRoomSubtitle && !isGroupChat ? additionalRoomDetails : ''}
                                     onPress={() => Navigation.navigate(ROUTES.REPORT_SETTINGS_NAME.getRoute(report.reportID))}
-                                    shouldCenter={shouldDisableRename}
                                 />
                             </View>
                         </OfflineWithFeedback>

--- a/src/pages/ReportDetailsPage.tsx
+++ b/src/pages/ReportDetailsPage.tsx
@@ -305,18 +305,12 @@ function ReportDetailsPage({policies, report, session, personalDetails}: ReportD
         );
     }, [report, icons, isMoneyRequestReport, isInvoiceReport, isGroupChat, isThread, styles]);
 
-    const reportName =
-        ReportUtils.isDeprecatedGroupDM(report) || ReportUtils.isGroupChat(report)
-            ? ReportUtils.getGroupChatName(undefined, false, report.reportID ?? '')
-            : ReportUtils.getReportName(report);
+    const reportName = ReportUtils.isDeprecatedGroupDM(report) || isGroupChat ? ReportUtils.getGroupChatName(undefined, false, report.reportID ?? '') : ReportUtils.getReportName(report);
 
     const additionalRoomDetails =
         (isPolicyExpenseChat && !!report?.isOwnPolicyExpenseChat) || ReportUtils.isExpenseReport(report) || isPolicyExpenseChat || isInvoiceRoom
             ? chatRoomSubtitle
             : `${translate('threads.in')} ${chatRoomSubtitle}`;
-
-    // const roomTitle = isPolicyExpenseChat || isGroupChat ? reportName : report?.reportName ?? reportName;
-    // const roomTitle = reportName;
 
     let roomDescription;
     if (isInvoiceRoom || isPolicyExpenseChat) {

--- a/src/pages/ReportDetailsPage.tsx
+++ b/src/pages/ReportDetailsPage.tsx
@@ -84,7 +84,7 @@ function ReportDetailsPage({policies, report, session, personalDetails}: ReportD
     const isInvoiceRoom = useMemo(() => ReportUtils.isInvoiceRoom(report), [report]);
     const canEditReportDescription = useMemo(() => ReportUtils.canEditReportDescription(report, policy), [report, policy]);
     const shouldShowReportDescription = isChatRoom && (canEditReportDescription || report.description !== '');
-    const linkedWorkspace = useMemo(() => Object.values(policies ?? {}).find((linkedPolicy) => linkedPolicy && linkedPolicy.id === report?.policyID) ?? null, [policies, report?.policyID]);
+    const linkedWorkspace = useMemo(() => Object.values(policies ?? {}).find((linkedPolicy) => linkedPolicy && linkedPolicy.id === report?.policyID), [policies, report?.policyID]);
     const shouldDisableRename = useMemo(() => ReportUtils.shouldDisableRename(report, linkedWorkspace), [report, linkedWorkspace]);
     const isDeprecatedGroupDM = useMemo(() => ReportUtils.isDeprecatedGroupDM(report), [report]);
     const parentNavigationSubtitleData = ReportUtils.getParentNavigationSubtitle(report);

--- a/src/pages/settings/Report/ReportSettingsPage.tsx
+++ b/src/pages/settings/Report/ReportSettingsPage.tsx
@@ -5,7 +5,6 @@ import FullPageNotFoundView from '@components/BlockingViews/FullPageNotFoundView
 import DisplayNames from '@components/DisplayNames';
 import HeaderWithBackButton from '@components/HeaderWithBackButton';
 import MenuItemWithTopDescription from '@components/MenuItemWithTopDescription';
-import OfflineWithFeedback from '@components/OfflineWithFeedback';
 import ScreenWrapper from '@components/ScreenWrapper';
 import ScrollView from '@components/ScrollView';
 import Text from '@components/Text';
@@ -16,7 +15,6 @@ import * as ReportUtils from '@libs/ReportUtils';
 import type {ReportSettingsNavigatorParamList} from '@navigation/types';
 import withReportOrNotFound from '@pages/home/report/withReportOrNotFound';
 import type {WithReportOrNotFoundProps} from '@pages/home/report/withReportOrNotFound';
-import * as ReportActions from '@userActions/Report';
 import CONST from '@src/CONST';
 import ROUTES from '@src/ROUTES';
 import type SCREENS from '@src/SCREENS';
@@ -27,29 +25,20 @@ type ReportSettingsPageProps = WithReportOrNotFoundProps & StackScreenProps<Repo
 function ReportSettingsPage({report, policies}: ReportSettingsPageProps) {
     const reportID = report?.reportID ?? '';
     const styles = useThemeStyles();
-    const isGroupChat = ReportUtils.isGroupChat(report);
     const {translate} = useLocalize();
     // The workspace the report is on, null if the user isn't a member of the workspace
     const linkedWorkspace = useMemo(() => Object.values(policies ?? {}).find((policy) => policy && policy.id === report?.policyID), [policies, report?.policyID]);
-    const shouldDisableRename = useMemo(() => ReportUtils.shouldDisableRename(report, linkedWorkspace), [report, linkedWorkspace]);
     const isMoneyRequestReport = ReportUtils.isMoneyRequestReport(report);
-
     const shouldDisableSettings = isEmptyObject(report) || ReportUtils.isArchivedRoom(report) || ReportUtils.isSelfDM(report);
-    const shouldShowRoomName = !ReportUtils.isPolicyExpenseChat(report) && !ReportUtils.isChatThread(report) && !ReportUtils.isInvoiceRoom(report);
     const notificationPreference =
         report?.notificationPreference && report.notificationPreference !== CONST.REPORT.NOTIFICATION_PREFERENCE.HIDDEN
             ? translate(`notificationPreferencesPage.notificationPreferences.${report.notificationPreference}`)
             : '';
     const writeCapability = ReportUtils.isAdminRoom(report) ? CONST.REPORT.WRITE_CAPABILITIES.ADMINS : report?.writeCapability ?? CONST.REPORT.WRITE_CAPABILITIES.ALL;
-
     const writeCapabilityText = translate(`writeCapabilityPage.writeCapability.${writeCapability}`);
     const shouldAllowWriteCapabilityEditing = useMemo(() => ReportUtils.canEditWriteCapability(report, linkedWorkspace), [report, linkedWorkspace]);
     const shouldAllowChangeVisibility = useMemo(() => ReportUtils.canEditRoomVisibility(report, linkedWorkspace), [report, linkedWorkspace]);
-
     const shouldShowNotificationPref = !isMoneyRequestReport && report?.notificationPreference !== CONST.REPORT.NOTIFICATION_PREFERENCE.HIDDEN;
-    const roomNameLabel = translate(isMoneyRequestReport ? 'workspace.editor.nameInputLabel' : 'newRoomPage.roomName');
-    const reportName = ReportUtils.getReportName(report);
-
     const shouldShowWriteCapability = !isMoneyRequestReport;
 
     return (
@@ -68,39 +57,7 @@ function ReportSettingsPage({report, policies}: ReportSettingsPageProps) {
                             onPress={() => Navigation.navigate(ROUTES.REPORT_SETTINGS_NOTIFICATION_PREFERENCES.getRoute(reportID))}
                         />
                     )}
-                    {shouldShowRoomName && (
-                        <OfflineWithFeedback
-                            pendingAction={report?.pendingFields?.reportName}
-                            errors={report?.errorFields?.reportName}
-                            errorRowStyles={[styles.ph5]}
-                            onClose={() => ReportActions.clearPolicyRoomNameErrors(reportID)}
-                        >
-                            {shouldDisableRename ? (
-                                <View style={[styles.ph5, styles.pv3]}>
-                                    <Text
-                                        style={[styles.textLabelSupporting, styles.lh16, styles.mb1]}
-                                        numberOfLines={1}
-                                    >
-                                        {roomNameLabel}
-                                    </Text>
-                                    <DisplayNames
-                                        fullTitle={reportName ?? ''}
-                                        tooltipEnabled
-                                        numberOfLines={1}
-                                        textStyles={[styles.optionAlternateText, styles.pre]}
-                                        shouldUseFullTitle
-                                    />
-                                </View>
-                            ) : (
-                                <MenuItemWithTopDescription
-                                    shouldShowRightIcon
-                                    title={report?.reportName === '' ? reportName : report?.reportName}
-                                    description={isGroupChat ? translate('common.name') : translate('newRoomPage.roomName')}
-                                    onPress={() => Navigation.navigate(ROUTES.REPORT_SETTINGS_NAME.getRoute(reportID))}
-                                />
-                            )}
-                        </OfflineWithFeedback>
-                    )}
+
                     {shouldShowWriteCapability &&
                         (shouldAllowWriteCapabilityEditing ? (
                             <MenuItemWithTopDescription

--- a/src/pages/settings/Report/RoomNamePage.tsx
+++ b/src/pages/settings/Report/RoomNamePage.tsx
@@ -2,7 +2,7 @@ import {useIsFocused} from '@react-navigation/native';
 import React, {useCallback, useRef} from 'react';
 import {View} from 'react-native';
 import {withOnyx} from 'react-native-onyx';
-import type {OnyxCollection, OnyxEntry} from 'react-native-onyx';
+import type {OnyxCollection} from 'react-native-onyx';
 import FullPageNotFoundView from '@components/BlockingViews/FullPageNotFoundView';
 import FormProvider from '@components/Form/FormProvider';
 import InputWrapper from '@components/Form/InputWrapper';
@@ -22,21 +22,18 @@ import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
 import ROUTES from '@src/ROUTES';
 import INPUT_IDS from '@src/types/form/RoomNameForm';
-import type {Policy, Report} from '@src/types/onyx';
+import type {Report} from '@src/types/onyx';
 
 type RoomNamePageOnyxProps = {
     /** All reports shared with the user */
     reports: OnyxCollection<Report>;
-
-    /** Policy of the report for which the name is being edited */
-    policy: OnyxEntry<Policy>;
 };
 
 type RoomNamePageProps = RoomNamePageOnyxProps & {
     report: Report;
 };
 
-function RoomNamePage({report, policy, reports}: RoomNamePageProps) {
+function RoomNamePage({report, reports}: RoomNamePageProps) {
     const styles = useThemeStyles();
     const roomNameInputRef = useRef<AnimatedTextInputRef>(null);
     const isFocused = useIsFocused();
@@ -78,7 +75,7 @@ function RoomNamePage({report, policy, reports}: RoomNamePageProps) {
             includeSafeAreaPaddingBottom={false}
             testID={RoomNamePage.displayName}
         >
-            <FullPageNotFoundView shouldShow={ReportUtils.shouldDisableRename(report, policy)}>
+            <FullPageNotFoundView shouldShow={ReportUtils.shouldDisableRename(report)}>
                 <HeaderWithBackButton
                     title={translate('newRoomPage.roomName')}
                     onBackButtonPress={() => Navigation.goBack(ROUTES.REPORT_SETTINGS.getRoute(report?.reportID ?? ''))}
@@ -111,8 +108,5 @@ RoomNamePage.displayName = 'RoomNamePage';
 export default withOnyx<RoomNamePageProps, RoomNamePageOnyxProps>({
     reports: {
         key: ONYXKEYS.COLLECTION.REPORT,
-    },
-    policy: {
-        key: ({report}) => `${ONYXKEYS.COLLECTION.POLICY}${report?.policyID}`,
     },
 })(RoomNamePage);

--- a/src/styles/index.ts
+++ b/src/styles/index.ts
@@ -2582,7 +2582,6 @@ const styles = (theme: ThemeColors) =>
             ...flex.flexColumn,
             ...flex.alignItemsCenter,
             paddingHorizontal: 20,
-            paddingBottom: 20,
         },
 
         reportDetailsRoomInfo: {


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->

This PR is opened because the contributor assigned for the issue #40262 has been banned and the PR #40858 can no longer be modified and merged. [Context here](https://expensify.slack.com/archives/C02NK2DQWUX/p1718239157243779).

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/pull/40262
PROPOSAL: https://github.com/Expensify/App/issues/40262#issuecomment-2164156184


### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->
#### Test 1

1. Go to a user created `room` in which you are a member.
2. Click on the header.
3. Verify that the RHP shows an item with `Room name` followed by editable room name followed by `in <workspace name>`.

#### Test 2

1. Go to a group chat in which you are a member.
2. Click on the header.
3. Verify that the RHP shows an item with `Group name` followed by editable group name.

- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

Same as `Tests`

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
5. Upload an image via copy paste
6. Verify a modal appears displaying a preview of that image
--->

Same as `Tests`

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>




https://github.com/Expensify/App/assets/102477862/fc745980-4c9c-4de6-92f4-6acd6f71feeb





<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>



https://github.com/Expensify/App/assets/102477862/82dfe812-7672-43c8-b825-4461d1b22904





<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>



https://github.com/Expensify/App/assets/102477862/8d40835a-dc60-4980-9370-fc2214ac9695





<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>



https://github.com/Expensify/App/assets/102477862/143475fa-b9d6-468e-901a-7feade94a6bb




<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>


https://github.com/Expensify/App/assets/102477862/83e8f6ee-9fdb-4ff3-88fd-d442ffe5b994

For all the following images, admin/creator is on left and member on the right.

Group Chat

<img width="1002" alt="groupChat" src="https://github.com/Expensify/App/assets/102477862/07f9c317-3bae-4b9d-8461-fe2d37185376">

Room

<img width="1002" alt="room" src="https://github.com/Expensify/App/assets/102477862/e10f450a-e248-4def-bf16-d8d67a67184e">

Policy Expense Chat

<img width="1002" alt="policyExpenseChatAdminAndMemberSide" src="https://github.com/Expensify/App/assets/102477862/969e6774-3037-4778-8105-495f9e7b61b2">

Default Rooms

<img width="1002" alt="defaultRoom" src="https://github.com/Expensify/App/assets/102477862/87a30a07-9b8f-4fe2-a607-78ef496fc746">

Chat Thread

<img width="1002" alt="chatThread" src="https://github.com/Expensify/App/assets/102477862/8b07a506-e571-4338-9cf6-35ecd088ac5d">

Invoices

<img width="1002" alt="invoices" src="https://github.com/Expensify/App/assets/102477862/ce6be35b-e185-4335-95b5-a7c609fb08d8">

Money Request Report

<img width="1002" alt="moneyRequestReport" src="https://github.com/Expensify/App/assets/102477862/5d598ee9-04cc-401f-bf3a-133f65701560">

Money Request 

<img width="1002" alt="moneyRequest" src="https://github.com/Expensify/App/assets/102477862/d0f5b753-bdff-4254-8283-6b26c9f0796c">

Task

<img width="1002" alt="task" src="https://github.com/Expensify/App/assets/102477862/210f99f7-8c30-4aa5-9237-3c66a3750b76">






<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Desktop</summary>



https://github.com/Expensify/App/assets/102477862/0bdad197-6301-427f-a145-e8d92c977376





<!-- add screenshots or videos here -->

</details>
