### PR TITLE
fix: comment linking e2e test

### DIFF
--- a/src/components/InvertedFlatList/BaseInvertedFlatList/index.e2e.tsx
+++ b/src/components/InvertedFlatList/BaseInvertedFlatList/index.e2e.tsx
@@ -1,6 +1,6 @@
 import React, {forwardRef, useMemo} from 'react';
 import type {FlatListProps, ScrollViewProps, ViewToken} from 'react-native';
-import {FlatList} from 'react-native';
+import {DeviceEventEmitter, FlatList} from 'react-native';
 import type {ReportAction} from '@src/types/onyx';
 
 type BaseInvertedFlatListProps = FlatListProps<ReportAction> & {
@@ -9,16 +9,13 @@ type BaseInvertedFlatListProps = FlatListProps<ReportAction> & {
 
 const AUTOSCROLL_TO_TOP_THRESHOLD = 128;
 
-let localViewableItems: ViewToken[];
-const getViewableItems = () => localViewableItems;
-
 function BaseInvertedFlatListE2e(props: BaseInvertedFlatListProps, ref: React.ForwardedRef<FlatList<ReportAction>>) {
     const {shouldEnableAutoScrollToTopThreshold, ...rest} = props;
 
     const handleViewableItemsChanged = useMemo(
         () =>
             ({viewableItems}: {viewableItems: ViewToken[]}) => {
-                localViewableItems = viewableItems;
+                DeviceEventEmitter.emit('onViewableItemsChanged', viewableItems);
             },
         [],
     );
@@ -51,4 +48,3 @@ function BaseInvertedFlatListE2e(props: BaseInvertedFlatListProps, ref: React.Fo
 BaseInvertedFlatListE2e.displayName = 'BaseInvertedFlatListE2e';
 
 export default forwardRef(BaseInvertedFlatListE2e);
-export {getViewableItems};

--- a/src/libs/E2E/tests/linkingTest.e2e.ts
+++ b/src/libs/E2E/tests/linkingTest.e2e.ts
@@ -1,11 +1,12 @@
+import {DeviceEventEmitter} from 'react-native';
 import type {NativeConfig} from 'react-native-config';
 import Config from 'react-native-config';
-import {getViewableItems} from '@components/InvertedFlatList/BaseInvertedFlatList/index.e2e';
 import Timing from '@libs/actions/Timing';
 import E2ELogin from '@libs/E2E/actions/e2eLogin';
 import waitForAppLoaded from '@libs/E2E/actions/waitForAppLoaded';
 import E2EClient from '@libs/E2E/client';
 import getConfigValueOrThrow from '@libs/E2E/utils/getConfigValueOrThrow';
+import getPromiseWithResolve from '@libs/E2E/utils/getPromiseWithResolve';
 import Navigation from '@libs/Navigation/Navigation';
 import Performance from '@libs/Performance';
 import CONST from '@src/CONST';
@@ -22,6 +23,29 @@ const test = (config: NativeConfig) => {
         if (neededLogin) {
             return waitForAppLoaded().then(() => E2EClient.submitTestDone());
         }
+
+        const [appearMessagePromise, appearMessageResolve] = getPromiseWithResolve();
+        const [switchReportPromise, switchReportResolve] = getPromiseWithResolve();
+
+        Promise.all([appearMessagePromise, switchReportPromise])
+            .then(() => {
+                console.debug('[E2E] Test completed successfully, exiting…');
+                E2EClient.submitTestDone();
+            })
+            .catch((err) => {
+                console.debug('[E2E] Error while submitting test results:', err);
+            });
+
+        const subscription = DeviceEventEmitter.addListener('onViewableItemsChanged', (res) => {
+            console.debug('[E2E] Viewable items retrieved, verifying correct message…', res);
+
+            if (!!res && res[0]?.item?.reportActionID === linkedReportActionID) {
+                appearMessageResolve();
+                subscription.remove();
+            } else {
+                console.debug('[E2E] Message verification failed');
+            }
+        });
 
         Performance.subscribeToMeasurements((entry) => {
             if (entry.name === CONST.TIMING.SIDEBAR_LOADED) {
@@ -41,27 +65,14 @@ const test = (config: NativeConfig) => {
 
             if (entry.name === CONST.TIMING.SWITCH_REPORT) {
                 console.debug('[E2E] Linking: 1');
-                setTimeout(() => {
-                    const res = getViewableItems();
-                    console.debug('[E2E] Viewable items retrieved, verifying correct message…');
 
-                    if (!!res && res[0]?.item?.reportActionID === linkedReportActionID) {
-                        E2EClient.submitTestResults({
-                            branch: Config.E2E_BRANCH,
-                            name: 'Comment linking',
-                            duration: entry.duration,
-                        })
-                            .then(() => {
-                                console.debug('[E2E] Test completed successfully, exiting…');
-                                E2EClient.submitTestDone();
-                            })
-                            .catch((err) => {
-                                console.debug('[E2E] Error while submitting test results:', err);
-                            });
-                    } else {
-                        console.debug('[E2E] Message verification failed');
-                    }
-                }, 3000);
+                E2EClient.submitTestResults({
+                    branch: Config.E2E_BRANCH,
+                    name: 'Comment linking',
+                    duration: entry.duration,
+                });
+
+                switchReportResolve();
             }
         });
     });

--- a/src/libs/E2E/tests/linkingTest.e2e.ts
+++ b/src/libs/E2E/tests/linkingTest.e2e.ts
@@ -43,7 +43,7 @@ const test = (config: NativeConfig) => {
                 appearMessageResolve();
                 subscription.remove();
             } else {
-                console.debug('[E2E] Message verification failed');
+                console.debug(`[E2E] Provided message id '${res?.[0]?.item?.reportActionID}' doesn't match to an expected '${linkedReportActionID}'. Waiting for a next one…`);
             }
         });
 


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details

Fixed flaky comment linking test.

> [!CAUTION]
> Even after merging this PR CI still may fail, because for `main` variant it will use a version from latest release and this version will not have changes from this PR.

The original problem was in the order of `onLayout`/`onViewableItemsChanged` events. Typically `onViewableItemsChanged` was firing first, then `onLayout` produced an expected measurement and after 3s we were reading data that was sent in `onViewableItemsChanged`.

But if we read this data and it is missing, then our test just hangs and then fails due to timeout restriction (I think it again can happen because of the fact that this test is executed in last order and the phone may be overheated and CPU can be slightly throttling).

In this PR I re-worked an approach and now we:
- don't use hardcoded interval - instead of that we emit and subscribe to events;
- listen to events simultaneously and finish test only when both events (measurement + visible item) arrived.

After these changes I re-assembled both apps and run test (also put my device to direct sun beams and put a case on it - in this case it overheats much faster). I could successfully pass all 4 test suite 3 times, so I think it's stable now (before I was getting the error on the hals of the first execution).

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/43972
$ https://github.com/Expensify/App/issues/43941
$ https://github.com/Expensify/App/issues/43928
PROPOSAL: N/A


### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

- [ ] run e2e pipeline and be sure that it's green;

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

N/A

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

N/A

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Desktop</summary>

<!-- add screenshots or videos here -->

</details>
