### PR TITLE
fix: CI upload source maps when deploying a new app version

### DIFF
--- a/.github/workflows/platformDeploy.yml
+++ b/.github/workflows/platformDeploy.yml
@@ -97,7 +97,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: android-sourcemap
-          path: android/app/build/generated/sourcemaps/react/release/*.map
+          path: android/app/build/generated/sourcemaps/react/productionRelease/index.android.bundle.map
 
       - name: Upload Android version to GitHub artifacts
         if: ${{ !fromJSON(env.SHOULD_DEPLOY_PRODUCTION) }}

--- a/.github/workflows/platformDeploy.yml
+++ b/.github/workflows/platformDeploy.yml
@@ -96,7 +96,7 @@ jobs:
       - name: Archive Android sourcemaps
         uses: actions/upload-artifact@v3
         with:
-          name: android-sourcemap
+          name: android-sourcemap-${{ github.ref_name }}
           path: android/app/build/generated/sourcemaps/react/productionRelease/index.android.bundle.map
 
       - name: Upload Android version to GitHub artifacts
@@ -248,7 +248,7 @@ jobs:
       - name: Archive iOS sourcemaps
         uses: actions/upload-artifact@v3
         with:
-          name: ios-sourcemap
+          name: ios-sourcemap-${{ github.ref_name }}
           path: main.jsbundle.map
 
       - name: Upload iOS version to GitHub artifacts

--- a/ios/.xcode.env
+++ b/ios/.xcode.env
@@ -9,3 +9,8 @@
 # For example, to use nvm with brew, add the following line
 # . "$(brew --prefix nvm)/nvm.sh" --no-use
 export NODE_BINARY=$(command -v node)
+
+# Provide a sourcemap path so that in release builds a source map file will be
+# created at the specified location.
+# (RN's default behaviour on iOS is to skip creating a sourcemap file):
+export SOURCEMAP_FILE="$(pwd)/../main.jsbundle.map";

--- a/patches/react-native+0.73.4+017+iOS-fix-whitespace-support-sourcemap.patch
+++ b/patches/react-native+0.73.4+017+iOS-fix-whitespace-support-sourcemap.patch
@@ -1,0 +1,37 @@
+diff --git a/node_modules/react-native/scripts/react-native-xcode.sh b/node_modules/react-native/scripts/react-native-xcode.sh
+index d6c382b..3e1742c 100755
+--- a/node_modules/react-native/scripts/react-native-xcode.sh
++++ b/node_modules/react-native/scripts/react-native-xcode.sh
+@@ -104,7 +104,7 @@ fi
+ 
+ BUNDLE_FILE="$CONFIGURATION_BUILD_DIR/main.jsbundle"
+ 
+-EXTRA_ARGS=
++EXTRA_ARGS=()
+ 
+ case "$PLATFORM_NAME" in
+   "macosx")
+@@ -131,12 +131,12 @@ if [[ $EMIT_SOURCEMAP == true ]]; then
+   else
+     PACKAGER_SOURCEMAP_FILE="$SOURCEMAP_FILE"
+   fi
+-  EXTRA_ARGS="$EXTRA_ARGS --sourcemap-output $PACKAGER_SOURCEMAP_FILE"
++  EXTRA_ARGS+=("--sourcemap-output" "$PACKAGER_SOURCEMAP_FILE")
+ fi
+ 
+ # Hermes doesn't require JS minification.
+ if [[ $USE_HERMES != false && $DEV == false ]]; then
+-  EXTRA_ARGS="$EXTRA_ARGS --minify false"
++  EXTRA_ARGS+=("--minify" "false")
+ fi
+ 
+ "$NODE_BINARY" $NODE_ARGS "$CLI_PATH" $BUNDLE_COMMAND \
+@@ -147,7 +147,7 @@ fi
+   --reset-cache \
+   --bundle-output "$BUNDLE_FILE" \
+   --assets-dest "$DEST" \
+-  $EXTRA_ARGS \
++  "${EXTRA_ARGS[@]}" \
+   $EXTRA_PACKAGER_ARGS
+ 
+ if [[ $USE_HERMES == false ]]; then

--- a/workflow_tests/assertions/platformDeployAssertions.ts
+++ b/workflow_tests/assertions/platformDeployAssertions.ts
@@ -64,7 +64,7 @@ function assertAndroidJobExecuted(workflowResult: Step[], didExecute = true, isP
     steps.push(
         createStepAssertion('Archive Android sourcemaps', true, null, 'ANDROID', 'Archiving Android sourcemaps', [
             {key: 'name', value: 'android-sourcemap'},
-            {key: 'path', value: 'android/app/build/generated/sourcemaps/react/release/*.map'},
+            {key: 'path', value: 'android/app/build/generated/sourcemaps/react/productionRelease/index.android.bundle.map'},
         ]),
     );
     if (!isProduction) {

--- a/workflow_tests/assertions/platformDeployAssertions.ts
+++ b/workflow_tests/assertions/platformDeployAssertions.ts
@@ -63,7 +63,8 @@ function assertAndroidJobExecuted(workflowResult: Step[], didExecute = true, isP
     }
     steps.push(
         createStepAssertion('Archive Android sourcemaps', true, null, 'ANDROID', 'Archiving Android sourcemaps', [
-            {key: 'name', value: 'android-sourcemap'},
+            // Note 1.2.3 comes from the ref name that we are on, which is the version we are deploying
+            {key: 'name', value: 'android-sourcemap-1.2.3'},
             {key: 'path', value: 'android/app/build/generated/sourcemaps/react/productionRelease/index.android.bundle.map'},
         ]),
     );
@@ -187,7 +188,8 @@ function assertIOSJobExecuted(workflowResult: Step[], didExecute = true, isProdu
     }
     steps.push(
         createStepAssertion('Archive iOS sourcemaps', true, null, 'IOS', 'Archiving sourcemaps', [
-            {key: 'name', value: 'ios-sourcemap'},
+            // Note 1.2.3 comes from the ref name that we are on, which is the version we are deploying
+            {key: 'name', value: 'ios-sourcemap-1.2.3'},
             {key: 'path', value: 'main.jsbundle.map'},
         ]),
     );


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->

(Note: This reverts commit fb23d52.)

This is the second attempt to fix uploading the source maps when we are deploying a new app version.
The first PR:

- https://github.com/Expensify/App/pull/43823

was reverted, because on iOS the build failed in the `Bundle React Native code and images` build phase. The error was because our iOS project path contains a whitespace `./ios/New Expensify/build/...`, and generating a source map to a path with a whitespace is broken in react native.
Someone already provided a fix for that, which will be available as part of react native v0.75. I created a patch for that:

- https://github.com/facebook/react-native/commit/e25a9b4c5d0e4c32dbc1eca071911e34faa177ce

**In addition to the first PR**, this introduces the change of naming our uploaded source maps to include the app version. This makes it very easy to later look up the artifact for fetching it, as we want to do it in this PR:

- https://github.com/Expensify/App/pull/43894

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/43649
PROPOSAL: https://github.com/Expensify/App/issues/43649#issuecomment-2172500712


### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

CI only, not applicable

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

CI only, not applicable

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos

CI only, not applicable