### PR TITLE
fix: [Track tax] Disabled tax rate can be selected.

### DIFF
--- a/src/pages/workspace/distanceRates/PolicyDistanceRateTaxRateEditPage.tsx
+++ b/src/pages/workspace/distanceRates/PolicyDistanceRateTaxRateEditPage.tsx
@@ -1,12 +1,13 @@
 import type {StackScreenProps} from '@react-navigation/stack';
-import React, {useMemo} from 'react';
+import React from 'react';
 import HeaderWithBackButton from '@components/HeaderWithBackButton';
 import ScreenWrapper from '@components/ScreenWrapper';
-import SelectionList from '@components/SelectionList';
-import RadioListItem from '@components/SelectionList/RadioListItem';
+import TaxPicker from '@components/TaxPicker';
 import useLocalize from '@hooks/useLocalize';
 import useThemeStyles from '@hooks/useThemeStyles';
 import Navigation from '@libs/Navigation/Navigation';
+import type * as OptionsListUtils from '@libs/OptionsListUtils';
+import * as TransactionUtils from '@libs/TransactionUtils';
 import type {SettingsNavigatorParamList} from '@navigation/types';
 import AccessOrNotFoundWrapper from '@pages/workspace/AccessOrNotFoundWrapper';
 import type {WithPolicyOnyxProps} from '@pages/workspace/withPolicy';
@@ -15,15 +16,6 @@ import * as DistanceRate from '@userActions/Policy/DistanceRate';
 import CONST from '@src/CONST';
 import ROUTES from '@src/ROUTES';
 import type SCREENS from '@src/SCREENS';
-import type {PendingAction} from '@src/types/onyx/OnyxCommon';
-
-type ListItemType = {
-    value: string;
-    text: string;
-    isSelected: boolean;
-    keyForList: string;
-    pendingAction?: PendingAction;
-};
 
 type PolicyDistanceRateTaxRateEditPageProps = WithPolicyOnyxProps & StackScreenProps<SettingsNavigatorParamList, typeof SCREENS.WORKSPACE.DISTANCE_RATE_TAX_RATE_EDIT>;
 
@@ -36,21 +28,10 @@ function PolicyDistanceRateTaxRateEditPage({route, policy}: PolicyDistanceRateTa
     const customUnit = customUnits[Object.keys(customUnits)[0]];
     const rate = customUnit?.rates[rateID];
     const taxRateExternalID = rate.attributes?.taxRateExternalID;
-    const taxRateItems: ListItemType[] = useMemo(() => {
-        const taxes = policy?.taxRates?.taxes;
-        const result = Object.entries(taxes ?? {}).map(([key, value]) => ({
-            value: key,
-            text: `${value.name} (${value.value})`,
-            isSelected: taxRateExternalID === key,
-            keyForList: key,
-            pendingAction: value.pendingAction,
-            isDisabled: value.pendingAction === CONST.RED_BRICK_ROAD_PENDING_ACTION.DELETE,
-        }));
-        return result;
-    }, [policy, taxRateExternalID]);
+    const selectedTaxRate = TransactionUtils.getWorkspaceTaxesSettingsName(policy, taxRateExternalID ?? '');
 
-    const onTaxRateChange = (newTaxRate: ListItemType) => {
-        if (taxRateExternalID === newTaxRate.value) {
+    const onTaxRateChange = (newTaxRate: OptionsListUtils.TaxRatesOption) => {
+        if (taxRateExternalID === newTaxRate.code) {
             Navigation.goBack();
             return;
         }
@@ -59,11 +40,15 @@ function PolicyDistanceRateTaxRateEditPage({route, policy}: PolicyDistanceRateTa
                 ...rate,
                 attributes: {
                     ...rate.attributes,
-                    taxRateExternalID: newTaxRate.value,
+                    taxRateExternalID: newTaxRate.code,
                 },
             },
         ]);
         Navigation.navigate(ROUTES.WORKSPACE_DISTANCE_RATE_DETAILS.getRoute(policyID, rateID));
+    };
+
+    const dismiss = () => {
+        Navigation.goBack(ROUTES.WORKSPACE_TAXES_SETTINGS.getRoute(policyID));
     };
 
     return (
@@ -78,16 +63,21 @@ function PolicyDistanceRateTaxRateEditPage({route, policy}: PolicyDistanceRateTa
                 shouldEnableMaxHeight
                 testID={PolicyDistanceRateTaxRateEditPage.displayName}
             >
-                <HeaderWithBackButton
-                    title={translate('workspace.taxes.taxRate')}
-                    shouldShowBackButton
-                />
-                <SelectionList
-                    sections={[{data: taxRateItems}]}
-                    ListItem={RadioListItem}
-                    onSelectRow={onTaxRateChange}
-                    initiallyFocusedOptionKey={taxRateItems.find((item) => item.isSelected)?.keyForList}
-                />
+                {({insets}) => (
+                    <>
+                        <HeaderWithBackButton
+                            title={translate('workspace.taxes.taxRate')}
+                            shouldShowBackButton
+                        />
+                        <TaxPicker
+                            selectedTaxRate={selectedTaxRate}
+                            policyID={policyID}
+                            insets={insets}
+                            onSubmit={onTaxRateChange}
+                            onDismiss={dismiss}
+                        />
+                    </>
+                )}
             </ScreenWrapper>
         </AccessOrNotFoundWrapper>
     );


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->

### Fixed Issues
$ https://github.com/Expensify/App/issues/43613
PROPOSAL: https://github.com/Expensify/App/issues/43613#issuecomment-2163975871


### Tests
Precondition: 

- Distance rates and Taxes are enabled
- Track tax is enabled

1. Go to workspace settings > Taxes
2. Disable a tax rate
3. Go to Distance rates
4. Click on any distance rate > Tax rate
5. Verify disabled tax rate is not shown

- [x] Verify that no errors appear in the JS console

### Offline tests
Precondition: 

- Distance rates and Taxes are enabled
- Track tax is enabled

1. Go to workspace settings > Taxes
2. Disable a tax rate
3. Go to Distance rates
4. Click on any distance rate > Tax rate
5. Verify disabled tax rate is not shown


### QA Steps
Precondition: 

- Distance rates and Taxes are enabled
- Track tax is enabled

1. Go to workspace settings > Taxes
2. Disable a tax rate
3. Go to Distance rates
4. Click on any distance rate > Tax rate
5. Verify disabled tax rate is not shown


- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

https://github.com/Expensify/App/assets/85894871/a65fa176-7e7e-45af-b7db-bc3dd003b0b0

</details>

<details>
<summary>Android: mWeb Chrome</summary>

https://github.com/Expensify/App/assets/85894871/810f60ee-4eae-4f9e-9b46-cde8289ed282

</details>

<details>
<summary>iOS: Native</summary>

https://github.com/Expensify/App/assets/85894871/3781427b-a980-45d2-83c9-bdbf353d5a8e

</details>

<details>
<summary>iOS: mWeb Safari</summary>

https://github.com/Expensify/App/assets/85894871/22f0b0ab-ebbf-44ad-8264-c5ee2f773d99

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

https://github.com/Expensify/App/assets/85894871/8e408ebc-ffcd-461a-b9bf-7cac8b2e4b83

</details>

<details>
<summary>MacOS: Desktop</summary>

https://github.com/Expensify/App/assets/85894871/201cecaf-da37-44e0-81b1-1b60954d96c0

</details>
