### PR TITLE
Fix Required Receipt Translations

### DIFF
--- a/src/languages/en.ts
+++ b/src/languages/en.ts
@@ -3182,7 +3182,8 @@ export default {
         perDayLimit: ({formattedLimit}: ViolationsPerDayLimitParams) => `Amount over daily ${formattedLimit}/person category limit`,
         receiptNotSmartScanned: 'Receipt not verified. Please confirm accuracy.',
         receiptRequired: ({formattedLimit, category}: ViolationsReceiptRequiredParams) =>
-            `Receipt required${formattedLimit ?? category ? ` over${formattedLimit ? ` ${formattedLimit}` : ''}${category ? ` ${category} category limit` : ''}` : ''}`,
+            // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+            `Receipt required${formattedLimit || category ? ` over${formattedLimit ? ` ${formattedLimit}` : ''}${category ? ` ${category} category limit` : ''}` : ''}`,
         reviewRequired: 'Review required',
         rter: ({brokenBankConnection, email, isAdmin, isTransactionOlderThan7Days, member}: ViolationsRterParams) => {
             if (brokenBankConnection) {

--- a/src/languages/en.ts
+++ b/src/languages/en.ts
@@ -3181,7 +3181,8 @@ export default {
         overLimitAttendee: ({formattedLimit}: ViolationsOverLimitParams) => `Amount over ${formattedLimit}/person limit`,
         perDayLimit: ({formattedLimit}: ViolationsPerDayLimitParams) => `Amount over daily ${formattedLimit}/person category limit`,
         receiptNotSmartScanned: 'Receipt not verified. Please confirm accuracy.',
-        receiptRequired: (params: ViolationsReceiptRequiredParams) => `Receipt required${params ? ` over ${params.formattedLimit}${params.category ? ' category limit' : ''}` : ''}`,
+        receiptRequired: ({formattedLimit, category}: ViolationsReceiptRequiredParams) =>
+            `Receipt required${formattedLimit ?? category ? ` over${formattedLimit ? ` ${formattedLimit}` : ''}${category ? ` ${category} category limit` : ''}` : ''}`,
         reviewRequired: 'Review required',
         rter: ({brokenBankConnection, email, isAdmin, isTransactionOlderThan7Days, member}: ViolationsRterParams) => {
             if (brokenBankConnection) {

--- a/src/languages/en.ts
+++ b/src/languages/en.ts
@@ -3181,9 +3181,23 @@ export default {
         overLimitAttendee: ({formattedLimit}: ViolationsOverLimitParams) => `Amount over ${formattedLimit}/person limit`,
         perDayLimit: ({formattedLimit}: ViolationsPerDayLimitParams) => `Amount over daily ${formattedLimit}/person category limit`,
         receiptNotSmartScanned: 'Receipt not verified. Please confirm accuracy.',
-        receiptRequired: ({formattedLimit, category}: ViolationsReceiptRequiredParams) =>
+        receiptRequired: ({formattedLimit, category}: ViolationsReceiptRequiredParams) => {
+            let message = 'Receipt required';
             // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-            `Receipt required${formattedLimit || category ? ` over${formattedLimit ? ` ${formattedLimit}` : ''}${category ? ` ${category} category limit` : ''}` : ''}`,
+            if (formattedLimit || category) {
+                message += ' over';
+
+                if (formattedLimit) {
+                    message += ` ${formattedLimit}`;
+                }
+
+                if (category) {
+                    message += ` category limit`;
+                }
+            }
+
+            return message;
+        },
         reviewRequired: 'Review required',
         rter: ({brokenBankConnection, email, isAdmin, isTransactionOlderThan7Days, member}: ViolationsRterParams) => {
             if (brokenBankConnection) {

--- a/src/languages/en.ts
+++ b/src/languages/en.ts
@@ -3186,7 +3186,6 @@ export default {
             // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
             if (formattedLimit || category) {
                 message += ' over';
-
                 if (formattedLimit) {
                     message += ` ${formattedLimit}`;
                 }

--- a/src/languages/en.ts
+++ b/src/languages/en.ts
@@ -3190,7 +3190,7 @@ export default {
                     message += ` ${formattedLimit}`;
                 }
                 if (category) {
-                    message += ` category limit`;
+                    message += ' category limit';
                 }
             }
 

--- a/src/languages/en.ts
+++ b/src/languages/en.ts
@@ -3190,7 +3190,6 @@ export default {
                 if (formattedLimit) {
                     message += ` ${formattedLimit}`;
                 }
-
                 if (category) {
                     message += ` category limit`;
                 }

--- a/src/languages/en.ts
+++ b/src/languages/en.ts
@@ -3183,8 +3183,7 @@ export default {
         receiptNotSmartScanned: 'Receipt not verified. Please confirm accuracy.',
         receiptRequired: ({formattedLimit, category}: ViolationsReceiptRequiredParams) => {
             let message = 'Receipt required';
-            // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-            if (formattedLimit || category) {
+            if (formattedLimit ?? category) {
                 message += ' over';
                 if (formattedLimit) {
                     message += ` ${formattedLimit}`;
@@ -3193,7 +3192,6 @@ export default {
                     message += ' category limit';
                 }
             }
-
             return message;
         },
         reviewRequired: 'Review required',

--- a/src/languages/es.ts
+++ b/src/languages/es.ts
@@ -3684,7 +3684,8 @@ export default {
         perDayLimit: ({formattedLimit}: ViolationsPerDayLimitParams) => `Importe supera el límite diario de la categoría${formattedLimit ? ` de ${formattedLimit}/persona` : ''}`,
         receiptNotSmartScanned: 'Recibo no verificado. Por favor, confirma tu exactitud',
         receiptRequired: ({formattedLimit, category}: ViolationsReceiptRequiredParams) =>
-            `Recibo obligatorio${formattedLimit ?? category ? ` para importes sobre${formattedLimit ? ` ${formattedLimit}` : ''}${category ? ' el límite de la categoría' : ''}` : ''}`,
+            // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+            `Recibo obligatorio${formattedLimit || category ? ` para importes sobre${formattedLimit ? ` ${formattedLimit}` : ''}${category ? ' el límite de la categoría' : ''}` : ''}`,
         reviewRequired: 'Revisión requerida',
         rter: ({brokenBankConnection, isAdmin, email, isTransactionOlderThan7Days, member}: ViolationsRterParams) => {
             if (brokenBankConnection) {

--- a/src/languages/es.ts
+++ b/src/languages/es.ts
@@ -3683,8 +3683,8 @@ export default {
         overLimitAttendee: ({formattedLimit}: ViolationsOverLimitParams) => `Importe supera el límite${formattedLimit ? ` de ${formattedLimit}/persona` : ''}`,
         perDayLimit: ({formattedLimit}: ViolationsPerDayLimitParams) => `Importe supera el límite diario de la categoría${formattedLimit ? ` de ${formattedLimit}/persona` : ''}`,
         receiptNotSmartScanned: 'Recibo no verificado. Por favor, confirma tu exactitud',
-        receiptRequired: (params: ViolationsReceiptRequiredParams) =>
-            `Recibo obligatorio${params ? ` para importes sobre${params.formattedLimit ? ` ${params.formattedLimit}` : ''}${params.category ? ' el límite de la categoría' : ''}` : ''}`,
+        receiptRequired: ({formattedLimit, category}: ViolationsReceiptRequiredParams) =>
+            `Recibo obligatorio${formattedLimit ?? category ? ` para importes sobre${formattedLimit ? ` ${formattedLimit}` : ''}${category ? ' el límite de la categoría' : ''}` : ''}`,
         reviewRequired: 'Revisión requerida',
         rter: ({brokenBankConnection, isAdmin, email, isTransactionOlderThan7Days, member}: ViolationsRterParams) => {
             if (brokenBankConnection) {

--- a/src/languages/es.ts
+++ b/src/languages/es.ts
@@ -3683,9 +3683,24 @@ export default {
         overLimitAttendee: ({formattedLimit}: ViolationsOverLimitParams) => `Importe supera el límite${formattedLimit ? ` de ${formattedLimit}/persona` : ''}`,
         perDayLimit: ({formattedLimit}: ViolationsPerDayLimitParams) => `Importe supera el límite diario de la categoría${formattedLimit ? ` de ${formattedLimit}/persona` : ''}`,
         receiptNotSmartScanned: 'Recibo no verificado. Por favor, confirma tu exactitud',
-        receiptRequired: ({formattedLimit, category}: ViolationsReceiptRequiredParams) =>
+        receiptRequired: ({formattedLimit, category}: ViolationsReceiptRequiredParams) => {
+            let message = 'Recibo obligatorio';
+
             // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-            `Recibo obligatorio${formattedLimit || category ? ` para importes sobre${formattedLimit ? ` ${formattedLimit}` : ''}${category ? ' el límite de la categoría' : ''}` : ''}`,
+            if (formattedLimit || category) {
+                message += ' para importes sobre';
+
+                if (formattedLimit) {
+                    message += ` ${formattedLimit}`;
+                }
+
+                if (category) {
+                    message += ' el límite de la categoría';
+                }
+            }
+
+            return message;
+        },
         reviewRequired: 'Revisión requerida',
         rter: ({brokenBankConnection, isAdmin, email, isTransactionOlderThan7Days, member}: ViolationsRterParams) => {
             if (brokenBankConnection) {

--- a/src/languages/es.ts
+++ b/src/languages/es.ts
@@ -3691,7 +3691,6 @@ export default {
                 if (formattedLimit) {
                     message += ` ${formattedLimit}`;
                 }
-
                 if (category) {
                     message += ' el límite de la categoría';
                 }

--- a/src/languages/es.ts
+++ b/src/languages/es.ts
@@ -3688,7 +3688,6 @@ export default {
             // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
             if (formattedLimit || category) {
                 message += ' para importes sobre';
-
                 if (formattedLimit) {
                     message += ` ${formattedLimit}`;
                 }

--- a/src/languages/es.ts
+++ b/src/languages/es.ts
@@ -3685,7 +3685,6 @@ export default {
         receiptNotSmartScanned: 'Recibo no verificado. Por favor, confirma tu exactitud',
         receiptRequired: ({formattedLimit, category}: ViolationsReceiptRequiredParams) => {
             let message = 'Recibo obligatorio';
-
             // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
             if (formattedLimit || category) {
                 message += ' para importes sobre';

--- a/src/languages/es.ts
+++ b/src/languages/es.ts
@@ -3685,8 +3685,7 @@ export default {
         receiptNotSmartScanned: 'Recibo no verificado. Por favor, confirma tu exactitud',
         receiptRequired: ({formattedLimit, category}: ViolationsReceiptRequiredParams) => {
             let message = 'Recibo obligatorio';
-            // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-            if (formattedLimit || category) {
+            if (formattedLimit ?? category) {
                 message += ' para importes sobre';
                 if (formattedLimit) {
                     message += ` ${formattedLimit}`;
@@ -3695,7 +3694,6 @@ export default {
                     message += ' el límite de la categoría';
                 }
             }
-
             return message;
         },
         reviewRequired: 'Revisión requerida',


### PR DESCRIPTION

<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/43939
PROPOSAL: https://github.com/Expensify/App/issues/43939#issuecomment-2176845081


### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

- [X] Verify that no errors appear in the JS console


Precondition : As a admin set up expense violation as " Receipt required amount" to "0" in OldDot control policy

1. Invite an employee to the above policy
2. As a employee submit a report without receipt
3. As an admin open the report submitted
4. Validate that the correct translation is shown ("receipt required").
 
### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

Same as tests

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

Same as tests


### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [X] I linked the correct issue in the `### Fixed Issues` section above
- [X] I wrote clear testing steps that cover the changes made in this PR
    - [X] I added steps for local testing in the `Tests` section
    - [X] I added steps for the expected offline behavior in the `Offline steps` section
    - [X] I added steps for Staging and/or Production testing in the `QA steps` section
    - [X] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [X] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [X] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [X] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [X] I ran the tests on **all platforms** & verified they passed on:
    - [X] Android: Native
    - [X] Android: mWeb Chrome
    - [X] iOS: Native
    - [X] iOS: mWeb Safari
    - [X] MacOS: Chrome / Safari
    - [X] MacOS: Desktop
- [X] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [X] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [X] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [X] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [X] I verified that comments were added to code that is not self explanatory
    - [X] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [X] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [X] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [X] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [X] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [X] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [X] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [X] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [X] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [X] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [X] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [X] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [X] I verified that if a function's arguments changed that all usages have also been updated correctly
- [X] If any new file was added I verified that:
    - [X] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [X] If a new CSS style is added I verified that:
    - [X] A similar style doesn't already exist
    - [X] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [X] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [X] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [X] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [X] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [X] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [X] I verified that all the inputs inside a form are aligned with each other.
    - [X] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [X] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [X] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

<img width="364" alt="Screenshot 2024-06-23 at 1 35 17 PM" src="https://github.com/Expensify/App/assets/59809993/10d749ff-0156-44fa-aff7-4f2b08ace0e1">

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

<img width="372" alt="Screenshot 2024-06-23 at 1 39 31 PM" src="https://github.com/Expensify/App/assets/59809993/852d6b4d-0e61-4c80-91bf-d8633c7aedce">


</details>

<details>
<summary>iOS: Native</summary>

<img width="348" alt="Screenshot 2024-06-23 at 1 33 46 PM" src="https://github.com/Expensify/App/assets/59809993/265a8ddc-f23f-4f2e-a4cf-4f535ecca20a">


<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>


<img width="417" alt="Screenshot 2024-06-23 at 1 39 19 PM" src="https://github.com/Expensify/App/assets/59809993/246fe1c2-47f1-4de1-a572-bc768a04ccfb">


<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

<img width="1496" alt="Screenshot 2024-06-23 at 1 31 02 PM" src="https://github.com/Expensify/App/assets/59809993/92be67fc-8c9e-43d4-8a00-9d7019a5f9bd">


</details>

<details>
<summary>MacOS: Desktop</summary>

<img width="1202" alt="Screenshot 2024-06-23 at 1 38 24 PM" src="https://github.com/Expensify/App/assets/59809993/3d8b2cd5-30d4-41d1-a2e8-7c967ef10c3d">


<!-- add screenshots or videos here -->

</details>
