### PR TITLE
[CP Staging] Add freezeScreenWithLazyLoading function

### DIFF
--- a/src/components/withPrepareCentralPaneScreen/index.native.tsx
+++ b/src/components/withPrepareCentralPaneScreen/index.native.tsx
@@ -2,9 +2,9 @@ import type React from 'react';
 import freezeScreenWithLazyLoading from '@libs/freezeScreenWithLazyLoading';
 
 /**
- * This HOC is dependent on the platform. On native platforms, screens that aren't already displayed in the navigation stack should be frozen to prevent unnecessary rendering.
+ * This higher-order function is dependent on the platform. On native platforms, screens that aren't already displayed in the navigation stack should be frozen to prevent unnecessary rendering.
  * It's handled this way only on mobile platforms because on the web, more than one screen is displayed in a wide layout, so these screens shouldn't be frozen.
  */
-export default function withPrepareCentralPaneScreen(componentGetter: () => React.ComponentType) {
-    return freezeScreenWithLazyLoading(componentGetter);
+export default function withPrepareCentralPaneScreen(lazyComponent: () => React.ComponentType) {
+    return freezeScreenWithLazyLoading(lazyComponent);
 }

--- a/src/components/withPrepareCentralPaneScreen/index.native.tsx
+++ b/src/components/withPrepareCentralPaneScreen/index.native.tsx
@@ -1,27 +1,10 @@
-import type {ComponentType, ForwardedRef, RefAttributes} from 'react';
-import React from 'react';
-import getComponentDisplayName from '@libs/getComponentDisplayName';
-import FreezeWrapper from '@libs/Navigation/FreezeWrapper';
+import type React from 'react';
+import freezeScreenWithLazyLoading from '@libs/freezeScreenWithLazyLoading';
 
 /**
  * This HOC is dependent on the platform. On native platforms, screens that aren't already displayed in the navigation stack should be frozen to prevent unnecessary rendering.
  * It's handled this way only on mobile platforms because on the web, more than one screen is displayed in a wide layout, so these screens shouldn't be frozen.
  */
-export default function withPrepareCentralPaneScreen<TProps, TRef>(
-    WrappedComponent: ComponentType<TProps & RefAttributes<TRef>>,
-): (props: TProps & React.RefAttributes<TRef>) => React.ReactElement | null {
-    function WithPrepareCentralPaneScreen(props: TProps, ref: ForwardedRef<TRef>) {
-        return (
-            <FreezeWrapper>
-                <WrappedComponent
-                    // eslint-disable-next-line react/jsx-props-no-spreading
-                    {...props}
-                    ref={ref}
-                />
-            </FreezeWrapper>
-        );
-    }
-
-    WithPrepareCentralPaneScreen.displayName = `WithPrepareCentralPaneScreen(${getComponentDisplayName(WrappedComponent)})`;
-    return React.forwardRef(WithPrepareCentralPaneScreen);
+export default function withPrepareCentralPaneScreen(componentGetter: () => React.ComponentType) {
+    return freezeScreenWithLazyLoading(componentGetter);
 }

--- a/src/components/withPrepareCentralPaneScreen/index.tsx
+++ b/src/components/withPrepareCentralPaneScreen/index.tsx
@@ -1,9 +1,9 @@
 import type React from 'react';
 
 /**
- * This HOC is dependent on the platform. On native platforms, screens that aren't already displayed in the navigation stack should be frozen to prevent unnecessary rendering.
+ * This higher-order function is dependent on the platform. On native platforms, screens that aren't already displayed in the navigation stack should be frozen to prevent unnecessary rendering.
  * It's handled this way only on mobile platforms because on the web, more than one screen is displayed in a wide layout, so these screens shouldn't be frozen.
  */
-export default function withPrepareCentralPaneScreen(componentGetter: () => React.ComponentType) {
-    return componentGetter;
+export default function withPrepareCentralPaneScreen(lazyComponent: () => React.ComponentType) {
+    return lazyComponent;
 }

--- a/src/components/withPrepareCentralPaneScreen/index.tsx
+++ b/src/components/withPrepareCentralPaneScreen/index.tsx
@@ -1,9 +1,9 @@
-import type {ComponentType} from 'react';
+import type React from 'react';
 
 /**
  * This HOC is dependent on the platform. On native platforms, screens that aren't already displayed in the navigation stack should be frozen to prevent unnecessary rendering.
  * It's handled this way only on mobile platforms because on the web, more than one screen is displayed in a wide layout, so these screens shouldn't be frozen.
  */
-export default function withPrepareCentralPaneScreen(WrappedComponent: ComponentType) {
-    return WrappedComponent;
+export default function withPrepareCentralPaneScreen(componentGetter: () => React.ComponentType) {
+    return componentGetter;
 }

--- a/src/libs/Navigation/AppNavigator/CENTRAL_PANE_SCREENS.tsx
+++ b/src/libs/Navigation/AppNavigator/CENTRAL_PANE_SCREENS.tsx
@@ -6,17 +6,17 @@ import type ReactComponentModule from '@src/types/utils/ReactComponentModule';
 type Screens = Partial<Record<CentralPaneName, () => React.ComponentType>>;
 
 const CENTRAL_PANE_SCREENS = {
-    [SCREENS.SETTINGS.WORKSPACES]: () => withPrepareCentralPaneScreen(require<ReactComponentModule>('../../../pages/workspace/WorkspacesListPage').default),
-    [SCREENS.SETTINGS.PREFERENCES.ROOT]: () => withPrepareCentralPaneScreen(require<ReactComponentModule>('../../../pages/settings/Preferences/PreferencesPage').default),
-    [SCREENS.SETTINGS.SECURITY]: () => withPrepareCentralPaneScreen(require<ReactComponentModule>('../../../pages/settings/Security/SecuritySettingsPage').default),
-    [SCREENS.SETTINGS.PROFILE.ROOT]: () => withPrepareCentralPaneScreen(require<ReactComponentModule>('../../../pages/settings/Profile/ProfilePage').default),
-    [SCREENS.SETTINGS.WALLET.ROOT]: () => withPrepareCentralPaneScreen(require<ReactComponentModule>('../../../pages/settings/Wallet/WalletPage').default),
-    [SCREENS.SETTINGS.ABOUT]: () => withPrepareCentralPaneScreen(require<ReactComponentModule>('../../../pages/settings/AboutPage/AboutPage').default),
-    [SCREENS.SETTINGS.TROUBLESHOOT]: () => withPrepareCentralPaneScreen(require<ReactComponentModule>('../../../pages/settings/Troubleshoot/TroubleshootPage').default),
-    [SCREENS.SETTINGS.SAVE_THE_WORLD]: () => withPrepareCentralPaneScreen(require<ReactComponentModule>('../../../pages/TeachersUnite/SaveTheWorldPage').default),
-    [SCREENS.SETTINGS.SUBSCRIPTION.ROOT]: () => withPrepareCentralPaneScreen(require<ReactComponentModule>('../../../pages/settings/Subscription/SubscriptionSettingsPage').default),
-    [SCREENS.SEARCH.CENTRAL_PANE]: () => withPrepareCentralPaneScreen(require<ReactComponentModule>('../../../pages/Search/SearchPage').default),
-    [SCREENS.REPORT]: () => withPrepareCentralPaneScreen(require<ReactComponentModule>('./ReportScreenWrapper').default),
+    [SCREENS.SETTINGS.WORKSPACES]: withPrepareCentralPaneScreen(() => require<ReactComponentModule>('../../../pages/workspace/WorkspacesListPage').default),
+    [SCREENS.SETTINGS.PREFERENCES.ROOT]: withPrepareCentralPaneScreen(() => require<ReactComponentModule>('../../../pages/settings/Preferences/PreferencesPage').default),
+    [SCREENS.SETTINGS.SECURITY]: withPrepareCentralPaneScreen(() => require<ReactComponentModule>('../../../pages/settings/Security/SecuritySettingsPage').default),
+    [SCREENS.SETTINGS.PROFILE.ROOT]: withPrepareCentralPaneScreen(() => require<ReactComponentModule>('../../../pages/settings/Profile/ProfilePage').default),
+    [SCREENS.SETTINGS.WALLET.ROOT]: withPrepareCentralPaneScreen(() => require<ReactComponentModule>('../../../pages/settings/Wallet/WalletPage').default),
+    [SCREENS.SETTINGS.ABOUT]: withPrepareCentralPaneScreen(() => require<ReactComponentModule>('../../../pages/settings/AboutPage/AboutPage').default),
+    [SCREENS.SETTINGS.TROUBLESHOOT]: withPrepareCentralPaneScreen(() => require<ReactComponentModule>('../../../pages/settings/Troubleshoot/TroubleshootPage').default),
+    [SCREENS.SETTINGS.SAVE_THE_WORLD]: withPrepareCentralPaneScreen(() => require<ReactComponentModule>('../../../pages/TeachersUnite/SaveTheWorldPage').default),
+    [SCREENS.SETTINGS.SUBSCRIPTION.ROOT]: withPrepareCentralPaneScreen(() => require<ReactComponentModule>('../../../pages/settings/Subscription/SubscriptionSettingsPage').default),
+    [SCREENS.SEARCH.CENTRAL_PANE]: withPrepareCentralPaneScreen(() => require<ReactComponentModule>('../../../pages/Search/SearchPage').default),
+    [SCREENS.REPORT]: withPrepareCentralPaneScreen(() => require<ReactComponentModule>('./ReportScreenWrapper').default),
 } satisfies Screens;
 
 export default CENTRAL_PANE_SCREENS;

--- a/src/libs/freezeScreenWithLazyLoading.tsx
+++ b/src/libs/freezeScreenWithLazyLoading.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
 import FreezeWrapper from './Navigation/FreezeWrapper';
 
-function FrozenComponent<TProps extends React.JSX.IntrinsicAttributes>(InnerComponent: React.ComponentType<TProps>) {
+function frozenScreen<TProps extends React.JSX.IntrinsicAttributes>(WrappedComponent: React.ComponentType<TProps>) {
     return (props: TProps) => (
         <FreezeWrapper>
-            <InnerComponent
+            <WrappedComponent
                 // eslint-disable-next-line react/jsx-props-no-spreading
                 {...props}
             />
@@ -12,9 +12,9 @@ function FrozenComponent<TProps extends React.JSX.IntrinsicAttributes>(InnerComp
     );
 }
 
-export default function freezeScreenWithLazyLoading(componentGetter: () => React.ComponentType) {
+export default function freezeScreenWithLazyLoading(lazyComponent: () => React.ComponentType) {
     return () => {
-        const Component = componentGetter();
-        return FrozenComponent(Component);
+        const Component = lazyComponent();
+        return frozenScreen(Component);
     };
 }

--- a/src/libs/freezeScreenWithLazyLoading.tsx
+++ b/src/libs/freezeScreenWithLazyLoading.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import FreezeWrapper from './Navigation/FreezeWrapper';
 
-function frozenScreen<TProps extends React.JSX.IntrinsicAttributes>(WrappedComponent: React.ComponentType<TProps>) {
+function FrozenScreen<TProps extends React.JSX.IntrinsicAttributes>(WrappedComponent: React.ComponentType<TProps>) {
     return (props: TProps) => (
         <FreezeWrapper>
             <WrappedComponent
@@ -15,6 +15,6 @@ function frozenScreen<TProps extends React.JSX.IntrinsicAttributes>(WrappedCompo
 export default function freezeScreenWithLazyLoading(lazyComponent: () => React.ComponentType) {
     return () => {
         const Component = lazyComponent();
-        return frozenScreen(Component);
+        return FrozenScreen(Component);
     };
 }

--- a/src/libs/freezeScreenWithLazyLoading.tsx
+++ b/src/libs/freezeScreenWithLazyLoading.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import FreezeWrapper from './Navigation/FreezeWrapper';
+
+function FrozenComponent<TProps extends React.JSX.IntrinsicAttributes>(InnerComponent: React.ComponentType<TProps>) {
+    return (props: TProps) => (
+        <FreezeWrapper>
+            <InnerComponent
+                // eslint-disable-next-line react/jsx-props-no-spreading
+                {...props}
+            />
+        </FreezeWrapper>
+    );
+}
+
+export default function freezeScreenWithLazyLoading(componentGetter: () => React.ComponentType) {
+    return () => {
+        const Component = componentGetter();
+        return FrozenComponent(Component);
+    };
+}


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->

This PR fixes the issue with flickering central pane screens.

This issue was caused by invoking `withPrepareCentralPaneScreen` HOC multiple times in `CENTRAL_PANE_SCREENS.tsx`. 

Previously, each screen in `CENTRAL_PANE_SCREENS` was stored as an arrow function that returns a lazily loaded component wrapped by a HOC, causing that HOC to be called multiple times. This HOC has now been refactored 
to a higher order function that takes an arrow function as a parameter, this logic prevents unnecessary re-rendering screens.

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/44419
$ https://github.com/Expensify/App/issues/44498
PROPOSAL:


### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

- [ ] Verify that no errors appear in the JS console

1. Launch New Expensify app.
2. Go to any chat with a submitted expense.
3. Click on the expense preview.
4. Click on the back button.
5. Verify if the page is rendered without flickering.

____

1. Open the app
2. Log in with a new Gmail account
3. Tap on FAB - Start chat
4. Enter a Gmail address that doesn't have an account yet
5. Tap on the account
6. Tap on the "+" button next to the composer

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

Same as tests

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos

https://github.com/Expensify/App/assets/36083550/e59ebbb1-0338-458b-a4d6-335915c83e01


<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

https://github.com/Expensify/App/assets/47774969/0cf61ff9-71c1-4f60-90d0-ae4507f9e3da


</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

https://github.com/Expensify/App/assets/47774969/3b15e65c-729f-4465-a926-41a70ba99178


</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

https://github.com/Expensify/App/assets/47774969/83b585ef-ce78-41a9-ac10-82285a3f0b76


</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

https://github.com/Expensify/App/assets/47774969/bc8d0d93-e724-4a1c-ba80-10bdebc0402f


</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

https://github.com/Expensify/App/assets/47774969/3784e99b-153a-4f37-b868-5a69fbacc6dc


</details>

<details>
<summary>MacOS: Desktop</summary>

<!-- add screenshots or videos here -->
https://github.com/Expensify/App/assets/47774969/90e5911c-67b7-4fa9-93d5-37fd3ff2c67f
</details>




