### PR TITLE
Fix: The emoji icons on reactions are not vertically centered

### DIFF
--- a/src/components/Reactions/EmojiReactionBubble.tsx
+++ b/src/components/Reactions/EmojiReactionBubble.tsx
@@ -7,7 +7,6 @@ import useStyleUtils from '@hooks/useStyleUtils';
 import useThemeStyles from '@hooks/useThemeStyles';
 import type {ReactionListEvent} from '@pages/home/ReportScreenContext';
 import CONST from '@src/CONST';
-import getEmojiReactionBubbleTextOffsetStyle from './getEmojiReactionBubbleTextOffsetStyle';
 
 type EmojiReactionBubbleProps = {
     /**
@@ -83,7 +82,7 @@ function EmojiReactionBubble(
             accessible
             dataSet={{[CONST.SELECTION_SCRAPER_HIDDEN_ELEMENT]: true}}
         >
-            <Text style={[styles.emojiReactionBubbleText, StyleUtils.getEmojiReactionBubbleTextStyle(isContextMenu), getEmojiReactionBubbleTextOffsetStyle()]}>{emojiCodes.join('')}</Text>
+            <Text style={[styles.emojiReactionBubbleText, StyleUtils.getEmojiReactionBubbleTextStyle(isContextMenu)]}>{emojiCodes.join('')}</Text>
             {count > 0 && <Text style={[styles.reactionCounterText, StyleUtils.getEmojiReactionCounterTextStyle(hasUserReacted)]}>{count}</Text>}
         </PressableWithSecondaryInteraction>
     );

--- a/src/components/Reactions/getEmojiReactionBubbleTextOffsetStyle/index.ios.ts
+++ b/src/components/Reactions/getEmojiReactionBubbleTextOffsetStyle/index.ios.ts
@@ -1,6 +1,0 @@
-function getEmojiReactionBubbleTextOffsetStyle() {
-    // https://github.com/Expensify/App/issues/36739
-    return {transform: [{translateY: 2}]};
-}
-
-export default getEmojiReactionBubbleTextOffsetStyle;

--- a/src/components/Reactions/getEmojiReactionBubbleTextOffsetStyle/index.ts
+++ b/src/components/Reactions/getEmojiReactionBubbleTextOffsetStyle/index.ts
@@ -1,5 +1,0 @@
-function getEmojiReactionBubbleTextOffsetStyle() {
-    return {transform: [{translateY: 0}]};
-}
-
-export default getEmojiReactionBubbleTextOffsetStyle;


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->

### Fixed Issues

$ https://github.com/Expensify/App/issues/44571
PROPOSAL: https://github.com/Expensify/App/issues/44571#issuecomment-2195837102


### Tests
1. Open Expensify App
2. Open a chat with messages
3. React with an emoji on a message
4. Verify the emoji reaction is centered

- [x] Verify that no errors appear in the JS console

### Offline tests
Same as Tests step

### QA Steps
Same as Tests step

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<img width="349" alt="Screenshot 2024-07-01 at 3 07 58 AM" src="https://github.com/Expensify/App/assets/64629613/7ad14148-b908-4042-99e0-548c0a0d0dcd">
<img width="349" alt="Screenshot 2024-07-01 at 3 08 13 AM" src="https://github.com/Expensify/App/assets/64629613/0da3ffe7-754f-4bea-a7b8-70fc0ae9d543">


</details>

<details>
<summary>Android: mWeb Chrome</summary>
<img width="397" alt="Screenshot 2024-07-01 at 2 42 01 AM" src="https://github.com/Expensify/App/assets/64629613/5f21c49c-aafc-46ad-92ab-a3b3c1ec32f1">
<img width="397" alt="Screenshot 2024-07-01 at 2 41 20 AM" src="https://github.com/Expensify/App/assets/64629613/656c70a4-645e-469d-bb2b-ae74852585ae">



</details>

<details>
<summary>iOS: Native</summary>
<img width="432" alt="Screenshot 2024-07-01 at 2 36 17 AM" src="https://github.com/Expensify/App/assets/64629613/c05e404b-6d53-4f8d-aebc-d517caee7f61">
<img width="432" alt="Screenshot 2024-07-01 at 2 35 33 AM" src="https://github.com/Expensify/App/assets/64629613/9cb563ec-53ed-4667-abd8-e2efa26c5732">


</details>

<details>
<summary>iOS: mWeb Safari</summary>
<img width="432" alt="Screenshot 2024-07-01 at 2 11 44 AM" src="https://github.com/Expensify/App/assets/64629613/b5453dcb-25dc-4e22-b273-760b013cdcf1">
<img width="432" alt="Screenshot 2024-07-01 at 2 11 17 AM" src="https://github.com/Expensify/App/assets/64629613/d40265f0-93fd-4587-a6c6-a9e722ec74a8">

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>
<img width="1247" alt="Screenshot 2024-07-01 at 2 05 24 AM" src="https://github.com/Expensify/App/assets/64629613/735f8454-2bb7-4caa-8687-a0ea6f5ef482">

</details>

<details>
<summary>MacOS: Desktop</summary>
<img width="1220" alt="Screenshot 2024-07-01 at 2 09 09 AM" src="https://github.com/Expensify/App/assets/64629613/58a95a5d-075d-498a-a786-d8240d767bf6">


</details>
