### PR TITLE
set initial system chat message for LHN preview

### DIFF
--- a/src/libs/SidebarUtils.ts
+++ b/src/libs/SidebarUtils.ts
@@ -397,23 +397,25 @@ function getOptionData({
             } else {
                 // Here we get the beginning of chat history message and append the display name for each user, adding pronouns if there are any.
                 // We also add a fullstop after the final name, the word "and" before the final name and commas between all previous names.
-                lastMessageText = displayNamesWithTooltips
-                    .map(({displayName, pronouns}, index) => {
-                        const formattedText = !pronouns ? displayName : `${displayName} (${pronouns})`;
+                lastMessageText =
+                    Localize.translate(preferredLocale, 'reportActionsView.beginningOfChatHistory') +
+                    displayNamesWithTooltips
+                        .map(({displayName, pronouns}, index) => {
+                            const formattedText = !pronouns ? displayName : `${displayName} (${pronouns})`;
 
-                        if (index === displayNamesWithTooltips.length - 1) {
-                            return `${formattedText}.`;
-                        }
-                        if (index === displayNamesWithTooltips.length - 2) {
-                            return `${formattedText} ${Localize.translate(preferredLocale, 'common.and')}`;
-                        }
-                        if (index < displayNamesWithTooltips.length - 2) {
-                            return `${formattedText},`;
-                        }
+                            if (index === displayNamesWithTooltips.length - 1) {
+                                return `${formattedText}.`;
+                            }
+                            if (index === displayNamesWithTooltips.length - 2) {
+                                return `${formattedText} ${Localize.translate(preferredLocale, 'common.and')}`;
+                            }
+                            if (index < displayNamesWithTooltips.length - 2) {
+                                return `${formattedText},`;
+                            }
 
-                        return '';
-                    })
-                    .join(' ');
+                            return '';
+                        })
+                        .join(' ');
             }
         }
 

--- a/src/libs/SidebarUtils.ts
+++ b/src/libs/SidebarUtils.ts
@@ -390,28 +390,31 @@ function getOptionData({
         }
     } else {
         if (!lastMessageText) {
-            // Here we get the beginning of chat history message and append the display name for each user, adding pronouns if there are any.
-            // We also add a fullstop after the final name, the word "and" before the final name and commas between all previous names.
-            lastMessageText = ReportUtils.isSelfDM(report)
-                ? Localize.translate(preferredLocale, 'reportActionsView.beginningOfChatHistorySelfDM')
-                : Localize.translate(preferredLocale, 'reportActionsView.beginningOfChatHistory') +
-                  displayNamesWithTooltips
-                      .map(({displayName, pronouns}, index) => {
-                          const formattedText = !pronouns ? displayName : `${displayName} (${pronouns})`;
+            if (ReportUtils.isSystemChat(report)) {
+                lastMessageText = Localize.translate(preferredLocale, 'reportActionsView.beginningOfChatHistorySystemDM');
+            } else if (ReportUtils.isSelfDM(report)) {
+                lastMessageText = Localize.translate(preferredLocale, 'reportActionsView.beginningOfChatHistorySelfDM');
+            } else {
+                // Here we get the beginning of chat history message and append the display name for each user, adding pronouns if there are any.
+                // We also add a fullstop after the final name, the word "and" before the final name and commas between all previous names.
+                lastMessageText = displayNamesWithTooltips
+                    .map(({displayName, pronouns}, index) => {
+                        const formattedText = !pronouns ? displayName : `${displayName} (${pronouns})`;
 
-                          if (index === displayNamesWithTooltips.length - 1) {
-                              return `${formattedText}.`;
-                          }
-                          if (index === displayNamesWithTooltips.length - 2) {
-                              return `${formattedText} ${Localize.translate(preferredLocale, 'common.and')}`;
-                          }
-                          if (index < displayNamesWithTooltips.length - 2) {
-                              return `${formattedText},`;
-                          }
+                        if (index === displayNamesWithTooltips.length - 1) {
+                            return `${formattedText}.`;
+                        }
+                        if (index === displayNamesWithTooltips.length - 2) {
+                            return `${formattedText} ${Localize.translate(preferredLocale, 'common.and')}`;
+                        }
+                        if (index < displayNamesWithTooltips.length - 2) {
+                            return `${formattedText},`;
+                        }
 
-                          return '';
-                      })
-                      .join(' ');
+                        return '';
+                    })
+                    .join(' ');
+            }
         }
 
         result.alternateText =


### PR DESCRIPTION
### Details

### Fixed Issues

$ https://github.com/Expensify/App/issues/43830
PROPOSAL: https://github.com/Expensify/App/issues/43830#issuecomment-2181227442


### Tests
Precondition: Have an account haven't setup expensify
 - User A starts a new chat with a new User B (User B doesn't have an Expensify account).
 - User B open message link from email

1. Log in with a user who hasn't set up Expensify
2. Open Expensify chat from LHN
3. Verify default system chat message `Welcome! Let's get you set up.` is displayed in the LHN

- [x] Verify that no errors appear in the JS console

### Offline tests


### QA Steps
Precondition: Have an account haven't setup expensify
 - User A starts a new chat with a new User B (User B doesn't have an Expensify account).
 - User B open message link from email

1. Log in with a user who hasn't set up Expensify
2. Open Expensify chat from LHN
3. Verify default system chat message `Welcome! Let's get you set up.` is displayed in the LHN

- [x] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>


https://github.com/Expensify/App/assets/11959869/add8d66e-8619-491e-bdd9-a1089023a352



</details>

<details>
<summary>Android: mWeb Chrome</summary>

https://github.com/Expensify/App/assets/11959869/cd4aab39-18ed-440a-abec-3045d53a0456


</details>

<details>
<summary>iOS: Native</summary>

https://github.com/Expensify/App/assets/11959869/ee554c71-d857-4a5d-8a48-ea72a7660040


</details>

<details>
<summary>iOS: mWeb Safari</summary>


https://github.com/Expensify/App/assets/11959869/99ed716b-af1e-41c9-aa66-dab7fe9316ed


</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

![Screenshot 2024-07-02 at 22 00 04](https://github.com/Expensify/App/assets/11959869/3d38f371-a485-4a3a-845c-8816057356ef)


</details>

<details>
<summary>MacOS: Desktop</summary>

![Screenshot 2024-07-02 at 22 01 28](https://github.com/Expensify/App/assets/11959869/c0882d88-01e5-4465-8d74-6c29def74cb6)


</details>
