### PR TITLE
[CP Staging] Revert "fix: Country field reverts to the previous selection"

### DIFF
--- a/src/components/StateSelector.tsx
+++ b/src/components/StateSelector.tsx
@@ -89,7 +89,7 @@ function StateSelector(
             brickRoadIndicator={errorText ? CONST.BRICK_ROAD_INDICATOR_STATUS.ERROR : undefined}
             errorText={errorText}
             onPress={() => {
-                const activeRoute = Navigation.getActiveRouteWithoutParams();
+                const activeRoute = Navigation.getActiveRoute();
                 didOpenStateSelector.current = true;
                 Navigation.navigate(stateSelectorRoute.getRoute(stateCode, activeRoute, label));
             }}


### PR DESCRIPTION
Reverts Expensify/App#44981

Fixes https://github.com/Expensify/App/issues/45060

Brings back https://github.com/Expensify/App/issues/44957 but that is less severe so to unblock the deploy, we are going to revert this fix

### QA steps

Pre-requisite: the user must have created a Workspace and have enabled Workflows.

1. Go to Settings > Workspaces > Workspace > Workflows.
2. Tap on "Connect bank account".
3. Select "Connect manually".
4. Go trough the add bank account process using the testing credentials.
5. Once you reach the Incorporation state page on the Company info section, tap on the field and try to select a state.
6. Once the user taps on an option, the selected option should be displayed on the Incorporation state field and the user should be able to continue with the add bank account process.