### PR TITLE
Revert "fix: Web - Profile - Hovering over the zoom tool does not display a tooltip."

### DIFF
--- a/src/components/AvatarCropModal/Slider.tsx
+++ b/src/components/AvatarCropModal/Slider.tsx
@@ -7,7 +7,6 @@ import type {SharedValue} from 'react-native-reanimated';
 import Tooltip from '@components/Tooltip';
 import useLocalize from '@hooks/useLocalize';
 import useThemeStyles from '@hooks/useThemeStyles';
-import * as Browser from '@libs/Browser';
 import ControlSelection from '@libs/ControlSelection';
 
 type SliderProps = {
@@ -63,7 +62,7 @@ function Slider({sliderValue, gestureCallbacks}: SliderProps) {
                             shiftVertical={-2}
                         >
                             {/* pointerEventsNone is a workaround to make sure the pan gesture works correctly on mobile safari */}
-                            <View style={[styles.sliderKnobTooltipView, Browser.isMobileSafari() && styles.pointerEventsNone]} />
+                            <View style={[styles.sliderKnobTooltipView, styles.pointerEventsNone]} />
                         </Tooltip>
                     )}
                 </Animated.View>


### PR DESCRIPTION
Reverts Expensify/App#44788

Candidate for causing the crash here: https://github.com/Expensify/App/issues/45162