### PR TITLE
Fix hourglass icon not displayed instead of Next Steps 

### DIFF
--- a/src/components/MoneyReportHeaderStatusBar.tsx
+++ b/src/components/MoneyReportHeaderStatusBar.tsx
@@ -7,6 +7,10 @@ import CONST from '@src/CONST';
 import type ReportNextStep from '@src/types/onyx/ReportNextStep';
 import Badge from './Badge';
 import RenderHTML from './RenderHTML';
+import variables from '@styles/variables';
+import Icon from './Icon';
+import useTheme from '@hooks/useTheme';
+import * as Expensicons from '@components/Icon/Expensicons';
 
 type MoneyReportHeaderStatusBarProps = {
     /** The next step for the report */
@@ -16,19 +20,31 @@ type MoneyReportHeaderStatusBarProps = {
 function MoneyReportHeaderStatusBar({nextStep}: MoneyReportHeaderStatusBarProps) {
     const styles = useThemeStyles();
     const {translate} = useLocalize();
+    const theme = useTheme();
 
     const messageContent = useMemo(() => {
         const messageArray = nextStep.message;
         return NextStepUtils.parseMessage(messageArray);
     }, [nextStep.message]);
 
+    const HOURGLASS_ICON = 'hourglass';
+
     return (
         <View style={[styles.dFlex, styles.flexRow, styles.alignItemsCenter, styles.overflowHidden, styles.w100, styles.headerStatusBarContainer]}>
             <View style={[styles.mr3]}>
+            {nextStep?.icon && nextStep.icon === HOURGLASS_ICON ? (
+                <Icon
+                    src={Expensicons.Hourglass}
+                    height={variables.iconSizeSmall}
+                    width={variables.iconSizeSmall}
+                    fill={theme.icon}
+                />
+            ) : (
                 <Badge
                     text={translate(nextStep.title === CONST.NEXT_STEP.FINISHED ? 'iou.finished' : 'iou.nextStep')}
                     badgeStyles={styles.ml0}
                 />
+            )}
             </View>
             <View style={[styles.dFlex, styles.flexRow, styles.flexShrink1]}>
                 <RenderHTML html={messageContent} />

--- a/src/components/MoneyReportHeaderStatusBar.tsx
+++ b/src/components/MoneyReportHeaderStatusBar.tsx
@@ -2,15 +2,15 @@ import React, {useMemo} from 'react';
 import {View} from 'react-native';
 import useLocalize from '@hooks/useLocalize';
 import useThemeStyles from '@hooks/useThemeStyles';
+import useTheme from '@hooks/useTheme';
 import * as NextStepUtils from '@libs/NextStepUtils';
 import CONST from '@src/CONST';
+import variables from '@styles/variables';
 import type ReportNextStep from '@src/types/onyx/ReportNextStep';
 import Badge from './Badge';
 import RenderHTML from './RenderHTML';
-import variables from '@styles/variables';
 import Icon from './Icon';
-import useTheme from '@hooks/useTheme';
-import * as Expensicons from '@components/Icon/Expensicons';
+import * as Expensicons from './Icon/Expensicons';
 
 type MoneyReportHeaderStatusBarProps = {
     /** The next step for the report */

--- a/src/components/MoneyReportHeaderStatusBar.tsx
+++ b/src/components/MoneyReportHeaderStatusBar.tsx
@@ -28,7 +28,9 @@ function MoneyReportHeaderStatusBar({nextStep}: MoneyReportHeaderStatusBarProps)
     }, [nextStep.message]);
 
     const iconComponent = useMemo(() => {
-        if (!nextStep.icon) return null;
+        if (!nextStep.icon) {
+            return null;
+        }
 
         const iconMap = {
             hourglass: Expensicons.Hourglass,
@@ -50,7 +52,7 @@ function MoneyReportHeaderStatusBar({nextStep}: MoneyReportHeaderStatusBarProps)
     return (
         <View style={[styles.dFlex, styles.flexRow, styles.alignItemsCenter, styles.overflowHidden, styles.w100, styles.headerStatusBarContainer]}>
             <View style={[styles.mr3]}>
-                {iconComponent || (
+                {iconComponent ?? (
                     <Badge
                         text={translate(nextStep.title === CONST.NEXT_STEP.FINISHED ? 'iou.finished' : 'iou.nextStep')}
                         badgeStyles={styles.ml0}

--- a/src/components/MoneyReportHeaderStatusBar.tsx
+++ b/src/components/MoneyReportHeaderStatusBar.tsx
@@ -27,24 +27,35 @@ function MoneyReportHeaderStatusBar({nextStep}: MoneyReportHeaderStatusBarProps)
         return NextStepUtils.parseMessage(messageArray);
     }, [nextStep.message]);
 
-    const HOURGLASS_ICON = 'hourglass';
+    const iconComponent = useMemo(() => {
+        if (!nextStep.icon) return null;
+
+        const iconMap = {
+            hourglass: Expensicons.Hourglass,
+            checkmark: Expensicons.Checkmark,
+            stopwatch: Expensicons.Stopwatch,
+        };
+
+        const IconSrc = iconMap[nextStep.icon];
+        return IconSrc ? (
+            <Icon
+                src={IconSrc}
+                height={variables.iconSizeSmall}
+                width={variables.iconSizeSmall}
+                fill={theme.icon}
+            />
+        ) : null;
+    }, [nextStep.icon, theme.icon]);    
 
     return (
         <View style={[styles.dFlex, styles.flexRow, styles.alignItemsCenter, styles.overflowHidden, styles.w100, styles.headerStatusBarContainer]}>
             <View style={[styles.mr3]}>
-                {nextStep?.icon && nextStep.icon === HOURGLASS_ICON ? (
-                    <Icon
-                        src={Expensicons.Hourglass}
-                        height={variables.iconSizeSmall}
-                        width={variables.iconSizeSmall}
-                        fill={theme.icon}
-                    />
-                ) : (
-                    <Badge
-                        text={translate(nextStep.title === CONST.NEXT_STEP.FINISHED ? 'iou.finished' : 'iou.nextStep')}
-                        badgeStyles={styles.ml0}
-                    />
-                )}
+            {iconComponent || (
+                <Badge
+                    text={translate(nextStep.title === CONST.NEXT_STEP.FINISHED ? 'iou.finished' : 'iou.nextStep')}
+                    badgeStyles={styles.ml0}
+                />
+            )}
             </View>
             <View style={[styles.dFlex, styles.flexRow, styles.flexShrink1]}>
                 <RenderHTML html={messageContent} />

--- a/src/components/MoneyReportHeaderStatusBar.tsx
+++ b/src/components/MoneyReportHeaderStatusBar.tsx
@@ -1,16 +1,16 @@
 import React, {useMemo} from 'react';
 import {View} from 'react-native';
 import useLocalize from '@hooks/useLocalize';
-import useThemeStyles from '@hooks/useThemeStyles';
 import useTheme from '@hooks/useTheme';
+import useThemeStyles from '@hooks/useThemeStyles';
 import * as NextStepUtils from '@libs/NextStepUtils';
-import CONST from '@src/CONST';
 import variables from '@styles/variables';
+import CONST from '@src/CONST';
 import type ReportNextStep from '@src/types/onyx/ReportNextStep';
 import Badge from './Badge';
-import RenderHTML from './RenderHTML';
 import Icon from './Icon';
 import * as Expensicons from './Icon/Expensicons';
+import RenderHTML from './RenderHTML';
 
 type MoneyReportHeaderStatusBarProps = {
     /** The next step for the report */
@@ -32,19 +32,19 @@ function MoneyReportHeaderStatusBar({nextStep}: MoneyReportHeaderStatusBarProps)
     return (
         <View style={[styles.dFlex, styles.flexRow, styles.alignItemsCenter, styles.overflowHidden, styles.w100, styles.headerStatusBarContainer]}>
             <View style={[styles.mr3]}>
-            {nextStep?.icon && nextStep.icon === HOURGLASS_ICON ? (
-                <Icon
-                    src={Expensicons.Hourglass}
-                    height={variables.iconSizeSmall}
-                    width={variables.iconSizeSmall}
-                    fill={theme.icon}
-                />
-            ) : (
-                <Badge
-                    text={translate(nextStep.title === CONST.NEXT_STEP.FINISHED ? 'iou.finished' : 'iou.nextStep')}
-                    badgeStyles={styles.ml0}
-                />
-            )}
+                {nextStep?.icon && nextStep.icon === HOURGLASS_ICON ? (
+                    <Icon
+                        src={Expensicons.Hourglass}
+                        height={variables.iconSizeSmall}
+                        width={variables.iconSizeSmall}
+                        fill={theme.icon}
+                    />
+                ) : (
+                    <Badge
+                        text={translate(nextStep.title === CONST.NEXT_STEP.FINISHED ? 'iou.finished' : 'iou.nextStep')}
+                        badgeStyles={styles.ml0}
+                    />
+                )}
             </View>
             <View style={[styles.dFlex, styles.flexRow, styles.flexShrink1]}>
                 <RenderHTML html={messageContent} />

--- a/src/components/MoneyReportHeaderStatusBar.tsx
+++ b/src/components/MoneyReportHeaderStatusBar.tsx
@@ -45,17 +45,17 @@ function MoneyReportHeaderStatusBar({nextStep}: MoneyReportHeaderStatusBarProps)
                 fill={theme.icon}
             />
         ) : null;
-    }, [nextStep.icon, theme.icon]);    
+    }, [nextStep.icon, theme.icon]);
 
     return (
         <View style={[styles.dFlex, styles.flexRow, styles.alignItemsCenter, styles.overflowHidden, styles.w100, styles.headerStatusBarContainer]}>
             <View style={[styles.mr3]}>
-            {iconComponent || (
-                <Badge
-                    text={translate(nextStep.title === CONST.NEXT_STEP.FINISHED ? 'iou.finished' : 'iou.nextStep')}
-                    badgeStyles={styles.ml0}
-                />
-            )}
+                {iconComponent || (
+                    <Badge
+                        text={translate(nextStep.title === CONST.NEXT_STEP.FINISHED ? 'iou.finished' : 'iou.nextStep')}
+                        badgeStyles={styles.ml0}
+                    />
+                )}
             </View>
             <View style={[styles.dFlex, styles.flexRow, styles.flexShrink1]}>
                 <RenderHTML html={messageContent} />

--- a/src/types/onyx/ReportNextStep.ts
+++ b/src/types/onyx/ReportNextStep.ts
@@ -82,6 +82,9 @@ type ReportNextStep = {
 
     /** An array listing the buttons to be displayed alongside the next step copy */
     buttons?: Record<string, Button>;
+    
+    /** The icon asset to display to the left of the text */
+    icon?: string | null;
 };
 
 export default ReportNextStep;

--- a/src/types/onyx/ReportNextStep.ts
+++ b/src/types/onyx/ReportNextStep.ts
@@ -82,9 +82,9 @@ type ReportNextStep = {
 
     /** An array listing the buttons to be displayed alongside the next step copy */
     buttons?: Record<string, Button>;
-    
-    /** The icon asset to display to the left of the text */
-    icon?: string | null;
+
+    /** The icon asset for the next step to display to the left of the text */
+    icon?: 'hourglass' | 'checkmark' | 'stopwatch';
 };
 
 export default ReportNextStep;


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->
Display the hourglass icon instead of "Next Steps", when it's available in the `MoneyReportHeaderStatusBarProps`.
![image](https://github.com/user-attachments/assets/83475ad8-042d-4137-aa98-6cf9e3e4b762)

The logic for this property (`icon`) to exists or not in the Next Steps is already done by https://github.com/Expensify/Web-Expensify/pull/42641.

See https://github.com/Expensify/Web-Expensify/pull/42641#issuecomment-2229035139
### Fixed Issues
Related to https://github.com/Expensify/App/issues/44785
### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

- [x] Verify that no errors appear in the JS console

**Prerequisite**: user A has created a Workspace and invited user B as employee

1. Log in to OldDot as user B
2. Create a report on the workspace, but do not add any expenses to it
3. Log in to NewDot ad user A
4. Go to the workspace chat with user B, click on the report with no expenses


### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

- [x] Verify that no errors appear in the JS console
Same as in tests 
### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Desktop</summary>

<!-- add screenshots or videos here -->

</details>