### PR TITLE
[No QA] Card reconciliation page

### DIFF
--- a/src/ONYXKEYS.ts
+++ b/src/ONYXKEYS.ts
@@ -451,6 +451,9 @@ const ONYXKEYS = {
 
         /** The bank account that Expensify Card payments will be reconciled against */
         SHARED_NVP_EXPENSIFY_CARD_CONTINUOUS_RECONCILIATION_CONNECTION: 'sharedNVP_expensifyCard_continuousReconciliationConnection_',
+
+        /** The value that indicates whether Continuous Reconciliation should be used on the domain */
+        SHARED_NVP_EXPENSIFY_CARD_USE_CONTINUOUS_RECONCILIATION: 'sharedNVP_expensifyCard_useContinuousReconciliation_',
     },
 
     /** List of Form ids */
@@ -699,6 +702,7 @@ type OnyxCollectionValuesMapping = {
     [ONYXKEYS.COLLECTION.SHARED_NVP_PRIVATE_EXPENSIFY_CARD_SETTINGS]: OnyxTypes.ExpensifyCardSettings;
     [ONYXKEYS.COLLECTION.WORKSPACE_CARDS_LIST]: OnyxTypes.WorkspaceCardsList;
     [ONYXKEYS.COLLECTION.SHARED_NVP_EXPENSIFY_CARD_CONTINUOUS_RECONCILIATION_CONNECTION]: OnyxTypes.BankAccount;
+    [ONYXKEYS.COLLECTION.SHARED_NVP_EXPENSIFY_CARD_USE_CONTINUOUS_RECONCILIATION]: boolean;
 };
 
 type OnyxValuesMapping = {

--- a/src/languages/en.ts
+++ b/src/languages/en.ts
@@ -3161,6 +3161,9 @@ export default {
             autoSync: 'Auto-sync',
             reimbursedReports: 'Sync reimbursed reports',
             cardReconciliation: 'Card reconciliation',
+            continuousReconciliation: 'Continuous Reconciliation',
+            continuousReconciliationDescription:
+                'Save hours on reconciliation each accounting period by having Expensify continuously reconcile Expensify Card statements and settlements on your behalf.',
             reconciliationAccount: 'Reconciliation account',
             chooseReconciliationAccount: {
                 chooseBankAccount: 'Choose the bank account that your Expensify Card payments will be reconciled against.',

--- a/src/languages/es.ts
+++ b/src/languages/es.ts
@@ -3151,6 +3151,9 @@ export default {
             autoSync: 'Autosincronización',
             reimbursedReports: 'Sincronizar informes reembolsados',
             cardReconciliation: 'Conciliación de tarjetas',
+            continuousReconciliation: 'Conciliación Continua',
+            continuousReconciliationDescription:
+                'Ahorra horas de conciliación en cada período contable haciendo que Expensify concilie continuamente los extractos y liquidaciones de la Tarjeta Expensify en tu nombre.',
             reconciliationAccount: 'Cuenta de conciliación',
             chooseReconciliationAccount: {
                 chooseBankAccount: 'Elige la cuenta bancaria con la que se conciliarán los pagos de tu Tarjeta Expensify.',

--- a/src/libs/actions/Card.ts
+++ b/src/libs/actions/Card.ts
@@ -207,6 +207,43 @@ function clearIssueNewCardFlow() {
     });
 }
 
+function toggleCardReconciliation(value: boolean, policyID: string) {
+    Onyx.merge(`${ONYXKEYS.COLLECTION.SHARED_NVP_EXPENSIFY_CARD_USE_CONTINUOUS_RECONCILIATION}${policyID}`, value);
+
+    // TODO: uncomment this code when the API is ready
+    // const optimisticData: OnyxUpdate[] = [
+    //     {
+    //         onyxMethod: Onyx.METHOD.MERGE,
+    //         key: `${ONYXKEYS.COLLECTION.SHARED_NVP_EXPENSIFY_CARD_USE_CONTINUOUS_RECONCILIATION}${policyID}`,
+    //         value,
+    //     },
+    // ];
+    //
+    // const successData: OnyxUpdate[] = [
+    //     {
+    //         onyxMethod: Onyx.METHOD.MERGE,
+    //         key: `${ONYXKEYS.COLLECTION.SHARED_NVP_EXPENSIFY_CARD_USE_CONTINUOUS_RECONCILIATION}${policyID}`,
+    //         value,
+    //     },
+    // ];
+    //
+    // const failureData: OnyxUpdate[] = [
+    //     {
+    //         onyxMethod: Onyx.METHOD.MERGE,
+    //         key: `${ONYXKEYS.COLLECTION.SHARED_NVP_EXPENSIFY_CARD_USE_CONTINUOUS_RECONCILIATION}${policyID}`,
+    //         value: !value,
+    //     },
+    // ];
+    //
+    // const parameters = {
+    //     workspaceAccountID: policyID,
+    //     shouldUseContinuousReconciliation: value,
+    //     reconciliationSettings: value ? {} : undefined
+    // };
+    //
+    // API.write(WRITE_COMMANDS.TOGGLE_CONTINUOUS_RECONCILIATION, parameters, {optimisticData, successData, failureData});
+}
+
 export {
     requestReplacementExpensifyCard,
     activatePhysicalExpensifyCard,
@@ -215,5 +252,6 @@ export {
     revealVirtualCardDetails,
     setIssueNewCardStepAndData,
     clearIssueNewCardFlow,
+    toggleCardReconciliation,
 };
 export type {ReplacementReason};

--- a/src/pages/workspace/accounting/reconciliation/CardReconciliationPage.tsx
+++ b/src/pages/workspace/accounting/reconciliation/CardReconciliationPage.tsx
@@ -53,13 +53,15 @@ function CardReconciliationPage({policy, route}: WithPolicyConnectionsProps) {
                         shouldPlaceSubtitleBelowSwitch
                     />
                 </View>
-                <MenuItemWithTopDescription
-                    // TODO: get a proper bank account title
-                    title="Checking 1111"
-                    description={translate('workspace.accounting.reconciliationAccount')}
-                    onPress={() => Navigation.navigate(ROUTES.WORKSPACE_ACCOUNTING_RECONCILIATION_ACCOUNT_SETTINGS.getRoute(policyID, connection))}
-                    shouldShowRightIcon
-                />
+                {!!isUsedContinuousReconciliation && (
+                    <MenuItemWithTopDescription
+                        // TODO: get a proper bank account title
+                        title="Checking 1111"
+                        description={translate('workspace.accounting.reconciliationAccount')}
+                        onPress={() => Navigation.navigate(ROUTES.WORKSPACE_ACCOUNTING_RECONCILIATION_ACCOUNT_SETTINGS.getRoute(policyID, connection))}
+                        shouldShowRightIcon
+                    />
+                )}
             </ScreenWrapper>
         </AccessOrNotFoundWrapper>
     );

--- a/src/pages/workspace/accounting/reconciliation/CardReconciliationPage.tsx
+++ b/src/pages/workspace/accounting/reconciliation/CardReconciliationPage.tsx
@@ -1,19 +1,35 @@
 import React from 'react';
+import {View} from 'react-native';
+import {useOnyx} from 'react-native-onyx';
+import type {ValueOf} from 'type-fest';
 import HeaderWithBackButton from '@components/HeaderWithBackButton';
+import MenuItemWithTopDescription from '@components/MenuItemWithTopDescription';
 import ScreenWrapper from '@components/ScreenWrapper';
-import ScrollView from '@components/ScrollView';
 import useLocalize from '@hooks/useLocalize';
 import useThemeStyles from '@hooks/useThemeStyles';
+import Navigation from '@navigation/Navigation';
 import AccessOrNotFoundWrapper from '@pages/workspace/AccessOrNotFoundWrapper';
 import type {WithPolicyConnectionsProps} from '@pages/workspace/withPolicyConnections';
 import withPolicyConnections from '@pages/workspace/withPolicyConnections';
+import ToggleSettingOptionRow from '@pages/workspace/workflows/ToggleSettingsOptionRow';
+import * as Card from '@userActions/Card';
 import CONST from '@src/CONST';
+import ONYXKEYS from '@src/ONYXKEYS';
+import ROUTES from '@src/ROUTES';
 
-function CardReconciliationPage({policy}: WithPolicyConnectionsProps) {
+function CardReconciliationPage({policy, route}: WithPolicyConnectionsProps) {
     const styles = useThemeStyles();
     const {translate} = useLocalize();
 
     const policyID = policy?.id ?? '-1';
+    // @ts-expect-error connection doesn't exist on type ReadOnly<{policyID: string}>
+    const connection = (route?.params?.connection as ValueOf<typeof CONST.POLICY.CONNECTIONS.NAME>) ?? '';
+
+    const toggleOption = (isEnabled: boolean) => {
+        Card.toggleCardReconciliation(isEnabled, policyID);
+    };
+
+    const [isUsedContinuousReconciliation] = useOnyx(`${ONYXKEYS.COLLECTION.SHARED_NVP_EXPENSIFY_CARD_USE_CONTINUOUS_RECONCILIATION}${policyID}`);
 
     return (
         <AccessOrNotFoundWrapper
@@ -27,7 +43,23 @@ function CardReconciliationPage({policy}: WithPolicyConnectionsProps) {
                 testID={CardReconciliationPage.displayName}
             >
                 <HeaderWithBackButton title={translate('workspace.accounting.cardReconciliation')} />
-                <ScrollView contentContainerStyle={[styles.ph5, styles.pb5]} />
+                <View style={[styles.mh5, styles.mb3]}>
+                    <ToggleSettingOptionRow
+                        switchAccessibilityLabel={translate('workspace.accounting.continuousReconciliation')}
+                        title={translate('workspace.accounting.continuousReconciliation')}
+                        isActive={!!isUsedContinuousReconciliation}
+                        onToggle={toggleOption}
+                        subtitle={translate('workspace.accounting.continuousReconciliationDescription')}
+                        shouldPlaceSubtitleBelowSwitch
+                    />
+                </View>
+                <MenuItemWithTopDescription
+                    // TODO: get a proper bank account title
+                    title="Checking 1111"
+                    description={translate('workspace.accounting.reconciliationAccount')}
+                    onPress={() => Navigation.navigate(ROUTES.WORKSPACE_ACCOUNTING_RECONCILIATION_ACCOUNT_SETTINGS.getRoute(policyID, connection))}
+                    shouldShowRightIcon
+                />
             </ScreenWrapper>
         </AccessOrNotFoundWrapper>
     );


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->

As mentioned in this comment https://github.com/Expensify/App/pull/44968#issuecomment-2222871667 - another PR for Card Reconciliation page content 

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/44315
PROPOSAL:


### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

PREREQUISITES: a workspace with accounting connections enabled

1. Go to Card reconciliation page 
MOBILE: with app built and simulator open type in terminal either:
`npx uri-scheme open new-expensify://settings/workspaces/<workspaceID>/accounting/<connection>/card-reconciliation --ios`
or
`npx uri-scheme open new-expensify://settings/workspaces/<workspaceID>/accounting/<connection>/card-reconciliation —android`
WEB/mWEB: add `settings/workspaces/<workspaceID>/accounting/<connection>/card-reconciliation` to the root URL
DESKTOP: with the app open type the address in the bar: `staging.new.expensify.com/settings/workspaces/<workspaceID>/accounting/<connection>/card-reconciliation` and open app from the prompt. (You must be logged to the same account on staging and in the desktop app)
2. Verify that the page is displayed properly
3. Verify that you can switch the toggle
4. After switching on the toggle you verify that you see a MenuItem with 'Reconciliation account' label and a bank name as the title (for now it's a mocked data)
5. Verify that clicking the MenuItem navigates to `/settings/workspaces/<workspaceID>/accounting/<connection>/card-reconciliation/account` (for now this page is hidden, but you will see a change in the URL)

- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
6. Upload an image via copy paste
7. Verify a modal appears displaying a preview of that image
--->

n/a

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] If we are not using the full Onyx data that we loaded, I've added the proper selector in order to ensure the component only re-renders when the data it is using changes
        - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.


### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->
![Screenshot_1721224724](https://github.com/user-attachments/assets/12177fd2-c3c4-461d-bfb1-c379d4cae6c4)
![Screenshot_1721224720](https://github.com/user-attachments/assets/7a502bdb-603a-469c-8c66-9b0629fc45fd)

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->
![Screenshot_1721224908](https://github.com/user-attachments/assets/83556860-f77c-4be6-8138-5fc490b85615)
![Screenshot_1721224910](https://github.com/user-attachments/assets/e0d7dd9a-3514-4bbe-a9b6-933aacdcbc64)

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->
![Simulator Screenshot - iPhone 15 Pro - 2024-07-17 at 15 33 55](https://github.com/user-attachments/assets/8bb32da8-d0d9-41c4-9f67-d985f0f3f1a1)
![Simulator Screenshot - iPhone 15 Pro - 2024-07-17 at 15 33 57](https://github.com/user-attachments/assets/bbc386c6-df36-472f-a9be-47928b96c813)

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->
![Simulator Screenshot - iPhone 15 Pro - 2024-07-17 at 15 34 51](https://github.com/user-attachments/assets/2964c87a-54f6-4ca3-8479-c182e798d1de)
![Simulator Screenshot - iPhone 15 Pro - 2024-07-17 at 15 34 53](https://github.com/user-attachments/assets/178c1b1b-f8c0-461d-b0a5-43257aece89b)

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->
<img width="811" alt="Screenshot 2024-07-17 at 15 22 55" src="https://github.com/user-attachments/assets/217859a8-dbce-4064-b4f1-f40be23029c5">
<img width="774" alt="Screenshot 2024-07-17 at 15 22 47" src="https://github.com/user-attachments/assets/8e381cfe-6ca8-44ed-b79d-89757ccbe121">

</details>

<details>
<summary>MacOS: Desktop</summary>

<!-- add screenshots or videos here -->
<img width="1033" alt="Screenshot 2024-07-17 at 15 22 31" src="https://github.com/user-attachments/assets/d6eb90b3-c2a4-459d-819b-5f697c582a61">
<img width="1036" alt="Screenshot 2024-07-17 at 15 22 25" src="https://github.com/user-attachments/assets/873d5c1e-ca0c-4370-8f1c-265b35928d34">

</details>
