### PR TITLE
Revert "fix: iOS - Distance - Center icon overlaps with compass icon."

### DIFF
--- a/src/components/MapView/MapView.tsx
+++ b/src/components/MapView/MapView.tsx
@@ -215,10 +215,6 @@ const MapView = forwardRef<MapViewHandle, ComponentProps>(
                     pitchEnabled={pitchEnabled}
                     attributionPosition={{...styles.r2, ...styles.b2}}
                     scaleBarEnabled={false}
-                    // We use scaleBarPosition with top: -32 to hide the scale bar on iOS because scaleBarEnabled={false} not work on iOS
-                    scaleBarPosition={{...styles.tn8, left: 0}}
-                    compassEnabled
-                    compassPosition={{...styles.l2, ...styles.t5}}
                     logoPosition={{...styles.l2, ...styles.b2}}
                     // eslint-disable-next-line react/jsx-props-no-spreading
                     {...responder.panHandlers}

--- a/src/styles/utils/positioning.ts
+++ b/src/styles/utils/positioning.ts
@@ -22,9 +22,6 @@ export default {
     t0: {
         top: 0,
     },
-    t5: {
-        top: 20,
-    },
     tn4: {
         top: -16,
     },


### PR DESCRIPTION
Reverts Expensify/App#44752