### PR TITLE
Removes P2P debit card option

### DIFF
--- a/src/components/AddPaymentMethodMenu.tsx
+++ b/src/components/AddPaymentMethodMenu.tsx
@@ -99,13 +99,14 @@ function AddPaymentMethodMenu({
                           },
                       ]
                     : []),
-                ...[
-                    {
-                        text: translate('common.debitCard'),
-                        icon: Expensicons.CreditCard,
-                        onSelected: () => onItemSelected(CONST.PAYMENT_METHODS.DEBIT_CARD),
-                    },
-                ],
+                // Adding a debit card for P2P payments is temporarily disabled
+                // ...[
+                //     {
+                //         text: translate('common.debitCard'),
+                //         icon: Expensicons.CreditCard,
+                //         onSelected: () => onItemSelected(CONST.PAYMENT_METHODS.DEBIT_CARD),
+                //     },
+                // ],
             ]}
             withoutOverlay
         />

--- a/src/components/AddPaymentMethodMenu.tsx
+++ b/src/components/AddPaymentMethodMenu.tsx
@@ -1,5 +1,5 @@
 import type {RefObject} from 'react';
-import React, { useEffect } from 'react';
+import React, {useEffect} from 'react';
 import type {View} from 'react-native';
 import type {OnyxEntry} from 'react-native-onyx';
 import {withOnyx} from 'react-native-onyx';
@@ -79,7 +79,7 @@ function AddPaymentMethodMenu({
         }
 
         onItemSelected(CONST.PAYMENT_METHODS.PERSONAL_BANK_ACCOUNT);
-    }, [isPersonalOnlyOption, isVisible]);
+    }, [isPersonalOnlyOption, isVisible, onItemSelected]);
 
     if (isPersonalOnlyOption) {
         return null;

--- a/src/components/AddPaymentMethodMenu.tsx
+++ b/src/components/AddPaymentMethodMenu.tsx
@@ -1,5 +1,5 @@
 import type {RefObject} from 'react';
-import React from 'react';
+import React, { useEffect } from 'react';
 import type {View} from 'react-native';
 import type {OnyxEntry} from 'react-native-onyx';
 import {withOnyx} from 'react-native-onyx';
@@ -69,6 +69,21 @@ function AddPaymentMethodMenu({
         ReportUtils.isExpenseReport(iouReport) || (isIOUReport && !ReportActionsUtils.hasRequestFromCurrentAccount(iouReport?.reportID ?? '-1', session?.accountID ?? -1));
 
     const canUsePersonalBankAccount = shouldShowPersonalBankAccountOption || isIOUReport;
+
+    const isPersonalOnlyOption = canUsePersonalBankAccount && !canUseBusinessBankAccount;
+
+    // We temporarily disabled P2P debit cards so we will automatically select the personal bank account option if there is no other option to select.
+    useEffect(() => {
+        if (!isVisible) {
+            return;
+        }
+
+        onItemSelected(CONST.PAYMENT_METHODS.PERSONAL_BANK_ACCOUNT);
+    }, [isPersonalOnlyOption, isVisible]);
+
+    if (isPersonalOnlyOption) {
+        return null;
+    }
 
     return (
         <PopoverMenu

--- a/src/pages/settings/Wallet/AddDebitCardPage.tsx
+++ b/src/pages/settings/Wallet/AddDebitCardPage.tsx
@@ -11,6 +11,9 @@ import * as PaymentMethods from '@userActions/PaymentMethods';
 import ONYXKEYS from '@src/ONYXKEYS';
 
 function DebitCardPage() {
+    // Temporarily disabled
+    return null;
+
     const {translate} = useLocalize();
     const [formData] = useOnyx(ONYXKEYS.FORMS.ADD_PAYMENT_CARD_FORM);
     const prevFormDataSetupComplete = usePrevious(!!formData?.setupComplete);

--- a/src/pages/settings/Wallet/AddDebitCardPage.tsx
+++ b/src/pages/settings/Wallet/AddDebitCardPage.tsx
@@ -9,10 +9,11 @@ import usePrevious from '@hooks/usePrevious';
 import Navigation from '@libs/Navigation/Navigation';
 import * as PaymentMethods from '@userActions/PaymentMethods';
 import ONYXKEYS from '@src/ONYXKEYS';
+import NotFoundPage from '@pages/ErrorPage/NotFoundPage';
 
 function DebitCardPage() {
     // Temporarily disabled
-    return null;
+    return <NotFoundPage />;
 
     const {translate} = useLocalize();
     const [formData] = useOnyx(ONYXKEYS.FORMS.ADD_PAYMENT_CARD_FORM);

--- a/src/pages/settings/Wallet/AddDebitCardPage.tsx
+++ b/src/pages/settings/Wallet/AddDebitCardPage.tsx
@@ -7,9 +7,9 @@ import ScreenWrapper from '@components/ScreenWrapper';
 import useLocalize from '@hooks/useLocalize';
 import usePrevious from '@hooks/usePrevious';
 import Navigation from '@libs/Navigation/Navigation';
+import NotFoundPage from '@pages/ErrorPage/NotFoundPage';
 import * as PaymentMethods from '@userActions/PaymentMethods';
 import ONYXKEYS from '@src/ONYXKEYS';
-import NotFoundPage from '@pages/ErrorPage/NotFoundPage';
 
 function DebitCardPage() {
     // Temporarily disabled

--- a/src/pages/settings/Wallet/PaymentMethodList.tsx
+++ b/src/pages/settings/Wallet/PaymentMethodList.tsx
@@ -260,10 +260,9 @@ function PaymentMethodList({
             return assignedCardsGrouped;
         }
 
-        const paymentCardList = fundList ?? {};
-
         // Hide any billing cards that are not P2P debit cards for now because you cannot make them your default method, or delete them
         // All payment cards are temporarily disabled for use as a payment method
+        // const paymentCardList = fundList ?? {};
         // const filteredCardList = Object.values(paymentCardList).filter((card) => !!card.accountData?.additionalData?.isP2PDebitCard);
         const filteredCardList = {};
         let combinedPaymentMethods = PaymentUtils.formatPaymentMethods(bankAccountList ?? {}, filteredCardList, styles);

--- a/src/pages/settings/Wallet/PaymentMethodList.tsx
+++ b/src/pages/settings/Wallet/PaymentMethodList.tsx
@@ -175,7 +175,8 @@ function PaymentMethodList({
     bankAccountList = {},
     buttonRef = () => {},
     cardList = {},
-    fundList = {},
+    // Temporarily disabled because P2P debit cards are disabled.
+    // fundList = {},
     filterType = '',
     listHeaderComponent,
     isLoadingPaymentMethods = true,
@@ -303,19 +304,7 @@ function PaymentMethodList({
             };
         });
         return combinedPaymentMethods;
-    }, [
-        shouldShowAssignedCards,
-        bankAccountList,
-        styles,
-        filterType,
-        isOffline,
-        cardList,
-        actionPaymentMethodType,
-        activePaymentMethodID,
-        StyleUtils,
-        shouldShowRightIcon,
-        onPress,
-    ]);
+    }, [shouldShowAssignedCards, bankAccountList, styles, filterType, isOffline, cardList, actionPaymentMethodType, activePaymentMethodID, StyleUtils, shouldShowRightIcon, onPress]);
 
     /**
      * Render placeholder when there are no payments methods

--- a/src/pages/settings/Wallet/PaymentMethodList.tsx
+++ b/src/pages/settings/Wallet/PaymentMethodList.tsx
@@ -45,7 +45,7 @@ type PaymentMethodListOnyxProps = {
     cardList: OnyxEntry<CardList>;
 
     /** List of user's cards */
-    fundList: OnyxEntry<FundList>;
+    // fundList: OnyxEntry<FundList>;
 
     /** Are we loading payment methods? */
     isLoadingPaymentMethods: OnyxEntry<boolean>;

--- a/src/pages/settings/Wallet/PaymentMethodList.tsx
+++ b/src/pages/settings/Wallet/PaymentMethodList.tsx
@@ -305,7 +305,6 @@ function PaymentMethodList({
         return combinedPaymentMethods;
     }, [
         shouldShowAssignedCards,
-        fundList,
         bankAccountList,
         styles,
         filterType,

--- a/src/pages/settings/Wallet/PaymentMethodList.tsx
+++ b/src/pages/settings/Wallet/PaymentMethodList.tsx
@@ -412,9 +412,10 @@ export default withOnyx<PaymentMethodListProps, PaymentMethodListOnyxProps>({
     cardList: {
         key: ONYXKEYS.CARD_LIST,
     },
-    fundList: {
-        key: ONYXKEYS.FUND_LIST,
-    },
+    // Temporarily disabled - used for P2P debit cards
+    // fundList: {
+    //     key: ONYXKEYS.FUND_LIST,
+    // },
     isLoadingPaymentMethods: {
         key: ONYXKEYS.IS_LOADING_PAYMENT_METHODS,
     },

--- a/src/pages/settings/Wallet/PaymentMethodList.tsx
+++ b/src/pages/settings/Wallet/PaymentMethodList.tsx
@@ -263,7 +263,9 @@ function PaymentMethodList({
         const paymentCardList = fundList ?? {};
 
         // Hide any billing cards that are not P2P debit cards for now because you cannot make them your default method, or delete them
-        const filteredCardList = Object.values(paymentCardList).filter((card) => !!card.accountData?.additionalData?.isP2PDebitCard);
+        // All payment cards are temporarily disabled for use as a payment method
+        // const filteredCardList = Object.values(paymentCardList).filter((card) => !!card.accountData?.additionalData?.isP2PDebitCard);
+        const filteredCardList = {};
         let combinedPaymentMethods = PaymentUtils.formatPaymentMethods(bankAccountList ?? {}, filteredCardList, styles);
 
         if (filterType !== '') {

--- a/src/pages/settings/Wallet/PaymentMethodList.tsx
+++ b/src/pages/settings/Wallet/PaymentMethodList.tsx
@@ -29,7 +29,7 @@ import * as PaymentMethods from '@userActions/PaymentMethods';
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
 import ROUTES from '@src/ROUTES';
-import type {AccountData, BankAccountList, CardList, FundList} from '@src/types/onyx';
+import type {AccountData, BankAccountList, CardList} from '@src/types/onyx';
 import type {BankIcon} from '@src/types/onyx/Bank';
 import type {Errors} from '@src/types/onyx/OnyxCommon';
 import type PaymentMethod from '@src/types/onyx/PaymentMethod';


### PR DESCRIPTION
### Details

Temporarily disables adding P2P debit cards and selecting them as default payment methods

cc @pecanoro @rafecolton 

### Fixed Issues
$ https://github.com/Expensify/Expensify/issues/415680

### Tests

**Verify that p2p debit cards can’t be added**

1. Create a new chat.
2. Tap the composer + button 
3. Select “Pay [user]”
4. Enter amount
5. Tap “Pay with Expensify”
6. Verify no debit card option appears

**Via Global Create**

1. Tap global create
2. Select “Pay someone”
3. Enter amount
4. Select user
5. Tap “Pay with Expensify”
6. Verify no debit card option appears

**Via Settings**

1. Navigate to /settings/wallet
2. Tap “+ Add bank account”
3. Verify there is no option to add debit card in the pop up menu and that the pop up menu does not appear at all
4. Verify the user is brought direction to the Add bank account setup flow

**Via direct links**

1. Navigate directly to pay/new/add-debit-card and settings/wallet/add-debit-card
2. Verify the “Not found page” appears

**For accounts with existing P2P debit cards**

1. Sign into account that has existing P2P debit card option
2. Navigate to Wallet page.
3. Verify they do not appear in the list of options. 

- [ ] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

![2024-07-26_09-18-41](https://github.com/user-attachments/assets/8702fb52-04f4-48e7-98bc-e63beb8a5f9a)
![2024-07-26_09-14-55](https://github.com/user-attachments/assets/9c223954-9189-472f-ae14-142f152d9e41)

</details>

<details>
<summary>MacOS: Desktop</summary>

<!-- add screenshots or videos here -->

</details>
