### PR TITLE
Add delay before calling reconnect when server is back up

### DIFF
--- a/src/libs/NetworkConnection.ts
+++ b/src/libs/NetworkConnection.ts
@@ -32,7 +32,7 @@ const triggerReconnectionCallbacks = throttle(
         let delay = 0;
 
         if (wasServerDown && isServerUp) {
-            delay = Math.floor(Math.random() * 21000); // Random delay between 0 and 20 seconds
+            delay = Math.floor(Math.random() * 61000); // Random delay between 0 and 20 seconds
             wasServerDown = false;
         }
         setTimeout(() => {

--- a/src/libs/NetworkConnection.ts
+++ b/src/libs/NetworkConnection.ts
@@ -32,7 +32,7 @@ const triggerReconnectionCallbacks = throttle(
         let delay = 0;
 
         if (wasServerDown && isServerUp) {
-            delay = Math.floor(Math.random() * 61000); // Random delay between 0 and 20 seconds
+            delay = Math.floor(Math.random() * 61000);
             wasServerDown = false;
         }
         setTimeout(() => {

--- a/src/libs/NetworkConnection.ts
+++ b/src/libs/NetworkConnection.ts
@@ -21,15 +21,26 @@ type ResponseJSON = {
 let callbackID = 0;
 const reconnectionCallbacks: Record<string, () => void> = {};
 
+let isServerUp = true;
+let wasServerDown = false;
+
 /**
  * Loop over all reconnection callbacks and fire each one
  */
 const triggerReconnectionCallbacks = throttle(
     (reason) => {
-        Log.info(`[NetworkConnection] Firing reconnection callbacks because ${reason}`);
-        Object.values(reconnectionCallbacks).forEach((callback) => {
-            callback();
-        });
+        let delay = 0;
+
+        if (wasServerDown && isServerUp) {
+            delay = Math.floor(Math.random() * 21000); // Random delay between 0 and 20 seconds
+            wasServerDown = false;
+        }
+        setTimeout(() => {
+            Log.info(`[NetworkConnection] Firing reconnection callbacks because ${reason}`);
+            Object.values(reconnectionCallbacks).forEach((callback) => {
+                callback();
+            });
+        }, delay);
     },
     5000,
     {trailing: false},
@@ -70,12 +81,12 @@ Onyx.connect({
         } else {
             // If we are no longer forcing offline fetch the NetInfo to set isOffline appropriately
             NetInfo.fetch().then((state) => {
-                const isInternetReachable = (state.isInternetReachable ?? false) === false;
-                setOfflineStatus(isInternetReachable, 'NetInfo checked if the internet is reachable');
+                const isInternetUnreachable = (state.isInternetReachable ?? false) === false;
+                setOfflineStatus(isInternetUnreachable || !isServerUp, 'NetInfo checked if the internet is reachable');
                 Log.info(
                     `[NetworkStatus] The force-offline mode was turned off. Getting the device network status from NetInfo. Network state: ${JSON.stringify(
                         state,
-                    )}. Setting the offline status to: ${isInternetReachable}.`,
+                    )}. Setting the offline status to: ${isInternetUnreachable}.`,
                 );
             });
         }
@@ -111,13 +122,31 @@ function subscribeToNetInfo(): () => void {
             reachabilityUrl: `${CONFIG.EXPENSIFY.DEFAULT_API_ROOT}api/Ping?accountID=${accountID || 'unknown'}`,
             reachabilityMethod: 'GET',
             reachabilityTest: (response) => {
+                console.log(JSON.stringify(response));
                 if (!response.ok) {
                     return Promise.resolve(false);
                 }
                 return response
                     .json()
-                    .then((json: ResponseJSON) => Promise.resolve(json.jsonCode === 200))
-                    .catch(() => Promise.resolve(false));
+                    .then((json: ResponseJSON) => {
+                        console.log(json.jsonCode);
+                        console.log(`isServerUp ${isServerUp}`);
+                        if (json.jsonCode !== 200 && isServerUp) {
+                            Log.info('[NetworkConnection] Received non-200 response from reachability test. Setting isServerUp status to false.');
+                            isServerUp = false;
+                            wasServerDown = true;
+                        } else if (json.jsonCode === 200 && !isServerUp) {
+                            Log.info('[NetworkConnection] Received 200 response from reachability test. Setting isServerUp status to true.');
+                            isServerUp = true;
+                        }
+                        return Promise.resolve(json.jsonCode === 200);
+                    })
+                    .catch(() => {
+                        console.log(`isServerUp ${isServerUp}`);
+                        isServerUp = false;
+                        wasServerDown = true;
+                        return Promise.resolve(false);
+                    });
             },
 
             // If a check is taking longer than this time we're considered offline
@@ -133,7 +162,7 @@ function subscribeToNetInfo(): () => void {
             Log.info('[NetworkConnection] Not setting offline status because shouldForceOffline = true');
             return;
         }
-        setOfflineStatus(state.isInternetReachable === false, 'NetInfo received a state change event');
+        setOfflineStatus(state.isInternetReachable === false || !isServerUp, 'NetInfo received a state change event');
         Log.info(`[NetworkStatus] NetInfo.addEventListener event coming, setting "offlineStatus" to ${!!state.isInternetReachable} with network state: ${JSON.stringify(state)}`);
         let networkStatus;
         if (!isBoolean(state.isInternetReachable)) {

--- a/src/libs/NetworkConnection.ts
+++ b/src/libs/NetworkConnection.ts
@@ -122,15 +122,12 @@ function subscribeToNetInfo(): () => void {
             reachabilityUrl: `${CONFIG.EXPENSIFY.DEFAULT_API_ROOT}api/Ping?accountID=${accountID || 'unknown'}`,
             reachabilityMethod: 'GET',
             reachabilityTest: (response) => {
-                console.log(JSON.stringify(response));
                 if (!response.ok) {
                     return Promise.resolve(false);
                 }
                 return response
                     .json()
                     .then((json: ResponseJSON) => {
-                        console.log(json.jsonCode);
-                        console.log(`isServerUp ${isServerUp}`);
                         if (json.jsonCode !== 200 && isServerUp) {
                             Log.info('[NetworkConnection] Received non-200 response from reachability test. Setting isServerUp status to false.');
                             isServerUp = false;
@@ -142,7 +139,6 @@ function subscribeToNetInfo(): () => void {
                         return Promise.resolve(json.jsonCode === 200);
                     })
                     .catch(() => {
-                        console.log(`isServerUp ${isServerUp}`);
                         isServerUp = false;
                         wasServerDown = true;
                         return Promise.resolve(false);


### PR DESCRIPTION
### Details

Add delay before calling reconnect when server is back up.

### Fixed Issues

$ https://github.com/Expensify/App/issues/46143
PROPOSAL: https://github.com/Expensify/App/issues/46143#issuecomment-2249931677

### Test steps

1. Ensure internet connection is working.
2. Simulate a server issue using dev tools (mock the ping API to have 400 code).
3. App should show "You appear to be offline".
4. Fix the artificial server issue via dev tools.
5. The reconnect API should be called after some delay (delay can be 0 - 20 seconds).

### QA steps

1. Ensure internet connection is working.
2. Simulate a server issue using dev tools (mock the ping API to have 400 code).
3. App should show "You appear to be offline".
4. Fix the artificial server issue.
5. The reconnect API should be called after some delay (delay can be 0 - 20 seconds).

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>


</details>

<details>
<summary>Android: mWeb Chrome</summary>

</details>


<details>
<summary>iOS: Native</summary>


</details>

<details>
<summary>iOS: mWeb Safari</summary>

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

https://github.com/user-attachments/assets/623b47bb-496b-44a2-ba00-6279575db77a

</details>

<details>
<summary>MacOS: Desktop</summary>


</details>