### PR TITLE
Fix: Dropdown button is not disabled when no selection is made

### DIFF
--- a/src/pages/ReportParticipantsPage.tsx
+++ b/src/pages/ReportParticipantsPage.tsx
@@ -270,6 +270,7 @@ function ReportParticipantsPage({report}: WithReportOrNotFoundProps) {
                         onPress={() => null}
                         options={bulkActionsButtonOptions}
                         style={[shouldUseNarrowLayout && styles.flexGrow1]}
+                        isDisabled={!selectedMembers.length}
                     />
                 ) : (
                     <Button

--- a/src/pages/workspace/WorkspaceMembersPage.tsx
+++ b/src/pages/workspace/WorkspaceMembersPage.tsx
@@ -516,6 +516,7 @@ function WorkspaceMembersPage({personalDetails, route, policy, currentUserPerson
                         options={getBulkActionsButtonOptions()}
                         isSplitButton={false}
                         style={[shouldUseNarrowLayout && styles.flexGrow1, shouldUseNarrowLayout && styles.mb3]}
+                        isDisabled={!selectedEmployees.length}
                     />
                 ) : (
                     <Button

--- a/src/pages/workspace/categories/WorkspaceCategoriesPage.tsx
+++ b/src/pages/workspace/categories/WorkspaceCategoriesPage.tsx
@@ -232,6 +232,7 @@ function WorkspaceCategoriesPage({route}: WorkspaceCategoriesPageProps) {
                     options={options}
                     isSplitButton={false}
                     style={[shouldUseNarrowLayout && styles.flexGrow1, shouldUseNarrowLayout && styles.mb3]}
+                    isDisabled={!selectedCategoriesArray.length}
                 />
             );
         }

--- a/src/pages/workspace/distanceRates/PolicyDistanceRatesPage.tsx
+++ b/src/pages/workspace/distanceRates/PolicyDistanceRatesPage.tsx
@@ -265,6 +265,7 @@ function PolicyDistanceRatesPage({
                     style={[shouldUseNarrowLayout && styles.flexGrow1]}
                     wrapperStyle={styles.w100}
                     isSplitButton={false}
+                    isDisabled={!selectedDistanceRates.length}
                 />
             )}
         </View>

--- a/src/pages/workspace/reportFields/ReportFieldsListValuesPage.tsx
+++ b/src/pages/workspace/reportFields/ReportFieldsListValuesPage.tsx
@@ -257,6 +257,7 @@ function ReportFieldsListValuesPage({
                     options={options}
                     isSplitButton={false}
                     style={[isSmallScreenWidth && styles.flexGrow1, isSmallScreenWidth && styles.mb3]}
+                    isDisabled={!selectedValuesArray.length}
                 />
             );
         }

--- a/src/pages/workspace/reportFields/WorkspaceReportFieldsPage.tsx
+++ b/src/pages/workspace/reportFields/WorkspaceReportFieldsPage.tsx
@@ -170,6 +170,7 @@ function WorkspaceReportFieldsPage({
                     options={options}
                     isSplitButton={false}
                     style={[shouldUseNarrowLayout && styles.flexGrow1, shouldUseNarrowLayout && styles.mb3]}
+                    isDisabled={!selectedReportFields.length}
                 />
             );
         }

--- a/src/pages/workspace/tags/WorkspaceTagsPage.tsx
+++ b/src/pages/workspace/tags/WorkspaceTagsPage.tsx
@@ -279,6 +279,7 @@ function WorkspaceTagsPage({route}: WorkspaceTagsPageProps) {
                 customText={translate('workspace.common.selected', {selectedNumber: selectedTagsArray.length})}
                 options={options}
                 style={[shouldUseNarrowLayout && styles.flexGrow1, shouldUseNarrowLayout && styles.mb3]}
+                isDisabled={!selectedTagsArray.length}
             />
         );
     };

--- a/src/pages/workspace/tags/WorkspaceViewTagsPage.tsx
+++ b/src/pages/workspace/tags/WorkspaceViewTagsPage.tsx
@@ -220,6 +220,7 @@ function WorkspaceViewTagsPage({route}: WorkspaceViewTagsProps) {
                 customText={translate('workspace.common.selected', {selectedNumber: selectedTagsArray.length})}
                 options={options}
                 style={[shouldUseNarrowLayout && styles.flexGrow1, shouldUseNarrowLayout && styles.mb3]}
+                isDisabled={!selectedTagsArray.length}
             />
         );
     };

--- a/src/pages/workspace/taxes/WorkspaceTaxesPage.tsx
+++ b/src/pages/workspace/taxes/WorkspaceTaxesPage.tsx
@@ -246,6 +246,7 @@ function WorkspaceTaxesPage({
             pressOnEnter
             isSplitButton={false}
             style={[shouldUseNarrowLayout && styles.flexGrow1, shouldUseNarrowLayout && styles.mb3]}
+            isDisabled={!selectedTaxesIDs.length}
         />
     );
 


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
This PR disables the selection dropdown button when no selection has been made

### Fixed Issues
$ https://github.com/Expensify/App/issues/46619
PROPOSAL: https://github.com/Expensify/App/issues/46619#issuecomment-2261596872


### Tests
This PR touches the following pages:

Report Participants Page
Workspace Members Page
Workspace Categories Page
Workspace Tags Page
Workspace Taxes Page
Workspace Report Fields Page
Workspace Report Fields Values Pages

For all these pages, follow the steps:
1. Make sure there are items in the list,
2. Long Press on an item and click Select
3. Click on the item to unselect it
4. Verify the dropdown button saying `0 selected` is disabled

Note: This affects only mobile devices, No tests required for Mac OS and desktop

### Offline tests
Same as Tests step

### QA Steps
Same as Tests step

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<img width="395" alt="Screenshot 2024-08-02 at 12 17 20 AM" src="https://github.com/user-attachments/assets/1aedb95b-9da2-48e2-91a5-4334256fada4">
<img width="395" alt="Screenshot 2024-08-02 at 12 17 30 AM" src="https://github.com/user-attachments/assets/c836f1ce-5dc4-4d0c-a826-9518a2232889">
<img width="395" alt="Screenshot 2024-08-02 at 12 18 03 AM" src="https://github.com/user-attachments/assets/2d5b4739-8261-45c5-8b57-0c3ab878f48e">
<img width="395" alt="Screenshot 2024-08-02 at 12 14 47 AM" src="https://github.com/user-attachments/assets/8313a0cf-c64f-413d-9a3c-b0109f127071">
<img width="395" alt="Screenshot 2024-08-02 at 12 15 05 AM" src="https://github.com/user-attachments/assets/e0a3af64-5d99-4e69-b87a-cdcf9450f91b">
<img width="395" alt="Screenshot 2024-08-02 at 12 15 19 AM" src="https://github.com/user-attachments/assets/4284265c-ab67-47ec-af02-31563ae61813">
<img width="395" alt="Screenshot 2024-08-02 at 12 15 32 AM" src="https://github.com/user-attachments/assets/89f018f8-daff-4db8-8223-daf758079542">
<img width="395" alt="Screenshot 2024-08-02 at 12 15 45 AM" src="https://github.com/user-attachments/assets/9f17a3f4-d07b-40a6-9351-5ff49d17cf5c">


</details>

<details>
<summary>Android: mWeb Chrome</summary>
<img width="395" alt="Screenshot 2024-08-01 at 11 37 43 PM" src="https://github.com/user-attachments/assets/2b6baac5-d123-4ff5-9bc6-1b3710ae4355">
<img width="395" alt="Screenshot 2024-08-01 at 11 37 33 PM" src="https://github.com/user-attachments/assets/73de28e0-56a2-4d31-82b0-77673faf4a53">
<img width="395" alt="Screenshot 2024-08-01 at 11 36 08 PM" src="https://github.com/user-attachments/assets/245cd0fd-9f7f-4f3a-8b72-b4a2ccd57b8c">
<img width="395" alt="Screenshot 2024-08-01 at 11 34 11 PM" src="https://github.com/user-attachments/assets/8f8abb9f-1d5e-4e40-8949-067f09272879">
<img width="395" alt="Screenshot 2024-08-01 at 11 34 25 PM" src="https://github.com/user-attachments/assets/96d9769a-8f01-43ef-8b61-a4345576c2cb">
<img width="395" alt="Screenshot 2024-08-01 at 11 34 37 PM" src="https://github.com/user-attachments/assets/97bb57e6-8d4f-45c4-985b-343be32831ca">
<img width="395" alt="Screenshot 2024-08-01 at 11 34 51 PM" src="https://github.com/user-attachments/assets/bb2ae770-a444-40fe-aba8-22582533d070">
<img width="395" alt="Screenshot 2024-08-01 at 11 35 25 PM" src="https://github.com/user-attachments/assets/702917f5-ea7b-44cf-bdce-e6726300390c">



</details>

<details>
<summary>iOS: Native</summary>

<img width="462" alt="Screenshot 2024-08-01 at 11 16 52 PM" src="https://github.com/user-attachments/assets/4179d4b4-8f31-4b26-9b9b-7a3ea7bfe508">
<img width="462" alt="Screenshot 2024-08-01 at 11 17 30 PM" src="https://github.com/user-attachments/assets/5b547d99-22b9-4475-bed2-9c0415b1b25f">
<img width="462" alt="Screenshot 2024-08-01 at 11 16 30 PM" src="https://github.com/user-attachments/assets/075369cb-babc-4b82-8a30-f4b60483cf2d">
<img width="462" alt="Screenshot 2024-08-01 at 11 14 07 PM" src="https://github.com/user-attachments/assets/c092cb36-bbb4-4ca1-aa17-28d1922a3189">
<img width="462" alt="Screenshot 2024-08-01 at 11 13 46 PM" src="https://github.com/user-attachments/assets/1a31fcc5-4d10-479f-86b2-d012794f276a">
<img width="462" alt="Screenshot 2024-08-01 at 11 13 30 PM" src="https://github.com/user-attachments/assets/4b70055c-14e0-4c82-92da-a23572846ca8">
<img width="462" alt="Screenshot 2024-08-01 at 11 13 14 PM" src="https://github.com/user-attachments/assets/227f7e98-47e6-468d-b6cd-6c328467fe7d">
<img width="462" alt="Screenshot 2024-08-01 at 11 19 50 PM" src="https://github.com/user-attachments/assets/6376556c-0eb1-4c86-a6ac-476c12d7e8cf">

</details>

<details>
<summary>iOS: mWeb Safari</summary>
<img width="462" alt="Screenshot 2024-08-01 at 11 28 51 PM" src="https://github.com/user-attachments/assets/50f00fa2-ea40-4efb-9e21-4b35bae915f2">
<img width="462" alt="Screenshot 2024-08-01 at 11 29 05 PM" src="https://github.com/user-attachments/assets/de07e1c3-23e7-493b-8e5d-ab3172bcd9a1">
<img width="462" alt="Screenshot 2024-08-01 at 11 28 40 PM" src="https://github.com/user-attachments/assets/5d204ded-eb4e-401a-9c82-f9aab5b401b7">
<img width="462" alt="Screenshot 2024-08-01 at 11 29 19 PM" src="https://github.com/user-attachments/assets/4c403518-fa89-4daf-9190-a6486ca22a15">
<img width="462" alt="Screenshot 2024-08-01 at 11 29 29 PM" src="https://github.com/user-attachments/assets/8d7e9f85-9106-4bca-8ffc-2d4533f03aba">
<img width="462" alt="Screenshot 2024-08-01 at 11 30 29 PM" src="https://github.com/user-attachments/assets/8c63eb15-abff-4de1-990f-1145ddf920bd">
<img width="462" alt="Screenshot 2024-08-01 at 11 29 50 PM" src="https://github.com/user-attachments/assets/ee7d535c-dbe3-430d-a743-64f8ed1ca92d">


</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

Selection mode is only on small screen devices

</details>

<details>
<summary>MacOS: Desktop</summary>

Selection mode only on small screen devices

</details>
