### PR TITLE
Support image pasting on Native (2)

### DIFF
--- a/patches/react-native+0.73.4+024+Add-onPaste-to-TextInput.patch
+++ b/patches/react-native+0.73.4+024+Add-onPaste-to-TextInput.patch
@@ -1,0 +1,686 @@
+diff --git a/node_modules/react-native/Libraries/Components/TextInput/AndroidTextInputNativeComponent.js b/node_modules/react-native/Libraries/Components/TextInput/AndroidTextInputNativeComponent.js
+index 55b770d..6d86715 100644
+--- a/node_modules/react-native/Libraries/Components/TextInput/AndroidTextInputNativeComponent.js
++++ b/node_modules/react-native/Libraries/Components/TextInput/AndroidTextInputNativeComponent.js
+@@ -464,6 +464,21 @@ export type NativeProps = $ReadOnly<{|
+     |}>,
+   >,
+ 
++  /**
++   * Invoked when the user performs the paste action.
++   */
++  onPaste?: ?DirectEventHandler<
++    $ReadOnly<{|
++      target: Int32,
++      items: $ReadOnlyArray<
++        $ReadOnly<{|
++          type: string,
++          data: string,
++        |}>,
++      >,
++    |}>,
++  >,
++
+   /**
+    * The string that will be rendered before text input has been entered.
+    */
+@@ -668,6 +683,9 @@ export const __INTERNAL_VIEW_CONFIG: PartialViewConfig = {
+     topScroll: {
+       registrationName: 'onScroll',
+     },
++    topPaste: {
++      registrationName: 'onPaste',
++    },
+   },
+   validAttributes: {
+     maxFontSizeMultiplier: true,
+@@ -719,6 +737,7 @@ export const __INTERNAL_VIEW_CONFIG: PartialViewConfig = {
+     textBreakStrategy: true,
+     onScroll: true,
+     onContentSizeChange: true,
++    onPaste: true,
+     disableFullscreenUI: true,
+     includeFontPadding: true,
+     fontWeight: true,
+diff --git a/node_modules/react-native/Libraries/Components/TextInput/RCTTextInputViewConfig.js b/node_modules/react-native/Libraries/Components/TextInput/RCTTextInputViewConfig.js
+index 88d3cc8..615c11f 100644
+--- a/node_modules/react-native/Libraries/Components/TextInput/RCTTextInputViewConfig.js
++++ b/node_modules/react-native/Libraries/Components/TextInput/RCTTextInputViewConfig.js
+@@ -97,6 +97,9 @@ const RCTTextInputViewConfig = {
+     topChangeSync: {
+       registrationName: 'onChangeSync',
+     },
++    topPaste: {
++      registrationName: 'onPaste',
++    },
+   },
+   validAttributes: {
+     fontSize: true,
+@@ -162,6 +165,7 @@ const RCTTextInputViewConfig = {
+       onSelectionChange: true,
+       onContentSizeChange: true,
+       onScroll: true,
++      onPaste: true,
+       onChangeSync: true,
+       onKeyPressSync: true,
+       onTextInput: true,
+diff --git a/node_modules/react-native/Libraries/Components/TextInput/TextInput.d.ts b/node_modules/react-native/Libraries/Components/TextInput/TextInput.d.ts
+index 2c0c099..2bf9d5a 100644
+--- a/node_modules/react-native/Libraries/Components/TextInput/TextInput.d.ts
++++ b/node_modules/react-native/Libraries/Components/TextInput/TextInput.d.ts
+@@ -483,6 +483,16 @@ export interface TextInputTextInputEventData {
+   range: {start: number; end: number};
+ }
+ 
++/**
++ * @see TextInputProps.onPaste
++ */
++export interface TextInputPasteEventData extends TargetedEvent {
++  items: Array<{
++    type: string;
++    data: string;
++  }>;
++}
++
+ /**
+  * @see https://reactnative.dev/docs/textinput#props
+  */
+@@ -804,6 +814,13 @@ export interface TextInputProps
+     | ((e: NativeSyntheticEvent<TextInputKeyPressEventData>) => void)
+     | undefined;
+ 
++  /**
++   * Invoked when the user performs the paste action.
++   */
++  onPaste?:
++    | ((e: NativeSyntheticEvent<TextInputPasteEventData>) => void)
++    | undefined;
++
+   /**
+    * The string that will be rendered before text input has been entered
+    */
+diff --git a/node_modules/react-native/Libraries/Components/TextInput/TextInput.flow.js b/node_modules/react-native/Libraries/Components/TextInput/TextInput.flow.js
+index 9adbfe9..b46437d 100644
+--- a/node_modules/react-native/Libraries/Components/TextInput/TextInput.flow.js
++++ b/node_modules/react-native/Libraries/Components/TextInput/TextInput.flow.js
+@@ -94,6 +94,18 @@ export type EditingEvent = SyntheticEvent<
+   |}>,
+ >;
+ 
++export type PasteEvent = SyntheticEvent<
++  $ReadOnly<{|
++    target: number,
++    items: $ReadOnlyArray<
++      $ReadOnly<{|
++        type: string,
++        data: string,
++      |}>,
++    >,
++  |}>,
++>;
++
+ type DataDetectorTypesType =
+   | 'phoneNumber'
+   | 'link'
+@@ -796,6 +808,11 @@ export type Props = $ReadOnly<{|
+    */
+   onScroll?: ?(e: ScrollEvent) => mixed,
+ 
++  /**
++   * Invoked when the user performs the paste action.
++   */
++  onPaste?: ?(e: PasteEvent) => mixed,
++
+   /**
+    * The string that will be rendered before text input has been entered.
+    */
+diff --git a/node_modules/react-native/Libraries/Components/TextInput/TextInput.js b/node_modules/react-native/Libraries/Components/TextInput/TextInput.js
+index 481938f..a74fda7 100644
+--- a/node_modules/react-native/Libraries/Components/TextInput/TextInput.js
++++ b/node_modules/react-native/Libraries/Components/TextInput/TextInput.js
+@@ -132,6 +132,18 @@ export type EditingEvent = SyntheticEvent<
+   |}>,
+ >;
+ 
++export type PasteEvent = SyntheticEvent<
++  $ReadOnly<{|
++    target: number,
++    items: $ReadOnlyArray<
++      $ReadOnly<{|
++        type: string,
++        data: string,
++      |}>,
++    >,
++  |}>,
++>;
++
+ type DataDetectorTypesType =
+   | 'phoneNumber'
+   | 'link'
+@@ -838,6 +850,11 @@ export type Props = $ReadOnly<{|
+    */
+   onScroll?: ?(e: ScrollEvent) => mixed,
+ 
++  /**
++   * Invoked when the user performs the paste action.
++   */
++  onPaste?: ?(e: PasteEvent) => mixed,
++
+   /**
+    * The string that will be rendered before text input has been entered.
+    */
+diff --git a/node_modules/react-native/Libraries/Text/TextInput/Multiline/RCTUITextView.mm b/node_modules/react-native/Libraries/Text/TextInput/Multiline/RCTUITextView.mm
+index 582b49c..ac31cb1 100644
+--- a/node_modules/react-native/Libraries/Text/TextInput/Multiline/RCTUITextView.mm
++++ b/node_modules/react-native/Libraries/Text/TextInput/Multiline/RCTUITextView.mm
+@@ -13,6 +13,9 @@
+ #import <React/RCTBackedTextInputDelegateAdapter.h>
+ #import <React/RCTTextAttributes.h>
+ 
++#import <MobileCoreServices/UTType.h>
++#import <UIKit/UIKit.h>
++
+ @implementation RCTUITextView {
+   UILabel *_placeholderView;
+   UITextView *_detachedTextView;
+@@ -166,7 +169,30 @@ - (void)setSelectedTextRange:(UITextRange *)selectedTextRange notifyDelegate:(BO
+ - (void)paste:(id)sender
+ {
+   _textWasPasted = YES;
+-  [super paste:sender];
++  UIPasteboard *clipboard = [UIPasteboard generalPasteboard];
++  if (clipboard.hasImages) {
++    for (NSItemProvider *itemProvider in [clipboard itemProviders]) {
++      if ([itemProvider canLoadObjectOfClass:[UIImage class]]) {
++        NSString *identifier = itemProvider.registeredTypeIdentifiers.firstObject;
++        if (identifier != nil) {
++          NSString *MIMEType = (__bridge_transfer NSString *)UTTypeCopyPreferredTagWithClass((__bridge CFStringRef)identifier, kUTTagClassMIMEType);
++          NSString *fileExtension = (__bridge_transfer NSString *)UTTypeCopyPreferredTagWithClass((__bridge CFStringRef)identifier, kUTTagClassFilenameExtension);
++          NSString *fileName = [NSString stringWithFormat:@"%@.%@", itemProvider.suggestedName ?: @"file", fileExtension];
++          NSString *filePath = [NSTemporaryDirectory() stringByAppendingPathComponent:fileName];
++          NSURL *fileURL = [NSURL fileURLWithPath:filePath];
++          NSData *fileData = [clipboard dataForPasteboardType:identifier];
++          [fileData writeToFile:filePath atomically:YES];
++          [_textInputDelegateAdapter didPaste:MIMEType withData:[fileURL absoluteString]];
++        }
++        break;
++      }
++    }
++  } else {
++    if (clipboard.hasStrings) {
++      [_textInputDelegateAdapter didPaste:@"text/plain" withData:clipboard.string];
++    }
++    [super paste:sender];
++  }
+ }
+ 
+ // Turn off scroll animation to fix flaky scrolling.
+@@ -258,6 +284,10 @@ - (BOOL)canPerformAction:(SEL)action withSender:(id)sender
+     return NO;
+   }
+ 
++  if (action == @selector(paste:) && [UIPasteboard generalPasteboard].hasImages) {
++    return YES;
++  }
++
+   return [super canPerformAction:action withSender:sender];
+ }
+ 
+diff --git a/node_modules/react-native/Libraries/Text/TextInput/RCTBackedTextInputDelegate.h b/node_modules/react-native/Libraries/Text/TextInput/RCTBackedTextInputDelegate.h
+index 7187177..748c4cc 100644
+--- a/node_modules/react-native/Libraries/Text/TextInput/RCTBackedTextInputDelegate.h
++++ b/node_modules/react-native/Libraries/Text/TextInput/RCTBackedTextInputDelegate.h
+@@ -36,6 +36,7 @@ NS_ASSUME_NONNULL_BEGIN
+ - (void)textInputDidChange;
+ 
+ - (void)textInputDidChangeSelection;
++- (void)textInputDidPaste:(NSString *)type withData:(NSString *)data;
+ 
+ @optional
+ 
+diff --git a/node_modules/react-native/Libraries/Text/TextInput/RCTBackedTextInputDelegateAdapter.h b/node_modules/react-native/Libraries/Text/TextInput/RCTBackedTextInputDelegateAdapter.h
+index f1c32e6..0ce9dfe 100644
+--- a/node_modules/react-native/Libraries/Text/TextInput/RCTBackedTextInputDelegateAdapter.h
++++ b/node_modules/react-native/Libraries/Text/TextInput/RCTBackedTextInputDelegateAdapter.h
+@@ -20,6 +20,7 @@ NS_ASSUME_NONNULL_BEGIN
+ 
+ - (void)skipNextTextInputDidChangeSelectionEventWithTextRange:(UITextRange *)textRange;
+ - (void)selectedTextRangeWasSet;
++- (void)didPaste:(NSString *)type withData:(NSString *)data;
+ 
+ @end
+ 
+@@ -30,6 +31,7 @@ NS_ASSUME_NONNULL_BEGIN
+ - (instancetype)initWithTextView:(UITextView<RCTBackedTextInputViewProtocol> *)backedTextInputView;
+ 
+ - (void)skipNextTextInputDidChangeSelectionEventWithTextRange:(UITextRange *)textRange;
++- (void)didPaste:(NSString *)type withData:(NSString *)data;
+ 
+ @end
+ 
+diff --git a/node_modules/react-native/Libraries/Text/TextInput/RCTBackedTextInputDelegateAdapter.mm b/node_modules/react-native/Libraries/Text/TextInput/RCTBackedTextInputDelegateAdapter.mm
+index 9dca6a5..b2c6b53 100644
+--- a/node_modules/react-native/Libraries/Text/TextInput/RCTBackedTextInputDelegateAdapter.mm
++++ b/node_modules/react-native/Libraries/Text/TextInput/RCTBackedTextInputDelegateAdapter.mm
+@@ -147,6 +147,11 @@ - (void)selectedTextRangeWasSet
+   [self textFieldProbablyDidChangeSelection];
+ }
+ 
++- (void)didPaste:(NSString *)type withData:(NSString *)data
++{
++  [_backedTextInputView.textInputDelegate textInputDidPaste:type withData:data];
++}
++
+ #pragma mark - Generalization
+ 
+ - (void)textFieldProbablyDidChangeSelection
+@@ -290,6 +295,11 @@ - (void)skipNextTextInputDidChangeSelectionEventWithTextRange:(UITextRange *)tex
+   _previousSelectedTextRange = textRange;
+ }
+ 
++- (void)didPaste:(NSString *)type withData:(NSString *)data
++{
++  [_backedTextInputView.textInputDelegate textInputDidPaste:type withData:data];
++}
++
+ #pragma mark - Generalization
+ 
+ - (void)textViewProbablyDidChangeSelection
+diff --git a/node_modules/react-native/Libraries/Text/TextInput/RCTBaseTextInputView.h b/node_modules/react-native/Libraries/Text/TextInput/RCTBaseTextInputView.h
+index 209947d..5092dbd 100644
+--- a/node_modules/react-native/Libraries/Text/TextInput/RCTBaseTextInputView.h
++++ b/node_modules/react-native/Libraries/Text/TextInput/RCTBaseTextInputView.h
+@@ -38,6 +38,7 @@ NS_ASSUME_NONNULL_BEGIN
+ @property (nonatomic, copy, nullable) RCTDirectEventBlock onChangeSync;
+ @property (nonatomic, copy, nullable) RCTDirectEventBlock onTextInput;
+ @property (nonatomic, copy, nullable) RCTDirectEventBlock onScroll;
++@property (nonatomic, copy, nullable) RCTDirectEventBlock onPaste;
+ 
+ @property (nonatomic, assign) NSInteger mostRecentEventCount;
+ @property (nonatomic, assign, readonly) NSInteger nativeEventCount;
+diff --git a/node_modules/react-native/Libraries/Text/TextInput/RCTBaseTextInputView.mm b/node_modules/react-native/Libraries/Text/TextInput/RCTBaseTextInputView.mm
+index b0d71dc..2e42fc9 100644
+--- a/node_modules/react-native/Libraries/Text/TextInput/RCTBaseTextInputView.mm
++++ b/node_modules/react-native/Libraries/Text/TextInput/RCTBaseTextInputView.mm
+@@ -562,6 +562,26 @@ - (void)textInputDidChangeSelection
+   });
+ }
+ 
++- (void)textInputDidPaste:(NSString *)type withData:(NSString *)data
++{
++  if (!_onPaste) {
++    return;
++  }
++
++  NSMutableArray *items = [NSMutableArray new];
++  [items addObject:@{
++    @"type" : type,
++    @"data" : data,
++  }];
++
++  NSDictionary *payload = @{
++    @"target" : self.reactTag,
++    @"items" : items,
++  };
++
++  _onPaste(payload);
++}
++
+ - (void)updateLocalData
+ {
+   [self enforceTextAttributesIfNeeded];
+diff --git a/node_modules/react-native/Libraries/Text/TextInput/RCTBaseTextInputViewManager.mm b/node_modules/react-native/Libraries/Text/TextInput/RCTBaseTextInputViewManager.mm
+index a19b555..8146c0d 100644
+--- a/node_modules/react-native/Libraries/Text/TextInput/RCTBaseTextInputViewManager.mm
++++ b/node_modules/react-native/Libraries/Text/TextInput/RCTBaseTextInputViewManager.mm
+@@ -66,6 +66,7 @@ @implementation RCTBaseTextInputViewManager {
+ RCT_EXPORT_VIEW_PROPERTY(onSelectionChange, RCTDirectEventBlock)
+ RCT_EXPORT_VIEW_PROPERTY(onTextInput, RCTDirectEventBlock)
+ RCT_EXPORT_VIEW_PROPERTY(onScroll, RCTDirectEventBlock)
++RCT_EXPORT_VIEW_PROPERTY(onPaste, RCTDirectEventBlock)
+ 
+ RCT_EXPORT_VIEW_PROPERTY(mostRecentEventCount, NSInteger)
+ 
+diff --git a/node_modules/react-native/Libraries/Text/TextInput/Singleline/RCTUITextField.mm b/node_modules/react-native/Libraries/Text/TextInput/Singleline/RCTUITextField.mm
+index 4d0afd9..a6afc7b 100644
+--- a/node_modules/react-native/Libraries/Text/TextInput/Singleline/RCTUITextField.mm
++++ b/node_modules/react-native/Libraries/Text/TextInput/Singleline/RCTUITextField.mm
+@@ -12,6 +12,9 @@
+ #import <React/RCTUtils.h>
+ #import <React/UIView+React.h>
+ 
++#import <MobileCoreServices/UTType.h>
++#import <UIKit/UIKit.h>
++
+ @implementation RCTUITextField {
+   RCTBackedTextFieldDelegateAdapter *_textInputDelegateAdapter;
+   NSDictionary<NSAttributedStringKey, id> *_defaultTextAttributes;
+@@ -139,6 +142,10 @@ - (BOOL)canPerformAction:(SEL)action withSender:(id)sender
+     return NO;
+   }
+ 
++  if (action == @selector(paste:) && [UIPasteboard generalPasteboard].hasImages) {
++    return YES;
++  }
++
+   return [super canPerformAction:action withSender:sender];
+ }
+ 
+@@ -204,7 +211,30 @@ - (void)setSelectedTextRange:(UITextRange *)selectedTextRange notifyDelegate:(BO
+ - (void)paste:(id)sender
+ {
+   _textWasPasted = YES;
+-  [super paste:sender];
++  UIPasteboard *clipboard = [UIPasteboard generalPasteboard];
++  if (clipboard.hasImages) {
++    for (NSItemProvider *itemProvider in [clipboard itemProviders]) {
++      if ([itemProvider canLoadObjectOfClass:[UIImage class]]) {
++        NSString *identifier = itemProvider.registeredTypeIdentifiers.firstObject;
++        if (identifier != nil) {
++          NSString *MIMEType = (__bridge_transfer NSString *)UTTypeCopyPreferredTagWithClass((__bridge CFStringRef)identifier, kUTTagClassMIMEType);
++          NSString *fileExtension = (__bridge_transfer NSString *)UTTypeCopyPreferredTagWithClass((__bridge CFStringRef)identifier, kUTTagClassFilenameExtension);
++          NSString *fileName = [NSString stringWithFormat:@"%@.%@", itemProvider.suggestedName ?: @"file", fileExtension];
++          NSString *filePath = [NSTemporaryDirectory() stringByAppendingPathComponent:fileName];
++          NSURL *fileURL = [NSURL fileURLWithPath:filePath];
++          NSData *fileData = [clipboard dataForPasteboardType:identifier];
++          [fileData writeToFile:filePath atomically:YES];
++          [_textInputDelegateAdapter didPaste:MIMEType withData:[fileURL absoluteString]];
++        }
++        break;
++      }
++    }
++  } else {
++    if (clipboard.hasStrings) {
++      [_textInputDelegateAdapter didPaste:@"text/plain" withData:clipboard.string];
++    }
++    [super paste:sender];
++  }
+ }
+ 
+ #pragma mark - Layout
+diff --git a/node_modules/react-native/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputComponentView.mm b/node_modules/react-native/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputComponentView.mm
+index 123968f..9626d49 100644
+--- a/node_modules/react-native/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputComponentView.mm
++++ b/node_modules/react-native/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputComponentView.mm
+@@ -426,6 +426,13 @@ - (void)textInputDidChangeSelection
+   }
+ }
+ 
++- (void)textInputDidPaste:(NSString *)type withData:(NSString *)data
++{
++  if (_eventEmitter) {
++    static_cast<const TextInputEventEmitter &>(*_eventEmitter).onPaste(std::string([type UTF8String]), std::string([data UTF8String]));
++  }
++}
++
+ #pragma mark - RCTBackedTextInputDelegate (UIScrollViewDelegate)
+ 
+ - (void)scrollViewDidScroll:(UIScrollView *)scrollView
+diff --git a/node_modules/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/PasteWatcher.java b/node_modules/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/PasteWatcher.java
+new file mode 100644
+index 0000000..bfb5819
+--- /dev/null
++++ b/node_modules/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/PasteWatcher.java
+@@ -0,0 +1,17 @@
++/*
++ * Copyright (c) Meta Platforms, Inc. and affiliates.
++ *
++ * This source code is licensed under the MIT license found in the
++ * LICENSE file in the root directory of this source tree.
++ */
++
++package com.facebook.react.views.textinput;
++
++/**
++ * Implement this interface to be informed of paste event in the
++ * ReactTextEdit This is used by the ReactTextInputManager to forward events
++ * from the EditText to JS
++ */
++interface PasteWatcher {
++  public void onPaste(String type, String data);
++}
+diff --git a/node_modules/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.java b/node_modules/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.java
+index 081f2b8..ff91d47 100644
+--- a/node_modules/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.java
++++ b/node_modules/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.java
+@@ -9,14 +9,17 @@ package com.facebook.react.views.textinput;
+ 
+ import static com.facebook.react.uimanager.UIManagerHelper.getReactContext;
+ 
+-import android.content.ClipData;
+ import android.content.ClipboardManager;
++import android.content.ClipData;
++import android.content.ClipDescription;
++import android.content.ContentResolver;
+ import android.content.Context;
+ import android.graphics.Color;
+ import android.graphics.Paint;
+ import android.graphics.Rect;
+ import android.graphics.Typeface;
+ import android.graphics.drawable.Drawable;
++import android.net.Uri;
+ import android.os.Build;
+ import android.os.Bundle;
+ import android.text.Editable;
+@@ -110,6 +113,7 @@ public class ReactEditText extends AppCompatEditText {
+   private @Nullable SelectionWatcher mSelectionWatcher;
+   private @Nullable ContentSizeWatcher mContentSizeWatcher;
+   private @Nullable ScrollWatcher mScrollWatcher;
++  private @Nullable PasteWatcher mPasteWatcher;
+   private InternalKeyListener mKeyListener;
+   private boolean mDetectScrollMovement = false;
+   private boolean mOnKeyPress = false;
+@@ -153,6 +157,7 @@ public class ReactEditText extends AppCompatEditText {
+       mKeyListener = new InternalKeyListener();
+     }
+     mScrollWatcher = null;
++    mPasteWatcher = null;
+     mTextAttributes = new TextAttributes();
+ 
+     applyTextAttributes();
+@@ -307,10 +312,31 @@ public class ReactEditText extends AppCompatEditText {
+    */
+   @Override
+   public boolean onTextContextMenuItem(int id) {
+-    if (id == android.R.id.paste) {
++    if (id == android.R.id.paste || id == android.R.id.pasteAsPlainText) {
+       if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+         id = android.R.id.pasteAsPlainText;
+-      } else {
++        if (mPasteWatcher != null) {
++          ClipboardManager clipboardManager =
++              (ClipboardManager) getContext().getSystemService(Context.CLIPBOARD_SERVICE);
++          ClipData clipData = clipboardManager.getPrimaryClip();
++          String type = null;
++          String data = null;
++          if (clipData.getDescription().hasMimeType(ClipDescription.MIMETYPE_TEXT_PLAIN)) {
++            type = ClipDescription.MIMETYPE_TEXT_PLAIN;
++            data = clipData.getItemAt(0).getText().toString();
++          } else {
++            Uri itemUri = clipData.getItemAt(0).getUri();
++            if (itemUri != null) {
++              ContentResolver cr = getReactContext(this).getContentResolver();
++              type = cr.getType(itemUri);
++              data = itemUri.toString();
++            }
++          }
++          if (type != null && data != null) {
++            mPasteWatcher.onPaste(type, data);
++          }
++        }
++      } else if (id == android.R.id.paste) {
+         ClipboardManager clipboard =
+             (ClipboardManager) getContext().getSystemService(Context.CLIPBOARD_SERVICE);
+         ClipData previousClipData = clipboard.getPrimaryClip();
+@@ -389,6 +415,10 @@ public class ReactEditText extends AppCompatEditText {
+     mScrollWatcher = scrollWatcher;
+   }
+ 
++  public void setPasteWatcher(PasteWatcher pasteWatcher) {
++    mPasteWatcher = pasteWatcher;
++  }
++
+   /**
+    * Attempt to set a selection or fail silently. Intentionally meant to handle bad inputs.
+    * EventCounter is the same one used as with text.
+diff --git a/node_modules/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java b/node_modules/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
+index e6bcfc4..902985d 100644
+--- a/node_modules/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
++++ b/node_modules/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
+@@ -273,6 +273,9 @@ public class ReactTextInputManager extends BaseViewManager<ReactEditText, Layout
+             .put(
+                 ScrollEventType.getJSEventName(ScrollEventType.SCROLL),
+                 MapBuilder.of("registrationName", "onScroll"))
++            .put(
++                "topPaste",
++                MapBuilder.of("registrationName", "onPaste"))
+             .build());
+     return eventTypeConstants;
+   }
+@@ -490,6 +493,15 @@ public class ReactTextInputManager extends BaseViewManager<ReactEditText, Layout
+     }
+   }
+ 
++  @ReactProp(name = "onPaste", defaultBoolean = false)
++  public void setOnPaste(final ReactEditText view, boolean onPaste) {
++    if (onPaste) {
++      view.setPasteWatcher(new ReactPasteWatcher(view));
++    } else {
++      view.setPasteWatcher(null);
++    }
++  }
++
+   @ReactProp(name = "onKeyPress", defaultBoolean = false)
+   public void setOnKeyPress(final ReactEditText view, boolean onKeyPress) {
+     view.setOnKeyPress(onKeyPress);
+@@ -1285,6 +1297,25 @@ public class ReactTextInputManager extends BaseViewManager<ReactEditText, Layout
+     }
+   }
+ 
++  private static class ReactPasteWatcher implements PasteWatcher {
++    private final ReactEditText mReactEditText;
++    private final EventDispatcher mEventDispatcher;
++    private final int mSurfaceId;
++
++    public ReactPasteWatcher(ReactEditText editText) {
++      mReactEditText = editText;
++      ReactContext reactContext = getReactContext(editText);
++      mEventDispatcher = getEventDispatcher(reactContext, editText);
++      mSurfaceId = UIManagerHelper.getSurfaceId(reactContext);
++    }
++
++    @Override
++    public void onPaste(String type, String data) {
++      mEventDispatcher.dispatchEvent(
++          new ReactTextInputPasteEvent(mSurfaceId, mReactEditText.getId(), type, data));
++    }
++  }
++
+   @Override
+   public @Nullable Map getExportedViewConstants() {
+     return MapBuilder.of(
+diff --git a/node_modules/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputPasteEvent.java b/node_modules/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputPasteEvent.java
+new file mode 100644
+index 0000000..78b14b7
+--- /dev/null
++++ b/node_modules/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputPasteEvent.java
+@@ -0,0 +1,63 @@
++/*
++ * Copyright (c) Meta Platforms, Inc. and affiliates.
++ *
++ * This source code is licensed under the MIT license found in the
++ * LICENSE file in the root directory of this source tree.
++ */
++
++package com.facebook.react.views.textinput;
++
++import androidx.annotation.Nullable;
++import com.facebook.react.bridge.Arguments;
++import com.facebook.react.bridge.WritableMap;
++import com.facebook.react.bridge.WritableArray;
++import com.facebook.react.uimanager.common.ViewUtil;
++import com.facebook.react.uimanager.events.Event;
++
++/**
++ * Event emitted by EditText native view when clipboard content is pasted
++ */
++class ReactTextInputPasteEvent extends Event<ReactTextInputPasteEvent> {
++
++  private static final String EVENT_NAME = "topPaste";
++
++  private String mType;
++  private String mData;
++
++  @Deprecated
++  public ReactTextInputPasteEvent(int viewId, String type, String data) {
++    this(ViewUtil.NO_SURFACE_ID, viewId, type, data);
++  }
++
++  public ReactTextInputPasteEvent(int surfaceId, int viewId, String type, String data) {
++    super(surfaceId, viewId);
++    mType = type;
++    mData = data;
++  }
++
++  @Override
++  public String getEventName() {
++    return EVENT_NAME;
++  }
++
++  @Override
++  public boolean canCoalesce() {
++    return false;
++  }
++
++  @Nullable
++  @Override
++  protected WritableMap getEventData() {
++    WritableMap eventData = Arguments.createMap();
++
++    WritableArray items = Arguments.createArray();
++    WritableMap item = Arguments.createMap();
++    item.putString("type", mType);
++    item.putString("data", mData);
++    items.pushMap(item);
++
++    eventData.putArray("items", items);
++
++    return eventData;
++  }
++}
+diff --git a/node_modules/react-native/ReactCommon/react/renderer/components/textinput/iostextinput/react/renderer/components/iostextinput/TextInputEventEmitter.cpp b/node_modules/react-native/ReactCommon/react/renderer/components/textinput/iostextinput/react/renderer/components/iostextinput/TextInputEventEmitter.cpp
+index 497569a..1a84b47 100644
+--- a/node_modules/react-native/ReactCommon/react/renderer/components/textinput/iostextinput/react/renderer/components/iostextinput/TextInputEventEmitter.cpp
++++ b/node_modules/react-native/ReactCommon/react/renderer/components/textinput/iostextinput/react/renderer/components/iostextinput/TextInputEventEmitter.cpp
+@@ -193,6 +193,19 @@ void TextInputEventEmitter::onScroll(
+       });
+ }
+ 
++void TextInputEventEmitter::onPaste(const std::string& type, const std::string& data) const {
++  dispatchEvent("onPaste", [type, data](jsi::Runtime& runtime) {
++    auto payload = jsi::Object(runtime);
++    auto items = jsi::Array(runtime, 1);
++    auto item = jsi::Object(runtime);
++    item.setProperty(runtime, "type", type);
++    item.setProperty(runtime, "data", data);
++    items.setValueAtIndex(runtime, 0, item);
++    payload.setProperty(runtime, "items", items);
++    return payload;
++  });
++}
++
+ void TextInputEventEmitter::dispatchTextInputEvent(
+     const std::string& name,
+     const TextInputMetrics& textInputMetrics,
+diff --git a/node_modules/react-native/ReactCommon/react/renderer/components/textinput/iostextinput/react/renderer/components/iostextinput/TextInputEventEmitter.h b/node_modules/react-native/ReactCommon/react/renderer/components/textinput/iostextinput/react/renderer/components/iostextinput/TextInputEventEmitter.h
+index 0ab2b18..781f083 100644
+--- a/node_modules/react-native/ReactCommon/react/renderer/components/textinput/iostextinput/react/renderer/components/iostextinput/TextInputEventEmitter.h
++++ b/node_modules/react-native/ReactCommon/react/renderer/components/textinput/iostextinput/react/renderer/components/iostextinput/TextInputEventEmitter.h
+@@ -47,6 +47,7 @@ class TextInputEventEmitter : public ViewEventEmitter {
+   void onKeyPress(const KeyPressMetrics& keyPressMetrics) const;
+   void onKeyPressSync(const KeyPressMetrics& keyPressMetrics) const;
+   void onScroll(const TextInputMetrics& textInputMetrics) const;
++  void onPaste(const std::string& type, const std::string& data) const;
+ 
+  private:
+   void dispatchTextInputEvent(

--- a/patches/react-native+0.73.4+024+Add-onPaste-to-TextInput.patch
+++ b/patches/react-native+0.73.4+024+Add-onPaste-to-TextInput.patch
@@ -43,12 +43,12 @@ index 55b770d..6d86715 100644
      includeFontPadding: true,
      fontWeight: true,
 diff --git a/node_modules/react-native/Libraries/Components/TextInput/RCTTextInputViewConfig.js b/node_modules/react-native/Libraries/Components/TextInput/RCTTextInputViewConfig.js
-index 88d3cc8..615c11f 100644
+index 8e60c9e..3cb6900 100644
 --- a/node_modules/react-native/Libraries/Components/TextInput/RCTTextInputViewConfig.js
 +++ b/node_modules/react-native/Libraries/Components/TextInput/RCTTextInputViewConfig.js
-@@ -97,6 +97,9 @@ const RCTTextInputViewConfig = {
-     topChangeSync: {
-       registrationName: 'onChangeSync',
+@@ -100,6 +100,9 @@ const RCTTextInputViewConfig = {
+     topClear: {
+       registrationName: 'onClear',
      },
 +    topPaste: {
 +      registrationName: 'onPaste',
@@ -56,7 +56,7 @@ index 88d3cc8..615c11f 100644
    },
    validAttributes: {
      fontSize: true,
-@@ -162,6 +165,7 @@ const RCTTextInputViewConfig = {
+@@ -165,6 +168,7 @@ const RCTTextInputViewConfig = {
        onSelectionChange: true,
        onContentSizeChange: true,
        onScroll: true,
@@ -65,7 +65,7 @@ index 88d3cc8..615c11f 100644
        onKeyPressSync: true,
        onTextInput: true,
 diff --git a/node_modules/react-native/Libraries/Components/TextInput/TextInput.d.ts b/node_modules/react-native/Libraries/Components/TextInput/TextInput.d.ts
-index 2c0c099..2bf9d5a 100644
+index 26a477f..280cbe2 100644
 --- a/node_modules/react-native/Libraries/Components/TextInput/TextInput.d.ts
 +++ b/node_modules/react-native/Libraries/Components/TextInput/TextInput.d.ts
 @@ -483,6 +483,16 @@ export interface TextInputTextInputEventData {
@@ -85,7 +85,7 @@ index 2c0c099..2bf9d5a 100644
  /**
   * @see https://reactnative.dev/docs/textinput#props
   */
-@@ -804,6 +814,13 @@ export interface TextInputProps
+@@ -811,6 +821,13 @@ export interface TextInputProps
      | ((e: NativeSyntheticEvent<TextInputKeyPressEventData>) => void)
      | undefined;
  
@@ -135,7 +135,7 @@ index 9adbfe9..b46437d 100644
     * The string that will be rendered before text input has been entered.
     */
 diff --git a/node_modules/react-native/Libraries/Components/TextInput/TextInput.js b/node_modules/react-native/Libraries/Components/TextInput/TextInput.js
-index 481938f..a74fda7 100644
+index 346acaa..abec1ee 100644
 --- a/node_modules/react-native/Libraries/Components/TextInput/TextInput.js
 +++ b/node_modules/react-native/Libraries/Components/TextInput/TextInput.js
 @@ -132,6 +132,18 @@ export type EditingEvent = SyntheticEvent<
@@ -330,10 +330,10 @@ index b0d71dc..2e42fc9 100644
  {
    [self enforceTextAttributesIfNeeded];
 diff --git a/node_modules/react-native/Libraries/Text/TextInput/RCTBaseTextInputViewManager.mm b/node_modules/react-native/Libraries/Text/TextInput/RCTBaseTextInputViewManager.mm
-index a19b555..8146c0d 100644
+index 4785987..16a9b8e 100644
 --- a/node_modules/react-native/Libraries/Text/TextInput/RCTBaseTextInputViewManager.mm
 +++ b/node_modules/react-native/Libraries/Text/TextInput/RCTBaseTextInputViewManager.mm
-@@ -66,6 +66,7 @@ @implementation RCTBaseTextInputViewManager {
+@@ -67,6 +67,7 @@ @implementation RCTBaseTextInputViewManager {
  RCT_EXPORT_VIEW_PROPERTY(onSelectionChange, RCTDirectEventBlock)
  RCT_EXPORT_VIEW_PROPERTY(onTextInput, RCTDirectEventBlock)
  RCT_EXPORT_VIEW_PROPERTY(onScroll, RCTDirectEventBlock)
@@ -399,7 +399,7 @@ index 4d0afd9..a6afc7b 100644
  
  #pragma mark - Layout
 diff --git a/node_modules/react-native/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputComponentView.mm b/node_modules/react-native/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputComponentView.mm
-index 123968f..9626d49 100644
+index 70754bf..3ab2c6a 100644
 --- a/node_modules/react-native/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputComponentView.mm
 +++ b/node_modules/react-native/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputComponentView.mm
 @@ -426,6 +426,13 @@ - (void)textInputDidChangeSelection
@@ -524,20 +524,20 @@ index 081f2b8..ff91d47 100644
     * Attempt to set a selection or fail silently. Intentionally meant to handle bad inputs.
     * EventCounter is the same one used as with text.
 diff --git a/node_modules/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java b/node_modules/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
-index e6bcfc4..902985d 100644
+index 53e5c49..26dc163 100644
 --- a/node_modules/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
 +++ b/node_modules/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
-@@ -273,6 +273,9 @@ public class ReactTextInputManager extends BaseViewManager<ReactEditText, Layout
+@@ -277,6 +277,9 @@ public class ReactTextInputManager extends BaseViewManager<ReactEditText, Layout
              .put(
-                 ScrollEventType.getJSEventName(ScrollEventType.SCROLL),
-                 MapBuilder.of("registrationName", "onScroll"))
+                 ReactTextClearEvent.EVENT_NAME,
+                 MapBuilder.of("registrationName", "onClear"))
 +            .put(
 +                "topPaste",
 +                MapBuilder.of("registrationName", "onPaste"))
              .build());
      return eventTypeConstants;
    }
-@@ -490,6 +493,15 @@ public class ReactTextInputManager extends BaseViewManager<ReactEditText, Layout
+@@ -509,6 +512,15 @@ public class ReactTextInputManager extends BaseViewManager<ReactEditText, Layout
      }
    }
  
@@ -553,7 +553,7 @@ index e6bcfc4..902985d 100644
    @ReactProp(name = "onKeyPress", defaultBoolean = false)
    public void setOnKeyPress(final ReactEditText view, boolean onKeyPress) {
      view.setOnKeyPress(onKeyPress);
-@@ -1285,6 +1297,25 @@ public class ReactTextInputManager extends BaseViewManager<ReactEditText, Layout
+@@ -1304,6 +1316,25 @@ public class ReactTextInputManager extends BaseViewManager<ReactEditText, Layout
      }
    }
  
@@ -649,10 +649,10 @@ index 0000000..78b14b7
 +  }
 +}
 diff --git a/node_modules/react-native/ReactCommon/react/renderer/components/textinput/iostextinput/react/renderer/components/iostextinput/TextInputEventEmitter.cpp b/node_modules/react-native/ReactCommon/react/renderer/components/textinput/iostextinput/react/renderer/components/iostextinput/TextInputEventEmitter.cpp
-index 497569a..1a84b47 100644
+index 1c10b11..de51df9 100644
 --- a/node_modules/react-native/ReactCommon/react/renderer/components/textinput/iostextinput/react/renderer/components/iostextinput/TextInputEventEmitter.cpp
 +++ b/node_modules/react-native/ReactCommon/react/renderer/components/textinput/iostextinput/react/renderer/components/iostextinput/TextInputEventEmitter.cpp
-@@ -193,6 +193,19 @@ void TextInputEventEmitter::onScroll(
+@@ -198,6 +198,19 @@ void TextInputEventEmitter::onScroll(
        });
  }
  
@@ -673,10 +673,10 @@ index 497569a..1a84b47 100644
      const std::string& name,
      const TextInputMetrics& textInputMetrics,
 diff --git a/node_modules/react-native/ReactCommon/react/renderer/components/textinput/iostextinput/react/renderer/components/iostextinput/TextInputEventEmitter.h b/node_modules/react-native/ReactCommon/react/renderer/components/textinput/iostextinput/react/renderer/components/iostextinput/TextInputEventEmitter.h
-index 0ab2b18..781f083 100644
+index bc5e624..07ccabc 100644
 --- a/node_modules/react-native/ReactCommon/react/renderer/components/textinput/iostextinput/react/renderer/components/iostextinput/TextInputEventEmitter.h
 +++ b/node_modules/react-native/ReactCommon/react/renderer/components/textinput/iostextinput/react/renderer/components/iostextinput/TextInputEventEmitter.h
-@@ -47,6 +47,7 @@ class TextInputEventEmitter : public ViewEventEmitter {
+@@ -48,6 +48,7 @@ class TextInputEventEmitter : public ViewEventEmitter {
    void onKeyPress(const KeyPressMetrics& keyPressMetrics) const;
    void onKeyPressSync(const KeyPressMetrics& keyPressMetrics) const;
    void onScroll(const TextInputMetrics& textInputMetrics) const;

--- a/patches/react-native+0.73.4+024+Add-onPaste-to-TextInput.patch
+++ b/patches/react-native+0.73.4+024+Add-onPaste-to-TextInput.patch
@@ -170,38 +170,41 @@ index 346acaa..abec1ee 100644
     * The string that will be rendered before text input has been entered.
     */
 diff --git a/node_modules/react-native/Libraries/Text/TextInput/Multiline/RCTUITextView.mm b/node_modules/react-native/Libraries/Text/TextInput/Multiline/RCTUITextView.mm
-index 582b49c..ac31cb1 100644
+index 582b49c..20807aa 100644
 --- a/node_modules/react-native/Libraries/Text/TextInput/Multiline/RCTUITextView.mm
 +++ b/node_modules/react-native/Libraries/Text/TextInput/Multiline/RCTUITextView.mm
-@@ -13,6 +13,9 @@
+@@ -13,6 +13,10 @@
  #import <React/RCTBackedTextInputDelegateAdapter.h>
  #import <React/RCTTextAttributes.h>
  
++#import <MobileCoreServices/MobileCoreServices.h>
 +#import <MobileCoreServices/UTType.h>
 +#import <UIKit/UIKit.h>
 +
  @implementation RCTUITextView {
    UILabel *_placeholderView;
    UITextView *_detachedTextView;
-@@ -166,7 +169,30 @@ - (void)setSelectedTextRange:(UITextRange *)selectedTextRange notifyDelegate:(BO
+@@ -166,7 +170,32 @@ - (void)setSelectedTextRange:(UITextRange *)selectedTextRange notifyDelegate:(BO
  - (void)paste:(id)sender
  {
    _textWasPasted = YES;
 -  [super paste:sender];
 +  UIPasteboard *clipboard = [UIPasteboard generalPasteboard];
 +  if (clipboard.hasImages) {
-+    for (NSItemProvider *itemProvider in [clipboard itemProviders]) {
-+      if ([itemProvider canLoadObjectOfClass:[UIImage class]]) {
-+        NSString *identifier = itemProvider.registeredTypeIdentifiers.firstObject;
-+        if (identifier != nil) {
-+          NSString *MIMEType = (__bridge_transfer NSString *)UTTypeCopyPreferredTagWithClass((__bridge CFStringRef)identifier, kUTTagClassMIMEType);
-+          NSString *fileExtension = (__bridge_transfer NSString *)UTTypeCopyPreferredTagWithClass((__bridge CFStringRef)identifier, kUTTagClassFilenameExtension);
-+          NSString *fileName = [NSString stringWithFormat:@"%@.%@", itemProvider.suggestedName ?: @"file", fileExtension];
-+          NSString *filePath = [NSTemporaryDirectory() stringByAppendingPathComponent:fileName];
-+          NSURL *fileURL = [NSURL fileURLWithPath:filePath];
-+          NSData *fileData = [clipboard dataForPasteboardType:identifier];
-+          [fileData writeToFile:filePath atomically:YES];
-+          [_textInputDelegateAdapter didPaste:MIMEType withData:[fileURL absoluteString]];
++    for (NSItemProvider *itemProvider in clipboard.itemProviders) {
++      if ([itemProvider hasItemConformingToTypeIdentifier:(NSString *)kUTTypeImage]) {
++        for (NSString *identifier in itemProvider.registeredTypeIdentifiers) {
++          if (UTTypeConformsTo((__bridge CFStringRef)identifier, kUTTypeImage)) {
++            NSString *MIMEType = (__bridge_transfer NSString *)UTTypeCopyPreferredTagWithClass((__bridge CFStringRef)identifier, kUTTagClassMIMEType);
++            NSString *fileExtension = (__bridge_transfer NSString *)UTTypeCopyPreferredTagWithClass((__bridge CFStringRef)identifier, kUTTagClassFilenameExtension);
++            NSString *fileName = [NSString stringWithFormat:@"%@.%@", [[NSUUID UUID] UUIDString], fileExtension];
++            NSString *filePath = [NSTemporaryDirectory() stringByAppendingPathComponent:fileName];
++            NSURL *fileURL = [NSURL fileURLWithPath:filePath];
++            NSData *fileData = [clipboard dataForPasteboardType:identifier];
++            [fileData writeToFile:filePath atomically:YES];
++            [_textInputDelegateAdapter didPaste:MIMEType withData:[fileURL absoluteString]];
++            break;
++          }
 +        }
 +        break;
 +      }
@@ -215,7 +218,7 @@ index 582b49c..ac31cb1 100644
  }
  
  // Turn off scroll animation to fix flaky scrolling.
-@@ -258,6 +284,10 @@ - (BOOL)canPerformAction:(SEL)action withSender:(id)sender
+@@ -258,6 +287,10 @@ - (BOOL)canPerformAction:(SEL)action withSender:(id)sender
      return NO;
    }
  
@@ -342,20 +345,21 @@ index 4785987..16a9b8e 100644
  RCT_EXPORT_VIEW_PROPERTY(mostRecentEventCount, NSInteger)
  
 diff --git a/node_modules/react-native/Libraries/Text/TextInput/Singleline/RCTUITextField.mm b/node_modules/react-native/Libraries/Text/TextInput/Singleline/RCTUITextField.mm
-index 4d0afd9..a6afc7b 100644
+index 4d0afd9..507df43 100644
 --- a/node_modules/react-native/Libraries/Text/TextInput/Singleline/RCTUITextField.mm
 +++ b/node_modules/react-native/Libraries/Text/TextInput/Singleline/RCTUITextField.mm
-@@ -12,6 +12,9 @@
+@@ -12,6 +12,10 @@
  #import <React/RCTUtils.h>
  #import <React/UIView+React.h>
  
++#import <MobileCoreServices/MobileCoreServices.h>
 +#import <MobileCoreServices/UTType.h>
 +#import <UIKit/UIKit.h>
 +
  @implementation RCTUITextField {
    RCTBackedTextFieldDelegateAdapter *_textInputDelegateAdapter;
    NSDictionary<NSAttributedStringKey, id> *_defaultTextAttributes;
-@@ -139,6 +142,10 @@ - (BOOL)canPerformAction:(SEL)action withSender:(id)sender
+@@ -139,6 +143,10 @@ - (BOOL)canPerformAction:(SEL)action withSender:(id)sender
      return NO;
    }
  
@@ -366,25 +370,27 @@ index 4d0afd9..a6afc7b 100644
    return [super canPerformAction:action withSender:sender];
  }
  
-@@ -204,7 +211,30 @@ - (void)setSelectedTextRange:(UITextRange *)selectedTextRange notifyDelegate:(BO
+@@ -204,7 +212,32 @@ - (void)setSelectedTextRange:(UITextRange *)selectedTextRange notifyDelegate:(BO
  - (void)paste:(id)sender
  {
    _textWasPasted = YES;
 -  [super paste:sender];
 +  UIPasteboard *clipboard = [UIPasteboard generalPasteboard];
 +  if (clipboard.hasImages) {
-+    for (NSItemProvider *itemProvider in [clipboard itemProviders]) {
-+      if ([itemProvider canLoadObjectOfClass:[UIImage class]]) {
-+        NSString *identifier = itemProvider.registeredTypeIdentifiers.firstObject;
-+        if (identifier != nil) {
-+          NSString *MIMEType = (__bridge_transfer NSString *)UTTypeCopyPreferredTagWithClass((__bridge CFStringRef)identifier, kUTTagClassMIMEType);
-+          NSString *fileExtension = (__bridge_transfer NSString *)UTTypeCopyPreferredTagWithClass((__bridge CFStringRef)identifier, kUTTagClassFilenameExtension);
-+          NSString *fileName = [NSString stringWithFormat:@"%@.%@", itemProvider.suggestedName ?: @"file", fileExtension];
-+          NSString *filePath = [NSTemporaryDirectory() stringByAppendingPathComponent:fileName];
-+          NSURL *fileURL = [NSURL fileURLWithPath:filePath];
-+          NSData *fileData = [clipboard dataForPasteboardType:identifier];
-+          [fileData writeToFile:filePath atomically:YES];
-+          [_textInputDelegateAdapter didPaste:MIMEType withData:[fileURL absoluteString]];
++    for (NSItemProvider *itemProvider in clipboard.itemProviders) {
++      if ([itemProvider hasItemConformingToTypeIdentifier:(NSString *)kUTTypeImage]) {
++        for (NSString *identifier in itemProvider.registeredTypeIdentifiers) {
++          if (UTTypeConformsTo((__bridge CFStringRef)identifier, kUTTypeImage)) {
++            NSString *MIMEType = (__bridge_transfer NSString *)UTTypeCopyPreferredTagWithClass((__bridge CFStringRef)identifier, kUTTagClassMIMEType);
++            NSString *fileExtension = (__bridge_transfer NSString *)UTTypeCopyPreferredTagWithClass((__bridge CFStringRef)identifier, kUTTagClassFilenameExtension);
++            NSString *fileName = [NSString stringWithFormat:@"%@.%@", [[NSUUID UUID] UUIDString], fileExtension];
++            NSString *filePath = [NSTemporaryDirectory() stringByAppendingPathComponent:fileName];
++            NSURL *fileURL = [NSURL fileURLWithPath:filePath];
++            NSData *fileData = [clipboard dataForPasteboardType:identifier];
++            [fileData writeToFile:filePath atomically:YES];
++            [_textInputDelegateAdapter didPaste:MIMEType withData:[fileURL absoluteString]];
++            break;
++          }
 +        }
 +        break;
 +      }

--- a/src/components/Composer/index.native.tsx
+++ b/src/components/Composer/index.native.tsx
@@ -1,8 +1,9 @@
 import type {MarkdownStyle} from '@expensify/react-native-live-markdown';
 import type {ForwardedRef} from 'react';
 import React, {useCallback, useMemo, useRef} from 'react';
-import type {NativeSyntheticEvent, TextInput, TextInputChangeEventData} from 'react-native';
+import type {NativeSyntheticEvent, TextInput, TextInputChangeEventData, TextInputPasteEventData} from 'react-native';
 import {StyleSheet} from 'react-native';
+import type {FileObject} from '@components/AttachmentModal';
 import type {AnimatedMarkdownTextInputRef} from '@components/RNMarkdownTextInput';
 import RNMarkdownTextInput from '@components/RNMarkdownTextInput';
 import useMarkdownStyle from '@hooks/useMarkdownStyle';
@@ -20,6 +21,7 @@ const excludeReportMentionStyle: Array<keyof MarkdownStyle> = ['mentionReport'];
 function Composer(
     {
         onClear: onClearProp = () => {},
+        onPasteFile = () => {},
         isDisabled = false,
         maxLines,
         isComposerFullSize = false,
@@ -70,6 +72,20 @@ function Composer(
         [onClearProp],
     );
 
+    const pasteFile = useCallback(
+        (e: NativeSyntheticEvent<TextInputPasteEventData>) => {
+            const clipboardContent = e.nativeEvent.items[0];
+            if (clipboardContent.type === 'text/plain') {
+                return;
+            }
+            const fileURI = clipboardContent.data;
+            const fileName = fileURI.split('/').pop();
+            const file: FileObject = {uri: fileURI, name: fileName, type: clipboardContent.type};
+            onPasteFile(file);
+        },
+        [onPasteFile],
+    );
+
     const maxHeightStyle = useMemo(() => StyleUtils.getComposerMaxHeightStyle(maxLines, isComposerFullSize), [StyleUtils, isComposerFullSize, maxLines]);
     const composerStyle = useMemo(() => StyleSheet.flatten([style, textContainsOnlyEmojis ? styles.onlyEmojisTextLineHeight : {}]), [style, textContainsOnlyEmojis, styles]);
 
@@ -90,6 +106,7 @@ function Composer(
             /* eslint-disable-next-line react/jsx-props-no-spreading */
             {...props}
             readOnly={isDisabled}
+            onPaste={pasteFile}
             onBlur={(e) => {
                 if (!isFocused) {
                     // eslint-disable-next-line react-compiler/react-compiler

--- a/src/components/Composer/types.ts
+++ b/src/components/Composer/types.ts
@@ -1,4 +1,5 @@
 import type {NativeSyntheticEvent, StyleProp, TextInputProps, TextInputSelectionChangeEventData, TextStyle} from 'react-native';
+import type {FileObject} from '@components/AttachmentModal';
 
 type TextSelection = {
     start: number;
@@ -37,7 +38,7 @@ type ComposerProps = Omit<TextInputProps, 'onClear'> & {
     onChangeText?: (numberOfLines: string) => void;
 
     /** Callback method to handle pasting a file */
-    onPasteFile?: (file: File) => void;
+    onPasteFile?: (file: FileObject) => void;
 
     /** General styles to apply to the text input */
     // eslint-disable-next-line react/forbid-prop-types

--- a/src/stories/Composer.stories.tsx
+++ b/src/stories/Composer.stories.tsx
@@ -3,6 +3,7 @@ import type {Meta} from '@storybook/react';
 import {ExpensiMark} from 'expensify-common';
 import React, {useState} from 'react';
 import {Image, View} from 'react-native';
+import type {FileObject} from '@components/AttachmentModal';
 import Composer from '@components/Composer';
 import type {ComposerProps} from '@components/Composer/types';
 import RenderHTML from '@components/RenderHTML';
@@ -29,7 +30,7 @@ const parser = new ExpensiMark();
 
 function Default(props: ComposerProps) {
     const StyleUtils = useStyleUtils();
-    const [pastedFile, setPastedFile] = useState<File | null>(null);
+    const [pastedFile, setPastedFile] = useState<FileObject | null>(null);
     const [comment, setComment] = useState(props.defaultValue);
     const renderedHTML = parser.replace(comment ?? '');
 
@@ -53,7 +54,7 @@ function Default(props: ComposerProps) {
                 <View style={[defaultStyles.p5, defaultStyles.borderBottom, defaultStyles.borderRight, defaultStyles.borderTop, defaultStyles.flex1]}>
                     <Text style={[defaultStyles.mb2, defaultStyles.textLabelSupporting]}>Rendered Comment</Text>
                     {!!renderedHTML && <RenderHTML html={renderedHTML} />}
-                    {!!pastedFile && (
+                    {!!pastedFile && pastedFile instanceof File && (
                         <View style={defaultStyles.mv3}>
                             <Image
                                 source={{uri: URL.createObjectURL(pastedFile)}}


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
`TextInput` is having a new callback `onPaste` (https://github.com/facebook/react-native/pull/45425) which is invoked when the user performs the paste action. The callback event contains the clipboard data. If files are found in the clipboard, upload them.

Second attempt of https://github.com/Expensify/App/pull/45722

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
5. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/41239
PROPOSAL: https://github.com/Expensify/App/issues/41239#issuecomment-2223319480


### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
6. Verify a modal appears displaying a preview of that image
--->

1. Copy image (from Gallery or Google search results)
2. Open any report
3. Paste the image
4. Verify that an attachment modal is displayed
5. Upload the photo
6. Verify the photo is uploaded with success


- [X] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

N/A

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

Same as Tests

- [X] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [X] I linked the correct issue in the `### Fixed Issues` section above
- [X] I wrote clear testing steps that cover the changes made in this PR
    - [X] I added steps for local testing in the `Tests` section
    - [X] I added steps for the expected offline behavior in the `Offline steps` section
    - [X] I added steps for Staging and/or Production testing in the `QA steps` section
    - [X] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [X] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [X] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [X] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [X] I ran the tests on **all platforms** & verified they passed on:
    - [X] Android: Native
    - [X] Android: mWeb Chrome
    - [X] iOS: Native
    - [X] iOS: mWeb Safari
    - [X] MacOS: Chrome / Safari
    - [X] MacOS: Desktop
- [X] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [X] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [X] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [X] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [X] I verified that comments were added to code that is not self explanatory
    - [X] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [X] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [X] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [X] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [X] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [X] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [X] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [X] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [X] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [X] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [X] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [X] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [X] I verified that if a function's arguments changed that all usages have also been updated correctly
- [X] If any new file was added I verified that:
    - [X] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [X] If a new CSS style is added I verified that:
    - [X] A similar style doesn't already exist
    - [X] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [X] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [X] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [X] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [X] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [X] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [X] I verified that all the inputs inside a form are aligned with each other.
    - [X] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [X] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [X] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/7d4bfa5c-bc69-440d-b8fa-532bc068ae37


</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/aa98a8e6-5669-468c-9a17-86c1daa184d0


</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/27f57cc4-a210-4790-a758-055d4dd5cbca


</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/fbb3d339-a90e-4806-80fc-015ed8143c7e


</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/3552b18e-7a64-4ee6-8f7b-b0ee6ee5ffd8


</details>

<details>
<summary>MacOS: Desktop</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/0bdcce3f-de60-451a-9037-1c8bb0a3745e


</details>
