### PR TITLE
Fix: `OnyxUpdateManager` ends up in a recursive endless loop, when previously applied Onyx updates are not chained (caused crashes on web)

### DIFF
--- a/src/libs/actions/OnyxUpdateManager/index.ts
+++ b/src/libs/actions/OnyxUpdateManager/index.ts
@@ -75,7 +75,7 @@ function handleOnyxUpdateGap(onyxUpdatesFromServer: OnyxEntry<OnyxUpdatesFromSer
         // When ONYX_UPDATES_FROM_SERVER is set, we pause the queue. Let's unpause
         // it so the app is not stuck forever without processing requests.
         SequentialQueue.unpause();
-        console.debug(`[OnyxUpdateManager] Ignoring Onyx updates while OpenApp hans't finished yet.`);
+        console.debug(`[OnyxUpdateManager] Ignoring Onyx updates while OpenApp hasn't finished yet.`);
         return;
     }
     // This key is shared across clients, thus every client/tab will have a copy and try to execute this method.

--- a/src/libs/actions/OnyxUpdateManager/utils/index.ts
+++ b/src/libs/actions/OnyxUpdateManager/utils/index.ts
@@ -89,7 +89,7 @@ function detectGapsAndSplit(lastUpdateIDFromClient: number): DetectGapAndSplitRe
         }
     }
 
-    let updatesAfterGaps: DeferredUpdatesDictionary = {};
+    const updatesAfterGaps: DeferredUpdatesDictionary = {};
     if (gapExists) {
         // If there is a gap and we didn't detect two chained updates, "firstUpdateToBeAppliedAfterGap" will always be the the last deferred update.
         // We will fetch all missing updates up to the previous update and can always apply the last deferred update.

--- a/src/libs/actions/OnyxUpdateManager/utils/index.ts
+++ b/src/libs/actions/OnyxUpdateManager/utils/index.ts
@@ -16,18 +16,30 @@ Onyx.connect({
 /**
  * In order for the deferred updates to be applied correctly in order,
  * we need to check if there are any gaps between deferred updates.
+ * If there are gaps, we need to split the deferred updates into two parts:
+ * 1. The applicable updates that can be applied immediately
+ * 2. The updates after the gaps that need to be fetched and applied first
  * @param updates The deferred updates to be checked for gaps
- * @param clientLastUpdateID An optional lastUpdateID passed to use instead of the lastUpdateIDAppliedToClient
+ * @param lastUpdateIDFromClient An optional lastUpdateID passed to use instead of the lastUpdateIDAppliedToClient
  * @returns
  */
-function detectGapsAndSplit(updates: DeferredUpdatesDictionary, clientLastUpdateID?: number): DetectGapAndSplitResult {
-    const lastUpdateIDFromClient = clientLastUpdateID ?? lastUpdateIDAppliedToClient ?? 0;
+function detectGapsAndSplit(lastUpdateIDFromClient: number): DetectGapAndSplitResult {
+    // We only want to apply deferred updates that are newer than the last update that was applied to the client.
+    // At this point, the missing updates from "GetMissingOnyxUpdates" have been applied already,
+    // so we can safely filter out any outdated deferred updates.
+    const pendingDeferredUpdates = DeferredOnyxUpdates.getUpdates({minUpdateID: lastUpdateIDFromClient});
 
-    const updateValues = Object.values(updates);
+    // If there are no remaining deferred updates after filtering out outdated updates,
+    // we don't need to iterate over the deferred updates and check for gaps.
+    if (Object.values(pendingDeferredUpdates).length === 0) {
+        return {applicableUpdates: {}, updatesAfterGaps: {}, latestMissingUpdateID: undefined};
+    }
+
+    const updateValues = Object.values(pendingDeferredUpdates);
     const applicableUpdates: DeferredUpdatesDictionary = {};
 
     let gapExists = false;
-    let firstUpdateAfterGaps: number | undefined;
+    let firstUpdateIDAfterGaps: number | undefined;
     let latestMissingUpdateID: number | undefined;
 
     for (const [index, update] of updateValues.entries()) {
@@ -36,59 +48,61 @@ function detectGapsAndSplit(updates: DeferredUpdatesDictionary, clientLastUpdate
         const lastUpdateID = Number(update.lastUpdateID);
         const previousUpdateID = Number(update.previousUpdateID);
 
-        // If an update is older than the last update that was applied to the client, we can skip it
-        // This should already be handled before, but we'll keep this as a safeguard.
-        if (lastUpdateID <= lastUpdateIDFromClient) {
-            // eslint-disable-next-line no-continue
-            continue;
-        }
+        // Whether the previous update (of the current update) is outdated, because there was a newer update applied to the client.
+        const isPreviousUpdateAlreadyApplied = previousUpdateID <= lastUpdateIDFromClient;
 
-        // If any update's previousUpdateID doesn't match the lastUpdateID from the previous update, the deferred updates aren't chained and there's a gap.
-        // For the first update, we need to check that the previousUpdateID of the fetched update is the same as the lastUpdateIDAppliedToClient.
+        // If any update's previousUpdateID doesn't match the lastUpdateID of the previous update,
+        // the deferred updates aren't chained and we detected a gap.
+        // For the first update, we need to check that the previousUpdateID of the current update is the same as the lastUpdateIDAppliedToClient.
         // For any other updates, we need to check if the previousUpdateID of the current update is found in the deferred updates.
         // If an update is chained, we can add it to the applicable updates.
-        const isChained = isFirst ? previousUpdateID === lastUpdateIDFromClient : !!updates[Number(update.previousUpdateID)];
-        if (isChained) {
-            // If a gap exists already, we will not add any more updates to the applicable updates.
-            // Instead, once there are two chained updates again, we can set "firstUpdateAfterGaps" to the first update after the current gap.
+        const isChainedToPreviousUpdate = isFirst ? isPreviousUpdateAlreadyApplied : !!pendingDeferredUpdates[previousUpdateID];
+        if (isChainedToPreviousUpdate) {
+            // If we found a gap in the deferred updates, we will not add any more updates to the applicable updates.
+            // Instead, if we find two chained updates, we can set "firstUpdateIDAfterGaps" to the first update after the gap.
             if (gapExists) {
-                // If "firstUpdateAfterGaps" hasn't been set yet and there was a gap, we need to set it to the first update after all gaps.
-                if (!firstUpdateAfterGaps) {
-                    firstUpdateAfterGaps = previousUpdateID;
+                // If there was a gap, "firstUpdateIDAfterGaps" isn't set and we find two chained updates,
+                // we need to set "firstUpdateIDAfterGaps" to the first update after the gap.
+                if (!firstUpdateIDAfterGaps) {
+                    firstUpdateIDAfterGaps = previousUpdateID;
                 }
             } else {
                 // If no gap exists yet, we can add the update to the applicable updates
                 applicableUpdates[lastUpdateID] = update;
             }
         } else {
-            // If the previousUpdateID of the update after the gap is older than the lastUpdateIDFromClient,
-            // we don't want to detect a missing update, since this would cause a recursion loop in "validateAndApplyDeferredUpdates".
-            if (previousUpdateID <= lastUpdateIDFromClient) {
+            // If a previous update has already been applied to the client we should not detect a gap.
+            // This can cause a recursion loop, because "validateAndApplyDeferredUpdates" will refetch
+            // missing updates up to the previous update, which will then be applied again.
+            if (isPreviousUpdateAlreadyApplied) {
                 // eslint-disable-next-line no-continue
                 continue;
             }
 
-            // When we find a (new) gap, we need to set "gapExists" to true and reset the "firstUpdateAfterGaps" variable,
-            // so that we can continue searching for the next update after all gaps
+            // When we find a (new) gap, we initially need to set "gapExists" to true
+            // and reset "firstUpdateIDAfterGaps" and continue searching the first update after all gaps.
             gapExists = true;
-            firstUpdateAfterGaps = undefined;
+            firstUpdateIDAfterGaps = undefined;
 
-            // If there is a gap, it means the previous update is the latest missing update.
+            // We need to set update the latest missing update to the previous update of the current unchained update.
             latestMissingUpdateID = previousUpdateID;
         }
     }
 
-    // When "firstUpdateAfterGaps" is not set yet, we need to set it to the last update in the list,
-    // because we will fetch all missing updates up to the previous one and can then always apply the last update in the deferred updates.
-    const firstUpdateAfterGapWithFallback = Math.max(firstUpdateAfterGaps ?? Number(updateValues[updateValues.length - 1].lastUpdateID), lastUpdateIDFromClient);
-
     let updatesAfterGaps: DeferredUpdatesDictionary = {};
     if (gapExists) {
-        updatesAfterGaps = Object.entries(updates).reduce<DeferredUpdatesDictionary>((acc, [lastUpdateID, update]) => {
-            if (Number(lastUpdateID) >= firstUpdateAfterGapWithFallback) {
-                acc[Number(lastUpdateID)] = update;
+        // If there is a gap and we didn't detect two chained updates, "firstUpdateToBeAppliedAfterGap" will always be the the last deferred update.
+        // We will fetch all missing updates up to the previous update and can always apply the last deferred update.
+        const firstUpdateToBeAppliedAfterGap = firstUpdateIDAfterGaps ?? Number(updateValues[updateValues.length - 1].lastUpdateID);
+
+        // Add all deferred updates after the gap(s) to "updatesAfterGaps".
+        // If "firstUpdateToBeAppliedAfterGap" is set to the last deferred update, the array will be empty.
+        Object.entries(pendingDeferredUpdates).forEach(([lastUpdateID, update]) => {
+            if (Number(lastUpdateID) < firstUpdateToBeAppliedAfterGap) {
+                return;
             }
-            return acc;
+
+            updatesAfterGaps[Number(lastUpdateID)] = update;
         }, {});
     }
 
@@ -104,20 +118,16 @@ function validateAndApplyDeferredUpdates(clientLastUpdateID?: number, previousPa
 
     Log.info('[DeferredUpdates] Processing deferred updates', false, {lastUpdateIDFromClient, previousParams});
 
-    // We only want to apply deferred updates that are newer than the last update that was applied to the client.
-    // At this point, the missing updates from "GetMissingOnyxUpdates" have been applied already, so we can safely filter out.
-    const pendingDeferredUpdates = DeferredOnyxUpdates.getUpdates({minUpdateID: lastUpdateIDFromClient});
+    const {applicableUpdates, updatesAfterGaps, latestMissingUpdateID} = detectGapsAndSplit(lastUpdateIDFromClient);
 
-    // If there are no remaining deferred updates after filtering out outdated ones,
-    // we can just unpause the queue and return
-    if (Object.values(pendingDeferredUpdates).length === 0) {
+    // If there are no applicable deferred updates and no missing deferred updates,
+    // we don't need to apply or re-fetch any updates. We can just unpause the queue by resolving.
+    if (Object.values(applicableUpdates).length === 0 && latestMissingUpdateID === undefined) {
         return Promise.resolve();
     }
 
-    const {applicableUpdates, updatesAfterGaps, latestMissingUpdateID} = detectGapsAndSplit(pendingDeferredUpdates, lastUpdateIDFromClient);
-
-    // If newer updates got applied in the meantime, we don't need to refetch for missing updates
-    // and can just re-trigger the "validateAndApplyDeferredUpdates" process
+    // If newer updates got applied, we don't need to refetch for missing updates
+    // and will re-trigger the "validateAndApplyDeferredUpdates" process
     if (latestMissingUpdateID) {
         Log.info('[DeferredUpdates] Gap detected in deferred updates', false, {lastUpdateIDFromClient, latestMissingUpdateID});
 
@@ -134,7 +144,8 @@ function validateAndApplyDeferredUpdates(clientLastUpdateID?: number, previousPa
 
                 DeferredOnyxUpdates.enqueue(updatesAfterGaps, {shouldPauseSequentialQueue: false});
 
-                // If lastUpdateIDAppliedToClient got updated in the meantime, we will just retrigger the validation and application of the current deferred updates.
+                // If lastUpdateIDAppliedToClient got updated, we will just retrigger the validation
+                // and application of the current deferred updates.
                 if (latestMissingUpdateID <= newLastUpdateIDFromClient) {
                     validateAndApplyDeferredUpdates(undefined, {newLastUpdateIDFromClient, latestMissingUpdateID})
                         .then(() => resolve(undefined))

--- a/tests/unit/OnyxUpdateManagerTest.ts
+++ b/tests/unit/OnyxUpdateManagerTest.ts
@@ -256,7 +256,7 @@ describe('OnyxUpdateManager', () => {
         });
     });
 
-    it('should only fetch missing updates that are not stale', () => {
+    it('should only fetch missing updates that are not outdated (older than already locally applied update)', () => {
         OnyxUpdateManager.handleOnyxUpdateGap(offsetedMockUpdate3);
         OnyxUpdateManager.handleOnyxUpdateGap(mockUpdate4);
 

--- a/tests/unit/OnyxUpdateManagerTest.ts
+++ b/tests/unit/OnyxUpdateManagerTest.ts
@@ -18,6 +18,7 @@ const ApplyUpdates = ApplyUpdatesImport as ApplyUpdatesMock;
 const OnyxUpdateManagerUtils = OnyxUpdateManagerUtilsImport as OnyxUpdateManagerUtilsMock;
 
 const mockUpdate3 = createOnyxMockUpdate(3);
+const offsetedMockUpdate3 = createOnyxMockUpdate(3, undefined, 2);
 const mockUpdate4 = createOnyxMockUpdate(4);
 const mockUpdate5 = createOnyxMockUpdate(5);
 const mockUpdate6 = createOnyxMockUpdate(6);
@@ -193,7 +194,7 @@ describe('OnyxUpdateManager', () => {
             // Even though there are multiple gaps in the deferred updates, we only want to fetch missing updates once per batch.
             expect(App.getMissingOnyxUpdates).toHaveBeenCalledTimes(1);
 
-            // validateAndApplyDeferredUpdates should be called twice, once for the initial deferred updates and once for the remaining deferred updates with gaps.
+            // validateAndApplyDeferredUpdates should be called once for the initial deferred updates
             // Unfortunately, we cannot easily count the calls of this function with Jest, since it recursively calls itself.
             // The intended assertion would look like this:
             // expect(OnyxUpdateManagerUtils.validateAndApplyDeferredUpdates).toHaveBeenCalledTimes(1);
@@ -252,6 +253,30 @@ describe('OnyxUpdateManager', () => {
             // Since the lastUpdateIDAppliedToClient has changed to 4 in the meantime and we're fetching updates 5-6 we only need to apply the remaining deferred updates (7).
             // eslint-disable-next-line @typescript-eslint/naming-convention
             expect(ApplyUpdates.applyUpdates).toHaveBeenNthCalledWith(2, {7: mockUpdate7});
+        });
+    });
+
+    it('should only fetch missing updates that are not stale', () => {
+        OnyxUpdateManager.handleOnyxUpdateGap(offsetedMockUpdate3);
+        OnyxUpdateManager.handleOnyxUpdateGap(mockUpdate4);
+
+        return OnyxUpdateManager.queryPromise.then(() => {
+            // After all missing and deferred updates have been applied, the lastUpdateIDAppliedToClient should be 4.
+            expect(lastUpdateIDAppliedToClient).toBe(4);
+
+            // validateAndApplyDeferredUpdates should be called once for the initial deferred updates
+            // Unfortunately, we cannot easily count the calls of this function with Jest, since it recursively calls itself.
+            // The intended assertion would look like this:
+            // expect(OnyxUpdateManagerUtils.validateAndApplyDeferredUpdates).toHaveBeenCalledTimes(1);
+
+            // There should be only one call to applyUpdates. The call should contain all the deferred update,
+            // since the locally applied updates have changed in the meantime.
+            expect(ApplyUpdates.applyUpdates).toHaveBeenCalledTimes(1);
+            // eslint-disable-next-line @typescript-eslint/naming-convention
+            expect(ApplyUpdates.applyUpdates).toHaveBeenCalledWith({3: offsetedMockUpdate3, 4: mockUpdate4});
+
+            // There are no gaps in the deferred updates, therefore only one call to getMissingOnyxUpdates should be triggered
+            expect(App.getMissingOnyxUpdates).toHaveBeenCalledTimes(1);
         });
     });
 });

--- a/tests/utils/createOnyxMockUpdate.ts
+++ b/tests/utils/createOnyxMockUpdate.ts
@@ -1,10 +1,10 @@
 import type {OnyxUpdate} from 'react-native-onyx';
 import type {OnyxUpdatesFromServer} from '@src/types/onyx';
 
-const createOnyxMockUpdate = (lastUpdateID: number, successData: OnyxUpdate[] = []): OnyxUpdatesFromServer => ({
+const createOnyxMockUpdate = (lastUpdateID: number, successData: OnyxUpdate[] = [], previousUpdateIDOffset = 1): OnyxUpdatesFromServer => ({
     type: 'https',
     lastUpdateID,
-    previousUpdateID: lastUpdateID - 1,
+    previousUpdateID: lastUpdateID - previousUpdateIDOffset,
     request: {
         command: 'TestCommand',
         successData,
@@ -15,7 +15,7 @@ const createOnyxMockUpdate = (lastUpdateID: number, successData: OnyxUpdate[] = 
     response: {
         jsonCode: 200,
         lastUpdateID,
-        previousUpdateID: lastUpdateID - 1,
+        previousUpdateID: lastUpdateID - previousUpdateIDOffset,
         onyxData: successData,
     },
 });


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

@AndrewGable @sakluger @hannojg 

### Details
<!-- Explanation of the change or anything fishy that is going on -->

This PR fixes a problem where the `OnyxUpdateManager` would end up in a recursive loop and therefore cause browser tabs to crash, because the recursive calls would build up the Stack and therefore memory. When memory consumption is to big, the browser tab will crash.

This problem was caused, because some Onyx updates from the backend "span over" the last update that was applied to the client. What i mean by that is that we keep track of the `lastUpdateID` of the last update, that was applied to the client in `ONYXKEYS.ONYX_UPDATES_LAST_UPDATE_ID_APPLIED_TO_CLIENT`. When a new (deferred) update has a `previousUpdateID` that is lower than `lastUpdateIDAppliedToClient`, this would cause the validation and application of deferred updates to end up in a loop, because we would always find a gap in the deferred updates.

 Example:

The current `lastUpdateIDAppliedToClient` is 10. Usually, the next (expected) update would have `lastUpdateID` of 11 and `previousUpdateID` of 10.

We didn't yet handle the case properly, when next update (for some reason) has `lastUpdateID` 11 and `previousUpdateID` of 9 (or lower). We can't take 9 as the last update to fetch for missing updates, but instead have to jump out of the recursive validation process.

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/44744
PROPOSAL:


### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

- [x] Verify that no errors appear in the JS console

1. Open NewDot in a Chrome tab with DevTools
2. Open OldDot in a different tab with DevTools and Network tab open
3. Create a report
4. Search for the `CreateReport` API call in the network log and copy it as node.js code
5. Use this script to create multiple new reports:

```javascript
const NUM_OF_REPORTS_PER_BATCH = 30;
const NUM_OF_REPORT_BATCHES = 100;
let reportCounter = 0;
let batchCounter = 0;

function fetchReport() {
  Promise.all(
    Array(NUM_OF_REPORTS_PER_BATCH)
      .fill(0)
      .map(() => {
        return /* PASTE FETCH CODE HERE*/.then((response) => {
          if (response.status !== 200) {
            return;
          }
          reportCounter++;
          console.log(`Report ${reportCounter + 1} created!`);

          return Promise.resolve(response);
        });
      })
  ).then(() => {
    batchCounter++;
    if (batchCounter >= NUM_OF_REPORT_BATCHES) {
      return;
    }
    fetchReport();
  });
}

fetchReport();
```

6. Look at the DevTools in NewDot
7. Make sure that these two logs are not occurring repeatedly/recursively: (with different update IDs)

```log
[info] [DeferredUpdates] Processing deferred updates - {"lastUpdateIDFromClient":1162701182,"previousParams":{"newLastUpdateIDFromClient":1162701182,"latestMissingUpdateID":1162699064}} 
[info] [DeferredUpdates] Gap detected in deferred updates - {"lastUpdateIDFromClient":1162701182,"latestMissingUpdateID":1162699064} 
```

8. Wait for ˜100-200 reports to be created
9. Make sure RAM usage of the chrome tab is not going up and the tab doesn't crash

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

None needed.

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
10. Upload an image via copy paste
11. Verify a modal appears displaying a preview of that image
--->

- [ ] Verify that no errors appear in the JS console

Make sure the chrome tab doesn't use too much RAM and doesn't crash when multiple reports are created.

For testing, follow same procedure as in Tests.

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)‰
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Desktop</summary>

<!-- add screenshots or videos here -->

</details>
