### PR TITLE
[No QA] Fix prod deploy GitHub comments

### DIFF
--- a/.github/actions/javascript/getDeployPullRequestList/getDeployPullRequestList.ts
+++ b/.github/actions/javascript/getDeployPullRequestList/getDeployPullRequestList.ts
@@ -103,7 +103,7 @@ async function run() {
         let reason = await shouldSkipVersion(lastSuccessfulDeploy, inputTag, isProductionDeploy);
         while (lastSuccessfulDeploy && reason) {
             console.log(
-                `Deploy of tag ${lastSuccessfulDeploy?.head_branch} was not valid as a base for comparison, looking at the next one. Reason: ${reason}`,
+                `Deploy of tag ${lastSuccessfulDeploy.head_branch} was not valid as a base for comparison, looking at the next one. Reason: ${reason}`,
                 lastSuccessfulDeploy.html_url,
             );
             lastSuccessfulDeploy = completedDeploys.shift();

--- a/.github/actions/javascript/getDeployPullRequestList/getDeployPullRequestList.ts
+++ b/.github/actions/javascript/getDeployPullRequestList/getDeployPullRequestList.ts
@@ -34,6 +34,9 @@ async function run() {
         let sameAsInputTag = false;
         let wrongEnvironment = false;
         let unsuccessfulDeploy = false;
+
+        // note: this while statement looks a bit weird because uses assignment as a condition: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/while#using_an_assignment_as_a_condition
+        // while ugly, it's beneficial in this case because it prevents extra network requests from happening unnecessarily (i.e: we only check wrongEnvironment if sameAsInputTag is false, etc...)
         while (
             (invalidReleaseBranch = !!lastSuccessfulDeploy?.head_branch) &&
             ((sameAsInputTag = lastSuccessfulDeploy?.head_branch === inputTag) ||

--- a/.github/actions/javascript/getDeployPullRequestList/getDeployPullRequestList.ts
+++ b/.github/actions/javascript/getDeployPullRequestList/getDeployPullRequestList.ts
@@ -76,11 +76,15 @@ async function run() {
         // note: this while statement looks a bit weird because uses assignments as conditions: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/while#using_an_assignment_as_a_condition
         // it's beneficial in this case because it prevents extra network requests from happening unnecessarily (i.e: we only check wrongEnvironment if sameAsInputTag is false, etc...)
         while (
+            // eslint-disable-next-line no-cond-assign
             (invalidReleaseBranch = !!lastSuccessfulDeploy?.head_branch) &&
             // we never want to compare a tag with itself. This check is necessary because prod deploys almost always have the same version as the last staging deploy.
             // In this case, the check for wrongEnvironment fails because the release that triggered that staging deploy is now finalized, so it looks like a prod deploy.
+            // eslint-disable-next-line no-cond-assign
             ((sameAsInputTag = lastSuccessfulDeploy?.head_branch === inputTag) ||
+                // eslint-disable-next-line no-cond-assign
                 (wrongEnvironment = await isReleaseValidBaseForEnvironment(lastSuccessfulDeploy?.head_branch, isProductionDeploy)) ||
+                // eslint-disable-next-line no-cond-assign
                 (unsuccessfulDeploy = !(await wasDeploySuccessful(lastSuccessfulDeploy.id))))
         ) {
             let reason;

--- a/.github/actions/javascript/getDeployPullRequestList/getDeployPullRequestList.ts
+++ b/.github/actions/javascript/getDeployPullRequestList/getDeployPullRequestList.ts
@@ -95,18 +95,24 @@ async function run() {
 
         // Find the most recent deploy workflow targeting the correct environment, for which at least one of the build jobs finished successfully
         let lastSuccessfulDeploy = completedDeploys.shift();
-        let reason = '';
-        // eslint-disable-next-line no-cond-assign
-        while (lastSuccessfulDeploy?.head_branch && (reason = await shouldSkipVersion(lastSuccessfulDeploy, inputTag, isProductionDeploy))) {
+
+        if (!lastSuccessfulDeploy) {
+            throw new Error('Could not find a prior successful deploy');
+        }
+
+        let reason = await shouldSkipVersion(lastSuccessfulDeploy, inputTag, isProductionDeploy);
+        while (lastSuccessfulDeploy && reason) {
             console.log(
                 `Deploy of tag ${lastSuccessfulDeploy?.head_branch} was not valid as a base for comparison, looking at the next one. Reason: ${reason}`,
                 lastSuccessfulDeploy.html_url,
             );
             lastSuccessfulDeploy = completedDeploys.shift();
-        }
 
-        if (!lastSuccessfulDeploy) {
-            throw new Error('Could not find a prior successful deploy');
+            if (!lastSuccessfulDeploy) {
+                throw new Error('Could not find a prior successful deploy');
+            }
+
+            reason = await shouldSkipVersion(lastSuccessfulDeploy, inputTag, isProductionDeploy);
         }
 
         const priorTag = lastSuccessfulDeploy.head_branch;

--- a/.github/actions/javascript/getDeployPullRequestList/getDeployPullRequestList.ts
+++ b/.github/actions/javascript/getDeployPullRequestList/getDeployPullRequestList.ts
@@ -1,8 +1,11 @@
 import * as core from '@actions/core';
 import * as github from '@actions/github';
+import type {RestEndpointMethodTypes} from '@octokit/plugin-rest-endpoint-methods/dist-types/generated/parameters-and-response-types';
 import {getJSONInput} from '@github/libs/ActionUtils';
 import GithubUtils from '@github/libs/GithubUtils';
 import GitUtils from '@github/libs/GitUtils';
+
+type WorkflowRun = RestEndpointMethodTypes['actions']['listWorkflowRuns']['response']['data']['workflow_runs'][number];
 
 /**
  * This function checks if a given release is a valid baseTag to get the PR list with `git log baseTag...endTag`.
@@ -45,6 +48,30 @@ async function wasDeploySuccessful(runID: number) {
     return jobsForWorkflowRun.some((job) => job.name.startsWith('Build and deploy') && job.conclusion === 'success');
 }
 
+/**
+ * This function checks if a given deploy workflow is a valid basis for comparison when listing PRs merged between two versions.
+ * It returns the reason a version should be skipped, or an empty string if the version should not be skipped.
+ */
+async function shouldSkipVersion(lastSuccessfulDeploy: WorkflowRun, inputTag: string, isProductionDeploy: boolean): Promise<string> {
+    if (!lastSuccessfulDeploy?.head_branch) {
+        // This should never happen. Just doing this to appease TS.
+        return '';
+    }
+
+    // we never want to compare a tag with itself. This check is necessary because prod deploys almost always have the same version as the last staging deploy.
+    // In this case, the next for wrong environment fails because the release that triggered that staging deploy is now finalized, so it looks like a prod deploy.
+    if (lastSuccessfulDeploy?.head_branch === inputTag) {
+        return `Same as input tag ${inputTag}`;
+    }
+    if (!(await isReleaseValidBaseForEnvironment(lastSuccessfulDeploy?.head_branch, isProductionDeploy))) {
+        return 'Was a staging deploy, we only want to compare with other production deploys';
+    }
+    if (!(await wasDeploySuccessful(lastSuccessfulDeploy.id))) {
+        return 'Was an unsuccessful deploy, nothing was deployed in that version';
+    }
+    return '';
+}
+
 async function run() {
     try {
         const inputTag = core.getInput('TAG', {required: true});
@@ -68,39 +95,9 @@ async function run() {
 
         // Find the most recent deploy workflow targeting the correct environment, for which at least one of the build jobs finished successfully
         let lastSuccessfulDeploy = completedDeploys.shift();
-        let invalidReleaseBranch = false;
-        let sameAsInputTag = false;
-        let wrongEnvironment = false;
-        let unsuccessfulDeploy = false;
-
-        // note: this while statement looks a bit weird because uses assignments as conditions: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/while#using_an_assignment_as_a_condition
-        // it's beneficial in this case because:
-        //    - keeping the async calls in the while loop conditional prevents extra network requests from happening unnecessarily (i.e: we only check wrongEnvironment if sameAsInputTag is false, etc...)
-        //    - using conditional assignment, we can keep track of why a release is being skipped over for the sake of logs + debugging
-        while (
-            // eslint-disable-next-line no-cond-assign
-            (invalidReleaseBranch = !!lastSuccessfulDeploy?.head_branch) &&
-            // we never want to compare a tag with itself. This check is necessary because prod deploys almost always have the same version as the last staging deploy.
-            // In this case, the check for wrongEnvironment fails because the release that triggered that staging deploy is now finalized, so it looks like a prod deploy.
-            // eslint-disable-next-line no-cond-assign
-            ((sameAsInputTag = lastSuccessfulDeploy?.head_branch === inputTag) ||
-                // eslint-disable-next-line no-cond-assign
-                (wrongEnvironment = await isReleaseValidBaseForEnvironment(lastSuccessfulDeploy?.head_branch, isProductionDeploy)) ||
-                // eslint-disable-next-line no-cond-assign
-                (unsuccessfulDeploy = !(await wasDeploySuccessful(lastSuccessfulDeploy.id))))
-        ) {
-            let reason;
-            if (invalidReleaseBranch) {
-                reason = 'Invalid release branch';
-            } else if (sameAsInputTag) {
-                reason = `Same as input tag ${inputTag}`;
-            } else if (wrongEnvironment) {
-                reason = `Was a ${isProductionDeploy ? 'staging' : 'production'} deploy, we only want to compare with ${isProductionDeploy ? 'production' : 'staging'} deploys`;
-            } else if (unsuccessfulDeploy) {
-                reason = 'Was an unsuccessful deploy';
-            } else {
-                reason = 'WTF?!';
-            }
+        let reason = '';
+        // eslint-disable-next-line no-cond-assign
+        while (lastSuccessfulDeploy?.head_branch && (reason = await shouldSkipVersion(lastSuccessfulDeploy, inputTag, isProductionDeploy))) {
             console.log(
                 `Deploy of tag ${lastSuccessfulDeploy?.head_branch} was not valid as a base for comparison, looking at the next one. Reason: ${reason}`,
                 lastSuccessfulDeploy.html_url,

--- a/.github/actions/javascript/getDeployPullRequestList/getDeployPullRequestList.ts
+++ b/.github/actions/javascript/getDeployPullRequestList/getDeployPullRequestList.ts
@@ -7,6 +7,8 @@ import GitUtils from '@github/libs/GitUtils';
 
 type WorkflowRun = RestEndpointMethodTypes['actions']['listWorkflowRuns']['response']['data']['workflow_runs'][number];
 
+const BUILD_AND_DEPLOY_JOB_NAME_PREFIX = 'Build and deploy';
+
 /**
  * This function checks if a given release is a valid baseTag to get the PR list with `git log baseTag...endTag`.
  *
@@ -45,7 +47,7 @@ async function wasDeploySuccessful(runID: number) {
             filter: 'latest',
         })
     ).data.jobs;
-    return jobsForWorkflowRun.some((job) => job.name.startsWith('Build and deploy') && job.conclusion === 'success');
+    return jobsForWorkflowRun.some((job) => job.name.startsWith(BUILD_AND_DEPLOY_JOB_NAME_PREFIX) && job.conclusion === 'success');
 }
 
 /**

--- a/.github/actions/javascript/getDeployPullRequestList/getDeployPullRequestList.ts
+++ b/.github/actions/javascript/getDeployPullRequestList/getDeployPullRequestList.ts
@@ -74,7 +74,9 @@ async function run() {
         let unsuccessfulDeploy = false;
 
         // note: this while statement looks a bit weird because uses assignments as conditions: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/while#using_an_assignment_as_a_condition
-        // it's beneficial in this case because it prevents extra network requests from happening unnecessarily (i.e: we only check wrongEnvironment if sameAsInputTag is false, etc...)
+        // it's beneficial in this case because:
+        //    - keeping the async calls in the while loop conditional prevents extra network requests from happening unnecessarily (i.e: we only check wrongEnvironment if sameAsInputTag is false, etc...)
+        //    - using conditional assignment, we can keep track of why a release is being skipped over for the sake of logs + debugging
         while (
             // eslint-disable-next-line no-cond-assign
             (invalidReleaseBranch = !!lastSuccessfulDeploy?.head_branch) &&

--- a/.github/actions/javascript/getDeployPullRequestList/index.js
+++ b/.github/actions/javascript/getDeployPullRequestList/index.js
@@ -11526,6 +11526,8 @@ async function run() {
         let sameAsInputTag = false;
         let wrongEnvironment = false;
         let unsuccessfulDeploy = false;
+        // note: this while statement looks a bit weird because uses assignment as a condition: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/while#using_an_assignment_as_a_condition
+        // while ugly, it's beneficial in this case because it prevents extra network requests from happening unnecessarily (i.e: we only check wrongEnvironment if sameAsInputTag is false, etc...)
         while ((invalidReleaseBranch = !!lastSuccessfulDeploy?.head_branch) &&
             ((sameAsInputTag = lastSuccessfulDeploy?.head_branch === inputTag) ||
                 (wrongEnvironment =

--- a/.github/actions/javascript/getDeployPullRequestList/index.js
+++ b/.github/actions/javascript/getDeployPullRequestList/index.js
@@ -11502,6 +11502,7 @@ const github = __importStar(__nccwpck_require__(5438));
 const ActionUtils_1 = __nccwpck_require__(6981);
 const GithubUtils_1 = __importDefault(__nccwpck_require__(9296));
 const GitUtils_1 = __importDefault(__nccwpck_require__(1547));
+const BUILD_AND_DEPLOY_JOB_NAME_PREFIX = 'Build and deploy';
 /**
  * This function checks if a given release is a valid baseTag to get the PR list with `git log baseTag...endTag`.
  *
@@ -11535,7 +11536,7 @@ async function wasDeploySuccessful(runID) {
         run_id: runID,
         filter: 'latest',
     })).data.jobs;
-    return jobsForWorkflowRun.some((job) => job.name.startsWith('Build and deploy') && job.conclusion === 'success');
+    return jobsForWorkflowRun.some((job) => job.name.startsWith(BUILD_AND_DEPLOY_JOB_NAME_PREFIX) && job.conclusion === 'success');
 }
 /**
  * This function checks if a given deploy workflow is a valid basis for comparison when listing PRs merged between two versions.

--- a/.github/actions/javascript/getDeployPullRequestList/index.js
+++ b/.github/actions/javascript/getDeployPullRequestList/index.js
@@ -11582,7 +11582,7 @@ async function run() {
         }
         let reason = await shouldSkipVersion(lastSuccessfulDeploy, inputTag, isProductionDeploy);
         while (lastSuccessfulDeploy && reason) {
-            console.log(`Deploy of tag ${lastSuccessfulDeploy?.head_branch} was not valid as a base for comparison, looking at the next one. Reason: ${reason}`, lastSuccessfulDeploy.html_url);
+            console.log(`Deploy of tag ${lastSuccessfulDeploy.head_branch} was not valid as a base for comparison, looking at the next one. Reason: ${reason}`, lastSuccessfulDeploy.html_url);
             lastSuccessfulDeploy = completedDeploys.shift();
             if (!lastSuccessfulDeploy) {
                 throw new Error('Could not find a prior successful deploy');

--- a/.github/actions/javascript/getDeployPullRequestList/index.js
+++ b/.github/actions/javascript/getDeployPullRequestList/index.js
@@ -11518,22 +11518,46 @@ async function run() {
             // Note: we filter out cancelled runs instead of looking only for success runs
             // because if a build fails on even one platform, then it will have the status 'failure'
             .filter((workflowRun) => workflowRun.conclusion !== 'cancelled');
+        // 9.0.20-6 -> data.prerelease is false and isProductionDeploy is true
+        // 9.0.20-5 -> data.prerelease is false and isProductionDeploy is false
         // Find the most recent deploy workflow targeting the correct environment, for which at least one of the build jobs finished successfully
         let lastSuccessfulDeploy = completedDeploys.shift();
-        while (lastSuccessfulDeploy?.head_branch &&
-            ((await GithubUtils_1.default.octokit.repos.getReleaseByTag({
-                owner: github.context.repo.owner,
-                repo: github.context.repo.repo,
-                tag: lastSuccessfulDeploy.head_branch,
-            })).data.prerelease === isProductionDeploy ||
-                !(await GithubUtils_1.default.octokit.actions.listJobsForWorkflowRun({
+        let invalidReleaseBranch = false;
+        let sameAsInputTag = false;
+        let wrongEnvironment = false;
+        let unsuccessfulDeploy = false;
+        while ((invalidReleaseBranch = !!lastSuccessfulDeploy?.head_branch) &&
+            ((sameAsInputTag = lastSuccessfulDeploy?.head_branch === inputTag) ||
+                (wrongEnvironment =
+                    (await GithubUtils_1.default.octokit.repos.getReleaseByTag({
+                        owner: github.context.repo.owner,
+                        repo: github.context.repo.repo,
+                        tag: lastSuccessfulDeploy.head_branch,
+                    })).data.prerelease === isProductionDeploy) ||
+                (unsuccessfulDeploy = !(await GithubUtils_1.default.octokit.actions.listJobsForWorkflowRun({
                     owner: github.context.repo.owner,
                     repo: github.context.repo.repo,
                     // eslint-disable-next-line @typescript-eslint/naming-convention
                     run_id: lastSuccessfulDeploy.id,
                     filter: 'latest',
-                })).data.jobs.some((job) => job.name.startsWith('Build and deploy') && job.conclusion === 'success'))) {
-            console.log(`Deploy was not a success: ${lastSuccessfulDeploy.html_url}, looking at the next one`);
+                })).data.jobs.some((job) => job.name.startsWith('Build and deploy') && job.conclusion === 'success')))) {
+            let reason;
+            if (invalidReleaseBranch) {
+                reason = 'Invalid release branch';
+            }
+            else if (sameAsInputTag) {
+                reason = `Same as input tag ${inputTag}`;
+            }
+            else if (wrongEnvironment) {
+                reason = `Was a ${isProductionDeploy ? 'staging' : 'production'} deploy, we only want to compare with ${isProductionDeploy ? 'production' : 'staging'} deploys`;
+            }
+            else if (unsuccessfulDeploy) {
+                reason = 'Was an unsuccessful deploy';
+            }
+            else {
+                reason = 'WTF?!';
+            }
+            console.log(`Deploy of tag ${lastSuccessfulDeploy?.head_branch} was not valid as a base for comparison, looking at the next one. Reason: ${reason}`, lastSuccessfulDeploy.html_url);
             lastSuccessfulDeploy = completedDeploys.shift();
         }
         if (!lastSuccessfulDeploy) {

--- a/.github/actions/javascript/getDeployPullRequestList/index.js
+++ b/.github/actions/javascript/getDeployPullRequestList/index.js
@@ -11560,12 +11560,19 @@ async function run() {
         let wrongEnvironment = false;
         let unsuccessfulDeploy = false;
         // note: this while statement looks a bit weird because uses assignments as conditions: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/while#using_an_assignment_as_a_condition
-        // it's beneficial in this case because it prevents extra network requests from happening unnecessarily (i.e: we only check wrongEnvironment if sameAsInputTag is false, etc...)
-        while ((invalidReleaseBranch = !!lastSuccessfulDeploy?.head_branch) &&
+        // it's beneficial in this case because:
+        //    - keeping the async calls in the while loop conditional prevents extra network requests from happening unnecessarily (i.e: we only check wrongEnvironment if sameAsInputTag is false, etc...)
+        //    - using conditional assignment, we can keep track of why a release is being skipped over for the sake of logs + debugging
+        while (
+        // eslint-disable-next-line no-cond-assign
+        (invalidReleaseBranch = !!lastSuccessfulDeploy?.head_branch) &&
             // we never want to compare a tag with itself. This check is necessary because prod deploys almost always have the same version as the last staging deploy.
             // In this case, the check for wrongEnvironment fails because the release that triggered that staging deploy is now finalized, so it looks like a prod deploy.
+            // eslint-disable-next-line no-cond-assign
             ((sameAsInputTag = lastSuccessfulDeploy?.head_branch === inputTag) ||
+                // eslint-disable-next-line no-cond-assign
                 (wrongEnvironment = await isReleaseValidBaseForEnvironment(lastSuccessfulDeploy?.head_branch, isProductionDeploy)) ||
+                // eslint-disable-next-line no-cond-assign
                 (unsuccessfulDeploy = !(await wasDeploySuccessful(lastSuccessfulDeploy.id))))) {
             let reason;
             if (invalidReleaseBranch) {

--- a/.github/actions/javascript/getDeployPullRequestList/index.js
+++ b/.github/actions/javascript/getDeployPullRequestList/index.js
@@ -11502,10 +11502,45 @@ const github = __importStar(__nccwpck_require__(5438));
 const ActionUtils_1 = __nccwpck_require__(6981);
 const GithubUtils_1 = __importDefault(__nccwpck_require__(9296));
 const GitUtils_1 = __importDefault(__nccwpck_require__(1547));
+/**
+ * This function checks if a given release is a valid baseTag to get the PR list with `git log baseTag...endTag`.
+ *
+ * The rules are:
+ *     - production deploys can only be compared with other production deploys
+ *     - staging deploys can be compared with other staging deploys or production deploys.
+ *       The reason is that the final staging release in each deploy cycle will BECOME a production release.
+ *       For example, imagine a checklist is closed with version 9.0.20-6; that's the most recent staging deploy, but the release for 9.0.20-6 is now finalized, so it looks like a prod deploy.
+ *       When 9.0.21-0 finishes deploying to staging, the most recent prerelease is 9.0.20-5. However, we want 9.0.20-6...9.0.21-0,
+ *       NOT 9.0.20-5...9.0.21-0 (so that the PR CP'd in 9.0.20-6 is not included in the next checklist)
+ */
+async function isReleaseValidBaseForEnvironment(releaseTag, isProductionDeploy) {
+    if (!isProductionDeploy) {
+        return true;
+    }
+    const isPrerelease = (await GithubUtils_1.default.octokit.repos.getReleaseByTag({
+        owner: github.context.repo.owner,
+        repo: github.context.repo.repo,
+        tag: releaseTag,
+    })).data.prerelease;
+    return !isPrerelease;
+}
+/**
+ * Was a given platformDeploy workflow run successful on at least one platform?
+ */
+async function wasDeploySuccessful(runID) {
+    const jobsForWorkflowRun = (await GithubUtils_1.default.octokit.actions.listJobsForWorkflowRun({
+        owner: github.context.repo.owner,
+        repo: github.context.repo.repo,
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        run_id: runID,
+        filter: 'latest',
+    })).data.jobs;
+    return jobsForWorkflowRun.some((job) => job.name.startsWith('Build and deploy') && job.conclusion === 'success');
+}
 async function run() {
     try {
         const inputTag = core.getInput('TAG', { required: true });
-        const isProductionDeploy = (0, ActionUtils_1.getJSONInput)('IS_PRODUCTION_DEPLOY', { required: false }, false);
+        const isProductionDeploy = !!(0, ActionUtils_1.getJSONInput)('IS_PRODUCTION_DEPLOY', { required: false }, false);
         const deployEnv = isProductionDeploy ? 'production' : 'staging';
         console.log(`Looking for PRs deployed to ${deployEnv} in ${inputTag}...`);
         const completedDeploys = (await GithubUtils_1.default.octokit.actions.listWorkflowRuns({
@@ -11518,31 +11553,20 @@ async function run() {
             // Note: we filter out cancelled runs instead of looking only for success runs
             // because if a build fails on even one platform, then it will have the status 'failure'
             .filter((workflowRun) => workflowRun.conclusion !== 'cancelled');
-        // 9.0.20-6 -> data.prerelease is false and isProductionDeploy is true
-        // 9.0.20-5 -> data.prerelease is false and isProductionDeploy is false
         // Find the most recent deploy workflow targeting the correct environment, for which at least one of the build jobs finished successfully
         let lastSuccessfulDeploy = completedDeploys.shift();
         let invalidReleaseBranch = false;
         let sameAsInputTag = false;
         let wrongEnvironment = false;
         let unsuccessfulDeploy = false;
-        // note: this while statement looks a bit weird because uses assignment as a condition: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/while#using_an_assignment_as_a_condition
-        // while ugly, it's beneficial in this case because it prevents extra network requests from happening unnecessarily (i.e: we only check wrongEnvironment if sameAsInputTag is false, etc...)
+        // note: this while statement looks a bit weird because uses assignments as conditions: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/while#using_an_assignment_as_a_condition
+        // it's beneficial in this case because it prevents extra network requests from happening unnecessarily (i.e: we only check wrongEnvironment if sameAsInputTag is false, etc...)
         while ((invalidReleaseBranch = !!lastSuccessfulDeploy?.head_branch) &&
+            // we never want to compare a tag with itself. This check is necessary because prod deploys almost always have the same version as the last staging deploy.
+            // In this case, the check for wrongEnvironment fails because the release that triggered that staging deploy is now finalized, so it looks like a prod deploy.
             ((sameAsInputTag = lastSuccessfulDeploy?.head_branch === inputTag) ||
-                (wrongEnvironment =
-                    (await GithubUtils_1.default.octokit.repos.getReleaseByTag({
-                        owner: github.context.repo.owner,
-                        repo: github.context.repo.repo,
-                        tag: lastSuccessfulDeploy.head_branch,
-                    })).data.prerelease === isProductionDeploy) ||
-                (unsuccessfulDeploy = !(await GithubUtils_1.default.octokit.actions.listJobsForWorkflowRun({
-                    owner: github.context.repo.owner,
-                    repo: github.context.repo.repo,
-                    // eslint-disable-next-line @typescript-eslint/naming-convention
-                    run_id: lastSuccessfulDeploy.id,
-                    filter: 'latest',
-                })).data.jobs.some((job) => job.name.startsWith('Build and deploy') && job.conclusion === 'success')))) {
+                (wrongEnvironment = await isReleaseValidBaseForEnvironment(lastSuccessfulDeploy?.head_branch, isProductionDeploy)) ||
+                (unsuccessfulDeploy = !(await wasDeploySuccessful(lastSuccessfulDeploy.id))))) {
             let reason;
             if (invalidReleaseBranch) {
                 reason = 'Invalid release branch';

--- a/.github/workflows/platformDeploy.yml
+++ b/.github/workflows/platformDeploy.yml
@@ -38,6 +38,7 @@ jobs:
     secrets: inherit
 
   android:
+    # WARNING: getDeployPullRequestList depends on this job name. do not change job name without adjusting that action accordingly
     name: Build and deploy Android
     needs: validateActor
     if: ${{ fromJSON(needs.validateActor.outputs.IS_DEPLOYER) }}
@@ -122,6 +123,7 @@ jobs:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }}
 
   desktop:
+    # WARNING: getDeployPullRequestList depends on this job name. do not change job name without adjusting that action accordingly
     name: Build and deploy Desktop
     needs: validateActor
     if: ${{ fromJSON(needs.validateActor.outputs.IS_DEPLOYER) }}
@@ -165,6 +167,7 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
 
   iOS:
+    # WARNING: getDeployPullRequestList depends on this job name. do not change job name without adjusting that action accordingly
     name: Build and deploy iOS
     needs: validateActor
     if: ${{ fromJSON(needs.validateActor.outputs.IS_DEPLOYER) }}
@@ -276,6 +279,7 @@ jobs:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }}
 
   web:
+    # WARNING: getDeployPullRequestList depends on this job name. do not change job name without adjusting that action accordingly
     name: Build and deploy Web
     needs: validateActor
     if: ${{ fromJSON(needs.validateActor.outputs.IS_DEPLOYER) }}


### PR DESCRIPTION
### Details
I've attempted to explain this PR clearly in code comments. But this PR accomplishes three things.

#### Problem: production deploys are being compared to themself
When a production deploy completes, no PRs are listed to be marked for deploy. What's happening here is:
    1. staging deploy for the final version in a checklist (i.e: `9.0.20-6`) finishes
    1. production deploy looks for the last completed production deploy by listing recent workflow runs. The most recent workflow run is the staging deploy for `9.0.20-6`. But there's nothing in the workflow run that shows the `event.action` that triggered it - it just says `event: release` for both staging and production deploys.
    1. So we look at the GitHub Release to check if it's a prerelease or not. However, by the time this action runs (at the end of the prod deploy), `9.0.20-6` is a final release, so it looks like a prod deploy.
    1. Then we end up comparing `9.0.20-6` to `9.0.20-6`, which yields no results 💥 

#### Solution
Never allow a version to be compared with itself when running `git log startTag...endTag`.

#### Problem: staging deploys are skipping a version

When a checklist is closed, one (or more) extra PR that's already been deployed to prod is included in the next checklist. What's happening here is:
    1. `9.0.20-6` is the most recent staging deploy, then we close the checklist.
    1. `9.0.20-6` becomes a final release.
    1. `9.0.21-0` looks for the most recent staging deploy, but when it checks `9.0.20-6`, it looks like a prod deploy.
    1. So it then looks at the last completed staging deploy (in this case it was actually `9.0.20-4` because `9.0.20-5` was cancelled in progress)
    1. Then we end up with `git log 9.0.20-4...9.0.21-0` instead of `git log 9.0.20-6...9.0.21-0`, so we include some extra PRs we shouldn't 💥 
    
#### Solution
Allow staging deploys to be compared with other staging deploys or prod deploys too.

#### Problem: this code was super ugly
Also this is just pretty confusing and we were missing logs that would have helped me figure this out faster

### Solution
I tried to make the code a bit cleaner and improved documentation via code comments (and this PR writeup 😉). Added some logs

### Fixed Issues
$ https://github.com/Expensify/App/issues/47461

### Tests
Live test with the next deploy checklist.

- [x] Verify that no errors appear in the JS console

### Offline tests
None.

### QA Steps
None.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Desktop</summary>

<!-- add screenshots or videos here -->

</details>
