### PR TITLE
Fix bugs connected to changed modal logic 

### DIFF
--- a/src/components/AttachmentModal.tsx
+++ b/src/components/AttachmentModal.tsx
@@ -435,6 +435,7 @@ function AttachmentModal({
                 onSelected: () => {
                     setIsDeleteReceiptConfirmModalVisible(true);
                 },
+                shouldCallAfterModalHide: true,
             });
         }
         return menuItems;

--- a/src/components/AvatarWithImagePicker.tsx
+++ b/src/components/AvatarWithImagePicker.tsx
@@ -11,7 +11,6 @@ import * as FileUtils from '@libs/fileDownload/FileUtils';
 import getImageResolution from '@libs/fileDownload/getImageResolution';
 import type {AvatarSource} from '@libs/UserUtils';
 import variables from '@styles/variables';
-import * as Modal from '@userActions/Modal';
 import CONST from '@src/CONST';
 import type {TranslationPaths} from '@src/languages/types';
 import type * as OnyxCommon from '@src/types/onyx/OnyxCommon';
@@ -44,6 +43,7 @@ type MenuItem = {
     icon: IconAsset;
     text: string;
     onSelected: () => void;
+    shouldCallAfterModalHide?: boolean;
 };
 
 type AvatarWithImagePickerProps = {
@@ -260,19 +260,19 @@ function AvatarWithImagePicker({
      * Create menu items list for avatar menu
      */
     const createMenuItems = (openPicker: OpenPicker): MenuItem[] => {
-        const menuItems = [
+        const menuItems: MenuItem[] = [
             {
                 icon: Expensicons.Upload,
                 text: translate('avatarWithImagePicker.uploadPhoto'),
-                onSelected: () =>
-                    Modal.close(() => {
-                        if (Browser.isSafari()) {
-                            return;
-                        }
-                        openPicker({
-                            onPicked: showAvatarCropModal,
-                        });
-                    }),
+                onSelected: () => {
+                    if (Browser.isSafari()) {
+                        return;
+                    }
+                    openPicker({
+                        onPicked: showAvatarCropModal,
+                    });
+                },
+                shouldCallAfterModalHide: true,
             },
         ];
 
@@ -344,14 +344,14 @@ function AvatarWithImagePicker({
                                     menuItems.push({
                                         icon: Expensicons.Eye,
                                         text: translate('avatarWithImagePicker.viewPhoto'),
-                                        onSelected: () =>
-                                            Modal.close(() => {
-                                                if (typeof onViewPhotoPress !== 'function') {
-                                                    show();
-                                                    return;
-                                                }
-                                                onViewPhotoPress();
-                                            }),
+                                        onSelected: () => {
+                                            if (typeof onViewPhotoPress !== 'function') {
+                                                show();
+                                                return;
+                                            }
+                                            onViewPhotoPress();
+                                        },
+                                        shouldCallAfterModalHide: true,
                                     });
                                 }
 

--- a/src/components/AvatarWithImagePicker.tsx
+++ b/src/components/AvatarWithImagePicker.tsx
@@ -219,6 +219,7 @@ function AvatarWithImagePicker({
      */
     const showAvatarCropModal = useCallback(
         (image: FileObject) => {
+            console.log('IMAGE: ', image);
             if (!isValidExtension(image)) {
                 setError('avatarWithImagePicker.notAllowedExtension', {allowedExtensions: CONST.AVATAR_ALLOWED_EXTENSIONS});
                 return;
@@ -265,6 +266,9 @@ function AvatarWithImagePicker({
                 icon: Expensicons.Upload,
                 text: translate('avatarWithImagePicker.uploadPhoto'),
                 onSelected: () => {
+                    if (Browser.isSafari()) {
+                        return;
+                    }
                     openPicker({
                         onPicked: showAvatarCropModal,
                     });
@@ -408,7 +412,9 @@ function AvatarWithImagePicker({
                                                 // In order for the file picker to open dynamically, the click
                                                 // function must be called from within an event handler that was initiated
                                                 // by the user on Safari.
+                                                console.log('INDEX: ', index);
                                                 if (index === 0 && Browser.isSafari()) {
+                                                    console.log('hejo');
                                                     openPicker({
                                                         onPicked: showAvatarCropModal,
                                                     });

--- a/src/components/AvatarWithImagePicker.tsx
+++ b/src/components/AvatarWithImagePicker.tsx
@@ -265,9 +265,6 @@ function AvatarWithImagePicker({
                 icon: Expensicons.Upload,
                 text: translate('avatarWithImagePicker.uploadPhoto'),
                 onSelected: () => {
-                    if (Browser.isSafari()) {
-                        return;
-                    }
                     openPicker({
                         onPicked: showAvatarCropModal,
                     });

--- a/src/components/AvatarWithImagePicker.tsx
+++ b/src/components/AvatarWithImagePicker.tsx
@@ -219,7 +219,6 @@ function AvatarWithImagePicker({
      */
     const showAvatarCropModal = useCallback(
         (image: FileObject) => {
-            console.log('IMAGE: ', image);
             if (!isValidExtension(image)) {
                 setError('avatarWithImagePicker.notAllowedExtension', {allowedExtensions: CONST.AVATAR_ALLOWED_EXTENSIONS});
                 return;
@@ -412,9 +411,7 @@ function AvatarWithImagePicker({
                                                 // In order for the file picker to open dynamically, the click
                                                 // function must be called from within an event handler that was initiated
                                                 // by the user on Safari.
-                                                console.log('INDEX: ', index);
                                                 if (index === 0 && Browser.isSafari()) {
-                                                    console.log('hejo');
                                                     openPicker({
                                                         onPicked: showAvatarCropModal,
                                                     });

--- a/src/components/ButtonWithDropdownMenu/index.tsx
+++ b/src/components/ButtonWithDropdownMenu/index.tsx
@@ -11,7 +11,6 @@ import useTheme from '@hooks/useTheme';
 import useThemeStyles from '@hooks/useThemeStyles';
 import useWindowDimensions from '@hooks/useWindowDimensions';
 import mergeRefs from '@libs/mergeRefs';
-import * as Modal from '@userActions/Modal';
 import CONST from '@src/CONST';
 import type {AnchorPosition} from '@src/styles';
 import type {ButtonWithDropdownMenuProps} from './types';
@@ -178,11 +177,12 @@ function ButtonWithDropdownMenu<IValueType>({
                     menuItems={options.map((item, index) => ({
                         ...item,
                         onSelected: item.onSelected
-                            ? () => Modal.close(() => item.onSelected?.())
+                            ? () => item.onSelected?.()
                             : () => {
                                   onOptionSelected?.(item);
                                   setSelectedItemIndex(index);
                               },
+                        shouldCallAfterModalHide: true,
                     }))}
                 />
             )}

--- a/src/components/PopoverMenu.tsx
+++ b/src/components/PopoverMenu.tsx
@@ -8,6 +8,7 @@ import useKeyboardShortcut from '@hooks/useKeyboardShortcut';
 import useResponsiveLayout from '@hooks/useResponsiveLayout';
 import useTheme from '@hooks/useTheme';
 import useThemeStyles from '@hooks/useThemeStyles';
+import * as Browser from '@libs/Browser';
 import * as Modal from '@userActions/Modal';
 import CONST from '@src/CONST';
 import type {AnchorPosition} from '@src/styles';
@@ -134,7 +135,7 @@ function PopoverMenu({
             setEnteredSubMenuIndexes([...enteredSubMenuIndexes, index]);
             const selectedSubMenuItemIndex = selectedItem?.subMenuItems.findIndex((option) => option.isSelected);
             setFocusedIndex(selectedSubMenuItemIndex);
-        } else if (selectedItem.shouldCallAfterModalHide) {
+        } else if (selectedItem.shouldCallAfterModalHide && !Browser.isSafari()) {
             Modal.close(() => {
                 onItemSelected(selectedItem, index);
                 selectedItem.onSelected?.();

--- a/src/components/PopoverMenu.tsx
+++ b/src/components/PopoverMenu.tsx
@@ -8,6 +8,7 @@ import useKeyboardShortcut from '@hooks/useKeyboardShortcut';
 import useResponsiveLayout from '@hooks/useResponsiveLayout';
 import useTheme from '@hooks/useTheme';
 import useThemeStyles from '@hooks/useThemeStyles';
+import * as Modal from '@userActions/Modal';
 import CONST from '@src/CONST';
 import type {AnchorPosition} from '@src/styles';
 import type AnchorAlignment from '@src/types/utils/AnchorAlignment';
@@ -35,6 +36,11 @@ type PopoverMenuItem = MenuItemProps & {
 
     /** Determines whether the menu item is disabled or not */
     disabled?: boolean;
+
+    /** Determines whether the menu item's onSelected() function is called after the modal is hidden
+     *  It is meant to be used in situations where, after clicking on the modal, another one is opened.
+     */
+    shouldCallAfterModalHide?: boolean;
 };
 
 type PopoverModalProps = Pick<ModalProps, 'animationIn' | 'animationOut' | 'animationInTiming'>;
@@ -128,6 +134,11 @@ function PopoverMenu({
             setEnteredSubMenuIndexes([...enteredSubMenuIndexes, index]);
             const selectedSubMenuItemIndex = selectedItem?.subMenuItems.findIndex((option) => option.isSelected);
             setFocusedIndex(selectedSubMenuItemIndex);
+        } else if (selectedItem.shouldCallAfterModalHide) {
+            Modal.close(() => {
+                onItemSelected(selectedItem, index);
+                selectedItem.onSelected?.();
+            });
         } else {
             onItemSelected(selectedItem, index);
             selectedItem.onSelected?.();

--- a/src/libs/Navigation/AppNavigator/AuthScreens.tsx
+++ b/src/libs/Navigation/AppNavigator/AuthScreens.tsx
@@ -305,7 +305,11 @@ function AuthScreens({session, lastOpenedPublicRoomID, initialLastUpdateIDApplie
         const unsubscribeSearchShortcut = KeyboardShortcut.subscribe(
             searchShortcutConfig.shortcutKey,
             () => {
-                Modal.close(Session.checkIfActionIsAllowed(() => Navigation.navigate(ROUTES.CHAT_FINDER)));
+                Modal.close(
+                    Session.checkIfActionIsAllowed(() => Navigation.navigate(ROUTES.CHAT_FINDER)),
+                    true,
+                    true,
+                );
             },
             shortcutsOverviewShortcutConfig.descriptionKey,
             shortcutsOverviewShortcutConfig.modifiers,

--- a/src/libs/actions/Modal.ts
+++ b/src/libs/actions/Modal.ts
@@ -5,6 +5,7 @@ const closeModals: Array<(isNavigating?: boolean) => void> = [];
 
 let onModalClose: null | (() => void);
 let isNavigate: undefined | boolean;
+let shouldCloseAll: boolean | undefined;
 
 /**
  * Allows other parts of the app to call modal close function
@@ -39,12 +40,13 @@ function closeTop() {
 /**
  * Close modal in other parts of the app
  */
-function close(onModalCloseCallback: () => void, isNavigating = true) {
+function close(onModalCloseCallback: () => void, isNavigating = true, shouldCloseAllModals = false) {
     if (closeModals.length === 0) {
         onModalCloseCallback();
         return;
     }
     onModalClose = onModalCloseCallback;
+    shouldCloseAll = shouldCloseAllModals;
     isNavigate = isNavigating;
     closeTop();
 }
@@ -53,7 +55,7 @@ function onModalDidClose() {
     if (!onModalClose) {
         return;
     }
-    if (closeModals.length) {
+    if (closeModals.length && shouldCloseAll) {
         closeTop();
         return;
     }

--- a/src/pages/home/report/ReportActionCompose/AttachmentPickerWithMenuItems.tsx
+++ b/src/pages/home/report/ReportActionCompose/AttachmentPickerWithMenuItems.tsx
@@ -23,7 +23,6 @@ import Navigation from '@libs/Navigation/Navigation';
 import * as ReportUtils from '@libs/ReportUtils';
 import * as SubscriptionUtils from '@libs/SubscriptionUtils';
 import * as IOU from '@userActions/IOU';
-import * as Modal from '@userActions/Modal';
 import * as Report from '@userActions/Report';
 import * as Task from '@userActions/Task';
 import type {IOUType} from '@src/CONST';
@@ -225,13 +224,13 @@ function AttachmentPickerWithMenuItems({
                     {
                         icon: Expensicons.Paperclip,
                         text: translate('reportActionCompose.addAttachment'),
-                        onSelected: () =>
-                            Modal.close(() => {
-                                if (Browser.isSafari()) {
-                                    return;
-                                }
-                                triggerAttachmentPicker();
-                            }),
+                        onSelected: () => {
+                            if (Browser.isSafari()) {
+                                return;
+                            }
+                            triggerAttachmentPicker();
+                        },
+                        shouldCallAfterModalHide: true,
                     },
                 ];
                 return (

--- a/src/pages/home/report/ReportActionCompose/AttachmentPickerWithMenuItems.tsx
+++ b/src/pages/home/report/ReportActionCompose/AttachmentPickerWithMenuItems.tsx
@@ -225,9 +225,6 @@ function AttachmentPickerWithMenuItems({
                         icon: Expensicons.Paperclip,
                         text: translate('reportActionCompose.addAttachment'),
                         onSelected: () => {
-                            if (Browser.isSafari()) {
-                                return;
-                            }
                             triggerAttachmentPicker();
                         },
                         shouldCallAfterModalHide: true,

--- a/src/pages/home/report/ReportActionCompose/AttachmentPickerWithMenuItems.tsx
+++ b/src/pages/home/report/ReportActionCompose/AttachmentPickerWithMenuItems.tsx
@@ -225,6 +225,9 @@ function AttachmentPickerWithMenuItems({
                         icon: Expensicons.Paperclip,
                         text: translate('reportActionCompose.addAttachment'),
                         onSelected: () => {
+                            if (Browser.isSafari()) {
+                                return;
+                            }
                             triggerAttachmentPicker();
                         },
                         shouldCallAfterModalHide: true,

--- a/src/pages/iou/request/step/IOURequestStepWaypoint.tsx
+++ b/src/pages/iou/request/step/IOURequestStepWaypoint.tsx
@@ -23,7 +23,6 @@ import useWindowDimensions from '@hooks/useWindowDimensions';
 import * as ErrorUtils from '@libs/ErrorUtils';
 import Navigation from '@libs/Navigation/Navigation';
 import * as ValidationUtils from '@libs/ValidationUtils';
-import * as Modal from '@userActions/Modal';
 import * as Transaction from '@userActions/Transaction';
 import CONST from '@src/CONST';
 import type {TranslationPaths} from '@src/languages/types';
@@ -179,11 +178,10 @@ function IOURequestStepWaypoint({
                             icon: Expensicons.Trashcan,
                             text: translate('distance.deleteWaypoint'),
                             onSelected: () => {
-                                Modal.close(() => {
-                                    setRestoreFocusType(undefined);
-                                    setIsDeleteStopModalOpen(true);
-                                });
+                                setRestoreFocusType(undefined);
+                                setIsDeleteStopModalOpen(true);
                             },
+                            shouldCallAfterModalHide: true,
                         },
                     ]}
                 />

--- a/src/pages/workspace/WorkspacesListPage.tsx
+++ b/src/pages/workspace/WorkspacesListPage.tsx
@@ -32,7 +32,6 @@ import * as PolicyUtils from '@libs/PolicyUtils';
 import * as ReportUtils from '@libs/ReportUtils';
 import type {AvatarSource} from '@libs/UserUtils';
 import * as App from '@userActions/App';
-import * as Modal from '@userActions/Modal';
 import * as Policy from '@userActions/Policy/Policy';
 import * as Session from '@userActions/Session';
 import CONST from '@src/CONST';
@@ -162,12 +161,12 @@ function WorkspacesListPage({policies, reimbursementAccount, reports, session}: 
                 threeDotsMenuItems.push({
                     icon: Expensicons.Trashcan,
                     text: translate('workspace.common.delete'),
-                    onSelected: () =>
-                        Modal.close(() => {
-                            setPolicyIDToDelete(item.policyID ?? '-1');
-                            setPolicyNameToDelete(item.title);
-                            setIsDeleteModalOpen(true);
-                        }),
+                    onSelected: () => {
+                        setPolicyIDToDelete(item.policyID ?? '-1');
+                        setPolicyNameToDelete(item.title);
+                        setIsDeleteModalOpen(true);
+                    },
+                    shouldCallAfterModalHide: true,
                 });
             }
 

--- a/src/pages/workspace/accounting/PolicyAccountingPage.tsx
+++ b/src/pages/workspace/accounting/PolicyAccountingPage.tsx
@@ -38,7 +38,6 @@ import Navigation from '@navigation/Navigation';
 import AccessOrNotFoundWrapper from '@pages/workspace/AccessOrNotFoundWrapper';
 import withPolicyConnections from '@pages/workspace/withPolicyConnections';
 import type {AnchorPosition} from '@styles/index';
-import * as Modal from '@userActions/Modal';
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
 import ROUTES from '@src/ROUTES';
@@ -98,7 +97,8 @@ function PolicyAccountingPage({policy}: PolicyAccountingPageProps) {
                       {
                           icon: Expensicons.Key,
                           text: translate('workspace.accounting.enterCredentials'),
-                          onSelected: () => Modal.close(() => startIntegrationFlow({name: connectedIntegration})),
+                          onSelected: () => startIntegrationFlow({name: connectedIntegration}),
+                          shouldCallAfterModalHide: true,
                           disabled: isOffline,
                           iconRight: Expensicons.NewWindow,
                           shouldShowRightIcon: true,
@@ -115,7 +115,8 @@ function PolicyAccountingPage({policy}: PolicyAccountingPageProps) {
             {
                 icon: Expensicons.Trashcan,
                 text: translate('workspace.accounting.disconnect'),
-                onSelected: () => Modal.close(() => setIsDisconnectModalOpen(true)),
+                onSelected: () => setIsDisconnectModalOpen(true),
+                shouldCallAfterModalHide: true,
             },
         ],
         [shouldShowEnterCredentials, translate, isOffline, policyID, connectedIntegration, startIntegrationFlow],


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->
### Fixed Issues
$ https://github.com/Expensify/App/issues/46852

### Details
This reverts commit 804bd26501ffcd16674d5ceb8f70b889f44c8c36, reversing changes made to 2026c7841091fc2acd5573a46b28ea03c40d8bfe.

There were two issues related to this fix: #47896 and #47876. Both issues were observed only on mWeb Safari. The root cause was that opening the image/attachment picker on Safari can't be done from `onSelected` prop, it needs a check and a call from the `onItemSelected()` function.

PROPOSAL:
I went back to the previous changes that fix the delete receipt problem but also added an additional check in the `PopoverMenu` component (`&& !Browser.isSafari`) which fixes the mWeb problems and since the `Modal.close(() =>` function is specifically required only for iOS, it's not needed in the Safari case.

### Tests
1. Open Expensify App on IOS
2. Submit an expense -> add a receipt 
3. Click the expense on the chat
4. Click on the receipt photo
5. Click `ThreeDotsMenu` in the upper right corner -> then `Delete receipt`
6. Confirm delete modal should appear

Additional issues resolved: 
$ https://github.com/Expensify/App/issues/47896
1. Open Expensify App on iPhone Safari
2. Create a group chat or select existing one
3. Click to see details of the chat
4. Click on the photo -> then `Upload photo`
5. Native menu should be shown with : `Photo library, Take Photo, Choose File`

$ https://github.com/Expensify/App/issues/47876
1. Open Expensify App on iPhone Safari
2. Select chosen chat
3. Click `+` -> `Add attachment`
4. Native menu should be shown with : `Photo library, Take Photo or Video, Choose File`

Below I uploaded videos to these 3 cases.

- [x] Verify that no errors appear in the JS console

### Offline tests
same as above
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

### QA Steps
Besides this issue, I changed code in `Modal` component, it would be great to test modals in different parts of the application.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

Deleting receipt: 

https://github.com/user-attachments/assets/c19bde7e-33cd-4717-8247-322e936e7261


Changing photo of a group chat: 

https://github.com/user-attachments/assets/c5837dc8-b5ae-4716-8db2-054d42872ca4


Adding attachment to a message:

https://github.com/user-attachments/assets/4378ef47-c23c-4e47-93a5-53517eb6e1f1


</details>

<details>
<summary>Android: mWeb Chrome</summary>

Deleting receipt: 

https://github.com/user-attachments/assets/4d325f32-d419-4be0-b5f0-2c9ef7a2278c


Changing photo of a group chat: 

https://github.com/user-attachments/assets/7aff20f1-da1c-4fda-871a-c163352052ff


Adding attachment to a message:

https://github.com/user-attachments/assets/a66f4b87-27e2-4cf7-9435-02c42fe3a579


</details>

<details>
<summary>iOS: Native</summary>
Deleting receipt: 

https://github.com/user-attachments/assets/4b97f2b9-d897-4847-a375-7bbd532caffb

Changing photo of a group chat: 

https://github.com/user-attachments/assets/2c25428d-5368-4ce8-a4bd-39b12a12ffbd

Adding attachment to a message:

https://github.com/user-attachments/assets/5a653a77-e6c5-4ad8-9213-a27cc30461a3


</details>

<details>
<summary>iOS: mWeb Safari</summary>

Deleting receipt: 

https://github.com/user-attachments/assets/d86bc5f3-bbfa-4568-9a42-643f1fb28759

Changing photo of a group chat: 

https://github.com/user-attachments/assets/accd702e-f568-4d83-8a49-798552d2d4aa

Adding attachment to a message:

https://github.com/user-attachments/assets/7287418c-4e78-4cd0-a377-a1a0dfa3d2cc

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

Deleting receipt: 


https://github.com/user-attachments/assets/be6c3ea1-9711-4816-b859-720e5f2bf724

Changing photo of a group chat: 


https://github.com/user-attachments/assets/8ff39c75-b28a-4b6a-a06d-7475bf168515

Adding attachment to a message:

https://github.com/user-attachments/assets/3ee0e242-be37-41d4-8c1b-4f124d1b4f2d


</details>

<details>
<summary>MacOS: Desktop</summary>

Deleting receipt: 


https://github.com/user-attachments/assets/3431efd9-e0ed-4e02-835b-d0501b5ec845


Changing photo of a group chat: 


https://github.com/user-attachments/assets/26b0f30c-1bc0-4f3f-8a51-0b915bcb7558


Adding attachment to a message:


https://github.com/user-attachments/assets/f6a3f5c9-1041-47a2-99dd-0a0fa04d197c




</details>
