### PR TITLE
fix: abracadabra page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -76,6 +76,7 @@
         "react-native": "0.75.2",
         "react-native-android-location-enabler": "^2.0.1",
         "react-native-blob-util": "0.19.4",
+        "react-native-bundle-splitter": "^3.0.1",
         "react-native-collapsible": "^1.6.2",
         "react-native-config": "1.5.0",
         "react-native-dev-menu": "^4.1.1",
@@ -34409,6 +34410,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/react-native-bundle-splitter": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/react-native-bundle-splitter/-/react-native-bundle-splitter-3.0.1.tgz",
+      "integrity": "sha512-YvG30oL+3uhPoYisRzMJLHjs5+X7NK8yLHqLKxLIvqZ9wGAvIJ+sJG09iQpLK+UCjEAEVP5he0F0vnzuokHyBw==",
+      "peerDependencies": {
+        "react": "*",
+        "react-native": ">=0.59.1"
       }
     },
     "node_modules/react-native-clean-project": {

--- a/package.json
+++ b/package.json
@@ -133,6 +133,7 @@
     "react-native": "0.75.2",
     "react-native-android-location-enabler": "^2.0.1",
     "react-native-blob-util": "0.19.4",
+    "react-native-bundle-splitter": "^3.0.1",
     "react-native-collapsible": "^1.6.2",
     "react-native-config": "1.5.0",
     "react-native-dev-menu": "^4.1.1",

--- a/patches/@react-navigation+core+6.4.11+002+proper-navigator-unmount-in-strict-mode.patch
+++ b/patches/@react-navigation+core+6.4.11+002+proper-navigator-unmount-in-strict-mode.patch
@@ -1,0 +1,52 @@
+diff --git a/node_modules/@react-navigation/core/lib/module/useNavigationBuilder.js b/node_modules/@react-navigation/core/lib/module/useNavigationBuilder.js
+index 6fb49e0..1f7c859 100644
+--- a/node_modules/@react-navigation/core/lib/module/useNavigationBuilder.js
++++ b/node_modules/@react-navigation/core/lib/module/useNavigationBuilder.js
+@@ -114,6 +114,16 @@ const getRouteConfigsFromChildren = (children, groupKey, groupOptions) => {
+   return configs;
+ };
+ 
++const useFullyMountedRef = () => {
++  const isFullyMountedRef = React.useRef(false);
++
++  React.useEffect(() => {
++    isFullyMountedRef.current = true;
++  }, []);
++
++  return isFullyMountedRef;
++};
++
+ /**
+  * Hook for building navigators.
+  *
+@@ -122,6 +132,7 @@ const getRouteConfigsFromChildren = (children, groupKey, groupOptions) => {
+  * @returns An object containing `state`, `navigation`, `descriptors` objects.
+  */
+ export default function useNavigationBuilder(createRouter, options) {
++  const isFullyMountedRef = useFullyMountedRef();
+   const navigatorKey = useRegisterNavigator();
+   const route = React.useContext(NavigationRouteContext);
+   const {
+@@ -298,10 +309,18 @@ export default function useNavigationBuilder(createRouter, options) {
+       setState(nextState);
+     }
+     return () => {
+-      // We need to clean up state for this navigator on unmount
+-      if (getCurrentState() !== undefined && getKey() === navigatorKey) {
+-        setCurrentState(undefined);
+-        stateCleanedUp.current = true;
++      const cleanup = () => {
++        // We need to clean up state for this navigator on unmount
++        if (getCurrentState() !== undefined && getKey() === navigatorKey) {
++          setCurrentState(undefined);
++          stateCleanedUp.current = true;
++        }
++      }
++
++      if (!isFullyMountedRef.current) {
++        cleanup();
++      } else {
++        setTimeout(cleanup, 0);
+       }
+     };
+     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -54,7 +54,7 @@ LogBox.ignoreLogs([
 
 const fill = {flex: 1};
 
-const StrictModeWrapper = CONFIG.USE_REACT_STRICT_MODE_IN_DEV ? React.StrictMode : ({children}: {children: React.ReactElement}) => children;
+const StrictModeWrapper = CONFIG.USE_REACT_STRICT_MODE_IN_DEV ? React.StrictMode : React.Fragment;
 
 function App({url}: AppProps) {
     useDefaultDragAndDrop();

--- a/src/libs/Navigation/AppNavigator/index.tsx
+++ b/src/libs/Navigation/AppNavigator/index.tsx
@@ -1,14 +1,13 @@
 import React, {lazy, memo, Suspense, useEffect, useState} from 'react';
 import {preload, register} from 'react-native-bundle-splitter';
-import lazyRetry from '@src/utils/lazyRetry';
+import lazyRetry, {retryImport} from '@src/utils/lazyRetry';
 
-// const AuthScreens = lazy(() => lazyRetry(() => import('./AuthScreens')));
 const PublicScreens = lazy(() => lazyRetry(() => import('./PublicScreens')));
 
+const AUTH_SCREENS = 'AuthScreens';
 const AuthScreens = register({
-    name: 'AuthScreens',
-    // TODO: add retry logic
-    loader: () => import('./AuthScreens'),
+    name: AUTH_SCREENS,
+    loader: () => retryImport(() => import('./AuthScreens')),
 });
 
 type AppNavigatorProps = {
@@ -20,10 +19,10 @@ function AppNavigator({authenticated}: AppNavigatorProps) {
     const [canNavigateToProtectedRoutes, setNavigateToProtectedRoutes] = useState(false);
 
     useEffect(() => {
-        // Preload Auth Screens to be sure navigator can be mounted synchronously to avoid problems
-        // described in https://github.com/Expensify/App/issues/44600
+        // Preload Auth Screens in advance to be sure that navigator can be mounted synchronously
+        // to avoid problems described in https://github.com/Expensify/App/issues/44600
         preload()
-            .component('AuthScreens')
+            .component(AUTH_SCREENS)
             .then(() => {
                 setNavigateToProtectedRoutes(true);
             });

--- a/src/utils/lazyRetry.ts
+++ b/src/utils/lazyRetry.ts
@@ -5,6 +5,8 @@ type Import<T> = Promise<{default: T}>;
 type ComponentImport<T> = () => Import<T>;
 
 /**
+ * Common retry mechanism for importing components.
+ *
  * Attempts to lazily import a React component with a retry mechanism on failure.
  * If the initial import fails the function will refresh the page once and retry the import.
  * If the import fails again after the refresh, the error is propagated.
@@ -12,8 +14,7 @@ type ComponentImport<T> = () => Import<T>;
  * @param componentImport - A function that returns a promise resolving to a lazily imported React component.
  * @returns A promise that resolves to the imported component or rejects with an error after a retry attempt.
  */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const lazyRetry = function <T extends ComponentType<any>>(componentImport: ComponentImport<T>): Import<T> {
+function retryImport<T>(componentImport: ComponentImport<T>): Import<T> {
     return new Promise((resolve, reject) => {
         // Retrieve the retry status from sessionStorage, defaulting to 'false' if not set
         const hasRefreshed = JSON.parse(sessionStorage.getItem(CONST.SESSION_STORAGE_KEYS.RETRY_LAZY_REFRESHED) ?? 'false') as boolean;
@@ -37,6 +38,12 @@ const lazyRetry = function <T extends ComponentType<any>>(componentImport: Compo
                 }
             });
     });
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const lazyRetry = function <T extends ComponentType<any>>(componentImport: ComponentImport<T>): Import<T> {
+    return retryImport(componentImport);
 };
 
 export default lazyRetry;
+export {retryImport};


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details

The fix consist from two parts:
- preload the component in advance to be able to mount it synchronously on a demand;
- clean up the state in asynchronous way if it's a real component unmount.

Let's consider each part in more details.

#### 1️⃣ preload the component in advance to be able to mount it synchronously on a demand

If we mount the component and the component is lazy and haven't been loaded yet, then when we switch navigator we remove old navigator, but a new one navigator doesn't have routes yet, so `react-navigation` clears a state, and when new routes are attached then a default route will be selected, because previous state was lost.

So we need to mount the screen/navigator synchronously.

#### 2️⃣ clean up the state in asynchronous way if it's a real component unmount

The synchronous clean up was added here - https://github.com/Expensify/App/pull/42592

The key thing is that now `unmount` is getting fired two times. If we have an asyncronous removal, then navigation just stops working (because we perform a navigation and then instantly run unmount - unmount fires asynchronously and removes just created new state).

To fix this problem I patched `react-navigation` and added `useFullyMountedRef` hook. It's returning `ref.current=false` if component is not fully mounted (i. e. unmount is about to be fired) and will update `ref.current=true` when component finished it's mounting.

This solution is not perfect, but currently `react-navigation@6` is not fully compatible with `StrictMode`, so we have to patch it. Most likely with `react-navigation@7` this patch will not be needed, because `react-navigation@7` supporting `StrictMode`.

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/44600
PROPOSAL: N/A


### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

1. Go to https://staging.new.expensify.com/
2. Log in with new Expensifail account
3. Copy the Magic link and change it to staging
4. Open a new tab and navigate to the staging magic link
5. Abracadabra page is displayed and prev tab gets redirected to inbox screen

> [!WARNING]
> Please, test a release version locally.

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

N/A

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

1. Go to https://staging.new.expensify.com/
2. Log in with new Expensifail account
3. Copy the Magic link and change it to staging
4. Open a new tab and navigate to the staging magic link
5. Abracadabra page is displayed and prev tab gets redirected to inbox screen

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

https://github.com/user-attachments/assets/b6d9b913-c645-4641-b008-582ba9135060

</details>

<details>
<summary>MacOS: Desktop</summary>

<!-- add screenshots or videos here -->

</details>
