### PR TITLE
Fix onboarding modal that flashes for user transitioning from OldDot

### DIFF
--- a/src/libs/actions/Report.ts
+++ b/src/libs/actions/Report.ts
@@ -57,7 +57,6 @@ import {prepareDraftComment} from '@libs/DraftCommentUtils';
 import * as EmojiUtils from '@libs/EmojiUtils';
 import * as Environment from '@libs/Environment/Environment';
 import * as ErrorUtils from '@libs/ErrorUtils';
-import hasCompletedGuidedSetupFlowSelector from '@libs/hasCompletedGuidedSetupFlowSelector';
 import HttpUtils from '@libs/HttpUtils';
 import isPublicScreenRoute from '@libs/isPublicScreenRoute';
 import * as Localize from '@libs/Localize';
@@ -110,7 +109,6 @@ import * as Modal from './Modal';
 import navigateFromNotification from './navigateFromNotification';
 import * as Session from './Session';
 import * as Welcome from './Welcome';
-import * as OnboardingFlow from './Welcome/OnboardingFlow';
 
 type SubscriberCallback = (isFromCurrentUser: boolean, reportActionID: string | undefined) => void;
 
@@ -2690,15 +2688,6 @@ function openReportFromDeepLink(url: string) {
 
                         const state = navigationRef.getRootState();
                         const currentFocusedRoute = findFocusedRoute(state);
-                        const hasCompletedGuidedSetupFlow = hasCompletedGuidedSetupFlowSelector(onboarding);
-
-                        // We need skip deeplinking if the user hasn't completed the guided setup flow.
-                        if (!hasCompletedGuidedSetupFlow) {
-                            Welcome.isOnboardingFlowCompleted({
-                                onNotCompleted: () => OnboardingFlow.startOnboardingFlow(),
-                            });
-                            return;
-                        }
 
                         if (isOnboardingFlowName(currentFocusedRoute?.name)) {
                             Welcome.setOnboardingErrorMessage(Localize.translateLocal('onboarding.purpose.errorBackButton'));

--- a/src/libs/actions/Report.ts
+++ b/src/libs/actions/Report.ts
@@ -57,6 +57,7 @@ import {prepareDraftComment} from '@libs/DraftCommentUtils';
 import * as EmojiUtils from '@libs/EmojiUtils';
 import * as Environment from '@libs/Environment/Environment';
 import * as ErrorUtils from '@libs/ErrorUtils';
+import hasCompletedGuidedSetupFlowSelector from '@libs/hasCompletedGuidedSetupFlowSelector';
 import HttpUtils from '@libs/HttpUtils';
 import isPublicScreenRoute from '@libs/isPublicScreenRoute';
 import * as Localize from '@libs/Localize';
@@ -109,6 +110,7 @@ import * as Modal from './Modal';
 import navigateFromNotification from './navigateFromNotification';
 import * as Session from './Session';
 import * as Welcome from './Welcome';
+import * as OnboardingFlow from './Welcome/OnboardingFlow';
 
 type SubscriberCallback = (isFromCurrentUser: boolean, reportActionID: string | undefined) => void;
 
@@ -2688,6 +2690,15 @@ function openReportFromDeepLink(url: string) {
 
                         const state = navigationRef.getRootState();
                         const currentFocusedRoute = findFocusedRoute(state);
+                        const hasCompletedGuidedSetupFlow = hasCompletedGuidedSetupFlowSelector(onboarding);
+
+                        // We need skip deeplinking if the user hasn't completed the guided setup flow.
+                        if (!hasCompletedGuidedSetupFlow) {
+                            Welcome.isOnboardingFlowCompleted({
+                                onNotCompleted: () => OnboardingFlow.startOnboardingFlow(),
+                            });
+                            return;
+                        }
 
                         if (isOnboardingFlowName(currentFocusedRoute?.name)) {
                             Welcome.setOnboardingErrorMessage(Localize.translateLocal('onboarding.purpose.errorBackButton'));

--- a/src/libs/hasCompletedGuidedSetupFlowSelector.ts
+++ b/src/libs/hasCompletedGuidedSetupFlowSelector.ts
@@ -6,7 +6,8 @@ function hasCompletedGuidedSetupFlowSelector(onboarding: OnyxValue<typeof ONYXKE
     if (Array.isArray(onboarding)) {
         return true;
     }
-    return onboarding?.hasCompletedGuidedSetupFlow ?? false;
+
+    return onboarding?.hasCompletedGuidedSetupFlow ?? true;
 }
 
 export default hasCompletedGuidedSetupFlowSelector;

--- a/src/libs/hasCompletedGuidedSetupFlowSelector.ts
+++ b/src/libs/hasCompletedGuidedSetupFlowSelector.ts
@@ -6,8 +6,7 @@ function hasCompletedGuidedSetupFlowSelector(onboarding: OnyxValue<typeof ONYXKE
     if (Array.isArray(onboarding)) {
         return true;
     }
-
-    return onboarding?.hasCompletedGuidedSetupFlow ?? true;
+    return onboarding?.hasCompletedGuidedSetupFlow ?? false;
 }
 
 export default hasCompletedGuidedSetupFlowSelector;


### PR DESCRIPTION
### Details

[Link to thread on slack](https://swmansion.slack.com/archives/C036QM0SLJK/p1726074674036609) that explains the issue.

There are two issues currently:
1. When the user has a slow internet connection, the app is rendered but `nvp_onboarding` is `undefined` for a second, because of the default false value [here](https://github.com/software-mansion-labs/expensify-app-fork/blob/4b41dd187dc63ab01af824f106f1ea1bb189523d/src/libs/hasCompletedGuidedSetupFlowSelector.ts#L9), the modal is displayed. The `nvp_onboarding` is then updated to either:
`[]` (empty array) - modal disappears
`{ signupQualifier: whatever }` - modal is still displayed as we are hitting the default value
2. :point_up: As 
[@vit](https://swmansion.slack.com/team/U0228UGAF3R)
 mentioned [above](https://expensify.slack.com/archives/C036QM0SLJK/p1726078149523029?thread_ts=1726074674.036609&cid=C036QM0SLJK), `nvp_onboarding` could be an object when transitioning from OldDot to NewDot if there are other values in the NVP such as `signupQualifier` (+ `hasCompletedGuidedSetupFlow` is `undefined`). With the current default value the modal is shown, which isn't intended.

Assuming we want to show the modal only for the users with the NVP where `hasCompletedGuidedSetupFlow` is set to `false`. I think the easiest fix would be to change the default value in the `hasCompletedGuidedSetupFlowSelector` to `true`.

In other words, the modal will be displayed only when the nvp is loaded and `hasCompletedGuidedSetupFlow` === `false`

### Fixed Issues
$ https://github.com/Expensify/App/issues/49245
PROPOSAL: N/A

### Tests
- [x] Verify that when creating a new account the onboarding modal is shown
- [x] Verify that when transitioning from OldDot to NewDot the onboarding modal is not shown (the easiest way to recreate is to create an account on OldDot and then after that login on NewDot with the same email)
- [x] Try setting different values for `nvp_onboarding` on OldDot with this snippet `NVP.set('onboarding', VALUE)`, do it in the OldDot console. (different values to test are: `{}`, `{test: true}`, `{hasCompletedGuidedSetupFlow:true}`, `{hasCompletedGuidedSetupFlow:false}`, `null`)
  - Only for hasCompletedGuidedSetupFlow:false the modal should be shown

⚠️ Verify that the above run also on poor internet connection (Inspect -> Network -> Slow 4G)

### Offline tests
N/A

### QA Steps
Same as tests

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
### Screenshots/Videos

<details>
<summary>MacOS: Chrome / Safari</summary>


https://github.com/user-attachments/assets/157f4f57-b48a-4e46-b0a0-17748d1f0e19



</details>
