### PR TITLE
Fix/49322 preserve selection on navigating rhp

### DIFF
--- a/src/components/SettlementButton/AnimatedSettlementButton.tsx
+++ b/src/components/SettlementButton/AnimatedSettlementButton.tsx
@@ -6,6 +6,7 @@ import variables from '@styles/variables';
 import CONST from '@src/CONST';
 import SettlementButton from '.';
 import type SettlementButtonProps from './types';
+import useLocalize from '@hooks/useLocalize';
 
 type AnimatedSettlementButtonProps = SettlementButtonProps & {
     isPaidAnimationRunning: boolean;
@@ -24,6 +25,7 @@ function AnimatedSettlementButton({isPaidAnimationRunning, onAnimationFinish, is
         transform: [{scale: buttonScale.value}],
         opacity: buttonOpacity.value,
     }));
+    const {translate, toLocaleDigit} = useLocalize();
     const paymentCompleteTextStyles = useAnimatedStyle(() => ({
         transform: [{scale: paymentCompleteTextScale.value}],
         opacity: paymentCompleteTextOpacity.value,
@@ -77,7 +79,7 @@ function AnimatedSettlementButton({isPaidAnimationRunning, onAnimationFinish, is
         <Animated.View style={containerStyles}>
             {isPaidAnimationRunning && (
                 <Animated.View style={paymentCompleteTextStyles}>
-                    <Text style={[styles.buttonMediumText]}>Payment complete</Text>
+                    <Text style={[styles.buttonMediumText]}>${translate('iou.paymentComplete')}</Text>
                 </Animated.View>
             )}
             <Animated.View style={buttonStyles}>

--- a/src/languages/en.ts
+++ b/src/languages/en.ts
@@ -807,6 +807,7 @@ export default {
         deleteConfirmation: ({count}: DeleteExpenseTranslationParams = {count: 1}) => `Are you sure that you want to delete ${Str.pluralize('this expense', 'these expenses', count)}?`,
         settledExpensify: 'Paid',
         settledElsewhere: 'Paid elsewhere',
+        paymentComplete: 'Payment comptete',
         individual: 'Individual',
         business: 'Business',
         settleExpensify: ({formattedAmount}: SettleExpensifyCardParams) => (formattedAmount ? `Pay ${formattedAmount} with Expensify` : `Pay with Expensify`),

--- a/src/languages/es.ts
+++ b/src/languages/es.ts
@@ -800,6 +800,7 @@ export default {
         deleteConfirmation: ({count}: DeleteExpenseTranslationParams = {count: 1}) => `¿Estás seguro de que quieres eliminar ${Str.pluralize('esta solicitud', 'estas solicitudes', count)}?`,
         settledExpensify: 'Pagado',
         settledElsewhere: 'Pagado de otra forma',
+        paymentComplete: 'pago completo',
         individual: 'Individual',
         business: 'Empresa',
         settleExpensify: ({formattedAmount}: SettleExpensifyCardParams) => (formattedAmount ? `Pagar ${formattedAmount} con Expensify` : `Pagar con Expensify`),

--- a/src/libs/Permissions.ts
+++ b/src/libs/Permissions.ts
@@ -5,7 +5,8 @@ import type Beta from '@src/types/onyx/Beta';
 import * as Environment from './Environment/Environment';
 
 function canUseAllBetas(betas: OnyxEntry<Beta[]>): boolean {
-    return !!betas?.includes(CONST.BETAS.ALL);
+    return true;
+    // return !!betas?.includes(CONST.BETAS.ALL);
 }
 
 function canUseDefaultRooms(betas: OnyxEntry<Beta[]>): boolean {

--- a/src/pages/workspace/WorkspaceMembersPage.tsx
+++ b/src/pages/workspace/WorkspaceMembersPage.tsx
@@ -286,16 +286,6 @@ function WorkspaceMembersPage({personalDetails, route, policy, currentUserPerson
         [selectedEmployees, addUser, removeUser, policy?.ownerAccountID, session?.accountID],
     );
 
-    const onSelectMember = (member: MemberOption) => {
-        if (selectionMode?.isEnabled) {
-            !member.isDisabledCheckbox && toggleUser(member?.accountID);
-            return;
-        }
-
-        setShouldPreserveSelection(true);
-        openMemberDetails(member);
-    };
-
     /** Opens the member details page */
     const openMemberDetails = useCallback(
         (item: MemberOption) => {
@@ -308,6 +298,17 @@ function WorkspaceMembersPage({personalDetails, route, policy, currentUserPerson
         },
         [isPolicyAdmin, policy, policyID, route.params.policyID],
     );
+
+    const onSelectMember = (member: MemberOption) => {
+        if (selectionMode?.isEnabled) {
+            if (!member.isDisabledCheckbox) {
+                toggleUser(member?.accountID);
+            }
+            return;
+        }
+        setShouldPreserveSelection(true);
+        openMemberDetails(member);
+    };
 
     /**
      * Dismisses the errors on one item

--- a/src/pages/workspace/WorkspaceMembersPage.tsx
+++ b/src/pages/workspace/WorkspaceMembersPage.tsx
@@ -677,7 +677,9 @@ function WorkspaceMembersPage({personalDetails, route, policy, currentUserPerson
                             disableKeyboardShortcuts={removeMembersConfirmModalVisible}
                             headerMessage={getHeaderMessage()}
                             headerContent={!shouldUseNarrowLayout && getHeaderContent()}
-                            onSelectRow={(item) => {selectionMode?.isEnabled ? (!item.isDisabledCheckbox && toggleUser(item?.accountID)):(setShouldPreserveSelection(true),openMemberDetails(item))}}
+                            onSelectRow={(item) => {
+                                selectionMode?.isEnabled ? !item.isDisabledCheckbox && toggleUser(item?.accountID) : (setShouldPreserveSelection(true), openMemberDetails(item));
+                            }}
                             shouldSingleExecuteRowSelect={!isPolicyAdmin}
                             onCheckboxPress={(item) => toggleUser(item.accountID)}
                             onSelectAll={() => toggleAllUsers(data)}

--- a/src/pages/workspace/WorkspaceMembersPage.tsx
+++ b/src/pages/workspace/WorkspaceMembersPage.tsx
@@ -92,6 +92,7 @@ function WorkspaceMembersPage({personalDetails, route, policy, currentUserPerson
 
     const [invitedEmailsToAccountIDsDraft] = useOnyx(`${ONYXKEYS.COLLECTION.WORKSPACE_INVITE_MEMBERS_DRAFT}${route.params.policyID.toString()}`);
     const {selectionMode} = useMobileSelectionMode();
+    const [shouldPreserveSelection, setShouldPreserveSelection] = useState(false);
     const [session] = useOnyx(ONYXKEYS.SESSION);
     const selectionListRef = useRef<SelectionListHandle>(null);
     const isFocused = useIsFocused();
@@ -144,10 +145,11 @@ function WorkspaceMembersPage({personalDetails, route, policy, currentUserPerson
 
     // useFocus would make getWorkspaceMembers get called twice on fresh login because policyEmployee is a dependency of getWorkspaceMembers.
     useEffect(() => {
-        if (!isFocused) {
-            setSelectedEmployees([]);
+        if (isFocused || shouldPreserveSelection) {
+            setShouldPreserveSelection(false);
             return;
         }
+        setSelectedEmployees([]);
         getWorkspaceMembers();
         // eslint-disable-next-line react-compiler/react-compiler, react-hooks/exhaustive-deps
     }, [isFocused]);
@@ -570,6 +572,7 @@ function WorkspaceMembersPage({personalDetails, route, policy, currentUserPerson
                 icon: Expensicons.Table,
                 text: translate('spreadsheet.importSpreadsheet'),
                 onSelected: () => {
+                    setShouldPreserveSelection(true);
                     if (isOffline) {
                         Modal.close(() => setIsOfflineModalVisible(true));
                         return;
@@ -674,7 +677,7 @@ function WorkspaceMembersPage({personalDetails, route, policy, currentUserPerson
                             disableKeyboardShortcuts={removeMembersConfirmModalVisible}
                             headerMessage={getHeaderMessage()}
                             headerContent={!shouldUseNarrowLayout && getHeaderContent()}
-                            onSelectRow={openMemberDetails}
+                            onSelectRow={(item) => {selectionMode?.isEnabled ? (!item.isDisabledCheckbox && toggleUser(item?.accountID)):(setShouldPreserveSelection(true),openMemberDetails(item))}}
                             shouldSingleExecuteRowSelect={!isPolicyAdmin}
                             onCheckboxPress={(item) => toggleUser(item.accountID)}
                             onSelectAll={() => toggleAllUsers(data)}

--- a/src/pages/workspace/WorkspaceMembersPage.tsx
+++ b/src/pages/workspace/WorkspaceMembersPage.tsx
@@ -286,6 +286,16 @@ function WorkspaceMembersPage({personalDetails, route, policy, currentUserPerson
         [selectedEmployees, addUser, removeUser, policy?.ownerAccountID, session?.accountID],
     );
 
+    const onSelectMember = (member: MemberOption) => {
+        if (selectionMode?.isEnabled) {
+            !member.isDisabledCheckbox && toggleUser(member?.accountID);
+            return;
+        }
+
+        setShouldPreserveSelection(true);
+        openMemberDetails(member);
+    };
+
     /** Opens the member details page */
     const openMemberDetails = useCallback(
         (item: MemberOption) => {
@@ -677,9 +687,7 @@ function WorkspaceMembersPage({personalDetails, route, policy, currentUserPerson
                             disableKeyboardShortcuts={removeMembersConfirmModalVisible}
                             headerMessage={getHeaderMessage()}
                             headerContent={!shouldUseNarrowLayout && getHeaderContent()}
-                            onSelectRow={(item) => {
-                                selectionMode?.isEnabled ? !item.isDisabledCheckbox && toggleUser(item?.accountID) : (setShouldPreserveSelection(true), openMemberDetails(item));
-                            }}
+                            onSelectRow={onSelectMember}
                             shouldSingleExecuteRowSelect={!isPolicyAdmin}
                             onCheckboxPress={(item) => toggleUser(item.accountID)}
                             onSelectAll={() => toggleAllUsers(data)}

--- a/src/pages/workspace/WorkspacePageWithSections.tsx
+++ b/src/pages/workspace/WorkspacePageWithSections.tsx
@@ -24,6 +24,7 @@ import type {Route} from '@src/ROUTES';
 import type {Policy} from '@src/types/onyx';
 import {isEmptyObject} from '@src/types/utils/EmptyObject';
 import type IconAsset from '@src/types/utils/IconAsset';
+import AccessOrNotFoundWrapper from './AccessOrNotFoundWrapper';
 import type {WithPolicyAndFullscreenLoadingProps} from './withPolicyAndFullscreenLoading';
 import withPolicyAndFullscreenLoading from './withPolicyAndFullscreenLoading';
 

--- a/src/pages/workspace/categories/WorkspaceCategoriesPage.tsx
+++ b/src/pages/workspace/categories/WorkspaceCategoriesPage.tsx
@@ -133,14 +133,6 @@ function WorkspaceCategoriesPage({route}: WorkspaceCategoriesPageProps) {
         const isAllSelected = availableCategories.length === Object.keys(selectedCategories).length;
         setSelectedCategories(isAllSelected ? {} : Object.fromEntries(availableCategories.map((item) => [item.keyForList, true])));
     };
-    const onSelectCategory = (category: PolicyOption) => {
-        if (selectionMode?.isEnabled) {
-            toggleCategory(category);
-            return;
-        }
-        setShouldPreserveSelection(true);
-        navigateToCategorySettings(category);
-    };
 
     const getCustomListHeader = () => (
         <View style={[styles.flex1, styles.flexRow, styles.justifyContentBetween, styles.pl3, styles.pr9, !canSelectMultiple && styles.m5]}>
@@ -155,6 +147,15 @@ function WorkspaceCategoriesPage({route}: WorkspaceCategoriesPageProps) {
             return;
         }
         Navigation.navigate(ROUTES.WORKSPACE_CATEGORY_SETTINGS.getRoute(policyId, category.keyForList));
+    };
+
+    const onSelectCategory = (category: PolicyOption) => {
+        if (selectionMode?.isEnabled) {
+            toggleCategory(category);
+            return;
+        }
+        setShouldPreserveSelection(true);
+        navigateToCategorySettings(category);
     };
 
     const navigateToCategoriesSettings = () => {

--- a/src/pages/workspace/categories/WorkspaceCategoriesPage.tsx
+++ b/src/pages/workspace/categories/WorkspaceCategoriesPage.tsx
@@ -94,6 +94,7 @@ function WorkspaceCategoriesPage({route}: WorkspaceCategoriesPageProps) {
     useEffect(() => {
         if (isFocused || shouldPreserveSelection) {
             setShouldPreserveSelection(false);
+            refreshSelection();
             return;
         }
         setSelectedCategories({});
@@ -134,7 +135,10 @@ function WorkspaceCategoriesPage({route}: WorkspaceCategoriesPageProps) {
         const isAllSelected = availableCategories.length === Object.keys(selectedCategories).length;
         setSelectedCategories(isAllSelected ? {} : Object.fromEntries(availableCategories.map((item) => [item.keyForList, true])));
     };
-
+    const refreshSelection = () => {
+        const availableCategories = categoryList.filter((category) => category.pendingAction !== CONST.RED_BRICK_ROAD_PENDING_ACTION.DELETE);
+        setSelectedCategories(Object.fromEntries(availableCategories.map((item) => Object.keys(selectedCategories).includes(item.keyForList) ? [item.keyForList, true]: [])));
+    }
     const getCustomListHeader = () => (
         <View style={[styles.flex1, styles.flexRow, styles.justifyContentBetween, styles.pl3, styles.pr9, !canSelectMultiple && styles.m5]}>
             <Text style={styles.searchInputStyle}>{translate('common.name')}</Text>

--- a/src/pages/workspace/categories/WorkspaceCategoriesPage.tsx
+++ b/src/pages/workspace/categories/WorkspaceCategoriesPage.tsx
@@ -97,6 +97,7 @@ function WorkspaceCategoriesPage({route}: WorkspaceCategoriesPageProps) {
             return;
         }
         setSelectedCategories({});
+        // eslint-disable-next-line react-compiler/react-compiler, react-hooks/exhaustive-deps
     }, [isFocused]);
 
     const categoryList = useMemo<PolicyOption[]>(

--- a/src/pages/workspace/categories/WorkspaceCategoriesPage.tsx
+++ b/src/pages/workspace/categories/WorkspaceCategoriesPage.tsx
@@ -412,7 +412,9 @@ function WorkspaceCategoriesPage({route}: WorkspaceCategoriesPageProps) {
                         onTurnOnSelectionMode={(item) => item && toggleCategory(item)}
                         sections={[{data: categoryList, isDisabled: false}]}
                         onCheckboxPress={toggleCategory}
-                        onSelectRow={(item) => {selectionMode?.isEnabled ? toggleCategory(item): (setShouldPreserveSelection(true),navigateToCategorySettings(item))}}
+                        onSelectRow={(item) => {
+                            selectionMode?.isEnabled ? toggleCategory(item) : (setShouldPreserveSelection(true), navigateToCategorySettings(item));
+                        }}
                         shouldPreventDefaultFocusOnSelectRow={!DeviceCapabilities.canUseTouchScreen()}
                         onSelectAll={toggleAllCategories}
                         ListItem={TableListItem}

--- a/src/pages/workspace/categories/WorkspaceCategoriesPage.tsx
+++ b/src/pages/workspace/categories/WorkspaceCategoriesPage.tsx
@@ -133,6 +133,14 @@ function WorkspaceCategoriesPage({route}: WorkspaceCategoriesPageProps) {
         const isAllSelected = availableCategories.length === Object.keys(selectedCategories).length;
         setSelectedCategories(isAllSelected ? {} : Object.fromEntries(availableCategories.map((item) => [item.keyForList, true])));
     };
+    const onSelectCategory = (category: PolicyOption) => {
+        if (selectionMode?.isEnabled) {
+            toggleCategory(category);
+            return;
+        }
+        setShouldPreserveSelection(true);
+        navigateToCategorySettings(category);
+    };
 
     const getCustomListHeader = () => (
         <View style={[styles.flex1, styles.flexRow, styles.justifyContentBetween, styles.pl3, styles.pr9, !canSelectMultiple && styles.m5]}>
@@ -412,9 +420,7 @@ function WorkspaceCategoriesPage({route}: WorkspaceCategoriesPageProps) {
                         onTurnOnSelectionMode={(item) => item && toggleCategory(item)}
                         sections={[{data: categoryList, isDisabled: false}]}
                         onCheckboxPress={toggleCategory}
-                        onSelectRow={(item) => {
-                            selectionMode?.isEnabled ? toggleCategory(item) : (setShouldPreserveSelection(true), navigateToCategorySettings(item));
-                        }}
+                        onSelectRow={onSelectCategory}
                         shouldPreventDefaultFocusOnSelectRow={!DeviceCapabilities.canUseTouchScreen()}
                         onSelectAll={toggleAllCategories}
                         ListItem={TableListItem}

--- a/src/pages/workspace/categories/WorkspaceCategoriesPage.tsx
+++ b/src/pages/workspace/categories/WorkspaceCategoriesPage.tsx
@@ -72,6 +72,7 @@ function WorkspaceCategoriesPage({route}: WorkspaceCategoriesPageProps) {
     const backTo = route.params?.backTo;
     const policy = usePolicy(policyId);
     const {selectionMode} = useMobileSelectionMode();
+    const [shouldPreserveSelection, setShouldPreserveSelection] = useState(false);
     const [policyCategories] = useOnyx(`${ONYXKEYS.COLLECTION.POLICY_CATEGORIES}${policyId}`);
     const isConnectedToAccounting = Object.keys(policy?.connections ?? {}).length > 0;
     const currentConnectionName = PolicyUtils.getCurrentConnectionName(policy);
@@ -91,7 +92,8 @@ function WorkspaceCategoriesPage({route}: WorkspaceCategoriesPageProps) {
     );
 
     useEffect(() => {
-        if (isFocused) {
+        if (isFocused || shouldPreserveSelection) {
+            setShouldPreserveSelection(false);
             return;
         }
         setSelectedCategories({});
@@ -308,6 +310,7 @@ function WorkspaceCategoriesPage({route}: WorkspaceCategoriesPageProps) {
                 icon: Expensicons.Table,
                 text: translate('spreadsheet.importSpreadsheet'),
                 onSelected: () => {
+                    setShouldPreserveSelection(true);
                     if (isOffline) {
                         Modal.close(() => setIsOfflineModalVisible(true));
                         return;
@@ -409,7 +412,7 @@ function WorkspaceCategoriesPage({route}: WorkspaceCategoriesPageProps) {
                         onTurnOnSelectionMode={(item) => item && toggleCategory(item)}
                         sections={[{data: categoryList, isDisabled: false}]}
                         onCheckboxPress={toggleCategory}
-                        onSelectRow={navigateToCategorySettings}
+                        onSelectRow={(item) => {selectionMode?.isEnabled ? toggleCategory(item): (setShouldPreserveSelection(true),navigateToCategorySettings(item))}}
                         shouldPreventDefaultFocusOnSelectRow={!DeviceCapabilities.canUseTouchScreen()}
                         onSelectAll={toggleAllCategories}
                         ListItem={TableListItem}

--- a/src/pages/workspace/distanceRates/PolicyDistanceRatesPage.tsx
+++ b/src/pages/workspace/distanceRates/PolicyDistanceRatesPage.tsx
@@ -99,6 +99,7 @@ function PolicyDistanceRatesPage({
             return;
         }
         setSelectedDistanceRates([]);
+        // eslint-disable-next-line react-compiler/react-compiler, react-hooks/exhaustive-deps
     }, [isFocused]);
 
     const distanceRatesList = useMemo<RateForList[]>(

--- a/src/pages/workspace/distanceRates/PolicyDistanceRatesPage.tsx
+++ b/src/pages/workspace/distanceRates/PolicyDistanceRatesPage.tsx
@@ -53,6 +53,7 @@ function PolicyDistanceRatesPage({
     const isFocused = useIsFocused();
     const policy = usePolicy(policyID);
     const {selectionMode} = useMobileSelectionMode();
+    const [shouldPreserveSelection, setShouldPreserveSelection] = useState(false);
 
     const canSelectMultiple = shouldUseNarrowLayout ? selectionMode?.isEnabled : true;
 
@@ -93,7 +94,8 @@ function PolicyDistanceRatesPage({
     );
 
     useEffect(() => {
-        if (isFocused) {
+        if (isFocused || shouldPreserveSelection) {
+            setShouldPreserveSelection(false);
             return;
         }
         setSelectedDistanceRates([]);
@@ -322,7 +324,7 @@ function PolicyDistanceRatesPage({
                         onTurnOnSelectionMode={(item) => item && toggleRate(item)}
                         sections={[{data: distanceRatesList, isDisabled: false}]}
                         onCheckboxPress={toggleRate}
-                        onSelectRow={openRateDetails}
+                        onSelectRow={(item) => {selectionMode?.isEnabled ? toggleRate(item):(setShouldPreserveSelection(true),openRateDetails(item))}}
                         onSelectAll={toggleAllRates}
                         onDismissError={dismissError}
                         ListItem={TableListItem}

--- a/src/pages/workspace/distanceRates/PolicyDistanceRatesPage.tsx
+++ b/src/pages/workspace/distanceRates/PolicyDistanceRatesPage.tsx
@@ -324,7 +324,9 @@ function PolicyDistanceRatesPage({
                         onTurnOnSelectionMode={(item) => item && toggleRate(item)}
                         sections={[{data: distanceRatesList, isDisabled: false}]}
                         onCheckboxPress={toggleRate}
-                        onSelectRow={(item) => {selectionMode?.isEnabled ? toggleRate(item):(setShouldPreserveSelection(true),openRateDetails(item))}}
+                        onSelectRow={(item) => {
+                            selectionMode?.isEnabled ? toggleRate(item) : (setShouldPreserveSelection(true), openRateDetails(item));
+                        }}
                         onSelectAll={toggleAllRates}
                         onDismissError={dismissError}
                         ListItem={TableListItem}

--- a/src/pages/workspace/distanceRates/PolicyDistanceRatesPage.tsx
+++ b/src/pages/workspace/distanceRates/PolicyDistanceRatesPage.tsx
@@ -195,6 +195,14 @@ function PolicyDistanceRatesPage({
         }
     };
 
+    const onSelectDistanceRate = (rate: RateForList) => {
+        if (selectionMode?.isEnabled) {
+            toggleRate(rate);
+            return;
+        }
+        setShouldPreserveSelection(true);
+        openRateDetails(rate);
+    };
     const getCustomListHeader = () => (
         <View style={[styles.flex1, styles.flexRow, styles.justifyContentBetween, styles.pl3, styles.pr9, !canSelectMultiple && styles.m5]}>
             <Text style={styles.searchInputStyle}>{translate('workspace.distanceRates.rate')}</Text>
@@ -324,9 +332,7 @@ function PolicyDistanceRatesPage({
                         onTurnOnSelectionMode={(item) => item && toggleRate(item)}
                         sections={[{data: distanceRatesList, isDisabled: false}]}
                         onCheckboxPress={toggleRate}
-                        onSelectRow={(item) => {
-                            selectionMode?.isEnabled ? toggleRate(item) : (setShouldPreserveSelection(true), openRateDetails(item));
-                        }}
+                        onSelectRow={onSelectDistanceRate}
                         onSelectAll={toggleAllRates}
                         onDismissError={dismissError}
                         ListItem={TableListItem}

--- a/src/pages/workspace/distanceRates/PolicyDistanceRatesPage.tsx
+++ b/src/pages/workspace/distanceRates/PolicyDistanceRatesPage.tsx
@@ -203,6 +203,7 @@ function PolicyDistanceRatesPage({
         setShouldPreserveSelection(true);
         openRateDetails(rate);
     };
+
     const getCustomListHeader = () => (
         <View style={[styles.flex1, styles.flexRow, styles.justifyContentBetween, styles.pl3, styles.pr9, !canSelectMultiple && styles.m5]}>
             <Text style={styles.searchInputStyle}>{translate('workspace.distanceRates.rate')}</Text>

--- a/src/pages/workspace/invoices/WorkspaceInvoicesPage.tsx
+++ b/src/pages/workspace/invoices/WorkspaceInvoicesPage.tsx
@@ -8,6 +8,7 @@ import type {FullScreenNavigatorParamList} from '@navigation/types';
 import WorkspacePageWithSections from '@pages/workspace/WorkspacePageWithSections';
 import CONST from '@src/CONST';
 import type SCREENS from '@src/SCREENS';
+import AccessOrNotFoundWrapper from '../AccessOrNotFoundWrapper';
 import WorkspaceInvoicesNoVBAView from './WorkspaceInvoicesNoVBAView';
 import WorkspaceInvoicesVBAView from './WorkspaceInvoicesVBAView';
 
@@ -18,21 +19,27 @@ function WorkspaceInvoicesPage({route}: WorkspaceInvoicesPageProps) {
     const styles = useThemeStyles();
     const {shouldUseNarrowLayout} = useResponsiveLayout();
     return (
-        <WorkspacePageWithSections
-            shouldUseScrollView
-            headerText={translate('workspace.common.invoices')}
-            guidesCallTaskID={CONST.GUIDES_CALL_TASK_IDS.WORKSPACE_INVOICES}
-            shouldShowOfflineIndicatorInWideScreen
-            shouldSkipVBBACall={false}
-            route={route}
+        <AccessOrNotFoundWrapper
+            accessVariants={[CONST.POLICY.ACCESS_VARIANTS.ADMIN, CONST.POLICY.ACCESS_VARIANTS.PAID]}
+            policyID={route.params.policyID}
+            featureName={CONST.POLICY.MORE_FEATURES.ARE_INVOICES_ENABLED}
         >
-            {(hasVBA?: boolean, policyID?: string) => (
-                <View style={[styles.mt3, shouldUseNarrowLayout ? styles.workspaceSectionMobile : styles.workspaceSection]}>
-                    {!hasVBA && policyID && <WorkspaceInvoicesNoVBAView policyID={policyID} />}
-                    {hasVBA && policyID && <WorkspaceInvoicesVBAView policyID={policyID} />}
-                </View>
-            )}
-        </WorkspacePageWithSections>
+            <WorkspacePageWithSections
+                shouldUseScrollView
+                headerText={translate('workspace.common.invoices')}
+                guidesCallTaskID={CONST.GUIDES_CALL_TASK_IDS.WORKSPACE_INVOICES}
+                shouldShowOfflineIndicatorInWideScreen
+                shouldSkipVBBACall={false}
+                route={route}
+            >
+                {(hasVBA?: boolean, policyID?: string) => (
+                    <View style={[styles.mt3, shouldUseNarrowLayout ? styles.workspaceSectionMobile : styles.workspaceSection]}>
+                        {!hasVBA && policyID && <WorkspaceInvoicesNoVBAView policyID={policyID} />}
+                        {hasVBA && policyID && <WorkspaceInvoicesVBAView policyID={policyID} />}
+                    </View>
+                )}
+            </WorkspacePageWithSections>
+        </AccessOrNotFoundWrapper>
     );
 }
 

--- a/src/pages/workspace/reportFields/WorkspaceReportFieldsPage.tsx
+++ b/src/pages/workspace/reportFields/WorkspaceReportFieldsPage.tsx
@@ -98,6 +98,7 @@ function WorkspaceReportFieldsPage({
             return;
         }
         setSelectedReportFields([]);
+        // eslint-disable-next-line react-compiler/react-compiler, react-hooks/exhaustive-deps
     }, [isFocused]);
 
     const reportFieldsSections = useMemo(() => {

--- a/src/pages/workspace/reportFields/WorkspaceReportFieldsPage.tsx
+++ b/src/pages/workspace/reportFields/WorkspaceReportFieldsPage.tsx
@@ -146,6 +146,10 @@ function WorkspaceReportFieldsPage({
         setSelectedReportFields(isAllSelected ? [] : availableReportFields);
     };
 
+    const navigateToReportFieldsSettings = (reportField: ReportFieldForList) => {
+        Navigation.navigate(ROUTES.WORKSPACE_REPORT_FIELDS_SETTINGS.getRoute(policyID, reportField.fieldID));
+    };
+
     const onSelectReportField = (field: ReportFieldForList) => {
         if (selectionMode?.isEnabled) {
             updateSelectedReportFields(field);
@@ -153,10 +157,6 @@ function WorkspaceReportFieldsPage({
         }
         setShouldPreserveSelection(true);
         navigateToReportFieldsSettings(field);
-    };
-
-    const navigateToReportFieldsSettings = (reportField: ReportFieldForList) => {
-        Navigation.navigate(ROUTES.WORKSPACE_REPORT_FIELDS_SETTINGS.getRoute(policyID, reportField.fieldID));
     };
 
     const handleDeleteReportFields = () => {

--- a/src/pages/workspace/reportFields/WorkspaceReportFieldsPage.tsx
+++ b/src/pages/workspace/reportFields/WorkspaceReportFieldsPage.tsx
@@ -146,6 +146,15 @@ function WorkspaceReportFieldsPage({
         setSelectedReportFields(isAllSelected ? [] : availableReportFields);
     };
 
+    const onSelectReportField = (field: ReportFieldForList) => {
+        if (selectionMode?.isEnabled) {
+            updateSelectedReportFields(field);
+            return;
+        }
+        setShouldPreserveSelection(true);
+        navigateToReportFieldsSettings(field);
+    };
+
     const navigateToReportFieldsSettings = (reportField: ReportFieldForList) => {
         Navigation.navigate(ROUTES.WORKSPACE_REPORT_FIELDS_SETTINGS.getRoute(policyID, reportField.fieldID));
     };
@@ -306,9 +315,7 @@ function WorkspaceReportFieldsPage({
                         onTurnOnSelectionMode={(item) => item && updateSelectedReportFields(item)}
                         sections={reportFieldsSections}
                         onCheckboxPress={updateSelectedReportFields}
-                        onSelectRow={(item) => {
-                            selectionMode?.isEnabled ? updateSelectedReportFields(item) : (setShouldPreserveSelection(true), navigateToReportFieldsSettings(item));
-                        }}
+                        onSelectRow={onSelectReportField}
                         onSelectAll={toggleAllReportFields}
                         ListItem={TableListItem}
                         customListHeader={getCustomListHeader()}

--- a/src/pages/workspace/reportFields/WorkspaceReportFieldsPage.tsx
+++ b/src/pages/workspace/reportFields/WorkspaceReportFieldsPage.tsx
@@ -306,7 +306,9 @@ function WorkspaceReportFieldsPage({
                         onTurnOnSelectionMode={(item) => item && updateSelectedReportFields(item)}
                         sections={reportFieldsSections}
                         onCheckboxPress={updateSelectedReportFields}
-                        onSelectRow={(item) => {selectionMode?.isEnabled ? updateSelectedReportFields(item):(setShouldPreserveSelection(true),navigateToReportFieldsSettings(item))}}
+                        onSelectRow={(item) => {
+                            selectionMode?.isEnabled ? updateSelectedReportFields(item) : (setShouldPreserveSelection(true), navigateToReportFieldsSettings(item));
+                        }}
                         onSelectAll={toggleAllReportFields}
                         ListItem={TableListItem}
                         customListHeader={getCustomListHeader()}

--- a/src/pages/workspace/reportFields/WorkspaceReportFieldsPage.tsx
+++ b/src/pages/workspace/reportFields/WorkspaceReportFieldsPage.tsx
@@ -74,6 +74,7 @@ function WorkspaceReportFieldsPage({
         return Object.fromEntries(Object.entries(policy.fieldList).filter(([_, value]) => value.fieldID !== 'text_title'));
     }, [policy]);
     const [selectedReportFields, setSelectedReportFields] = useState<PolicyReportField[]>([]);
+    const [shouldPreserveSelection, setShouldPreserveSelection] = useState(false);
     const [deleteReportFieldsConfirmModalVisible, setDeleteReportFieldsConfirmModalVisible] = useState(false);
     const hasAccountingConnections = PolicyUtils.hasAccountingConnections(policy);
     const isConnectedToAccounting = Object.keys(policy?.connections ?? {}).length > 0;
@@ -92,7 +93,8 @@ function WorkspaceReportFieldsPage({
     useFocusEffect(fetchReportFields);
 
     useEffect(() => {
-        if (isFocused) {
+        if (isFocused || shouldPreserveSelection) {
+            setShouldPreserveSelection(false);
             return;
         }
         setSelectedReportFields([]);
@@ -304,7 +306,7 @@ function WorkspaceReportFieldsPage({
                         onTurnOnSelectionMode={(item) => item && updateSelectedReportFields(item)}
                         sections={reportFieldsSections}
                         onCheckboxPress={updateSelectedReportFields}
-                        onSelectRow={navigateToReportFieldsSettings}
+                        onSelectRow={(item) => {selectionMode?.isEnabled ? updateSelectedReportFields(item):(setShouldPreserveSelection(true),navigateToReportFieldsSettings(item))}}
                         onSelectAll={toggleAllReportFields}
                         ListItem={TableListItem}
                         customListHeader={getCustomListHeader()}

--- a/src/pages/workspace/tags/WorkspaceTagsPage.tsx
+++ b/src/pages/workspace/tags/WorkspaceTagsPage.tsx
@@ -423,7 +423,9 @@ function WorkspaceTagsPage({route}: WorkspaceTagsPageProps) {
                         onTurnOnSelectionMode={(item) => item && toggleTag(item)}
                         sections={[{data: tagList, isDisabled: false}]}
                         onCheckboxPress={toggleTag}
-                        onSelectRow={(item) => {selectionMode?.isEnabled ? toggleTag(item): (setShouldPreserveSelection(true),navigateToTagSettings(item))}}
+                        onSelectRow={(item) => {
+                            selectionMode?.isEnabled ? toggleTag(item) : (setShouldPreserveSelection(true), navigateToTagSettings(item));
+                        }}
                         shouldSingleExecuteRowSelect={!canSelectMultiple}
                         onSelectAll={toggleAllTags}
                         ListItem={TableListItem}

--- a/src/pages/workspace/tags/WorkspaceTagsPage.tsx
+++ b/src/pages/workspace/tags/WorkspaceTagsPage.tsx
@@ -152,15 +152,6 @@ function WorkspaceTagsPage({route}: WorkspaceTagsPageProps) {
         setSelectedTags(isAllSelected ? {} : Object.fromEntries(availableTags.map((item) => [item.value, true])));
     };
 
-    const onSelectTag = (tag: TagListItem) => {
-        if (selectionMode?.isEnabled) {
-            toggleTag(tag);
-            return;
-        }
-        setShouldPreserveSelection(true);
-        navigateToTagSettings(tag);
-    };
-
     const getCustomListHeader = () => {
         const header = (
             <View
@@ -196,6 +187,15 @@ function WorkspaceTagsPage({route}: WorkspaceTagsPageProps) {
             return;
         }
         Navigation.navigate(ROUTES.WORKSPACE_TAG_SETTINGS.getRoute(policyID, 0, tag.value));
+    };
+
+    const onSelectTag = (tag: TagListItem) => {
+        if (selectionMode?.isEnabled) {
+            toggleTag(tag);
+            return;
+        }
+        setShouldPreserveSelection(true);
+        navigateToTagSettings(tag);
     };
 
     const selectedTagsArray = Object.keys(selectedTags).filter((key) => selectedTags[key]);

--- a/src/pages/workspace/tags/WorkspaceTagsPage.tsx
+++ b/src/pages/workspace/tags/WorkspaceTagsPage.tsx
@@ -152,6 +152,15 @@ function WorkspaceTagsPage({route}: WorkspaceTagsPageProps) {
         setSelectedTags(isAllSelected ? {} : Object.fromEntries(availableTags.map((item) => [item.value, true])));
     };
 
+    const onSelectTag = (tag: TagListItem) => {
+        if (selectionMode?.isEnabled) {
+            toggleTag(tag);
+            return;
+        }
+        setShouldPreserveSelection(true);
+        navigateToTagSettings(tag);
+    };
+
     const getCustomListHeader = () => {
         const header = (
             <View
@@ -423,9 +432,7 @@ function WorkspaceTagsPage({route}: WorkspaceTagsPageProps) {
                         onTurnOnSelectionMode={(item) => item && toggleTag(item)}
                         sections={[{data: tagList, isDisabled: false}]}
                         onCheckboxPress={toggleTag}
-                        onSelectRow={(item) => {
-                            selectionMode?.isEnabled ? toggleTag(item) : (setShouldPreserveSelection(true), navigateToTagSettings(item));
-                        }}
+                        onSelectRow={onSelectTag}
                         shouldSingleExecuteRowSelect={!canSelectMultiple}
                         onSelectAll={toggleAllTags}
                         ListItem={TableListItem}

--- a/src/pages/workspace/tags/WorkspaceTagsPage.tsx
+++ b/src/pages/workspace/tags/WorkspaceTagsPage.tsx
@@ -65,6 +65,7 @@ function WorkspaceTagsPage({route}: WorkspaceTagsPageProps) {
     const policy = usePolicy(policyID);
     const [policyTags] = useOnyx(`${ONYXKEYS.COLLECTION.POLICY_TAGS}${policyID}`);
     const {selectionMode} = useMobileSelectionMode();
+    const [shouldPreserveSelection, setShouldPreserveSelection] = useState(false);
     const {environmentURL} = useEnvironment();
     const isConnectedToAccounting = Object.keys(policy?.connections ?? {}).length > 0;
     const currentConnectionName = PolicyUtils.getCurrentConnectionName(policy);
@@ -80,7 +81,8 @@ function WorkspaceTagsPage({route}: WorkspaceTagsPageProps) {
     useFocusEffect(fetchTags);
 
     useEffect(() => {
-        if (isFocused) {
+        if (isFocused || shouldPreserveSelection) {
+            setShouldPreserveSelection(false);
             return;
         }
         setSelectedTags({});
@@ -300,6 +302,7 @@ function WorkspaceTagsPage({route}: WorkspaceTagsPageProps) {
                 icon: Expensicons.Table,
                 text: translate('spreadsheet.importSpreadsheet'),
                 onSelected: () => {
+                    setShouldPreserveSelection(true);
                     if (isOffline) {
                         Modal.close(() => setIsOfflineModalVisible(true));
                         return;
@@ -420,7 +423,7 @@ function WorkspaceTagsPage({route}: WorkspaceTagsPageProps) {
                         onTurnOnSelectionMode={(item) => item && toggleTag(item)}
                         sections={[{data: tagList, isDisabled: false}]}
                         onCheckboxPress={toggleTag}
-                        onSelectRow={navigateToTagSettings}
+                        onSelectRow={(item) => {selectionMode?.isEnabled ? toggleTag(item): (setShouldPreserveSelection(true),navigateToTagSettings(item))}}
                         shouldSingleExecuteRowSelect={!canSelectMultiple}
                         onSelectAll={toggleAllTags}
                         ListItem={TableListItem}

--- a/src/pages/workspace/tags/WorkspaceTagsPage.tsx
+++ b/src/pages/workspace/tags/WorkspaceTagsPage.tsx
@@ -86,6 +86,7 @@ function WorkspaceTagsPage({route}: WorkspaceTagsPageProps) {
             return;
         }
         setSelectedTags({});
+        // eslint-disable-next-line react-compiler/react-compiler, react-hooks/exhaustive-deps
     }, [isFocused]);
 
     const getPendingAction = (policyTagList: PolicyTagList): PendingAction | undefined => {

--- a/src/pages/workspace/taxes/WorkspaceTaxesPage.tsx
+++ b/src/pages/workspace/taxes/WorkspaceTaxesPage.tsx
@@ -83,6 +83,7 @@ function WorkspaceTaxesPage({
             return;
         }
         setSelectedTaxesIDs([]);
+        // eslint-disable-next-line react-compiler/react-compiler, react-hooks/exhaustive-deps
     }, [isFocused]);
 
     const textForDefault = useCallback(

--- a/src/pages/workspace/taxes/WorkspaceTaxesPage.tsx
+++ b/src/pages/workspace/taxes/WorkspaceTaxesPage.tsx
@@ -150,15 +150,6 @@ function WorkspaceTaxesPage({
         });
     };
 
-    const onSelectTax = (tax: ListItem) => {
-        if (selectionMode?.isEnabled) {
-            toggleTax(tax);
-            return;
-        }
-        setShouldPreserveSelection(true);
-        navigateToEditTaxRate(tax);
-    };
-
     const getCustomListHeader = () => (
         <View style={[styles.flex1, styles.flexRow, styles.justifyContentBetween, styles.pl3, styles.pr9, !canSelectMultiple && styles.m5]}>
             <Text style={styles.searchInputStyle}>{translate('common.name')}</Text>
@@ -191,6 +182,15 @@ function WorkspaceTaxesPage({
             return;
         }
         Navigation.navigate(ROUTES.WORKSPACE_TAX_EDIT.getRoute(policyID, taxRate.keyForList));
+    };
+
+    const onSelectTax = (tax: ListItem) => {
+        if (selectionMode?.isEnabled) {
+            toggleTax(tax);
+            return;
+        }
+        setShouldPreserveSelection(true);
+        navigateToEditTaxRate(tax);
     };
 
     const dropdownMenuOptions = useMemo(() => {

--- a/src/pages/workspace/taxes/WorkspaceTaxesPage.tsx
+++ b/src/pages/workspace/taxes/WorkspaceTaxesPage.tsx
@@ -315,7 +315,9 @@ function WorkspaceTaxesPage({
                     onTurnOnSelectionMode={(item) => item && toggleTax(item)}
                     sections={[{data: taxesList, isDisabled: false}]}
                     onCheckboxPress={toggleTax}
-                    onSelectRow={(item) => {selectionMode?.isEnabled ? toggleTax(item):(setShouldPreserveSelection(true),navigateToEditTaxRate(item))}}
+                    onSelectRow={(item) => {
+                        selectionMode?.isEnabled ? toggleTax(item) : (setShouldPreserveSelection(true), navigateToEditTaxRate(item));
+                    }}
                     onSelectAll={toggleAllTaxes}
                     ListItem={TableListItem}
                     customListHeader={getCustomListHeader()}

--- a/src/pages/workspace/taxes/WorkspaceTaxesPage.tsx
+++ b/src/pages/workspace/taxes/WorkspaceTaxesPage.tsx
@@ -55,6 +55,7 @@ function WorkspaceTaxesPage({
     const [selectedTaxesIDs, setSelectedTaxesIDs] = useState<string[]>([]);
     const [isDeleteModalVisible, setIsDeleteModalVisible] = useState(false);
     const {selectionMode} = useMobileSelectionMode();
+    const [shouldPreserveSelection, setShouldPreserveSelection] = useState(false);
     const defaultExternalID = policy?.taxRates?.defaultExternalID;
     const foreignTaxDefault = policy?.taxRates?.foreignTaxDefault;
     const isFocused = useIsFocused();
@@ -77,7 +78,8 @@ function WorkspaceTaxesPage({
     );
 
     useEffect(() => {
-        if (isFocused) {
+        if (isFocused || shouldPreserveSelection) {
+            setShouldPreserveSelection(false);
             return;
         }
         setSelectedTaxesIDs([]);
@@ -313,7 +315,7 @@ function WorkspaceTaxesPage({
                     onTurnOnSelectionMode={(item) => item && toggleTax(item)}
                     sections={[{data: taxesList, isDisabled: false}]}
                     onCheckboxPress={toggleTax}
-                    onSelectRow={navigateToEditTaxRate}
+                    onSelectRow={(item) => {selectionMode?.isEnabled ? toggleTax(item):(setShouldPreserveSelection(true),navigateToEditTaxRate(item))}}
                     onSelectAll={toggleAllTaxes}
                     ListItem={TableListItem}
                     customListHeader={getCustomListHeader()}

--- a/src/pages/workspace/taxes/WorkspaceTaxesPage.tsx
+++ b/src/pages/workspace/taxes/WorkspaceTaxesPage.tsx
@@ -150,6 +150,15 @@ function WorkspaceTaxesPage({
         });
     };
 
+    const onSelectTax = (tax: ListItem) => {
+        if (selectionMode?.isEnabled) {
+            toggleTax(tax);
+            return;
+        }
+        setShouldPreserveSelection(true);
+        navigateToEditTaxRate(tax);
+    };
+
     const getCustomListHeader = () => (
         <View style={[styles.flex1, styles.flexRow, styles.justifyContentBetween, styles.pl3, styles.pr9, !canSelectMultiple && styles.m5]}>
             <Text style={styles.searchInputStyle}>{translate('common.name')}</Text>
@@ -315,9 +324,7 @@ function WorkspaceTaxesPage({
                     onTurnOnSelectionMode={(item) => item && toggleTax(item)}
                     sections={[{data: taxesList, isDisabled: false}]}
                     onCheckboxPress={toggleTax}
-                    onSelectRow={(item) => {
-                        selectionMode?.isEnabled ? toggleTax(item) : (setShouldPreserveSelection(true), navigateToEditTaxRate(item));
-                    }}
+                    onSelectRow={onSelectTax}
                     onSelectAll={toggleAllTaxes}
                     ListItem={TableListItem}
                     customListHeader={getCustomListHeader()}


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
Summary
- Changes are made for selection modals of following pages
  1. WorkspaceMembersPage
  2. WorkspaceCategoriesPage
  3. PolicyDistanceRatesPage
  4. WorkspaceReportFieldsPage
  5. WorkspaceTagsPage
  6. WorkspaceTaxesPage
- When using mobile device and selection modal is enabled - on clicking item row, prevent navigation to item -> details page and toggle item selection.
- On desktop devices - on clicking item row, navigate to item -> details page and preserve current selection when navigating back from item -> details page.
- Preserve selection for other RHN pages which could be opened when selection modal is enabled (ie. import spreadsheet page).

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
8. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/49322
PROPOSAL: https://github.com/Expensify/App/issues/49322#issuecomment-2354681501


### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.
same as QA tests.
For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
9. Verify a modal appears displaying a preview of that image
--->
For Desktop devices -
1. Go to Settings > Profile > Select any collect workspace.
2. Enable all features (Distance rates, Categories, Tags, Taxes).
3 Go to members page and select few members using checkbox.
4. Click on any member to open member details.
5. Navigate back to members page.
6. Verify selection is preserved.
7. Navigate to any other page. e.g. (Distance rates, Categories, Tags, Taxes) and comeback.
8. Verify selection is cleared.
9. For Distance rates, Categories, Tags, Taxes and Report Fields repeat step 3 to 8.

For Mobile devices -
1. Go to Settings > Profile > Select any collect workspace.
2. Enable all features (Distance rates, Categories, Tags, Taxes).
3. Long press a member and start selection mode.
4. Click on any member.
5. Verify selection is toggled when clicking on any part of row.
6. For Distance rates, Categories, Tags, Taxes and Report Fields repeat step 3 to 8.

- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->
same as QA tests.

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

https://github.com/user-attachments/assets/4a1c3acb-f9c6-463f-a787-2f001e608953



</details>

<details>
<summary>Android: mWeb Chrome</summary>

https://github.com/user-attachments/assets/49ef7f71-9aa3-47ac-b1d0-6b4840d296f5

</details>

<details>
<summary>iOS: Native</summary>

https://github.com/user-attachments/assets/77123723-4f32-4b25-abe9-45d9d6250748

</details>

<details>
<summary>iOS: mWeb Safari</summary>

https://github.com/user-attachments/assets/eb1bdc74-21cf-4d48-bae3-093468c89aaf

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>


https://github.com/user-attachments/assets/94db8e08-b9a1-4d69-96a6-59ab2086be83


</details>

<details>
<summary>MacOS: Desktop</summary>


https://github.com/user-attachments/assets/6ee1ad52-35ef-409d-b76a-1fd823ebd5cb


</details>




