### PR TITLE
Fix: VisionCamera session is not deinitialized/recycled when screen gets unmounted on `native-stack`

### DIFF
--- a/patches/react-native-vision-camera+4.0.0-beta.13+001+rn75-compatibility.patch
+++ b/patches/react-native-vision-camera+4.0.0-beta.13+001+rn75-compatibility.patch
@@ -1335,7 +1335,7 @@ index 0000000..46c2c2c
 +#endif /* RCT_NEW_ARCH_ENABLED */
 diff --git a/node_modules/react-native-vision-camera/ios/RNCameraView.mm b/node_modules/react-native-vision-camera/ios/RNCameraView.mm
 new file mode 100644
-index 0000000..019be20
+index 0000000..b90427e
 --- /dev/null
 +++ b/node_modules/react-native-vision-camera/ios/RNCameraView.mm
 @@ -0,0 +1,377 @@
@@ -1384,7 +1384,7 @@ index 0000000..019be20
 +
 +    //The remaining part of the initializer is standard Objective-C code to create views and layout them with AutoLayout. Here we can change whatever we want to.
 +    _view = [[CameraView alloc] init];
-+    _view.delegate = self;    
++    _view.delegate = self;
 +
 +    self.contentView = _view;
 +}
@@ -1397,9 +1397,9 @@ index 0000000..019be20
 +{
 +    const auto &newViewProps = *std::static_pointer_cast<CameraViewProps const>(props);
 +    const auto &oldViewProps = *std::static_pointer_cast<CameraViewProps const>(_props);
-+    
++
 +    NSMutableArray* changedProps = [[NSMutableArray alloc] init];
-+    
++
 +    if(oldViewProps.isActive != newViewProps.isActive){
 +        _view.isActive = newViewProps.isActive;
 +        [changedProps addObject:@"isActive"];
@@ -1496,12 +1496,12 @@ index 0000000..019be20
 +        _view.enableFpsGraph = newViewProps.enableFpsGraph;
 +        [changedProps addObject:@"enableFpsGraph"];
 +    }
-+    
-+        
++
++
 +    if(_view.format == nil){
 +        _view.format =[ [NSMutableDictionary alloc] init];
 +    }
-+    
++
 +
 +    //Checking format props, TODO: find cleaner way to do it
 +    if(oldViewProps.format.supportsDepthCapture != newViewProps.format.supportsDepthCapture){
@@ -1521,7 +1521,7 @@ index 0000000..019be20
 +        [_view.format setValue:newPixelFormats forKey:@"pixelFormats"];
 +        [changedProps addObject:@"format"];
 +    }
-+    
++
 +    if(oldViewProps.format.videoStabilizationModes.size() != newViewProps.format.videoStabilizationModes.size()){
 +        NSMutableArray* newVideoStabilizationModes = [[NSMutableArray alloc] init];
 +        for(int i = 0; i < newViewProps.format.videoStabilizationModes.size(); i++){
@@ -1530,7 +1530,7 @@ index 0000000..019be20
 +        [_view.format setValue:newVideoStabilizationModes forKey:@"videoStabilizationModes"];
 +        [changedProps addObject:@"format"];
 +    }
-+    
++
 +    if(oldViewProps.format.photoHeight != newViewProps.format.photoHeight){
 +        [_view.format setValue:[NSNumber numberWithDouble:newViewProps.format.photoHeight] forKey:@"photoHeight"];
 +        [changedProps addObject:@"format"];
@@ -1578,11 +1578,11 @@ index 0000000..019be20
 +        [_view.format setValue:supportsPhotoHDR forKey:@"supportsPhotoHDR"];
 +        [changedProps addObject:@"format"];
 +    }
-+    
++
 +    if (_view.format.count == 0) {
 +        _view.format = nil;
 +    }
-+    
++
 +    if(_view.codeScannerOptions == nil){
 +        _view.codeScannerOptions =[[NSMutableDictionary alloc] init];
 +    }
@@ -1595,12 +1595,12 @@ index 0000000..019be20
 +        [_view.codeScannerOptions setValue:newCodeTypes forKey:@"codeTypes"];
 +        [changedProps addObject:@"codeScannerOptions"];
 +    }
-+    
++
 +    if(oldViewProps.codeScannerOptions.interval != newViewProps.codeScannerOptions.interval){
 +        [_view.codeScannerOptions setValue:[NSNumber numberWithDouble:newViewProps.codeScannerOptions.interval] forKey:@"interval"];
 +        [changedProps addObject:@"codeScannerOptions"];
 +    }
-+    
++
 +    if(
 +       oldViewProps.codeScannerOptions.regionOfInterest.x != newViewProps.codeScannerOptions.regionOfInterest.x ||
 +       oldViewProps.codeScannerOptions.regionOfInterest.y != newViewProps.codeScannerOptions.regionOfInterest.y ||
@@ -1616,7 +1616,7 @@ index 0000000..019be20
 +        [_view.codeScannerOptions setValue:newRegionOfInterest forKey:@"regionOfInterest"];
 +        [changedProps addObject:@"codeScannerOptions"];
 +    }
-+    
++
 +    if (_view.codeScannerOptions.count == 0) {
 +        _view.codeScannerOptions = nil;
 +    }
@@ -2005,25 +2005,6 @@ index 0000000..e47e42f
 @@ -0,0 +1 @@
 +{"version":3,"file":"CameraViewNativeComponent.d.ts","sourceRoot":"","sources":["../../../src/specs/CameraViewNativeComponent.ts"],"names":[],"mappings":";;AACA,OAAO,KAAK,EAAE,aAAa,EAAE,SAAS,EAAE,MAAM,cAAc,CAAC;AAC7D,OAAO,KAAK,EAAE,kBAAkB,EAAE,MAAM,EAAE,KAAK,EAAE,MAAM,2CAA2C,CAAC;AAGnG,MAAM,MAAM,yBAAyB,GAAG,aAAa,CAAC,WAAW,CAAC,CAAC;AAEnE,MAAM,WAAW,WAAY,SAAQ,SAAS;IAC5C,gBAAgB,EAAE,OAAO,CAAC;IAC1B,sBAAsB,CAAC,EAAE,MAAM,CAAC;IAChC,QAAQ,EAAE,MAAM,CAAC;IACjB,oBAAoB,EAAE,OAAO,CAAC;IAC9B,cAAc,EAAE,OAAO,CAAC;IACxB,uBAAuB,EAAE,OAAO,CAAC;IACjC,mBAAmB,EAAE,MAAM,CAAC;IAC5B,QAAQ,EAAE,OAAO,CAAC;IAClB,KAAK,CAAC,EAAE,OAAO,CAAC;IAChB,KAAK,CAAC,EAAE,OAAO,CAAC;IAChB,KAAK,CAAC,EAAE,OAAO,CAAC;IAChB,KAAK,CAAC,EAAE,MAAM,CAAC;IACf,IAAI,CAAC,EAAE,MAAM,CAAC;IACd,QAAQ,CAAC,EAAE,MAAM,CAAC;IAClB,iBAAiB,CAAC,EAAE,OAAO,CAAC;IAC5B,cAAc,CAAC,EAAE,OAAO,CAAC;IACzB,UAAU,CAAC,EAAE,MAAM,CAAC;IACpB,MAAM,CAAC,EAAE,QAAQ,CAAC;QAChB,oBAAoB,CAAC,EAAE,OAAO,CAAC;QAC/B,WAAW,EAAE,MAAM,CAAC;QACpB,UAAU,EAAE,MAAM,CAAC;QACnB,WAAW,EAAE,MAAM,CAAC;QACpB,UAAU,EAAE,MAAM,CAAC;QACnB,MAAM,EAAE,MAAM,CAAC;QACf,MAAM,EAAE,MAAM,CAAC;QACf,MAAM,EAAE,MAAM,CAAC;QACf,MAAM,EAAE,MAAM,CAAC;QACf,WAAW,EAAE,MAAM,CAAC;QACpB,gBAAgB,EAAE,OAAO,CAAC;QAC1B,gBAAgB,EAAE,OAAO,CAAC;QAC1B,eAAe,EAAE,MAAM,CAAC;QACxB,uBAAuB,EAAE,MAAM,EAAE,CAAC;QAClC,YAAY,EAAE,MAAM,EAAE,CAAC;KACxB,CAAC,CAAC;IACH,WAAW,EAAE,MAAM,CAAC;IACpB,GAAG,CAAC,EAAE,KAAK,CAAC;IACZ,QAAQ,CAAC,EAAE,OAAO,CAAC;IACnB,QAAQ,CAAC,EAAE,OAAO,CAAC;IACnB,aAAa,CAAC,EAAE,OAAO,CAAC;IACxB,sBAAsB,CAAC,EAAE,MAAM,CAAC;IAChC,eAAe,CAAC,EAAE,OAAO,CAAC;IAC1B,kCAAkC,CAAC,EAAE,OAAO,CAAC;IAC7C,WAAW,CAAC,EAAE,MAAM,CAAC;IACrB,kBAAkB,CAAC,EAAE,QAAQ,CAAC;QAC5B,SAAS,CAAC,EAAE,MAAM,EAAE,CAAC;QACrB,QAAQ,CAAC,EAAE,MAAM,CAAC;QAClB,gBAAgB,CAAC,EAAE,QAAQ,CAAC;YAC1B,CAAC,CAAC,EAAE,MAAM,CAAC;YACX,CAAC,CAAC,EAAE,MAAM,CAAC;YACX,KAAK,CAAC,EAAE,MAAM,CAAC;YACf,MAAM,CAAC,EAAE,MAAM,CAAC;SACjB,CAAC,CAAC;KACJ,CAAC,CAAC;IACH,aAAa,CAAC,EAAE,kBAAkB,CAChC,QAAQ,CAAC;QACP,KAAK,CAAC,EAAE,QAAQ,CAAC;YACf,IAAI,CAAC,EAAE,MAAM,CAAC;YACd,KAAK,CAAC,EAAE,MAAM,CAAC;YACf,KAAK,CAAC,EAAE,QAAQ,CAAC;gBAAE,CAAC,EAAE,MAAM,CAAC;gBAAC,CAAC,EAAE,MAAM,CAAC;gBAAC,KAAK,EAAE,MAAM,CAAC;gBAAC,MAAM,EAAE,MAAM,CAAA;aAAC,CAAC,CAAC;SAC1E,CAAC,CAAC;QACH,KAAK,CAAC,EAAE,QAAQ,CAAC;YAAE,KAAK,EAAE,KAAK,CAAC;YAAC,MAAM,EAAE,KAAK,CAAA;SAAE,CAAC,CAAC;QAClD,OAAO,CAAC,EAAE,QAAQ,CAAC;YAAE,CAAC,EAAE,MAAM,CAAC;YAAC,CAAC,EAAE,MAAM,CAAA;SAAE,CAAC,CAAC;KAC9C,CAAC,CACH,CAAC;IACF,SAAS,CAAC,EAAE,kBAAkB,CAC5B,QAAQ,CAAC;QACP,IAAI,EAAE,MAAM,CAAC;KACd,CAAC,CACH,CAAC;IACF,SAAS,CAAC,EAAE,kBAAkB,CAAC,QAAQ,CAAC,EAAE,CAAC,CAAC,CAAC;IAC7C,SAAS,CAAC,EAAE,kBAAkB,CAAC,QAAQ,CAAC,EAAE,CAAC,CAAC,CAAC;IAC7C,aAAa,CAAC,EAAE,kBAAkB,CAAC,QAAQ,CAAC,EAAE,CAAC,CAAC,CAAC;IACjD,OAAO,CAAC,EAAE,kBAAkB,CAC1B,QAAQ,CAAC;QACP,IAAI,EAAE,MAAM,CAAC;QACb,OAAO,EAAE,MAAM,CAAC;QAChB,KAAK,EAAE,QAAQ,CAAC;YAAE,IAAI,EAAE,MAAM,CAAC;YAAC,MAAM,EAAE,MAAM,CAAC;YAAC,OAAO,EAAE,MAAM,CAAC;YAAC,OAAO,EAAE,MAAM,CAAA;SAAE,CAAC,CAAC;KACrF,CAAC,CACH,CAAC;IACF,WAAW,EAAE,kBAAkB,CAAC,QAAQ,CAAC,EAAE,CAAC,CAAC,CAAC;CAC/C;;AAED,wBAAiE"}
 \ No newline at end of file
-diff --git a/node_modules/react-native-vision-camera/package.json b/node_modules/react-native-vision-camera/package.json
-index 86352fa..7af9577 100644
---- a/node_modules/react-native-vision-camera/package.json
-+++ b/node_modules/react-native-vision-camera/package.json
-@@ -166,5 +166,13 @@
-       ]
-     ]
-   },
--  "packageManager": "yarn@1.22.19+sha1.4ba7fc5c6e704fce2066ecbfb0b0d8976fe62447"
-+  "codegenConfig": {
-+    "name": "RNVisioncameraSpec",
-+    "type": "all",
-+    "jsSrcsDir": "./src/specs",
-+    "android": {
-+      "javaPackageName": "com.mrousavy.camera"
-+    }
-+  },
-+  "packageManager": "yarn@1.22.19"
- }
 diff --git a/node_modules/react-native-vision-camera/src/Camera.tsx b/node_modules/react-native-vision-camera/src/Camera.tsx
 index 18733ba..1668322 100644
 --- a/node_modules/react-native-vision-camera/src/Camera.tsx

--- a/patches/react-native-vision-camera+4.0.0-beta.13+001+rn75-compatibility.patch
+++ b/patches/react-native-vision-camera+4.0.0-beta.13+001+rn75-compatibility.patch
@@ -1335,7 +1335,7 @@ index 0000000..46c2c2c
 +#endif /* RCT_NEW_ARCH_ENABLED */
 diff --git a/node_modules/react-native-vision-camera/ios/RNCameraView.mm b/node_modules/react-native-vision-camera/ios/RNCameraView.mm
 new file mode 100644
-index 0000000..b90427e
+index 0000000..019be20
 --- /dev/null
 +++ b/node_modules/react-native-vision-camera/ios/RNCameraView.mm
 @@ -0,0 +1,377 @@
@@ -1384,7 +1384,7 @@ index 0000000..b90427e
 +
 +    //The remaining part of the initializer is standard Objective-C code to create views and layout them with AutoLayout. Here we can change whatever we want to.
 +    _view = [[CameraView alloc] init];
-+    _view.delegate = self;
++    _view.delegate = self;    
 +
 +    self.contentView = _view;
 +}
@@ -1397,9 +1397,9 @@ index 0000000..b90427e
 +{
 +    const auto &newViewProps = *std::static_pointer_cast<CameraViewProps const>(props);
 +    const auto &oldViewProps = *std::static_pointer_cast<CameraViewProps const>(_props);
-+
++    
 +    NSMutableArray* changedProps = [[NSMutableArray alloc] init];
-+
++    
 +    if(oldViewProps.isActive != newViewProps.isActive){
 +        _view.isActive = newViewProps.isActive;
 +        [changedProps addObject:@"isActive"];
@@ -1496,12 +1496,12 @@ index 0000000..b90427e
 +        _view.enableFpsGraph = newViewProps.enableFpsGraph;
 +        [changedProps addObject:@"enableFpsGraph"];
 +    }
-+
-+
++    
++        
 +    if(_view.format == nil){
 +        _view.format =[ [NSMutableDictionary alloc] init];
 +    }
-+
++    
 +
 +    //Checking format props, TODO: find cleaner way to do it
 +    if(oldViewProps.format.supportsDepthCapture != newViewProps.format.supportsDepthCapture){
@@ -1521,7 +1521,7 @@ index 0000000..b90427e
 +        [_view.format setValue:newPixelFormats forKey:@"pixelFormats"];
 +        [changedProps addObject:@"format"];
 +    }
-+
++    
 +    if(oldViewProps.format.videoStabilizationModes.size() != newViewProps.format.videoStabilizationModes.size()){
 +        NSMutableArray* newVideoStabilizationModes = [[NSMutableArray alloc] init];
 +        for(int i = 0; i < newViewProps.format.videoStabilizationModes.size(); i++){
@@ -1530,7 +1530,7 @@ index 0000000..b90427e
 +        [_view.format setValue:newVideoStabilizationModes forKey:@"videoStabilizationModes"];
 +        [changedProps addObject:@"format"];
 +    }
-+
++    
 +    if(oldViewProps.format.photoHeight != newViewProps.format.photoHeight){
 +        [_view.format setValue:[NSNumber numberWithDouble:newViewProps.format.photoHeight] forKey:@"photoHeight"];
 +        [changedProps addObject:@"format"];
@@ -1578,11 +1578,11 @@ index 0000000..b90427e
 +        [_view.format setValue:supportsPhotoHDR forKey:@"supportsPhotoHDR"];
 +        [changedProps addObject:@"format"];
 +    }
-+
++    
 +    if (_view.format.count == 0) {
 +        _view.format = nil;
 +    }
-+
++    
 +    if(_view.codeScannerOptions == nil){
 +        _view.codeScannerOptions =[[NSMutableDictionary alloc] init];
 +    }
@@ -1595,12 +1595,12 @@ index 0000000..b90427e
 +        [_view.codeScannerOptions setValue:newCodeTypes forKey:@"codeTypes"];
 +        [changedProps addObject:@"codeScannerOptions"];
 +    }
-+
++    
 +    if(oldViewProps.codeScannerOptions.interval != newViewProps.codeScannerOptions.interval){
 +        [_view.codeScannerOptions setValue:[NSNumber numberWithDouble:newViewProps.codeScannerOptions.interval] forKey:@"interval"];
 +        [changedProps addObject:@"codeScannerOptions"];
 +    }
-+
++    
 +    if(
 +       oldViewProps.codeScannerOptions.regionOfInterest.x != newViewProps.codeScannerOptions.regionOfInterest.x ||
 +       oldViewProps.codeScannerOptions.regionOfInterest.y != newViewProps.codeScannerOptions.regionOfInterest.y ||
@@ -1616,7 +1616,7 @@ index 0000000..b90427e
 +        [_view.codeScannerOptions setValue:newRegionOfInterest forKey:@"regionOfInterest"];
 +        [changedProps addObject:@"codeScannerOptions"];
 +    }
-+
++    
 +    if (_view.codeScannerOptions.count == 0) {
 +        _view.codeScannerOptions = nil;
 +    }
@@ -2005,6 +2005,25 @@ index 0000000..e47e42f
 @@ -0,0 +1 @@
 +{"version":3,"file":"CameraViewNativeComponent.d.ts","sourceRoot":"","sources":["../../../src/specs/CameraViewNativeComponent.ts"],"names":[],"mappings":";;AACA,OAAO,KAAK,EAAE,aAAa,EAAE,SAAS,EAAE,MAAM,cAAc,CAAC;AAC7D,OAAO,KAAK,EAAE,kBAAkB,EAAE,MAAM,EAAE,KAAK,EAAE,MAAM,2CAA2C,CAAC;AAGnG,MAAM,MAAM,yBAAyB,GAAG,aAAa,CAAC,WAAW,CAAC,CAAC;AAEnE,MAAM,WAAW,WAAY,SAAQ,SAAS;IAC5C,gBAAgB,EAAE,OAAO,CAAC;IAC1B,sBAAsB,CAAC,EAAE,MAAM,CAAC;IAChC,QAAQ,EAAE,MAAM,CAAC;IACjB,oBAAoB,EAAE,OAAO,CAAC;IAC9B,cAAc,EAAE,OAAO,CAAC;IACxB,uBAAuB,EAAE,OAAO,CAAC;IACjC,mBAAmB,EAAE,MAAM,CAAC;IAC5B,QAAQ,EAAE,OAAO,CAAC;IAClB,KAAK,CAAC,EAAE,OAAO,CAAC;IAChB,KAAK,CAAC,EAAE,OAAO,CAAC;IAChB,KAAK,CAAC,EAAE,OAAO,CAAC;IAChB,KAAK,CAAC,EAAE,MAAM,CAAC;IACf,IAAI,CAAC,EAAE,MAAM,CAAC;IACd,QAAQ,CAAC,EAAE,MAAM,CAAC;IAClB,iBAAiB,CAAC,EAAE,OAAO,CAAC;IAC5B,cAAc,CAAC,EAAE,OAAO,CAAC;IACzB,UAAU,CAAC,EAAE,MAAM,CAAC;IACpB,MAAM,CAAC,EAAE,QAAQ,CAAC;QAChB,oBAAoB,CAAC,EAAE,OAAO,CAAC;QAC/B,WAAW,EAAE,MAAM,CAAC;QACpB,UAAU,EAAE,MAAM,CAAC;QACnB,WAAW,EAAE,MAAM,CAAC;QACpB,UAAU,EAAE,MAAM,CAAC;QACnB,MAAM,EAAE,MAAM,CAAC;QACf,MAAM,EAAE,MAAM,CAAC;QACf,MAAM,EAAE,MAAM,CAAC;QACf,MAAM,EAAE,MAAM,CAAC;QACf,WAAW,EAAE,MAAM,CAAC;QACpB,gBAAgB,EAAE,OAAO,CAAC;QAC1B,gBAAgB,EAAE,OAAO,CAAC;QAC1B,eAAe,EAAE,MAAM,CAAC;QACxB,uBAAuB,EAAE,MAAM,EAAE,CAAC;QAClC,YAAY,EAAE,MAAM,EAAE,CAAC;KACxB,CAAC,CAAC;IACH,WAAW,EAAE,MAAM,CAAC;IACpB,GAAG,CAAC,EAAE,KAAK,CAAC;IACZ,QAAQ,CAAC,EAAE,OAAO,CAAC;IACnB,QAAQ,CAAC,EAAE,OAAO,CAAC;IACnB,aAAa,CAAC,EAAE,OAAO,CAAC;IACxB,sBAAsB,CAAC,EAAE,MAAM,CAAC;IAChC,eAAe,CAAC,EAAE,OAAO,CAAC;IAC1B,kCAAkC,CAAC,EAAE,OAAO,CAAC;IAC7C,WAAW,CAAC,EAAE,MAAM,CAAC;IACrB,kBAAkB,CAAC,EAAE,QAAQ,CAAC;QAC5B,SAAS,CAAC,EAAE,MAAM,EAAE,CAAC;QACrB,QAAQ,CAAC,EAAE,MAAM,CAAC;QAClB,gBAAgB,CAAC,EAAE,QAAQ,CAAC;YAC1B,CAAC,CAAC,EAAE,MAAM,CAAC;YACX,CAAC,CAAC,EAAE,MAAM,CAAC;YACX,KAAK,CAAC,EAAE,MAAM,CAAC;YACf,MAAM,CAAC,EAAE,MAAM,CAAC;SACjB,CAAC,CAAC;KACJ,CAAC,CAAC;IACH,aAAa,CAAC,EAAE,kBAAkB,CAChC,QAAQ,CAAC;QACP,KAAK,CAAC,EAAE,QAAQ,CAAC;YACf,IAAI,CAAC,EAAE,MAAM,CAAC;YACd,KAAK,CAAC,EAAE,MAAM,CAAC;YACf,KAAK,CAAC,EAAE,QAAQ,CAAC;gBAAE,CAAC,EAAE,MAAM,CAAC;gBAAC,CAAC,EAAE,MAAM,CAAC;gBAAC,KAAK,EAAE,MAAM,CAAC;gBAAC,MAAM,EAAE,MAAM,CAAA;aAAC,CAAC,CAAC;SAC1E,CAAC,CAAC;QACH,KAAK,CAAC,EAAE,QAAQ,CAAC;YAAE,KAAK,EAAE,KAAK,CAAC;YAAC,MAAM,EAAE,KAAK,CAAA;SAAE,CAAC,CAAC;QAClD,OAAO,CAAC,EAAE,QAAQ,CAAC;YAAE,CAAC,EAAE,MAAM,CAAC;YAAC,CAAC,EAAE,MAAM,CAAA;SAAE,CAAC,CAAC;KAC9C,CAAC,CACH,CAAC;IACF,SAAS,CAAC,EAAE,kBAAkB,CAC5B,QAAQ,CAAC;QACP,IAAI,EAAE,MAAM,CAAC;KACd,CAAC,CACH,CAAC;IACF,SAAS,CAAC,EAAE,kBAAkB,CAAC,QAAQ,CAAC,EAAE,CAAC,CAAC,CAAC;IAC7C,SAAS,CAAC,EAAE,kBAAkB,CAAC,QAAQ,CAAC,EAAE,CAAC,CAAC,CAAC;IAC7C,aAAa,CAAC,EAAE,kBAAkB,CAAC,QAAQ,CAAC,EAAE,CAAC,CAAC,CAAC;IACjD,OAAO,CAAC,EAAE,kBAAkB,CAC1B,QAAQ,CAAC;QACP,IAAI,EAAE,MAAM,CAAC;QACb,OAAO,EAAE,MAAM,CAAC;QAChB,KAAK,EAAE,QAAQ,CAAC;YAAE,IAAI,EAAE,MAAM,CAAC;YAAC,MAAM,EAAE,MAAM,CAAC;YAAC,OAAO,EAAE,MAAM,CAAC;YAAC,OAAO,EAAE,MAAM,CAAA;SAAE,CAAC,CAAC;KACrF,CAAC,CACH,CAAC;IACF,WAAW,EAAE,kBAAkB,CAAC,QAAQ,CAAC,EAAE,CAAC,CAAC,CAAC;CAC/C;;AAED,wBAAiE"}
 \ No newline at end of file
+diff --git a/node_modules/react-native-vision-camera/package.json b/node_modules/react-native-vision-camera/package.json
+index 86352fa..7af9577 100644
+--- a/node_modules/react-native-vision-camera/package.json
++++ b/node_modules/react-native-vision-camera/package.json
+@@ -166,5 +166,13 @@
+       ]
+     ]
+   },
+-  "packageManager": "yarn@1.22.19+sha1.4ba7fc5c6e704fce2066ecbfb0b0d8976fe62447"
++  "codegenConfig": {
++    "name": "RNVisioncameraSpec",
++    "type": "all",
++    "jsSrcsDir": "./src/specs",
++    "android": {
++      "javaPackageName": "com.mrousavy.camera"
++    }
++  },
++  "packageManager": "yarn@1.22.19"
+ }
 diff --git a/node_modules/react-native-vision-camera/src/Camera.tsx b/node_modules/react-native-vision-camera/src/Camera.tsx
 index 18733ba..1668322 100644
 --- a/node_modules/react-native-vision-camera/src/Camera.tsx

--- a/patches/react-native-vision-camera+4.0.0-beta.13+002+native-stack-unmount-recycle-camera-session.patch
+++ b/patches/react-native-vision-camera+4.0.0-beta.13+002+native-stack-unmount-recycle-camera-session.patch
@@ -1,50 +1,46 @@
 diff --git a/node_modules/react-native-vision-camera/ios/RNCameraView.mm b/node_modules/react-native-vision-camera/ios/RNCameraView.mm
-index b90427e..feccc33 100644
+index b90427e..0be4171 100644
 --- a/node_modules/react-native-vision-camera/ios/RNCameraView.mm
 +++ b/node_modules/react-native-vision-camera/ios/RNCameraView.mm
-@@ -34,26 +34,46 @@ + (ComponentDescriptorProvider)componentDescriptorProvider
+@@ -34,26 +34,43 @@ + (ComponentDescriptorProvider)componentDescriptorProvider
      return concreteComponentDescriptorProvider<CameraViewComponentDescriptor>();
  }
  
-+- (void) initCamera {
-+  static const auto defaultProps = std::make_shared<const CameraViewProps>();
-+  _props = defaultProps;
-+
-+  //The remaining part of the initializer is standard Objective-C code to create views and layout them with AutoLayout. Here we can change whatever we want to.
-+  _view = [[CameraView alloc] init];
-+  _view.delegate = self;
-+
-+  self.contentView = _view;
-+}
-+
- - (instancetype)initWithFrame:(CGRect)frame
- {
-     self = [super initWithFrame:frame];
+-- (instancetype)initWithFrame:(CGRect)frame
+-{
+-    self = [super initWithFrame:frame];
 -if (self) {
 -    static const auto defaultProps = std::make_shared<const CameraViewProps>();
--    _props = defaultProps;
-+    if (self) {
-+      [self initCamera];
-+    }
-+    return self;
-+}
-+
++- (void) initCamera {
++    static const auto defaultProps = std::make_shared<const ameraViewProps>();
+     _props = defaultProps;
  
 -    //The remaining part of the initializer is standard Objective-C code to create views and layout them with AutoLayout. Here we can change whatever we want to.
--    _view = [[CameraView alloc] init];
--    _view.delegate = self;
-+- (void) prepareForRecycle {
-+  [super prepareForRecycle];
++    // The remaining part of the initializer is standard bjective-C code to create views and layout them with utoLayout. Here we can change whatever we want to.
+     _view = [[CameraView alloc] init];
+     _view.delegate = self;
  
--    self.contentView = _view;
-+  _view.delegate = nil;
-+  _view = nil;
-+  self.contentView = nil;
+     self.contentView = _view;
  }
  
 -return self;
-+- (void) updateLayoutMetrics:(const facebook::react::LayoutMetrics &)layoutMetrics oldLayoutMetrics:(const facebook::react::LayoutMetrics &)oldLayoutMetrics {
-+  [super updateLayoutMetrics:layoutMetrics oldLayoutMetrics:oldLayoutMetrics];
++- (instancetype)initWithFrame:(CGRect)frame
++{
++    self = [super initWithFrame:frame];
++    if (self) {
++        [self initCamera];
++    }
++
++    return self;
++}
++
++- (void) prepareForRecycle {
++    [super prepareForRecycle];
++
++    self.contentView = _view;
++    _view.delegate = nil;
++    _view = nil;
++    self.contentView = nil;
  }
  
  // why we need this func -> https://reactnative.dev/docs/next/the-new-architecture/pillars-fabric-components#write-the-native-ios-code

--- a/patches/react-native-vision-camera+4.0.0-beta.13+002+native-stack-unmount-recycle-camera-session.patch
+++ b/patches/react-native-vision-camera+4.0.0-beta.13+002+native-stack-unmount-recycle-camera-session.patch
@@ -1,0 +1,59 @@
+diff --git a/node_modules/react-native-vision-camera/ios/RNCameraView.mm b/node_modules/react-native-vision-camera/ios/RNCameraView.mm
+index b90427e..feccc33 100644
+--- a/node_modules/react-native-vision-camera/ios/RNCameraView.mm
++++ b/node_modules/react-native-vision-camera/ios/RNCameraView.mm
+@@ -34,26 +34,46 @@ + (ComponentDescriptorProvider)componentDescriptorProvider
+     return concreteComponentDescriptorProvider<CameraViewComponentDescriptor>();
+ }
+ 
++- (void) initCamera {
++  static const auto defaultProps = std::make_shared<const CameraViewProps>();
++  _props = defaultProps;
++
++  //The remaining part of the initializer is standard Objective-C code to create views and layout them with AutoLayout. Here we can change whatever we want to.
++  _view = [[CameraView alloc] init];
++  _view.delegate = self;
++
++  self.contentView = _view;
++}
++
+ - (instancetype)initWithFrame:(CGRect)frame
+ {
+     self = [super initWithFrame:frame];
+-if (self) {
+-    static const auto defaultProps = std::make_shared<const CameraViewProps>();
+-    _props = defaultProps;
++    if (self) {
++      [self initCamera];
++    }
++    return self;
++}
++
+ 
+-    //The remaining part of the initializer is standard Objective-C code to create views and layout them with AutoLayout. Here we can change whatever we want to.
+-    _view = [[CameraView alloc] init];
+-    _view.delegate = self;
++- (void) prepareForRecycle {
++  [super prepareForRecycle];
+ 
+-    self.contentView = _view;
++  _view.delegate = nil;
++  _view = nil;
++  self.contentView = nil;
+ }
+ 
+-return self;
++- (void) updateLayoutMetrics:(const facebook::react::LayoutMetrics &)layoutMetrics oldLayoutMetrics:(const facebook::react::LayoutMetrics &)oldLayoutMetrics {
++  [super updateLayoutMetrics:layoutMetrics oldLayoutMetrics:oldLayoutMetrics];
+ }
+ 
+ // why we need this func -> https://reactnative.dev/docs/next/the-new-architecture/pillars-fabric-components#write-the-native-ios-code
+ - (void)updateProps:(Props::Shared const &)props oldProps:(Props::Shared const &)oldProps
+ {
++    if (_view == nil) {
++      [self initCamera];
++    }
++
+     const auto &newViewProps = *std::static_pointer_cast<CameraViewProps const>(props);
+     const auto &oldViewProps = *std::static_pointer_cast<CameraViewProps const>(_props);
+ 

--- a/patches/react-native-vision-camera+4.0.0-beta.13+002+native-stack-unmount-recycle-camera-session.patch
+++ b/patches/react-native-vision-camera+4.0.0-beta.13+002+native-stack-unmount-recycle-camera-session.patch
@@ -12,7 +12,7 @@ index b90427e..0be4171 100644
 -if (self) {
 -    static const auto defaultProps = std::make_shared<const CameraViewProps>();
 +- (void) initCamera {
-+    static const auto defaultProps = std::make_shared<const ameraViewProps>();
++    static const auto defaultProps = std::make_shared<const CameraViewProps>();
      _props = defaultProps;
  
 -    //The remaining part of the initializer is standard Objective-C code to create views and layout them with AutoLayout. Here we can change whatever we want to.


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

@mountiny @ishpaul777 @chiragsalian 

### Details
<!-- Explanation of the change or anything fishy that is going on -->

Fixes an issue with `react-native-vision-camera@4.0.0-beta.13` where the `CameraSession` doesn't get de-initialized and/or recycled, when the screen gets popped/unmounted from the Navigation stack in `@react-navigation/native-stack`.

> [!NOTE]  
> This PR is needed in https://github.com/Expensify/App/pull/37891

Since the fixing patch is based on another patch that we introduced in https://github.com/Expensify/App/pull/45289, we can't (yet) create an upstream issue for this.

I raised this issue Margelo-internally so we can fix this once `react-native-vision-camera` is fully migrated to the New Architecture.

We should also think about updating `react-native-vision-camera` to the latest (stable) version, because there are some new changes related to New Arch support.

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/49988

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/49988
$ https://github.com/Expensify/App/pull/37891
PROPOSAL: https://github.com/Expensify/App/pull/37891#issuecomment-2383283177


### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

- [ ] Verify that no errors appear in the JS console

1. Open the App on a physical iOS device
2. Click the FAB and go to "Submit expense"
3. Make sure the camera starts up.
4. Navigate back to the Home screen
5. Make sure, the "green camera indicator" in the iOS StatusBar/Dynamic Island/Notch disappears.
6. Go to "Submit expense" again and make sure the camera starts up again.

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
7. Upload an image via copy paste
8. Verify a modal appears displaying a preview of that image
--->

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Desktop</summary>

<!-- add screenshots or videos here -->

</details>
