### PR TITLE
[NoQA] Update e2e dev instructions

### DIFF
--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -41,18 +41,16 @@ npm run android
 
 3. We need to modify the app entry to point to the one for the tests. Therefore rename `./index.js` to `./appIndex.js` temporarily.
 
-4. Create a new `./index.js` with the following content:
-```js
-require('./src/libs/E2E/reactNativeLaunchingTest');
-```
+4. Temporarily add to the `package.json` a `main` field pointing to the e2e entry file:
+  
+  ```diff
+  {
+    "private": true,
++ "main": "src/libs/E2E/reactNativeEntry.ts"
+  }
+  ```
 
-5. In `./src/libs/E2E/reactNativeLaunchingTest.ts` change the main app import to the new `./appIndex.js` file:
-```diff
-- import '../../../index';
-+ import '../../../appIndex';
-```
-
-6. You can now run the tests. This command will invoke the test runner:
+5. You can now run the tests. This command will invoke the test runner:
 
 ```sh
 npm run test:e2e:dev


### PR DESCRIPTION
Since we have switched to expo we can make the e2e dev instructions simpler. This PR is updating a section of the e2e developer guide (hence i skipped the default PR template).

(Note: i am hanno from margelo, an expert agency, we've build the e2e testing pipeline)