### PR TITLE
Move the logic of excluding contacts of DMs already included in reports to `filterOptions`

### DIFF
--- a/src/components/CategoryPicker.tsx
+++ b/src/components/CategoryPicker.tsx
@@ -44,20 +44,14 @@ function CategoryPicker({selectedCategory, policyID, onSubmit}: CategoryPickerPr
     const [sections, headerMessage, shouldShowTextInput] = useMemo(() => {
         const categories = policyCategories ?? policyCategoriesDraft ?? {};
         const validPolicyRecentlyUsedCategories = policyRecentlyUsedCategories?.filter?.((p) => !isEmptyObject(p));
-        const {categoryOptions} = OptionsListUtils.getFilteredOptions(
-            [],
-            [],
-            [],
-            debouncedSearchValue,
+        const {categoryOptions} = OptionsListUtils.getFilteredOptions({
+            searchValue: debouncedSearchValue,
             selectedOptions,
-            [],
-            false,
-            false,
-            true,
+            includeP2P: false,
+            includeCategories: true,
             categories,
-            validPolicyRecentlyUsedCategories,
-            false,
-        );
+            recentlyUsedCategories: validPolicyRecentlyUsedCategories,
+        });
 
         const categoryData = categoryOptions?.at(0)?.data ?? [];
         const header = OptionsListUtils.getHeaderMessageForNonUserList(categoryData.length > 0, debouncedSearchValue);

--- a/src/components/Search/SearchFiltersParticipantsSelector.tsx
+++ b/src/components/Search/SearchFiltersParticipantsSelector.tsx
@@ -57,28 +57,13 @@ function SearchFiltersParticipantsSelector({initialAccountIDs, onFiltersUpdate}:
             return defaultListOptions;
         }
 
-        return OptionsListUtils.getFilteredOptions(
-            options.reports,
-            options.personalDetails,
-            undefined,
-            '',
+        return OptionsListUtils.getFilteredOptions({
+            reports: options.reports,
+            personalDetails: options.personalDetails,
             selectedOptions,
-            CONST.EXPENSIFY_EMAILS,
-            false,
-            true,
-            false,
-            {},
-            [],
-            false,
-            {},
-            [],
-            true,
-            false,
-            false,
-            0,
-            undefined,
-            false,
-        );
+            excludeLogins: CONST.EXPENSIFY_EMAILS,
+            maxRecentReportsToShow: 0,
+        });
     }, [areOptionsInitialized, options.personalDetails, options.reports, selectedOptions]);
 
     const chatOptions = useMemo(() => {

--- a/src/components/TagPicker/index.tsx
+++ b/src/components/TagPicker/index.tsx
@@ -1,6 +1,5 @@
 import React, {useMemo, useState} from 'react';
-import type {OnyxEntry} from 'react-native-onyx';
-import {withOnyx} from 'react-native-onyx';
+import {useOnyx} from 'react-native-onyx';
 import SelectionList from '@components/SelectionList';
 import RadioListItem from '@components/SelectionList/RadioListItem';
 import useLocalize from '@hooks/useLocalize';
@@ -10,7 +9,7 @@ import * as PolicyUtils from '@libs/PolicyUtils';
 import type * as ReportUtils from '@libs/ReportUtils';
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
-import type {PolicyTag, PolicyTagLists, PolicyTags, RecentlyUsedTags} from '@src/types/onyx';
+import type {PolicyTag, PolicyTags} from '@src/types/onyx';
 import type {PendingAction} from '@src/types/onyx/OnyxCommon';
 
 type SelectedTagOption = {
@@ -21,15 +20,7 @@ type SelectedTagOption = {
     pendingAction?: PendingAction;
 };
 
-type TagPickerOnyxProps = {
-    /** Collection of tag list on a policy */
-    policyTags: OnyxEntry<PolicyTagLists>;
-
-    /** List of recently used tags */
-    policyRecentlyUsedTags: OnyxEntry<RecentlyUsedTags>;
-};
-
-type TagPickerProps = TagPickerOnyxProps & {
+type TagPickerProps = {
     /** The policyID we are getting tags for */
     // It's used in withOnyx HOC.
     // eslint-disable-next-line react/no-unused-prop-types
@@ -51,7 +42,9 @@ type TagPickerProps = TagPickerOnyxProps & {
     tagListIndex: number;
 };
 
-function TagPicker({selectedTag, tagListName, policyTags, tagListIndex, policyRecentlyUsedTags, shouldShowDisabledAndSelectedOption = false, onSubmit}: TagPickerProps) {
+function TagPicker({selectedTag, tagListName, policyID, tagListIndex, shouldShowDisabledAndSelectedOption = false, onSubmit}: TagPickerProps) {
+    const [policyTags] = useOnyx(`${ONYXKEYS.COLLECTION.POLICY_TAGS}${policyID}`);
+    const [policyRecentlyUsedTags] = useOnyx(`${ONYXKEYS.COLLECTION.POLICY_RECENTLY_USED_TAGS}${policyID}`);
     const styles = useThemeStyles();
     const {translate} = useLocalize();
     const [searchValue, setSearchValue] = useState('');
@@ -122,13 +115,6 @@ function TagPicker({selectedTag, tagListName, policyTags, tagListIndex, policyRe
 
 TagPicker.displayName = 'TagPicker';
 
-export default withOnyx<TagPickerProps, TagPickerOnyxProps>({
-    policyTags: {
-        key: ({policyID}) => `${ONYXKEYS.COLLECTION.POLICY_TAGS}${policyID}`,
-    },
-    policyRecentlyUsedTags: {
-        key: ({policyID}) => `${ONYXKEYS.COLLECTION.POLICY_RECENTLY_USED_TAGS}${policyID}`,
-    },
-})(TagPicker);
+export default TagPicker;
 
 export type {SelectedTagOption};

--- a/src/components/TagPicker/index.tsx
+++ b/src/components/TagPicker/index.tsx
@@ -87,7 +87,16 @@ function TagPicker({selectedTag, tagListName, policyTags, tagListIndex, policyRe
     }, [selectedOptions, policyTagList, shouldShowDisabledAndSelectedOption]);
 
     const sections = useMemo(
-        () => OptionsListUtils.getFilteredOptions([], [], [], searchValue, selectedOptions, [], false, false, false, {}, [], true, enabledTags, policyRecentlyUsedTagsList, false).tagOptions,
+        () =>
+            OptionsListUtils.getFilteredOptions({
+                searchValue,
+                selectedOptions,
+                includeP2P: false,
+                includeTags: true,
+                tags: enabledTags,
+                recentlyUsedTags: policyRecentlyUsedTagsList,
+                canInviteUser: false,
+            }).tagOptions,
         [searchValue, enabledTags, selectedOptions, policyRecentlyUsedTagsList],
     );
 

--- a/src/libs/OptionsListUtils.ts
+++ b/src/libs/OptionsListUtils.ts
@@ -2265,7 +2265,7 @@ function getFilteredOptions(params: FilteredOptionsParamsWithDefaultSearchValue 
         recentlyUsedPolicyReportFieldOptions = [],
         includeInvoiceRooms = false,
         action,
-        sortByReportTypeInSearch,
+        sortByReportTypeInSearch = false,
     } = params;
     return getOptions(
         {reports, personalDetails},

--- a/src/libs/OptionsListUtils.ts
+++ b/src/libs/OptionsListUtils.ts
@@ -2236,12 +2236,9 @@ type FilteredOptionsParams = {
 
 type FilteredOptionsParamsWithDefaultSearchValue = Omit<FilteredOptionsParams, 'searchValue'> & {searchValue?: ''};
 
-type FilteredOptionsParamsWithoutOptions = Omit<FilteredOptionsParams, 'reports' | 'personalDetails'> & { reports?: []; personalDetails?: [] };
+type FilteredOptionsParamsWithoutOptions = Omit<FilteredOptionsParams, 'reports' | 'personalDetails'> & {reports?: []; personalDetails?: []};
 
-function getFilteredOptions(
-    params: FilteredOptionsParamsWithDefaultSearchValue | FilteredOptionsParamsWithoutOptions,
-) {
-
+function getFilteredOptions(params: FilteredOptionsParamsWithDefaultSearchValue | FilteredOptionsParamsWithoutOptions) {
     const {
         reports = [],
         personalDetails = [],

--- a/src/libs/OptionsListUtils.ts
+++ b/src/libs/OptionsListUtils.ts
@@ -2487,14 +2487,17 @@ function filterOptions(options: Options, searchInputValue: string, config?: Filt
         preferPolicyExpenseChat = false,
         preferRecentExpenseReports = false,
     } = config ?? {};
+    function filteredPersonalDetailsOfRecentReports(recentReports: ReportUtils.OptionData[], personalDetails: ReportUtils.OptionData[]) {
+        const excludedLogins = new Set(recentReports.map((report) => report.login));
+        return personalDetails.filter((personalDetail) => !excludedLogins.has(personalDetail.login));
+    }
     if (searchInputValue.trim() === '' && maxRecentReportsToShow > 0) {
         const recentReports = options.recentReports.slice(0, maxRecentReportsToShow);
-        const excludedLogins = new Set(recentReports.map((report) => report.login));
-        const filteredPersonalDetails = options.personalDetails.filter((personalDetail) => !excludedLogins.has(personalDetail.login));
+        const personalDetails = filteredPersonalDetailsOfRecentReports(recentReports, options.personalDetails);
         return {
             ...options,
             recentReports,
-            personalDetails: filteredPersonalDetails,
+            personalDetails,
         };
     }
 
@@ -2538,8 +2541,7 @@ function filterOptions(options: Options, searchInputValue: string, config?: Filt
 
         const currentUserOption = isSearchStringMatch(term, currentUserOptionSearchText) ? items.currentUserOption : null;
 
-        const excludedLogins = new Set(recentReports.map((report) => report.login));
-        const filteredPersonalDetails = personalDetails.filter((personalDetail) => !excludedLogins.has(personalDetail.login));
+        const filteredPersonalDetails = filteredPersonalDetailsOfRecentReports(recentReports, personalDetails);
 
         return {
             recentReports: recentReports ?? [],
@@ -2574,13 +2576,10 @@ function filterOptions(options: Options, searchInputValue: string, config?: Filt
     if (maxRecentReportsToShow > 0 && recentReports.length > maxRecentReportsToShow) {
         recentReports.splice(maxRecentReportsToShow);
     }
-
-    const excludedLogins = new Set(recentReports.map((report) => report.login));
-    const filteredPersonalDetails = personalDetails.filter((personalDetail) => !excludedLogins.has(personalDetail.login));
-    personalDetails = filteredPersonalDetails;
+    const filteredPersonalDetails = filteredPersonalDetailsOfRecentReports(recentReports, personalDetails);
 
     return {
-        personalDetails,
+        personalDetails: filteredPersonalDetails,
         recentReports: orderOptions(recentReports, searchValue, {preferChatroomsOverThreads, preferPolicyExpenseChat, preferRecentExpenseReports}),
         userToInvite,
         currentUserOption: matchResults.currentUserOption,

--- a/src/libs/OptionsListUtils.ts
+++ b/src/libs/OptionsListUtils.ts
@@ -2538,9 +2538,12 @@ function filterOptions(options: Options, searchInputValue: string, config?: Filt
 
         const currentUserOption = isSearchStringMatch(term, currentUserOptionSearchText) ? items.currentUserOption : null;
 
+        const excludedLogins = new Set(recentReports.map((report) => report.login));
+        const filteredPersonalDetails = personalDetails.filter((personalDetail) => !excludedLogins.has(personalDetail.login));
+
         return {
             recentReports: recentReports ?? [],
-            personalDetails: personalDetails ?? [],
+            personalDetails: filteredPersonalDetails ?? [],
             userToInvite: null,
             currentUserOption,
             categoryOptions: [],

--- a/src/libs/OptionsListUtils.ts
+++ b/src/libs/OptionsListUtils.ts
@@ -2073,11 +2073,6 @@ function getOptions(
                     }
                 }
             }
-
-            // Add this login to the exclude list so it won't appear when we process the personal details
-            if (reportOption.login) {
-                optionsToExclude.push({login: reportOption.login});
-            }
         }
     }
 
@@ -2493,7 +2488,14 @@ function filterOptions(options: Options, searchInputValue: string, config?: Filt
         preferRecentExpenseReports = false,
     } = config ?? {};
     if (searchInputValue.trim() === '' && maxRecentReportsToShow > 0) {
-        return {...options, recentReports: options.recentReports.slice(0, maxRecentReportsToShow)};
+        const recentReports = options.recentReports.slice(0, maxRecentReportsToShow);
+        const excludedLogins = new Set(recentReports.map(report => report.login));
+        const filteredPersonalDetails = options.personalDetails.filter(personalDetail => !excludedLogins.has(personalDetail.login));
+        return {
+            ...options,
+            recentReports,
+            personalDetails: filteredPersonalDetails,
+        };
     }
 
     const parsedPhoneNumber = PhoneNumber.parsePhoneNumber(LoginUtils.appendCountryCode(Str.removeSMSDomain(searchInputValue)));
@@ -2569,6 +2571,11 @@ function filterOptions(options: Options, searchInputValue: string, config?: Filt
     if (maxRecentReportsToShow > 0 && recentReports.length > maxRecentReportsToShow) {
         recentReports.splice(maxRecentReportsToShow);
     }
+
+    const excludedLogins = new Set(recentReports.map(report => report.login));
+    const filteredPersonalDetails = personalDetails.filter(personalDetail => !excludedLogins.has(personalDetail.login));
+    personalDetails = filteredPersonalDetails;
+
 
     return {
         personalDetails,

--- a/src/libs/OptionsListUtils.ts
+++ b/src/libs/OptionsListUtils.ts
@@ -2540,12 +2540,9 @@ function filterOptions(options: Options, searchInputValue: string, config?: Filt
         const currentUserOptionSearchText = items.currentUserOption ? uniqFast(getCurrentUserSearchTerms(items.currentUserOption)).join(' ') : '';
 
         const currentUserOption = isSearchStringMatch(term, currentUserOptionSearchText) ? items.currentUserOption : null;
-
-        const filteredPersonalDetails = filteredPersonalDetailsOfRecentReports(recentReports, personalDetails);
-
         return {
             recentReports: recentReports ?? [],
-            personalDetails: filteredPersonalDetails ?? [],
+            personalDetails: personalDetails ?? [],
             userToInvite: null,
             currentUserOption,
             categoryOptions: [],
@@ -2557,6 +2554,7 @@ function filterOptions(options: Options, searchInputValue: string, config?: Filt
     let {recentReports, personalDetails} = matchResults;
 
     if (sortByReportTypeInSearch) {
+        personalDetails = filteredPersonalDetailsOfRecentReports(recentReports, personalDetails);
         recentReports = recentReports.concat(personalDetails);
         personalDetails = [];
         recentReports = orderOptions(recentReports, searchValue);

--- a/src/libs/OptionsListUtils.ts
+++ b/src/libs/OptionsListUtils.ts
@@ -2205,34 +2205,71 @@ function getIOUConfirmationOptionsFromPayeePersonalDetail(personalDetail: OnyxEn
 /**
  * Build the options for the New Group view
  */
+type FilteredOptionsParams = {
+    reports?: Array<SearchOption<Report>>;
+    personalDetails?: Array<SearchOption<PersonalDetails>>;
+    betas?: OnyxEntry<Beta[]>;
+    searchValue?: string;
+    selectedOptions?: Array<Partial<ReportUtils.OptionData>>;
+    excludeLogins?: string[];
+    includeOwnedWorkspaceChats?: boolean;
+    includeP2P?: boolean;
+    includeCategories?: boolean;
+    categories?: PolicyCategories;
+    recentlyUsedCategories?: string[];
+    includeTags?: boolean;
+    tags?: PolicyTags | Array<PolicyTag | SelectedTagOption>;
+    recentlyUsedTags?: string[];
+    canInviteUser?: boolean;
+    includeSelectedOptions?: boolean;
+    includeTaxRates?: boolean;
+    taxRates?: TaxRatesWithDefault;
+    maxRecentReportsToShow?: number;
+    includeSelfDM?: boolean;
+    includePolicyReportFieldOptions?: boolean;
+    policyReportFieldOptions?: string[];
+    recentlyUsedPolicyReportFieldOptions?: string[];
+    includeInvoiceRooms?: boolean;
+    action?: IOUAction;
+    sortByReportTypeInSearch?: boolean;
+};
+
+type FilteredOptionsParamsWithDefaultSearchValue = Omit<FilteredOptionsParams, 'searchValue'> & {searchValue?: ''};
+
+type FilteredOptionsParamsWithoutOptions = Omit<FilteredOptionsParams, 'reports' | 'personalDetails'> & { reports?: []; personalDetails?: [] };
+
 function getFilteredOptions(
-    reports: Array<SearchOption<Report>> = [],
-    personalDetails: Array<SearchOption<PersonalDetails>> = [],
-    betas: OnyxEntry<Beta[]> = [],
-    searchValue = '',
-    selectedOptions: Array<Partial<ReportUtils.OptionData>> = [],
-    excludeLogins: string[] = [],
-    includeOwnedWorkspaceChats = false,
-    includeP2P = true,
-    includeCategories = false,
-    categories: PolicyCategories = {},
-    recentlyUsedCategories: string[] = [],
-    includeTags = false,
-    tags: PolicyTags | Array<PolicyTag | SelectedTagOption> = {},
-    recentlyUsedTags: string[] = [],
-    canInviteUser = true,
-    includeSelectedOptions = false,
-    includeTaxRates = false,
-    maxRecentReportsToShow: number = CONST.IOU.MAX_RECENT_REPORTS_TO_SHOW,
-    taxRates: TaxRatesWithDefault = {} as TaxRatesWithDefault,
-    includeSelfDM = false,
-    includePolicyReportFieldOptions = false,
-    policyReportFieldOptions: string[] = [],
-    recentlyUsedPolicyReportFieldOptions: string[] = [],
-    includeInvoiceRooms = false,
-    action: IOUAction | undefined = undefined,
-    sortByReportTypeInSearch = false,
+    params: FilteredOptionsParamsWithDefaultSearchValue | FilteredOptionsParamsWithoutOptions,
 ) {
+
+    const {
+        reports = [],
+        personalDetails = [],
+        betas = [],
+        searchValue = '',
+        selectedOptions = [],
+        excludeLogins = [],
+        includeOwnedWorkspaceChats = false,
+        includeP2P = true,
+        includeCategories = false,
+        categories = {},
+        recentlyUsedCategories = [],
+        includeTags = false,
+        tags = {},
+        recentlyUsedTags = [],
+        canInviteUser = true,
+        includeSelectedOptions = false,
+        includeTaxRates = false,
+        maxRecentReportsToShow = CONST.IOU.MAX_RECENT_REPORTS_TO_SHOW,
+        taxRates = {} as TaxRatesWithDefault,
+        includeSelfDM = false,
+        includePolicyReportFieldOptions = false,
+        policyReportFieldOptions = [],
+        recentlyUsedPolicyReportFieldOptions = [],
+        includeInvoiceRooms = false,
+        action,
+        sortByReportTypeInSearch,
+    } = params;
     return getOptions(
         {reports, personalDetails},
         {

--- a/src/libs/OptionsListUtils.ts
+++ b/src/libs/OptionsListUtils.ts
@@ -2234,6 +2234,13 @@ type FilteredOptionsParams = {
     sortByReportTypeInSearch?: boolean;
 };
 
+// It is not recommended to pass a search value to getFilteredOptions when passing reports and personalDetails.
+// If a search value is passed, the search value should be passed to filterOptions.
+// When it is necessary to pass a search value when passing reports and personalDetails, follow these steps:
+// 1. Use getFilteredOptions with reports and personalDetails only, without the search value.
+// 2. Pass the returned options from getFilteredOptions to filterOptions along with the search value.
+// The above constraints are enforced with TypeScript.
+
 type FilteredOptionsParamsWithDefaultSearchValue = Omit<FilteredOptionsParams, 'searchValue'> & {searchValue?: ''};
 
 type FilteredOptionsParamsWithoutOptions = Omit<FilteredOptionsParams, 'reports' | 'personalDetails'> & {reports?: []; personalDetails?: []};
@@ -2521,6 +2528,7 @@ function filterOptions(options: Options, searchInputValue: string, config?: Filt
         preferPolicyExpenseChat = false,
         preferRecentExpenseReports = false,
     } = config ?? {};
+    // Remove the personal details for the DMs that are already in the recent reports so that we don't show duplicates
     function filteredPersonalDetailsOfRecentReports(recentReports: ReportUtils.OptionData[], personalDetails: ReportUtils.OptionData[]) {
         const excludedLogins = new Set(recentReports.map((report) => report.login));
         return personalDetails.filter((personalDetail) => !excludedLogins.has(personalDetail.login));

--- a/src/libs/OptionsListUtils.ts
+++ b/src/libs/OptionsListUtils.ts
@@ -2489,8 +2489,8 @@ function filterOptions(options: Options, searchInputValue: string, config?: Filt
     } = config ?? {};
     if (searchInputValue.trim() === '' && maxRecentReportsToShow > 0) {
         const recentReports = options.recentReports.slice(0, maxRecentReportsToShow);
-        const excludedLogins = new Set(recentReports.map(report => report.login));
-        const filteredPersonalDetails = options.personalDetails.filter(personalDetail => !excludedLogins.has(personalDetail.login));
+        const excludedLogins = new Set(recentReports.map((report) => report.login));
+        const filteredPersonalDetails = options.personalDetails.filter((personalDetail) => !excludedLogins.has(personalDetail.login));
         return {
             ...options,
             recentReports,
@@ -2572,10 +2572,9 @@ function filterOptions(options: Options, searchInputValue: string, config?: Filt
         recentReports.splice(maxRecentReportsToShow);
     }
 
-    const excludedLogins = new Set(recentReports.map(report => report.login));
-    const filteredPersonalDetails = personalDetails.filter(personalDetail => !excludedLogins.has(personalDetail.login));
+    const excludedLogins = new Set(recentReports.map((report) => report.login));
+    const filteredPersonalDetails = personalDetails.filter((personalDetail) => !excludedLogins.has(personalDetail.login));
     personalDetails = filteredPersonalDetails;
-
 
     return {
         personalDetails,

--- a/src/pages/EditReportFieldDropdown.tsx
+++ b/src/pages/EditReportFieldDropdown.tsx
@@ -1,6 +1,5 @@
 import React, {useCallback, useMemo} from 'react';
-import {withOnyx} from 'react-native-onyx';
-import type {OnyxEntry} from 'react-native-onyx';
+import {useOnyx} from 'react-native-onyx';
 import Icon from '@components/Icon';
 import * as Expensicons from '@components/Icon/Expensicons';
 import SelectionList from '@components/SelectionList';
@@ -12,7 +11,6 @@ import useTheme from '@hooks/useTheme';
 import localeCompare from '@libs/LocaleCompare';
 import * as OptionsListUtils from '@libs/OptionsListUtils';
 import ONYXKEYS from '@src/ONYXKEYS';
-import type {RecentlyUsedReportFields} from '@src/types/onyx';
 
 type EditReportFieldDropdownPageComponentProps = {
     /** Value of the policy report field */
@@ -32,13 +30,10 @@ type EditReportFieldDropdownPageComponentProps = {
     onSubmit: (form: Record<string, string>) => void;
 };
 
-type EditReportFieldDropdownPageOnyxProps = {
-    recentlyUsedReportFields: OnyxEntry<RecentlyUsedReportFields>;
-};
+type EditReportFieldDropdownPageProps = EditReportFieldDropdownPageComponentProps;
 
-type EditReportFieldDropdownPageProps = EditReportFieldDropdownPageComponentProps & EditReportFieldDropdownPageOnyxProps;
-
-function EditReportFieldDropdownPage({onSubmit, fieldKey, fieldValue, fieldOptions, recentlyUsedReportFields}: EditReportFieldDropdownPageProps) {
+function EditReportFieldDropdownPage({onSubmit, fieldKey, fieldValue, fieldOptions}: EditReportFieldDropdownPageProps) {
+    const [recentlyUsedReportFields] = useOnyx(ONYXKEYS.RECENTLY_USED_REPORT_FIELDS);
     const [searchValue, debouncedSearchValue, setSearchValue] = useDebouncedState('');
     const theme = useTheme();
     const {translate} = useLocalize();
@@ -105,8 +100,4 @@ function EditReportFieldDropdownPage({onSubmit, fieldKey, fieldValue, fieldOptio
 
 EditReportFieldDropdownPage.displayName = 'EditReportFieldDropdownPage';
 
-export default withOnyx<EditReportFieldDropdownPageProps, EditReportFieldDropdownPageOnyxProps>({
-    recentlyUsedReportFields: {
-        key: () => ONYXKEYS.RECENTLY_USED_REPORT_FIELDS,
-    },
-})(EditReportFieldDropdownPage);
+export default EditReportFieldDropdownPage;

--- a/src/pages/EditReportFieldDropdown.tsx
+++ b/src/pages/EditReportFieldDropdown.tsx
@@ -64,37 +64,22 @@ function EditReportFieldDropdownPage({onSubmit, fieldKey, fieldValue, fieldOptio
     const [sections, headerMessage] = useMemo(() => {
         const validFieldOptions = fieldOptions?.filter((option) => !!option)?.sort(localeCompare);
 
-        const {policyReportFieldOptions} = OptionsListUtils.getFilteredOptions(
-            [],
-            [],
-            [],
-            debouncedSearchValue,
-            [
+        const {policyReportFieldOptions} = OptionsListUtils.getFilteredOptions({
+            searchValue: debouncedSearchValue,
+            selectedOptions: [
                 {
                     keyForList: fieldValue,
                     searchText: fieldValue,
                     text: fieldValue,
                 },
             ],
-            [],
-            false,
-            false,
-            false,
-            {},
-            [],
-            false,
-            {},
-            [],
-            false,
-            false,
-            undefined,
-            CONST.IOU.MAX_RECENT_REPORTS_TO_SHOW,
-            undefined,
-            undefined,
-            true,
-            validFieldOptions,
-            recentlyUsedOptions,
-        );
+            
+            includeP2P: false,
+            canInviteUser: false,
+            includePolicyReportFieldOptions: true,
+            policyReportFieldOptions: validFieldOptions,
+            recentlyUsedPolicyReportFieldOptions: recentlyUsedOptions,
+    });
 
         const policyReportFieldData = policyReportFieldOptions?.[0]?.data ?? [];
         const header = OptionsListUtils.getHeaderMessageForNonUserList(policyReportFieldData.length > 0, debouncedSearchValue);

--- a/src/pages/EditReportFieldDropdown.tsx
+++ b/src/pages/EditReportFieldDropdown.tsx
@@ -73,13 +73,13 @@ function EditReportFieldDropdownPage({onSubmit, fieldKey, fieldValue, fieldOptio
                     text: fieldValue,
                 },
             ],
-            
+
             includeP2P: false,
             canInviteUser: false,
             includePolicyReportFieldOptions: true,
             policyReportFieldOptions: validFieldOptions,
             recentlyUsedPolicyReportFieldOptions: recentlyUsedOptions,
-    });
+        });
 
         const policyReportFieldData = policyReportFieldOptions?.[0]?.data ?? [];
         const header = OptionsListUtils.getHeaderMessageForNonUserList(policyReportFieldData.length > 0, debouncedSearchValue);

--- a/src/pages/EditReportFieldDropdown.tsx
+++ b/src/pages/EditReportFieldDropdown.tsx
@@ -11,7 +11,6 @@ import useLocalize from '@hooks/useLocalize';
 import useTheme from '@hooks/useTheme';
 import localeCompare from '@libs/LocaleCompare';
 import * as OptionsListUtils from '@libs/OptionsListUtils';
-import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
 import type {RecentlyUsedReportFields} from '@src/types/onyx';
 

--- a/src/pages/NewChatPage.tsx
+++ b/src/pages/NewChatPage.tsx
@@ -52,28 +52,15 @@ function useOptions({isGroupChat}: NewChatPageProps) {
     });
 
     const defaultOptions = useMemo(() => {
-        const filteredOptions = OptionsListUtils.getFilteredOptions(
-            listOptions.reports ?? [],
-            listOptions.personalDetails ?? [],
-            betas ?? [],
-            '',
+        const filteredOptions = OptionsListUtils.getFilteredOptions({
+            reports: listOptions.reports ?? [],
+            personalDetails: listOptions.personalDetails ?? [],
+            betas: betas ?? [],
             selectedOptions,
-            isGroupChat ? excludedGroupEmails : [],
-            false,
-            true,
-            false,
-            {},
-            [],
-            false,
-            {},
-            [],
-            true,
-            undefined,
-            undefined,
-            0,
-            undefined,
-            true,
-        );
+            excludeLogins: isGroupChat ? excludedGroupEmails : [],
+            maxRecentReportsToShow: 0,
+            includeSelfDM: true,
+        });
         return filteredOptions;
     }, [betas, isGroupChat, listOptions.personalDetails, listOptions.reports, selectedOptions]);
 

--- a/src/pages/iou/request/MoneyRequestParticipantsSelector.tsx
+++ b/src/pages/iou/request/MoneyRequestParticipantsSelector.tsx
@@ -133,7 +133,7 @@ function MoneyRequestParticipantsSelector({
             action,
             sortByReportTypeInSearch: isPaidGroupPolicy,
             searchValue: '',
-    });
+        });
 
         return optionList;
     }, [
@@ -149,7 +149,7 @@ function MoneyRequestParticipantsSelector({
         options.reports,
         participants,
         isPaidGroupPolicy,
-        debouncedSearchTerm
+        debouncedSearchTerm,
     ]);
 
     const chatOptions = useMemo(() => {

--- a/src/pages/iou/request/MoneyRequestParticipantsSelector.tsx
+++ b/src/pages/iou/request/MoneyRequestParticipantsSelector.tsx
@@ -114,40 +114,26 @@ function MoneyRequestParticipantsSelector({
             };
         }
 
-        const optionList = OptionsListUtils.getFilteredOptions(
-            options.reports,
-            options.personalDetails,
+        const optionList = OptionsListUtils.getFilteredOptions({
+            reports: options.reports,
+            personalDetails: options.personalDetails,
             betas,
-            '',
-            participants as Participant[],
-            CONST.EXPENSIFY_EMAILS,
+            selectedOptions: participants as Participant[],
+            excludeLogins: CONST.EXPENSIFY_EMAILS,
 
             // If we are using this component in the "Submit expense" or the combined submit/track flow then we pass the includeOwnedWorkspaceChats argument so that the current user
             // sees the option to submit an expense from their admin on their own Workspace Chat.
-            (iouType === CONST.IOU.TYPE.SUBMIT || iouType === CONST.IOU.TYPE.CREATE || iouType === CONST.IOU.TYPE.SPLIT) && action !== CONST.IOU.ACTION.SUBMIT,
+            includeOwnedWorkspaceChats: (iouType === CONST.IOU.TYPE.SUBMIT || iouType === CONST.IOU.TYPE.CREATE || iouType === CONST.IOU.TYPE.SPLIT) && action !== CONST.IOU.ACTION.SUBMIT,
 
             // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-            (canUseP2PDistanceRequests || iouRequestType !== CONST.IOU.REQUEST_TYPE.DISTANCE) && !isCategorizeOrShareAction,
-            false,
-            {},
-            [],
-            false,
-            {},
-            [],
+            includeP2P: (canUseP2PDistanceRequests || iouRequestType !== CONST.IOU.REQUEST_TYPE.DISTANCE) && !isCategorizeOrShareAction,
             // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-            (canUseP2PDistanceRequests || iouRequestType !== CONST.IOU.REQUEST_TYPE.DISTANCE) && !isCategorizeOrShareAction,
-            false,
-            false,
-            0,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            iouType === CONST.IOU.TYPE.INVOICE,
+            canInviteUser: (canUseP2PDistanceRequests || iouRequestType !== CONST.IOU.REQUEST_TYPE.DISTANCE) && !isCategorizeOrShareAction,
+            includeInvoiceRooms: iouType === CONST.IOU.TYPE.INVOICE,
             action,
-            isPaidGroupPolicy,
-        );
+            sortByReportTypeInSearch: isPaidGroupPolicy,
+            searchValue: '',
+    });
 
         return optionList;
     }, [
@@ -163,6 +149,7 @@ function MoneyRequestParticipantsSelector({
         options.reports,
         participants,
         isPaidGroupPolicy,
+        debouncedSearchTerm
     ]);
 
     const chatOptions = useMemo(() => {

--- a/src/pages/iou/request/MoneyRequestParticipantsSelector.tsx
+++ b/src/pages/iou/request/MoneyRequestParticipantsSelector.tsx
@@ -149,7 +149,6 @@ function MoneyRequestParticipantsSelector({
         options.reports,
         participants,
         isPaidGroupPolicy,
-        debouncedSearchTerm,
     ]);
 
     const chatOptions = useMemo(() => {

--- a/src/pages/iou/request/MoneyRequestParticipantsSelector.tsx
+++ b/src/pages/iou/request/MoneyRequestParticipantsSelector.tsx
@@ -133,6 +133,7 @@ function MoneyRequestParticipantsSelector({
             action,
             sortByReportTypeInSearch: isPaidGroupPolicy,
             searchValue: '',
+            maxRecentReportsToShow: 0,
         });
 
         return optionList;

--- a/src/pages/settings/Security/AddDelegate/AddDelegatePage.tsx
+++ b/src/pages/settings/Security/AddDelegate/AddDelegatePage.tsx
@@ -30,7 +30,7 @@ function useOptions() {
         const {recentReports, personalDetails, userToInvite, currentUserOption} = OptionsListUtils.getFilteredOptions({
             reports: optionsList.reports,
             personalDetails: optionsList.personalDetails,
-            betas: betas,
+            betas,
 
             excludeLogins: [...CONST.EXPENSIFY_EMAILS, ...existingDelegates],
 

--- a/src/pages/settings/Security/AddDelegate/AddDelegatePage.tsx
+++ b/src/pages/settings/Security/AddDelegate/AddDelegatePage.tsx
@@ -27,26 +27,15 @@ function useOptions() {
     const existingDelegates = useMemo(() => account?.delegatedAccess?.delegates?.map((delegate) => delegate.email) ?? [], [account?.delegatedAccess?.delegates]);
 
     const defaultOptions = useMemo(() => {
-        const {recentReports, personalDetails, userToInvite, currentUserOption} = OptionsListUtils.getFilteredOptions(
-            optionsList.reports,
-            optionsList.personalDetails,
-            betas,
-            '',
-            [],
-            [...CONST.EXPENSIFY_EMAILS, ...existingDelegates],
-            false,
-            true,
-            false,
-            {},
-            [],
-            false,
-            {},
-            [],
-            true,
-            false,
-            false,
-            0,
-        );
+        const {recentReports, personalDetails, userToInvite, currentUserOption} = OptionsListUtils.getFilteredOptions({
+            reports: optionsList.reports,
+            personalDetails: optionsList.personalDetails,
+            betas: betas,
+
+            excludeLogins: [...CONST.EXPENSIFY_EMAILS, ...existingDelegates],
+
+            maxRecentReportsToShow: 0,
+        });
 
         const headerMessage = OptionsListUtils.getHeaderMessage((recentReports?.length || 0) + (personalDetails?.length || 0) !== 0, !!userToInvite, '');
 

--- a/src/pages/tasks/TaskAssigneeSelectorModal.tsx
+++ b/src/pages/tasks/TaskAssigneeSelectorModal.tsx
@@ -40,26 +40,14 @@ function useOptions() {
     const {options: optionsList, areOptionsInitialized} = useOptionsList();
 
     const defaultOptions = useMemo(() => {
-        const {recentReports, personalDetails, userToInvite, currentUserOption} = OptionsListUtils.getFilteredOptions(
-            optionsList.reports,
-            optionsList.personalDetails,
+        const {recentReports, personalDetails, userToInvite, currentUserOption} = OptionsListUtils.getFilteredOptions({
+            reports: optionsList.reports,
+            personalDetails: optionsList.personalDetails,
             betas,
-            '',
-            [],
-            CONST.EXPENSIFY_EMAILS,
-            false,
-            true,
-            false,
-            {},
-            [],
-            false,
-            {},
-            [],
-            true,
-            false,
-            false,
-            0,
-        );
+            excludeLogins: CONST.EXPENSIFY_EMAILS,
+
+            maxRecentReportsToShow: 0,
+        });
 
         const headerMessage = OptionsListUtils.getHeaderMessage((recentReports?.length || 0) + (personalDetails?.length || 0) !== 0 || !!currentUserOption, !!userToInvite, '');
 

--- a/tests/perf-test/OptionsListUtils.perf-test.ts
+++ b/tests/perf-test/OptionsListUtils.perf-test.ts
@@ -105,10 +105,10 @@ describe('OptionsListUtils', () => {
     });
 
     /* Testing getFilteredOptions */
-    test('[OptionsListUtils] getFilteredOptions', async () => {
+    test('[OptionsListUtils] getFilteredOptions with search value', async () => {
         await waitForBatchedUpdates();
-        // Ideally getFilteredOptions should not be used with both options and search value
-        // The more performant filterOptions should be used instead to pass search value with options containing reports and personal details
+        // It's recommended not to use getFilteredOptions with both options and a search value
+        // For better performance, use filterOptions instead, especially when passing a search value with options that include reports and personal details.
         // @ts-expect-error pass both options and search value together
         await measureFunction(() => OptionsListUtils.getFilteredOptions({reports: options.reports, personalDetails: options.personalDetails, betas: mockedBetas, searchValue: SEARCH_VALUE}));
     });

--- a/tests/perf-test/OptionsListUtils.perf-test.ts
+++ b/tests/perf-test/OptionsListUtils.perf-test.ts
@@ -109,7 +109,7 @@ describe('OptionsListUtils', () => {
         await waitForBatchedUpdates();
         // Ideally getFilteredOptions should not be used with both options and search value
         // The more performant filterOptions should be used instead to pass search value with options containing reports and personal details
-        // @ts-expect-error
+        // @ts-expect-error pass both options and search value together
         await measureFunction(() => OptionsListUtils.getFilteredOptions({reports: options.reports, personalDetails: options.personalDetails, betas: mockedBetas, searchValue: SEARCH_VALUE}));
     });
 

--- a/tests/perf-test/OptionsListUtils.perf-test.ts
+++ b/tests/perf-test/OptionsListUtils.perf-test.ts
@@ -105,9 +105,12 @@ describe('OptionsListUtils', () => {
     });
 
     /* Testing getFilteredOptions */
-    test('[OptionsListUtils] getFilteredOptions with search value', async () => {
+    test('[OptionsListUtils] getFilteredOptions', async () => {
         await waitForBatchedUpdates();
-        await measureFunction(() => OptionsListUtils.getFilteredOptions(options.reports, options.personalDetails, mockedBetas, SEARCH_VALUE));
+        // Ideally getFilteredOptions should not be used with both options and search value
+        // The more performant filterOptions should be used instead to pass search value with options containing reports and personal details
+        // @ts-expect-error
+        await measureFunction(() => OptionsListUtils.getFilteredOptions({reports: options.reports, personalDetails: options.personalDetails, betas: mockedBetas, searchValue: SEARCH_VALUE}));
     });
 
     /* Testing getShareDestinationOptions */

--- a/tests/unit/OptionsListUtilsTest.ts
+++ b/tests/unit/OptionsListUtilsTest.ts
@@ -525,7 +525,7 @@ describe('OptionsListUtils', () => {
 
     it('getFilteredOptions() for group Chat', () => {
         // When we call getFilteredOptions() with no search value
-        let results = OptionsListUtils.getFilteredOptions(OPTIONS.reports, OPTIONS.personalDetails, [], '');
+        const results = OptionsListUtils.getFilteredOptions(OPTIONS.reports, OPTIONS.personalDetails, [], '');
 
         // Then we should expect only a maxmimum of 5 recent reports to be returned
         expect(results.recentReports.length).toBe(5);
@@ -578,7 +578,7 @@ describe('OptionsListUtils', () => {
         // Test by excluding Concierge from the results
         results = OptionsListUtils.getFilteredOptions(OPTIONS_WITH_CONCIERGE.reports, OPTIONS_WITH_CONCIERGE.personalDetails, [], '', [], [CONST.EMAIL.CONCIERGE]);
 
-        // We should expect all the personalDetails to show (minus 
+        // We should expect all the personalDetails to show (minus
         // the currently logged in user and Concierge)
         // Filtering of personalDetails that have reports is done in filterOptions
         expect(results.personalDetails.length).toBe(Object.values(OPTIONS_WITH_CONCIERGE.personalDetails).length - 2);
@@ -598,7 +598,7 @@ describe('OptionsListUtils', () => {
         // Test by excluding Receipts from the results
         results = OptionsListUtils.getFilteredOptions(OPTIONS_WITH_RECEIPTS.reports, OPTIONS_WITH_RECEIPTS.personalDetails, [], '', [], [CONST.EMAIL.RECEIPTS]);
 
-        // We should expect all the personalDetails to show (minus 
+        // We should expect all the personalDetails to show (minus
         // the currently logged in user and Concierge)
         // Filtering of personalDetails that have reports is done in filterOptions
         expect(results.personalDetails.length).toBe(Object.values(OPTIONS_WITH_RECEIPTS.personalDetails).length - 2);

--- a/tests/unit/OptionsListUtilsTest.ts
+++ b/tests/unit/OptionsListUtilsTest.ts
@@ -404,7 +404,7 @@ describe('OptionsListUtils', () => {
 
     it('getSearchOptions()', () => {
         // When we filter in the Search view without providing a searchValue
-        let results = OptionsListUtils.getSearchOptions(OPTIONS, '', [CONST.BETAS.ALL]);
+        const results = OptionsListUtils.getSearchOptions(OPTIONS, '', [CONST.BETAS.ALL]);
 
         // All 2 personalDetails (including those that have reports) should be returned
         // Filtering of personalDetails that have reports is done in filterOptions
@@ -439,10 +439,6 @@ describe('OptionsListUtils', () => {
         expect(results.personalDetails.at(6)?.text).toBe('Spider-Man');
         expect(results.personalDetails.at(7)?.text).toBe('The Incredible Hulk');
         expect(results.personalDetails.at(8)?.text).toBe('Thor');
-        // expect(results.personalDetails.at(0)?.text).toBe('Black Widow');
-        // expect(results.personalDetails.at(1)?.text).toBe('Invisible Woman');
-        // expect(results.personalDetails.at(2)?.text).toBe('Spider-Man');
-        // expect(results.personalDetails.at(3)?.text).toBe('The Incredible Hulk');
 
         // Then the result which has an existing report should also have the reportID attached
         const personalDetailWithExistingReport = results.personalDetails.find((personalDetail) => personalDetail.login === 'peterparker@expensify.com');
@@ -525,7 +521,7 @@ describe('OptionsListUtils', () => {
 
     it('getFilteredOptions() for group Chat', () => {
         // When we call getFilteredOptions() with no search value
-        const results = OptionsListUtils.getFilteredOptions(OPTIONS.reports, OPTIONS.personalDetails, [], '');
+        let results = OptionsListUtils.getFilteredOptions(OPTIONS.reports, OPTIONS.personalDetails, [], '');
 
         // Then we should expect only a maxmimum of 5 recent reports to be returned
         expect(results.recentReports.length).toBe(5);

--- a/tests/unit/OptionsListUtilsTest.ts
+++ b/tests/unit/OptionsListUtilsTest.ts
@@ -419,7 +419,7 @@ describe('OptionsListUtils', () => {
         const MAX_RECENT_REPORTS = 5;
 
         // When we call getFilteredOptions() with no search value
-        let results = OptionsListUtils.getFilteredOptions(OPTIONS.reports, OPTIONS.personalDetails, [], '');
+        let results = OptionsListUtils.getFilteredOptions({reports: OPTIONS.reports, personalDetails: OPTIONS.personalDetails});
 
         // We should expect maximimum of 5 recent reports to be returned
         expect(results.recentReports.length).toBe(MAX_RECENT_REPORTS);
@@ -445,7 +445,7 @@ describe('OptionsListUtils', () => {
         expect(personalDetailWithExistingReport?.reportID).toBe('2');
 
         // When we only pass personal details
-        results = OptionsListUtils.getFilteredOptions([], OPTIONS.personalDetails, [], '');
+        results = OptionsListUtils.getFilteredOptions({personalDetails: OPTIONS.personalDetails});
 
         // We should expect personal details sorted alphabetically
         expect(results.personalDetails.at(0)?.text).toBe('Black Panther');
@@ -454,39 +454,16 @@ describe('OptionsListUtils', () => {
         expect(results.personalDetails.at(3)?.text).toBe('Invisible Woman');
 
         // When we don't include personal detail to the result
-        results = OptionsListUtils.getFilteredOptions(
-            [],
-            [],
-            [],
-            '',
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            0,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            false,
-        );
+        results = OptionsListUtils.getFilteredOptions({
+            maxRecentReportsToShow: 0,
+        });
 
         // Then no personal detail options will be returned
         expect(results.personalDetails.length).toBe(0);
 
         // Test for Concierge's existence in chat options
 
-        results = OptionsListUtils.getFilteredOptions(OPTIONS_WITH_CONCIERGE.reports, OPTIONS_WITH_CONCIERGE.personalDetails);
+        results = OptionsListUtils.getFilteredOptions({reports: OPTIONS_WITH_CONCIERGE.reports, personalDetails: OPTIONS_WITH_CONCIERGE.personalDetails});
 
         // Concierge is included in the results by default. We should expect all the personalDetails to show
         // (minus the currently logged in user)
@@ -495,7 +472,11 @@ describe('OptionsListUtils', () => {
         expect(results.recentReports).toEqual(expect.arrayContaining([expect.objectContaining({login: 'concierge@expensify.com'})]));
 
         // Test by excluding Concierge from the results
-        results = OptionsListUtils.getFilteredOptions(OPTIONS_WITH_CONCIERGE.reports, OPTIONS_WITH_CONCIERGE.personalDetails, [], '', [], [CONST.EMAIL.CONCIERGE]);
+        results = OptionsListUtils.getFilteredOptions({
+            reports: OPTIONS_WITH_CONCIERGE.reports,
+            personalDetails: OPTIONS_WITH_CONCIERGE.personalDetails,
+            excludeLogins: [CONST.EMAIL.CONCIERGE],
+        });
 
         // All the personalDetails should be returned minus the currently logged in user and Concierge
         // Filtering of personalDetails that have reports is done in filterOptions
@@ -503,7 +484,7 @@ describe('OptionsListUtils', () => {
         expect(results.personalDetails).not.toEqual(expect.arrayContaining([expect.objectContaining({login: 'concierge@expensify.com'})]));
 
         // Test by excluding Chronos from the results
-        results = OptionsListUtils.getFilteredOptions(OPTIONS_WITH_CHRONOS.reports, OPTIONS_WITH_CHRONOS.personalDetails, [], '', [], [CONST.EMAIL.CHRONOS]);
+        results = OptionsListUtils.getFilteredOptions({reports: OPTIONS_WITH_CHRONOS.reports, personalDetails: OPTIONS_WITH_CHRONOS.personalDetails, excludeLogins: [CONST.EMAIL.CHRONOS]});
 
         // All the personalDetails should be returned minus the currently logged in user and Concierge
         // Filtering of personalDetails that have reports is done in filterOptions
@@ -511,7 +492,11 @@ describe('OptionsListUtils', () => {
         expect(results.personalDetails).not.toEqual(expect.arrayContaining([expect.objectContaining({login: 'chronos@expensify.com'})]));
 
         // Test by excluding Receipts from the results
-        results = OptionsListUtils.getFilteredOptions(OPTIONS_WITH_RECEIPTS.reports, OPTIONS_WITH_RECEIPTS.personalDetails, [], '', [], [CONST.EMAIL.RECEIPTS]);
+        results = OptionsListUtils.getFilteredOptions({
+            reports: OPTIONS_WITH_RECEIPTS.reports,
+            personalDetails: OPTIONS_WITH_RECEIPTS.personalDetails,
+            excludeLogins: [CONST.EMAIL.RECEIPTS],
+        });
 
         // All the personalDetails should be returned minus the currently logged in user and Concierge
         // Filtering of personalDetails that have reports is done in filterOptions
@@ -521,7 +506,7 @@ describe('OptionsListUtils', () => {
 
     it('getFilteredOptions() for group Chat', () => {
         // When we call getFilteredOptions() with no search value
-        let results = OptionsListUtils.getFilteredOptions(OPTIONS.reports, OPTIONS.personalDetails, [], '');
+        let results = OptionsListUtils.getFilteredOptions({reports: OPTIONS.reports, personalDetails: OPTIONS.personalDetails});
 
         // Then we should expect only a maxmimum of 5 recent reports to be returned
         expect(results.recentReports.length).toBe(5);
@@ -548,7 +533,7 @@ describe('OptionsListUtils', () => {
         expect(personalDetailsOverlapWithReports).toBe(false);
 
         // When we provide no selected options to getFilteredOptions()
-        results = OptionsListUtils.getFilteredOptions(OPTIONS.reports, OPTIONS.personalDetails, [], '', []);
+        results = OptionsListUtils.getFilteredOptions({reports: OPTIONS.reports, personalDetails: OPTIONS.personalDetails});
 
         // Then one of our older report options (not in our five most recent) should appear in the personalDetails
         // but not in recentReports
@@ -556,14 +541,14 @@ describe('OptionsListUtils', () => {
         expect(results.personalDetails.every((option) => option.login !== 'peterparker@expensify.com')).toBe(false);
 
         // When we provide a "selected" option to getFilteredOptions()
-        results = OptionsListUtils.getFilteredOptions(OPTIONS.reports, OPTIONS.personalDetails, [], '', [{login: 'peterparker@expensify.com'}]);
+        results = OptionsListUtils.getFilteredOptions({reports: OPTIONS.reports, personalDetails: OPTIONS.personalDetails, excludeLogins: ['peterparker@expensify.com']});
 
         // Then the option should not appear anywhere in either list
         expect(results.recentReports.every((option) => option.login !== 'peterparker@expensify.com')).toBe(true);
         expect(results.personalDetails.every((option) => option.login !== 'peterparker@expensify.com')).toBe(true);
 
         // Test Concierge's existence in new group options
-        results = OptionsListUtils.getFilteredOptions(OPTIONS_WITH_CONCIERGE.reports, OPTIONS_WITH_CONCIERGE.personalDetails);
+        results = OptionsListUtils.getFilteredOptions({reports: OPTIONS_WITH_CONCIERGE.reports, personalDetails: OPTIONS_WITH_CONCIERGE.personalDetails});
 
         // Concierge is included in the results by default. We should expect all the personalDetails to show
         // (minus the currently logged in user)
@@ -572,7 +557,11 @@ describe('OptionsListUtils', () => {
         expect(results.recentReports).toEqual(expect.arrayContaining([expect.objectContaining({login: 'concierge@expensify.com'})]));
 
         // Test by excluding Concierge from the results
-        results = OptionsListUtils.getFilteredOptions(OPTIONS_WITH_CONCIERGE.reports, OPTIONS_WITH_CONCIERGE.personalDetails, [], '', [], [CONST.EMAIL.CONCIERGE]);
+        results = OptionsListUtils.getFilteredOptions({
+            reports: OPTIONS_WITH_CONCIERGE.reports,
+            personalDetails: OPTIONS_WITH_CONCIERGE.personalDetails,
+            excludeLogins: [CONST.EMAIL.CONCIERGE],
+        });
 
         // We should expect all the personalDetails to show (minus
         // the currently logged in user and Concierge)
@@ -582,7 +571,7 @@ describe('OptionsListUtils', () => {
         expect(results.recentReports).not.toEqual(expect.arrayContaining([expect.objectContaining({login: 'concierge@expensify.com'})]));
 
         // Test by excluding Chronos from the results
-        results = OptionsListUtils.getFilteredOptions(OPTIONS_WITH_CHRONOS.reports, OPTIONS_WITH_CHRONOS.personalDetails, [], '', [], [CONST.EMAIL.CHRONOS]);
+        results = OptionsListUtils.getFilteredOptions({reports: OPTIONS_WITH_CHRONOS.reports, personalDetails: OPTIONS_WITH_CHRONOS.personalDetails, excludeLogins: [CONST.EMAIL.CHRONOS]});
 
         // We should expect all the personalDetails to show (minus
         // the currently logged in user and Concierge)
@@ -592,7 +581,11 @@ describe('OptionsListUtils', () => {
         expect(results.recentReports).not.toEqual(expect.arrayContaining([expect.objectContaining({login: 'chronos@expensify.com'})]));
 
         // Test by excluding Receipts from the results
-        results = OptionsListUtils.getFilteredOptions(OPTIONS_WITH_RECEIPTS.reports, OPTIONS_WITH_RECEIPTS.personalDetails, [], '', [], [CONST.EMAIL.RECEIPTS]);
+        results = OptionsListUtils.getFilteredOptions({
+            reports: OPTIONS_WITH_RECEIPTS.reports,
+            personalDetails: OPTIONS_WITH_RECEIPTS.personalDetails,
+            excludeLogins: [CONST.EMAIL.RECEIPTS],
+        });
 
         // We should expect all the personalDetails to show (minus
         // the currently logged in user and Concierge)
@@ -1102,61 +1095,54 @@ describe('OptionsListUtils', () => {
             },
         ];
 
-        const smallResult = OptionsListUtils.getFilteredOptions(OPTIONS.reports, OPTIONS.personalDetails, [], emptySearch, [], [], false, false, true, smallCategoriesList);
+        const smallResult = OptionsListUtils.getFilteredOptions({
+            reports: OPTIONS.reports,
+            personalDetails: OPTIONS.personalDetails,
+            searchValue: emptySearch,
+            includeP2P: false,
+            includeCategories: true,
+            categories: smallCategoriesList,
+        });
         expect(smallResult.categoryOptions).toStrictEqual(smallResultList);
 
-        const smallSearchResult = OptionsListUtils.getFilteredOptions(OPTIONS.reports, OPTIONS.personalDetails, [], search, [], [], false, false, true, smallCategoriesList);
+        const smallSearchResult = OptionsListUtils.getFilteredOptions({searchValue: search, includeP2P: false, includeCategories: true, categories: smallCategoriesList});
         expect(smallSearchResult.categoryOptions).toStrictEqual(smallSearchResultList);
 
-        const smallWrongSearchResult = OptionsListUtils.getFilteredOptions(OPTIONS.reports, OPTIONS.personalDetails, [], wrongSearch, [], [], false, false, true, smallCategoriesList);
+        const smallWrongSearchResult = OptionsListUtils.getFilteredOptions({searchValue: wrongSearch, includeP2P: false, includeCategories: true, categories: smallCategoriesList});
         expect(smallWrongSearchResult.categoryOptions).toStrictEqual(smallWrongSearchResultList);
 
-        const largeResult = OptionsListUtils.getFilteredOptions(
-            OPTIONS.reports,
-            OPTIONS.personalDetails,
-            [],
-            emptySearch,
+        const largeResult = OptionsListUtils.getFilteredOptions({
+            searchValue: emptySearch,
             selectedOptions,
-            [],
-            false,
-            false,
-            true,
-            largeCategoriesList,
+            includeP2P: false,
+            includeCategories: true,
+            categories: largeCategoriesList,
             recentlyUsedCategories,
-        );
+        });
         expect(largeResult.categoryOptions).toStrictEqual(largeResultList);
 
-        const largeSearchResult = OptionsListUtils.getFilteredOptions(
-            OPTIONS.reports,
-            OPTIONS.personalDetails,
-            [],
-            search,
+        const largeSearchResult = OptionsListUtils.getFilteredOptions({
+            searchValue: search,
             selectedOptions,
-            [],
-            false,
-            false,
-            true,
-            largeCategoriesList,
+
+            includeP2P: false,
+            includeCategories: true,
+            categories: largeCategoriesList,
             recentlyUsedCategories,
-        );
+        });
         expect(largeSearchResult.categoryOptions).toStrictEqual(largeSearchResultList);
 
-        const largeWrongSearchResult = OptionsListUtils.getFilteredOptions(
-            OPTIONS.reports,
-            OPTIONS.personalDetails,
-            [],
-            wrongSearch,
+        const largeWrongSearchResult = OptionsListUtils.getFilteredOptions({
+            searchValue: wrongSearch,
             selectedOptions,
-            [],
-            false,
-            false,
-            true,
-            largeCategoriesList,
+            includeP2P: false,
+            includeCategories: true,
+            categories: largeCategoriesList,
             recentlyUsedCategories,
-        );
+        });
         expect(largeWrongSearchResult.categoryOptions).toStrictEqual(largeWrongSearchResultList);
 
-        const emptyResult = OptionsListUtils.getFilteredOptions(OPTIONS.reports, OPTIONS.personalDetails, [], search, selectedOptions, [], false, false, true, emptyCategoriesList);
+        const emptyResult = OptionsListUtils.getFilteredOptions({searchValue: search, selectedOptions, includeP2P: false, includeCategories: true, categories: emptyCategoriesList});
         expect(emptyResult.categoryOptions).toStrictEqual(emptySelectedResultList);
     });
 
@@ -1448,81 +1434,29 @@ describe('OptionsListUtils', () => {
             },
         ];
 
-        const smallResult = OptionsListUtils.getFilteredOptions(OPTIONS.reports, OPTIONS.personalDetails, [], emptySearch, [], [], false, false, false, {}, [], true, smallTagsList);
+        const smallResult = OptionsListUtils.getFilteredOptions({searchValue: emptySearch, includeP2P: false, includeTags: true, tags: smallTagsList});
         expect(smallResult.tagOptions).toStrictEqual(smallResultList);
 
-        const smallSearchResult = OptionsListUtils.getFilteredOptions(OPTIONS.reports, OPTIONS.personalDetails, [], search, [], [], false, false, false, {}, [], true, smallTagsList);
+        const smallSearchResult = OptionsListUtils.getFilteredOptions({searchValue: search, includeP2P: false, includeTags: true, tags: smallTagsList});
         expect(smallSearchResult.tagOptions).toStrictEqual(smallSearchResultList);
 
-        const smallWrongSearchResult = OptionsListUtils.getFilteredOptions(
-            OPTIONS.reports,
-            OPTIONS.personalDetails,
-            [],
-            wrongSearch,
-            [],
-            [],
-            false,
-            false,
-            false,
-            {},
-            [],
-            true,
-            smallTagsList,
-        );
+        const smallWrongSearchResult = OptionsListUtils.getFilteredOptions({searchValue: wrongSearch, includeP2P: false, includeTags: true, tags: smallTagsList});
         expect(smallWrongSearchResult.tagOptions).toStrictEqual(smallWrongSearchResultList);
 
-        const largeResult = OptionsListUtils.getFilteredOptions(
-            OPTIONS.reports,
-            OPTIONS.personalDetails,
-            [],
-            emptySearch,
-            selectedOptions,
-            [],
-            false,
-            false,
-            false,
-            {},
-            [],
-            true,
-            largeTagsList,
-            recentlyUsedTags,
-        );
+        const largeResult = OptionsListUtils.getFilteredOptions({searchValue: emptySearch, selectedOptions, includeP2P: false, includeTags: true, tags: largeTagsList, recentlyUsedTags});
         expect(largeResult.tagOptions).toStrictEqual(largeResultList);
 
-        const largeSearchResult = OptionsListUtils.getFilteredOptions(
-            OPTIONS.reports,
-            OPTIONS.personalDetails,
-            [],
-            search,
-            selectedOptions,
-            [],
-            false,
-            false,
-            false,
-            {},
-            [],
-            true,
-            largeTagsList,
-            recentlyUsedTags,
-        );
+        const largeSearchResult = OptionsListUtils.getFilteredOptions({searchValue: search, selectedOptions, includeP2P: false, includeTags: true, tags: largeTagsList, recentlyUsedTags});
         expect(largeSearchResult.tagOptions).toStrictEqual(largeSearchResultList);
 
-        const largeWrongSearchResult = OptionsListUtils.getFilteredOptions(
-            OPTIONS.reports,
-            OPTIONS.personalDetails,
-            [],
-            wrongSearch,
+        const largeWrongSearchResult = OptionsListUtils.getFilteredOptions({
+            searchValue: wrongSearch,
             selectedOptions,
-            [],
-            false,
-            false,
-            false,
-            {},
-            [],
-            true,
-            largeTagsList,
+            includeP2P: false,
+            includeTags: true,
+            tags: largeTagsList,
             recentlyUsedTags,
-        );
+        });
         expect(largeWrongSearchResult.tagOptions).toStrictEqual(largeWrongSearchResultList);
     });
 
@@ -2731,7 +2665,7 @@ describe('OptionsListUtils', () => {
         it('should not return any results if the search value is on an exluded logins list', () => {
             const searchText = 'admin@expensify.com';
 
-            const options = OptionsListUtils.getFilteredOptions(OPTIONS.reports, OPTIONS.personalDetails, [], searchText, [], CONST.EXPENSIFY_EMAILS);
+            const options = OptionsListUtils.getFilteredOptions({reports: OPTIONS.reports, personalDetails: OPTIONS.personalDetails, excludeLogins: CONST.EXPENSIFY_EMAILS});
             const filterOptions = OptionsListUtils.filterOptions(options, searchText, {excludeLogins: CONST.EXPENSIFY_EMAILS});
             expect(filterOptions.recentReports.length).toBe(0);
         });
@@ -2825,7 +2759,7 @@ describe('OptionsListUtils', () => {
         });
 
         it('should show the option from personal details when searching for personal detail with no existing report (getFilteredOptions)', () => {
-            const options = OptionsListUtils.getFilteredOptions(OPTIONS.reports, OPTIONS.personalDetails, [], '');
+            const options = OptionsListUtils.getFilteredOptions({reports: OPTIONS.reports, personalDetails: OPTIONS.personalDetails});
             const filteredOptions = OptionsListUtils.filterOptions(options, 'hulk');
 
             expect(filteredOptions.recentReports.length).toBe(0);
@@ -2835,7 +2769,7 @@ describe('OptionsListUtils', () => {
         });
 
         it('should return all matching reports and personal details (getFilteredOptions)', () => {
-            const options = OptionsListUtils.getFilteredOptions(OPTIONS.reports, OPTIONS.personalDetails, [], '');
+            const options = OptionsListUtils.getFilteredOptions({reports: OPTIONS.reports, personalDetails: OPTIONS.personalDetails});
             const filteredOptions = OptionsListUtils.filterOptions(options, '.com');
 
             expect(filteredOptions.recentReports.length).toBe(5);
@@ -2846,7 +2780,7 @@ describe('OptionsListUtils', () => {
         });
 
         it('should not return any options or user to invite if there are no search results and the string does not match a potential email or phone (getFilteredOptions)', () => {
-            const options = OptionsListUtils.getFilteredOptions(OPTIONS.reports, OPTIONS.personalDetails, [], '');
+            const options = OptionsListUtils.getFilteredOptions({reports: OPTIONS.reports, personalDetails: OPTIONS.personalDetails});
             const filteredOptions = OptionsListUtils.filterOptions(options, 'marc@expensify');
 
             expect(filteredOptions.recentReports.length).toBe(0);
@@ -2855,7 +2789,8 @@ describe('OptionsListUtils', () => {
         });
 
         it('should not return any options but should return an user to invite if no matching options exist and the search value is a potential email (getFilteredOptions)', () => {
-            const options = OptionsListUtils.getFilteredOptions(OPTIONS.reports, OPTIONS.personalDetails, [], '');
+            // const options = OptionsListUtils.getFilteredOptions(OPTIONS.reports, OPTIONS.personalDetails, [], '');
+            const options = OptionsListUtils.getFilteredOptions({reports: OPTIONS.reports, personalDetails: OPTIONS.personalDetails});
             const filteredOptions = OptionsListUtils.filterOptions(options, 'marc@expensify.com');
 
             expect(filteredOptions.recentReports.length).toBe(0);
@@ -2864,7 +2799,7 @@ describe('OptionsListUtils', () => {
         });
 
         it('should return user to invite when search term has a period with options for it that do not contain the period (getFilteredOptions)', () => {
-            const options = OptionsListUtils.getFilteredOptions(OPTIONS.reports, OPTIONS.personalDetails, [], '');
+            const options = OptionsListUtils.getFilteredOptions({reports: OPTIONS.reports, personalDetails: OPTIONS.personalDetails});
             const filteredOptions = OptionsListUtils.filterOptions(options, 'peter.parker@expensify.com');
 
             expect(filteredOptions.recentReports.length).toBe(0);
@@ -2872,7 +2807,7 @@ describe('OptionsListUtils', () => {
         });
 
         it('should not return options but should return an user to invite if no matching options exist and the search value is a potential phone number (getFilteredOptions)', () => {
-            const options = OptionsListUtils.getFilteredOptions(OPTIONS.reports, OPTIONS.personalDetails, [], '');
+            const options = OptionsListUtils.getFilteredOptions({reports: OPTIONS.reports, personalDetails: OPTIONS.personalDetails});
             const filteredOptions = OptionsListUtils.filterOptions(options, '5005550006');
 
             expect(filteredOptions.recentReports.length).toBe(0);
@@ -2882,7 +2817,7 @@ describe('OptionsListUtils', () => {
         });
 
         it('should not return options but should return an user to invite if no matching options exist and the search value is a potential phone number with country code added (getFilteredOptions)', () => {
-            const options = OptionsListUtils.getFilteredOptions(OPTIONS.reports, OPTIONS.personalDetails, [], '');
+            const options = OptionsListUtils.getFilteredOptions({reports: OPTIONS.reports, personalDetails: OPTIONS.personalDetails});
             const filteredOptions = OptionsListUtils.filterOptions(options, '+15005550006');
 
             expect(filteredOptions.recentReports.length).toBe(0);
@@ -2892,7 +2827,7 @@ describe('OptionsListUtils', () => {
         });
 
         it('should not return options but should return an user to invite if no matching options exist and the search value is a potential phone number with special characters added (getFilteredOptions)', () => {
-            const options = OptionsListUtils.getFilteredOptions(OPTIONS.reports, OPTIONS.personalDetails, [], '');
+            const options = OptionsListUtils.getFilteredOptions({reports: OPTIONS.reports, personalDetails: OPTIONS.personalDetails});
             const filteredOptions = OptionsListUtils.filterOptions(options, '+1 (800)324-3233');
 
             expect(filteredOptions.recentReports.length).toBe(0);
@@ -2902,7 +2837,8 @@ describe('OptionsListUtils', () => {
         });
 
         it('should not return any options or user to invite if contact number contains alphabet characters (getFilteredOptions)', () => {
-            const options = OptionsListUtils.getFilteredOptions(OPTIONS.reports, OPTIONS.personalDetails, [], '');
+            // const options = OptionsListUtils.getFilteredOptions(OPTIONS.reports, OPTIONS.personalDetails, [], '');
+            const options = OptionsListUtils.getFilteredOptions({reports: OPTIONS.reports, personalDetails: OPTIONS.personalDetails});
             const filteredOptions = OptionsListUtils.filterOptions(options, '998243aaaa');
 
             expect(filteredOptions.recentReports.length).toBe(0);
@@ -2911,14 +2847,14 @@ describe('OptionsListUtils', () => {
         });
 
         it('should not return any options if search value does not match any personal details (getFilteredOptions)', () => {
-            const options = OptionsListUtils.getFilteredOptions(OPTIONS.reports, OPTIONS.personalDetails, [], '');
+            const options = OptionsListUtils.getFilteredOptions({reports: OPTIONS.reports, personalDetails: OPTIONS.personalDetails});
             const filteredOptions = OptionsListUtils.filterOptions(options, 'magneto');
 
             expect(filteredOptions.personalDetails.length).toBe(0);
         });
 
         it('should return one recent report and no personal details if a search value provides an email (getFilteredOptions)', () => {
-            const options = OptionsListUtils.getFilteredOptions(OPTIONS.reports, OPTIONS.personalDetails, [], '');
+            const options = OptionsListUtils.getFilteredOptions({reports: OPTIONS.reports, personalDetails: OPTIONS.personalDetails});
             const filteredOptions = OptionsListUtils.filterOptions(options, 'peterparker@expensify.com', {sortByReportTypeInSearch: true});
             expect(filteredOptions.recentReports.length).toBe(1);
             expect(filteredOptions.recentReports.at(0)?.text).toBe('Spider-Man');
@@ -2926,7 +2862,7 @@ describe('OptionsListUtils', () => {
         });
 
         it('should return all matching reports and personal details (getFilteredOptions)', () => {
-            const options = OptionsListUtils.getFilteredOptions(OPTIONS.reports, OPTIONS.personalDetails, [], '');
+            const options = OptionsListUtils.getFilteredOptions({reports: OPTIONS.reports, personalDetails: OPTIONS.personalDetails});
             const filteredOptions = OptionsListUtils.filterOptions(options, '.com');
 
             expect(filteredOptions.personalDetails.length).toBe(4);

--- a/tests/unit/OptionsListUtilsTest.ts
+++ b/tests/unit/OptionsListUtilsTest.ts
@@ -404,9 +404,11 @@ describe('OptionsListUtils', () => {
 
     it('getSearchOptions()', () => {
         // When we filter in the Search view without providing a searchValue
-        const results = OptionsListUtils.getSearchOptions(OPTIONS, '', [CONST.BETAS.ALL]);
-        // Then the 2 personalDetails that don't have reports should be returned
-        expect(results.personalDetails.length).toBe(2);
+        let results = OptionsListUtils.getSearchOptions(OPTIONS, '', [CONST.BETAS.ALL]);
+
+        // All 2 personalDetails (including those that have reports) should be returned
+        // Filtering of personalDetails that have reports is done in filterOptions
+        expect(results.personalDetails.length).toBe(9);
 
         // Then all of the reports should be shown including the archived rooms.
         expect(results.recentReports.length).toBe(Object.values(OPTIONS.reports).length);
@@ -422,15 +424,25 @@ describe('OptionsListUtils', () => {
         // We should expect maximimum of 5 recent reports to be returned
         expect(results.recentReports.length).toBe(MAX_RECENT_REPORTS);
 
-        // We should expect all personalDetails to be returned,
-        // minus the currently logged in user and recent reports count
-        expect(results.personalDetails.length).toBe(Object.values(OPTIONS.personalDetails).length - 1 - MAX_RECENT_REPORTS);
+        // We should expect all personalDetails except the currently logged in user to be returned
+        // Filtering of personalDetails that have reports is done in filterOptions
+        expect(results.personalDetails.length).toBe(Object.values(OPTIONS.personalDetails).length - 1);
 
+        // All personal details including those that have reports should be returned
         // We should expect personal details sorted alphabetically
-        expect(results.personalDetails.at(0)?.text).toBe('Black Widow');
-        expect(results.personalDetails.at(1)?.text).toBe('Invisible Woman');
-        expect(results.personalDetails.at(2)?.text).toBe('Spider-Man');
-        expect(results.personalDetails.at(3)?.text).toBe('The Incredible Hulk');
+        expect(results.personalDetails.at(0)?.text).toBe('Black Panther');
+        expect(results.personalDetails.at(1)?.text).toBe('Black Widow');
+        expect(results.personalDetails.at(2)?.text).toBe('Captain America');
+        expect(results.personalDetails.at(3)?.text).toBe('Invisible Woman');
+        expect(results.personalDetails.at(4)?.text).toBe('Mister Fantastic');
+        expect(results.personalDetails.at(5)?.text).toBe('Mr Sinister');
+        expect(results.personalDetails.at(6)?.text).toBe('Spider-Man');
+        expect(results.personalDetails.at(7)?.text).toBe('The Incredible Hulk');
+        expect(results.personalDetails.at(8)?.text).toBe('Thor');
+        // expect(results.personalDetails.at(0)?.text).toBe('Black Widow');
+        // expect(results.personalDetails.at(1)?.text).toBe('Invisible Woman');
+        // expect(results.personalDetails.at(2)?.text).toBe('Spider-Man');
+        // expect(results.personalDetails.at(3)?.text).toBe('The Incredible Hulk');
 
         // Then the result which has an existing report should also have the reportID attached
         const personalDetailWithExistingReport = results.personalDetails.find((personalDetail) => personalDetail.login === 'peterparker@expensify.com');
@@ -481,29 +493,33 @@ describe('OptionsListUtils', () => {
         results = OptionsListUtils.getFilteredOptions(OPTIONS_WITH_CONCIERGE.reports, OPTIONS_WITH_CONCIERGE.personalDetails);
 
         // Concierge is included in the results by default. We should expect all the personalDetails to show
-        // (minus the 5 that are already showing and the currently logged in user)
-        expect(results.personalDetails.length).toBe(Object.values(OPTIONS_WITH_CONCIERGE.personalDetails).length - 1 - MAX_RECENT_REPORTS);
+        // (minus the currently logged in user)
+        // Filtering of personalDetails that have reports is done in filterOptions
+        expect(results.personalDetails.length).toBe(Object.values(OPTIONS_WITH_CONCIERGE.personalDetails).length - 1);
         expect(results.recentReports).toEqual(expect.arrayContaining([expect.objectContaining({login: 'concierge@expensify.com'})]));
 
         // Test by excluding Concierge from the results
         results = OptionsListUtils.getFilteredOptions(OPTIONS_WITH_CONCIERGE.reports, OPTIONS_WITH_CONCIERGE.personalDetails, [], '', [], [CONST.EMAIL.CONCIERGE]);
 
         // All the personalDetails should be returned minus the currently logged in user and Concierge
-        expect(results.personalDetails.length).toBe(Object.values(OPTIONS_WITH_CONCIERGE.personalDetails).length - 2 - MAX_RECENT_REPORTS);
+        // Filtering of personalDetails that have reports is done in filterOptions
+        expect(results.personalDetails.length).toBe(Object.values(OPTIONS_WITH_CONCIERGE.personalDetails).length - 2);
         expect(results.personalDetails).not.toEqual(expect.arrayContaining([expect.objectContaining({login: 'concierge@expensify.com'})]));
 
         // Test by excluding Chronos from the results
         results = OptionsListUtils.getFilteredOptions(OPTIONS_WITH_CHRONOS.reports, OPTIONS_WITH_CHRONOS.personalDetails, [], '', [], [CONST.EMAIL.CHRONOS]);
 
         // All the personalDetails should be returned minus the currently logged in user and Concierge
-        expect(results.personalDetails.length).toBe(Object.values(OPTIONS_WITH_CHRONOS.personalDetails).length - 2 - MAX_RECENT_REPORTS);
+        // Filtering of personalDetails that have reports is done in filterOptions
+        expect(results.personalDetails.length).toBe(Object.values(OPTIONS_WITH_CHRONOS.personalDetails).length - 2);
         expect(results.personalDetails).not.toEqual(expect.arrayContaining([expect.objectContaining({login: 'chronos@expensify.com'})]));
 
         // Test by excluding Receipts from the results
         results = OptionsListUtils.getFilteredOptions(OPTIONS_WITH_RECEIPTS.reports, OPTIONS_WITH_RECEIPTS.personalDetails, [], '', [], [CONST.EMAIL.RECEIPTS]);
 
         // All the personalDetails should be returned minus the currently logged in user and Concierge
-        expect(results.personalDetails.length).toBe(Object.values(OPTIONS_WITH_RECEIPTS.personalDetails).length - 2 - MAX_RECENT_REPORTS);
+        // Filtering of personalDetails that have reports is done in filterOptions
+        expect(results.personalDetails.length).toBe(Object.values(OPTIONS_WITH_RECEIPTS.personalDetails).length - 2);
         expect(results.personalDetails).not.toEqual(expect.arrayContaining([expect.objectContaining({login: 'receipts@expensify.com'})]));
     });
 
@@ -514,15 +530,21 @@ describe('OptionsListUtils', () => {
         // Then we should expect only a maxmimum of 5 recent reports to be returned
         expect(results.recentReports.length).toBe(5);
 
-        // And we should expect all the personalDetails to show (minus the 5 that are already
-        // showing and the currently logged in user)
-        expect(results.personalDetails.length).toBe(Object.values(OPTIONS.personalDetails).length - 6);
+        // And we should expect all the personalDetails to show except the currently logged in user
+        // Filtering of personalDetails that have reports is done in filterOptions
+        expect(results.personalDetails.length).toBe(Object.values(OPTIONS.personalDetails).length - 1);
 
+        // All personal details including those that have reports should be returned
         // We should expect personal details sorted alphabetically
-        expect(results.personalDetails.at(0)?.text).toBe('Black Widow');
-        expect(results.personalDetails.at(1)?.text).toBe('Invisible Woman');
-        expect(results.personalDetails.at(2)?.text).toBe('Spider-Man');
-        expect(results.personalDetails.at(3)?.text).toBe('The Incredible Hulk');
+        expect(results.personalDetails.at(0)?.text).toBe('Black Panther');
+        expect(results.personalDetails.at(1)?.text).toBe('Black Widow');
+        expect(results.personalDetails.at(2)?.text).toBe('Captain America');
+        expect(results.personalDetails.at(3)?.text).toBe('Invisible Woman');
+        expect(results.personalDetails.at(4)?.text).toBe('Mister Fantastic');
+        expect(results.personalDetails.at(5)?.text).toBe('Mr Sinister');
+        expect(results.personalDetails.at(6)?.text).toBe('Spider-Man');
+        expect(results.personalDetails.at(7)?.text).toBe('The Incredible Hulk');
+        expect(results.personalDetails.at(8)?.text).toBe('Thor');
 
         // And none of our personalDetails should include any of the users with recent reports
         const reportLogins = results.recentReports.map((reportOption) => reportOption.login);
@@ -548,34 +570,38 @@ describe('OptionsListUtils', () => {
         results = OptionsListUtils.getFilteredOptions(OPTIONS_WITH_CONCIERGE.reports, OPTIONS_WITH_CONCIERGE.personalDetails);
 
         // Concierge is included in the results by default. We should expect all the personalDetails to show
-        // (minus the 5 that are already showing and the currently logged in user)
-        expect(results.personalDetails.length).toBe(Object.values(OPTIONS_WITH_CONCIERGE.personalDetails).length - 6);
+        // (minus the currently logged in user)
+        // Filtering of personalDetails that have reports is done in filterOptions
+        expect(results.personalDetails.length).toBe(Object.values(OPTIONS_WITH_CONCIERGE.personalDetails).length - 1);
         expect(results.recentReports).toEqual(expect.arrayContaining([expect.objectContaining({login: 'concierge@expensify.com'})]));
 
         // Test by excluding Concierge from the results
         results = OptionsListUtils.getFilteredOptions(OPTIONS_WITH_CONCIERGE.reports, OPTIONS_WITH_CONCIERGE.personalDetails, [], '', [], [CONST.EMAIL.CONCIERGE]);
 
-        // We should expect all the personalDetails to show (minus the 5 that are already showing,
+        // We should expect all the personalDetails to show (minus 
         // the currently logged in user and Concierge)
-        expect(results.personalDetails.length).toBe(Object.values(OPTIONS_WITH_CONCIERGE.personalDetails).length - 7);
+        // Filtering of personalDetails that have reports is done in filterOptions
+        expect(results.personalDetails.length).toBe(Object.values(OPTIONS_WITH_CONCIERGE.personalDetails).length - 2);
         expect(results.personalDetails).not.toEqual(expect.arrayContaining([expect.objectContaining({login: 'concierge@expensify.com'})]));
         expect(results.recentReports).not.toEqual(expect.arrayContaining([expect.objectContaining({login: 'concierge@expensify.com'})]));
 
         // Test by excluding Chronos from the results
         results = OptionsListUtils.getFilteredOptions(OPTIONS_WITH_CHRONOS.reports, OPTIONS_WITH_CHRONOS.personalDetails, [], '', [], [CONST.EMAIL.CHRONOS]);
 
-        // We should expect all the personalDetails to show (minus the 5 that are already showing,
+        // We should expect all the personalDetails to show (minus
         // the currently logged in user and Concierge)
-        expect(results.personalDetails.length).toBe(Object.values(OPTIONS_WITH_CHRONOS.personalDetails).length - 7);
+        // Filtering of personalDetails that have reports is done in filterOptions
+        expect(results.personalDetails.length).toBe(Object.values(OPTIONS_WITH_CHRONOS.personalDetails).length - 2);
         expect(results.personalDetails).not.toEqual(expect.arrayContaining([expect.objectContaining({login: 'chronos@expensify.com'})]));
         expect(results.recentReports).not.toEqual(expect.arrayContaining([expect.objectContaining({login: 'chronos@expensify.com'})]));
 
         // Test by excluding Receipts from the results
         results = OptionsListUtils.getFilteredOptions(OPTIONS_WITH_RECEIPTS.reports, OPTIONS_WITH_RECEIPTS.personalDetails, [], '', [], [CONST.EMAIL.RECEIPTS]);
 
-        // We should expect all the personalDetails to show (minus the 5 that are already showing,
+        // We should expect all the personalDetails to show (minus 
         // the currently logged in user and Concierge)
-        expect(results.personalDetails.length).toBe(Object.values(OPTIONS_WITH_RECEIPTS.personalDetails).length - 7);
+        // Filtering of personalDetails that have reports is done in filterOptions
+        expect(results.personalDetails.length).toBe(Object.values(OPTIONS_WITH_RECEIPTS.personalDetails).length - 2);
         expect(results.personalDetails).not.toEqual(expect.arrayContaining([expect.objectContaining({login: 'receipts@expensify.com'})]));
         expect(results.recentReports).not.toEqual(expect.arrayContaining([expect.objectContaining({login: 'receipts@expensify.com'})]));
     });
@@ -2610,7 +2636,7 @@ describe('OptionsListUtils', () => {
             const options = OptionsListUtils.getSearchOptions(OPTIONS, '', [CONST.BETAS.ALL]);
             const filteredOptions = OptionsListUtils.filterOptions(options, '');
 
-            expect(options.recentReports.length + options.personalDetails.length).toBe(filteredOptions.recentReports.length + filteredOptions.personalDetails.length);
+            expect(filteredOptions.recentReports.length + filteredOptions.personalDetails.length).toBe(12);
         });
 
         it('should return filtered options in correct order', () => {

--- a/tests/unit/OptionsListUtilsTest.ts
+++ b/tests/unit/OptionsListUtilsTest.ts
@@ -2789,7 +2789,6 @@ describe('OptionsListUtils', () => {
         });
 
         it('should not return any options but should return an user to invite if no matching options exist and the search value is a potential email (getFilteredOptions)', () => {
-            // const options = OptionsListUtils.getFilteredOptions(OPTIONS.reports, OPTIONS.personalDetails, [], '');
             const options = OptionsListUtils.getFilteredOptions({reports: OPTIONS.reports, personalDetails: OPTIONS.personalDetails});
             const filteredOptions = OptionsListUtils.filterOptions(options, 'marc@expensify.com');
 
@@ -2837,7 +2836,6 @@ describe('OptionsListUtils', () => {
         });
 
         it('should not return any options or user to invite if contact number contains alphabet characters (getFilteredOptions)', () => {
-            // const options = OptionsListUtils.getFilteredOptions(OPTIONS.reports, OPTIONS.personalDetails, [], '');
             const options = OptionsListUtils.getFilteredOptions({reports: OPTIONS.reports, personalDetails: OPTIONS.personalDetails});
             const filteredOptions = OptionsListUtils.filterOptions(options, '998243aaaa');
 


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->
Presently, `getOptions` excludes the contacts of DM reports included in `recentReports`. These are reduced to 5 recent reports in the participant selection page of "Submit Expense" flow if we pass a `maxRecentReportsToShow` to `filterOptions`. Because the contacts of these DM reports are excluded already in `getOptions`, these do not appear in the "Contacts" section. The logic of exclusion of Contacts for reports added in recent reports is moved from `getOptions` to `filterOptions` to fix this issue.

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/48114
PROPOSAL: https://github.com/Expensify/App/issues/48114#issuecomment-2323418693


### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

[Pre-requisite]: Login an account with more than 5 (say 10 DM) reports.

Test 1:
1. Click on FAB > "Submit Expense" > "Manual" > Input any amount > "Next" 
2. Do not input anything in the search box yet
3. Verify that 
-- there are 5 recent reports in "Recents" section
-- all contacts of DMs not included in the "Recents" section are included in the "Contacts" section
-- contact of any DM shown in "Recents" section is not shown in "Contacts" section
4. Input a search term
5. Verify that 
-- there are 5 recent reports matching with the search term in "Recents" section
-- all contacts (matching with the search term) of DMs not included in the "Recents" section are included in the "Contacts" section
-- contact of any DM report matching with the search term shown in "Recents" section is not shown in "Contacts" section

Test 2:
1. Click on FAB > "Start Chat"
2. Follow steps 2 to 5 of Test 1 and verify the results

Test 3:
1. Go to any DM report
2. Click on "+" in composer > "Assign task"
3. Input title > "Next"
4. Follow steps 2 to 5 of Test 1 and verify the results

Test 4:
1. Click on "Settings" > "Workspaces" > Click on any workspace > "Members" > "Invite Member"
2. Verify that all "Contacts" are shown in options
3. Input a text in the search input
4. Verify that "Contacts" matching with the search term are shown in the options
 
- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->
[Pre-requisite]: Login an account with more than 5 (say 10 DM) reports.

Test 1:
1. Click on FAB > "Submit Expense" > "Manual" > Input any amount > "Next" 
2. Do not input anything in the search box yet
3. Verify that 
-- there are 5 recent reports in "Recents" section
-- all contacts of DMs not included in the "Recents" section are included in the "Contacts" section
-- contact of any DM shown in "Recents" section is not shown in "Contacts" section
4. Input a search term
5. Verify that 
-- there are 5 recent reports matching with the search term in "Recents" section
-- all contacts (matching with the search term) of DMs not included in the "Recents" section are included in the "Contacts" section
-- contact of any DM report matching with the search term shown in "Recents" section is not shown in "Contacts" section

Test 2:
1. Click on FAB > "Start Chat"
2. Follow steps 2 to 5 of Test 1 and verify the results

Test 3:
1. Go to any DM report
2. Click on "+" in composer > "Assign task"
3. Input title > "Next"
4. Follow steps 2 to 5 of Test 1 and verify the results

Test 4:
1. Click on "Settings" > "Workspaces" > Click on any workspace > "Members" > "Invite Member"
2. Verify that all "Contacts" are shown in options
3. Input a text in the search input
4. Verify that "Contacts" matching with the search term are shown in the options
 
### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
6. Upload an image via copy paste
7. Verify a modal appears displaying a preview of that image
--->

[Pre-requisite]: Login an account with more than 5 (say 10 DM) reports.

Test 1:
1. Click on FAB > "Submit Expense" > "Manual" > Input any amount > "Next" 
2. Do not input anything in the search box yet
3. Verify that 
-- there are 5 recent reports in "Recents" section
-- all contacts of DMs not included in the "Recents" section are included in the "Contacts" section
-- contact of any DM shown in "Recents" section is not shown in "Contacts" section
4. Input a search term
5. Verify that 
-- there are 5 recent reports matching with the search term in "Recents" section
-- all contacts (matching with the search term) of DMs not included in the "Recents" section are included in the "Contacts" section
-- contact of any DM report matching with the search term shown in "Recents" section is not shown in "Contacts" section

Test 2:
1. Click on FAB > "Start Chat"
2. Follow steps 2 to 5 of Test 1 and verify the results

Test 3:
1. Go to any DM report
2. Click on "+" in composer > "Assign task"
3. Input title > "Next"
4. Follow steps 2 to 5 of Test 1 and verify the results

Test 4:
1. Click on "Settings" > "Workspaces" > Click on any workspace > "Members" > "Invite Member"
2. Verify that all "Contacts" are shown in options
3. Input a text in the search input
4. Verify that "Contacts" matching with the search term are shown in the options
 

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>



https://github.com/user-attachments/assets/a8899fc7-a82d-4b74-8905-f29df523efc5




https://github.com/user-attachments/assets/999827a4-a4d3-4e36-b128-b517fcc64718

https://github.com/user-attachments/assets/7863412f-7c5d-4c2f-a3ae-e353350ee0ed











<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>



https://github.com/user-attachments/assets/0d7ac3af-a2aa-437c-95be-e62c60bb9238




<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>



https://github.com/user-attachments/assets/3ba1e6c8-f03a-41f4-ad58-a7acc60b8931




<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>



https://github.com/user-attachments/assets/4821d30f-805f-4b1d-b391-b93d8f3182c7




<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>



https://github.com/user-attachments/assets/210f9753-546b-453f-b94f-f067c80b8cae




<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Desktop</summary>




https://github.com/user-attachments/assets/1c6e9367-16f7-453e-a207-555b52aaeafb





<!-- add screenshots or videos here -->

</details>

