### PR TITLE
Fix paid green marker for Native

### DIFF
--- a/src/components/ReportActionItem/ReportPreview.tsx
+++ b/src/components/ReportActionItem/ReportPreview.tsx
@@ -134,16 +134,9 @@ function ReportPreview({
     const iouSettled = ReportUtils.isSettled(iouReportID) || action?.childStatusNum === CONST.REPORT.STATUS_NUM.REIMBURSED;
     const previewMessageOpacity = useSharedValue(1);
     const previewMessageStyle = useAnimatedStyle(() => ({
-        ...styles.flex1,
-        ...styles.flexRow,
-        ...styles.alignItemsCenter,
         opacity: previewMessageOpacity.value,
     }));
     const checkMarkScale = useSharedValue(iouSettled ? 1 : 0);
-    const checkMarkStyle = useAnimatedStyle(() => ({
-        ...styles.defaultCheckmarkWrapper,
-        transform: [{scale: checkMarkScale.value}],
-    }));
 
     const moneyRequestComment = action?.childLastMoneyRequestComment ?? '';
     const isPolicyExpenseChat = ReportUtils.isPolicyExpenseChat(chatReport);
@@ -471,7 +464,7 @@ function ReportPreview({
                             <View style={shouldShowSettlementButton ? {} : styles.expenseAndReportPreviewTextButtonContainer}>
                                 <View style={styles.expenseAndReportPreviewTextContainer}>
                                     <View style={styles.flexRow}>
-                                        <Animated.View style={previewMessageStyle}>
+                                        <Animated.View style={[styles.flex1, styles.flexRow, styles.alignItemsCenter, previewMessageStyle]}>
                                             <Text style={[styles.textLabelSupporting, styles.lh16]}>{previewMessage}</Text>
                                         </Animated.View>
                                         {shouldShowRBR && (
@@ -493,7 +486,7 @@ function ReportPreview({
                                             <View style={[styles.flex1, styles.flexRow, styles.alignItemsCenter]}>
                                                 <Text style={styles.textHeadlineH1}>{getDisplayAmount()}</Text>
                                                 {iouSettled && (
-                                                    <Animated.View style={checkMarkStyle}>
+                                                    <Animated.View style={[styles.defaultCheckmarkWrapper, {transform: [{scale: checkMarkScale}]}]}>
                                                         <Icon
                                                             src={Expensicons.Checkmark}
                                                             fill={theme.iconSuccessFill}


### PR DESCRIPTION
### Details

Expense preview does not display green checkmark when the expense is paid.
Technically what happened here - issue related to combination of re-renders threads and `useAnimatedStyle`.
`useSharedValue` is running in 2 threads - JS and UI. When we set a new value `(from 0 to 1)` - we store value in JS and tells UI thread that value can be used in styling. `useAnimatedStyle` is  also running in 2 threads - JS and UI. Both of them initially stored `{ scale: 0 }`. When we set a new value `useAnimatedStyle` both sync JS and UI thread and prepare on UI thread new styles - which ready to be used/painting - but -  When we moving away to next screen - UI thread will be changed - and `useAnimatedStyle` will lost/cancel animation styling.  Technically we just still have correct useSharedValue value on JS thread - UI thread does not have those updates. To put those updates in UI thread - we need to reset useSharedValue to 0 and set again to 1 (to run again  useAnimatedStyle hook with new value) - which is overkill.
Correct solution here - just not rely on `useAnimatedStyle` UI thread at all to build styling (because in our special case it will be destroyed during navigating to next screen). We can just rely on useSharedValue and use animation style directly in render.

### Fixed Issues

$ https://github.com/Expensify/App/issues/50219
PROPOSAL:


### Tests
1. Launch New Expensify app.
2. Open DM with user that has no unsettled expense.
3. Submit an expense.
4. Tap on the expense preview.
5. As the other user, pay the expense.
6. Wait for the system message to show up in the combined report.
7. Long press on the paid system message > Reply in thread.
8. Tap app back button twice to go back to the main chat.
9. Verify that green paid mark is shown

- [x] Verify that no errors appear in the JS console

### Offline tests
Fix is not influence on offline pattern for that workflow

### QA Steps
1. Launch New Expensify app.
2. Open DM with user that has no unsettled expense.
3. Submit an expense.
4. Tap on the expense preview.
5. As the other user, pay the expense.
6. Wait for the system message to show up in the combined report.
7. Long press on the paid system message > Reply in thread.
8. Tap app back button twice to go back to the main chat.
9. Verify that green paid mark is shown

- [x] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>


https://github.com/user-attachments/assets/05ca9ef1-7c1f-4e17-8d04-f9da458dc376


</details>

<details>
<summary>Android: mWeb Chrome</summary>


https://github.com/user-attachments/assets/947c2166-bb75-4269-939e-cc8e0b426785


</details>

<details>
<summary>iOS: Native</summary>


https://github.com/user-attachments/assets/c12cfd86-9e47-4112-bc2b-81bac330a041


</details>

<details>
<summary>iOS: mWeb Safari</summary>

https://github.com/user-attachments/assets/b7dda306-15cf-4f93-b1e1-a4a2ac8a7b87

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>



https://github.com/user-attachments/assets/5d4c0ddd-1f08-4d45-8319-4e118223df7f



</details>

<details>
<summary>MacOS: Desktop</summary>


https://github.com/user-attachments/assets/e948ccb4-0569-436b-822a-b40b24e077d6


</details>
