### PR TITLE
Remove list headers

### DIFF
--- a/src/components/SelectionList/CardListItem.tsx
+++ b/src/components/SelectionList/CardListItem.tsx
@@ -12,7 +12,7 @@ import type {BankIcon} from '@src/types/onyx/Bank';
 import BaseListItem from './BaseListItem';
 import type {BaseListItemProps, ListItem} from './types';
 
-type CardListItemProps<TItem extends ListItem> = BaseListItemProps<TItem & {bankIcon?: BankIcon; lastFourPAN?: string}>;
+type CardListItemProps<TItem extends ListItem> = BaseListItemProps<TItem & {bankIcon?: BankIcon; lastFourPAN?: string; isVirtual?: boolean}>;
 
 function CardListItem<TItem extends ListItem>({
     item,
@@ -37,6 +37,11 @@ function CardListItem<TItem extends ListItem>({
             onSelectRow(item);
         }
     }, [item, onCheckboxPress, onSelectRow]);
+
+    const subtitleText =
+        `${item.lastFourPAN ? `${translate('paymentMethodList.accountLastFour')} ${item.lastFourPAN}` : ''}` +
+        `${item.lastFourPAN && item.isVirtual ? ` ${CONST.DOT_SEPARATOR} ` : ''}` +
+        `${item.isVirtual ? translate('workspace.expensifyCard.virtual') : ''}`;
 
     return (
         <BaseListItem
@@ -79,10 +84,10 @@ function CardListItem<TItem extends ListItem>({
                                 item.alternateText ? styles.mb1 : null,
                             ]}
                         />
-                        {!!item.lastFourPAN && (
+                        {!!subtitleText && (
                             <TextWithTooltip
                                 shouldShowTooltip={showTooltip}
-                                text={`${translate('paymentMethodList.accountLastFour')} ${item.lastFourPAN}`}
+                                text={subtitleText}
                                 style={[styles.textLabelSupporting, styles.lh16, styles.pre]}
                             />
                         )}

--- a/src/pages/Search/SearchAdvancedFiltersPage/SearchFiltersCardPage.tsx
+++ b/src/pages/Search/SearchAdvancedFiltersPage/SearchFiltersCardPage.tsx
@@ -35,6 +35,7 @@ function SearchFiltersCardPage() {
 
                 return {
                     lastFourPAN: card.lastFourPAN,
+                    isVirtual: card?.nameValuePairs?.isVirtual,
                     text: card.bank,
                     keyForList: card.cardID.toString(),
                     isSelected: newCards.includes(card.cardID.toString()),

--- a/src/pages/Search/SearchAdvancedFiltersPage/SearchFiltersCategoryPage.tsx
+++ b/src/pages/Search/SearchAdvancedFiltersPage/SearchFiltersCategoryPage.tsx
@@ -50,7 +50,6 @@ function SearchFiltersCategoryPage() {
             />
             <View style={[styles.flex1, safePaddingBottomStyle]}>
                 <SearchMultipleSelectionPicker
-                    pickerTitle={translate('common.category')}
                     items={categoryItems}
                     initiallySelectedItems={selectedCategoriesItems}
                     onSaveSelection={onSaveSelection}

--- a/src/pages/Search/SearchAdvancedFiltersPage/SearchFiltersCurrencyPage.tsx
+++ b/src/pages/Search/SearchAdvancedFiltersPage/SearchFiltersCurrencyPage.tsx
@@ -56,7 +56,6 @@ function SearchFiltersCurrencyPage() {
             />
             <View style={[styles.flex1]}>
                 <SearchMultipleSelectionPicker
-                    pickerTitle={translate('search.filters.currency')}
                     items={currencyItems}
                     initiallySelectedItems={selectedCurrenciesItems}
                     onSaveSelection={handleOnSubmit}

--- a/src/pages/Search/SearchAdvancedFiltersPage/SearchFiltersExpenseTypePage.tsx
+++ b/src/pages/Search/SearchAdvancedFiltersPage/SearchFiltersExpenseTypePage.tsx
@@ -54,7 +54,6 @@ function SearchFiltersExpenseTypePage() {
             />
             <View style={[styles.flex1]}>
                 <SearchMultipleSelectionPicker
-                    pickerTitle={translate('search.expenseType')}
                     items={expenseTypesItems}
                     initiallySelectedItems={initiallySelectedItems}
                     onSaveSelection={updateExpenseTypeFilter}

--- a/src/pages/Search/SearchAdvancedFiltersPage/SearchFiltersTagPage.tsx
+++ b/src/pages/Search/SearchAdvancedFiltersPage/SearchFiltersTagPage.tsx
@@ -56,7 +56,6 @@ function SearchFiltersTagPage() {
             />
             <View style={[styles.flex1]}>
                 <SearchMultipleSelectionPicker
-                    pickerTitle={translate('common.tag')}
                     items={tagItems}
                     initiallySelectedItems={selectedTagsItems}
                     onSaveSelection={updateTagFilter}

--- a/src/pages/Search/SearchAdvancedFiltersPage/SearchFiltersTaxRatePage.tsx
+++ b/src/pages/Search/SearchAdvancedFiltersPage/SearchFiltersTaxRatePage.tsx
@@ -57,7 +57,6 @@ function SearchFiltersTaxRatePage() {
             />
             <View style={[styles.flex1]}>
                 <SearchMultipleSelectionPicker
-                    pickerTitle={translate('workspace.taxes.taxRate')}
                     items={taxItems}
                     initiallySelectedItems={selectedTaxesItems}
                     onSaveSelection={updateTaxRateFilters}


### PR DESCRIPTION
### Details
Removes the unnecessary list headers for the Expense type, Tag, Category, Currency and Tax rate search filter selection lists.

### Fixed Issues
$ https://github.com/Expensify/App/issues/50654

### Tests
Pre-requisite: a workspace with tags, categories and taxes enabled.  A user with a virtual card assigned.

1. Navigate to the Search page
2. Open the filters tab
3. Open the `Card` filter, verify that the virtual card has a `• Virtual` label next to the last four digits of the card
4. Verify that the following filters don't have any headers above the list
- Expense type
- Tag
- Category
- Currency
- Tax rate

- [x] Verify that no errors appear in the JS console

### Offline tests
N/A

### QA Steps
Same as tests

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>
![Screenshot 2024-10-11 at 8 59 19 AM](https://github.com/user-attachments/assets/d2e310a8-c234-418e-aa6b-63856130336d)
![Screenshot 2024-10-11 at 8 59 34 AM](https://github.com/user-attachments/assets/0e1cfc6a-3b32-4468-856b-8354596dd6a5)
![Screenshot 2024-10-11 at 9 00 02 AM](https://github.com/user-attachments/assets/396619ec-96e8-41a3-add5-3ed80e92e832)
![Screenshot 2024-10-11 at 9 00 18 AM](https://github.com/user-attachments/assets/49aad8a4-2204-4703-a7cc-cd24d375de14)
![Screenshot 2024-10-11 at 9 39 14 AM](https://github.com/user-attachments/assets/9537f5bd-a2fa-48f5-8431-8308a8bda779)

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Desktop</summary>

<!-- add screenshots or videos here -->

</details>
