### PR TITLE
[Self-guided tours v1] Add self-guided tours in Search Page Empty State

### DIFF
--- a/src/CONST.ts
+++ b/src/CONST.ts
@@ -754,8 +754,8 @@ const CONST = {
     // Use Environment.getEnvironmentURL to get the complete URL with port number
     DEV_NEW_EXPENSIFY_URL: 'https://dev.new.expensify.com:',
     NAVATTIC: {
-        ADMIN_TOUR: 'http://expensify.navattic.com/kh204a7',
-        EMPLOYEE_TOUR: 'http://expensify.navattic.com/35609gb',
+        ADMIN_TOUR: 'https://expensify.navattic.com/kh204a7',
+        EMPLOYEE_TOUR: 'https://expensify.navattic.com/35609gb',
     },
 
     OLDDOT_URLS: {

--- a/src/CONST.ts
+++ b/src/CONST.ts
@@ -753,6 +753,11 @@ const CONST = {
     DELAYED_SUBMISSION_HELP_URL: 'https://help.expensify.com/articles/expensify-classic/reports/Automatically-submit-employee-reports',
     // Use Environment.getEnvironmentURL to get the complete URL with port number
     DEV_NEW_EXPENSIFY_URL: 'https://dev.new.expensify.com:',
+    NAVATTIC: {
+        ADMIN_TOUR: 'http://expensify.navattic.com/kh204a7',
+        EMPLOYEE_TOUR: 'http://expensify.navattic.com/35609gb',
+    },
+
     OLDDOT_URLS: {
         ADMIN_POLICIES_URL: 'admin_policies',
         ADMIN_DOMAINS_URL: 'admin_domains',

--- a/src/components/EmptyStateComponent/index.tsx
+++ b/src/components/EmptyStateComponent/index.tsx
@@ -98,17 +98,21 @@ function EmptyStateComponent({
                     <View style={shouldUseNarrowLayout ? styles.p5 : styles.p8}>
                         <Text style={[styles.textAlignCenter, styles.textHeadlineH1, styles.mb2, titleStyles]}>{title}</Text>
                         {typeof subtitle === 'string' ? <Text style={[styles.textAlignCenter, styles.textSupporting, styles.textNormal]}>{subtitle}</Text> : subtitle}
-                        <View style={[styles.flexRow, styles.gap2, styles.justifyContentCenter]}>
+                        <View style={[styles.gap2, styles.mt5, !shouldUseNarrowLayout ? styles.flexRow : undefined]}>
                             {buttons?.map(({buttonText, buttonAction, success}, index) => (
-                                <Button
-                                    // eslint-disable-next-line react/no-array-index-key
+                                // eslint-disable-next-line react/no-array-index-key
+                                <View
                                     key={index}
-                                    success={success}
-                                    onPress={buttonAction}
-                                    text={buttonText}
-                                    style={[styles.mt5, styles.w41]}
-                                    large
-                                />
+                                    style={styles.flex1}
+                                >
+                                    <Button
+                                        // eslint-disable-next-line react/no-array-index-key
+                                        success={success}
+                                        onPress={buttonAction}
+                                        text={buttonText}
+                                        large
+                                    />
+                                </View>
                             ))}
                         </View>
                     </View>

--- a/src/components/EmptyStateComponent/index.tsx
+++ b/src/components/EmptyStateComponent/index.tsx
@@ -99,7 +99,7 @@ function EmptyStateComponent({
                         <Text style={[styles.textAlignCenter, styles.textHeadlineH1, styles.mb2, titleStyles]}>{title}</Text>
                         {typeof subtitle === 'string' ? <Text style={[styles.textAlignCenter, styles.textSupporting, styles.textNormal]}>{subtitle}</Text> : subtitle}
                         <View style={[styles.gap2, styles.mt5, !shouldUseNarrowLayout ? styles.flexRow : undefined]}>
-                            {buttons?.map(({buttonText, buttonAction, success}, index) => (                              
+                            {buttons?.map(({buttonText, buttonAction, success}, index) => (
                                 <View
                                     // eslint-disable-next-line react/no-array-index-key
                                     key={index}

--- a/src/components/EmptyStateComponent/index.tsx
+++ b/src/components/EmptyStateComponent/index.tsx
@@ -18,8 +18,7 @@ function EmptyStateComponent({
     SkeletonComponent,
     headerMediaType,
     headerMedia,
-    buttonText,
-    buttonAction,
+    buttons,
     containerStyles,
     title,
     titleStyles,
@@ -99,15 +98,18 @@ function EmptyStateComponent({
                     <View style={shouldUseNarrowLayout ? styles.p5 : styles.p8}>
                         <Text style={[styles.textAlignCenter, styles.textHeadlineH1, styles.mb2, titleStyles]}>{title}</Text>
                         {typeof subtitle === 'string' ? <Text style={[styles.textAlignCenter, styles.textSupporting, styles.textNormal]}>{subtitle}</Text> : subtitle}
-                        {!!buttonText && !!buttonAction && (
-                            <Button
-                                success
-                                onPress={buttonAction}
-                                text={buttonText}
-                                style={[styles.mt5]}
-                                large
-                            />
-                        )}
+                        <View style={[styles.flexRow, styles.gap2, styles.justifyContentCenter]}>
+                            {buttons?.map(({buttonText, buttonAction, success}, index) => (
+                                <Button
+                                    key={index}
+                                    success={success}
+                                    onPress={buttonAction}
+                                    text={buttonText}
+                                    style={[styles.mt5, styles.w41]}
+                                    large
+                                />
+                            ))}
+                        </View>
                     </View>
                 </View>
             </View>

--- a/src/components/EmptyStateComponent/index.tsx
+++ b/src/components/EmptyStateComponent/index.tsx
@@ -101,6 +101,7 @@ function EmptyStateComponent({
                         <View style={[styles.flexRow, styles.gap2, styles.justifyContentCenter]}>
                             {buttons?.map(({buttonText, buttonAction, success}, index) => (
                                 <Button
+                                    // eslint-disable-next-line react/no-array-index-key
                                     key={index}
                                     success={success}
                                     onPress={buttonAction}

--- a/src/components/EmptyStateComponent/index.tsx
+++ b/src/components/EmptyStateComponent/index.tsx
@@ -99,14 +99,13 @@ function EmptyStateComponent({
                         <Text style={[styles.textAlignCenter, styles.textHeadlineH1, styles.mb2, titleStyles]}>{title}</Text>
                         {typeof subtitle === 'string' ? <Text style={[styles.textAlignCenter, styles.textSupporting, styles.textNormal]}>{subtitle}</Text> : subtitle}
                         <View style={[styles.gap2, styles.mt5, !shouldUseNarrowLayout ? styles.flexRow : undefined]}>
-                            {buttons?.map(({buttonText, buttonAction, success}, index) => (
-                                // eslint-disable-next-line react/no-array-index-key
+                            {buttons?.map(({buttonText, buttonAction, success}, index) => (                              
                                 <View
+                                    // eslint-disable-next-line react/no-array-index-key
                                     key={index}
                                     style={styles.flex1}
                                 >
                                     <Button
-                                        // eslint-disable-next-line react/no-array-index-key
                                         success={success}
                                         onPress={buttonAction}
                                         text={buttonText}

--- a/src/components/EmptyStateComponent/types.ts
+++ b/src/components/EmptyStateComponent/types.ts
@@ -9,13 +9,14 @@ import type IconAsset from '@src/types/utils/IconAsset';
 
 type ValidSkeletons = typeof SearchRowSkeleton | typeof TableRowSkeleton;
 type MediaTypes = ValueOf<typeof CONST.EMPTY_STATE_MEDIA>;
+type Button = {buttonText?: string; buttonAction?: () => void; success?: boolean};
 
 type SharedProps<T> = {
     SkeletonComponent: ValidSkeletons;
     title: string;
     titleStyles?: StyleProp<TextStyle>;
     subtitle: string | React.ReactNode;
-    buttons?: Array<{buttonText?: string; buttonAction?: () => void; success?: boolean}>;
+    buttons?: Array<Button>;
     containerStyles?: StyleProp<ViewStyle>;
     headerStyles?: StyleProp<ViewStyle>;
     headerMediaType: T;

--- a/src/components/EmptyStateComponent/types.ts
+++ b/src/components/EmptyStateComponent/types.ts
@@ -16,7 +16,7 @@ type SharedProps<T> = {
     title: string;
     titleStyles?: StyleProp<TextStyle>;
     subtitle: string | React.ReactNode;
-    buttons?: Array<Button>;
+    buttons?: Button[];
     containerStyles?: StyleProp<ViewStyle>;
     headerStyles?: StyleProp<ViewStyle>;
     headerMediaType: T;

--- a/src/components/EmptyStateComponent/types.ts
+++ b/src/components/EmptyStateComponent/types.ts
@@ -15,7 +15,7 @@ type SharedProps<T> = {
     title: string;
     titleStyles?: StyleProp<TextStyle>;
     subtitle: string | React.ReactNode;
-    buttons?: {buttonText?: string; buttonAction?: () => void; success?: boolean}[];
+    buttons?: Array<{buttonText?: string; buttonAction?: () => void; success?: boolean}>;
     containerStyles?: StyleProp<ViewStyle>;
     headerStyles?: StyleProp<ViewStyle>;
     headerMediaType: T;

--- a/src/components/EmptyStateComponent/types.ts
+++ b/src/components/EmptyStateComponent/types.ts
@@ -15,8 +15,7 @@ type SharedProps<T> = {
     title: string;
     titleStyles?: StyleProp<TextStyle>;
     subtitle: string | React.ReactNode;
-    buttonText?: string;
-    buttonAction?: () => void;
+    buttons?: {buttonText?: string; buttonAction?: () => void; success?: boolean}[];
     containerStyles?: StyleProp<ViewStyle>;
     headerStyles?: StyleProp<ViewStyle>;
     headerMediaType: T;

--- a/src/languages/en.ts
+++ b/src/languages/en.ts
@@ -4244,6 +4244,10 @@ const translations = {
                 title: 'Nothing to show',
                 subtitle: 'Try creating something using the green + button.',
             },
+            emptyExpenseResults: {
+                title: "You haven't created any expenses yet",
+                subtitle: 'Use the green button below to create an expense or take a tour of Expensify to learn more.',
+            },
             emptyTripResults: {
                 title: 'No trips to display',
                 subtitle: 'Get started by booking your first trip below.',
@@ -5077,6 +5081,9 @@ const translations = {
             hasChildReportAwaitingAction: 'Has child report awaiting action',
             hasMissingInvoiceBankAccount: 'Has missing invoice bank account',
         },
+    },
+    emptySearchView: {
+        takeATour: 'Take a tour',
     },
 };
 

--- a/src/languages/es.ts
+++ b/src/languages/es.ts
@@ -4292,8 +4292,8 @@ const translations = {
                 subtitle: 'Por favor intenta crear algo usando el botón verde.',
             },
             emptyExpenseResults: {
-                title: "You haven't created any expenses yet",
-                subtitle: 'Use the green button below to create an expense or take a tour of Expensify to learn more.',
+                title: 'Aún no has creado ningún gasto',
+                subtitle: 'Usa el botón verde de abajo para crear un gasto o realiza un recorrido por Expensify para aprender más.',
             },
             emptyTripResults: {
                 title: 'No tienes viajes',
@@ -5598,7 +5598,7 @@ const translations = {
         },
     },
     emptySearchView: {
-        takeATour: 'Take a tour',
+        takeATour: 'Realiza un recorrido',
     },
 };
 

--- a/src/languages/es.ts
+++ b/src/languages/es.ts
@@ -4291,6 +4291,10 @@ const translations = {
                 title: 'No hay nada que ver aquí',
                 subtitle: 'Por favor intenta crear algo usando el botón verde.',
             },
+            emptyExpenseResults: {
+                title: "You haven't created any expenses yet",
+                subtitle: 'Use the green button below to create an expense or take a tour of Expensify to learn more.',
+            },
             emptyTripResults: {
                 title: 'No tienes viajes',
                 subtitle: 'Reserva tu primer viaje a continuación.',
@@ -5592,6 +5596,9 @@ const translations = {
             hasChildReportAwaitingAction: 'Informe secundario pendiente de acción',
             hasMissingInvoiceBankAccount: 'Falta la cuenta bancaria de la factura',
         },
+    },
+    emptySearchView: {
+        takeATour: 'Take a tour',
     },
 };
 

--- a/src/languages/es.ts
+++ b/src/languages/es.ts
@@ -4293,7 +4293,7 @@ const translations = {
             },
             emptyExpenseResults: {
                 title: 'Aún no has creado ningún gasto',
-                subtitle: 'Usa el botón verde de abajo para crear un gasto o realiza un recorrido por Expensify para aprender más.',
+                subtitle: 'Usa el botón verde de abajo para crear un gasto o haz un tour por Expensify para aprender más.',
             },
             emptyTripResults: {
                 title: 'No tienes viajes',
@@ -5598,7 +5598,7 @@ const translations = {
         },
     },
     emptySearchView: {
-        takeATour: 'Realiza un recorrido',
+        takeATour: 'Haz un tour',
     },
 };
 

--- a/src/pages/Search/EmptySearchView.tsx
+++ b/src/pages/Search/EmptySearchView.tsx
@@ -113,7 +113,6 @@ function EmptySearchView({type}: EmptySearchViewProps) {
                         },
                     ],
                 };
-            case CONST.SEARCH.DATA_TYPES.CHAT:
             case CONST.SEARCH.DATA_TYPES.EXPENSE:
                 return {
                     headerMedia: LottieAnimations.GenericEmptyState,
@@ -130,6 +129,7 @@ function EmptySearchView({type}: EmptySearchViewProps) {
                     ],
                     headerContentStyles: styles.emptyStateFolderWebStyles,
                 };
+            case CONST.SEARCH.DATA_TYPES.CHAT:
             case CONST.SEARCH.DATA_TYPES.INVOICE:
             default:
                 return {

--- a/src/pages/Search/EmptySearchView.tsx
+++ b/src/pages/Search/EmptySearchView.tsx
@@ -140,7 +140,7 @@ function EmptySearchView({type}: EmptySearchViewProps) {
                     headerContentStyles: styles.emptyStateFolderWebStyles,
                 };
         }
-    }, [type, StyleUtils, translate, theme, styles, subtitleComponent, ctaErrorMessage]);
+    }, [type, StyleUtils, translate, theme, styles, subtitleComponent, ctaErrorMessage, navatticLink]);
 
     return (
         <EmptyStateComponent
@@ -151,8 +151,6 @@ function EmptySearchView({type}: EmptySearchViewProps) {
             title={content.title}
             titleStyles={content.titleStyles}
             subtitle={content.subtitle}
-            // buttonText={content.buttonText}
-            // buttonAction={content.buttonAction}
             buttons={content.buttons}
             headerContentStyles={[styles.h100, styles.w100, content.headerContentStyles]}
             lottieWebViewStyles={styles.emptyStateFolderWebStyles}

--- a/src/styles/utils/sizing.ts
+++ b/src/styles/utils/sizing.ts
@@ -33,10 +33,6 @@ export default {
         width: '25%',
     },
 
-    w41: {
-        width: 164,
-    },
-
     mh100: {
         maxHeight: '100%',
     },

--- a/src/styles/utils/sizing.ts
+++ b/src/styles/utils/sizing.ts
@@ -33,6 +33,10 @@ export default {
         width: '25%',
     },
 
+    w41: {
+        width: 164,
+    },
+
     mh100: {
         maxHeight: '100%',
     },


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->
This PR adds self guided tours in the empty state view of Search Page.

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/50926
PROPOSAL:


### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->
Test 1:
1. Logon to ND with a new account.
2. Select any onboarding purpose other than "Manage my team expenses".
3. Click on "Search" in the bottom tab bar.
4. Verify that two buttons "Take a tour" and "Create Expense" are shown in the empty state view of the Search Page in the center pane.
5. Click on the "Take a tour" button.
6. Verify that you are taken to the employee-focused tour.
7. Click on the "Create Expense" button.
8. Verify that the RHP for "Submit Expense" flow opens.

Test 2:
1. Logon to ND with a new account.
2. Select "Manage my team expenses" as the onboarding purpose.
3. Follow steps 3 to 5 in Test 1.
4. Click on the "Take a tour" button.
5. Verify that you are taken to the admin-focused tour.
6. Click on the "Create Expense" button.
7. Verify that the RHP for "Submit Expense" flow opens.

- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->
NA
### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
9. Upload an image via copy paste
10. Verify a modal appears displaying a preview of that image
--->
Same as Tests

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed): Reported them on Slack [here](https://expensify.slack.com/archives/C049HHMV9SM/p1726072125690969).
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message: https://expensify.slack.com/archives/C01GTK53T8Q/p1729139650549599
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>


https://github.com/user-attachments/assets/ec3e279c-f517-4d63-b1ec-cdf9eeda9907





<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>



https://github.com/user-attachments/assets/12389972-6ff5-4971-a8ce-a49ede59ef37




<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>



https://github.com/user-attachments/assets/c1783fb9-d1dd-4655-ab6e-13f0cc5a096d





<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>




https://github.com/user-attachments/assets/aafdfe99-ca3e-4d62-96f6-f17360c239cb




<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>




https://github.com/user-attachments/assets/b5e15cd4-7dd3-4a96-9069-d837c9bb6b6a






<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Desktop</summary>



https://github.com/user-attachments/assets/75c37799-45d9-4155-9bcd-afdcc4c040e3




<!-- add screenshots or videos here -->

</details>
