### PR TITLE
[No QA] Update Configure-Xero.md

### DIFF
--- a/docs/articles/new-expensify/connections/xero/Configure-Xero.md
+++ b/docs/articles/new-expensify/connections/xero/Configure-Xero.md
@@ -1,11 +1,75 @@
 ---
 title: Configure Xero
-description: Coming soon
+description: How to configure your settings for Xero
 ---
+ 
+To configure your Xero settings, complete the steps below.
 
-# FAQ
+# Step 1: Configure import settings
 
-## How do I know if a report successfully exported to Xero?
+The following steps help you determine how data will be imported from Xero to Expensify. 
+
+<ol type="a">
+   <li>Under the Accounting settings for your workspace, click <b>Import</b> under the Xero connection.</li>
+   <li>Select an option for each of the following settings to determine what information will be imported from Xero into Expensify:</li>
+       <ul>
+           <li><b>Xero organization</b>: Select which Xero organization your Expensify workspace is connected to. Each organization can only be connected to one workspace at a time.</li>
+           <li><b>Chart of Accounts</b>: Your Xero chart of accounts and any accounts marked as “Show In Expense Claims” will be automatically imported into Expensify as Categories. This cannot be amended.</li>
+           <li><b>Tracking Categories</b>: Choose whether to import your Xero categories for cost centers and regions as tags in Expensify.</li>
+           <li><b>Re-bill Customers</b>: When enabled, Xero customer contacts are imported into Expensify as tags for expense tracking. After exporting to Xero, tagged billable expenses can be included on a sales invoice to your customer.</li>
+           <li><b>Taxes</b>: Choose whether to import tax rates and tax defaults from Xero.</li>
+       </ul>  
+</ol>
+
+# Step 2: Configure export settings
+The following steps help you determine how data will be exported from Expensify to Xero.
+
+<ol type="a">
+   <li>Under the Accounting settings for your workspace, click <b>Export</b> under the Xero connection.</li>
+   <li>Review each of the following export settings:</li>
+       <ul>
+           <li><b>Preferred Exporter</b>: Choose whether to assign a Workspace Admin as the Preferred Exporter. Once selected, the Preferred Exporter automatically receives reports for export in their account to help automate the exporting process.</li>
+       </ul>  
+</ol> 
+{% include info.html %}
+- Other Workspace Admins will still be able to export to Xero. 
+- If you set different export accounts for individual company cards under your domain settings, then your Preferred Exporter must be a Domain Admin.
+{% include end-info.html %}
+
+<ol type="a">
+      <ul>
+           <li><b>Export Out-of-Pocket Expenses as</b>: All out-of-pocket expenses will be exported as purchase bills. This cannot be amended.</li>
+           <li><b>Purchase Bill Date</b>: Choose whether to use the date of the last expense, export date, or submitted date.</li>
+           <li><b>Export invoices as</b>: All invoices exported to Xero will be as sales invoices. This cannot be amended.</li>
+           <li><b>Export company card expenses as</b>: All company card expenses are exported to Xero as bank transactions. This cannot be amended.</li>
+           <li><b>Xero Bank Account</b>: Select which bank account will be used to post bank transactions when non-reimbursable expenses are exported.</li>
+      </ul>
+</ol>
+
+# Step 3: Configure advanced settings
+
+The following steps help you determine the advanced settings for your connection, like auto-sync.
+
+<ol type="a">
+   <li>Under the Accounting settings for your workspace, click <b>Advanced</b> under the Xero connection.</li>
+   <li>Select an option for each of the following settings:</li>
+      <ul>
+           <li><b>Auto-sync</b>: Choose whether to enable Xero to automatically communicate changes with Expensify to ensure that the data shared between the two systems is up-to-date. New report approvals/reimbursements will be synced during the next auto-sync period. Once you’ve added a business bank account for ACH reimbursement, any reimbursable expenses will be sent to Xero automatically when the report is reimbursed. For non-reimbursable reports, Expensify automatically queues the report to export to Xero after it has completed the approval workflow in Expensify.</li>
+           <li><b>Set Purchase Bill Status</b>: Choose the status of your purchase bills:</li>
+              <ul>
+                 <li>Draft</li>
+                 <li>Awaiting Approval</li>
+                 <li>Awaiting Payment</li>                
+              </ul>
+           <li><b>Sync Reimbursed Reports</b>: Choose whether to enable report syncing for reimbursed expenses. If enabled, all reports that are marked as Paid in Xero will also show in Expensify as Paid. If enabled, you must also select the Xero account that reimbursements are coming out of, and Expensify will automatically create the payment in Xero.</li>
+           <li><b>Xero Bill Payment Account</b>: If you enable Sync Reimbursed Reports, you must select the Xero Bill Payment account your reimbursements will come from.</li>
+           <li><b>Xero Invoice Collections Account</b>: If you are exporting invoices from Expensify, select the invoice collection account that you want invoices to appear under once they are marked as paid.</li>
+      </ul>
+</ol>
+
+{% include faq-begin.md %}
+
+## How do I know if a report is successfully exported to Xero?
 
 When a report exports successfully, a message is posted in the related Expensify Chat room.
 
@@ -22,4 +86,4 @@ When an admin manually exports a report, Expensify will warn them if the report 
 - If Auto Sync was disabled when your Workspace was linked to Xero, enabling it won’t impact existing reports that haven’t been exported.
 - If a report has been exported and reimbursed via ACH, it will be automatically marked as paid in Xero during the next sync.
 - If a report has been exported and marked as paid in Xero, it will be automatically marked as reimbursed in Expensify during the next sync.
-- If a report has not yet been exported to Xero, it won’t be automatically exported.
+- If a report has not yet been exported to Xero, it won’t be automatically exported. {% include faq-end.md %}

--- a/docs/articles/new-expensify/connections/xero/Configure-Xero.md
+++ b/docs/articles/new-expensify/connections/xero/Configure-Xero.md
@@ -86,4 +86,6 @@ When an admin manually exports a report, Expensify will warn them if the report 
 - If Auto Sync was disabled when your Workspace was linked to Xero, enabling it won’t impact existing reports that haven’t been exported.
 - If a report has been exported and reimbursed via ACH, it will be automatically marked as paid in Xero during the next sync.
 - If a report has been exported and marked as paid in Xero, it will be automatically marked as reimbursed in Expensify during the next sync.
-- If a report has not yet been exported to Xero, it won’t be automatically exported. {% include faq-end.md %}
+- If a report has not yet been exported to Xero, it won’t be automatically exported.
+
+{% include faq-end.md %}


### PR DESCRIPTION
### Details

I'm updating the formatting and content on the Xero configurations page according to feedback here: https://expensify.slack.com/archives/C02QSAC6BJ8/p1730224734500449

### Fixed Issues
$ https://github.com/Expensify/Expensify/issues/438678

### Tests

1. Go to help.expensify.com
2. Navigate to New Expensify > Connections > Xero > Configure Xero
3. Verify that the article has content and there are no formatting errors

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->
- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] If we are not using the full Onyx data that we loaded, I've added the proper selector in order to ensure the component only re-renders when the data it is using changes
        - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.
### Screenshots/Videosundefined