### PR TITLE
[CP Staging] Correct validation message for legal name 

### DIFF
--- a/src/components/SubStepForms/FullNameStep.tsx
+++ b/src/components/SubStepForms/FullNameStep.tsx
@@ -44,7 +44,7 @@ type FullNameStepProps<TFormID extends keyof OnyxFormValuesMapping> = SubStepPro
     /** Should show the help link or not */
     shouldShowHelpLinks?: boolean;
 
-    /** Custom label of the first input  */
+    /** Custom label of the first name input  */
     customFirstNameLabel?: string;
 
     /** Custom label of the last name input */

--- a/src/components/SubStepForms/FullNameStep.tsx
+++ b/src/components/SubStepForms/FullNameStep.tsx
@@ -41,7 +41,14 @@ type FullNameStepProps<TFormID extends keyof OnyxFormValuesMapping> = SubStepPro
         lastName: string;
     };
 
+    /** Should show the help link or not */
     shouldShowHelpLinks?: boolean;
+
+    /** Custom label of the first input  */
+    customFirstNameLabel?: string;
+
+    /** Custom label of the second input */
+    customLastNameLabel?: string;
 };
 
 function FullNameStep<TFormID extends keyof OnyxFormValuesMapping>({
@@ -55,6 +62,8 @@ function FullNameStep<TFormID extends keyof OnyxFormValuesMapping>({
     defaultValues,
     isEditing,
     shouldShowHelpLinks = true,
+    customFirstNameLabel,
+    customLastNameLabel,
 }: FullNameStepProps<TFormID>) {
     const {translate} = useLocalize();
     const styles = useThemeStyles();
@@ -64,15 +73,33 @@ function FullNameStep<TFormID extends keyof OnyxFormValuesMapping>({
             const errors = ValidationUtils.getFieldRequiredErrors(values, stepFields);
 
             const firstName = values[firstNameInputID as keyof FormOnyxValues<TFormID>] as string;
-            if (firstName && !ValidationUtils.isValidLegalName(firstName)) {
+            if (!ValidationUtils.isRequiredFulfilled(firstName)) {
                 // @ts-expect-error type mismatch to be fixed
                 errors[firstNameInputID] = translate('common.error.fieldRequired');
+            } else if (!ValidationUtils.isValidLegalName(firstName)) {
+                // @ts-expect-error type mismatch to be fixed
+                errors[firstNameInputID] = translate('privatePersonalDetails.error.hasInvalidCharacter');
+            } else if (firstName.length > CONST.LEGAL_NAME.MAX_LENGTH) {
+                // @ts-expect-error type mismatch to be fixed
+                errors[firstNameInputID] = translate('common.error.characterLimitExceedCounter', {
+                    length: firstName.length,
+                    limit: CONST.LEGAL_NAME.MAX_LENGTH,
+                });
             }
 
             const lastName = values[lastNameInputID as keyof FormOnyxValues<TFormID>] as string;
-            if (lastName && !ValidationUtils.isValidLegalName(lastName)) {
+            if (!ValidationUtils.isRequiredFulfilled(lastName)) {
                 // @ts-expect-error type mismatch to be fixed
                 errors[lastNameInputID] = translate('common.error.fieldRequired');
+            } else if (!ValidationUtils.isValidLegalName(lastName)) {
+                // @ts-expect-error type mismatch to be fixed
+                errors[lastNameInputID] = translate('privatePersonalDetails.error.hasInvalidCharacter');
+            } else if (lastName.length > CONST.LEGAL_NAME.MAX_LENGTH) {
+                // @ts-expect-error type mismatch to be fixed
+                errors[lastNameInputID] = translate('common.error.characterLimitExceedCounter', {
+                    length: lastName.length,
+                    limit: CONST.LEGAL_NAME.MAX_LENGTH,
+                });
             }
             return errors;
         },
@@ -92,8 +119,8 @@ function FullNameStep<TFormID extends keyof OnyxFormValuesMapping>({
                 <InputWrapper
                     InputComponent={TextInput}
                     inputID={firstNameInputID}
-                    label={translate('common.firstName')}
-                    aria-label={translate('common.firstName')}
+                    label={customFirstNameLabel ?? translate('personalInfoStep.legalFirstName')}
+                    aria-label={customFirstNameLabel ?? translate('personalInfoStep.legalFirstName')}
                     role={CONST.ROLE.PRESENTATION}
                     defaultValue={defaultValues.firstName}
                     shouldSaveDraft={!isEditing}
@@ -102,8 +129,8 @@ function FullNameStep<TFormID extends keyof OnyxFormValuesMapping>({
                 <InputWrapper
                     InputComponent={TextInput}
                     inputID={lastNameInputID}
-                    label={translate('common.lastName')}
-                    aria-label={translate('common.lastName')}
+                    label={customLastNameLabel ?? translate('personalInfoStep.legalLastName')}
+                    aria-label={customLastNameLabel ?? translate('personalInfoStep.legalLastName')}
                     role={CONST.ROLE.PRESENTATION}
                     defaultValue={defaultValues.lastName}
                     shouldSaveDraft={!isEditing}

--- a/src/components/SubStepForms/FullNameStep.tsx
+++ b/src/components/SubStepForms/FullNameStep.tsx
@@ -47,7 +47,7 @@ type FullNameStepProps<TFormID extends keyof OnyxFormValuesMapping> = SubStepPro
     /** Custom label of the first input  */
     customFirstNameLabel?: string;
 
-    /** Custom label of the second input */
+    /** Custom label of the last name input */
     customLastNameLabel?: string;
 };
 

--- a/src/pages/MissingPersonalDetails/substeps/LegalName.tsx
+++ b/src/pages/MissingPersonalDetails/substeps/LegalName.tsx
@@ -1,12 +1,8 @@
-import React, {useCallback} from 'react';
-import type {FormInputErrors, FormOnyxValues} from '@components/Form/types';
+import React from 'react';
 import FullNameStep from '@components/SubStepForms/FullNameStep';
 import useLocalize from '@hooks/useLocalize';
 import usePersonalDetailsFormSubmit from '@hooks/usePersonalDetailsFormSubmit';
-import * as ErrorUtils from '@libs/ErrorUtils';
-import * as ValidationUtils from '@libs/ValidationUtils';
 import type {CustomSubStepProps} from '@pages/MissingPersonalDetails/types';
-import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
 import INPUT_IDS from '@src/types/form/PersonalDetailsForm';
 

--- a/src/pages/MissingPersonalDetails/substeps/LegalName.tsx
+++ b/src/pages/MissingPersonalDetails/substeps/LegalName.tsx
@@ -20,40 +20,6 @@ function LegalName({isEditing, onNext, onMove, personalDetailsValues}: CustomSub
         lastName: personalDetailsValues[INPUT_IDS.LEGAL_LAST_NAME],
     };
 
-    const validate = useCallback(
-        (values: FormOnyxValues<typeof ONYXKEYS.FORMS.PERSONAL_DETAILS_FORM>): FormInputErrors<typeof ONYXKEYS.FORMS.PERSONAL_DETAILS_FORM> => {
-            const errors: FormInputErrors<typeof ONYXKEYS.FORMS.PERSONAL_DETAILS_FORM> = {};
-            if (!ValidationUtils.isRequiredFulfilled(values[INPUT_IDS.LEGAL_FIRST_NAME])) {
-                errors[INPUT_IDS.LEGAL_FIRST_NAME] = translate('common.error.fieldRequired');
-            } else if (!ValidationUtils.isValidLegalName(values[INPUT_IDS.LEGAL_FIRST_NAME])) {
-                errors[INPUT_IDS.LEGAL_FIRST_NAME] = translate('privatePersonalDetails.error.hasInvalidCharacter');
-            } else if (values[INPUT_IDS.LEGAL_FIRST_NAME].length > CONST.LEGAL_NAME.MAX_LENGTH) {
-                errors[INPUT_IDS.LEGAL_FIRST_NAME] = translate('common.error.characterLimitExceedCounter', {
-                    length: values[INPUT_IDS.LEGAL_FIRST_NAME].length,
-                    limit: CONST.LEGAL_NAME.MAX_LENGTH,
-                });
-            }
-            if (ValidationUtils.doesContainReservedWord(values[INPUT_IDS.LEGAL_FIRST_NAME], CONST.DISPLAY_NAME.RESERVED_NAMES)) {
-                ErrorUtils.addErrorMessage(errors, INPUT_IDS.LEGAL_FIRST_NAME, translate('personalDetails.error.containsReservedWord'));
-            }
-            if (!ValidationUtils.isRequiredFulfilled(values[INPUT_IDS.LEGAL_LAST_NAME])) {
-                errors[INPUT_IDS.LEGAL_LAST_NAME] = translate('common.error.fieldRequired');
-            } else if (!ValidationUtils.isValidLegalName(values[INPUT_IDS.LEGAL_LAST_NAME])) {
-                errors[INPUT_IDS.LEGAL_LAST_NAME] = translate('privatePersonalDetails.error.hasInvalidCharacter');
-            } else if (values[INPUT_IDS.LEGAL_LAST_NAME].length > CONST.LEGAL_NAME.MAX_LENGTH) {
-                errors[INPUT_IDS.LEGAL_LAST_NAME] = translate('common.error.characterLimitExceedCounter', {
-                    length: values[INPUT_IDS.LEGAL_LAST_NAME].length,
-                    limit: CONST.LEGAL_NAME.MAX_LENGTH,
-                });
-            }
-            if (ValidationUtils.doesContainReservedWord(values[INPUT_IDS.LEGAL_LAST_NAME], CONST.DISPLAY_NAME.RESERVED_NAMES)) {
-                ErrorUtils.addErrorMessage(errors, INPUT_IDS.LEGAL_LAST_NAME, translate('personalDetails.error.containsReservedWord'));
-            }
-            return errors;
-        },
-        [translate],
-    );
-
     const handleSubmit = usePersonalDetailsFormSubmit({
         fieldIds: STEP_FIELDS,
         onNext,
@@ -68,7 +34,6 @@ function LegalName({isEditing, onNext, onMove, personalDetailsValues}: CustomSub
             formID={ONYXKEYS.FORMS.PERSONAL_DETAILS_FORM}
             formTitle={translate('privatePersonalDetails.enterLegalName')}
             onSubmit={handleSubmit}
-            customValidate={validate}
             stepFields={STEP_FIELDS}
             firstNameInputID={INPUT_IDS.LEGAL_FIRST_NAME}
             lastNameInputID={INPUT_IDS.LEGAL_LAST_NAME}


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
<!-- Explain what your change does and how it addresses the linked issue -->
Update the validation message for `FullNameStep` component, which's a common component that is used for legal name form.

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/51776
PROPOSAL: N/A


### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

**Expensify Card:**
1. Login with any account.
2. Go to workspace settings > Expensify Card.
3. Click Issue new card.
4. Click Connect manually.
5. Enter account numbers > Next.
6. On "What's your legal name" step, enter number on the fields..
7. Click Next.
8. Verify that the error message shows correctly.


**Enable payments:**

1. Log in to the App
2. Go to Settings -> Wallet
3. Add bank account
4. Click "Enable wallet"
5. Verify that Legal Name page has correct validation.


**Reimbursement account - personal info:**

1. Log in to the App
2. Create new workspace
3. Add new member
4. Go to More features section and enable Expensify Card option
5. Go to Expensify Card section that just appeared
6. Tap Issue new card
7. Go through the process of connecting to the bank account etc.
8. At some point of the process you'll need to provide requestor information like first and last name, date of birth etc. - test.
9. Verify that Legal Name page has correct validation.


**Missing personal info for issuing the card:**

1. Log in to the App as User A
2. Go to the Workspace that you are admin of
3. Invite completely new user (User B)
4. Turn on Expensify Card for this workspace if not done yet
5. Set it up
6. Tap "Issue new card" and issue the card for User B
7. Log in to the App as User B
8. Go to the Workspace chat - you should see the "Add shipping details" button - tap it
9. You'll see the multiple step form asking you to fill your personal details - test it.
10. Verify that Legal Name page has correct validation.
- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

Same as Tests.

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->
Same as Tests.
- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/dd42de5a-788a-4f23-8934-0f437e447134

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->


https://github.com/user-attachments/assets/04b90766-84fe-4a5b-ba9e-3e3b82a18bca




</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/d7be8626-0162-4e11-991f-34276819e341


</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/d8acd6fa-dbab-4eb8-8fac-cc237bdc1792


</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/c4f8b813-6fd0-4622-8e01-3ffab197d6fe

https://github.com/user-attachments/assets/9cbde131-3b8c-4a72-ac06-0eb698dac34d


https://github.com/user-attachments/assets/2540bb9e-728a-446a-a010-8f25f651e26e



</details>

<details>
<summary>MacOS: Desktop</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/2fd28f47-f0a5-4cf3-ab08-e8448ef4fe4f


</details>
