### PR TITLE
[CP Staging] Revert "Fix some bugs on Bank account Flow"

### DIFF
--- a/src/pages/ReimbursementAccount/ReimbursementAccountPage.tsx
+++ b/src/pages/ReimbursementAccount/ReimbursementAccountPage.tsx
@@ -2,7 +2,7 @@ import type {RouteProp} from '@react-navigation/native';
 import type {StackScreenProps} from '@react-navigation/stack';
 import {Str} from 'expensify-common';
 import lodashPick from 'lodash/pick';
-import React, {useCallback, useEffect, useRef, useState} from 'react';
+import React, {useEffect, useRef, useState} from 'react';
 import {View} from 'react-native';
 import {useOnyx} from 'react-native-onyx';
 import type {ValueOf} from 'type-fest';
@@ -178,6 +178,7 @@ function ReimbursementAccountPage({route, policy}: ReimbursementAccountPageProps
      which acts similarly to `componentDidUpdate` when the `reimbursementAccount` dependency changes.
      */
     const [hasACHDataBeenLoaded, setHasACHDataBeenLoaded] = useState(reimbursementAccount !== CONST.REIMBURSEMENT_ACCOUNT.DEFAULT_DATA && isPreviousPolicy);
+    const [shouldShowContinueSetupButton, setShouldShowContinueSetupButton] = useState(getShouldShowContinueSetupButtonInitialValue());
 
     function getBankAccountFields(fieldNames: InputID[]): Partial<ACHDataReimbursementAccount> {
         return {
@@ -188,28 +189,21 @@ function ReimbursementAccountPage({route, policy}: ReimbursementAccountPageProps
     /**
      * Returns true if a VBBA exists in any state other than OPEN or LOCKED
      */
-    const hasInProgressVBBA = useCallback(() => {
+    function hasInProgressVBBA(): boolean {
         return !!achData?.bankAccountID && !!achData?.state && achData?.state !== BankAccount.STATE.OPEN && achData?.state !== BankAccount.STATE.LOCKED;
-    }, [achData?.bankAccountID, achData?.state]);
+    }
 
     /*
      * Calculates the state used to show the "Continue with setup" view. If a bank account setup is already in progress and
      * no specific further step was passed in the url we'll show the workspace bank account reset modal if the user wishes to start over
      */
-    const getShouldShowContinueSetupButtonInitialValue = useCallback(() => {
+    function getShouldShowContinueSetupButtonInitialValue(): boolean {
         if (!hasInProgressVBBA()) {
             // Since there is no VBBA in progress, we won't need to show the component ContinueBankAccountSetup
             return false;
         }
         return achData?.state === BankAccount.STATE.PENDING || [CONST.BANK_ACCOUNT.STEP.BANK_ACCOUNT, ''].includes(getStepToOpenFromRouteParams(route));
-    }, [achData?.state, hasInProgressVBBA, route]);
-
-    const [shouldShowContinueSetupButton, setShouldShowContinueSetupButton] = useState(getShouldShowContinueSetupButtonInitialValue());
-
-    useEffect(() => {
-        setShouldShowContinueSetupButton(getShouldShowContinueSetupButtonInitialValue());
-        setHasACHDataBeenLoaded(reimbursementAccount !== CONST.REIMBURSEMENT_ACCOUNT.DEFAULT_DATA && isPreviousPolicy);
-    }, [achData, getShouldShowContinueSetupButtonInitialValue, isPreviousPolicy, reimbursementAccount]);
+    }
 
     const handleNextNonUSDBankAccountStep = () => {
         switch (nonUSDBankAccountStep) {

--- a/src/pages/workspace/expensifyCard/WorkspaceExpensifyCardPageEmptyState.tsx
+++ b/src/pages/workspace/expensifyCard/WorkspaceExpensifyCardPageEmptyState.tsx
@@ -22,6 +22,7 @@ import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
 import ROUTES from '@src/ROUTES';
 import type SCREENS from '@src/SCREENS';
+import {isEmptyObject} from '@src/types/utils/EmptyObject';
 
 const expensifyCardFeatures: FeatureListItem[] = [
     {
@@ -54,15 +55,15 @@ function WorkspaceExpensifyCardPageEmptyState({route, policy}: WorkspaceExpensif
     const eligibleBankAccounts = CardUtils.getEligibleBankAccountsForCard(bankAccountList ?? {});
 
     const reimbursementAccountStatus = reimbursementAccount?.achData?.state ?? '';
-    const isSetupUnfinished = !eligibleBankAccounts.length && reimbursementAccountStatus && reimbursementAccountStatus !== CONST.BANK_ACCOUNT.STATE.OPEN;
+    const isSetupUnfinished = isEmptyObject(bankAccountList) && reimbursementAccountStatus && reimbursementAccountStatus !== CONST.BANK_ACCOUNT.STATE.OPEN;
 
     const startFlow = useCallback(() => {
-        if (!eligibleBankAccounts.length) {
+        if (!eligibleBankAccounts.length || isSetupUnfinished) {
             Navigation.navigate(ROUTES.BANK_ACCOUNT_WITH_STEP_TO_OPEN.getRoute('new', policy?.id, ROUTES.WORKSPACE_EXPENSIFY_CARD.getRoute(policy?.id ?? '-1')));
         } else {
             Navigation.navigate(ROUTES.WORKSPACE_EXPENSIFY_CARD_BANK_ACCOUNT.getRoute(policy?.id ?? '-1'));
         }
-    }, [eligibleBankAccounts.length, policy?.id]);
+    }, [eligibleBankAccounts.length, isSetupUnfinished, policy?.id]);
 
     const confirmCurrencyChangeAndHideModal = useCallback(() => {
         if (!policy) {


### PR DESCRIPTION
Reverts Expensify/App#51315


Fix deploy blocker:
- https://github.com/Expensify/App/issues/51823
- https://github.com/Expensify/App/issues/51854


QA Steps: 

Bug 1:

1. Tap profile icon -- workspaces-- workspace
2. Tap more features - enable workflow
3. Tap workflow in workspace settings
4. Tap connect bank account
5. Complete the flow using region bank - selecting account ending 1111
6. Note user directed to continue set up page instead of "manually add bank account page"
7. Navigate to settings and tap connect bank - continue set up
8. On tapping next on manually enter bank account page, user directed to continue set up page again
9. When we revisit the page by tapping next, user directed to personal information page
10. Verify on tapping "next" in manually enter bank account page, user must not be directed to continue set up page


Bug 2: 

1. profile icon > workspaces > enable workflow
2. Tap workflow in workspace settings > connect bank account
3. Select the Manual method to add a bank account
4. Go through the flow until "Validate account" page
5. Submit three random amounts
6. Verify that the validate code you entered is incorrect, please try again" error is shown in "Validate account" page