### PR TITLE
[Search v2.5] Allow Searching for multiple statuses

### DIFF
--- a/src/components/Search/SearchStatusBar.tsx
+++ b/src/components/Search/SearchStatusBar.tsx
@@ -177,10 +177,18 @@ function SearchStatusBar({queryJSON, onStatusChange}: SearchStatusBarProps) {
             {options.map((item, index) => {
                 const onPress = singleExecution(() => {
                     onStatusChange?.();
-                    const query = SearchQueryUtils.buildSearchQueryString({...queryJSON, status: item.status});
+                    let newStatus;
+                    if (Array.isArray(queryJSON.status)) {
+                        newStatus = queryJSON.status.includes(item.status)
+                            ? queryJSON.status.filter((status) => status !== item.status)
+                            : [...queryJSON.status, item.status];
+                    } else {
+                        newStatus = queryJSON.status === item.status ? [] : [queryJSON.status, item.status];
+                    }
+                    const query = SearchQueryUtils.buildSearchQueryString({...queryJSON, status: newStatus});
                     Navigation.setParams({q: query});
                 });
-                const isActive = queryJSON.status === item.status;
+                const isActive = Array.isArray(queryJSON.status) ? queryJSON.status.includes(item.status) : queryJSON.status === item.status;
                 const isFirstItem = index === 0;
                 const isLastItem = index === options.length - 1;
 

--- a/src/components/Search/SearchStatusBar.tsx
+++ b/src/components/Search/SearchStatusBar.tsx
@@ -179,9 +179,7 @@ function SearchStatusBar({queryJSON, onStatusChange}: SearchStatusBarProps) {
                     onStatusChange?.();
                     let newStatus;
                     if (Array.isArray(queryJSON.status)) {
-                        newStatus = queryJSON.status.includes(item.status)
-                            ? queryJSON.status.filter((status) => status !== item.status)
-                            : [...queryJSON.status, item.status];
+                        newStatus = queryJSON.status.includes(item.status) ? queryJSON.status.filter((status) => status !== item.status) : [...queryJSON.status, item.status];
                     } else {
                         newStatus = queryJSON.status === item.status ? [] : [queryJSON.status, item.status];
                     }

--- a/src/components/Search/SearchStatusBar.tsx
+++ b/src/components/Search/SearchStatusBar.tsx
@@ -177,13 +177,7 @@ function SearchStatusBar({queryJSON, onStatusChange}: SearchStatusBarProps) {
             {options.map((item, index) => {
                 const onPress = singleExecution(() => {
                     onStatusChange?.();
-                    let newStatus;
-                    if (Array.isArray(queryJSON.status)) {
-                        newStatus = queryJSON.status.includes(item.status) ? queryJSON.status.filter((status) => status !== item.status) : [...queryJSON.status, item.status];
-                    } else {
-                        newStatus = queryJSON.status === item.status ? [] : [queryJSON.status, item.status];
-                    }
-                    const query = SearchQueryUtils.buildSearchQueryString({...queryJSON, status: newStatus});
+                    const query = SearchQueryUtils.buildSearchQueryString({...queryJSON, status: item.status});
                     Navigation.setParams({q: query});
                 });
                 const isActive = Array.isArray(queryJSON.status) ? queryJSON.status.includes(item.status) : queryJSON.status === item.status;

--- a/src/components/Search/index.tsx
+++ b/src/components/Search/index.tsx
@@ -191,7 +191,8 @@ function Search({queryJSON, onSearchListScroll, contentContainerStyle}: SearchPr
 
     // There's a race condition in Onyx which makes it return data from the previous Search, so in addition to checking that the data is loaded
     // we also need to check that the searchResults matches the type and status of the current search
-    const isDataLoaded = searchResults?.data !== undefined && searchResults?.search?.type === type && searchResults?.search?.status === status;
+    const isDataLoaded = searchResults?.data !== undefined && searchResults?.search?.type === type && Array.isArray(status) ? searchResults?.search?.status === status.join(',') : searchResults?.search?.status === status;
+
     const shouldShowLoadingState = !isOffline && !isDataLoaded;
     const shouldShowLoadingMoreItems = !shouldShowLoadingState && searchResults?.search?.isLoading && searchResults?.search?.offset > 0;
     const isSearchResultsEmpty = !searchResults?.data || SearchUIUtils.isSearchResultsEmpty(searchResults);
@@ -402,7 +403,9 @@ function Search({queryJSON, onSearchListScroll, contentContainerStyle}: SearchPr
     };
 
     const shouldShowYear = SearchUIUtils.shouldShowYear(searchResults?.data);
-    const shouldShowSorting = sortableSearchStatuses.includes(status);
+    const shouldShowSorting = Array.isArray(status) 
+        ? status.some((s) => sortableSearchStatuses.includes(s))
+        : sortableSearchStatuses.includes(status);
 
     return (
         <SelectionListWithModal<ReportListItemType | TransactionListItemType | ReportActionListItemType>

--- a/src/components/Search/index.tsx
+++ b/src/components/Search/index.tsx
@@ -191,7 +191,10 @@ function Search({queryJSON, onSearchListScroll, contentContainerStyle}: SearchPr
 
     // There's a race condition in Onyx which makes it return data from the previous Search, so in addition to checking that the data is loaded
     // we also need to check that the searchResults matches the type and status of the current search
-    const isDataLoaded = searchResults?.data !== undefined && searchResults?.search?.type === type && Array.isArray(status) ? searchResults?.search?.status === status.join(',') : searchResults?.search?.status === status;
+    const isDataLoaded =
+        searchResults?.data !== undefined && searchResults?.search?.type === type && Array.isArray(status)
+            ? searchResults?.search?.status === status.join(',')
+            : searchResults?.search?.status === status;
 
     const shouldShowLoadingState = !isOffline && !isDataLoaded;
     const shouldShowLoadingMoreItems = !shouldShowLoadingState && searchResults?.search?.isLoading && searchResults?.search?.offset > 0;
@@ -403,9 +406,7 @@ function Search({queryJSON, onSearchListScroll, contentContainerStyle}: SearchPr
     };
 
     const shouldShowYear = SearchUIUtils.shouldShowYear(searchResults?.data);
-    const shouldShowSorting = Array.isArray(status) 
-        ? status.some((s) => sortableSearchStatuses.includes(s))
-        : sortableSearchStatuses.includes(status);
+    const shouldShowSorting = Array.isArray(status) ? status.some((s) => sortableSearchStatuses.includes(s)) : sortableSearchStatuses.includes(status);
 
     return (
         <SelectionListWithModal<ReportListItemType | TransactionListItemType | ReportActionListItemType>

--- a/src/components/Search/types.ts
+++ b/src/components/Search/types.ts
@@ -30,7 +30,7 @@ type ExpenseSearchStatus = ValueOf<typeof CONST.SEARCH.STATUS.EXPENSE>;
 type InvoiceSearchStatus = ValueOf<typeof CONST.SEARCH.STATUS.INVOICE>;
 type TripSearchStatus = ValueOf<typeof CONST.SEARCH.STATUS.TRIP>;
 type ChatSearchStatus = ValueOf<typeof CONST.SEARCH.STATUS.CHAT>;
-type SearchStatus = ExpenseSearchStatus | InvoiceSearchStatus | TripSearchStatus | ChatSearchStatus;
+type SearchStatus = ExpenseSearchStatus | InvoiceSearchStatus | TripSearchStatus | ChatSearchStatus | Array<ExpenseSearchStatus | InvoiceSearchStatus | TripSearchStatus | ChatSearchStatus>;
 
 type SearchContext = {
     currentSearchHash: number;

--- a/src/libs/SearchQueryUtils.ts
+++ b/src/libs/SearchQueryUtils.ts
@@ -617,7 +617,9 @@ function buildCannedSearchQuery({
     status?: SearchStatus;
     policyID?: string;
 } = {}): SearchQueryString {
-    const queryString = policyID ? `type:${type} status:${Array.isArray(status) ? status.join(',') : status} policyID:${policyID}` : `type:${type} status:${Array.isArray(status) ? status.join(',') : status}`;
+    const queryString = policyID
+        ? `type:${type} status:${Array.isArray(status) ? status.join(',') : status} policyID:${policyID}`
+        : `type:${type} status:${Array.isArray(status) ? status.join(',') : status}`;
 
     // Parse the query to fill all default query fields with values
     const normalizedQueryJSON = buildSearchQueryJSON(queryString);

--- a/src/libs/SearchQueryUtils.ts
+++ b/src/libs/SearchQueryUtils.ts
@@ -488,8 +488,13 @@ function buildFilterFormValuesFromQuery(
 
     const [typeKey = '', typeValue] = Object.entries(CONST.SEARCH.DATA_TYPES).find(([, value]) => value === queryJSON.type) ?? [];
     filtersForm[FILTER_KEYS.TYPE] = typeValue ? queryJSON.type : CONST.SEARCH.DATA_TYPES.EXPENSE;
-    const [statusKey] = Object.entries(CONST.SEARCH.STATUS).find(([, value]) => Object.values(value).includes(queryJSON.status)) ?? [];
-    filtersForm[FILTER_KEYS.STATUS] = typeKey === statusKey ? queryJSON.status : CONST.SEARCH.STATUS.EXPENSE.ALL;
+    const [statusKey] = Object.entries(CONST.SEARCH.STATUS).find(([, value]) => 
+        Array.isArray(queryJSON.status)
+            ? queryJSON.status.some((status) => Object.values(value).includes(status))
+            : Object.values(value).includes(queryJSON.status)
+    ) ?? [];
+    
+    filtersForm[FILTER_KEYS.STATUS] = typeKey === statusKey ? Array.isArray(queryJSON.status) ? queryJSON.status.join(',') : queryJSON.status : CONST.SEARCH.STATUS.EXPENSE.ALL;
 
     if (queryJSON.policyID) {
         filtersForm[FILTER_KEYS.POLICY_ID] = queryJSON.policyID;

--- a/src/libs/SearchQueryUtils.ts
+++ b/src/libs/SearchQueryUtils.ts
@@ -233,7 +233,7 @@ function getUpdatedAmountValue(filterName: ValueOf<typeof CONST.SEARCH.SYNTAX_FI
 function getQueryHashes(query: SearchQueryJSON): {primaryHash: number; recentSearchHash: number} {
     let orderedQuery = '';
     orderedQuery += `${CONST.SEARCH.SYNTAX_ROOT_KEYS.TYPE}:${query.type}`;
-    orderedQuery += ` ${CONST.SEARCH.SYNTAX_ROOT_KEYS.STATUS}:${query.status}`;
+    orderedQuery += ` ${CONST.SEARCH.SYNTAX_ROOT_KEYS.STATUS}:${Array.isArray(query.status) ? query.status.join(',') : query.status}`;
 
     query.flatFilters.forEach((filter) => {
         filter.filters.sort((a, b) => localeCompare(a.value.toString(), b.value.toString()));
@@ -295,7 +295,11 @@ function buildSearchQueryString(queryJSON?: SearchQueryJSON) {
         const queryFieldValue = existingFieldValue ?? defaultQueryJSON?.[key];
 
         if (queryFieldValue) {
-            queryParts.push(`${key}:${queryFieldValue}`);
+            if (Array.isArray(queryFieldValue)) {
+                queryParts.push(`${key}:${queryFieldValue.join(',')}`);
+            } else {
+                queryParts.push(`${key}:${queryFieldValue}`);
+            }
         }
     }
 
@@ -493,7 +497,11 @@ function buildFilterFormValuesFromQuery(
             Array.isArray(queryJSON.status) ? queryJSON.status.some((status) => Object.values(value).includes(status)) : Object.values(value).includes(queryJSON.status),
         ) ?? [];
 
-    filtersForm[FILTER_KEYS.STATUS] = typeKey === statusKey ? (Array.isArray(queryJSON.status) ? queryJSON.status.join(',') : queryJSON.status) : CONST.SEARCH.STATUS.EXPENSE.ALL;
+    if (typeKey === statusKey) {
+        filtersForm[FILTER_KEYS.STATUS] = Array.isArray(queryJSON.status) ? queryJSON.status.join(',') : queryJSON.status;
+    } else {
+        filtersForm[FILTER_KEYS.STATUS] = CONST.SEARCH.STATUS.EXPENSE.ALL;
+    }
 
     if (queryJSON.policyID) {
         filtersForm[FILTER_KEYS.POLICY_ID] = queryJSON.policyID;

--- a/src/libs/SearchQueryUtils.ts
+++ b/src/libs/SearchQueryUtils.ts
@@ -561,7 +561,7 @@ function buildUserReadableQueryString(
     const {type, status} = queryJSON;
     const filters = queryJSON.flatFilters ?? {};
 
-    let title = `type:${type} status:${status}`;
+    let title = `type:${type} status:${Array.isArray(status) ? status.join(',') : status}`;
 
     for (const filterObject of filters) {
         const key = filterObject.key;

--- a/src/libs/SearchQueryUtils.ts
+++ b/src/libs/SearchQueryUtils.ts
@@ -488,13 +488,12 @@ function buildFilterFormValuesFromQuery(
 
     const [typeKey = '', typeValue] = Object.entries(CONST.SEARCH.DATA_TYPES).find(([, value]) => value === queryJSON.type) ?? [];
     filtersForm[FILTER_KEYS.TYPE] = typeValue ? queryJSON.type : CONST.SEARCH.DATA_TYPES.EXPENSE;
-    const [statusKey] = Object.entries(CONST.SEARCH.STATUS).find(([, value]) => 
-        Array.isArray(queryJSON.status)
-            ? queryJSON.status.some((status) => Object.values(value).includes(status))
-            : Object.values(value).includes(queryJSON.status)
-    ) ?? [];
-    
-    filtersForm[FILTER_KEYS.STATUS] = typeKey === statusKey ? Array.isArray(queryJSON.status) ? queryJSON.status.join(',') : queryJSON.status : CONST.SEARCH.STATUS.EXPENSE.ALL;
+    const [statusKey] =
+        Object.entries(CONST.SEARCH.STATUS).find(([, value]) =>
+            Array.isArray(queryJSON.status) ? queryJSON.status.some((status) => Object.values(value).includes(status)) : Object.values(value).includes(queryJSON.status),
+        ) ?? [];
+
+    filtersForm[FILTER_KEYS.STATUS] = typeKey === statusKey ? (Array.isArray(queryJSON.status) ? queryJSON.status.join(',') : queryJSON.status) : CONST.SEARCH.STATUS.EXPENSE.ALL;
 
     if (queryJSON.policyID) {
         filtersForm[FILTER_KEYS.POLICY_ID] = queryJSON.policyID;

--- a/src/libs/SearchQueryUtils.ts
+++ b/src/libs/SearchQueryUtils.ts
@@ -609,7 +609,7 @@ function buildCannedSearchQuery({
     status?: SearchStatus;
     policyID?: string;
 } = {}): SearchQueryString {
-    const queryString = policyID ? `type:${type} status:${status} policyID:${policyID}` : `type:${type} status:${status}`;
+    const queryString = policyID ? `type:${type} status:${Array.isArray(status) ? status.join(',') : status} policyID:${policyID}` : `type:${type} status:${Array.isArray(status) ? status.join(',') : status}`;
 
     // Parse the query to fill all default query fields with values
     const normalizedQueryJSON = buildSearchQueryJSON(queryString);


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
<!-- Explain what your change does and how it addresses the linked issue -->
Handle multiple statuses

https://github.com/user-attachments/assets/b1c2f87f-9c24-47ad-83f6-846f0622c1d5

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
Frontend part of https://github.com/Expensify/App/issues/51838


### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

-  [x] Verify that no errors appear in the JS console

**Prerequisite**: having a workspace with expenses in different statuses (e.g `drafts`,  `outstanding` etc).

1. Go to `Search` page 
2. Replace the URL search parameters with `{url}/search?q=type%3Aexpense%20status%3Aoutstanding,drafts%20sortBy%3Adate%20sortOrder%3Adesc`
3. You should see corresponding results for outstanding and drafts expenses. Both statuses should be highlighted
4. Click on another status
5. It should automatically keep only one status selected

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.


For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->


- [x] Verify that no errors appear in the JS console


Same as in tests 


### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->


- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [X] I verified that similar component doesn't exist in the codebase
- [X] I verified that all props are defined accurately and each prop has a `/** comment above it */`
- [X] I verified that each file is named correctly
- [X] I verified that each component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
- [X] I verified that the only data being stored in component state is data necessary for rendering and nothing else
- [X] In component if we are not using the full Onyx data that we loaded, I've added the proper selector in order to ensure the component only re-renders when the data it is using changes
- [X] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
- [X] I verified that component internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
- [X] I verified that all JSX used for rendering exists in the render method
- [X] I verified that each component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions


### Screenshots/Videos
<details>
<summary>Android: Native</summary>


<!-- add screenshots or videos here -->


</details>


<details>
<summary>Android: mWeb Chrome</summary>


<!-- add screenshots or videos here -->


</details>


<details>
<summary>iOS: Native</summary>


<!-- add screenshots or videos here -->


</details>


<details>
<summary>iOS: mWeb Safari</summary>


<!-- add screenshots or videos here -->


</details>


<details>
<summary>MacOS: Chrome / Safari</summary>

https://github.com/user-attachments/assets/b1c2f87f-9c24-47ad-83f6-846f0622c1d5
<!-- add screenshots or videos here -->


</details>


<details>
<summary>MacOS: Desktop</summary>


<!-- add screenshots or videos here -->


</details>

