### PR TITLE
[CP Staging] Revert "Fix pay someone flow for unvalidated accounts"

### DIFF
--- a/src/libs/Network/SequentialQueue.ts
+++ b/src/libs/Network/SequentialQueue.ts
@@ -138,8 +138,8 @@ function flush() {
         return;
     }
 
-    if (PersistedRequests.getAll().length === 0 && QueuedOnyxUpdates.isEmpty()) {
-        Log.info('[SequentialQueue] Unable to flush. No requests or queued Onyx updates to process.');
+    if (PersistedRequests.getAll().length === 0) {
+        Log.info('[SequentialQueue] Unable to flush. No requests to process.');
         return;
     }
 

--- a/src/libs/actions/OnyxUpdateManager/index.ts
+++ b/src/libs/actions/OnyxUpdateManager/index.ts
@@ -1,13 +1,11 @@
-import type {OnyxEntry, OnyxUpdate} from 'react-native-onyx';
+import type {OnyxEntry} from 'react-native-onyx';
 import Onyx from 'react-native-onyx';
 import * as ActiveClientManager from '@libs/ActiveClientManager';
 import Log from '@libs/Log';
-import * as NetworkStore from '@libs/Network/NetworkStore';
 import * as SequentialQueue from '@libs/Network/SequentialQueue';
 import * as App from '@userActions/App';
-import updateSessionAuthTokens from '@userActions/Session/updateSessionAuthTokens';
 import ONYXKEYS from '@src/ONYXKEYS';
-import type {OnyxUpdatesFromServer, Session} from '@src/types/onyx';
+import type {OnyxUpdatesFromServer} from '@src/types/onyx';
 import {isValidOnyxUpdateFromServer} from '@src/types/onyx/OnyxUpdatesFromServer';
 import * as OnyxUpdateManagerUtils from './utils';
 import * as DeferredOnyxUpdates from './utils/DeferredOnyxUpdates';
@@ -92,10 +90,6 @@ function handleOnyxUpdateGap(onyxUpdatesFromServer: OnyxEntry<OnyxUpdatesFromSer
         return;
     }
 
-    // Check if one of these onyx updates is for the authToken. If it is, let's update our authToken now because our
-    // current authToken is probably invalid.
-    updateAuthTokenIfNecessary(onyxUpdatesFromServer);
-
     const updateParams = onyxUpdatesFromServer;
     const lastUpdateIDFromServer = onyxUpdatesFromServer.lastUpdateID;
     const previousUpdateIDFromServer = onyxUpdatesFromServer.previousUpdateID;
@@ -148,29 +142,6 @@ function handleOnyxUpdateGap(onyxUpdatesFromServer: OnyxEntry<OnyxUpdatesFromSer
     }
 
     DeferredOnyxUpdates.getMissingOnyxUpdatesQueryPromise()?.finally(finalizeUpdatesAndResumeQueue);
-}
-
-function updateAuthTokenIfNecessary(onyxUpdatesFromServer: OnyxEntry<OnyxUpdatesFromServer>): void {
-    // Consolidate all of the given Onyx updates
-    const onyxUpdates: OnyxUpdate[] = [];
-    onyxUpdatesFromServer?.updates?.forEach((updateEvent) => onyxUpdates.push(...updateEvent.data));
-    onyxUpdates.push(...(onyxUpdatesFromServer?.response?.onyxData ?? []));
-
-    // Find any session updates
-    const sessionUpdates = onyxUpdates?.filter((onyxUpdate) => onyxUpdate.key === ONYXKEYS.SESSION);
-
-    // If any of the updates changes the authToken, let's update it now
-    sessionUpdates?.forEach((sessionUpdate) => {
-        const session = (sessionUpdate.value ?? {}) as Session;
-        const newAuthToken = session.authToken ?? '';
-        if (!newAuthToken) {
-            return;
-        }
-
-        Log.info('[OnyxUpdateManager] Found an authToken update while handling an Onyx update gap. Updating the authToken.');
-        updateSessionAuthTokens(newAuthToken);
-        NetworkStore.setAuthToken(newAuthToken);
-    });
 }
 
 export default () => {

--- a/src/libs/actions/QueuedOnyxUpdates.ts
+++ b/src/libs/actions/QueuedOnyxUpdates.ts
@@ -19,8 +19,4 @@ function flushQueue(): Promise<void> {
     });
 }
 
-function isEmpty() {
-    return queuedOnyxUpdates.length === 0;
-}
-
-export {queueOnyxUpdates, flushQueue, isEmpty};
+export {queueOnyxUpdates, flushQueue};

--- a/src/libs/actions/User.ts
+++ b/src/libs/actions/User.ts
@@ -559,16 +559,6 @@ function validateLogin(accountID: number, validateCode: string) {
             onyxMethod: Onyx.METHOD.MERGE,
             key: ONYXKEYS.ACCOUNT,
             value: {
-                isLoading: true,
-            },
-        },
-    ];
-
-    const finallyData: OnyxUpdate[] = [
-        {
-            onyxMethod: Onyx.METHOD.MERGE,
-            key: ONYXKEYS.ACCOUNT,
-            value: {
                 isLoading: false,
             },
         },
@@ -576,7 +566,7 @@ function validateLogin(accountID: number, validateCode: string) {
 
     const parameters: ValidateLoginParams = {accountID, validateCode};
 
-    API.write(WRITE_COMMANDS.VALIDATE_LOGIN, parameters, {optimisticData, finallyData});
+    API.write(WRITE_COMMANDS.VALIDATE_LOGIN, parameters, {optimisticData});
     Navigation.navigate(ROUTES.HOME);
 }
 

--- a/src/pages/settings/Wallet/VerifyAccountPage.tsx
+++ b/src/pages/settings/Wallet/VerifyAccountPage.tsx
@@ -21,8 +21,6 @@ function VerifyAccountPage({route}: VerifyAccountPageProps) {
     const loginData = loginList?.[contactMethod];
     const validateLoginError = ErrorUtils.getEarliestErrorField(loginData, 'validateLogin');
     const [isUserValidated] = useOnyx(ONYXKEYS.USER, {selector: (user) => !!user?.validated});
-    const [accountID] = useOnyx(ONYXKEYS.SESSION, {selector: (session) => session?.accountID ?? 0});
-
     const [isValidateCodeActionModalVisible, setIsValidateCodeActionModalVisible] = useState(true);
 
     const navigateBackTo = route?.params?.backTo;
@@ -30,10 +28,10 @@ function VerifyAccountPage({route}: VerifyAccountPageProps) {
     useEffect(() => () => User.clearUnvalidatedNewContactMethodAction(), []);
 
     const handleSubmitForm = useCallback(
-        (validateCode: string) => {
-            User.validateLogin(accountID ?? 0, validateCode);
+        (submitCode: string) => {
+            User.validateSecondaryLogin(loginList, contactMethod ?? '', submitCode);
         },
-        [accountID],
+        [loginList, contactMethod],
     );
 
     const clearError = useCallback(() => {


### PR DESCRIPTION
Straight Reverts Expensify/App#50835

cc @arosiclair 

### Details
Fixes the pay someone flow when attempting to validate the account. When there is a Onyx update gap detected after calling `ValidateLogin`, we use the new `authToken` in the response before attempting to fetch missing updates since the current authToken is invalidated.

### Fixed Issues
$ https://github.com/Expensify/App/issues/52454
$ https://github.com/Expensify/App/issues/52456
$ https://github.com/Expensify/App/issues/52455
$ https://github.com/Expensify/App/issues/52453

### Tests

Confirm the linked blockers are no longer reproducible

### Offline tests

None

### QA Steps

Same as Tests