### PR TITLE
Fix distance amount changes after submitting track distance expense with description

### DIFF
--- a/src/libs/API/parameters/CategorizeTrackedExpenseParams.ts
+++ b/src/libs/API/parameters/CategorizeTrackedExpenseParams.ts
@@ -11,7 +11,6 @@ type CategorizeTrackedExpenseParams = {
     moneyRequestPreviewReportActionID: string;
     moneyRequestReportID: string;
     moneyRequestCreatedReportActionID: string;
-    customUnitRateID: string;
     actionableWhisperReportActionID: string;
     modifiedExpenseReportActionID: string;
     reportPreviewReportActionID: string;
@@ -22,6 +21,7 @@ type CategorizeTrackedExpenseParams = {
     taxAmount: number;
     billable?: boolean;
     waypoints?: string;
+    customUnitRateID?: string;
 };
 
 export default CategorizeTrackedExpenseParams;

--- a/src/libs/API/parameters/CategorizeTrackedExpenseParams.ts
+++ b/src/libs/API/parameters/CategorizeTrackedExpenseParams.ts
@@ -11,6 +11,7 @@ type CategorizeTrackedExpenseParams = {
     moneyRequestPreviewReportActionID: string;
     moneyRequestReportID: string;
     moneyRequestCreatedReportActionID: string;
+    customUnitRateID: string;
     actionableWhisperReportActionID: string;
     modifiedExpenseReportActionID: string;
     reportPreviewReportActionID: string;
@@ -20,6 +21,7 @@ type CategorizeTrackedExpenseParams = {
     taxCode: string;
     taxAmount: number;
     billable?: boolean;
+    waypoints?: string;
 };
 
 export default CategorizeTrackedExpenseParams;

--- a/src/libs/API/parameters/ShareTrackedExpenseParams.ts
+++ b/src/libs/API/parameters/ShareTrackedExpenseParams.ts
@@ -20,6 +20,8 @@ type ShareTrackedExpenseParams = {
     taxCode: string;
     taxAmount: number;
     billable?: boolean;
+    customUnitRateID: string;
+    waypoints?: string;
 };
 
 export default ShareTrackedExpenseParams;

--- a/src/libs/API/parameters/ShareTrackedExpenseParams.ts
+++ b/src/libs/API/parameters/ShareTrackedExpenseParams.ts
@@ -20,7 +20,7 @@ type ShareTrackedExpenseParams = {
     taxCode: string;
     taxAmount: number;
     billable?: boolean;
-    customUnitRateID: string;
+    customUnitRateID?: string;
     waypoints?: string;
 };
 

--- a/src/libs/actions/IOU.ts
+++ b/src/libs/actions/IOU.ts
@@ -3405,6 +3405,8 @@ function categorizeTrackedExpense(
     billable?: boolean,
     receipt?: Receipt,
     createdWorkspaceParams?: CreateWorkspaceParams,
+    waypoints?: string,
+    customUnitRateID?: string,
 ) {
     const {optimisticData, successData, failureData} = onyxData ?? {};
 
@@ -3451,6 +3453,8 @@ function categorizeTrackedExpense(
         policyExpenseCreatedReportActionID: createdWorkspaceParams?.expenseCreatedReportActionID,
         adminsChatReportID: createdWorkspaceParams?.adminsChatReportID,
         adminsCreatedReportActionID: createdWorkspaceParams?.adminsCreatedReportActionID,
+        waypoints,
+        customUnitRateID,
     };
 
     API.write(WRITE_COMMANDS.CATEGORIZE_TRACKED_EXPENSE, parameters, {optimisticData, successData, failureData});
@@ -3486,6 +3490,8 @@ function shareTrackedExpense(
     billable?: boolean,
     receipt?: Receipt,
     createdWorkspaceParams?: CreateWorkspaceParams,
+    waypoints?: string,
+    customUnitRateID?: string,
 ) {
     const {optimisticData, successData, failureData} = onyxData ?? {};
 
@@ -3532,6 +3538,8 @@ function shareTrackedExpense(
         policyExpenseCreatedReportActionID: createdWorkspaceParams?.expenseCreatedReportActionID,
         adminsChatReportID: createdWorkspaceParams?.adminsChatReportID,
         adminsCreatedReportActionID: createdWorkspaceParams?.adminsCreatedReportActionID,
+        waypoints,
+        customUnitRateID,
     };
 
     API.write(WRITE_COMMANDS.SHARE_TRACKED_EXPENSE, parameters, {optimisticData, successData, failureData});
@@ -3833,6 +3841,8 @@ function trackExpense(
         value: recentServerValidatedWaypoints,
     });
 
+    const waypoints = validWaypoints ? JSON.stringify(sanitizeRecentWaypoints(validWaypoints)) : undefined;
+
     switch (action) {
         case CONST.IOU.ACTION.CATEGORIZE: {
             if (!linkedTrackedExpenseReportAction || !actionableWhisperReportActionID || !linkedTrackedExpenseReportID) {
@@ -3863,6 +3873,8 @@ function trackExpense(
                 billable,
                 trackedReceipt,
                 createdWorkspaceParams,
+                waypoints,
+                customUnitRateID,
             );
             break;
         }
@@ -3894,6 +3906,8 @@ function trackExpense(
                 billable,
                 trackedReceipt,
                 createdWorkspaceParams,
+                waypoints,
+                customUnitRateID,
             );
             break;
         }
@@ -3922,7 +3936,7 @@ function trackExpense(
                 receiptGpsPoints: gpsPoints ? JSON.stringify(gpsPoints) : undefined,
                 transactionThreadReportID: transactionThreadReportID ?? '-1',
                 createdReportActionIDForThread: createdReportActionIDForThread ?? '-1',
-                waypoints: validWaypoints ? JSON.stringify(sanitizeRecentWaypoints(validWaypoints)) : undefined,
+                waypoints,
                 customUnitRateID,
             };
             if (actionableWhisperReportActionIDParam) {


### PR DESCRIPTION
### Explanation of Change
Implement required changes from BE request: we need to pass both `waypoints` and `customUnitRateID` for `CategorizeTrackedExpense ` and `ShareTrackedExpense ` API calls

### Fixed Issues

$ https://github.com/Expensify/App/issues/51417
PROPOSAL: https://github.com/Expensify/App/issues/51417#issuecomment-2473455649


### Tests
1. Go to staging.new.expensify.com
2. Go to self DM
3. Click + > Track expense > Distance
4. Enter waypoints > Next
5. On confirmation page, click Description
6. Enter a description and save it (important)
7. Take note of the distance
8. Click Track expense
9. Click Categorize it from the whisper
10. Select workspace, then category and submit it
11. Go to transaction thread
12. Verify that the distance in the transaction thread will not change after submitting track distance expense with description

- [x] Verify that no errors appear in the JS console

### Offline tests
Nothing changed in offline mode

### QA Steps

1. Go to staging.new.expensify.com
2. Go to self DM
3. Click + > Track expense > Distance
4. Enter waypoints > Next
5. On confirmation page, click Description
6. Enter a description and save it (important)
7. Take note of the distance
8. Click Track expense
9. Click Categorize it from the whisper
10. Select workspace, then category and submit it
11. Go to transaction thread
12. Verify that the distance in the transaction thread will not change after submitting track distance expense with description

- [x] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>


https://github.com/user-attachments/assets/a77c1924-4c6b-484c-9a56-02c8ccb7d2f1


</details>

<details>
<summary>Android: mWeb Chrome</summary>


https://github.com/user-attachments/assets/0b36737f-1ae9-418d-9a77-0db59863b5a9


</details>

<details>
<summary>iOS: Native</summary>


https://github.com/user-attachments/assets/21a41418-f6e5-4758-b8d6-079215d90dd8


</details>

<details>
<summary>iOS: mWeb Safari</summary>


https://github.com/user-attachments/assets/e2947744-e56c-431a-9f32-363ec1159eb1


</details>

<details>
<summary>MacOS: Chrome / Safari</summary>


https://github.com/user-attachments/assets/347223a7-95d4-4e85-a8fb-8a0329f9d8e3


</details>

<details>
<summary>MacOS: Desktop</summary>


https://github.com/user-attachments/assets/d712ccd7-c615-48ae-96eb-d1bfbe200a25


</details>
