### PR TITLE
Fix that onboarding tasks are duplicated when switching chat

### DIFF
--- a/src/libs/actions/Report.ts
+++ b/src/libs/actions/Report.ts
@@ -872,8 +872,8 @@ function openReport(
     const isInviteOnboardingComplete = introSelected?.isInviteOnboardingComplete ?? false;
     const isOnboardingCompleted = onboarding?.hasCompletedGuidedSetupFlow ?? false;
 
-    // Add guided setup data only when nvp_introSelected is set and guided setup is not completed
-    // OldDot users will never have introSelected set, so they will not see guided setup
+    // Prepare guided setup data only when nvp_introSelected is set and onboarding is not completed
+    // OldDot users will never have nvp_introSelected set, so they will not see guided setup messages
     if (introSelected && !isOnboardingCompleted && !isInviteOnboardingComplete) {
         const {choice, inviteType} = introSelected;
         const isInviteIOUorInvoice = inviteType === CONST.ONBOARDING_INVITE_TYPES.IOU || inviteType === CONST.ONBOARDING_INVITE_TYPES.INVOICE;

--- a/src/libs/actions/Report.ts
+++ b/src/libs/actions/Report.ts
@@ -872,6 +872,8 @@ function openReport(
     const isInviteOnboardingComplete = introSelected?.isInviteOnboardingComplete ?? false;
     const isOnboardingCompleted = onboarding?.hasCompletedGuidedSetupFlow ?? false;
 
+    // Add guided setup data only when nvp_introSelected is set and guided setup is not completed
+    // OldDot users will never have introSelected set, so they will not see guided setup
     if (introSelected && !isOnboardingCompleted && !isInviteOnboardingComplete) {
         const {choice, inviteType} = introSelected;
         const isInviteIOUorInvoice = inviteType === CONST.ONBOARDING_INVITE_TYPES.IOU || inviteType === CONST.ONBOARDING_INVITE_TYPES.INVOICE;

--- a/src/libs/actions/Report.ts
+++ b/src/libs/actions/Report.ts
@@ -99,6 +99,7 @@ import type {
     IntroSelected,
     InvitedEmailsToAccountIDs,
     NewGroupChatDraft,
+    Onboarding,
     OnboardingPurpose,
     PersonalDetailsList,
     PolicyReportField,
@@ -108,7 +109,6 @@ import type {
     ReportActionReactions,
     ReportUserIsTyping,
 } from '@src/types/onyx';
-import Onboarding from '@src/types/onyx/Onboarding';
 import type {Decision} from '@src/types/onyx/OriginalMessage';
 import type {ConnectionName} from '@src/types/onyx/Policy';
 import type Report from '@src/types/onyx/Report';

--- a/src/libs/actions/Report.ts
+++ b/src/libs/actions/Report.ts
@@ -108,6 +108,7 @@ import type {
     ReportActionReactions,
     ReportUserIsTyping,
 } from '@src/types/onyx';
+import Onboarding from '@src/types/onyx/Onboarding';
 import type {Decision} from '@src/types/onyx/OriginalMessage';
 import type {ConnectionName} from '@src/types/onyx/Policy';
 import type Report from '@src/types/onyx/Report';
@@ -277,6 +278,17 @@ let quickAction: OnyxEntry<QuickAction> = {};
 Onyx.connect({
     key: ONYXKEYS.NVP_QUICK_ACTION_GLOBAL_CREATE,
     callback: (val) => (quickAction = val),
+});
+
+let onboarding: OnyxEntry<Onboarding>;
+Onyx.connect({
+    key: ONYXKEYS.NVP_ONBOARDING,
+    callback: (val) => {
+        if (Array.isArray(val)) {
+            return;
+        }
+        onboarding = val;
+    },
 });
 
 let introSelected: OnyxEntry<IntroSelected> = {};
@@ -858,8 +870,9 @@ function openReport(
     };
 
     const isInviteOnboardingComplete = introSelected?.isInviteOnboardingComplete ?? false;
+    const isOnboardingCompleted = onboarding?.hasCompletedGuidedSetupFlow ?? false;
 
-    if (introSelected && !isInviteOnboardingComplete) {
+    if (introSelected && !isOnboardingCompleted && !isInviteOnboardingComplete) {
         const {choice, inviteType} = introSelected;
         const isInviteIOUorInvoice = inviteType === CONST.ONBOARDING_INVITE_TYPES.IOU || inviteType === CONST.ONBOARDING_INVITE_TYPES.INVOICE;
         const isInviteChoiceCorrect = choice === CONST.ONBOARDING_CHOICES.ADMIN || choice === CONST.ONBOARDING_CHOICES.SUBMIT || choice === CONST.ONBOARDING_CHOICES.CHAT_SPLIT;

--- a/src/types/onyx/index.ts
+++ b/src/types/onyx/index.ts
@@ -41,6 +41,7 @@ import type MobileSelectionMode from './MobileSelectionMode';
 import type Modal from './Modal';
 import type Network from './Network';
 import type NewGroupChatDraft from './NewGroupChatDraft';
+import type Onboarding from './Onboarding';
 import type OnyxInputOrEntry from './OnyxInputOrEntry';
 import type {OnyxUpdateEvent, OnyxUpdatesFromServer} from './OnyxUpdatesFromServer';
 import type {DecisionName, OriginalMessageIOU} from './OriginalMessage';
@@ -237,6 +238,7 @@ export type {
     SaveSearch,
     RecentSearchItem,
     ImportedSpreadsheet,
+    Onboarding,
     OnboardingPurpose,
     ValidateMagicCodeAction,
 };


### PR DESCRIPTION
### Explanation of Change

Fixes a regression https://github.com/Expensify/App/issues/52543 that was caused by https://github.com/Expensify/App/pull/46052

The problem was that we generated onboarding messages twice, first for onboarding flow and then first time a report was opened. Now we check NVP_ONBOARDING so that messages are never duplicated.

### Fixed Issues
$ https://github.com/Expensify/App/issues/52543
PROPOSAL: N/A


### Tests

### Usual onboarding

1. Create a new gmail user
2. Verify that the "What do you want to do today?" modal appears
3. Select the purpose "Chat and split expenses with friends"
4. Click on "Continue"
5. Verify that the "What’s your name?" modal appears
6. Enter any names
7. Click on "Continue"
8. Close the video modal
9. Open the Concierge chat
10. Verify that the app has generated a welcome message and onboarding tasks in Concierge chat
11. Open the Concierge chat again

### Workspace Non-admin:
1. On the first account create or use an existing worspace
2. Add a member using an email add an account that you know doesn't exist yet
3. Make sure the account you've invited is set as just a Member
4. Proceed to your email and press on the link on the bottom of the invitation email you've received
5. Confirm that that a Concierge message appears and it shows the correct content, as well as an onboarding video.

### Workspace Admin:
1. On the first account create or use an existing worspace
2. Add a member using an email add an account that you know doesn't exist yet
3. Press on the newly invited user and make sure that his role is set to Admin
4. Proceed to your email and press on the link on the bottom of the invitation email you've received
5. Confirm that that a Concierge message appears and it shows the correct content, as well as an onboarding video.

### DM / Group Chat:
1. On the first account create or use an existing DM or Group Chat
2. Add a member using an email add an account that you know doesn't exist yet, in the case of the room you can add by mentioning the user
3. Proceed to your email and press on the link on the bottom of the invitation email you've received
4. Confirm that that a Concierge message appears and it shows the correct content, as well as an onboarding video. Make sure the ~Start a chat~ is checked off & struck through.

### User-created Room:
1. On the first account create or use an existing user-created room
2. Add a member using an email add an account that you know doesn't exist yet, do it by mentioning the gmail in the room chat
3. Proceed to your email and press on the link on the bottom of the invitation email you've received
4. Confirm that that a Concierge message appears and it shows the correct content, as well as an onboarding video.

### Offline tests
N/A

### QA Steps
Same as tests

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
### Screenshots/Videos
<details>
<summary>Onboarding</summary>


https://github.com/user-attachments/assets/1240b23e-41b2-47ee-b8cc-39a76d164cdd



</details>

<details>
<summary>Invite from chat</summary>


https://github.com/user-attachments/assets/b53dd388-82bc-43ab-9288-92059ed1ebaf



</details>

<summary>Invite from workspace</summary>

https://github.com/user-attachments/assets/6c88e3e1-5718-4472-a60b-5bbb64230b20




</details>
