### PR TITLE
update: Update workspace switcher to look and act more like a filter.

### DIFF
--- a/src/components/SelectionList/BaseSelectionList.tsx
+++ b/src/components/SelectionList/BaseSelectionList.tsx
@@ -67,6 +67,7 @@ function BaseSelectionList<TItem extends ListItem>(
         showScrollIndicator = true,
         showLoadingPlaceholder = false,
         showConfirmButton = false,
+        shouldUseDefaultTheme = false,
         shouldPreventDefaultFocusOnSelectRow = false,
         containerStyle,
         sectionListStyle,
@@ -832,7 +833,7 @@ function BaseSelectionList<TItem extends ListItem>(
                     {showConfirmButton && (
                         <FixedFooter style={[styles.mtAuto]}>
                             <Button
-                                success
+                                success={!shouldUseDefaultTheme}
                                 large
                                 style={[styles.w100]}
                                 text={confirmButtonText || translate('common.confirm')}

--- a/src/components/SelectionList/types.ts
+++ b/src/components/SelectionList/types.ts
@@ -476,7 +476,7 @@ type BaseSelectionListProps<TItem extends ListItem> = Partial<ChildrenProps> & {
     /** Whether to show the default confirm button */
     showConfirmButton?: boolean;
 
-    /** Whether to use default theme for confirm button */
+    /** Whether to use the default theme for the confirm button */
     shouldUseDefaultTheme?: boolean;
 
     /** Whether tooltips should be shown */

--- a/src/components/SelectionList/types.ts
+++ b/src/components/SelectionList/types.ts
@@ -476,6 +476,9 @@ type BaseSelectionListProps<TItem extends ListItem> = Partial<ChildrenProps> & {
     /** Whether to show the default confirm button */
     showConfirmButton?: boolean;
 
+    /** Whether to use default theme for confirm button */
+    shouldUseDefaultTheme?: boolean;
+
     /** Whether tooltips should be shown */
     shouldShowTooltips?: boolean;
 

--- a/src/languages/en.ts
+++ b/src/languages/en.ts
@@ -2478,6 +2478,7 @@ const translations = {
             notAuthorized: `You don't have access to this page. If you're trying to join this workspace, just ask the workspace owner to add you as a member. Something else? Reach out to ${CONST.EMAIL.CONCIERGE}.`,
             goToRoom: ({roomName}: GoToRoomParams) => `Go to ${roomName} room`,
             goToWorkspace: 'Go to workspace',
+            clearFilter: 'Clear filter',
             workspaceName: 'Workspace name',
             workspaceOwner: 'Owner',
             workspaceType: 'Workspace type',
@@ -3704,7 +3705,7 @@ const translations = {
             description: 'Rooms are a great place to discuss and work with multiple people. To begin collaborating, create or join a workspace',
         },
         switcher: {
-            headerTitle: 'Choose a workspace',
+            headerTitle: 'Filter by workspace',
             everythingSection: 'Everything',
             placeholder: 'Find a workspace',
         },

--- a/src/languages/es.ts
+++ b/src/languages/es.ts
@@ -2501,6 +2501,7 @@ const translations = {
             notAuthorized: `No tienes acceso a esta página. Si estás intentando unirte a este espacio de trabajo, pide al dueño del espacio de trabajo que te añada como miembro. ¿Necesitas algo más? Comunícate con ${CONST.EMAIL.CONCIERGE}`,
             goToRoom: ({roomName}: GoToRoomParams) => `Ir a la sala ${roomName}`,
             goToWorkspace: 'Ir al espacio de trabajo',
+            clearFilter: 'Borrar filtro',
             workspaceName: 'Nombre del espacio de trabajo',
             workspaceOwner: 'Dueño',
             workspaceType: 'Tipo de espacio de trabajo',
@@ -3749,7 +3750,7 @@ const translations = {
             description: 'Las salas son un gran lugar para discutir y trabajar con varias personas. Para comenzar a colaborar, cree o únase a un espacio de trabajo',
         },
         switcher: {
-            headerTitle: 'Elige un espacio de trabajo',
+            headerTitle: 'Filtrar por espacio de trabajo',
             everythingSection: 'Todo',
             placeholder: 'Encuentra un espacio de trabajo',
         },

--- a/src/pages/WorkspaceSwitcherPage/index.tsx
+++ b/src/pages/WorkspaceSwitcherPage/index.tsx
@@ -81,7 +81,11 @@ function WorkspaceSwitcherPage() {
                 return;
             }
 
-            const {policyID} = option;
+            let {policyID} = option;
+
+            if (policyID && policyID === activeWorkspaceID) {
+                policyID = undefined;
+            }
 
             setActiveWorkspaceID(policyID);
             Navigation.goBack();

--- a/src/pages/WorkspaceSwitcherPage/index.tsx
+++ b/src/pages/WorkspaceSwitcherPage/index.tsx
@@ -153,6 +153,7 @@ function WorkspaceSwitcherPage() {
         <ScreenWrapper
             testID={WorkspaceSwitcherPage.displayName}
             includeSafeAreaPaddingBottom={false}
+            shouldEnableMaxHeight
         >
             {({didScreenTransitionEnd}) => (
                 <>

--- a/src/pages/WorkspaceSwitcherPage/index.tsx
+++ b/src/pages/WorkspaceSwitcherPage/index.tsx
@@ -1,5 +1,4 @@
 import React, {useCallback, useMemo} from 'react';
-import {View} from 'react-native';
 import {useOnyx} from 'react-native-onyx';
 import HeaderWithBackButton from '@components/HeaderWithBackButton';
 import * as Expensicons from '@components/Icon/Expensicons';
@@ -7,13 +6,10 @@ import ScreenWrapper from '@components/ScreenWrapper';
 import SelectionList from '@components/SelectionList';
 import type {ListItem, SectionListDataType} from '@components/SelectionList/types';
 import UserListItem from '@components/SelectionList/UserListItem';
-import Text from '@components/Text';
 import useActiveWorkspace from '@hooks/useActiveWorkspace';
 import useDebouncedState from '@hooks/useDebouncedState';
 import useLocalize from '@hooks/useLocalize';
 import useNetwork from '@hooks/useNetwork';
-import useTheme from '@hooks/useTheme';
-import useThemeStyles from '@hooks/useThemeStyles';
 import Navigation from '@libs/Navigation/Navigation';
 import * as PolicyUtils from '@libs/PolicyUtils';
 import {sortWorkspacesBySelected} from '@libs/PolicyUtils';
@@ -35,8 +31,6 @@ type WorkspaceListItem = {
 const WorkspaceCardCreateAWorkspaceInstance = <WorkspaceCardCreateAWorkspace />;
 
 function WorkspaceSwitcherPage() {
-    const styles = useThemeStyles();
-    const theme = useTheme();
     const {isOffline} = useNetwork();
     const [searchTerm, debouncedSearchTerm, setSearchTerm] = useDebouncedState('');
     const {translate} = useLocalize();
@@ -166,30 +160,6 @@ function WorkspaceSwitcherPage() {
                         title={translate('workspace.switcher.headerTitle')}
                         onBackButtonPress={Navigation.goBack}
                     />
-                    <View style={[styles.ph5, styles.flexRow, styles.justifyContentBetween, styles.alignItemsCenter, styles.mb1]}>
-                        <Text
-                            style={styles.label}
-                            color={theme.textSupporting}
-                        >
-                            {translate('workspace.switcher.everythingSection')}
-                        </Text>
-                    </View>
-                    <UserListItem
-                        item={defaultPolicy}
-                        isFocused={activeWorkspaceID === undefined}
-                        showTooltip={false}
-                        onSelectRow={() => selectPolicy(defaultPolicy)}
-                        pressableStyle={styles.flexRow}
-                        shouldSyncFocus={false}
-                    />
-                    <View style={[styles.ph5, styles.mv2]}>
-                        <Text
-                            style={styles.label}
-                            color={theme.textSupporting}
-                        >
-                            {translate('common.workspaces')}
-                        </Text>
-                    </View>
                     <SelectionList<WorkspaceListItem>
                         ListItem={UserListItem}
                         sections={sections}
@@ -202,6 +172,10 @@ function WorkspaceSwitcherPage() {
                         shouldShowListEmptyContent={shouldShowCreateWorkspace}
                         initiallyFocusedOptionKey={activeWorkspaceID ?? CONST.WORKSPACE_SWITCHER.NAME}
                         showLoadingPlaceholder={fetchStatus.status === 'loading' || !didScreenTransitionEnd}
+                        showConfirmButton
+                        shouldUseDefaultTheme
+                        confirmButtonText={translate('workspace.common.clearFilter')}
+                        onConfirm={() => selectPolicy(defaultPolicy)}
                     />
                 </>
             )}

--- a/src/pages/WorkspaceSwitcherPage/index.tsx
+++ b/src/pages/WorkspaceSwitcherPage/index.tsx
@@ -172,7 +172,7 @@ function WorkspaceSwitcherPage() {
                         shouldShowListEmptyContent={shouldShowCreateWorkspace}
                         initiallyFocusedOptionKey={activeWorkspaceID ?? CONST.WORKSPACE_SWITCHER.NAME}
                         showLoadingPlaceholder={fetchStatus.status === 'loading' || !didScreenTransitionEnd}
-                        showConfirmButton
+                        showConfirmButton={!!activeWorkspaceID}
                         shouldUseDefaultTheme
                         confirmButtonText={translate('workspace.common.clearFilter')}
                         onConfirm={() => selectPolicy(defaultPolicy)}

--- a/src/pages/WorkspaceSwitcherPage/index.tsx
+++ b/src/pages/WorkspaceSwitcherPage/index.tsx
@@ -77,11 +77,7 @@ function WorkspaceSwitcherPage() {
 
     const selectPolicy = useCallback(
         (policyID?: string) => {
-            let newPolicyID = policyID;
-
-            if (policyID && policyID === activeWorkspaceID) {
-                newPolicyID = undefined;
-            }
+            const newPolicyID = policyID === activeWorkspaceID ? undefined : policyID;
 
             setActiveWorkspaceID(newPolicyID);
             Navigation.goBack();

--- a/src/pages/WorkspaceSwitcherPage/index.tsx
+++ b/src/pages/WorkspaceSwitcherPage/index.tsx
@@ -76,21 +76,17 @@ function WorkspaceSwitcherPage() {
     );
 
     const selectPolicy = useCallback(
-        (option?: WorkspaceListItem) => {
-            if (!option) {
-                return;
-            }
-
-            let {policyID} = option;
+        (policyID?: string) => {
+            let newPolicyID = policyID;
 
             if (policyID && policyID === activeWorkspaceID) {
-                policyID = undefined;
+                newPolicyID = undefined;
             }
 
-            setActiveWorkspaceID(policyID);
+            setActiveWorkspaceID(newPolicyID);
             Navigation.goBack();
-            if (policyID !== activeWorkspaceID) {
-                Navigation.navigateWithSwitchPolicyID({policyID});
+            if (newPolicyID !== activeWorkspaceID) {
+                Navigation.navigateWithSwitchPolicyID({policyID: newPolicyID});
             }
         },
         [activeWorkspaceID, setActiveWorkspaceID],
@@ -145,14 +141,6 @@ function WorkspaceSwitcherPage() {
     const headerMessage = filteredAndSortedUserWorkspaces.length === 0 && usersWorkspaces.length ? translate('common.noResultsFound') : '';
     const shouldShowCreateWorkspace = usersWorkspaces.length === 0;
 
-    const defaultPolicy = {
-        text: CONST.WORKSPACE_SWITCHER.NAME,
-        icons: [{source: Expensicons.ExpensifyAppIcon, name: CONST.WORKSPACE_SWITCHER.NAME, type: CONST.ICON_TYPE_AVATAR}],
-        brickRoadIndicator: getIndicatorTypeForPolicy(undefined),
-        keyForList: CONST.WORKSPACE_SWITCHER.NAME,
-        isSelected: activeWorkspaceID === undefined,
-    };
-
     return (
         <ScreenWrapper
             testID={WorkspaceSwitcherPage.displayName}
@@ -168,7 +156,7 @@ function WorkspaceSwitcherPage() {
                     <SelectionList<WorkspaceListItem>
                         ListItem={UserListItem}
                         sections={sections}
-                        onSelectRow={selectPolicy}
+                        onSelectRow={(option) => selectPolicy(option.policyID)}
                         textInputLabel={usersWorkspaces.length >= CONST.STANDARD_LIST_ITEM_LIMIT ? translate('common.search') : undefined}
                         textInputValue={searchTerm}
                         onChangeText={setSearchTerm}
@@ -180,7 +168,7 @@ function WorkspaceSwitcherPage() {
                         showConfirmButton={!!activeWorkspaceID}
                         shouldUseDefaultTheme
                         confirmButtonText={translate('workspace.common.clearFilter')}
-                        onConfirm={() => selectPolicy(defaultPolicy)}
+                        onConfirm={() => selectPolicy(undefined)}
                     />
                 </>
             )}


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
- This PR updates the header title from `Choose a workspace` to `Filter by workspace` and removes everything section from workspace switcher along with the `workspaces` label.
- It also adds a new `Clear filter` button to deselect the currently selected workspace, making it function more like a filter.

| Before update | After update |
| ------------- | ------------- |
| <img width="376" alt="switcher_before" src="https://github.com/user-attachments/assets/ea23b1fd-d3ea-4e05-b805-45ef2ab19e31"> | <img width="376" alt="switcher_after" src="https://github.com/user-attachments/assets/097536ad-acd2-4917-af47-b065023c70fc">  |


### Fixed Issues
$ https://github.com/Expensify/App/issues/52654
PROPOSAL: https://github.com/Expensify/App/issues/52654#issuecomment-2479850259


### Tests
1. Open workspace switcher > verify header title is changed to `Filter by workspace`.
2. Verify everything section is removed and `workspaces` label is removed.
3. Select a workspace > Verify `Clear filter` button is shown at the bottom
4. Click on `Clear filter` button > Verify workspace filter & `Clear filter` button is removed.

- [x] Verify that no errors appear in the JS console

### Offline tests
1. Open workspace switcher > verify header title is changed to `Filter by workspace`.
2. Verify everything section is removed and `workspaces` label is removed.
3. Select a workspace > Verify `Clear filter` button is shown at the bottom
4. Click on `Clear filter` button > Verify workspace filter & `Clear filter` button is removed.

### QA Steps
1. Open workspace switcher > verify header title is changed to `Filter by workspace`.
2. Verify everything section is removed and `workspaces` label is removed.
3. Select a workspace > Verify `Clear filter` button is shown at the bottom
4. Click on `Clear filter` button > Verify workspace filter & `Clear filter` button is removed.

// TODO: These must be filled out, or the issue title must include "[No QA]."

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message: https://expensify.slack.com/archives/C01GTK53T8Q/p1732657548039909
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

https://github.com/user-attachments/assets/d731ed25-8a0b-48bf-af5a-9cbf194e8171

</details>

<details>
<summary>Android: mWeb Chrome</summary>

https://github.com/user-attachments/assets/d0be90e3-56bc-4585-a9bd-e6c81bb9ec80

</details>

<details>
<summary>iOS: Native</summary>

https://github.com/user-attachments/assets/2e1d7d39-009c-48ae-88e4-f70bd1fcac85

</details>

<details>
<summary>iOS: mWeb Safari</summary>

https://github.com/user-attachments/assets/a2932d32-77e1-46e0-b645-b79c8d8e25d0

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

https://github.com/user-attachments/assets/82506c20-6e98-4bc4-8d8b-9e593be5a8a1

</details>

<details>
<summary>MacOS: Desktop</summary>

https://github.com/user-attachments/assets/df3c0d9e-b437-4714-877e-f9c9baa2278c

</details>
