### PR TITLE
Update SearchPageHeaderInput to display recent search and chats

### DIFF
--- a/src/components/Search/SearchPageHeaderInput.tsx
+++ b/src/components/Search/SearchPageHeaderInput.tsx
@@ -229,7 +229,10 @@ function SearchPageHeaderInput({queryJSON, children}: SearchPageHeaderInputProps
     }
 
     const hideAutocompleteList = () => setIsAutocompleteListVisible(false);
-    const showAutocompleteList = () => setIsAutocompleteListVisible(true);
+    const showAutocompleteList = () => {
+        listRef.current?.updateAndScrollToFocusedIndex(0);
+        setIsAutocompleteListVisible(true);
+    };
 
     const searchQueryItem = {
         text: textInputValue,
@@ -252,12 +255,12 @@ function SearchPageHeaderInput({queryJSON, children}: SearchPageHeaderInputProps
               {boxShadow: variables.popoverMenuShadow},
           ]
         : [styles.pt4];
-    const inputWrapperStyle = isAutocompleteListVisible ? styles.ph2 : null;
+    const inputWrapperActiveStyle = isAutocompleteListVisible ? styles.ph2 : null;
 
     return (
         <View
             dataSet={{dragArea: false}}
-            style={[styles.searchResultsHeaderBar, styles.mh85vh, isAutocompleteListVisible && styles.ph3]}
+            style={[styles.searchResultsHeaderBar, isAutocompleteListVisible && styles.ph3]}
         >
             <View style={[styles.appBG, ...autocompleteInputStyle]}>
                 <SearchRouterInput
@@ -272,12 +275,12 @@ function SearchPageHeaderInput({queryJSON, children}: SearchPageHeaderInputProps
                     onBlur={hideAutocompleteList}
                     wrapperStyle={[styles.searchRouterInputResults, styles.br2]}
                     wrapperFocusedStyle={styles.searchRouterInputResultsFocused}
-                    outerWrapperStyle={inputWrapperStyle}
+                    outerWrapperStyle={[inputWrapperActiveStyle, styles.pb2]}
                     rightComponent={children}
                     routerListRef={listRef}
                     ref={textInputRef}
                 />
-                <View style={[styles.pt2, !isAutocompleteListVisible && styles.dNone]}>
+                <View style={[styles.mh85vh, !isAutocompleteListVisible && styles.dNone]}>
                     <SearchRouterList
                         autocompleteQueryValue={autocompleteQueryValue}
                         searchQueryItem={searchQueryItem}

--- a/src/components/Search/SearchPageHeaderInput.tsx
+++ b/src/components/Search/SearchPageHeaderInput.tsx
@@ -1,3 +1,4 @@
+import {useIsFocused} from '@react-navigation/native';
 import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import {View} from 'react-native';
 import {useOnyx} from 'react-native-onyx';
@@ -86,18 +87,21 @@ function SearchPageHeaderInput({queryJSON, children}: SearchPageHeaderInputProps
     const [isAutocompleteListVisible, setIsAutocompleteListVisible] = useState(false);
     const listRef = useRef<SelectionListHandle>(null);
     const textInputRef = useRef<AnimatedTextInputRef>(null);
+    const isFocused = useIsFocused();
     const {registerSearchPageInput, unregisterSearchPageInput} = useSearchRouterContext();
 
-    // If query is non-canned that means Search Input is displayed, so we need to register it in the context.
+    // If query is non-canned that means Search Input is displayed, so we need to register its ref in the context.
     useEffect(() => {
-        if (isCannedQuery || !textInputRef.current) {
-            return unregisterSearchPageInput();
+        if (!isFocused) {
+            return;
         }
 
-        registerSearchPageInput(textInputRef.current);
-
-        return unregisterSearchPageInput;
-    }, [isCannedQuery, registerSearchPageInput, unregisterSearchPageInput]);
+        if (!isCannedQuery && textInputRef.current) {
+            registerSearchPageInput(textInputRef.current);
+        } else {
+            unregisterSearchPageInput();
+        }
+    }, [isCannedQuery, isFocused, registerSearchPageInput, unregisterSearchPageInput]);
 
     useEffect(() => {
         const substitutionsMap = buildSubstitutionsMap(originalInputQuery, personalDetails, reports, taxRates);

--- a/src/components/Search/SearchPageHeaderInput.tsx
+++ b/src/components/Search/SearchPageHeaderInput.tsx
@@ -136,7 +136,6 @@ function SearchPageHeaderInput({queryJSON, children}: SearchPageHeaderInputProps
                 return;
             }
 
-            // TODO remove special handling of policyID after navigation is merged https://github.com/Expensify/App/pull/49539
             if (queryJSON.policyID) {
                 userQueryJSON.policyID = queryJSON.policyID;
             }
@@ -160,8 +159,6 @@ function SearchPageHeaderInput({queryJSON, children}: SearchPageHeaderInputProps
         (item: OptionData | SearchQueryItem) => {
             if (isSearchQueryItem(item)) {
                 if (!item.searchQuery) {
-                    // Special case where empty item resets Search to default query
-                    Navigation.navigate(ROUTES.SEARCH_CENTRAL_PANE.getRoute({query: ''}));
                     return;
                 }
 

--- a/src/components/Search/SearchPageHeaderInput.tsx
+++ b/src/components/Search/SearchPageHeaderInput.tsx
@@ -86,29 +86,23 @@ function SearchPageHeaderInput({queryJSON, children}: SearchPageHeaderInputProps
     const [isAutocompleteListVisible, setIsAutocompleteListVisible] = useState(false);
     const listRef = useRef<SelectionListHandle>(null);
     const textInputRef = useRef<BaseTextInputRef>(null);
-    const {registerSearchPageInput} = useSearchRouterContext();
+    const {registerSearchPageInput, unregisterSearchPageInput} = useSearchRouterContext();
+
+    // If query is non-canned that means Search Input is displayed, so we need to register it in the context.
+    useEffect(() => {
+        if (isCannedQuery || !textInputRef.current) {
+            return unregisterSearchPageInput();
+        }
+
+        registerSearchPageInput(textInputRef.current);
+
+        return unregisterSearchPageInput;
+    }, [isCannedQuery, registerSearchPageInput, unregisterSearchPageInput]);
 
     useEffect(() => {
         const substitutionsMap = buildSubstitutionsMap(originalInputQuery, personalDetails, reports, taxRates);
         setAutocompleteSubstitutions(substitutionsMap);
     }, [originalInputQuery, personalDetails, reports, taxRates]);
-
-    // If query is non-canned that means Search Input is displayed so we need to register it in the context
-    useEffect(() => {
-        if (!isCannedQuery) {
-            registerSearchPageInput(() => {
-                setIsAutocompleteListVisible(true);
-                textInputRef.current?.focus();
-                listRef.current?.updateAndScrollToFocusedIndex(0);
-            });
-        } else {
-            registerSearchPageInput(undefined);
-        }
-
-        return () => {
-            registerSearchPageInput(undefined);
-        };
-    }, [registerSearchPageInput, isCannedQuery]);
 
     const onSearchQueryChange = useCallback(
         (userQuery: string) => {

--- a/src/components/Search/SearchPageHeaderInput.tsx
+++ b/src/components/Search/SearchPageHeaderInput.tsx
@@ -78,7 +78,7 @@ function SearchPageHeaderInput({queryJSON, children}: SearchPageHeaderInputProps
     const headerText = isCannedQuery ? translate(getHeaderContent(type).titleText) : '';
 
     // The actual input text that the user sees
-    const [textInputValue, setTextInputValue] = useState(queryText); // initial empty space to avoid quick flash of placeholder text
+    const [textInputValue, setTextInputValue] = useState(queryText);
     // The input text that was last used for autocomplete; needed for the SearchRouterList when browsing list via arrow keys
     const [autocompleteQueryValue, setAutocompleteQueryValue] = useState(queryText);
 
@@ -142,6 +142,7 @@ function SearchPageHeaderInput({queryJSON, children}: SearchPageHeaderInputProps
                 return;
             }
 
+            // TODO remove special handling of policyID after navigation is merged https://github.com/Expensify/App/pull/49539
             if (queryJSON.policyID) {
                 userQueryJSON.policyID = queryJSON.policyID;
             }

--- a/src/components/Search/SearchPageHeaderInput.tsx
+++ b/src/components/Search/SearchPageHeaderInput.tsx
@@ -6,11 +6,11 @@ import Icon from '@components/Icon';
 import * as Expensicons from '@components/Icon/Expensicons';
 import * as Illustrations from '@components/Icon/Illustrations';
 import {usePersonalDetails} from '@components/OnyxProvider';
+import type {AnimatedTextInputRef} from '@components/RNTextInput';
 import {isSearchQueryItem} from '@components/SelectionList/Search/SearchQueryListItem';
 import type {SearchQueryItem} from '@components/SelectionList/Search/SearchQueryListItem';
 import type {SelectionListHandle} from '@components/SelectionList/types';
 import Text from '@components/Text';
-import type {BaseTextInputRef} from '@components/TextInput/BaseTextInput/types';
 import useLocalize from '@hooks/useLocalize';
 import useThemeStyles from '@hooks/useThemeStyles';
 import * as SearchActions from '@libs/actions/Search';
@@ -85,7 +85,7 @@ function SearchPageHeaderInput({queryJSON, children}: SearchPageHeaderInputProps
     const [autocompleteSubstitutions, setAutocompleteSubstitutions] = useState<SubstitutionMap>({});
     const [isAutocompleteListVisible, setIsAutocompleteListVisible] = useState(false);
     const listRef = useRef<SelectionListHandle>(null);
-    const textInputRef = useRef<BaseTextInputRef>(null);
+    const textInputRef = useRef<AnimatedTextInputRef>(null);
     const {registerSearchPageInput, unregisterSearchPageInput} = useSearchRouterContext();
 
     // If query is non-canned that means Search Input is displayed, so we need to register it in the context.
@@ -229,14 +229,16 @@ function SearchPageHeaderInput({queryJSON, children}: SearchPageHeaderInputProps
         setIsAutocompleteListVisible(true);
     };
 
-    const searchQueryItem = {
-        text: textInputValue,
-        singleIcon: Expensicons.MagnifyingGlass,
-        searchQuery: textInputValue,
-        itemStyle: styles.activeComponentBG,
-        keyForList: 'findItem',
-        searchItemType: CONST.SEARCH.SEARCH_ROUTER_ITEM_TYPE.SEARCH,
-    };
+    const searchQueryItem = textInputValue
+        ? {
+              text: textInputValue,
+              singleIcon: Expensicons.MagnifyingGlass,
+              searchQuery: textInputValue,
+              itemStyle: styles.activeComponentBG,
+              keyForList: 'findItem',
+              searchItemType: CONST.SEARCH.SEARCH_ROUTER_ITEM_TYPE.SEARCH,
+          }
+        : undefined;
 
     // we need `- BORDER_WIDTH` to achieve the effect that the input will not "jump"
     const popoverHorizontalPosition = 12 - BORDER_WIDTH;

--- a/src/components/Search/SearchRouter/SearchRouter.tsx
+++ b/src/components/Search/SearchRouter/SearchRouter.tsx
@@ -84,7 +84,7 @@ function SearchRouter({onRouterClose, shouldHideInputCaret}: SearchRouterProps) 
     const listRef = useRef<SelectionListHandle>(null);
 
     // The actual input text that the user sees
-    const [textInputValue, debouncedInputValue, setTextInputValue] = useDebouncedState('', 500);
+    const [textInputValue, , setTextInputValue] = useDebouncedState('', 500);
     // The input text that was last used for autocomplete; needed for the SearchRouterList when browsing list via arrow keys
     const [autocompleteQueryValue, setAutocompleteQueryValue] = useState(textInputValue);
     const [autocompleteSubstitutions, setAutocompleteSubstitutions] = useState<SubstitutionMap>({});

--- a/src/components/Search/SearchRouter/SearchRouter.tsx
+++ b/src/components/Search/SearchRouter/SearchRouter.tsx
@@ -6,12 +6,12 @@ import {useOnyx} from 'react-native-onyx';
 import type {ValueOf} from 'type-fest';
 import HeaderWithBackButton from '@components/HeaderWithBackButton';
 import * as Expensicons from '@components/Icon/Expensicons';
-import {usePersonalDetails} from '@components/OnyxProvider';
 import {useOptionsList} from '@components/OptionListContextProvider';
 import type {SearchQueryString} from '@components/Search/types';
 import {isSearchQueryItem} from '@components/SelectionList/Search/SearchQueryListItem';
 import type {SearchQueryItem} from '@components/SelectionList/Search/SearchQueryListItem';
 import type {SelectionListHandle} from '@components/SelectionList/types';
+import type {BaseTextInputRef} from '@components/TextInput/BaseTextInput/types';
 import useActiveWorkspace from '@hooks/useActiveWorkspace';
 import useDebouncedState from '@hooks/useDebouncedState';
 import useKeyboardShortcut from '@hooks/useKeyboardShortcut';
@@ -21,14 +21,12 @@ import useThemeStyles from '@hooks/useThemeStyles';
 import * as InputUtils from '@libs/InputUtils';
 import * as OptionsListUtils from '@libs/OptionsListUtils';
 import type {SearchOption} from '@libs/OptionsListUtils';
-import {getAllTaxRates} from '@libs/PolicyUtils';
 import type {OptionData} from '@libs/ReportUtils';
 import * as SearchAutocompleteUtils from '@libs/SearchAutocompleteUtils';
 import * as SearchQueryUtils from '@libs/SearchQueryUtils';
 import Navigation from '@navigation/Navigation';
 import variables from '@styles/variables';
 import * as ReportUserActions from '@userActions/Report';
-import Timing from '@userActions/Timing';
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
 import ROUTES from '@src/ROUTES';
@@ -75,33 +73,26 @@ type SearchRouterProps = {
 };
 
 function SearchRouter({onRouterClose, shouldHideInputCaret}: SearchRouterProps) {
-    const styles = useThemeStyles();
     const {translate} = useLocalize();
+    const styles = useThemeStyles();
     const [betas] = useOnyx(ONYXKEYS.BETAS);
-    const [recentSearches, recentSearchesMetadata] = useOnyx(ONYXKEYS.RECENT_SEARCHES);
+    const [, recentSearchesMetadata] = useOnyx(ONYXKEYS.RECENT_SEARCHES);
     const [isSearchingForReports] = useOnyx(ONYXKEYS.IS_SEARCHING_FOR_REPORTS, {initWithStoredValues: false});
-    const [autocompleteSubstitutions, setAutocompleteSubstitutions] = useState<SubstitutionMap>({});
     const {activeWorkspaceID} = useActiveWorkspace();
 
-    const personalDetails = usePersonalDetails();
-    const [reports = {}] = useOnyx(ONYXKEYS.COLLECTION.REPORT);
-    const taxRates = getAllTaxRates();
-
-    const {shouldUseNarrowLayout, isLargeScreenWidth} = useResponsiveLayout();
+    const {shouldUseNarrowLayout} = useResponsiveLayout();
     const listRef = useRef<SelectionListHandle>(null);
 
     // The actual input text that the user sees
     const [textInputValue, debouncedInputValue, setTextInputValue] = useDebouncedState('', 500);
     // The input text that was last used for autocomplete; needed for the SearchRouterList when browsing list via arrow keys
     const [autocompleteQueryValue, setAutocompleteQueryValue] = useState(textInputValue);
+    const [autocompleteSubstitutions, setAutocompleteSubstitutions] = useState<SubstitutionMap>({});
+    const textInputRef = useRef<BaseTextInputRef>(null);
 
     const contextualReportID = useNavigationState<Record<string, {reportID: string}>, string | undefined>((state) => {
         return state?.routes.at(-1)?.params?.reportID;
     });
-
-    const sortedRecentSearches = useMemo(() => {
-        return Object.values(recentSearches ?? {}).sort((a, b) => b.timestamp.localeCompare(a.timestamp));
-    }, [recentSearches]);
 
     const {options, areOptionsInitialized} = useOptionsList();
     const searchOptions = useMemo(() => {
@@ -111,45 +102,9 @@ function SearchRouter({onRouterClose, shouldHideInputCaret}: SearchRouterProps) 
         return OptionsListUtils.getSearchOptions(options, betas ?? []);
     }, [areOptionsInitialized, betas, options]);
 
-    const filteredOptions = useMemo(() => {
-        if (debouncedInputValue.trim() === '') {
-            return {
-                recentReports: [],
-                personalDetails: [],
-                userToInvite: null,
-            };
-        }
-
-        Timing.start(CONST.TIMING.SEARCH_FILTER_OPTIONS);
-        const newOptions = OptionsListUtils.filterOptions(searchOptions, debouncedInputValue, {sortByReportTypeInSearch: true, preferChatroomsOverThreads: true});
-        Timing.end(CONST.TIMING.SEARCH_FILTER_OPTIONS);
-
-        return {
-            recentReports: newOptions.recentReports,
-            personalDetails: newOptions.personalDetails,
-            userToInvite: newOptions.userToInvite,
-        };
-    }, [debouncedInputValue, searchOptions]);
-
-    const recentReports: OptionData[] = useMemo(() => {
-        if (debouncedInputValue === '') {
-            return searchOptions.recentReports.slice(0, 20);
-        }
-
-        const reportOptions: OptionData[] = [...filteredOptions.recentReports, ...filteredOptions.personalDetails];
-        if (filteredOptions.userToInvite) {
-            reportOptions.push(filteredOptions.userToInvite);
-        }
-        return reportOptions.slice(0, 20);
-    }, [debouncedInputValue, filteredOptions, searchOptions]);
-
     const reportForContextualSearch = contextualReportID ? searchOptions.recentReports?.find((option) => option.reportID === contextualReportID) : undefined;
 
-    useEffect(() => {
-        ReportUserActions.searchInServer(debouncedInputValue.trim());
-    }, [debouncedInputValue]);
-
-    const sections = [];
+    const additionalSections = [];
 
     if (reportForContextualSearch && !textInputValue) {
         const reportQueryValue = reportForContextualSearch.text ?? reportForContextualSearch.alternateText ?? reportForContextualSearch.reportID;
@@ -170,7 +125,7 @@ function SearchRouter({onRouterClose, shouldHideInputCaret}: SearchRouterProps) 
             autocompleteID = reportForContextualSearch.policyID ?? '';
         }
 
-        sections.push({
+        additionalSections.push({
             data: [
                 {
                     text: `${translate('search.searchIn')} ${reportForContextualSearch.text ?? reportForContextualSearch.alternateText}`,
@@ -187,24 +142,6 @@ function SearchRouter({onRouterClose, shouldHideInputCaret}: SearchRouterProps) 
         });
     }
 
-    const recentSearchesData = sortedRecentSearches?.slice(0, 5).map(({query, timestamp}) => {
-        const searchQueryJSON = SearchQueryUtils.buildSearchQueryJSON(query);
-        return {
-            text: searchQueryJSON ? SearchQueryUtils.buildUserReadableQueryString(searchQueryJSON, personalDetails, reports, taxRates) : query,
-            singleIcon: Expensicons.History,
-            searchQuery: query,
-            keyForList: timestamp,
-            searchItemType: CONST.SEARCH.SEARCH_ROUTER_ITEM_TYPE.SEARCH,
-        };
-    });
-
-    if (!textInputValue && recentSearchesData && recentSearchesData.length > 0) {
-        sections.push({title: translate('search.recentSearches'), data: recentSearchesData});
-    }
-
-    const styledRecentReports = recentReports.map((item) => ({...item, pressableStyle: styles.br2, wrapperStyle: [styles.pr3, styles.pl3]}));
-    sections.push({title: translate('search.recentChats'), data: styledRecentReports});
-
     const searchQueryItem = textInputValue
         ? {
               text: textInputValue,
@@ -217,13 +154,13 @@ function SearchRouter({onRouterClose, shouldHideInputCaret}: SearchRouterProps) 
         : undefined;
 
     const shouldScrollRef = useRef(false);
-    const searchRouterInputRef = useRef(null);
     // Trigger scrollToRight when input value changes and shouldScroll is true
     useEffect(() => {
-        if (!searchRouterInputRef.current || !shouldScrollRef.current) {
+        if (!textInputRef.current || !shouldScrollRef.current) {
             return;
         }
-        InputUtils.scrollToRight(searchRouterInputRef.current);
+
+        InputUtils.scrollToRight(textInputRef.current);
         shouldScrollRef.current = false;
     }, [debouncedInputValue]);
 
@@ -268,69 +205,68 @@ function SearchRouter({onRouterClose, shouldHideInputCaret}: SearchRouterProps) 
         [autocompleteSubstitutions, onRouterClose, setTextInputValue, activeWorkspaceID],
     );
 
-    const onListItemPress = (item: OptionData | SearchQueryItem) => {
-        if (isSearchQueryItem(item)) {
-            if (!item.searchQuery) {
+    const onListItemPress = useCallback(
+        (item: OptionData | SearchQueryItem) => {
+            if (isSearchQueryItem(item)) {
+                if (!item.searchQuery) {
+                    return;
+                }
+
+                if (item.searchItemType === CONST.SEARCH.SEARCH_ROUTER_ITEM_TYPE.CONTEXTUAL_SUGGESTION) {
+                    const searchQuery = getContextualSearchQuery(item);
+                    onSearchQueryChange(`${searchQuery} `, true);
+
+                    const autocompleteKey = getContextualSearchAutocompleteKey(item);
+                    if (autocompleteKey && item.autocompleteID) {
+                        const substitutions = {...autocompleteSubstitutions, [autocompleteKey]: item.autocompleteID};
+
+                        setAutocompleteSubstitutions(substitutions);
+                    }
+                } else if (item.searchItemType === CONST.SEARCH.SEARCH_ROUTER_ITEM_TYPE.AUTOCOMPLETE_SUGGESTION && textInputValue) {
+                    const trimmedUserSearchQuery = SearchAutocompleteUtils.getQueryWithoutAutocompletedPart(textInputValue);
+                    onSearchQueryChange(`${trimmedUserSearchQuery}${SearchQueryUtils.sanitizeSearchValue(item.searchQuery)} `);
+
+                    if (item.text && item.autocompleteID) {
+                        const substitutions = {...autocompleteSubstitutions, [item.text]: item.autocompleteID};
+
+                        setAutocompleteSubstitutions(substitutions);
+                    }
+                    // needed for android mWeb
+                    textInputRef.current?.focus();
+                } else {
+                    submitSearch(item.searchQuery);
+                }
+            } else {
+                onRouterClose();
+
+                if (item?.reportID) {
+                    Navigation.navigate(ROUTES.REPORT_WITH_ID.getRoute(item?.reportID));
+                } else if ('login' in item) {
+                    ReportUserActions.navigateToAndOpenReport(item.login ? [item.login] : [], false);
+                }
+            }
+        },
+        [autocompleteSubstitutions, onRouterClose, onSearchQueryChange, submitSearch, textInputValue],
+    );
+
+    const updateAutocompleteSubstitutions = useCallback(
+        (item: SearchQueryItem) => {
+            if (!item.autocompleteID || !item.text) {
                 return;
             }
 
-            if (item.searchItemType === CONST.SEARCH.SEARCH_ROUTER_ITEM_TYPE.CONTEXTUAL_SUGGESTION) {
-                const searchQuery = getContextualSearchQuery(item);
-                onSearchQueryChange(`${searchQuery} `, true);
-
-                const autocompleteKey = getContextualSearchAutocompleteKey(item);
-                if (autocompleteKey && item.autocompleteID) {
-                    const substitutions = {...autocompleteSubstitutions, [autocompleteKey]: item.autocompleteID};
-
-                    setAutocompleteSubstitutions(substitutions);
-                }
-            } else if (item.searchItemType === CONST.SEARCH.SEARCH_ROUTER_ITEM_TYPE.AUTOCOMPLETE_SUGGESTION && textInputValue) {
-                const trimmedUserSearchQuery = SearchAutocompleteUtils.getQueryWithoutAutocompletedPart(textInputValue);
-                onSearchQueryChange(`${trimmedUserSearchQuery}${SearchQueryUtils.sanitizeSearchValue(item.searchQuery)} `);
-
-                if (item.text && item.autocompleteID) {
-                    const substitutions = {...autocompleteSubstitutions, [item.text]: item.autocompleteID};
-
-                    setAutocompleteSubstitutions(substitutions);
-                }
-            } else {
-                submitSearch(item.searchQuery);
-            }
-        } else {
-            onRouterClose();
-
-            if (item?.reportID) {
-                Navigation.navigate(ROUTES.REPORT_WITH_ID.getRoute(item?.reportID));
-            } else if ('login' in item) {
-                ReportUserActions.navigateToAndOpenReport(item.login ? [item.login] : [], false);
-            }
-        }
-    };
-
-    const onListItemFocus = (focusedItem: SearchQueryItem) => {
-        if (!focusedItem.searchQuery) {
-            return;
-        }
-
-        const trimmedUserSearchQuery = SearchAutocompleteUtils.getQueryWithoutAutocompletedPart(textInputValue);
-        setTextInputValue(`${trimmedUserSearchQuery}${SearchQueryUtils.sanitizeSearchValue(focusedItem.searchQuery)} `);
-
-        if (focusedItem.autocompleteID && focusedItem.text) {
-            const substitutions = {...autocompleteSubstitutions, [focusedItem.text]: focusedItem.autocompleteID};
-
+            const substitutions = {...autocompleteSubstitutions, [item.text]: item.autocompleteID};
             setAutocompleteSubstitutions(substitutions);
-        }
-    };
+        },
+        [autocompleteSubstitutions],
+    );
 
     useKeyboardShortcut(CONST.KEYBOARD_SHORTCUTS.ESCAPE, () => {
         onRouterClose();
     });
 
     const modalWidth = shouldUseNarrowLayout ? styles.w100 : {width: variables.searchRouterPopoverWidth};
-
-    const isDataLoaded = useMemo(() => {
-        return (!contextualReportID || contextualReportID !== undefined) && !isLoadingOnyxValue(recentSearchesMetadata) && recentReports.length > 0;
-    }, [contextualReportID, recentSearchesMetadata, recentReports]);
+    const isRecentSearchesDataLoaded = !isLoadingOnyxValue(recentSearchesMetadata);
 
     return (
         <View
@@ -343,11 +279,10 @@ function SearchRouter({onRouterClose, shouldHideInputCaret}: SearchRouterProps) 
                     onBackButtonPress={() => onRouterClose()}
                 />
             )}
-            {(isDataLoaded || !!debouncedInputValue) && (
+            {isRecentSearchesDataLoaded && (
                 <>
                     <SearchRouterInput
                         value={textInputValue}
-                        ref={searchRouterInputRef}
                         isFullWidth={shouldUseNarrowLayout}
                         onSearchQueryChange={onSearchQueryChange}
                         onSubmit={() => {
@@ -360,14 +295,15 @@ function SearchRouter({onRouterClose, shouldHideInputCaret}: SearchRouterProps) 
                         outerWrapperStyle={[shouldUseNarrowLayout ? styles.mv3 : styles.mv2, shouldUseNarrowLayout ? styles.mh5 : styles.mh2]}
                         wrapperFocusedStyle={[styles.borderColorFocus]}
                         isSearchingForReports={isSearchingForReports}
+                        ref={textInputRef}
                     />
                     <SearchRouterList
-                        autocompleteQueryValue={autocompleteQueryValue}
+                        autocompleteQueryValue={autocompleteQueryValue || textInputValue}
                         searchQueryItem={searchQueryItem}
-                        additionalSections={sections}
+                        additionalSections={additionalSections}
                         onListItemPress={onListItemPress}
-                        onListItemFocus={onListItemFocus}
-                        initiallyFocusedOptionKey={isLargeScreenWidth ? styledRecentReports.at(0)?.keyForList : undefined}
+                        setTextQuery={setTextInputValue}
+                        updateAutocompleteSubstitutions={updateAutocompleteSubstitutions}
                         ref={listRef}
                     />
                 </>

--- a/src/components/Search/SearchRouter/SearchRouter.tsx
+++ b/src/components/Search/SearchRouter/SearchRouter.tsx
@@ -7,11 +7,11 @@ import type {ValueOf} from 'type-fest';
 import HeaderWithBackButton from '@components/HeaderWithBackButton';
 import * as Expensicons from '@components/Icon/Expensicons';
 import {useOptionsList} from '@components/OptionListContextProvider';
+import type {AnimatedTextInputRef} from '@components/RNTextInput';
 import type {SearchQueryString} from '@components/Search/types';
 import {isSearchQueryItem} from '@components/SelectionList/Search/SearchQueryListItem';
 import type {SearchQueryItem} from '@components/SelectionList/Search/SearchQueryListItem';
 import type {SelectionListHandle} from '@components/SelectionList/types';
-import type {BaseTextInputRef} from '@components/TextInput/BaseTextInput/types';
 import useActiveWorkspace from '@hooks/useActiveWorkspace';
 import useDebouncedState from '@hooks/useDebouncedState';
 import useKeyboardShortcut from '@hooks/useKeyboardShortcut';
@@ -88,7 +88,7 @@ function SearchRouter({onRouterClose, shouldHideInputCaret}: SearchRouterProps) 
     // The input text that was last used for autocomplete; needed for the SearchRouterList when browsing list via arrow keys
     const [autocompleteQueryValue, setAutocompleteQueryValue] = useState(textInputValue);
     const [autocompleteSubstitutions, setAutocompleteSubstitutions] = useState<SubstitutionMap>({});
-    const textInputRef = useRef<BaseTextInputRef>(null);
+    const textInputRef = useRef<AnimatedTextInputRef>(null);
 
     const contextualReportID = useNavigationState<Record<string, {reportID: string}>, string | undefined>((state) => {
         return state?.routes.at(-1)?.params?.reportID;
@@ -162,7 +162,7 @@ function SearchRouter({onRouterClose, shouldHideInputCaret}: SearchRouterProps) 
 
         InputUtils.scrollToRight(textInputRef.current);
         shouldScrollRef.current = false;
-    }, [debouncedInputValue]);
+    }, []);
 
     const onSearchQueryChange = useCallback(
         (userQuery: string, autoScrollToRight = false) => {

--- a/src/components/Search/SearchRouter/SearchRouterContext.tsx
+++ b/src/components/Search/SearchRouter/SearchRouterContext.tsx
@@ -1,5 +1,5 @@
 import React, {useContext, useMemo, useRef, useState} from 'react';
-import type {BaseTextInputRef} from '@components/TextInput/BaseTextInput/types';
+import type {AnimatedTextInputRef} from '@components/RNTextInput';
 import isSearchTopmostCentralPane from '@navigation/isSearchTopmostCentralPane';
 import * as Modal from '@userActions/Modal';
 import type ChildrenProps from '@src/types/utils/ChildrenProps';
@@ -9,7 +9,7 @@ type SearchRouterContext = {
     openSearchRouter: () => void;
     closeSearchRouter: () => void;
     toggleSearch: () => void;
-    registerSearchPageInput: (ref: BaseTextInputRef) => void;
+    registerSearchPageInput: (ref: AnimatedTextInputRef) => void;
     unregisterSearchPageInput: () => void;
 };
 
@@ -27,7 +27,7 @@ const Context = React.createContext<SearchRouterContext>(defaultSearchContext);
 function SearchRouterContextProvider({children}: ChildrenProps) {
     const [isSearchRouterDisplayed, setIsSearchRouterDisplayed] = useState(false);
     const searchRouterDisplayedRef = useRef(false);
-    const searchPageInputRef = useRef<BaseTextInputRef | undefined>();
+    const searchPageInputRef = useRef<AnimatedTextInputRef>();
 
     const routerContext = useMemo(() => {
         const openSearchRouter = () => {
@@ -52,7 +52,7 @@ function SearchRouterContextProvider({children}: ChildrenProps) {
             const isUserOnSearchPage = isSearchTopmostCentralPane();
 
             if (isUserOnSearchPage && searchPageInputRef.current) {
-                if (searchPageInputRef.current?.isFocused()) {
+                if (searchPageInputRef.current.isFocused()) {
                     searchPageInputRef.current.blur();
                 } else {
                     searchPageInputRef.current.focus();
@@ -64,7 +64,7 @@ function SearchRouterContextProvider({children}: ChildrenProps) {
             }
         };
 
-        const registerSearchPageInput = (ref: BaseTextInputRef) => {
+        const registerSearchPageInput = (ref: AnimatedTextInputRef) => {
             searchPageInputRef.current = ref;
         };
 

--- a/src/components/Search/SearchRouter/SearchRouterContext.tsx
+++ b/src/components/Search/SearchRouter/SearchRouterContext.tsx
@@ -1,25 +1,33 @@
 import React, {useContext, useMemo, useRef, useState} from 'react';
+import type {BaseTextInputRef} from '@components/TextInput/BaseTextInput/types';
 import isSearchTopmostCentralPane from '@navigation/isSearchTopmostCentralPane';
 import * as Modal from '@userActions/Modal';
 import type ChildrenProps from '@src/types/utils/ChildrenProps';
 
-const defaultSearchContext = {
+type SearchRouterContext = {
+    isSearchRouterDisplayed: boolean;
+    openSearchRouter: () => void;
+    closeSearchRouter: () => void;
+    toggleSearch: () => void;
+    registerSearchPageInput: (ref: BaseTextInputRef) => void;
+    unregisterSearchPageInput: () => void;
+};
+
+const defaultSearchContext: SearchRouterContext = {
     isSearchRouterDisplayed: false,
     openSearchRouter: () => {},
     closeSearchRouter: () => {},
     toggleSearch: () => {},
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    registerSearchPageInput: (fn?: () => void) => {},
+    registerSearchPageInput: () => {},
+    unregisterSearchPageInput: () => {},
 };
-
-type SearchRouterContext = typeof defaultSearchContext;
 
 const Context = React.createContext<SearchRouterContext>(defaultSearchContext);
 
 function SearchRouterContextProvider({children}: ChildrenProps) {
     const [isSearchRouterDisplayed, setIsSearchRouterDisplayed] = useState(false);
     const searchRouterDisplayedRef = useRef(false);
-    const searchPageFocusInputRef = useRef<(() => void) | undefined>(undefined);
+    const searchPageInputRef = useRef<BaseTextInputRef | undefined>();
 
     const routerContext = useMemo(() => {
         const openSearchRouter = () => {
@@ -39,12 +47,16 @@ function SearchRouterContextProvider({children}: ChildrenProps) {
 
         // There are callbacks that live outside of React render-loop and interact with SearchRouter
         // So we need a function that is based on ref to correctly open/close it
-        // When on `/search` Page we instead focus the Input
+        // When user is on `/search` page we focus the Input instead of showing router
         const toggleSearch = () => {
             const isUserOnSearchPage = isSearchTopmostCentralPane();
 
-            if (isUserOnSearchPage && searchPageFocusInputRef.current) {
-                searchPageFocusInputRef.current?.();
+            if (isUserOnSearchPage && searchPageInputRef.current) {
+                if (searchPageInputRef.current?.isFocused()) {
+                    searchPageInputRef.current.blur();
+                } else {
+                    searchPageInputRef.current.focus();
+                }
             } else if (searchRouterDisplayedRef.current) {
                 closeSearchRouter();
             } else {
@@ -52,8 +64,12 @@ function SearchRouterContextProvider({children}: ChildrenProps) {
             }
         };
 
-        const registerSearchPageInput = (focusSearchInput?: () => void) => {
-            searchPageFocusInputRef.current = focusSearchInput;
+        const registerSearchPageInput = (ref: BaseTextInputRef) => {
+            searchPageInputRef.current = ref;
+        };
+
+        const unregisterSearchPageInput = () => {
+            searchPageInputRef.current = undefined;
         };
 
         return {
@@ -62,6 +78,7 @@ function SearchRouterContextProvider({children}: ChildrenProps) {
             closeSearchRouter,
             toggleSearch,
             registerSearchPageInput,
+            unregisterSearchPageInput,
         };
     }, [isSearchRouterDisplayed, setIsSearchRouterDisplayed]);
 

--- a/src/components/Search/SearchRouter/SearchRouterContext.tsx
+++ b/src/components/Search/SearchRouter/SearchRouterContext.tsx
@@ -43,8 +43,6 @@ function SearchRouterContextProvider({children}: ChildrenProps) {
         const toggleSearch = () => {
             const isUserOnSearchPage = isSearchTopmostCentralPane();
 
-            console.log('toggle', {isUserOnSearchPage, ref: searchPageFocusInputRef.current});
-
             if (isUserOnSearchPage && searchPageFocusInputRef.current) {
                 searchPageFocusInputRef.current?.();
             } else if (searchRouterDisplayedRef.current) {

--- a/src/components/Search/SearchRouter/SearchRouterContext.tsx
+++ b/src/components/Search/SearchRouter/SearchRouterContext.tsx
@@ -1,4 +1,5 @@
 import React, {useContext, useMemo, useRef, useState} from 'react';
+import isSearchTopmostCentralPane from '@navigation/isSearchTopmostCentralPane';
 import * as Modal from '@userActions/Modal';
 import type ChildrenProps from '@src/types/utils/ChildrenProps';
 
@@ -6,7 +7,9 @@ const defaultSearchContext = {
     isSearchRouterDisplayed: false,
     openSearchRouter: () => {},
     closeSearchRouter: () => {},
-    toggleSearchRouter: () => {},
+    toggleSearch: () => {},
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    registerSearchPageInput: (fn?: () => void) => {},
 };
 
 type SearchRouterContext = typeof defaultSearchContext;
@@ -16,6 +19,7 @@ const Context = React.createContext<SearchRouterContext>(defaultSearchContext);
 function SearchRouterContextProvider({children}: ChildrenProps) {
     const [isSearchRouterDisplayed, setIsSearchRouterDisplayed] = useState(false);
     const searchRouterDisplayedRef = useRef(false);
+    const searchPageFocusInputRef = useRef<(() => void) | undefined>(undefined);
 
     const routerContext = useMemo(() => {
         const openSearchRouter = () => {
@@ -35,19 +39,31 @@ function SearchRouterContextProvider({children}: ChildrenProps) {
 
         // There are callbacks that live outside of React render-loop and interact with SearchRouter
         // So we need a function that is based on ref to correctly open/close it
-        const toggleSearchRouter = () => {
-            if (searchRouterDisplayedRef.current) {
+        // When on `/search` Page we instead focus the Input
+        const toggleSearch = () => {
+            const isUserOnSearchPage = isSearchTopmostCentralPane();
+
+            console.log('toggle', {isUserOnSearchPage, ref: searchPageFocusInputRef.current});
+
+            if (isUserOnSearchPage && searchPageFocusInputRef.current) {
+                searchPageFocusInputRef.current?.();
+            } else if (searchRouterDisplayedRef.current) {
                 closeSearchRouter();
             } else {
                 openSearchRouter();
             }
         };
 
+        const registerSearchPageInput = (focusSearchInput?: () => void) => {
+            searchPageFocusInputRef.current = focusSearchInput;
+        };
+
         return {
             isSearchRouterDisplayed,
             openSearchRouter,
             closeSearchRouter,
-            toggleSearchRouter,
+            toggleSearch,
+            registerSearchPageInput,
         };
     }, [isSearchRouterDisplayed, setIsSearchRouterDisplayed]);
 

--- a/src/components/Search/SearchRouter/SearchRouterInput.tsx
+++ b/src/components/Search/SearchRouter/SearchRouterInput.tsx
@@ -137,4 +137,4 @@ function SearchRouterInput(
 
 SearchRouterInput.displayName = 'SearchRouterInput';
 
-export default React.forwardRef(SearchRouterInput);
+export default forwardRef(SearchRouterInput);

--- a/src/components/Search/SearchRouter/SearchRouterInput.tsx
+++ b/src/components/Search/SearchRouter/SearchRouterInput.tsx
@@ -91,7 +91,6 @@ function SearchRouterInput(
             <View style={[styles.flexRow, styles.alignItemsCenter, wrapperStyle ?? styles.searchRouterTextInputContainer, isFocused && wrapperFocusedStyle]}>
                 <View style={styles.flex1}>
                     <TextInput
-                        ref={ref}
                         testID="search-router-text-input"
                         value={value}
                         onChangeText={onSearchQueryChange}
@@ -122,6 +121,7 @@ function SearchRouterInput(
                             onBlur?.();
                         }}
                         isLoading={!!isSearchingForReports}
+                        ref={ref}
                     />
                 </View>
                 {!!rightComponent && <View style={styles.pr3}>{rightComponent}</View>}
@@ -137,4 +137,4 @@ function SearchRouterInput(
 
 SearchRouterInput.displayName = 'SearchRouterInput';
 
-export default forwardRef(SearchRouterInput);
+export default React.forwardRef(SearchRouterInput);

--- a/src/components/Search/SearchRouter/SearchRouterList.tsx
+++ b/src/components/Search/SearchRouter/SearchRouterList.tsx
@@ -399,6 +399,10 @@ function SearchRouterList(
         sections.push({data: [searchQueryItem]});
     }
 
+    if (additionalSections) {
+        sections.push(...additionalSections);
+    }
+
     if (!autocompleteQueryValue && recentSearchesData && recentSearchesData.length > 0) {
         sections.push({title: translate('search.recentSearches'), data: recentSearchesData});
     }
@@ -419,10 +423,6 @@ function SearchRouterList(
         });
 
         sections.push({title: translate('search.suggestions'), data: autocompleteData});
-    }
-
-    if (additionalSections) {
-        sections.push(...additionalSections);
     }
 
     const onArrowFocus = useCallback(

--- a/src/components/Search/SearchRouter/SearchRouterList.tsx
+++ b/src/components/Search/SearchRouter/SearchRouterList.tsx
@@ -1,8 +1,9 @@
 import {Str} from 'expensify-common';
-import React, {forwardRef, useMemo, useState} from 'react';
+import React, {forwardRef, useEffect, useMemo, useState} from 'react';
 import type {ForwardedRef} from 'react';
 import {useOnyx} from 'react-native-onyx';
 import * as Expensicons from '@components/Icon/Expensicons';
+import {usePersonalDetails} from '@components/OnyxProvider';
 import {useOptionsList} from '@components/OptionListContextProvider';
 import type {SearchFilterKey} from '@components/Search/types';
 import SelectionList from '@components/SelectionList';
@@ -29,6 +30,9 @@ import {
     getAutocompleteTaxList,
     parseForAutocomplete,
 } from '@libs/SearchAutocompleteUtils';
+import * as SearchAutocompleteUtils from '@libs/SearchAutocompleteUtils';
+import * as SearchQueryUtils from '@libs/SearchQueryUtils';
+import * as ReportUserActions from '@userActions/Report';
 import Timing from '@userActions/Timing';
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
@@ -51,16 +55,14 @@ type SearchRouterListProps = {
     /** Any extra sections that should be displayed in the router list */
     additionalSections?: Array<SectionListDataType<OptionData | SearchQueryItem>>;
 
-    shouldPreventDefault?: boolean;
-
     /** Callback to call when an item is clicked/selected */
     onListItemPress: (item: OptionData | SearchQueryItem) => void;
 
-    /** Callback to call when an item is focused via arrow buttons */
-    onListItemFocus: (item: SearchQueryItem) => void;
+    /** Callback to call when user did not click an item but still text query should be changed */
+    setTextQuery: (item: string) => void;
 
-    /** Item `keyForList` to focus initially */
-    initiallyFocusedOptionKey?: string | null;
+    /** Callback to call when the list of autocomplete substitutions should be updated */
+    updateAutocompleteSubstitutions: (item: SearchQueryItem) => void;
 };
 
 const defaultListOptions = {
@@ -109,7 +111,7 @@ function SearchRouterItem(props: UserListItemProps<OptionData> | SearchQueryList
 
 // Todo rename to SearchAutocompleteList once it's used in both Router and SearchPage
 function SearchRouterList(
-    {autocompleteQueryValue, searchQueryItem, additionalSections, shouldPreventDefault = true, onListItemFocus, onListItemPress, initiallyFocusedOptionKey}: SearchRouterListProps,
+    {autocompleteQueryValue, searchQueryItem, additionalSections, onListItemPress, setTextQuery, updateAutocompleteSubstitutions, initiallyFocusedOptionKey}: SearchRouterListProps,
     ref: ForwardedRef<SelectionListHandle>,
 ) {
     const styles = useThemeStyles();
@@ -119,6 +121,26 @@ function SearchRouterList(
     const {activeWorkspaceID} = useActiveWorkspace();
     const policy = usePolicy(activeWorkspaceID);
     const [betas] = useOnyx(ONYXKEYS.BETAS);
+    const [recentSearches] = useOnyx(ONYXKEYS.RECENT_SEARCHES);
+
+    const personalDetails = usePersonalDetails();
+    const [reports = {}] = useOnyx(ONYXKEYS.COLLECTION.REPORT);
+    const taxRates = getAllTaxRates();
+
+    const sortedRecentSearches = useMemo(() => {
+        return Object.values(recentSearches ?? {}).sort((a, b) => b.timestamp.localeCompare(a.timestamp));
+    }, [recentSearches]);
+
+    const recentSearchesData = sortedRecentSearches?.slice(0, 5).map(({query, timestamp}) => {
+        const searchQueryJSON = SearchQueryUtils.buildSearchQueryJSON(query);
+        return {
+            text: searchQueryJSON ? SearchQueryUtils.buildUserReadableQueryString(searchQueryJSON, personalDetails, reports, taxRates) : query,
+            singleIcon: Expensicons.History,
+            searchQuery: query,
+            keyForList: timestamp,
+            searchItemType: CONST.SEARCH.SEARCH_ROUTER_ITEM_TYPE.SEARCH,
+        };
+    });
 
     const {options, areOptionsInitialized} = useOptionsList();
     const searchOptions = useMemo(() => {
@@ -174,7 +196,6 @@ function SearchRouterList(
         return autocompleteOptions;
     }, [areOptionsInitialized, options.personalDetails, options.reports]);
 
-    const taxRates = getAllTaxRates();
     const taxAutocompleteList = useMemo(() => getAutocompleteTaxList(taxRates, policy), [policy, taxRates]);
 
     const [allPolicyCategories] = useOnyx(ONYXKEYS.COLLECTION.POLICY_CATEGORIES);
@@ -351,6 +372,11 @@ function SearchRouterList(
         cardAutocompleteList,
     ]);
 
+    useEffect(() => {
+        ReportUserActions.searchInServer(autocompleteQueryValue.trim());
+    }, [autocompleteQueryValue]);
+
+    /* Sections generation */
     const sections: Array<SectionListDataType<OptionData | SearchQueryItem>> = [];
 
     const [isInitialRender, setIsInitialRender] = useState(true);
@@ -358,6 +384,29 @@ function SearchRouterList(
     if (searchQueryItem) {
         sections.push({data: [searchQueryItem]});
     }
+
+    if (!autocompleteQueryValue && recentSearchesData && recentSearchesData.length > 0) {
+        sections.push({title: translate('search.recentSearches'), data: recentSearchesData});
+    }
+
+    const recentReportsOptions = useMemo(() => {
+        if (autocompleteQueryValue.trim() === '') {
+            return searchOptions.recentReports.slice(0, 20);
+        }
+
+        Timing.start(CONST.TIMING.SEARCH_FILTER_OPTIONS);
+        const filteredOptions = OptionsListUtils.filterOptions(searchOptions, autocompleteQueryValue, {sortByReportTypeInSearch: true, preferChatroomsOverThreads: true});
+        Timing.end(CONST.TIMING.SEARCH_FILTER_OPTIONS);
+
+        const reportOptions: OptionData[] = [...filteredOptions.recentReports, ...filteredOptions.personalDetails];
+        if (filteredOptions.userToInvite) {
+            reportOptions.push(filteredOptions.userToInvite);
+        }
+        return reportOptions.slice(0, 20);
+    }, [autocompleteQueryValue, searchOptions]);
+
+    const styledRecentReports = recentReportsOptions.map((item) => ({...item, pressableStyle: styles.br2, wrapperStyle: [styles.pr3, styles.pl3]}));
+    sections.push({title: translate('search.recentChats'), data: styledRecentReports});
 
     if (autocompleteSuggestions.length > 0) {
         const autocompleteData = autocompleteSuggestions.map(({filterKey, text, autocompleteID}) => {
@@ -379,11 +428,13 @@ function SearchRouterList(
     }
 
     const onArrowFocus = (focusedItem: OptionData | SearchQueryItem) => {
-        if (!isSearchQueryItem(focusedItem) || focusedItem?.searchItemType !== CONST.SEARCH.SEARCH_ROUTER_ITEM_TYPE.AUTOCOMPLETE_SUGGESTION) {
+        if (!isSearchQueryItem(focusedItem) || !focusedItem.searchQuery || focusedItem?.searchItemType !== CONST.SEARCH.SEARCH_ROUTER_ITEM_TYPE.AUTOCOMPLETE_SUGGESTION) {
             return;
         }
 
-        onListItemFocus(focusedItem);
+        const trimmedUserSearchQuery = SearchAutocompleteUtils.getQueryWithoutAutocompletedPart(autocompleteQueryValue);
+        setTextQuery(`${trimmedUserSearchQuery}${SearchQueryUtils.sanitizeSearchValue(focusedItem.searchQuery)} `);
+        updateAutocompleteSubstitutions(focusedItem);
     };
 
     return (
@@ -403,9 +454,8 @@ function SearchRouterList(
             sectionTitleStyles={styles.mhn2}
             shouldSingleExecuteRowSelect
             onArrowFocus={onArrowFocus}
-            shouldPreventDefault={shouldPreventDefault}
             ref={ref}
-            initiallyFocusedOptionKey={initiallyFocusedOptionKey}
+            initiallyFocusedOptionKey={shouldUseNarrowLayout ? undefined : styledRecentReports.at(0)?.keyForList}
             shouldScrollToFocusedIndex={!isInitialRender}
         />
     );

--- a/src/libs/Navigation/AppNavigator/AuthScreens.tsx
+++ b/src/libs/Navigation/AppNavigator/AuthScreens.tsx
@@ -237,7 +237,7 @@ function AuthScreens({session, lastOpenedPublicRoomID, initialLastUpdateIDApplie
     const rootNavigatorOptions = useRootNavigatorOptions();
     const {canUseDefaultRooms} = usePermissions();
     const {activeWorkspaceID} = useActiveWorkspace();
-    const {toggleSearchRouter} = useSearchRouterContext();
+    const {toggleSearch} = useSearchRouterContext();
 
     const modal = useRef<OnyxTypes.Modal>({});
     const [didPusherInit, setDidPusherInit] = useState(false);
@@ -365,7 +365,7 @@ function AuthScreens({session, lastOpenedPublicRoomID, initialLastUpdateIDApplie
                     if (isOnboardingFlowName(currentFocusedRoute?.name)) {
                         return;
                     }
-                    toggleSearchRouter();
+                    toggleSearch();
                 })();
             },
             shortcutsOverviewShortcutConfig.descriptionKey,

--- a/src/libs/Navigation/isSearchTopmostCentralPane.ts
+++ b/src/libs/Navigation/isSearchTopmostCentralPane.ts
@@ -11,12 +11,7 @@ const isSearchTopmostCentralPane = (): boolean => {
     }
 
     const topmostCentralPaneRoute = getTopmostCentralPaneRoute(rootState);
-
-    if (topmostCentralPaneRoute?.name === SCREENS.SEARCH.CENTRAL_PANE) {
-        return true;
-    }
-
-    return false;
+    return topmostCentralPaneRoute?.name === SCREENS.SEARCH.CENTRAL_PANE;
 };
 
 export default isSearchTopmostCentralPane;


### PR DESCRIPTION
### Explanation of Change
This PR refactors SearchPageHeaderInput and SearchRouter, to put all (expect contextual search) Router features into the Input on Search results.
Also when `cmd+k` shortcut is used while on Search Results Page, then we will focus on the Input and not show the Router.

#### Fixed bugs
 - if the query is empty, the first item on the list will also be empty, and will navigate to default search
 - focus on android mobile: https://github.com/Expensify/App/pull/52568#issuecomment-2501822936
 - [VERIFY] check performance regression - https://github.com/Expensify/App/pull/52568#issuecomment-2502041114

#### Other things
1. I was unable to properly fix box height: https://github.com/Expensify/App/pull/52568#issuecomment-2501822697 The reason is that I believe this is a problem deeper in the SelectionList. I played with different styles, max-heights etc and none of this changed the behavior.
I'm providing a video which shows that from the perspective of Search list components there is exactly 1 render, which introduces all the items, and there is nothing weird happening with data lengths. Thus the source of the flicker is most likely inside `SelectionList`, and I'd prefer to not change this list in this PR

<details>
<summary>flicker with console logs of renders</summary>

https://github.com/user-attachments/assets/ee474c6c-08cc-464d-bd7e-34706ca1455c

</details>
2. Keyboard navigation will sometimes jump out from suggestions the Search results below. This happens only when we have 1 item in the list, and so I think it should not be a big problem. The source lies much deeper in the code, because `SelectionList` simply always attaches a global keyboard handler for arrows UP/DOWN, and is not ready to work in cases where there are 2 lists. Source: https://github.com/Expensify/App/blob/main/src/components/SelectionList/BaseSelectionList.tsx#L317
This is a bigger problem that should be solved in a separate issue IMO.

### Fixed Issues
$ https://github.com/Expensify/App/issues/53126
PROPOSAL:


### Tests
- verify that cmd+k will focus Input when on Search results page
- verify that the Input on Search results page has the same items as Router
- verify you can navigate from Search results page to a chat via list items

### Offline tests

### QA Steps
Same as Tests

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

</details>

<details>
<summary>Android: mWeb Chrome</summary>
Android focus bug fix

https://github.com/user-attachments/assets/a9356624-5f19-4ad5-8bfc-84cb28639692

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>


https://github.com/user-attachments/assets/3d99aeb8-b75e-4869-bc5d-8f3848294dca



</details>

<details>
<summary>MacOS: Desktop</summary>

<!-- add screenshots or videos here -->

</details>
