### PR TITLE
Migrate animated to reanimated Tooltip and Switch

### DIFF
--- a/src/components/Switch.tsx
+++ b/src/components/Switch.tsx
@@ -44,17 +44,17 @@ function Switch({isOn, onToggle, accessibilityLabel, disabled, showLockIcon, dis
                 disabledAction?.();
                 return;
             }
-            offsetX.value = withTiming(isOn ? OFFSET_X.OFF : OFFSET_X.ON, {duration: 300});
+            offsetX.set(withTiming(isOn ? OFFSET_X.OFF : OFFSET_X.ON, {duration: 300}));
             onToggle(!isOn);
         });
     };
 
     const animatedThumbStyle = useAnimatedStyle(() => ({
-        transform: [{translateX: offsetX.value}],
+        transform: [{translateX: offsetX.get()}],
     }));
 
     const animatedSwitchTrackStyle = useAnimatedStyle(() => ({
-        backgroundColor: interpolateColor(offsetX.value, [OFFSET_X.OFF, OFFSET_X.ON], [theme.icon, theme.success]),
+        backgroundColor: interpolateColor(offsetX.get(), [OFFSET_X.OFF, OFFSET_X.ON], [theme.icon, theme.success]),
     }));
 
     return (

--- a/src/components/Switch.tsx
+++ b/src/components/Switch.tsx
@@ -1,8 +1,8 @@
-import React, {useEffect, useRef} from 'react';
-import {Animated, InteractionManager} from 'react-native';
+import React from 'react';
+import {InteractionManager} from 'react-native';
+import Animated, {interpolateColor, useAnimatedStyle, useSharedValue, withTiming} from 'react-native-reanimated';
 import useTheme from '@hooks/useTheme';
 import useThemeStyles from '@hooks/useThemeStyles';
-import useNativeDriver from '@libs/useNativeDriver';
 import CONST from '@src/CONST';
 import Icon from './Icon';
 import * as Expensicons from './Icon/Expensicons';
@@ -35,7 +35,7 @@ const OFFSET_X = {
 
 function Switch({isOn, onToggle, accessibilityLabel, disabled, showLockIcon, disabledAction}: SwitchProps) {
     const styles = useThemeStyles();
-    const offsetX = useRef(new Animated.Value(isOn ? OFFSET_X.ON : OFFSET_X.OFF));
+    const offsetX = useSharedValue(isOn ? OFFSET_X.ON : OFFSET_X.OFF);
     const theme = useTheme();
 
     const handleSwitchPress = () => {
@@ -44,22 +44,22 @@ function Switch({isOn, onToggle, accessibilityLabel, disabled, showLockIcon, dis
                 disabledAction?.();
                 return;
             }
+            offsetX.value = withTiming(isOn ? OFFSET_X.OFF : OFFSET_X.ON, {duration: 300});
             onToggle(!isOn);
         });
     };
 
-    useEffect(() => {
-        Animated.timing(offsetX.current, {
-            toValue: isOn ? OFFSET_X.ON : OFFSET_X.OFF,
-            duration: 300,
-            useNativeDriver,
-        }).start();
-    }, [isOn]);
+    const animatedThumbStyle = useAnimatedStyle(() => ({
+        transform: [{translateX: offsetX.value}],
+    }));
+
+    const animatedSwitchTrackStyle = useAnimatedStyle(() => ({
+        backgroundColor: interpolateColor(offsetX.value, [OFFSET_X.OFF, OFFSET_X.ON], [theme.icon, theme.success]),
+    }));
 
     return (
         <PressableWithFeedback
             disabled={!disabledAction && disabled}
-            style={[styles.switchTrack, !isOn && styles.switchInactive]}
             onPress={handleSwitchPress}
             onLongPress={handleSwitchPress}
             role={CONST.ROLE.SWITCH}
@@ -69,16 +69,17 @@ function Switch({isOn, onToggle, accessibilityLabel, disabled, showLockIcon, dis
             hoverDimmingValue={1}
             pressDimmingValue={0.8}
         >
-            {/* eslint-disable-next-line react-compiler/react-compiler */}
-            <Animated.View style={[styles.switchThumb, styles.switchThumbTransformation(offsetX.current)]}>
-                {(!!disabled || !!showLockIcon) && (
-                    <Icon
-                        src={Expensicons.Lock}
-                        fill={isOn ? theme.text : theme.icon}
-                        width={styles.toggleSwitchLockIcon.width}
-                        height={styles.toggleSwitchLockIcon.height}
-                    />
-                )}
+            <Animated.View style={[styles.switchTrack, animatedSwitchTrackStyle]}>
+                <Animated.View style={[styles.switchThumb, animatedThumbStyle]}>
+                    {(!!disabled || !!showLockIcon) && (
+                        <Icon
+                            src={Expensicons.Lock}
+                            fill={isOn ? theme.text : theme.icon}
+                            width={styles.toggleSwitchLockIcon.width}
+                            height={styles.toggleSwitchLockIcon.height}
+                        />
+                    )}
+                </Animated.View>
             </Animated.View>
         </PressableWithFeedback>
     );

--- a/src/components/Tooltip/BaseGenericTooltip/index.native.tsx
+++ b/src/components/Tooltip/BaseGenericTooltip/index.native.tsx
@@ -1,8 +1,9 @@
 import {Portal} from '@gorhom/portal';
 import React, {useMemo, useRef, useState} from 'react';
-import {Animated, InteractionManager, View} from 'react-native';
+import {InteractionManager, View} from 'react-native';
 // eslint-disable-next-line no-restricted-imports
 import type {View as RNView} from 'react-native';
+import Animated, {useAnimatedStyle} from 'react-native-reanimated';
 import TransparentOverlay from '@components/AutoCompleteSuggestions/AutoCompleteSuggestionsPortal/TransparentOverlay/TransparentOverlay';
 import Text from '@components/Text';
 import useStyleUtils from '@hooks/useStyleUtils';
@@ -46,13 +47,12 @@ function BaseGenericTooltip({
     const rootWrapper = useRef<RNView>(null);
 
     const StyleUtils = useStyleUtils();
-
-    const {animationStyle, rootWrapperStyle, textStyle, pointerWrapperStyle, pointerStyle} = useMemo(
+    const {rootWrapperStyle, textStyle, pointerWrapperStyle, pointerStyle} = useMemo(
         () =>
             StyleUtils.getTooltipStyles({
                 // eslint-disable-next-line react-compiler/react-compiler
                 tooltip: rootWrapper.current,
-                currentSize: animation,
+                currentSize: animation.value,
                 windowWidth,
                 xOffset,
                 yOffset,
@@ -86,6 +86,10 @@ function BaseGenericTooltip({
             wrapperStyle,
         ],
     );
+
+    const animationStyle = useAnimatedStyle(() => {
+        return StyleUtils.getTooltipAnimatedStyles({tooltipContentWidth: contentMeasuredWidth, tooltipWrapperHeight: wrapperMeasuredHeight, currentSize: animation});
+    });
 
     let content;
     if (renderTooltipContent) {

--- a/src/components/Tooltip/BaseGenericTooltip/index.native.tsx
+++ b/src/components/Tooltip/BaseGenericTooltip/index.native.tsx
@@ -52,7 +52,6 @@ function BaseGenericTooltip({
             StyleUtils.getTooltipStyles({
                 // eslint-disable-next-line react-compiler/react-compiler
                 tooltip: rootWrapper.current,
-                currentSize: animation.value,
                 windowWidth,
                 xOffset,
                 yOffset,
@@ -70,7 +69,6 @@ function BaseGenericTooltip({
             }),
         [
             StyleUtils,
-            animation,
             windowWidth,
             xOffset,
             yOffset,

--- a/src/components/Tooltip/BaseGenericTooltip/index.tsx
+++ b/src/components/Tooltip/BaseGenericTooltip/index.tsx
@@ -70,7 +70,6 @@ function BaseGenericTooltip({
         () =>
             StyleUtils.getTooltipStyles({
                 tooltip: rootWrapper.current,
-                currentSize: animation.value,
                 windowWidth,
                 xOffset,
                 yOffset,
@@ -87,7 +86,6 @@ function BaseGenericTooltip({
             }),
         [
             StyleUtils,
-            animation,
             windowWidth,
             xOffset,
             yOffset,

--- a/src/components/Tooltip/BaseGenericTooltip/index.tsx
+++ b/src/components/Tooltip/BaseGenericTooltip/index.tsx
@@ -1,7 +1,8 @@
 /* eslint-disable react-compiler/react-compiler */
 import React, {useLayoutEffect, useMemo, useRef, useState} from 'react';
 import ReactDOM from 'react-dom';
-import {Animated, View} from 'react-native';
+import {View} from 'react-native';
+import Animated, {useAnimatedStyle} from 'react-native-reanimated';
 import TransparentOverlay from '@components/AutoCompleteSuggestions/AutoCompleteSuggestionsPortal/TransparentOverlay/TransparentOverlay';
 import Text from '@components/Text';
 import useStyleUtils from '@hooks/useStyleUtils';
@@ -15,6 +16,7 @@ import type {BaseGenericTooltipProps} from './types';
 // We also update the state on layout changes which will be triggered often.
 // There will be n number of tooltip components in the page.
 // It's good to memoize this one.
+
 function BaseGenericTooltip({
     animation,
     windowWidth,
@@ -64,11 +66,11 @@ function BaseGenericTooltip({
         }
     }, []);
 
-    const {animationStyle, rootWrapperStyle, textStyle, pointerWrapperStyle, pointerStyle} = useMemo(
+    const {rootWrapperStyle, textStyle, pointerWrapperStyle, pointerStyle} = useMemo(
         () =>
             StyleUtils.getTooltipStyles({
                 tooltip: rootWrapper.current,
-                currentSize: animation,
+                currentSize: animation.value,
                 windowWidth,
                 xOffset,
                 yOffset,
@@ -101,6 +103,10 @@ function BaseGenericTooltip({
             wrapperStyle,
         ],
     );
+
+    const animationStyle = useAnimatedStyle(() => {
+        return StyleUtils.getTooltipAnimatedStyles({tooltipContentWidth: contentMeasuredWidth, tooltipWrapperHeight: wrapperMeasuredHeight, currentSize: animation});
+    });
 
     let content;
     if (renderTooltipContent) {

--- a/src/components/Tooltip/BaseGenericTooltip/types.ts
+++ b/src/components/Tooltip/BaseGenericTooltip/types.ts
@@ -1,6 +1,5 @@
 import type {SharedValue} from 'react-native-reanimated';
 import type {SharedTooltipProps} from '@components/Tooltip/types';
-import { SharedValue } from "react-native-reanimated";
 
 type BaseGenericTooltipProps = {
     /** Window width */

--- a/src/components/Tooltip/BaseGenericTooltip/types.ts
+++ b/src/components/Tooltip/BaseGenericTooltip/types.ts
@@ -1,12 +1,13 @@
 import type {Animated} from 'react-native';
 import type {SharedTooltipProps} from '@components/Tooltip/types';
+import { SharedValue } from "react-native-reanimated";
 
 type BaseGenericTooltipProps = {
     /** Window width */
     windowWidth: number;
 
     /** Tooltip Animation value */
-    animation: Animated.Value;
+    animation: SharedValue<number>;
 
     /** The distance between the left side of the wrapper view and the left side of the window */
     xOffset: number;

--- a/src/components/Tooltip/BaseGenericTooltip/types.ts
+++ b/src/components/Tooltip/BaseGenericTooltip/types.ts
@@ -1,5 +1,6 @@
 import type {SharedValue} from 'react-native-reanimated';
 import type {SharedTooltipProps} from '@components/Tooltip/types';
+import { SharedValue } from "react-native-reanimated";
 
 type BaseGenericTooltipProps = {
     /** Window width */

--- a/src/components/Tooltip/BaseGenericTooltip/types.ts
+++ b/src/components/Tooltip/BaseGenericTooltip/types.ts
@@ -1,6 +1,5 @@
-import type {Animated} from 'react-native';
+import type {SharedValue} from 'react-native-reanimated';
 import type {SharedTooltipProps} from '@components/Tooltip/types';
-import { SharedValue } from "react-native-reanimated";
 
 type BaseGenericTooltipProps = {
     /** Window width */

--- a/src/components/Tooltip/GenericTooltip.tsx
+++ b/src/components/Tooltip/GenericTooltip.tsx
@@ -82,19 +82,21 @@ function GenericTooltip({
 
         // When TooltipSense is active, immediately show the tooltip
         if (TooltipSense.isActive() && !shouldForceAnimate) {
-            animation.value = 1;
+            animation.set(1);
         } else {
-            isTooltipSenseInitiator.value = true;
-            animation.value = withDelay(
-                500,
-                withTiming(
-                    1,
-                    {
-                        duration: 140,
-                    },
-                    (finished) => {
-                        isAnimationCanceled.value = !finished;
-                    },
+            isTooltipSenseInitiator.set(true);
+            animation.set(
+                withDelay(
+                    500,
+                    withTiming(
+                        1,
+                        {
+                            duration: 140,
+                        },
+                        (finished) => {
+                            isAnimationCanceled.set(!finished);
+                        },
+                    ),
                 ),
             );
         }
@@ -105,8 +107,8 @@ function GenericTooltip({
     useEffect(() => {
         // if the tooltip text changed before the initial animation was finished, then the tooltip won't be shown
         // we need to show the tooltip again
-        if (isVisible && isAnimationCanceled.value && text && prevText !== text) {
-            isAnimationCanceled.value = false;
+        if (isVisible && isAnimationCanceled.get() && text && prevText !== text) {
+            isAnimationCanceled.set(false);
             showTooltip();
         }
     }, [isVisible, text, prevText, showTooltip, isAnimationCanceled]);
@@ -130,13 +132,13 @@ function GenericTooltip({
     const hideTooltip = useCallback(() => {
         cancelAnimation(animation);
 
-        if (TooltipSense.isActive() && !isTooltipSenseInitiator.value) {
+        if (TooltipSense.isActive() && !isTooltipSenseInitiator.get()) {
             // eslint-disable-next-line react-compiler/react-compiler
-            animation.value = 0;
+            animation.set(0);
         } else {
             // Hide the first tooltip which initiated the TooltipSense with animation
-            isTooltipSenseInitiator.value = false;
-            animation.value = 0;
+            isTooltipSenseInitiator.set(false);
+            animation.set(0);
         }
         TooltipSense.deactivate();
         setIsVisible(false);

--- a/src/components/Tooltip/GenericTooltip.tsx
+++ b/src/components/Tooltip/GenericTooltip.tsx
@@ -1,12 +1,11 @@
-import React, {memo, useCallback, useEffect, useImperativeHandle, useRef, useState} from 'react';
+import React, {memo, useCallback, useEffect, useState} from 'react';
 import type {LayoutRectangle} from 'react-native';
-import {Animated} from 'react-native';
+import {cancelAnimation, runOnJS, useSharedValue, withDelay, withTiming} from 'react-native-reanimated';
 import useLocalize from '@hooks/useLocalize';
 import usePrevious from '@hooks/usePrevious';
 import useWindowDimensions from '@hooks/useWindowDimensions';
 import Log from '@libs/Log';
 import StringUtils from '@libs/StringUtils';
-import TooltipRefManager from '@libs/TooltipRefManager';
 import variables from '@styles/variables';
 import CONST from '@src/CONST';
 import callOrReturn from '@src/types/utils/callOrReturn';
@@ -60,9 +59,9 @@ function GenericTooltip({
     const [shouldUseOverlay, setShouldUseOverlay] = useState(shouldUseOverlayProp);
 
     // Whether the tooltip is first tooltip to activate the TooltipSense
-    const isTooltipSenseInitiator = useRef(false);
-    const animation = useRef(new Animated.Value(0));
-    const isAnimationCanceled = useRef(false);
+    const animationSharedValue = useSharedValue<number>(0);
+    const isTooltipSenseInitiatorShared = useSharedValue<boolean>(true);
+    const isAnimationCanceledShared = useSharedValue<boolean>(false);
     const prevText = usePrevious(text);
 
     useEffect(() => {
@@ -79,21 +78,27 @@ function GenericTooltip({
         setIsRendered(true);
         setIsVisible(true);
 
-        animation.current.stopAnimation();
+        cancelAnimation(animationSharedValue);
 
         // When TooltipSense is active, immediately show the tooltip
         if (TooltipSense.isActive() && !shouldForceAnimate) {
-            animation.current.setValue(1);
+            animationSharedValue.value = 1;
         } else {
-            isTooltipSenseInitiator.current = true;
-            Animated.timing(animation.current, {
-                toValue: 1,
-                duration: 140,
-                delay: 500,
-                useNativeDriver: false,
-            }).start(({finished}) => {
-                isAnimationCanceled.current = !finished;
-            });
+            isTooltipSenseInitiatorShared.value = true;
+            animationSharedValue.value = withDelay(
+                500,
+                withTiming(
+                    1,
+                    {
+                        duration: 140,
+                    },
+                    (finished) => {
+                        runOnJS(() => {
+                            isAnimationCanceledShared.value = !finished;
+                        })();
+                    },
+                ),
+            );
         }
         TooltipSense.activate();
     }, [shouldForceAnimate]);
@@ -102,8 +107,8 @@ function GenericTooltip({
     useEffect(() => {
         // if the tooltip text changed before the initial animation was finished, then the tooltip won't be shown
         // we need to show the tooltip again
-        if (isVisible && isAnimationCanceled.current && text && prevText !== text) {
-            isAnimationCanceled.current = false;
+        if (isVisible && isAnimationCanceledShared.value && text && prevText !== text) {
+            isAnimationCanceledShared.value = false;
             showTooltip();
         }
     }, [isVisible, text, prevText, showTooltip]);
@@ -125,22 +130,17 @@ function GenericTooltip({
      * Hide the tooltip in an animation.
      */
     const hideTooltip = useCallback(() => {
-        animation.current.stopAnimation();
+        cancelAnimation(animationSharedValue);
 
-        if (TooltipSense.isActive() && !isTooltipSenseInitiator.current) {
-            animation.current.setValue(0);
+        if (TooltipSense.isActive() && !isTooltipSenseInitiatorShared.value) {
+            // eslint-disable-next-line react-compiler/react-compiler
+            animationSharedValue.value = 0;
         } else {
             // Hide the first tooltip which initiated the TooltipSense with animation
-            isTooltipSenseInitiator.current = false;
-            Animated.timing(animation.current, {
-                toValue: 0,
-                duration: 140,
-                useNativeDriver: false,
-            }).start();
+            isTooltipSenseInitiatorShared.value = false;
+            animationSharedValue.value = 0;
         }
-
         TooltipSense.deactivate();
-
         setIsVisible(false);
     }, []);
 
@@ -153,8 +153,6 @@ function GenericTooltip({
         onHideTooltip();
     }, [shouldUseOverlay, onHideTooltip, hideTooltip]);
 
-    useImperativeHandle(TooltipRefManager.ref, () => ({hideTooltip}), [hideTooltip]);
-
     // Skip the tooltip and return the children if the text is empty, we don't have a render function.
     if (StringUtils.isEmptyString(text) && renderTooltipContent == null) {
         // eslint-disable-next-line react-compiler/react-compiler
@@ -166,7 +164,7 @@ function GenericTooltip({
             {isRendered && (
                 <BaseGenericTooltip
                     // eslint-disable-next-line react-compiler/react-compiler
-                    animation={animation.current}
+                    animation={animationSharedValue}
                     windowWidth={windowWidth}
                     xOffset={xOffset}
                     yOffset={yOffset}

--- a/src/styles/index.ts
+++ b/src/styles/index.ts
@@ -3128,7 +3128,6 @@ const styles = (theme: ThemeColors) =>
             justifyContent: 'center',
             borderRadius: 20,
             padding: 15,
-            backgroundColor: theme.success,
         },
 
         switchInactive: {
@@ -3145,11 +3144,6 @@ const styles = (theme: ThemeColors) =>
             alignItems: 'center',
             backgroundColor: theme.appBG,
         },
-
-        switchThumbTransformation: (translateX: AnimatableNumericValue) =>
-            ({
-                transform: [{translateX}],
-            } satisfies ViewStyle),
 
         radioButtonContainer: {
             backgroundColor: theme.componentBG,

--- a/src/styles/utils/generators/TooltipStyleUtils/index.ts
+++ b/src/styles/utils/generators/TooltipStyleUtils/index.ts
@@ -270,7 +270,7 @@ const createTooltipStyleUtils: StyleUtilGenerator<GetTooltipStylesStyleUtil> = (
         const isTooltipSizeReady = tooltipWidth !== undefined && props.tooltipWrapperHeight !== undefined;
         let scale = 1;
         if (isTooltipSizeReady) {
-            scale = props.currentSize.value;
+            scale = props.currentSize.get();
         }
         return {
             transform: [{scale}],

--- a/src/styles/utils/generators/TooltipStyleUtils/index.ts
+++ b/src/styles/utils/generators/TooltipStyleUtils/index.ts
@@ -1,5 +1,6 @@
 import type {StyleProp, TextStyle, View, ViewStyle} from 'react-native';
-import {Animated, StyleSheet} from 'react-native';
+import {StyleSheet} from 'react-native';
+import type {SharedValue} from 'react-native-reanimated';
 import FontUtils from '@styles/utils/FontUtils';
 // eslint-disable-next-line no-restricted-imports
 import type StyleUtilGenerator from '@styles/utils/generators/types';
@@ -30,7 +31,7 @@ type TooltipStyles = {
 
 type TooltipParams = {
     tooltip: View | HTMLDivElement | null;
-    currentSize: Animated.Value;
+    currentSize: number;
     windowWidth: number;
     xOffset: number;
     yOffset: number;
@@ -47,7 +48,13 @@ type TooltipParams = {
     shouldAddHorizontalPadding?: boolean;
 };
 
-type GetTooltipStylesStyleUtil = {getTooltipStyles: (props: TooltipParams) => TooltipStyles};
+type TooltipAnimationProps = {
+    tooltipContentWidth?: number;
+    tooltipWrapperHeight?: number;
+    currentSize: SharedValue<number>;
+};
+
+type GetTooltipStylesStyleUtil = {getTooltipStyles: (props: TooltipParams) => TooltipStyles; getTooltipAnimatedStyles: (props: TooltipAnimationProps) => {transform: [{scale: number}]}};
 
 /**
  * Generate styles for the tooltip component.
@@ -108,7 +115,7 @@ const createTooltipStyleUtils: StyleUtilGenerator<GetTooltipStylesStyleUtil> = (
         const isTooltipSizeReady = tooltipWidth !== undefined && tooltipHeight !== undefined;
 
         // Set the scale to 1 to be able to measure the tooltip size correctly when it's not ready yet.
-        let scale = new Animated.Value(1);
+        let scale = 1;
         let shouldShowBelow = false;
         let horizontalShift = 0;
         let horizontalShiftPointer = 0;
@@ -267,6 +274,21 @@ const createTooltipStyleUtils: StyleUtilGenerator<GetTooltipStylesStyleUtil> = (
                 borderTopColor: customWrapperStyle.backgroundColor ?? theme.heading,
                 ...pointerAdditionalStyle,
             },
+        };
+    },
+
+    // Utility function to create and manage scale animations with React Native Reanimated
+
+    getTooltipAnimatedStyles: (props: TooltipAnimationProps) => {
+        const tooltipHorizontalPadding = spacing.ph2.paddingHorizontal * 2;
+        const tooltipWidth = props.tooltipContentWidth && props.tooltipContentWidth + tooltipHorizontalPadding + 1;
+        const isTooltipSizeReady = tooltipWidth !== undefined && props.tooltipWrapperHeight !== undefined;
+        let scale = 1;
+        if (isTooltipSizeReady) {
+            scale = props.currentSize.value;
+        }
+        return {
+            transform: [{scale}],
         };
     },
 });

--- a/src/styles/utils/generators/TooltipStyleUtils/index.ts
+++ b/src/styles/utils/generators/TooltipStyleUtils/index.ts
@@ -22,7 +22,6 @@ const POINTER_HEIGHT = 4;
 const POINTER_WIDTH = 12;
 
 type TooltipStyles = {
-    animationStyle: ViewStyle;
     rootWrapperStyle: ViewStyle;
     textStyle: TextStyle;
     pointerWrapperStyle: ViewStyle;
@@ -31,7 +30,6 @@ type TooltipStyles = {
 
 type TooltipParams = {
     tooltip: View | HTMLDivElement | null;
-    currentSize: number;
     windowWidth: number;
     xOffset: number;
     yOffset: number;
@@ -83,7 +81,6 @@ type GetTooltipStylesStyleUtil = {getTooltipStyles: (props: TooltipParams) => To
 const createTooltipStyleUtils: StyleUtilGenerator<GetTooltipStylesStyleUtil> = ({theme, styles}) => ({
     getTooltipStyles: ({
         tooltip,
-        currentSize,
         windowWidth,
         xOffset,
         yOffset,
@@ -114,8 +111,6 @@ const createTooltipStyleUtils: StyleUtilGenerator<GetTooltipStylesStyleUtil> = (
 
         const isTooltipSizeReady = tooltipWidth !== undefined && tooltipHeight !== undefined;
 
-        // Set the scale to 1 to be able to measure the tooltip size correctly when it's not ready yet.
-        let scale = 1;
         let shouldShowBelow = false;
         let horizontalShift = 0;
         let horizontalShiftPointer = 0;
@@ -136,9 +131,6 @@ const createTooltipStyleUtils: StyleUtilGenerator<GetTooltipStylesStyleUtil> = (
                 yOffset - tooltipHeight - POINTER_HEIGHT < GUTTER_WIDTH + titleBarHeight ||
                 !!(tooltip && isOverlappingAtTop(tooltip, xOffset, yOffset, tooltipTargetWidth, tooltipTargetHeight)) ||
                 anchorAlignment.vertical === CONST.MODAL.ANCHOR_ORIGIN_VERTICAL.TOP;
-
-            // When the tooltip size is ready, we can start animating the scale.
-            scale = currentSize;
 
             // Determine if we need to shift the tooltip horizontally to prevent it
             // from displaying too near to the edge of the screen.
@@ -223,12 +215,6 @@ const createTooltipStyleUtils: StyleUtilGenerator<GetTooltipStylesStyleUtil> = (
         }
 
         return {
-            animationStyle: {
-                // remember Transform causes a new Local cordinate system
-                // https://drafts.csswg.org/css-transforms-1/#transform-rendering
-                // so Position fixed children will be relative to this new Local cordinate system
-                transform: [{scale}],
-            },
             rootWrapperStyle: {
                 ...tooltipPlatformStyle,
                 backgroundColor: theme.heading,
@@ -277,8 +263,7 @@ const createTooltipStyleUtils: StyleUtilGenerator<GetTooltipStylesStyleUtil> = (
         };
     },
 
-    // Utility function to create and manage scale animations with React Native Reanimated
-
+    /** Utility function to create and manage scale animations with React Native Reanimated */
     getTooltipAnimatedStyles: (props: TooltipAnimationProps) => {
         const tooltipHorizontalPadding = spacing.ph2.paddingHorizontal * 2;
         const tooltipWidth = props.tooltipContentWidth && props.tooltipContentWidth + tooltipHorizontalPadding + 1;


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
Swap use animated from react-native to react-native-reanimated so we have big performance gains in animations

### Fixed Issues
$ https://github.com/Expensify/App/issues/52920

PROPOSAL:
[here](https://swmansion.slack.com/archives/C05LX9D6E07/p1732198006656509)

### Tests
1. On the web, just hover over any field that should have a tooltip and see if it displays.

  expected behavior:
  - on first hover tooltip appears with animation
  - if it has not been 1s since the previous hover, the animation is not activated and the tooltip simply appears right away
  - if it has been 1s, the animation appears 

2. On all platforms switch any switch and see if it works

expected behavior:
- every time the swithch is clicked, there is a smooth on and off animation

- [x] Verify that no errors appear in the JS console

### Offline tests
Are not needed

### QA Steps

1. On the web, just hover over any field that should have a tooltip and see if it displays.

  expected behavior:
  - on first hover tooltip appears with animation
  - if it has not been 1s since the previous hover, the animation is not activated and the tooltip simply appears right away
  - if it has been 1s, the animation appears 

2. On all platforms switch any switch and see if it works

expected behavior:
- every time the swithch is clicked, there is a smooth on and off animation

- [X] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [X] I linked the correct issue in the `### Fixed Issues` section above
- [X] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

https://github.com/user-attachments/assets/b517f237-e259-40af-9c81-a2c3f46b8e67

</details>

<details>
<summary>Android: mWeb Chrome</summary>


https://github.com/user-attachments/assets/e02d4143-f7e7-4d93-a429-d5cd1fdd37f7


</details>

<details>
<summary>iOS: Native</summary>

https://github.com/user-attachments/assets/9fa936db-0166-4670-b818-1272ae43fdec

</details>

<details>
<summary>iOS: mWeb Safari</summary>


https://github.com/user-attachments/assets/e1e4af9e-9a2d-4873-9cbb-1a06032d06f6


</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

https://github.com/user-attachments/assets/7b721a35-8e74-4eb0-a937-4d77ac44b5d2

</details>

<details>
<summary>MacOS: Desktop</summary>

https://github.com/user-attachments/assets/64601e3d-7c38-4260-be92-1230f68db0c8


</details>
