### PR TITLE
(RN Patch) TextLayout: take full width if text wrapped

### DIFF
--- a/patches/react-native+0.75.2+024+measureText-full-width-if-wraps.patch
+++ b/patches/react-native+0.75.2+024+measureText-full-width-if-wraps.patch
@@ -1,0 +1,53 @@
+diff --git a/node_modules/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/TextLayoutManager.java b/node_modules/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/TextLayoutManager.java
+index 2921f84..93da34c 100644
+--- a/node_modules/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/TextLayoutManager.java
++++ b/node_modules/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/TextLayoutManager.java
+@@ -579,6 +579,10 @@ public class TextLayoutManager {
+       for (int lineIndex = 0; lineIndex < calculatedLineCount; lineIndex++) {
+         boolean endsWithNewLine =
+             text.length() > 0 && text.charAt(layout.getLineEnd(lineIndex) - 1) == '\n';
++        if (!endsWithNewLine && lineIndex + 1 < layout.getLineCount()) {
++          calculatedWidth = width;
++          break;
++        }
+         float lineWidth =
+             endsWithNewLine ? layout.getLineMax(lineIndex) : layout.getLineWidth(lineIndex);
+         if (lineWidth > calculatedWidth) {
+diff --git a/node_modules/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/RCTTextLayoutManager.mm b/node_modules/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/RCTTextLayoutManager.mm
+index b4a7033..499e12e 100644
+--- a/node_modules/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/RCTTextLayoutManager.mm
++++ b/node_modules/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/RCTTextLayoutManager.mm
+@@ -285,8 +285,33 @@ static NSLineBreakMode RCTNSLineBreakModeFromEllipsizeMode(EllipsizeMode ellipsi
+   NSTextContainer *textContainer = layoutManager.textContainers.firstObject;
+   [layoutManager ensureLayoutForTextContainer:textContainer];
+ 
++  NSRange glyphRange = [layoutManager glyphRangeForTextContainer:textContainer];
++  __block BOOL textDidWrap = NO;
++  [layoutManager
++      enumerateLineFragmentsForGlyphRange:glyphRange
++                               usingBlock:^(
++                                   CGRect overallRect,
++                                   CGRect usedRect,
++                                   NSTextContainer *_Nonnull usedTextContainer,
++                                   NSRange lineGlyphRange,
++                                   BOOL *_Nonnull stop) {
++                                 NSRange range = [layoutManager characterRangeForGlyphRange:lineGlyphRange
++                                                                           actualGlyphRange:nil];
++                                 NSUInteger lastCharacterIndex = range.location + range.length - 1;
++                                 BOOL endsWithNewLine =
++                                     [textStorage.string characterAtIndex:lastCharacterIndex] == '\n';
++                                 if (!endsWithNewLine && textStorage.string.length > lastCharacterIndex + 1) {
++                                   textDidWrap = YES;
++                                   *stop = YES;
++                                 }
++                               }];
++
+   CGSize size = [layoutManager usedRectForTextContainer:textContainer].size;
+ 
++  if (textDidWrap) {
++    size.width = textContainer.size.width;
++  }
++
+   size = (CGSize){RCTCeilPixelValue(size.width), RCTCeilPixelValue(size.height)};
+ 
+   __block auto attachments = TextMeasurement::Attachments{};


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
<!-- Explain what your change does and how it addresses the linked issue -->
Patch to apply [TextLayout: take full width if text wrapped](https://github.com/facebook/react-native/pull/47435)


### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/21219
PROPOSAL: https://github.com/Expensify/App/issues/21219#issuecomment-2490973453


### Tests

1. Click FAB >  Start chat
2. Select a couple participants by clicking Add to group
3. Click Next
4. Change group name to: `Testing, longemaillongemaillongemaillongemail.com`
5. Go to LHN
6. Verify the group chat title takes full width (or as much width as it can)

| Bad ❌ | Good ✅ |
|:-----:|:------:|
|  <img width="480" alt="Bad rendering" src="https://github.com/user-attachments/assets/fa0d7d13-c03b-47e1-ac22-60e4424d08de">     |     <img width="480" alt="Good rendering" src="https://github.com/user-attachments/assets/ee12d0fb-570b-4465-87ef-baa8ff22e4c6">   |




- [X] Verify that no errors appear in the JS console

### Offline tests

Same as Tests

### QA Steps

Same as Tests

- [X] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [X] I linked the correct issue in the `### Fixed Issues` section above
- [X] I wrote clear testing steps that cover the changes made in this PR
    - [X] I added steps for local testing in the `Tests` section
    - [X] I added steps for the expected offline behavior in the `Offline steps` section
    - [X] I added steps for Staging and/or Production testing in the `QA steps` section
    - [X] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [X] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [X] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [X] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [X] I ran the tests on **all platforms** & verified they passed on:
    - [X] Android: Native
    - [X] Android: mWeb Chrome
    - [X] iOS: Native
    - [X] iOS: mWeb Safari
    - [X] MacOS: Chrome / Safari
    - [X] MacOS: Desktop
- [X] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [X] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [X] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [X] I verified that comments were added to code that is not self explanatory
    - [X] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [X] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [X] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [X] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [X] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [X] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [X] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [X] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [X] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [X] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [X] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [X] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [X] I verified that if a function's arguments changed that all usages have also been updated correctly
- [X] If any new file was added I verified that:
    - [X] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [X] If a new CSS style is added I verified that:
    - [X] A similar style doesn't already exist
    - [X] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [X] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [X] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [X] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [X] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [X] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [X] I verified that all the inputs inside a form are aligned with each other.
    - [X] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [X] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [X] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [X] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->
<img width="480" alt="android" src="https://github.com/user-attachments/assets/d9b2a993-1f79-4a09-b2bb-f1958520a1af">

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->
<img width="480" alt="mweb-chrome" src="https://github.com/user-attachments/assets/3d5fccf6-d1d2-4021-b2b1-3297a0e37bfc">

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->
<img width="559" alt="ios" src="https://github.com/user-attachments/assets/e36cc58a-5d2e-4825-957f-deb187060e0e">

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->
<img width="559" alt="mweb-safari" src="https://github.com/user-attachments/assets/4f183149-47f7-445a-80eb-ffb8ff676092">

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->
<img width="1840" alt="web" src="https://github.com/user-attachments/assets/23cd8e01-d462-4beb-bf6c-5491c770c8da">

</details>

<details>
<summary>MacOS: Desktop</summary>

<!-- add screenshots or videos here -->
<img width="1312" alt="desktop" src="https://github.com/user-attachments/assets/9feaddfa-ae89-4a52-866a-cf293841e666">

</details>

