### PR TITLE
Fix unstable sound level

### DIFF
--- a/src/components/VideoPlayer/BaseVideoPlayer.tsx
+++ b/src/components/VideoPlayer/BaseVideoPlayer.tsx
@@ -188,9 +188,6 @@ function BaseVideoPlayer({
         [playVideo, videoResumeTryNumberRef],
     );
 
-    const prevIsMutedRef = useRef(false);
-    const prevVolumeRef = useRef(0);
-
     const handlePlaybackStatusUpdate = useCallback(
         (status: AVPlaybackStatus) => {
             if (!status.isLoaded) {
@@ -210,15 +207,6 @@ function BaseVideoPlayer({
             } else if (status.isPlaying && isEnded) {
                 setIsEnded(false);
             }
-
-            if (prevIsMutedRef.current && prevVolumeRef.current === 0 && !status.isMuted) {
-                updateVolume(Platform.OS === 'web' ? 0.25 : 1);
-            }
-            if (isFullScreenRef.current && prevVolumeRef.current !== 0 && status.volume === 0 && !status.isMuted) {
-                currentVideoPlayerRef.current?.setStatusAsync({isMuted: true});
-            }
-            prevIsMutedRef.current = status.isMuted;
-            prevVolumeRef.current = status.volume;
 
             const isVideoPlaying = status.isPlaying;
             // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
@@ -266,7 +254,15 @@ function BaseVideoPlayer({
                     if (!('isMuted' in status)) {
                         return;
                     }
-
+                    // updateVolume((value) => {
+                    //     const valueToSet = value === 0 ? 0.25 : value;
+                    //     console.log("_________________________________________")
+                    //     console.log('valueToSet', valueToSet);
+                    //     console.log('status', status);
+                    //     console.log("_________________________________________")
+                    //
+                    //     return status.isMuted ? 0 : status.volume || valueToSet;
+                    // });
                     updateVolume(status.isMuted ? 0 : status.volume || 1);
                 });
 

--- a/src/components/VideoPlayer/BaseVideoPlayer.tsx
+++ b/src/components/VideoPlayer/BaseVideoPlayer.tsx
@@ -90,7 +90,7 @@ function BaseVideoPlayer({
     const isCurrentlyURLSet = currentlyPlayingURL === url;
     const isUploading = CONST.ATTACHMENT_LOCAL_URL_PREFIX.some((prefix) => url.startsWith(prefix));
     const videoStateRef = useRef<AVPlaybackStatus | null>(null);
-    const {updateVolume, lastNonZeroVolume, volume} = useVolumeContext();
+    const {updateVolume, lastNonZeroVolume} = useVolumeContext();
     const {videoPopoverMenuPlayerRef, currentPlaybackSpeed, setCurrentPlaybackSpeed} = useVideoPopoverMenuContext();
     const {source} = videoPopoverMenuPlayerRef.current?.props ?? {};
     const shouldUseNewRate = typeof source === 'number' || !source || source.uri !== sourceURL;
@@ -210,6 +210,8 @@ function BaseVideoPlayer({
                 setIsEnded(false);
             }
 
+            // These two conditions are essential for the mute and unmute functionality to work properly during
+            // fullscreen playback on the web
             if (prevIsMuted.get() && prevVolume.get() === 0 && !status.isMuted) {
                 updateVolume(lastNonZeroVolume.get());
             }

--- a/src/components/VideoPlayer/BaseVideoPlayer.tsx
+++ b/src/components/VideoPlayer/BaseVideoPlayer.tsx
@@ -5,7 +5,7 @@ import debounce from 'lodash/debounce';
 import type {MutableRefObject} from 'react';
 import React, {useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState} from 'react';
 import type {GestureResponderEvent} from 'react-native';
-import {View} from 'react-native';
+import {Platform, View} from 'react-native';
 import {runOnJS, useAnimatedStyle, useSharedValue, withTiming} from 'react-native-reanimated';
 import AttachmentOfflineIndicator from '@components/AttachmentOfflineIndicator';
 import FullScreenLoadingIndicator from '@components/FullscreenLoadingIndicator';
@@ -212,7 +212,7 @@ function BaseVideoPlayer({
             }
 
             if (prevIsMutedRef.current && prevVolumeRef.current === 0 && !status.isMuted) {
-                updateVolume(0.25);
+                updateVolume(Platform.OS === 'web' ? 0.25 : 1);
             }
             if (isFullScreenRef.current && prevVolumeRef.current !== 0 && status.volume === 0 && !status.isMuted) {
                 currentVideoPlayerRef.current?.setStatusAsync({isMuted: true});

--- a/src/components/VideoPlayer/BaseVideoPlayer.tsx
+++ b/src/components/VideoPlayer/BaseVideoPlayer.tsx
@@ -5,7 +5,7 @@ import debounce from 'lodash/debounce';
 import type {MutableRefObject} from 'react';
 import React, {useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState} from 'react';
 import type {GestureResponderEvent} from 'react-native';
-import {Platform, View} from 'react-native';
+import {View} from 'react-native';
 import {runOnJS, useAnimatedStyle, useSharedValue, withTiming} from 'react-native-reanimated';
 import AttachmentOfflineIndicator from '@components/AttachmentOfflineIndicator';
 import FullScreenLoadingIndicator from '@components/FullscreenLoadingIndicator';
@@ -254,15 +254,7 @@ function BaseVideoPlayer({
                     if (!('isMuted' in status)) {
                         return;
                     }
-                    // updateVolume((value) => {
-                    //     const valueToSet = value === 0 ? 0.25 : value;
-                    //     console.log("_________________________________________")
-                    //     console.log('valueToSet', valueToSet);
-                    //     console.log('status', status);
-                    //     console.log("_________________________________________")
-                    //
-                    //     return status.isMuted ? 0 : status.volume || valueToSet;
-                    // });
+
                     updateVolume(status.isMuted ? 0 : status.volume || 1);
                 });
 

--- a/src/components/VideoPlayer/VideoPlayerControls/VolumeButton/index.tsx
+++ b/src/components/VideoPlayer/VideoPlayerControls/VolumeButton/index.tsx
@@ -33,7 +33,7 @@ const getVolumeIcon = (volume: number) => {
 function VolumeButton({style, small = false}: VolumeButtonProps) {
     const styles = useThemeStyles();
     const {translate} = useLocalize();
-    const {updateVolume, volume} = useVolumeContext();
+    const {updateVolume, volume, previousVolume} = useVolumeContext();
     const [sliderHeight, setSliderHeight] = useState(1);
     const [volumeIcon, setVolumeIcon] = useState({icon: getVolumeIcon(volume.get())});
     const [isSliderBeingUsed, setIsSliderBeingUsed] = useState(false);
@@ -95,7 +95,11 @@ function VolumeButton({style, small = false}: VolumeButtonProps) {
 
                     <IconButton
                         tooltipText={volume.get() === 0 ? translate('videoPlayer.unmute') : translate('videoPlayer.mute')}
-                        onPress={() => updateVolume(volume.get() === 0 ? 1 : 0)}
+                        onPress={() =>
+                            updateVolume((value) => {
+                                return value === 0 ? previousVolume.get() : 0;
+                            })
+                        }
                         src={volumeIcon.icon}
                         small={small}
                         shouldForceRenderingTooltipBelow

--- a/src/components/VideoPlayer/VideoPlayerControls/VolumeButton/index.tsx
+++ b/src/components/VideoPlayer/VideoPlayerControls/VolumeButton/index.tsx
@@ -73,6 +73,13 @@ function VolumeButton({style, small = false}: VolumeButtonProps) {
         runOnJS(updateIcon)(volume.get());
     }, [volume]);
 
+    const toggleMute = () => {
+        if (volume.get() !== 0) {
+            lastNonZeroVolume.set(volume.get());
+        }
+        updateVolume(volume.get() === 0 ? lastNonZeroVolume.get() : 0);
+    };
+
     return (
         <Hoverable>
             {(isHovered) => (
@@ -95,11 +102,7 @@ function VolumeButton({style, small = false}: VolumeButtonProps) {
 
                     <IconButton
                         tooltipText={volume.get() === 0 ? translate('videoPlayer.unmute') : translate('videoPlayer.mute')}
-                        onPress={() =>
-                            updateVolume((value) => {
-                                return value === 0 ? lastNonZeroVolume.get() : 0;
-                            })
-                        }
+                        onPress={toggleMute}
                         src={volumeIcon.icon}
                         small={small}
                         shouldForceRenderingTooltipBelow

--- a/src/components/VideoPlayer/VideoPlayerControls/VolumeButton/index.tsx
+++ b/src/components/VideoPlayer/VideoPlayerControls/VolumeButton/index.tsx
@@ -33,7 +33,7 @@ const getVolumeIcon = (volume: number) => {
 function VolumeButton({style, small = false}: VolumeButtonProps) {
     const styles = useThemeStyles();
     const {translate} = useLocalize();
-    const {updateVolume, volume, previousVolume} = useVolumeContext();
+    const {updateVolume, volume, lastNonZeroVolume} = useVolumeContext();
     const [sliderHeight, setSliderHeight] = useState(1);
     const [volumeIcon, setVolumeIcon] = useState({icon: getVolumeIcon(volume.get())});
     const [isSliderBeingUsed, setIsSliderBeingUsed] = useState(false);
@@ -97,7 +97,7 @@ function VolumeButton({style, small = false}: VolumeButtonProps) {
                         tooltipText={volume.get() === 0 ? translate('videoPlayer.unmute') : translate('videoPlayer.mute')}
                         onPress={() =>
                             updateVolume((value) => {
-                                return value === 0 ? previousVolume.get() : 0;
+                                return value === 0 ? lastNonZeroVolume.get() : 0;
                             })
                         }
                         src={volumeIcon.icon}

--- a/src/components/VideoPlayer/VideoPlayerControls/VolumeButton/index.tsx
+++ b/src/components/VideoPlayer/VideoPlayerControls/VolumeButton/index.tsx
@@ -33,7 +33,7 @@ const getVolumeIcon = (volume: number) => {
 function VolumeButton({style, small = false}: VolumeButtonProps) {
     const styles = useThemeStyles();
     const {translate} = useLocalize();
-    const {updateVolume, volume, lastNonZeroVolume} = useVolumeContext();
+    const {updateVolume, volume, toggleMute} = useVolumeContext();
     const [sliderHeight, setSliderHeight] = useState(1);
     const [volumeIcon, setVolumeIcon] = useState({icon: getVolumeIcon(volume.get())});
     const [isSliderBeingUsed, setIsSliderBeingUsed] = useState(false);
@@ -72,13 +72,6 @@ function VolumeButton({style, small = false}: VolumeButtonProps) {
         runOnJS(updateVolume)(volume.get());
         runOnJS(updateIcon)(volume.get());
     }, [volume]);
-
-    const toggleMute = () => {
-        if (volume.get() !== 0) {
-            lastNonZeroVolume.set(volume.get());
-        }
-        updateVolume(volume.get() === 0 ? lastNonZeroVolume.get() : 0);
-    };
 
     return (
         <Hoverable>

--- a/src/components/VideoPlayerContexts/VolumeContext.tsx
+++ b/src/components/VideoPlayerContexts/VolumeContext.tsx
@@ -9,26 +9,20 @@ const Context = React.createContext<VolumeContext | null>(null);
 function VolumeContextProvider({children}: ChildrenProps) {
     const {currentVideoPlayerRef, originalParent} = usePlaybackContext();
     const volume = useSharedValue(0);
+    // We need this field to remember the last value before clicking mute
     const lastNonZeroVolume = useSharedValue(1);
 
     const updateVolume = useCallback(
-        (newVolume: number | ((actualValue: number) => number)) => {
+        (newVolume: number) => {
             if (!currentVideoPlayerRef.current) {
                 return;
             }
-            const volumeValue = typeof newVolume === 'function' ? newVolume(volume.get()) : newVolume;
-
             currentVideoPlayerRef.current.setStatusAsync({
-                volume: volumeValue,
-                isMuted: volumeValue === 0,
+                volume: newVolume,
+                isMuted: newVolume === 0,
             });
 
-            volume.set((value: number) => {
-                if (value !== 0) {
-                    lastNonZeroVolume.set(value);
-                }
-                return volumeValue;
-            });
+            volume.set(newVolume);
         },
         [currentVideoPlayerRef, volume],
     );

--- a/src/components/VideoPlayerContexts/types.ts
+++ b/src/components/VideoPlayerContexts/types.ts
@@ -26,6 +26,7 @@ type VolumeContext = {
     updateVolume: (newVolume: number) => void;
     volume: SharedValue<number>;
     lastNonZeroVolume: SharedValue<number>;
+    toggleMute: () => void;
 };
 
 type VideoPopoverMenuContext = {

--- a/src/components/VideoPlayerContexts/types.ts
+++ b/src/components/VideoPlayerContexts/types.ts
@@ -25,7 +25,7 @@ type PlaybackContext = {
 type VolumeContext = {
     updateVolume: (newVolume: number | ((value: number) => number)) => void;
     volume: SharedValue<number>;
-    previousVolume: SharedValue<number>;
+    lastNonZeroVolume: SharedValue<number>;
 };
 
 type VideoPopoverMenuContext = {

--- a/src/components/VideoPlayerContexts/types.ts
+++ b/src/components/VideoPlayerContexts/types.ts
@@ -23,8 +23,9 @@ type PlaybackContext = {
 };
 
 type VolumeContext = {
-    updateVolume: (newVolume: number) => void;
+    updateVolume: (newVolume: number | ((value: number) => number)) => void;
     volume: SharedValue<number>;
+    previousVolume: SharedValue<number>;
 };
 
 type VideoPopoverMenuContext = {

--- a/src/components/VideoPlayerContexts/types.ts
+++ b/src/components/VideoPlayerContexts/types.ts
@@ -23,7 +23,7 @@ type PlaybackContext = {
 };
 
 type VolumeContext = {
-    updateVolume: (newVolume: number | ((value: number) => number)) => void;
+    updateVolume: (newVolume: number) => void;
     volume: SharedValue<number>;
     lastNonZeroVolume: SharedValue<number>;
 };


### PR DESCRIPTION

### Explanation of Change
The logic responsible for proper mute and unmute functionality has been implemented, eliminating audio instability issues on mobile devices.

### Fixed Issues
$ https://github.com/Expensify/App/issues/52858

$
PROPOSAL:


### Tests
1. Open any chat.
2. Send a video.
3. Play the video.
4. Adjust the volume several times.
#### Expected behavior:
The volume remains at the level it was set to.

- [x] Verify that no errors appear in the JS console

### Offline tests
unnecessary

### QA Steps
Same as tests

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>


https://github.com/user-attachments/assets/3d74e303-3b27-4bfc-8ca0-018fa7543d5a


</details>

<details>
<summary>Android: mWeb Chrome</summary>

https://github.com/user-attachments/assets/437fd5ed-efb9-4712-91ab-83148de0b551

</details>

<details>
<summary>iOS: Native</summary>

https://github.com/user-attachments/assets/2170afbb-4f3d-4000-b36b-45270aa65a35

</details>

<details>
<summary>iOS: mWeb Safari</summary>

https://github.com/user-attachments/assets/15f2460e-a25d-4783-a0b5-3c7ad492f2d4

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>


https://github.com/user-attachments/assets/ddf6c8f1-91a9-401a-9877-a4e05de29868

</details>

<details>
<summary>MacOS: Desktop</summary>

https://github.com/user-attachments/assets/07875d07-0c4b-42f6-bed3-9638f9f8122d

</details>
