### PR TITLE
fix: ProfileAvatar (modal) page has no slide in animation

### DIFF
--- a/src/components/AttachmentModal.tsx
+++ b/src/components/AttachmentModal.tsx
@@ -1,5 +1,5 @@
 import {Str} from 'expensify-common';
-import React, {forwardRef, memo, useCallback, useEffect, useImperativeHandle, useMemo, useRef, useState} from 'react';
+import React, {memo, useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import {Animated, Keyboard, View} from 'react-native';
 import {GestureHandlerRootView} from 'react-native-gesture-handler';
 import {useOnyx} from 'react-native-onyx';
@@ -138,532 +138,516 @@ type AttachmentModalProps = {
     attachmentLink?: string;
 };
 
-type AttachmentModalHandle = {
-    open: () => void;
-    close: () => void;
-};
+function AttachmentModal({
+    source = '',
+    onConfirm,
+    defaultOpen = false,
+    originalFileName = '',
+    isAuthTokenRequired = false,
+    allowDownload = false,
+    isTrackExpenseAction = false,
+    report,
+    onModalShow = () => {},
+    onModalHide = () => {},
+    onCarouselAttachmentChange = () => {},
+    isReceiptAttachment = false,
+    isWorkspaceAvatar = false,
+    maybeIcon = false,
+    headerTitle,
+    children,
+    fallbackSource,
+    canEditReceipt = false,
+    onModalClose = () => {},
+    isLoading = false,
+    shouldShowNotFoundPage = false,
+    type = undefined,
+    accountID = undefined,
+    shouldDisableSendButton = false,
+    attachmentLink = '',
+}: AttachmentModalProps) {
+    const styles = useThemeStyles();
+    const StyleUtils = useStyleUtils();
+    const [isModalOpen, setIsModalOpen] = useState(defaultOpen);
+    const [shouldLoadAttachment, setShouldLoadAttachment] = useState(false);
+    const [isAttachmentInvalid, setIsAttachmentInvalid] = useState(false);
+    const [isDeleteReceiptConfirmModalVisible, setIsDeleteReceiptConfirmModalVisible] = useState(false);
+    const [isAuthTokenRequiredState, setIsAuthTokenRequiredState] = useState(isAuthTokenRequired);
+    const [attachmentInvalidReasonTitle, setAttachmentInvalidReasonTitle] = useState<TranslationPaths | null>(null);
+    const [attachmentInvalidReason, setAttachmentInvalidReason] = useState<TranslationPaths | null>(null);
+    const [sourceState, setSourceState] = useState<AvatarSource>(() => source);
+    const [modalType, setModalType] = useState<ModalType>(CONST.MODAL.MODAL_TYPE.CENTERED_UNSWIPEABLE);
+    const [isConfirmButtonDisabled, setIsConfirmButtonDisabled] = useState(false);
+    const [confirmButtonFadeAnimation] = useState(() => new Animated.Value(1));
+    const [isDownloadButtonReadyToBeShown, setIsDownloadButtonReadyToBeShown] = React.useState(true);
+    const isPDFLoadError = useRef(false);
+    const {windowWidth} = useWindowDimensions();
+    const {shouldUseNarrowLayout} = useResponsiveLayout();
+    const nope = useSharedValue(false);
+    const isOverlayModalVisible = (isReceiptAttachment && isDeleteReceiptConfirmModalVisible) || (!isReceiptAttachment && isAttachmentInvalid);
+    const iouType = useMemo(() => (isTrackExpenseAction ? CONST.IOU.TYPE.TRACK : CONST.IOU.TYPE.SUBMIT), [isTrackExpenseAction]);
+    const parentReportAction = ReportActionsUtils.getReportAction(report?.parentReportID ?? '-1', report?.parentReportActionID ?? '-1');
+    const transactionID = ReportActionsUtils.isMoneyRequestAction(parentReportAction) ? ReportActionsUtils.getOriginalMessage(parentReportAction)?.IOUTransactionID ?? '-1' : '-1';
+    const [transaction] = useOnyx(`${ONYXKEYS.COLLECTION.TRANSACTION}${transactionID}`);
+    const [currentAttachmentLink, setCurrentAttachmentLink] = useState(attachmentLink);
 
-const AttachmentModalImplementation = forwardRef<AttachmentModalHandle, AttachmentModalProps>(
-    (
-        {
-            source = '',
-            onConfirm,
-            defaultOpen = false,
-            originalFileName = '',
-            isAuthTokenRequired = false,
-            allowDownload = false,
-            isTrackExpenseAction = false,
-            report,
-            onModalShow = () => {},
-            onModalHide = () => {},
-            onCarouselAttachmentChange = () => {},
-            isReceiptAttachment = false,
-            isWorkspaceAvatar = false,
-            maybeIcon = false,
-            headerTitle,
-            children,
-            fallbackSource,
-            canEditReceipt = false,
-            onModalClose = () => {},
-            isLoading = false,
-            shouldShowNotFoundPage = false,
-            type = undefined,
-            accountID = undefined,
-            shouldDisableSendButton = false,
-            attachmentLink = '',
+    const [file, setFile] = useState<FileObject | undefined>(
+        originalFileName
+            ? {
+                  name: originalFileName,
+              }
+            : undefined,
+    );
+    const {translate} = useLocalize();
+    const {isOffline} = useNetwork();
+
+    const isLocalSource = typeof sourceState === 'string' && /^file:|^blob:/.test(sourceState);
+
+    useEffect(() => {
+        setFile(originalFileName ? {name: originalFileName} : undefined);
+    }, [originalFileName]);
+
+    /**
+     * Keeps the attachment source in sync with the attachment displayed currently in the carousel.
+     */
+    const onNavigate = useCallback(
+        (attachment: Attachment) => {
+            setSourceState(attachment.source);
+            setFile(attachment.file);
+            setIsAuthTokenRequiredState(attachment.isAuthTokenRequired ?? false);
+            onCarouselAttachmentChange(attachment);
+            setCurrentAttachmentLink(attachment?.attachmentLink ?? '');
         },
-        ref,
-    ) => {
-        const styles = useThemeStyles();
-        const StyleUtils = useStyleUtils();
-        const [isModalOpen, setIsModalOpen] = useState(defaultOpen);
-        const [shouldLoadAttachment, setShouldLoadAttachment] = useState(false);
-        const [isAttachmentInvalid, setIsAttachmentInvalid] = useState(false);
-        const [isDeleteReceiptConfirmModalVisible, setIsDeleteReceiptConfirmModalVisible] = useState(false);
-        const [isAuthTokenRequiredState, setIsAuthTokenRequiredState] = useState(isAuthTokenRequired);
-        const [attachmentInvalidReasonTitle, setAttachmentInvalidReasonTitle] = useState<TranslationPaths | null>(null);
-        const [attachmentInvalidReason, setAttachmentInvalidReason] = useState<TranslationPaths | null>(null);
-        const [sourceState, setSourceState] = useState<AvatarSource>(() => source);
-        const [modalType, setModalType] = useState<ModalType>(CONST.MODAL.MODAL_TYPE.CENTERED_UNSWIPEABLE);
-        const [isConfirmButtonDisabled, setIsConfirmButtonDisabled] = useState(false);
-        const [confirmButtonFadeAnimation] = useState(() => new Animated.Value(1));
-        const [isDownloadButtonReadyToBeShown, setIsDownloadButtonReadyToBeShown] = React.useState(true);
-        const isPDFLoadError = useRef(false);
-        const {windowWidth} = useWindowDimensions();
-        const {shouldUseNarrowLayout} = useResponsiveLayout();
-        const nope = useSharedValue(false);
-        const isOverlayModalVisible = (isReceiptAttachment && isDeleteReceiptConfirmModalVisible) || (!isReceiptAttachment && isAttachmentInvalid);
-        const iouType = useMemo(() => (isTrackExpenseAction ? CONST.IOU.TYPE.TRACK : CONST.IOU.TYPE.SUBMIT), [isTrackExpenseAction]);
-        const parentReportAction = ReportActionsUtils.getReportAction(report?.parentReportID ?? '-1', report?.parentReportActionID ?? '-1');
-        const transactionID = ReportActionsUtils.isMoneyRequestAction(parentReportAction) ? ReportActionsUtils.getOriginalMessage(parentReportAction)?.IOUTransactionID ?? '-1' : '-1';
-        const [transaction] = useOnyx(`${ONYXKEYS.COLLECTION.TRANSACTION}${transactionID}`);
-        const [currentAttachmentLink, setCurrentAttachmentLink] = useState(attachmentLink);
+        [onCarouselAttachmentChange],
+    );
 
-        const [file, setFile] = useState<FileObject | undefined>(
-            originalFileName
-                ? {
-                      name: originalFileName,
-                  }
-                : undefined,
-        );
-        const {translate} = useLocalize();
-        const {isOffline} = useNetwork();
+    /**
+     * If our attachment is a PDF, return the unswipeablge Modal type.
+     */
+    const getModalType = useCallback(
+        (sourceURL: string, fileObject: FileObject) =>
+            sourceURL && (Str.isPDF(sourceURL) || (fileObject && Str.isPDF(fileObject.name ?? translate('attachmentView.unknownFilename'))))
+                ? CONST.MODAL.MODAL_TYPE.CENTERED_UNSWIPEABLE
+                : CONST.MODAL.MODAL_TYPE.CENTERED,
+        [translate],
+    );
 
-        const isLocalSource = typeof sourceState === 'string' && /^file:|^blob:/.test(sourceState);
-
-        useEffect(() => {
-            setFile(originalFileName ? {name: originalFileName} : undefined);
-        }, [originalFileName]);
-
-        /**
-         * Keeps the attachment source in sync with the attachment displayed currently in the carousel.
-         */
-        const onNavigate = useCallback(
-            (attachment: Attachment) => {
-                setSourceState(attachment.source);
-                setFile(attachment.file);
-                setIsAuthTokenRequiredState(attachment.isAuthTokenRequired ?? false);
-                onCarouselAttachmentChange(attachment);
-                setCurrentAttachmentLink(attachment?.attachmentLink ?? '');
-            },
-            [onCarouselAttachmentChange],
-        );
-
-        /**
-         * If our attachment is a PDF, return the unswipeablge Modal type.
-         */
-        const getModalType = useCallback(
-            (sourceURL: string, fileObject: FileObject) =>
-                sourceURL && (Str.isPDF(sourceURL) || (fileObject && Str.isPDF(fileObject.name ?? translate('attachmentView.unknownFilename'))))
-                    ? CONST.MODAL.MODAL_TYPE.CENTERED_UNSWIPEABLE
-                    : CONST.MODAL.MODAL_TYPE.CENTERED,
-            [translate],
-        );
-
-        const setDownloadButtonVisibility = useCallback(
-            (isButtonVisible: boolean) => {
-                if (isDownloadButtonReadyToBeShown === isButtonVisible) {
-                    return;
-                }
-                setIsDownloadButtonReadyToBeShown(isButtonVisible);
-            },
-            [isDownloadButtonReadyToBeShown],
-        );
-
-        /**
-         * Download the currently viewed attachment.
-         */
-        const downloadAttachment = useCallback(() => {
-            let sourceURL = sourceState;
-            if (isAuthTokenRequiredState && typeof sourceURL === 'string') {
-                sourceURL = addEncryptedAuthTokenToURL(sourceURL);
+    const setDownloadButtonVisibility = useCallback(
+        (isButtonVisible: boolean) => {
+            if (isDownloadButtonReadyToBeShown === isButtonVisible) {
+                return;
             }
+            setIsDownloadButtonReadyToBeShown(isButtonVisible);
+        },
+        [isDownloadButtonReadyToBeShown],
+    );
 
-            if (typeof sourceURL === 'string') {
-                const fileName = type === CONST.ATTACHMENT_TYPE.SEARCH ? FileUtils.getFileName(`${sourceURL}`) : file?.name;
-                fileDownload(sourceURL, fileName ?? '');
+    /**
+     * Download the currently viewed attachment.
+     */
+    const downloadAttachment = useCallback(() => {
+        let sourceURL = sourceState;
+        if (isAuthTokenRequiredState && typeof sourceURL === 'string') {
+            sourceURL = addEncryptedAuthTokenToURL(sourceURL);
+        }
+
+        if (typeof sourceURL === 'string') {
+            const fileName = type === CONST.ATTACHMENT_TYPE.SEARCH ? FileUtils.getFileName(`${sourceURL}`) : file?.name;
+            fileDownload(sourceURL, fileName ?? '');
+        }
+
+        // At ios, if the keyboard is open while opening the attachment, then after downloading
+        // the attachment keyboard will show up. So, to fix it we need to dismiss the keyboard.
+        Keyboard.dismiss();
+    }, [isAuthTokenRequiredState, sourceState, file, type]);
+
+    /**
+     * Execute the onConfirm callback and close the modal.
+     */
+    const submitAndClose = useCallback(() => {
+        // If the modal has already been closed or the confirm button is disabled
+        // do not submit.
+        if (!isModalOpen || isConfirmButtonDisabled) {
+            return;
+        }
+
+        if (onConfirm) {
+            onConfirm(Object.assign(file ?? {}, {source: sourceState} as FileObject));
+        }
+
+        setIsModalOpen(false);
+        // eslint-disable-next-line react-compiler/react-compiler, react-hooks/exhaustive-deps
+    }, [isModalOpen, isConfirmButtonDisabled, onConfirm, file, sourceState]);
+
+    /**
+     * Close the confirm modals.
+     */
+    const closeConfirmModal = useCallback(() => {
+        setIsAttachmentInvalid(false);
+        setIsDeleteReceiptConfirmModalVisible(false);
+    }, []);
+
+    /**
+     * Detach the receipt and close the modal.
+     */
+    const deleteAndCloseModal = useCallback(() => {
+        IOU.detachReceipt(transaction?.transactionID ?? '-1');
+        setIsDeleteReceiptConfirmModalVisible(false);
+        Navigation.goBack(ROUTES.REPORT_WITH_ID_DETAILS.getRoute(report?.reportID ?? '-1'));
+    }, [transaction, report]);
+
+    const isValidFile = useCallback(
+        (fileObject: FileObject) =>
+            FileUtils.validateImageForCorruption(fileObject)
+                .then(() => {
+                    if (fileObject.size && fileObject.size > CONST.API_ATTACHMENT_VALIDATIONS.MAX_SIZE) {
+                        setIsAttachmentInvalid(true);
+                        setAttachmentInvalidReasonTitle('attachmentPicker.attachmentTooLarge');
+                        setAttachmentInvalidReason('attachmentPicker.sizeExceeded');
+                        return false;
+                    }
+
+                    if (fileObject.size && fileObject.size < CONST.API_ATTACHMENT_VALIDATIONS.MIN_SIZE) {
+                        setIsAttachmentInvalid(true);
+                        setAttachmentInvalidReasonTitle('attachmentPicker.attachmentTooSmall');
+                        setAttachmentInvalidReason('attachmentPicker.sizeNotMet');
+                        return false;
+                    }
+
+                    return true;
+                })
+                .catch(() => {
+                    setIsAttachmentInvalid(true);
+                    setAttachmentInvalidReasonTitle('attachmentPicker.attachmentError');
+                    setAttachmentInvalidReason('attachmentPicker.errorWhileSelectingCorruptedAttachment');
+                    return false;
+                }),
+        [],
+    );
+
+    const isDirectoryCheck = useCallback((data: FileObject) => {
+        if ('webkitGetAsEntry' in data && (data as DataTransferItem).webkitGetAsEntry()?.isDirectory) {
+            setIsAttachmentInvalid(true);
+            setAttachmentInvalidReasonTitle('attachmentPicker.attachmentError');
+            setAttachmentInvalidReason('attachmentPicker.folderNotAllowedMessage');
+            return false;
+        }
+        return true;
+    }, []);
+
+    const validateAndDisplayFileToUpload = useCallback(
+        (data: FileObject) => {
+            if (!data || !isDirectoryCheck(data)) {
+                return;
             }
-
-            // At ios, if the keyboard is open while opening the attachment, then after downloading
-            // the attachment keyboard will show up. So, to fix it we need to dismiss the keyboard.
-            Keyboard.dismiss();
-        }, [isAuthTokenRequiredState, sourceState, file, type]);
-
-        /**
-         * Execute the onConfirm callback and close the modal.
-         */
-        const submitAndClose = useCallback(() => {
-            // If the modal has already been closed or the confirm button is disabled
-            // do not submit.
-            if (!isModalOpen || isConfirmButtonDisabled) {
+            let fileObject = data;
+            if ('getAsFile' in data && typeof data.getAsFile === 'function') {
+                fileObject = data.getAsFile() as FileObject;
+            }
+            if (!fileObject) {
                 return;
             }
 
-            if (onConfirm) {
-                onConfirm(Object.assign(file ?? {}, {source: sourceState} as FileObject));
-            }
+            isValidFile(fileObject).then((isValid) => {
+                if (!isValid) {
+                    return;
+                }
+                if (fileObject instanceof File) {
+                    /**
+                     * Cleaning file name, done here so that it covers all cases:
+                     * upload, drag and drop, copy-paste
+                     */
+                    let updatedFile = fileObject;
+                    const cleanName = FileUtils.cleanFileName(updatedFile.name);
+                    if (updatedFile.name !== cleanName) {
+                        updatedFile = new File([updatedFile], cleanName, {type: updatedFile.type});
+                    }
+                    const inputSource = URL.createObjectURL(updatedFile);
+                    updatedFile.uri = inputSource;
+                    const inputModalType = getModalType(inputSource, updatedFile);
+                    setIsModalOpen(true);
+                    setSourceState(inputSource);
+                    setFile(updatedFile);
+                    setModalType(inputModalType);
+                } else if (fileObject.uri) {
+                    const inputModalType = getModalType(fileObject.uri, fileObject);
+                    setIsModalOpen(true);
+                    setSourceState(fileObject.uri);
+                    setFile(fileObject);
+                    setModalType(inputModalType);
+                }
+            });
+        },
+        [isValidFile, getModalType, isDirectoryCheck],
+    );
 
-            setIsModalOpen(false);
-            // eslint-disable-next-line react-compiler/react-compiler, react-hooks/exhaustive-deps
-        }, [isModalOpen, isConfirmButtonDisabled, onConfirm, file, sourceState]);
+    /**
+     * close the modal
+     */
+    const closeModal = useCallback(() => {
+        setIsModalOpen(false);
 
-        /**
-         * Close the confirm modals.
-         */
-        const closeConfirmModal = useCallback(() => {
-            setIsAttachmentInvalid(false);
-            setIsDeleteReceiptConfirmModalVisible(false);
-        }, []);
+        if (typeof onModalClose === 'function') {
+            onModalClose();
+        }
 
-        /**
-         * Detach the receipt and close the modal.
-         */
-        const deleteAndCloseModal = useCallback(() => {
-            IOU.detachReceipt(transaction?.transactionID ?? '-1');
-            setIsDeleteReceiptConfirmModalVisible(false);
-            Navigation.goBack(ROUTES.REPORT_WITH_ID_DETAILS.getRoute(report?.reportID ?? '-1'));
-        }, [transaction, report]);
+        // eslint-disable-next-line react-compiler/react-compiler, react-hooks/exhaustive-deps
+    }, [onModalClose]);
 
-        const isValidFile = useCallback(
-            (fileObject: FileObject) =>
-                FileUtils.validateImageForCorruption(fileObject)
-                    .then(() => {
-                        if (fileObject.size && fileObject.size > CONST.API_ATTACHMENT_VALIDATIONS.MAX_SIZE) {
-                            setIsAttachmentInvalid(true);
-                            setAttachmentInvalidReasonTitle('attachmentPicker.attachmentTooLarge');
-                            setAttachmentInvalidReason('attachmentPicker.sizeExceeded');
-                            return false;
-                        }
+    /**
+     *  open the modal
+     */
+    const openModal = useCallback(() => {
+        setIsModalOpen(true);
+    }, []);
 
-                        if (fileObject.size && fileObject.size < CONST.API_ATTACHMENT_VALIDATIONS.MIN_SIZE) {
-                            setIsAttachmentInvalid(true);
-                            setAttachmentInvalidReasonTitle('attachmentPicker.attachmentTooSmall');
-                            setAttachmentInvalidReason('attachmentPicker.sizeNotMet');
-                            return false;
-                        }
+    useEffect(() => {
+        setSourceState(() => source);
+    }, [source]);
 
-                        return true;
-                    })
-                    .catch(() => {
+    useEffect(() => {
+        setIsAuthTokenRequiredState(isAuthTokenRequired);
+    }, [isAuthTokenRequired]);
+
+    const sourceForAttachmentView = sourceState || source;
+
+    const threeDotsMenuItems = useMemo(() => {
+        if (!isReceiptAttachment) {
+            return [];
+        }
+
+        const menuItems = [];
+        if (canEditReceipt) {
+            menuItems.push({
+                icon: Expensicons.Camera,
+                text: translate('common.replace'),
+                onSelected: () => {
+                    closeModal();
+                    Navigation.navigate(
+                        ROUTES.MONEY_REQUEST_STEP_SCAN.getRoute(
+                            CONST.IOU.ACTION.EDIT,
+                            iouType,
+                            transaction?.transactionID ?? '-1',
+                            report?.reportID ?? '-1',
+                            Navigation.getActiveRouteWithoutParams(),
+                        ),
+                    );
+                },
+            });
+        }
+        if (!isOffline && allowDownload && !isLocalSource) {
+            menuItems.push({
+                icon: Expensicons.Download,
+                text: translate('common.download'),
+                onSelected: () => downloadAttachment(),
+            });
+        }
+        if (
+            !TransactionUtils.hasEReceipt(transaction) &&
+            TransactionUtils.hasReceipt(transaction) &&
+            !TransactionUtils.isReceiptBeingScanned(transaction) &&
+            canEditReceipt &&
+            !TransactionUtils.hasMissingSmartscanFields(transaction)
+        ) {
+            menuItems.push({
+                icon: Expensicons.Trashcan,
+                text: translate('receipt.deleteReceipt'),
+                onSelected: () => {
+                    setIsDeleteReceiptConfirmModalVisible(true);
+                },
+                shouldCallAfterModalHide: true,
+            });
+        }
+        return menuItems;
+        // eslint-disable-next-line react-compiler/react-compiler, react-hooks/exhaustive-deps
+    }, [isReceiptAttachment, transaction, file, sourceState, iouType]);
+
+    // There are a few things that shouldn't be set until we absolutely know if the file is a receipt or an attachment.
+    // props.isReceiptAttachment will be null until its certain what the file is, in which case it will then be true|false.
+    let headerTitleNew = headerTitle;
+    let shouldShowDownloadButton = false;
+    let shouldShowThreeDotsButton = false;
+    if (!isEmptyObject(report) || type === CONST.ATTACHMENT_TYPE.SEARCH) {
+        headerTitleNew = translate(isReceiptAttachment ? 'common.receipt' : 'common.attachment');
+        shouldShowDownloadButton = allowDownload && isDownloadButtonReadyToBeShown && !shouldShowNotFoundPage && !isReceiptAttachment && !isOffline && !isLocalSource;
+        shouldShowThreeDotsButton = isReceiptAttachment && isModalOpen && threeDotsMenuItems.length !== 0;
+    }
+    const context = useMemo(
+        () => ({
+            pagerItems: [{source: sourceForAttachmentView, index: 0, isActive: true}],
+            activePage: 0,
+            pagerRef: undefined,
+            isPagerScrolling: nope,
+            isScrollEnabled: nope,
+            onTap: () => {},
+            onScaleChanged: () => {},
+            onSwipeDown: closeModal,
+        }),
+        [closeModal, nope, sourceForAttachmentView],
+    );
+
+    const submitRef = useRef<View | HTMLElement>(null);
+
+    return (
+        <>
+            <Modal
+                type={modalType}
+                onClose={isOverlayModalVisible ? closeConfirmModal : closeModal}
+                isVisible={isModalOpen}
+                onModalShow={() => {
+                    onModalShow();
+                    setShouldLoadAttachment(true);
+                }}
+                onModalHide={() => {
+                    if (!isPDFLoadError.current) {
+                        onModalHide();
+                    }
+                    setShouldLoadAttachment(false);
+                    if (isPDFLoadError.current) {
                         setIsAttachmentInvalid(true);
                         setAttachmentInvalidReasonTitle('attachmentPicker.attachmentError');
                         setAttachmentInvalidReason('attachmentPicker.errorWhileSelectingCorruptedAttachment');
+                    }
+                }}
+                propagateSwipe
+                initialFocus={() => {
+                    if (!submitRef.current) {
                         return false;
-                    }),
-            [],
-        );
-
-        const isDirectoryCheck = useCallback((data: FileObject) => {
-            if ('webkitGetAsEntry' in data && (data as DataTransferItem).webkitGetAsEntry()?.isDirectory) {
-                setIsAttachmentInvalid(true);
-                setAttachmentInvalidReasonTitle('attachmentPicker.attachmentError');
-                setAttachmentInvalidReason('attachmentPicker.folderNotAllowedMessage');
-                return false;
-            }
-            return true;
-        }, []);
-
-        const validateAndDisplayFileToUpload = useCallback(
-            (data: FileObject) => {
-                if (!data || !isDirectoryCheck(data)) {
-                    return;
-                }
-                let fileObject = data;
-                if ('getAsFile' in data && typeof data.getAsFile === 'function') {
-                    fileObject = data.getAsFile() as FileObject;
-                }
-                if (!fileObject) {
-                    return;
-                }
-
-                isValidFile(fileObject).then((isValid) => {
-                    if (!isValid) {
-                        return;
                     }
-                    if (fileObject instanceof File) {
-                        /**
-                         * Cleaning file name, done here so that it covers all cases:
-                         * upload, drag and drop, copy-paste
-                         */
-                        let updatedFile = fileObject;
-                        const cleanName = FileUtils.cleanFileName(updatedFile.name);
-                        if (updatedFile.name !== cleanName) {
-                            updatedFile = new File([updatedFile], cleanName, {type: updatedFile.type});
-                        }
-                        const inputSource = URL.createObjectURL(updatedFile);
-                        updatedFile.uri = inputSource;
-                        const inputModalType = getModalType(inputSource, updatedFile);
-                        setIsModalOpen(true);
-                        setSourceState(inputSource);
-                        setFile(updatedFile);
-                        setModalType(inputModalType);
-                    } else if (fileObject.uri) {
-                        const inputModalType = getModalType(fileObject.uri, fileObject);
-                        setIsModalOpen(true);
-                        setSourceState(fileObject.uri);
-                        setFile(fileObject);
-                        setModalType(inputModalType);
-                    }
-                });
-            },
-            [isValidFile, getModalType, isDirectoryCheck],
-        );
-
-        /**
-         * close the modal
-         */
-        const closeModal = useCallback(() => {
-            setIsModalOpen(false);
-
-            if (typeof onModalClose === 'function') {
-                onModalClose();
-            }
-
-            // eslint-disable-next-line react-compiler/react-compiler, react-hooks/exhaustive-deps
-        }, [onModalClose]);
-
-        /**
-         *  open the modal
-         */
-        const openModal = useCallback(() => {
-            setIsModalOpen(true);
-        }, []);
-
-        useImperativeHandle(ref, () => ({
-            close: closeModal,
-            open: openModal,
-        }));
-
-        useEffect(() => {
-            setSourceState(() => source);
-        }, [source]);
-
-        useEffect(() => {
-            setIsAuthTokenRequiredState(isAuthTokenRequired);
-        }, [isAuthTokenRequired]);
-
-        const sourceForAttachmentView = sourceState || source;
-
-        const threeDotsMenuItems = useMemo(() => {
-            if (!isReceiptAttachment) {
-                return [];
-            }
-
-            const menuItems = [];
-            if (canEditReceipt) {
-                menuItems.push({
-                    icon: Expensicons.Camera,
-                    text: translate('common.replace'),
-                    onSelected: () => {
-                        closeModal();
-                        Navigation.navigate(
-                            ROUTES.MONEY_REQUEST_STEP_SCAN.getRoute(
-                                CONST.IOU.ACTION.EDIT,
-                                iouType,
-                                transaction?.transactionID ?? '-1',
-                                report?.reportID ?? '-1',
-                                Navigation.getActiveRouteWithoutParams(),
-                            ),
-                        );
-                    },
-                });
-            }
-            if (!isOffline && allowDownload && !isLocalSource) {
-                menuItems.push({
-                    icon: Expensicons.Download,
-                    text: translate('common.download'),
-                    onSelected: () => downloadAttachment(),
-                });
-            }
-            if (
-                !TransactionUtils.hasEReceipt(transaction) &&
-                TransactionUtils.hasReceipt(transaction) &&
-                !TransactionUtils.isReceiptBeingScanned(transaction) &&
-                canEditReceipt &&
-                !TransactionUtils.hasMissingSmartscanFields(transaction)
-            ) {
-                menuItems.push({
-                    icon: Expensicons.Trashcan,
-                    text: translate('receipt.deleteReceipt'),
-                    onSelected: () => {
-                        setIsDeleteReceiptConfirmModalVisible(true);
-                    },
-                    shouldCallAfterModalHide: true,
-                });
-            }
-            return menuItems;
-            // eslint-disable-next-line react-compiler/react-compiler, react-hooks/exhaustive-deps
-        }, [isReceiptAttachment, transaction, file, sourceState, iouType]);
-
-        // There are a few things that shouldn't be set until we absolutely know if the file is a receipt or an attachment.
-        // props.isReceiptAttachment will be null until its certain what the file is, in which case it will then be true|false.
-        let headerTitleNew = headerTitle;
-        let shouldShowDownloadButton = false;
-        let shouldShowThreeDotsButton = false;
-        if (!isEmptyObject(report) || type === CONST.ATTACHMENT_TYPE.SEARCH) {
-            headerTitleNew = translate(isReceiptAttachment ? 'common.receipt' : 'common.attachment');
-            shouldShowDownloadButton = allowDownload && isDownloadButtonReadyToBeShown && !shouldShowNotFoundPage && !isReceiptAttachment && !isOffline && !isLocalSource;
-            shouldShowThreeDotsButton = isReceiptAttachment && isModalOpen && threeDotsMenuItems.length !== 0;
-        }
-        const context = useMemo(
-            () => ({
-                pagerItems: [{source: sourceForAttachmentView, index: 0, isActive: true}],
-                activePage: 0,
-                pagerRef: undefined,
-                isPagerScrolling: nope,
-                isScrollEnabled: nope,
-                onTap: () => {},
-                onScaleChanged: () => {},
-                onSwipeDown: closeModal,
-            }),
-            [closeModal, nope, sourceForAttachmentView],
-        );
-
-        const submitRef = useRef<View | HTMLElement>(null);
-
-        return (
-            <>
-                <Modal
-                    type={modalType}
-                    onClose={isOverlayModalVisible ? closeConfirmModal : closeModal}
-                    isVisible={isModalOpen}
-                    onModalShow={() => {
-                        onModalShow();
-                        setShouldLoadAttachment(true);
-                    }}
-                    onModalHide={() => {
-                        if (!isPDFLoadError.current) {
-                            onModalHide();
-                        }
-                        setShouldLoadAttachment(false);
-                        if (isPDFLoadError.current) {
-                            setIsAttachmentInvalid(true);
-                            setAttachmentInvalidReasonTitle('attachmentPicker.attachmentError');
-                            setAttachmentInvalidReason('attachmentPicker.errorWhileSelectingCorruptedAttachment');
-                        }
-                    }}
-                    propagateSwipe
-                    initialFocus={() => {
-                        if (!submitRef.current) {
-                            return false;
-                        }
-                        return submitRef.current;
-                    }}
-                >
-                    <GestureHandlerRootView style={styles.flex1}>
-                        {shouldUseNarrowLayout && <HeaderGap />}
-                        <HeaderWithBackButton
-                            title={headerTitleNew}
-                            shouldShowBorderBottom
-                            shouldShowDownloadButton={shouldShowDownloadButton}
-                            onDownloadButtonPress={() => downloadAttachment()}
-                            shouldShowCloseButton={!shouldUseNarrowLayout}
-                            shouldShowBackButton={shouldUseNarrowLayout}
-                            onBackButtonPress={closeModal}
-                            onCloseButtonPress={closeModal}
-                            shouldShowThreeDotsButton={shouldShowThreeDotsButton}
-                            threeDotsAnchorPosition={styles.threeDotsPopoverOffsetAttachmentModal(windowWidth)}
-                            threeDotsMenuItems={threeDotsMenuItems}
-                            shouldOverlayDots
-                            subTitleLink={currentAttachmentLink ?? ''}
-                        />
-                        <View style={styles.imageModalImageCenterContainer}>
-                            {isLoading && <FullScreenLoadingIndicator />}
-                            {shouldShowNotFoundPage && !isLoading && (
-                                <BlockingView
-                                    icon={Illustrations.ToddBehindCloud}
-                                    iconWidth={variables.modalTopIconWidth}
-                                    iconHeight={variables.modalTopIconHeight}
-                                    title={translate('notFound.notHere')}
-                                    subtitle={translate('notFound.pageNotFound')}
-                                    linkKey="notFound.goBackHome"
-                                    shouldShowLink
-                                    onLinkPress={() => Navigation.dismissModal()}
-                                />
-                            )}
-                            {!shouldShowNotFoundPage &&
-                                (!isEmptyObject(report) && !isReceiptAttachment ? (
-                                    <AttachmentCarousel
-                                        accountID={accountID}
-                                        type={type}
-                                        report={report}
-                                        onNavigate={onNavigate}
-                                        onClose={closeModal}
-                                        source={source}
-                                        setDownloadButtonVisibility={setDownloadButtonVisibility}
-                                        attachmentLink={currentAttachmentLink}
-                                    />
-                                ) : (
-                                    !!sourceForAttachmentView &&
-                                    shouldLoadAttachment &&
-                                    !isLoading && (
-                                        <AttachmentCarouselPagerContext.Provider value={context}>
-                                            <AttachmentView
-                                                containerStyles={[styles.mh5]}
-                                                source={sourceForAttachmentView}
-                                                isAuthTokenRequired={isAuthTokenRequiredState}
-                                                file={file}
-                                                onToggleKeyboard={setIsConfirmButtonDisabled}
-                                                onPDFLoadError={() => {
-                                                    isPDFLoadError.current = true;
-                                                    setIsModalOpen(false);
-                                                }}
-                                                isWorkspaceAvatar={isWorkspaceAvatar}
-                                                maybeIcon={maybeIcon}
-                                                fallbackSource={fallbackSource}
-                                                isUsedInAttachmentModal
-                                                transactionID={transaction?.transactionID}
-                                                isUploaded={!isEmptyObject(report)}
-                                            />
-                                        </AttachmentCarouselPagerContext.Provider>
-                                    )
-                                ))}
-                        </View>
-                        {/* If we have an onConfirm method show a confirmation button */}
-                        {!!onConfirm && !isConfirmButtonDisabled && (
-                            <SafeAreaConsumer>
-                                {({safeAreaPaddingBottomStyle}) => (
-                                    <Animated.View style={[StyleUtils.fade(confirmButtonFadeAnimation), safeAreaPaddingBottomStyle]}>
-                                        <Button
-                                            ref={viewRef(submitRef)}
-                                            success
-                                            large
-                                            style={[styles.buttonConfirm, shouldUseNarrowLayout ? {} : styles.attachmentButtonBigScreen]}
-                                            textStyles={[styles.buttonConfirmText]}
-                                            text={translate('common.send')}
-                                            onPress={submitAndClose}
-                                            isDisabled={isConfirmButtonDisabled || shouldDisableSendButton}
-                                            pressOnEnter
-                                        />
-                                    </Animated.View>
-                                )}
-                            </SafeAreaConsumer>
-                        )}
-                        {isReceiptAttachment && (
-                            <ConfirmModal
-                                title={translate('receipt.deleteReceipt')}
-                                isVisible={isDeleteReceiptConfirmModalVisible}
-                                onConfirm={deleteAndCloseModal}
-                                onCancel={closeConfirmModal}
-                                prompt={translate('receipt.deleteConfirmation')}
-                                confirmText={translate('common.delete')}
-                                cancelText={translate('common.cancel')}
-                                danger
+                    return submitRef.current;
+                }}
+            >
+                <GestureHandlerRootView style={styles.flex1}>
+                    {shouldUseNarrowLayout && <HeaderGap />}
+                    <HeaderWithBackButton
+                        title={headerTitleNew}
+                        shouldShowBorderBottom
+                        shouldShowDownloadButton={shouldShowDownloadButton}
+                        onDownloadButtonPress={() => downloadAttachment()}
+                        shouldShowCloseButton={!shouldUseNarrowLayout}
+                        shouldShowBackButton={shouldUseNarrowLayout}
+                        onBackButtonPress={closeModal}
+                        onCloseButtonPress={closeModal}
+                        shouldShowThreeDotsButton={shouldShowThreeDotsButton}
+                        threeDotsAnchorPosition={styles.threeDotsPopoverOffsetAttachmentModal(windowWidth)}
+                        threeDotsMenuItems={threeDotsMenuItems}
+                        shouldOverlayDots
+                        subTitleLink={currentAttachmentLink ?? ''}
+                    />
+                    <View style={styles.imageModalImageCenterContainer}>
+                        {isLoading && <FullScreenLoadingIndicator />}
+                        {shouldShowNotFoundPage && !isLoading && (
+                            <BlockingView
+                                icon={Illustrations.ToddBehindCloud}
+                                iconWidth={variables.modalTopIconWidth}
+                                iconHeight={variables.modalTopIconHeight}
+                                title={translate('notFound.notHere')}
+                                subtitle={translate('notFound.pageNotFound')}
+                                linkKey="notFound.goBackHome"
+                                shouldShowLink
+                                onLinkPress={() => Navigation.dismissModal()}
                             />
                         )}
-                    </GestureHandlerRootView>
-                </Modal>
-                {!isReceiptAttachment && (
-                    <ConfirmModal
-                        title={attachmentInvalidReasonTitle ? translate(attachmentInvalidReasonTitle) : ''}
-                        onConfirm={closeConfirmModal}
-                        onCancel={closeConfirmModal}
-                        isVisible={isAttachmentInvalid}
-                        prompt={attachmentInvalidReason ? translate(attachmentInvalidReason) : ''}
-                        confirmText={translate('common.close')}
-                        shouldShowCancelButton={false}
-                        onModalHide={() => {
-                            if (!isPDFLoadError.current) {
-                                return;
-                            }
-                            isPDFLoadError.current = false;
-                            onModalHide?.();
-                        }}
-                    />
-                )}
+                        {!shouldShowNotFoundPage &&
+                            (!isEmptyObject(report) && !isReceiptAttachment ? (
+                                <AttachmentCarousel
+                                    accountID={accountID}
+                                    type={type}
+                                    report={report}
+                                    onNavigate={onNavigate}
+                                    onClose={closeModal}
+                                    source={source}
+                                    setDownloadButtonVisibility={setDownloadButtonVisibility}
+                                    attachmentLink={currentAttachmentLink}
+                                />
+                            ) : (
+                                !!sourceForAttachmentView &&
+                                shouldLoadAttachment &&
+                                !isLoading && (
+                                    <AttachmentCarouselPagerContext.Provider value={context}>
+                                        <AttachmentView
+                                            containerStyles={[styles.mh5]}
+                                            source={sourceForAttachmentView}
+                                            isAuthTokenRequired={isAuthTokenRequiredState}
+                                            file={file}
+                                            onToggleKeyboard={setIsConfirmButtonDisabled}
+                                            onPDFLoadError={() => {
+                                                isPDFLoadError.current = true;
+                                                setIsModalOpen(false);
+                                            }}
+                                            isWorkspaceAvatar={isWorkspaceAvatar}
+                                            maybeIcon={maybeIcon}
+                                            fallbackSource={fallbackSource}
+                                            isUsedInAttachmentModal
+                                            transactionID={transaction?.transactionID}
+                                            isUploaded={!isEmptyObject(report)}
+                                        />
+                                    </AttachmentCarouselPagerContext.Provider>
+                                )
+                            ))}
+                    </View>
+                    {/* If we have an onConfirm method show a confirmation button */}
+                    {!!onConfirm && !isConfirmButtonDisabled && (
+                        <SafeAreaConsumer>
+                            {({safeAreaPaddingBottomStyle}) => (
+                                <Animated.View style={[StyleUtils.fade(confirmButtonFadeAnimation), safeAreaPaddingBottomStyle]}>
+                                    <Button
+                                        ref={viewRef(submitRef)}
+                                        success
+                                        large
+                                        style={[styles.buttonConfirm, shouldUseNarrowLayout ? {} : styles.attachmentButtonBigScreen]}
+                                        textStyles={[styles.buttonConfirmText]}
+                                        text={translate('common.send')}
+                                        onPress={submitAndClose}
+                                        isDisabled={isConfirmButtonDisabled || shouldDisableSendButton}
+                                        pressOnEnter
+                                    />
+                                </Animated.View>
+                            )}
+                        </SafeAreaConsumer>
+                    )}
+                    {isReceiptAttachment && (
+                        <ConfirmModal
+                            title={translate('receipt.deleteReceipt')}
+                            isVisible={isDeleteReceiptConfirmModalVisible}
+                            onConfirm={deleteAndCloseModal}
+                            onCancel={closeConfirmModal}
+                            prompt={translate('receipt.deleteConfirmation')}
+                            confirmText={translate('common.delete')}
+                            cancelText={translate('common.cancel')}
+                            danger
+                        />
+                    )}
+                </GestureHandlerRootView>
+            </Modal>
+            {!isReceiptAttachment && (
+                <ConfirmModal
+                    title={attachmentInvalidReasonTitle ? translate(attachmentInvalidReasonTitle) : ''}
+                    onConfirm={closeConfirmModal}
+                    onCancel={closeConfirmModal}
+                    isVisible={isAttachmentInvalid}
+                    prompt={attachmentInvalidReason ? translate(attachmentInvalidReason) : ''}
+                    confirmText={translate('common.close')}
+                    shouldShowCancelButton={false}
+                    onModalHide={() => {
+                        if (!isPDFLoadError.current) {
+                            return;
+                        }
+                        isPDFLoadError.current = false;
+                        onModalHide?.();
+                    }}
+                />
+            )}
 
-                {children?.({
-                    displayFileInModal: validateAndDisplayFileToUpload,
-                    show: openModal,
-                })}
-            </>
-        );
-    },
-);
+            {children?.({
+                displayFileInModal: validateAndDisplayFileToUpload,
+                show: openModal,
+            })}
+        </>
+    );
+}
 
-const AttachmentModal = memo(AttachmentModalImplementation);
 AttachmentModal.displayName = 'AttachmentModal';
 
-export default AttachmentModal;
+export default memo(AttachmentModal);
 
-export type {Attachment, AttachmentModalHandle, FileObject, ImagePickerResponse};
+export type {Attachment, FileObject, ImagePickerResponse};

--- a/src/components/Modal/BaseModal.tsx
+++ b/src/components/Modal/BaseModal.tsx
@@ -1,6 +1,6 @@
 import {PortalHost} from '@gorhom/portal';
-import React, {forwardRef, useCallback, useEffect, useMemo, useRef} from 'react';
-import {View} from 'react-native';
+import React, {forwardRef, useCallback, useEffect, useMemo, useRef, useState} from 'react';
+import {InteractionManager, View} from 'react-native';
 import ReactNativeModal from 'react-native-modal';
 import ColorSchemeWrapper from '@components/ColorSchemeWrapper';
 import FocusTrapForModal from '@components/FocusTrap/FocusTrapForModal';
@@ -24,7 +24,7 @@ import type BaseModalProps from './types';
 
 function BaseModal(
     {
-        isVisible,
+        isVisible: isVisibleProp,
         onClose,
         shouldSetModalVisibility = true,
         onModalHide = () => {},
@@ -67,6 +67,18 @@ function BaseModal(
     const keyboardStateContextValue = useKeyboardState();
 
     const safeAreaInsets = useSafeAreaInsets();
+
+    const [isVisible, setIsVisible] = useState(false);
+    useEffect(() => {
+        if (isVisibleProp) {
+            InteractionManager.runAfterInteractions(() => {
+                setIsVisible(true);
+            });
+            return;
+        }
+
+        setIsVisible(false);
+    }, [isVisibleProp]);
 
     const isVisibleRef = useRef(isVisible);
     const wasVisible = usePrevious(isVisible);

--- a/src/pages/settings/Profile/ProfileAvatar.tsx
+++ b/src/pages/settings/Profile/ProfileAvatar.tsx
@@ -1,7 +1,6 @@
 import React, {useEffect} from 'react';
 import type {OnyxEntry} from 'react-native-onyx';
 import {withOnyx} from 'react-native-onyx';
-import type {AttachmentModalHandle} from '@components/AttachmentModal';
 import AttachmentModal from '@components/AttachmentModal';
 import Navigation from '@libs/Navigation/Navigation';
 import type {PlatformStackScreenProps} from '@libs/Navigation/PlatformStackNavigation/types';
@@ -10,6 +9,7 @@ import * as PersonalDetailsUtils from '@libs/PersonalDetailsUtils';
 import * as UserUtils from '@libs/UserUtils';
 import * as ValidationUtils from '@libs/ValidationUtils';
 import * as PersonalDetails from '@userActions/PersonalDetails';
+import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
 import type SCREENS from '@src/SCREENS';
 import type {PersonalDetailsList, PersonalDetailsMetadata} from '@src/types/onyx';
@@ -36,22 +36,23 @@ function ProfileAvatar({route, personalDetails, personalDetailsMetadata, isLoadi
         PersonalDetails.openPublicProfilePage(accountID);
     }, [accountID, avatarURL]);
 
-    const attachmenModalRef = React.useRef<AttachmentModalHandle>(null);
-    useEffect(() => {
-        setTimeout(() => {
-            attachmenModalRef.current?.open();
-        }, 200);
-    }, []);
+    // const attachmenModalRef = React.useRef<AttachmentModalHandle>(null);
+    // useEffect(() => {
+    //     InteractionManager.runAfterInteractions(() => {
+    //         attachmenModalRef.current?.open();
+    //     });
+    // }, []);
 
     return (
         <AttachmentModal
-            ref={attachmenModalRef}
+            // ref={attachmenModalRef}
+            defaultOpen
             headerTitle={displayName}
             source={UserUtils.getFullSizeAvatar(avatarURL, accountID)}
             onModalClose={() => {
                 setTimeout(() => {
                     Navigation.goBack();
-                }, 200);
+                }, CONST.ANIMATED_TRANSITION);
             }}
             originalFileName={personalDetail?.originalFileName ?? ''}
             isLoading={!!isLoading}

--- a/src/pages/settings/Profile/ProfileAvatar.tsx
+++ b/src/pages/settings/Profile/ProfileAvatar.tsx
@@ -1,6 +1,7 @@
 import React, {useEffect} from 'react';
 import type {OnyxEntry} from 'react-native-onyx';
 import {withOnyx} from 'react-native-onyx';
+import type {AttachmentModalHandle} from '@components/AttachmentModal';
 import AttachmentModal from '@components/AttachmentModal';
 import Navigation from '@libs/Navigation/Navigation';
 import type {PlatformStackScreenProps} from '@libs/Navigation/PlatformStackNavigation/types';
@@ -29,19 +30,28 @@ function ProfileAvatar({route, personalDetails, personalDetailsMetadata, isLoadi
     const displayName = PersonalDetailsUtils.getDisplayNameOrDefault(personalDetail);
 
     useEffect(() => {
-        if (!ValidationUtils.isValidAccountRoute(Number(accountID)) ?? !!avatarURL) {
+        if (!ValidationUtils.isValidAccountRoute(Number(accountID)) || !!avatarURL) {
             return;
         }
         PersonalDetails.openPublicProfilePage(accountID);
     }, [accountID, avatarURL]);
 
+    const attachmenModalRef = React.useRef<AttachmentModalHandle>(null);
+    useEffect(() => {
+        setTimeout(() => {
+            attachmenModalRef.current?.open();
+        }, 200);
+    }, []);
+
     return (
         <AttachmentModal
+            ref={attachmenModalRef}
             headerTitle={displayName}
-            defaultOpen
             source={UserUtils.getFullSizeAvatar(avatarURL, accountID)}
             onModalClose={() => {
-                Navigation.goBack();
+                setTimeout(() => {
+                    Navigation.goBack();
+                }, 200);
             }}
             originalFileName={personalDetail?.originalFileName ?? ''}
             isLoading={!!isLoading}

--- a/src/pages/settings/Profile/ProfileAvatar.tsx
+++ b/src/pages/settings/Profile/ProfileAvatar.tsx
@@ -1,6 +1,5 @@
 import React, {useEffect} from 'react';
-import type {OnyxEntry} from 'react-native-onyx';
-import {withOnyx} from 'react-native-onyx';
+import {useOnyx} from 'react-native-onyx';
 import AttachmentModal from '@components/AttachmentModal';
 import Navigation from '@libs/Navigation/Navigation';
 import type {PlatformStackScreenProps} from '@libs/Navigation/PlatformStackNavigation/types';
@@ -12,17 +11,14 @@ import * as PersonalDetails from '@userActions/PersonalDetails';
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
 import type SCREENS from '@src/SCREENS';
-import type {PersonalDetailsList, PersonalDetailsMetadata} from '@src/types/onyx';
 
-type ProfileAvatarOnyxProps = {
-    personalDetails: OnyxEntry<PersonalDetailsList>;
-    personalDetailsMetadata: OnyxEntry<Record<string, PersonalDetailsMetadata>>;
-    isLoadingApp: OnyxEntry<boolean>;
-};
+type ProfileAvatarProps = PlatformStackScreenProps<AuthScreensParamList, typeof SCREENS.PROFILE_AVATAR>;
 
-type ProfileAvatarProps = ProfileAvatarOnyxProps & PlatformStackScreenProps<AuthScreensParamList, typeof SCREENS.PROFILE_AVATAR>;
+function ProfileAvatar({route}: ProfileAvatarProps) {
+    const [personalDetails] = useOnyx(ONYXKEYS.PERSONAL_DETAILS_LIST);
+    const [personalDetailsMetadata] = useOnyx(ONYXKEYS.PERSONAL_DETAILS_METADATA);
+    const [isLoadingApp = true] = useOnyx(ONYXKEYS.IS_LOADING_APP);
 
-function ProfileAvatar({route, personalDetails, personalDetailsMetadata, isLoadingApp = true}: ProfileAvatarProps) {
     const personalDetail = personalDetails?.[route.params.accountID];
     const avatarURL = personalDetail?.avatar ?? '';
     const accountID = Number(route.params.accountID ?? '-1');
@@ -55,14 +51,4 @@ function ProfileAvatar({route, personalDetails, personalDetailsMetadata, isLoadi
 
 ProfileAvatar.displayName = 'ProfileAvatar';
 
-export default withOnyx<ProfileAvatarProps, ProfileAvatarOnyxProps>({
-    personalDetails: {
-        key: ONYXKEYS.PERSONAL_DETAILS_LIST,
-    },
-    personalDetailsMetadata: {
-        key: ONYXKEYS.PERSONAL_DETAILS_METADATA,
-    },
-    isLoadingApp: {
-        key: ONYXKEYS.IS_LOADING_APP,
-    },
-})(ProfileAvatar);
+export default ProfileAvatar;

--- a/src/pages/settings/Profile/ProfileAvatar.tsx
+++ b/src/pages/settings/Profile/ProfileAvatar.tsx
@@ -36,16 +36,8 @@ function ProfileAvatar({route, personalDetails, personalDetailsMetadata, isLoadi
         PersonalDetails.openPublicProfilePage(accountID);
     }, [accountID, avatarURL]);
 
-    // const attachmenModalRef = React.useRef<AttachmentModalHandle>(null);
-    // useEffect(() => {
-    //     InteractionManager.runAfterInteractions(() => {
-    //         attachmenModalRef.current?.open();
-    //     });
-    // }, []);
-
     return (
         <AttachmentModal
-            // ref={attachmenModalRef}
             defaultOpen
             headerTitle={displayName}
             source={UserUtils.getFullSizeAvatar(avatarURL, accountID)}


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

@mountiny 

### Explanation of Change
<!-- Explain what your change does and how it addresses the linked issue -->

This PR includes a temporary fix for the slide in animations of modal screens like the `ProfileAvatar` screen. The reason the animation was not visible is because the screens with NativeStack only get mounted once we navigate there and the screen has not finished rendering/mounting when the modal animates in.

Similarly, when we animate the modal out, we'll have to delay the back navigation by the modal animation duration.

Ultimately, we should think about migrating `react-native-modal`/RN Modal screens to `@react-navigation` modal screens.

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/53362
PROPOSAL:


### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

- [x] Verify that no errors appear in the JS console

1. Go to a report -> Profile
2. Press on the avatar
3. Make sure the modal slide in animation is visible and smooth
4. Press on the back button
5. Make sure the slide out animation is visible and smooth

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
6. Upload an image via copy paste
7. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->
Same as in Tests.

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/307ada6e-b699-4c5d-a9ca-5097b1107c0b

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->


Uploading Simulator Screen Recording - iPhone 16 Pro - 2024-12-03 at 20.54.28.mp4…

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->


https://github.com/user-attachments/assets/b254e436-206e-4aac-af73-1ab71377d7b1



</details>

<details>
<summary>MacOS: Desktop</summary>

<!-- add screenshots or videos here -->

</details>
