### PR TITLE
fix: change horizontal padding for physical card form default renderer

### DIFF
--- a/src/pages/settings/Wallet/Card/BaseGetPhysicalCard.tsx
+++ b/src/pages/settings/Wallet/Card/BaseGetPhysicalCard.tsx
@@ -173,6 +173,14 @@ function BaseGetPhysicalCard({
         [cardToBeIssued?.cardID, draftValues, session?.authToken, privatePersonalDetails],
     );
 
+    const handleBackButtonPress = useCallback(() => {
+        if (currentCardID) {
+            Navigation.goBack(ROUTES.SETTINGS_WALLET_DOMAINCARD.getRoute(currentCardID));
+            return;
+        }
+        Navigation.goBack();
+    }, [currentCardID]);
+
     return (
         <ScreenWrapper
             shouldEnablePickerAvoiding={false}
@@ -181,12 +189,7 @@ function BaseGetPhysicalCard({
         >
             <HeaderWithBackButton
                 title={title}
-                onBackButtonPress={() => {
-                    if (currentCardID) {
-                        Navigation.goBack(ROUTES.SETTINGS_WALLET_DOMAINCARD.getRoute(currentCardID));
-                    }
-                    Navigation.goBack();
-                }}
+                onBackButtonPress={handleBackButtonPress}
             />
             <Text style={[styles.textHeadline, styles.mh5, styles.mb5]}>{headline}</Text>
             {renderContent({onSubmit, submitButtonText, children, onValidate})}

--- a/src/pages/settings/Wallet/Card/BaseGetPhysicalCard.tsx
+++ b/src/pages/settings/Wallet/Card/BaseGetPhysicalCard.tsx
@@ -69,8 +69,9 @@ function DefaultRenderContent({onSubmit, submitButtonText, children, onValidate}
         <FormProvider
             formID={ONYXKEYS.FORMS.GET_PHYSICAL_CARD_FORM}
             submitButtonText={submitButtonText}
+            submitButtonStyles={styles.mh5}
             onSubmit={onSubmit}
-            style={[styles.flex1, styles.mh5]}
+            style={styles.flex1}
             validate={onValidate}
         >
             {children}

--- a/src/pages/settings/Wallet/Card/GetPhysicalCardAddress.tsx
+++ b/src/pages/settings/Wallet/Card/GetPhysicalCardAddress.tsx
@@ -1,6 +1,5 @@
 import React, {useCallback, useEffect, useState} from 'react';
-import {withOnyx} from 'react-native-onyx';
-import type {OnyxEntry} from 'react-native-onyx';
+import {useOnyx} from 'react-native-onyx';
 import AddressForm from '@components/AddressForm';
 import useLocalize from '@hooks/useLocalize';
 import * as FormActions from '@libs/actions/FormActions';
@@ -10,26 +9,21 @@ import type {Country} from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
 import ROUTES from '@src/ROUTES';
 import type SCREENS from '@src/SCREENS';
-import type {GetPhysicalCardForm} from '@src/types/form';
 import INPUT_IDS from '@src/types/form/GetPhysicalCardForm';
 import type {Address} from '@src/types/onyx/PrivatePersonalDetails';
 import BaseGetPhysicalCard from './BaseGetPhysicalCard';
 import type {RenderContentProps} from './BaseGetPhysicalCard';
 
-type GetPhysicalCardAddressOnyxProps = {
-    /** Draft values used by the get physical card form */
-    draftValues: OnyxEntry<GetPhysicalCardForm>;
-};
-
-type GetPhysicalCardAddressProps = GetPhysicalCardAddressOnyxProps & PlatformStackScreenProps<SettingsNavigatorParamList, typeof SCREENS.SETTINGS.WALLET.CARD_GET_PHYSICAL.ADDRESS>;
+type GetPhysicalCardAddressProps = PlatformStackScreenProps<SettingsNavigatorParamList, typeof SCREENS.SETTINGS.WALLET.CARD_GET_PHYSICAL.ADDRESS>;
 
 function GetPhysicalCardAddress({
-    draftValues,
     route: {
         params: {country: countryFromUrl, domain},
     },
 }: GetPhysicalCardAddressProps) {
     const {translate} = useLocalize();
+
+    const [draftValues] = useOnyx(ONYXKEYS.FORMS.GET_PHYSICAL_CARD_FORM_DRAFT);
 
     const {addressLine1, addressLine2} = draftValues ?? {};
     const [country, setCountry] = useState(draftValues?.country);
@@ -116,8 +110,4 @@ function GetPhysicalCardAddress({
 
 GetPhysicalCardAddress.displayName = 'GetPhysicalCardAddress';
 
-export default withOnyx<GetPhysicalCardAddressProps, GetPhysicalCardAddressOnyxProps>({
-    draftValues: {
-        key: ONYXKEYS.FORMS.GET_PHYSICAL_CARD_FORM_DRAFT,
-    },
-})(GetPhysicalCardAddress);
+export default GetPhysicalCardAddress;

--- a/src/pages/settings/Wallet/Card/GetPhysicalCardConfirm.tsx
+++ b/src/pages/settings/Wallet/Card/GetPhysicalCardConfirm.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
-import {withOnyx} from 'react-native-onyx';
-import type {OnyxEntry} from 'react-native-onyx';
+import {useOnyx} from 'react-native-onyx';
 import * as Expensicons from '@components/Icon/Expensicons';
 import MenuItemWithTopDescription from '@components/MenuItemWithTopDescription';
 import Text from '@components/Text';
@@ -14,7 +13,6 @@ import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
 import ROUTES from '@src/ROUTES';
 import type SCREENS from '@src/SCREENS';
-import type {GetPhysicalCardForm} from '@src/types/form';
 import BaseGetPhysicalCard from './BaseGetPhysicalCard';
 
 const goToGetPhysicalCardName = (domain: string) => {
@@ -29,21 +27,17 @@ const goToGetPhysicalCardAddress = (domain: string) => {
     Navigation.navigate(ROUTES.SETTINGS_WALLET_CARD_GET_PHYSICAL_ADDRESS.getRoute(domain), CONST.NAVIGATION.ACTION_TYPE.PUSH);
 };
 
-type GetPhysicalCardConfirmOnyxProps = {
-    /** Draft values used by the get physical card form */
-    draftValues: OnyxEntry<GetPhysicalCardForm>;
-};
-
-type GetPhysicalCardConfirmProps = GetPhysicalCardConfirmOnyxProps & PlatformStackScreenProps<SettingsNavigatorParamList, typeof SCREENS.SETTINGS.WALLET.CARD_GET_PHYSICAL.CONFIRM>;
+type GetPhysicalCardConfirmProps = PlatformStackScreenProps<SettingsNavigatorParamList, typeof SCREENS.SETTINGS.WALLET.CARD_GET_PHYSICAL.CONFIRM>;
 
 function GetPhysicalCardConfirm({
-    draftValues,
     route: {
         params: {domain},
     },
 }: GetPhysicalCardConfirmProps) {
     const styles = useThemeStyles();
     const {translate} = useLocalize();
+
+    const [draftValues] = useOnyx(ONYXKEYS.FORMS.GET_PHYSICAL_CARD_FORM_DRAFT);
 
     const {addressLine1, addressLine2, city = '', state = '', zipPostCode = '', country = '', phoneNumber = '', legalFirstName = '', legalLastName = ''} = draftValues ?? {};
 
@@ -94,8 +88,4 @@ function GetPhysicalCardConfirm({
 
 GetPhysicalCardConfirm.displayName = 'GetPhysicalCardConfirm';
 
-export default withOnyx<GetPhysicalCardConfirmProps, GetPhysicalCardConfirmOnyxProps>({
-    draftValues: {
-        key: ONYXKEYS.FORMS.GET_PHYSICAL_CARD_FORM_DRAFT,
-    },
-})(GetPhysicalCardConfirm);
+export default GetPhysicalCardConfirm;

--- a/src/pages/settings/Wallet/Card/GetPhysicalCardName.tsx
+++ b/src/pages/settings/Wallet/Card/GetPhysicalCardName.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import {View} from 'react-native';
 import {withOnyx} from 'react-native-onyx';
 import type {OnyxEntry} from 'react-native-onyx';
 import InputWrapper from '@components/Form/InputWrapper';
@@ -66,29 +67,31 @@ function GetPhysicalCardName({
             title={translate('getPhysicalCard.header')}
             onValidate={onValidate}
         >
-            <InputWrapper
-                InputComponent={TextInput}
-                inputID={INPUT_IDS.LEGAL_FIRST_NAME}
-                name={INPUT_IDS.LEGAL_FIRST_NAME}
-                label={translate('getPhysicalCard.legalFirstName')}
-                aria-label={translate('getPhysicalCard.legalFirstName')}
-                role={CONST.ROLE.PRESENTATION}
-                autoCapitalize="words"
-                defaultValue={legalFirstName}
-                shouldSaveDraft
-            />
-            <InputWrapper
-                InputComponent={TextInput}
-                inputID={INPUT_IDS.LEGAL_LAST_NAME}
-                name={INPUT_IDS.LEGAL_LAST_NAME}
-                label={translate('getPhysicalCard.legalLastName')}
-                aria-label={translate('getPhysicalCard.legalLastName')}
-                role={CONST.ROLE.PRESENTATION}
-                autoCapitalize="words"
-                defaultValue={legalLastName}
-                containerStyles={styles.mt5}
-                shouldSaveDraft
-            />
+            <View style={styles.mh5}>
+                <InputWrapper
+                    InputComponent={TextInput}
+                    inputID={INPUT_IDS.LEGAL_FIRST_NAME}
+                    name={INPUT_IDS.LEGAL_FIRST_NAME}
+                    label={translate('getPhysicalCard.legalFirstName')}
+                    aria-label={translate('getPhysicalCard.legalFirstName')}
+                    role={CONST.ROLE.PRESENTATION}
+                    autoCapitalize="words"
+                    defaultValue={legalFirstName}
+                    shouldSaveDraft
+                />
+                <InputWrapper
+                    InputComponent={TextInput}
+                    inputID={INPUT_IDS.LEGAL_LAST_NAME}
+                    name={INPUT_IDS.LEGAL_LAST_NAME}
+                    label={translate('getPhysicalCard.legalLastName')}
+                    aria-label={translate('getPhysicalCard.legalLastName')}
+                    role={CONST.ROLE.PRESENTATION}
+                    autoCapitalize="words"
+                    defaultValue={legalLastName}
+                    containerStyles={styles.mt5}
+                    shouldSaveDraft
+                />
+            </View>
         </BaseGetPhysicalCard>
     );
 }

--- a/src/pages/settings/Wallet/Card/GetPhysicalCardName.tsx
+++ b/src/pages/settings/Wallet/Card/GetPhysicalCardName.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import {View} from 'react-native';
-import {withOnyx} from 'react-native-onyx';
+import {useOnyx} from 'react-native-onyx';
 import type {OnyxEntry} from 'react-native-onyx';
 import InputWrapper from '@components/Form/InputWrapper';
 import TextInput from '@components/TextInput';
@@ -22,21 +22,17 @@ type OnValidateResult = {
     legalLastName?: string;
 };
 
-type GetPhysicalCardNameOnyxProps = {
-    /** Draft values used by the get physical card form */
-    draftValues: OnyxEntry<GetPhysicalCardForm>;
-};
-
-type GetPhysicalCardNameProps = GetPhysicalCardNameOnyxProps & PlatformStackScreenProps<SettingsNavigatorParamList, typeof SCREENS.SETTINGS.WALLET.CARD_GET_PHYSICAL.NAME>;
+type GetPhysicalCardNameProps = PlatformStackScreenProps<SettingsNavigatorParamList, typeof SCREENS.SETTINGS.WALLET.CARD_GET_PHYSICAL.NAME>;
 
 function GetPhysicalCardName({
-    draftValues,
     route: {
         params: {domain},
     },
 }: GetPhysicalCardNameProps) {
     const styles = useThemeStyles();
     const {translate} = useLocalize();
+
+    const [draftValues] = useOnyx(ONYXKEYS.FORMS.GET_PHYSICAL_CARD_FORM_DRAFT);
 
     const {legalFirstName = '', legalLastName = ''} = draftValues ?? {};
 
@@ -98,8 +94,4 @@ function GetPhysicalCardName({
 
 GetPhysicalCardName.displayName = 'GetPhysicalCardName';
 
-export default withOnyx<GetPhysicalCardNameProps, GetPhysicalCardNameOnyxProps>({
-    draftValues: {
-        key: ONYXKEYS.FORMS.GET_PHYSICAL_CARD_FORM_DRAFT,
-    },
-})(GetPhysicalCardName);
+export default GetPhysicalCardName;

--- a/src/pages/settings/Wallet/Card/GetPhysicalCardPhone.tsx
+++ b/src/pages/settings/Wallet/Card/GetPhysicalCardPhone.tsx
@@ -1,9 +1,11 @@
 import React from 'react';
+import {View} from 'react-native';
 import {withOnyx} from 'react-native-onyx';
 import type {OnyxEntry} from 'react-native-onyx';
 import InputWrapper from '@components/Form/InputWrapper';
 import TextInput from '@components/TextInput';
 import useLocalize from '@hooks/useLocalize';
+import useThemeStyles from '@hooks/useThemeStyles';
 import * as LoginUtils from '@libs/LoginUtils';
 import type {PlatformStackScreenProps} from '@libs/Navigation/PlatformStackNavigation/types';
 import type {SettingsNavigatorParamList} from '@navigation/types';
@@ -33,6 +35,7 @@ function GetPhysicalCardPhone({
     draftValues,
 }: GetPhysicalCardPhoneProps) {
     const {translate} = useLocalize();
+    const styles = useThemeStyles();
 
     const {phoneNumber = ''} = draftValues ?? {};
 
@@ -59,16 +62,18 @@ function GetPhysicalCardPhone({
             title={translate('getPhysicalCard.header')}
             onValidate={onValidate}
         >
-            <InputWrapper
-                InputComponent={TextInput}
-                inputID={INPUT_IDS.PHONE_NUMBER}
-                name={INPUT_IDS.PHONE_NUMBER}
-                label={translate('getPhysicalCard.phoneNumber')}
-                aria-label={translate('getPhysicalCard.phoneNumber')}
-                role={CONST.ROLE.PRESENTATION}
-                defaultValue={phoneNumber}
-                shouldSaveDraft
-            />
+            <View style={styles.mh5}>
+                <InputWrapper
+                    InputComponent={TextInput}
+                    inputID={INPUT_IDS.PHONE_NUMBER}
+                    name={INPUT_IDS.PHONE_NUMBER}
+                    label={translate('getPhysicalCard.phoneNumber')}
+                    aria-label={translate('getPhysicalCard.phoneNumber')}
+                    role={CONST.ROLE.PRESENTATION}
+                    defaultValue={phoneNumber}
+                    shouldSaveDraft
+                />
+            </View>
         </BaseGetPhysicalCard>
     );
 }

--- a/src/pages/settings/Wallet/Card/GetPhysicalCardPhone.tsx
+++ b/src/pages/settings/Wallet/Card/GetPhysicalCardPhone.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import {View} from 'react-native';
-import {withOnyx} from 'react-native-onyx';
+import {useOnyx} from 'react-native-onyx';
 import type {OnyxEntry} from 'react-native-onyx';
 import InputWrapper from '@components/Form/InputWrapper';
 import TextInput from '@components/TextInput';
@@ -21,21 +21,17 @@ type OnValidateResult = {
     phoneNumber?: string;
 };
 
-type GetPhysicalCardPhoneOnyxProps = {
-    /** Draft values used by the get physical card form */
-    draftValues: OnyxEntry<GetPhysicalCardForm>;
-};
-
-type GetPhysicalCardPhoneProps = GetPhysicalCardPhoneOnyxProps & PlatformStackScreenProps<SettingsNavigatorParamList, typeof SCREENS.SETTINGS.WALLET.CARD_GET_PHYSICAL.ADDRESS>;
+type GetPhysicalCardPhoneProps = PlatformStackScreenProps<SettingsNavigatorParamList, typeof SCREENS.SETTINGS.WALLET.CARD_GET_PHYSICAL.ADDRESS>;
 
 function GetPhysicalCardPhone({
     route: {
         params: {domain},
     },
-    draftValues,
 }: GetPhysicalCardPhoneProps) {
     const {translate} = useLocalize();
     const styles = useThemeStyles();
+
+    const [draftValues] = useOnyx(ONYXKEYS.FORMS.GET_PHYSICAL_CARD_FORM_DRAFT);
 
     const {phoneNumber = ''} = draftValues ?? {};
 
@@ -80,8 +76,4 @@ function GetPhysicalCardPhone({
 
 GetPhysicalCardPhone.displayName = 'GetPhysicalCardPhone';
 
-export default withOnyx<GetPhysicalCardPhoneProps, GetPhysicalCardPhoneOnyxProps>({
-    draftValues: {
-        key: ONYXKEYS.FORMS.GET_PHYSICAL_CARD_FORM_DRAFT,
-    },
-})(GetPhysicalCardPhone);
+export default GetPhysicalCardPhone;


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
<!-- Explain what your change does and how it addresses the linked issue -->

UI fix for: https://github.com/Expensify/App/issues/50394#issuecomment-2527644286
Navigation issue fix: https://github.com/Expensify/App/issues/50394#issuecomment-2528057602

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/50394
PROPOSAL: -


### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

1. [Admin] invite a new member (new Expensify user or a user that doesn't have the shipping details filled in) to the Workspace
2. [Admin] Issue a new Expensify Card for the newly added user.
3. [User] Go to wallet -> select the card -> click Get physical card
4. [User] Verify that for the each steps the elements (inputs, titles, buttons) are properly aligned (check Screenshots/Videos) 

Navigation issue:
[While doing step 4 from above]
1. Go through the flow - stop at the confirmation step.
2. Click on the first item - Legal name - you should be redirected to the Legal Name step.
3. Click on the header back button - verify that you're taken back to the confirmation step.
4. Do the same for the rest of the list items (phone number, address).

- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
6. Upload an image via copy paste
7. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->

// TODO: These must be filled out, or the issue title must include "[No QA]."

Same as above.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] If we are not using the full Onyx data that we loaded, I've added the proper selector in order to ensure the component only re-renders when the data it is using changes
        - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.


### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->
![Simulator Screenshot - iPhone 15 Pro - 2024-12-09 at 15 26 19](https://github.com/user-attachments/assets/69771c37-c79e-41d4-b74c-8d9dcdd88f06)
![Simulator Screenshot - iPhone 15 Pro - 2024-12-09 at 15 26 16](https://github.com/user-attachments/assets/6c7a0488-177c-4b3e-97fd-bcaa490fd49b)
![Simulator Screenshot - iPhone 15 Pro - 2024-12-09 at 15 26 09](https://github.com/user-attachments/assets/aff91ace-c0d6-4e2d-b644-79774eb5f585)
![Simulator Screenshot - iPhone 15 Pro - 2024-12-09 at 15 25 49](https://github.com/user-attachments/assets/1dff51f5-6054-479a-9013-3bf54594b640)
![Simulator Screenshot - iPhone 15 Pro - 2024-12-09 at 15 26 32](https://github.com/user-attachments/assets/b360f796-b9cb-4062-8f3c-e576bfa25923)

https://github.com/user-attachments/assets/1eaa7fb2-7cd0-43c5-841d-fc637f39938f

</details>



<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->
<img width="1120" alt="Screenshot 2024-12-09 at 14 50 46" src="https://github.com/user-attachments/assets/be73e5c4-2908-4385-aea1-57cc715c7700">
<img width="1123" alt="Screenshot 2024-12-09 at 14 50 58" src="https://github.com/user-attachments/assets/a8f96169-dde1-4c10-bd82-2391fc651230">
<img width="1120" alt="Screenshot 2024-12-09 at 14 50 36" src="https://github.com/user-attachments/assets/aefb2815-800d-47dc-9c65-3ced676d5796">
<img width="1125" alt="Screenshot 2024-12-09 at 14 53 25" src="https://github.com/user-attachments/assets/44279a1c-6e7d-4dc9-8efe-af8fa0f86769">

https://github.com/user-attachments/assets/ef6a5e60-0c18-4509-b00f-050ccde7283b

</details>

<details>
<summary>MacOS: Desktop</summary>

<!-- add screenshots or videos here -->

</details>
