### PR TITLE
Fix: Remove GBR and 'Add a bank account' for paid invoices

### DIFF
--- a/src/components/ReportActionItem/ReportPreview.tsx
+++ b/src/components/ReportActionItem/ReportPreview.tsx
@@ -346,7 +346,8 @@ function ReportPreview({
 
     const shouldShowSettlementButton = (shouldShowPayButton || shouldShowApproveButton) && !showRTERViolationMessage && !shouldShowBrokenConnectionViolation;
 
-    const shouldPromptUserToAddBankAccount = ReportUtils.hasMissingPaymentMethod(userWallet, iouReportID) || ReportUtils.hasMissingInvoiceBankAccount(iouReportID);
+    const shouldPromptUserToAddBankAccount =
+        (ReportUtils.hasMissingPaymentMethod(userWallet, iouReportID) || ReportUtils.hasMissingInvoiceBankAccount(iouReportID)) && !ReportUtils.isSettled(iouReportID);
     const shouldShowRBR = hasErrors && !iouSettled;
 
     /*

--- a/src/libs/ReportUtils.ts
+++ b/src/libs/ReportUtils.ts
@@ -2801,7 +2801,7 @@ function getReasonAndReportActionThatRequiresAttention(
         };
     }
 
-    if (hasMissingInvoiceBankAccount(optionOrReport.reportID)) {
+    if (hasMissingInvoiceBankAccount(optionOrReport.reportID) && !isSettled(optionOrReport.reportID)) {
         return {
             reason: CONST.REQUIRES_ATTENTION_REASONS.HAS_MISSING_INVOICE_BANK_ACCOUNT,
         };
@@ -2809,7 +2809,11 @@ function getReasonAndReportActionThatRequiresAttention(
 
     if (isInvoiceRoom(optionOrReport)) {
         const reportAction = Object.values(reportActions).find(
-            (action) => action.actionName === CONST.REPORT.ACTIONS.TYPE.REPORT_PREVIEW && action.childReportID && hasMissingInvoiceBankAccount(action.childReportID),
+            (action) =>
+                action.actionName === CONST.REPORT.ACTIONS.TYPE.REPORT_PREVIEW &&
+                action.childReportID &&
+                hasMissingInvoiceBankAccount(action.childReportID) &&
+                !isSettled(action.childReportID),
         );
 
         return reportAction

--- a/src/pages/home/report/ReportActionItemMessage.tsx
+++ b/src/pages/home/report/ReportActionItemMessage.tsx
@@ -131,12 +131,14 @@ function ReportActionItemMessage({action, displayAsGroup, reportID, style, isHid
         Navigation.navigate(ROUTES.WORKSPACE_INVOICES.getRoute(policyID));
     };
 
+    const shouldShowAddBankAccountButton = action.actionName === CONST.REPORT.ACTIONS.TYPE.IOU && ReportUtils.hasMissingInvoiceBankAccount(reportID) && !ReportUtils.isSettled(reportID);
+
     return (
         <View style={[styles.chatItemMessage, style]}>
             {!isHidden ? (
                 <>
                     {renderReportActionItemFragments(isApprovedOrSubmittedReportAction)}
-                    {action.actionName === CONST.REPORT.ACTIONS.TYPE.IOU && ReportUtils.hasMissingInvoiceBankAccount(reportID) && (
+                    {shouldShowAddBankAccountButton && (
                         <Button
                             style={[styles.mt2, styles.alignSelfStart]}
                             success


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
<!-- Explain what your change does and how it addresses the linked issue -->

This PR fixes the GBR to "Add a bank account" persiststing in the LHN despite the invoice being marked as "Paid elsewhere". There are 4 key places where this shows up which are all covered in this PR:
- the sidebar (LHN) parent report containing 2 or more child invoices with the same issue
- the sidebar (LHN) report GBR for child invoices
- the report action message showing the `Add a bank account` button
- the parent report preview including groups of 2 or more invoices

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/53577
PROPOSAL: https://github.com/Expensify/App/issues/53577#issuecomment-2524960552


### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

**Precondition**: The account must have bank account added and showing up in both Settings > Wallet section and WS Settings > Workflows section.

1. Send an invoice from this workspace to another user account (@gmail.com).
2. Log into the receiving account (@gmail.com), and mark the invoice as "Paid elsewhere."
3. Wait for a month and verify that there's no GBR to "Add a bank account" in the sidebar (LHN) report associated with paid invoice from (2).

**Note**: See before / after screenshots below for a better grasp of what the fix does.

- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

**N/A**.

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->

**Precondition**: The account must have bank account added and showing up in both Settings > Wallet section and WS Settings > Workflows section.

1. Create a test workspace using your @expensify.com account and make sure BA is added in WS Settings > Workflows section as well as in Settings > Wallet (user's side).
2. Send an invoice from this workspace to another user account (@gmail.com).
3. Log into the receiving account (@gmail.com), and mark the invoice as "Paid elsewhere."
5. Wait for a month and verify that there's no GBR to "Add a bank account" in the sidebar (LHN) report associated with paid invoice from (3).

**Note**: See before / after screenshots below for a better grasp of what the fix does.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

| Before (LHN) | After (LHN) |
| ------------- | ------------- |
| <img width="375" alt="before-main" src="https://github.com/user-attachments/assets/f3f45c13-d837-440c-a938-2a87583c20b0"> | <img width="375" alt="after-main" src="https://github.com/user-attachments/assets/37c284ac-3242-493c-b8e0-ecdf47d7640e"> |

| Before (Parent report) | After (Parent report) |
| ------------- | ------------- |
| <img width="375" alt="before-parent" src="https://github.com/user-attachments/assets/d3477db3-38c9-48e4-9f60-d3a5a7fc4bae"> | <img width="375" alt="after-parent" src="https://github.com/user-attachments/assets/fb844440-17d7-46fe-85be-786b9fda3ba4"> |

| Before (Child invoice) | After (Child invoice) |
| ------------- | ------------- |
| <img width="375" alt="before-child" src="https://github.com/user-attachments/assets/48c6ea86-b8b7-486e-8b35-bcf7973b7905"> | <img width="375" alt="after-child" src="https://github.com/user-attachments/assets/b16d40eb-5ef2-4c7e-9d82-be0689975228"> |

</details>

<details>
<summary>Android: mWeb Chrome</summary>

| Before (LHN) | After (LHN) |
| ------------- | ------------- |
| <img width="375" alt="before-main" src="https://github.com/user-attachments/assets/871c50ce-18ef-4a64-82e6-b36fff15cd8c"> | <img width="375" alt="after-main" src="https://github.com/user-attachments/assets/b825a028-592d-4faa-9370-234ce3d72a68"> |

| Before (Parent report) | After (Parent report) |
| ------------- | ------------- |
| <img width="375" alt="before-parent" src="https://github.com/user-attachments/assets/b86e2e41-fdaa-4493-b7f9-4e806d092a33"> | <img width="375" alt="after-parent" src="https://github.com/user-attachments/assets/42b094ee-b8d0-4add-9765-f5669a79024c"> |

| Before (Child invoice) | After (Child invoice) |
| ------------- | ------------- |
| <img width="375" alt="before-child" src="https://github.com/user-attachments/assets/99637987-e812-405e-8874-15ce1d3491f7"> | <img width="375" alt="after-child" src="https://github.com/user-attachments/assets/905e7231-c1fd-477d-ad4b-8bb084132e55"> |

</details>

<details>
<summary>iOS: Native</summary>

| Before (LHN) | After (LHN) |
| ------------- | ------------- |
| <img width="375" alt="before-main" src="https://github.com/user-attachments/assets/0097fef5-49f5-4690-9016-9755aceb90fc"> | <img width="375" alt="after-main" src="https://github.com/user-attachments/assets/d9bbeb2a-afc2-466b-972a-359214eeb462"> |

| Before (Parent report) | After (Parent report) |
| ------------- | ------------- |
| <img width="375" alt="before-parent" src="https://github.com/user-attachments/assets/64ae180e-63b2-42e0-8e4d-eeee7c0f11ab"> | <img width="375" alt="after-parent" src="https://github.com/user-attachments/assets/760e278f-0509-4f57-b859-57c1cb13e9bf"> |

| Before (Child invoice) | After (Child invoice) |
| ------------- | ------------- |
| <img width="375" alt="before-child" src="https://github.com/user-attachments/assets/2bacf74c-6aa3-42cb-805d-36955c998a2b"> | <img width="375" alt="after-child" src="https://github.com/user-attachments/assets/9ddfa549-44ab-4d17-a4f1-6200f6124b5c"> |

</details>

<details>
<summary>iOS: mWeb Safari</summary>

| Before (LHN) | After (LHN) |
| ------------- | ------------- |
| <img width="375" alt="before-main" src="https://github.com/user-attachments/assets/00649176-b8d6-4d54-8dfb-5f6af649f647"> | <img width="375" alt="after-main" src="https://github.com/user-attachments/assets/789cf9fb-67a5-4de0-a895-f36db67efe8a"> |

| Before (Parent report) | After (Parent report) |
| ------------- | ------------- |
| <img width="375" alt="before-parent" src="https://github.com/user-attachments/assets/d96b25f4-95f8-4d7d-b1ae-693a30759c3a"> | <img width="375" alt="after-parent" src="https://github.com/user-attachments/assets/043612ec-0983-4a2c-98d8-ab4342f2c69e"> |

| Before (Child invoice) | After (Child invoice) |
| ------------- | ------------- |
| <img width="375" alt="before-child" src="https://github.com/user-attachments/assets/a758b202-d09e-4d35-8346-5d145e028b9e"> | <img width="375" alt="after-child" src="https://github.com/user-attachments/assets/fe9800d1-271d-41ad-a8c2-2c4fb533a62d"> |

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

| Before (parent) | After (parent) |
| ------------- | ------------- |
| <img width="1433" alt="before-2" src="https://github.com/user-attachments/assets/a8b7f81b-78d9-467c-b37d-dce6f09844ee"> | <img width="1433" alt="after-2" src="https://github.com/user-attachments/assets/667bb3f5-4259-4716-b6cc-61324f56545d"> |

| Before (child) | After (child) |
| ------------- | ------------- |
| <img width="1433" alt="before-1" src="https://github.com/user-attachments/assets/6cd6476c-ccef-4738-af9b-dc9a0859112b"> | <img width="1433" alt="after-1" src="https://github.com/user-attachments/assets/90f3b1ff-5575-440d-bfc0-d72e7a7c12b1"> |

</details>

<details>
<summary>MacOS: Desktop</summary>

| Before (parent) | After (parent) |
| ------------- | ------------- |
| <img width="1200" alt="desktop-before-main-parent" src="https://github.com/user-attachments/assets/663edc83-d206-4073-8c52-4b4e68bd02af"> | <img width="1200" alt="desktop-after-parent" src="https://github.com/user-attachments/assets/786279ca-87bc-41e2-bc8c-520d3df40765"> |

| Before (child) | After (child) |
| ------------- | ------------- |
| <img width="1200" alt="desktop-before-child" src="https://github.com/user-attachments/assets/c62a4d2d-50c4-421b-8fed-ee608a1f7d13"> | <img width="1200" alt="desktop-after-child" src="https://github.com/user-attachments/assets/f63a6608-d03b-463f-a95a-f6fcc4c4c0bb"> |

</details>
