### PR TITLE
Fix chunk load error refresh

### DIFF
--- a/src/CONST.ts
+++ b/src/CONST.ts
@@ -349,6 +349,7 @@ const CONST = {
     SCREEN_TRANSITION_END_TIMEOUT: 1000,
     ARROW_HIDE_DELAY: 3000,
     MAX_IMAGE_CANVAS_AREA: 16777216,
+    CHUNK_LOAD_ERROR: 'ChunkLoadError',
 
     API_ATTACHMENT_VALIDATIONS: {
         // 24 megabytes in bytes, this is limit set on servers, do not update without wider internal discussion

--- a/src/components/ErrorBoundary/BaseErrorBoundary.tsx
+++ b/src/components/ErrorBoundary/BaseErrorBoundary.tsx
@@ -27,7 +27,7 @@ function BaseErrorBoundary({logError = () => {}, errorMessage, children}: BaseEr
 
     return (
         <ErrorBoundary
-            fallback={updateRequired ? <UpdateRequiredView /> : <GenericErrorPage />}
+            FallbackComponent={updateRequired ? UpdateRequiredView : GenericErrorPage}
             onError={catchError}
         >
             {children}

--- a/src/hooks/usePageRefresh/index.ts
+++ b/src/hooks/usePageRefresh/index.ts
@@ -3,13 +3,13 @@ import {useErrorBoundary} from 'react-error-boundary';
 import CONST from '@src/CONST';
 import type UsePageRefresh from './type';
 
-const usePageRefresh: UsePageRefresh = () => {
+const usePageRefresh: UsePageRefresh = (isChunkLoadError?: boolean) => {
     const {resetBoundary} = useErrorBoundary();
 
     return () => {
         const lastRefreshTimestamp = JSON.parse(sessionStorage.getItem(CONST.SESSION_STORAGE_KEYS.LAST_REFRESH_TIMESTAMP) ?? 'null') as string;
 
-        if (lastRefreshTimestamp === null || differenceInMilliseconds(Date.now(), Number(lastRefreshTimestamp)) > CONST.ERROR_WINDOW_RELOAD_TIMEOUT) {
+        if (!isChunkLoadError && (lastRefreshTimestamp === null || differenceInMilliseconds(Date.now(), Number(lastRefreshTimestamp)) > CONST.ERROR_WINDOW_RELOAD_TIMEOUT)) {
             resetBoundary();
             sessionStorage.setItem(CONST.SESSION_STORAGE_KEYS.LAST_REFRESH_TIMESTAMP, Date.now().toString());
 

--- a/src/hooks/usePageRefresh/index.ts
+++ b/src/hooks/usePageRefresh/index.ts
@@ -3,10 +3,10 @@ import {useErrorBoundary} from 'react-error-boundary';
 import CONST from '@src/CONST';
 import type UsePageRefresh from './type';
 
-const usePageRefresh: UsePageRefresh = (isChunkLoadError?: boolean) => {
+const usePageRefresh: UsePageRefresh = () => {
     const {resetBoundary} = useErrorBoundary();
 
-    return () => {
+    return (isChunkLoadError?: boolean) => {
         const lastRefreshTimestamp = JSON.parse(sessionStorage.getItem(CONST.SESSION_STORAGE_KEYS.LAST_REFRESH_TIMESTAMP) ?? 'null') as string;
 
         if (!isChunkLoadError && (lastRefreshTimestamp === null || differenceInMilliseconds(Date.now(), Number(lastRefreshTimestamp)) > CONST.ERROR_WINDOW_RELOAD_TIMEOUT)) {

--- a/src/hooks/usePageRefresh/type.ts
+++ b/src/hooks/usePageRefresh/type.ts
@@ -1,3 +1,3 @@
-type UsePageRefresh = (isChunkLoadError?: boolean) => () => void;
+type UsePageRefresh = () => (isChunkLoadError?: boolean) => void;
 
 export default UsePageRefresh;

--- a/src/hooks/usePageRefresh/type.ts
+++ b/src/hooks/usePageRefresh/type.ts
@@ -1,3 +1,3 @@
-type UsePageRefresh = () => () => void;
+type UsePageRefresh = (isChunkLoadError?: boolean) => () => void;
 
 export default UsePageRefresh;

--- a/src/pages/ErrorPage/GenericErrorPage.tsx
+++ b/src/pages/ErrorPage/GenericErrorPage.tsx
@@ -18,12 +18,13 @@ import * as Session from '@userActions/Session';
 import CONST from '@src/CONST';
 import ErrorBodyText from './ErrorBodyText';
 
-function GenericErrorPage() {
+function GenericErrorPage({error}: {error?: {message?: string; name?: string}}) {
     const theme = useTheme();
     const styles = useThemeStyles();
     const StyleUtils = useStyleUtils();
     const {translate} = useLocalize();
-    const refreshPage = usePageRefresh();
+    const isChunkLoadError = error?.name === CONST.CHUNK_LOAD_ERROR || /Loading chunk [\d]+ failed/.test(error?.message ?? '');
+    const refreshPage = usePageRefresh(isChunkLoadError);
 
     return (
         <SafeAreaConsumer>

--- a/src/pages/ErrorPage/GenericErrorPage.tsx
+++ b/src/pages/ErrorPage/GenericErrorPage.tsx
@@ -24,7 +24,7 @@ function GenericErrorPage({error}: {error?: Error}) {
     const StyleUtils = useStyleUtils();
     const {translate} = useLocalize();
     const isChunkLoadError = error?.name === CONST.CHUNK_LOAD_ERROR || /Loading chunk [\d]+ failed/.test(error?.message ?? '');
-    const refreshPage = usePageRefresh(isChunkLoadError);
+    const refreshPage = usePageRefresh();
 
     return (
         <SafeAreaConsumer>
@@ -61,7 +61,7 @@ function GenericErrorPage({error}: {error?: Error}) {
                                         success
                                         text={translate('genericErrorPage.refresh')}
                                         style={styles.mr3}
-                                        onPress={refreshPage}
+                                        onPress={() => refreshPage(isChunkLoadError)}
                                     />
                                     <Button
                                         text={translate('initialSettingsPage.signOut')}

--- a/src/pages/ErrorPage/GenericErrorPage.tsx
+++ b/src/pages/ErrorPage/GenericErrorPage.tsx
@@ -18,7 +18,7 @@ import * as Session from '@userActions/Session';
 import CONST from '@src/CONST';
 import ErrorBodyText from './ErrorBodyText';
 
-function GenericErrorPage({error}: {error?: {message?: string; name?: string}}) {
+function GenericErrorPage({error}: {error?: Error}) {
     const theme = useTheme();
     const styles = useThemeStyles();
     const StyleUtils = useStyleUtils();


### PR DESCRIPTION
### Explanation of Change
Wr should immediately refresh the page - when chunk loading was failed. Currently we allow user to click twice on r`efresh button` in `Something wrong page ` - which does not make sense in current situation.

### Fixed Issues

$ https://github.com/Expensify/App/issues/52312
PROPOSAL:


### Tests
Issue is hard to test. Such case may happened if user will move away from web more than a few hours.
For the C+ easier test may be with using mock data like:
```
const error1 = {name: 'ChunkLoadError'};
const error2 = {message: 'Loading chunk 189 failed'};
```
1. Run the web app.
2. Wait until some hours pass and in console will be shown ChunkError
3. Click refresh button
4. Verify that page is reloaded

For C+:
1. Run the web app.
2. Add in code mock data
3. Force error for the page (anything that will crash the page)
4. Click refresh button
5. Verify that page is reloaded

- [x] Verify that no errors appear in the JS console

### Offline tests
No changes

### QA Steps
Same as Tests section

- [x] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>


https://github.com/user-attachments/assets/34a746de-990a-4641-a7be-25467e317402


</details>

<details>
<summary>Android: mWeb Chrome</summary>


https://github.com/user-attachments/assets/758421bd-49fd-41a4-8737-078363624cd3


</details>

<details>
<summary>iOS: Native</summary>


https://github.com/user-attachments/assets/f671011f-0e39-4dfb-88c0-1629cde42f5c


</details>

<details>
<summary>iOS: mWeb Safari</summary>


https://github.com/user-attachments/assets/dd06cc8c-ce83-4adc-8e3f-4cecdf22be4d


</details>

<details>
<summary>MacOS: Chrome / Safari</summary>


https://github.com/user-attachments/assets/f8ae9ec7-aa96-4854-ac31-d704f3de35c0


</details>

<details>
<summary>MacOS: Desktop</summary>


https://github.com/user-attachments/assets/dd5668e8-a017-4e90-a2e7-37561b1e6a65


</details>
