### PR TITLE
feat: remove `KeyboardAvoidingView` compat layer

### DIFF
--- a/src/components/HeaderWithBackButton/index.tsx
+++ b/src/components/HeaderWithBackButton/index.tsx
@@ -10,7 +10,6 @@ import PressableWithoutFeedback from '@components/Pressable/PressableWithoutFeed
 import SearchButton from '@components/Search/SearchRouter/SearchButton';
 import ThreeDotsMenu from '@components/ThreeDotsMenu';
 import Tooltip from '@components/Tooltip';
-import useKeyboardState from '@hooks/useKeyboardState';
 import useLocalize from '@hooks/useLocalize';
 import useStyleUtils from '@hooks/useStyleUtils';
 import useTheme from '@hooks/useTheme';
@@ -72,7 +71,6 @@ function HeaderWithBackButton({
     const StyleUtils = useStyleUtils();
     const [isDownloadButtonActive, temporarilyDisableDownloadButton] = useThrottledButtonState();
     const {translate} = useLocalize();
-    const {isKeyboardShown} = useKeyboardState();
 
     // If the icon is present, the header bar should be taller and use different font.
     const isCentralPaneSettings = !!icon;
@@ -155,7 +153,7 @@ function HeaderWithBackButton({
                     <Tooltip text={translate('common.back')}>
                         <PressableWithoutFeedback
                             onPress={() => {
-                                if (isKeyboardShown) {
+                                if (Keyboard.isVisible()) {
                                     Keyboard.dismiss();
                                 }
                                 const topmostReportId = Navigation.getTopmostReportId();

--- a/src/components/KeyboardAvoidingView/index.android.tsx
+++ b/src/components/KeyboardAvoidingView/index.android.tsx
@@ -1,133 +1,15 @@
-import React, {forwardRef, useCallback, useMemo, useState} from 'react';
-import type {LayoutRectangle, View, ViewProps} from 'react-native';
-import {useKeyboardContext, useKeyboardHandler} from 'react-native-keyboard-controller';
-import Reanimated, {interpolate, runOnUI, useAnimatedStyle, useDerivedValue, useSharedValue} from 'react-native-reanimated';
-import {useSafeAreaFrame} from 'react-native-safe-area-context';
+/*
+ * The KeyboardAvoidingView is only used on ios
+ */
+import React from 'react';
+import {KeyboardAvoidingView as KeyboardAvoidingViewComponent} from 'react-native-keyboard-controller';
 import type {KeyboardAvoidingViewProps} from './types';
 
-const useKeyboardAnimation = () => {
-    const {reanimated} = useKeyboardContext();
+function KeyboardAvoidingView(props: KeyboardAvoidingViewProps) {
+    // eslint-disable-next-line react/jsx-props-no-spreading
+    return <KeyboardAvoidingViewComponent {...props} />;
+}
 
-    // calculate it only once on mount, to avoid `SharedValue` reads during a render
-    const [initialHeight] = useState(() => -reanimated.height.get());
-    const [initialProgress] = useState(() => reanimated.progress.get());
-
-    const heightWhenOpened = useSharedValue(initialHeight);
-    const height = useSharedValue(initialHeight);
-    const progress = useSharedValue(initialProgress);
-    const isClosed = useSharedValue(initialProgress === 0);
-
-    useKeyboardHandler(
-        {
-            onStart: (e) => {
-                'worklet';
-
-                progress.set(e.progress);
-                height.set(e.height);
-
-                if (e.height > 0) {
-                    isClosed.set(false);
-                    heightWhenOpened.set(e.height);
-                }
-            },
-            onEnd: (e) => {
-                'worklet';
-
-                isClosed.set(e.height === 0);
-                height.set(e.height);
-                progress.set(e.progress);
-            },
-        },
-        [],
-    );
-
-    return {height, progress, heightWhenOpened, isClosed};
-};
-
-const defaultLayout: LayoutRectangle = {
-    x: 0,
-    y: 0,
-    width: 0,
-    height: 0,
-};
-
-/**
- * View that moves out of the way when the keyboard appears by automatically
- * adjusting its height, position, or bottom padding.
- *
- * This `KeyboardAvoidingView` acts as a backward compatible layer for the previous Android behavior (prior to edge-to-edge mode).
- * We can use `KeyboardAvoidingView` directly from the `react-native-keyboard-controller` package, but in this case animations are stuttering and it's better to handle as a separate task.
- */
-const KeyboardAvoidingView = forwardRef<View, React.PropsWithChildren<KeyboardAvoidingViewProps>>(
-    ({behavior, children, contentContainerStyle, enabled = true, keyboardVerticalOffset = 0, style, onLayout: onLayoutProps, ...props}, ref) => {
-        const initialFrame = useSharedValue<LayoutRectangle | null>(null);
-        const frame = useDerivedValue(() => initialFrame.get() ?? defaultLayout);
-
-        const keyboard = useKeyboardAnimation();
-        const {height: screenHeight} = useSafeAreaFrame();
-
-        const relativeKeyboardHeight = useCallback(() => {
-            'worklet';
-
-            const keyboardY = screenHeight - keyboard.heightWhenOpened.get() - keyboardVerticalOffset;
-
-            return Math.max(frame.get().y + frame.get().height - keyboardY, 0);
-        }, [screenHeight, keyboard.heightWhenOpened, keyboardVerticalOffset, frame]);
-
-        const onLayoutWorklet = useCallback(
-            (layout: LayoutRectangle) => {
-                'worklet';
-
-                if (keyboard.isClosed.get() || initialFrame.get() === null) {
-                    initialFrame.set(layout);
-                }
-            },
-            [initialFrame, keyboard.isClosed],
-        );
-        const onLayout = useCallback<NonNullable<ViewProps['onLayout']>>(
-            (e) => {
-                runOnUI(onLayoutWorklet)(e.nativeEvent.layout);
-                onLayoutProps?.(e);
-            },
-            [onLayoutProps, onLayoutWorklet],
-        );
-
-        const animatedStyle = useAnimatedStyle(() => {
-            const bottom = interpolate(keyboard.progress.get(), [0, 1], [0, relativeKeyboardHeight()]);
-            const bottomHeight = enabled ? bottom : 0;
-
-            switch (behavior) {
-                case 'height':
-                    if (!keyboard.isClosed.get()) {
-                        return {
-                            height: frame.get().height - bottomHeight,
-                            flex: 0,
-                        };
-                    }
-
-                    return {};
-
-                case 'padding':
-                    return {paddingBottom: bottomHeight};
-
-                default:
-                    return {};
-            }
-        }, [behavior, enabled, relativeKeyboardHeight]);
-        const combinedStyles = useMemo(() => [style, animatedStyle], [style, animatedStyle]);
-
-        return (
-            <Reanimated.View
-                ref={ref}
-                style={combinedStyles}
-                onLayout={onLayout}
-                // eslint-disable-next-line react/jsx-props-no-spreading
-                {...props}
-            >
-                {children}
-            </Reanimated.View>
-        );
-    },
-);
+KeyboardAvoidingView.displayName = 'KeyboardAvoidingView';
 
 export default KeyboardAvoidingView;

--- a/src/components/ScreenWrapper.tsx
+++ b/src/components/ScreenWrapper.tsx
@@ -7,7 +7,6 @@ import {PickerAvoidingView} from 'react-native-picker-select';
 import type {EdgeInsets} from 'react-native-safe-area-context';
 import useEnvironment from '@hooks/useEnvironment';
 import useInitialDimensions from '@hooks/useInitialWindowDimensions';
-import useKeyboardState from '@hooks/useKeyboardState';
 import useNetwork from '@hooks/useNetwork';
 import useResponsiveLayout from '@hooks/useResponsiveLayout';
 import useStyledSafeAreaInsets from '@hooks/useStyledSafeAreaInsets';
@@ -158,18 +157,11 @@ function ScreenWrapper(
     const {isSmallScreenWidth, shouldUseNarrowLayout} = useResponsiveLayout();
     const {initialHeight} = useInitialDimensions();
     const styles = useThemeStyles();
-    const keyboardState = useKeyboardState();
     const {isDevelopment} = useEnvironment();
     const {isOffline} = useNetwork();
     const [didScreenTransitionEnd, setDidScreenTransitionEnd] = useState(false);
     const maxHeight = shouldEnableMaxHeight ? windowHeight : undefined;
     const minHeight = shouldEnableMinHeight && !Browser.isSafari() ? initialHeight : undefined;
-    const isKeyboardShown = keyboardState?.isKeyboardShown ?? false;
-
-    const isKeyboardShownRef = useRef<boolean>(false);
-
-    // eslint-disable-next-line react-compiler/react-compiler
-    isKeyboardShownRef.current = keyboardState?.isKeyboardShown ?? false;
 
     const route = useRoute();
     const shouldReturnToOldDot = useMemo(() => {
@@ -191,7 +183,7 @@ function ScreenWrapper(
         PanResponder.create({
             onMoveShouldSetPanResponderCapture: (_e, gestureState) => {
                 const isHorizontalSwipe = Math.abs(gestureState.dx) > Math.abs(gestureState.dy);
-                const shouldDismissKeyboard = shouldDismissKeyboardBeforeClose && isKeyboardShown && Browser.isMobile();
+                const shouldDismissKeyboard = shouldDismissKeyboardBeforeClose && Keyboard.isVisible() && Browser.isMobile();
 
                 return isHorizontalSwipe && shouldDismissKeyboard;
             },
@@ -221,7 +213,7 @@ function ScreenWrapper(
         // described here https://reactnavigation.org/docs/preventing-going-back/#limitations
         const beforeRemoveSubscription = shouldDismissKeyboardBeforeClose
             ? navigation.addListener('beforeRemove', () => {
-                  if (!isKeyboardShownRef.current) {
+                  if (!Keyboard.isVisible()) {
                       return;
                   }
                   Keyboard.dismiss();

--- a/src/components/withKeyboardState.tsx
+++ b/src/components/withKeyboardState.tsx
@@ -1,7 +1,6 @@
-import type {ComponentType, ForwardedRef, ReactElement, RefAttributes} from 'react';
-import React, {createContext, forwardRef, useEffect, useMemo, useState} from 'react';
+import type {ReactElement} from 'react';
+import React, {createContext, useEffect, useMemo, useState} from 'react';
 import {Keyboard} from 'react-native';
-import getComponentDisplayName from '@libs/getComponentDisplayName';
 import type ChildrenProps from '@src/types/utils/ChildrenProps';
 
 type KeyboardStateContextValue = {
@@ -42,28 +41,6 @@ function KeyboardStateProvider({children}: ChildrenProps): ReactElement | null {
         [keyboardHeight],
     );
     return <KeyboardStateContext.Provider value={contextValue}>{children}</KeyboardStateContext.Provider>;
-}
-
-export default function withKeyboardState<TProps extends KeyboardStateContextValue, TRef>(
-    WrappedComponent: ComponentType<TProps & RefAttributes<TRef>>,
-): (props: Omit<TProps, keyof KeyboardStateContextValue> & React.RefAttributes<TRef>) => ReactElement | null {
-    function WithKeyboardState(props: Omit<TProps, keyof KeyboardStateContextValue>, ref: ForwardedRef<TRef>) {
-        return (
-            <KeyboardStateContext.Consumer>
-                {(keyboardStateProps) => (
-                    <WrappedComponent
-                        // eslint-disable-next-line react/jsx-props-no-spreading
-                        {...keyboardStateProps}
-                        // eslint-disable-next-line react/jsx-props-no-spreading
-                        {...(props as TProps)}
-                        ref={ref}
-                    />
-                )}
-            </KeyboardStateContext.Consumer>
-        );
-    }
-    WithKeyboardState.displayName = `withKeyboardState(${getComponentDisplayName(WrappedComponent)})`;
-    return forwardRef(WithKeyboardState);
 }
 
 export type {KeyboardStateContextValue};


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change

- use `KeyboardAvoidingView` directly from `react-native-keyboard-controller` (without our fork)
- optimize some component re-render and replace `isKeyboardShown` with `Keyboard.isVisible()`.

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/52958
PROPOSAL: N/A


### Tests

1. go through all pages in app and make sure keyboard resize transitions are animated on Android;

### Offline tests

N/A

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->

1. go through all pages in app and make sure keyboard resize transitions are animated on Android;

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

https://github.com/user-attachments/assets/65da04da-4aa7-4652-b79c-b3a7be7d6587

</details>

<details>
<summary>Android: mWeb Chrome</summary>

https://github.com/user-attachments/assets/e37a9d41-2018-4f9d-8fa3-a49d64520e70

</details>

<details>
<summary>iOS: Native</summary>

https://github.com/user-attachments/assets/c8edc8c0-e292-4eba-b7bf-49cb7cbb67e8

</details>

<details>
<summary>iOS: mWeb Safari</summary>

https://github.com/user-attachments/assets/7c3f1e2e-714c-41ac-be45-8a87b64565f8

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Desktop</summary>

<!-- add screenshots or videos here -->

</details>
