### PR TITLE
Refactor SMS Delivery Failure sign in flow

### DIFF
--- a/src/languages/en.ts
+++ b/src/languages/en.ts
@@ -483,6 +483,7 @@ const translations = {
         skip: 'Skip',
         chatWithAccountManager: ({accountManagerDisplayName}: ChatWithAccountManagerParams) => `Need something specific? Chat with your account manager, ${accountManagerDisplayName}.`,
         chatNow: 'Chat now',
+        validate: 'Validate',
     },
     supportalNoAccess: {
         title: 'Not so fast',
@@ -1843,7 +1844,10 @@ const translations = {
         toUnblock: ' to unblock your login.',
     },
     smsDeliveryFailurePage: {
-        smsDeliveryFailureMessage: ({login}: OurEmailProviderParams) => `We've been unable to deliver SMS messages to ${login}, so we've suspended it for 24 hours.`,
+        smsDeliveryFailureMessage: ({login}: OurEmailProviderParams) =>
+            `We've been unable to deliver SMS messages to ${login}, so we've suspended it for 24 hours. Please try validating your number:`,
+        validationFailed: 'Validation failed because it hasn’t been 24 hours since your last attempt.',
+        validationSuccess: 'Your number has been validated! Click below to send a new magic sign-in code.',
     },
     welcomeSignUpForm: {
         join: 'Join',

--- a/src/languages/es.ts
+++ b/src/languages/es.ts
@@ -474,6 +474,7 @@ const translations = {
         days: 'días',
         chatWithAccountManager: ({accountManagerDisplayName}: ChatWithAccountManagerParams) => `¿Necesitas algo específico? Habla con tu gerente de cuenta, ${accountManagerDisplayName}.`,
         chatNow: 'Chatear ahora',
+        validate: 'Validar',
     },
     supportalNoAccess: {
         title: 'No tan rápido',
@@ -1848,7 +1849,10 @@ const translations = {
         toUnblock: ' para desbloquear el inicio de sesión.',
     },
     smsDeliveryFailurePage: {
-        smsDeliveryFailureMessage: ({login}: OurEmailProviderParams) => `No hemos podido entregar mensajes SMS a ${login}, por lo que lo hemos suspendido durante 24 horas.`,
+        smsDeliveryFailureMessage: ({login}: OurEmailProviderParams) =>
+            `No hemos podido entregar mensajes SMS a ${login}, por lo que lo hemos suspendido durante 24 horas. Por favor, intenta validar tu número:`,
+        validationFailed: 'La validación falló porque no han pasado 24 horas desde tu último intento.',
+        validationSuccess: '¡Tu número ha sido validado! Haz clic abajo para enviar un nuevo código mágico de inicio de sesión.',
     },
     welcomeSignUpForm: {
         join: 'Unirse',

--- a/src/languages/es.ts
+++ b/src/languages/es.ts
@@ -1850,7 +1850,7 @@ const translations = {
     },
     smsDeliveryFailurePage: {
         smsDeliveryFailureMessage: ({login}: OurEmailProviderParams) =>
-            `No hemos podido entregar mensajes SMS a ${login}, por lo que lo hemos suspendido durante 24 horas. Por favor, intenta validar tu número:`,
+            `No hemos podido entregar mensajes SMS a ${login}, así que lo hemos suspendido durante 24 horas. Por favor, intenta validar tu número:`,
         validationFailed: 'La validación falló porque no han pasado 24 horas desde tu último intento.',
         validationSuccess: '¡Tu número ha sido validado! Haz clic abajo para enviar un nuevo código mágico de inicio de sesión.',
     },

--- a/src/libs/API/parameters/ResetSMSDeliveryFailureParams.ts
+++ b/src/libs/API/parameters/ResetSMSDeliveryFailureParams.ts
@@ -1,0 +1,5 @@
+type ResetSMSDeliveryFailureParams = {
+    email: string;
+};
+
+export default ResetSMSDeliveryFailureParams;

--- a/src/libs/API/parameters/ResetSMSDeliveryFailureParams.ts
+++ b/src/libs/API/parameters/ResetSMSDeliveryFailureParams.ts
@@ -1,5 +1,5 @@
 type ResetSMSDeliveryFailureParams = {
-    email: string;
+    login: string;
 };
 
 export default ResetSMSDeliveryFailureParams;

--- a/src/libs/API/parameters/index.ts
+++ b/src/libs/API/parameters/index.ts
@@ -356,3 +356,4 @@ export type {default as JoinAccessiblePolicyParams} from './JoinAccessiblePolicy
 export type {default as ImportPerDiemRatesParams} from './ImportPerDiemRatesParams';
 export type {default as ExportPerDiemCSVParams} from './ExportPerDiemCSVParams';
 export type {default as DismissProductTrainingParams} from './DismissProductTraining';
+export type {default as ResetSMSDeliveryFailureParams} from './ResetSMSDeliveryFailureParams';

--- a/src/libs/API/types.ts
+++ b/src/libs/API/types.ts
@@ -441,6 +441,7 @@ const WRITE_COMMANDS = {
     UPDATE_INVOICE_COMPANY_WEBSITE: 'UpdateInvoiceCompanyWebsite',
     VALIDATE_USER_AND_GET_ACCESSIBLE_POLICIES: 'ValidateUserAndGetAccessiblePolicies',
     DISMISS_PRODUCT_TRAINING: 'DismissProductTraining',
+    RESET_SMS_DELIVERY_FAILURE: 'ResetSMSDeliveryFailure',
 } as const;
 
 type WriteCommand = ValueOf<typeof WRITE_COMMANDS>;
@@ -766,6 +767,7 @@ type WriteCommandParameters = {
     [WRITE_COMMANDS.UPDATE_SUBSCRIPTION_ADD_NEW_USERS_AUTOMATICALLY]: Parameters.UpdateSubscriptionAddNewUsersAutomaticallyParams;
     [WRITE_COMMANDS.UPDATE_SUBSCRIPTION_SIZE]: Parameters.UpdateSubscriptionSizeParams;
     [WRITE_COMMANDS.REQUEST_TAX_EXEMPTION]: null;
+    [WRITE_COMMANDS.RESET_SMS_DELIVERY_FAILURE]: Parameters.ResetSMSDeliveryFailureParams;
 
     [WRITE_COMMANDS.DELETE_MONEY_REQUEST_ON_SEARCH]: Parameters.DeleteMoneyRequestOnSearchParams;
     [WRITE_COMMANDS.HOLD_MONEY_REQUEST_ON_SEARCH]: Parameters.HoldMoneyRequestOnSearchParams;

--- a/src/libs/actions/Session/index.ts
+++ b/src/libs/actions/Session/index.ts
@@ -1204,10 +1204,45 @@ function isUserOnPrivateDomain() {
 /**
  * To reset SMS delivery failure
  */
-function resetSMSDeliveryFailure(email: string) {
-    const params: ResetSMSDeliveryFailureParams = {email};
+function resetSMSDeliveryFailure(login: string) {
+    const params: ResetSMSDeliveryFailureParams = {login};
 
-    API.write(WRITE_COMMANDS.RESET_SMS_DELIVERY_FAILURE, params);
+    const optimisticData: OnyxUpdate[] = [
+        {
+            onyxMethod: Onyx.METHOD.MERGE,
+            key: ONYXKEYS.ACCOUNT,
+            value: {
+                smsDeliveryFailureStatus: {
+                    isLoading: true,
+                    isReset: true,
+                },
+            },
+        },
+    ];
+    const successData: OnyxUpdate[] = [
+        {
+            onyxMethod: Onyx.METHOD.MERGE,
+            key: ONYXKEYS.ACCOUNT,
+            value: {
+                smsDeliveryFailureStatus: {
+                    isLoading: false,
+                },
+            },
+        },
+    ];
+    const failureData: OnyxUpdate[] = [
+        {
+            onyxMethod: Onyx.METHOD.MERGE,
+            key: ONYXKEYS.ACCOUNT,
+            value: {
+                smsDeliveryFailureStatus: {
+                    isLoading: false,
+                },
+            },
+        },
+    ];
+
+    API.write(WRITE_COMMANDS.RESET_SMS_DELIVERY_FAILURE, params, {optimisticData, successData, failureData});
 }
 
 export {

--- a/src/libs/actions/Session/index.ts
+++ b/src/libs/actions/Session/index.ts
@@ -1212,9 +1212,9 @@ function resetSMSDeliveryFailure(login: string) {
             onyxMethod: Onyx.METHOD.MERGE,
             key: ONYXKEYS.ACCOUNT,
             value: {
+                errors: null,
                 smsDeliveryFailureStatus: {
                     isLoading: true,
-                    isReset: true,
                 },
             },
         },
@@ -1226,6 +1226,7 @@ function resetSMSDeliveryFailure(login: string) {
             value: {
                 smsDeliveryFailureStatus: {
                     isLoading: false,
+                    isReset: true,
                 },
             },
         },
@@ -1235,6 +1236,7 @@ function resetSMSDeliveryFailure(login: string) {
             onyxMethod: Onyx.METHOD.MERGE,
             key: ONYXKEYS.ACCOUNT,
             value: {
+                errors: ErrorUtils.getMicroSecondOnyxErrorWithTranslationKey('common.genericErrorMessage'),
                 smsDeliveryFailureStatus: {
                     isLoading: false,
                 },

--- a/src/libs/actions/Session/index.ts
+++ b/src/libs/actions/Session/index.ts
@@ -17,6 +17,7 @@ import type {
     RequestAccountValidationLinkParams,
     RequestNewValidateCodeParams,
     RequestUnlinkValidationLinkParams,
+    ResetSMSDeliveryFailureParams,
     SignInUserWithLinkParams,
     SignUpUserParams,
     UnlinkLoginParams,
@@ -1200,6 +1201,15 @@ function isUserOnPrivateDomain() {
     return false;
 }
 
+/**
+ * To reset SMS delivery failure
+ */
+function resetSMSDeliveryFailure(email: string) {
+    const params: ResetSMSDeliveryFailureParams = {email};
+
+    API.write(WRITE_COMMANDS.RESET_SMS_DELIVERY_FAILURE, params);
+}
+
 export {
     beginSignIn,
     beginAppleSignIn,
@@ -1239,4 +1249,5 @@ export {
     signInAfterTransitionFromOldDot,
     validateUserAndGetAccessiblePolicies,
     isUserOnPrivateDomain,
+    resetSMSDeliveryFailure,
 };

--- a/src/pages/signin/SMSDeliveryFailurePage.tsx
+++ b/src/pages/signin/SMSDeliveryFailurePage.tsx
@@ -27,6 +27,7 @@ function SMSDeliveryFailurePage() {
     }, [credentials?.login]);
 
     const SMSDeliveryFailureMessage = account?.smsDeliveryFailureStatus?.message;
+    const hasSMSDeliveryFailure = account?.smsDeliveryFailureStatus?.hasSMSDeliveryFailure;
 
     useEffect(() => {
         if (!isKeyboardShown) {
@@ -35,22 +36,67 @@ function SMSDeliveryFailurePage() {
         Keyboard.dismiss();
     }, [isKeyboardShown]);
 
+    if (hasSMSDeliveryFailure === true) {
+        return (
+            <>
+                <View style={[styles.mv3, styles.flexRow]}>
+                    <View style={[styles.flex1]}>
+                        <Text>
+                            {translate('smsDeliveryFailurePage.validationFailed')} {SMSDeliveryFailureMessage}
+                        </Text>
+                    </View>
+                </View>
+                <View style={[styles.mv4, styles.flexRow, styles.justifyContentBetween, styles.alignItemsEnd]}>
+                    <Button
+                        success
+                        medium
+                        text={translate('common.buttonConfirm')}
+                        onPress={() => Session.clearSignInData()}
+                        pressOnEnter
+                        style={styles.w100}
+                    />
+                </View>
+            </>
+        );
+    }
+
+    if (hasSMSDeliveryFailure === false) {
+        return (
+            <>
+                <View style={[styles.mv3, styles.flexRow]}>
+                    <View style={[styles.flex1]}>
+                        <Text>{translate('smsDeliveryFailurePage.validationSuccess')}</Text>
+                    </View>
+                </View>
+                <View style={[styles.mv4, styles.flexRow, styles.justifyContentBetween, styles.alignItemsEnd]}>
+                    <Button
+                        success
+                        medium
+                        text={translate('common.send')}
+                        onPress={() => Session.beginSignIn(login)}
+                        pressOnEnter
+                        style={styles.w100}
+                    />
+                </View>
+            </>
+        );
+    }
+
     return (
         <>
             <View style={[styles.mv3, styles.flexRow]}>
                 <View style={[styles.flex1]}>
-                    <Text>
-                        {translate('smsDeliveryFailurePage.smsDeliveryFailureMessage', {login})} {SMSDeliveryFailureMessage}
-                    </Text>
+                    <Text>{translate('smsDeliveryFailurePage.smsDeliveryFailureMessage', {login})}</Text>
                 </View>
             </View>
             <View style={[styles.mv4, styles.flexRow, styles.justifyContentBetween, styles.alignItemsEnd]}>
                 <Button
                     success
                     medium
-                    text={translate('common.buttonConfirm')}
-                    onPress={() => Session.clearSignInData()}
+                    text={translate('common.validate')}
+                    onPress={() => console.log('resetSMSDeliveryFailure')}
                     pressOnEnter
+                    style={styles.w100}
                 />
             </View>
             <View style={[styles.mt3, styles.mb2]}>

--- a/src/pages/signin/SMSDeliveryFailurePage.tsx
+++ b/src/pages/signin/SMSDeliveryFailurePage.tsx
@@ -3,10 +3,12 @@ import React, {useEffect, useMemo} from 'react';
 import {Keyboard, View} from 'react-native';
 import {useOnyx} from 'react-native-onyx';
 import Button from '@components/Button';
+import FormAlertWithSubmitButton from '@components/FormAlertWithSubmitButton';
 import Text from '@components/Text';
 import useKeyboardState from '@hooks/useKeyboardState';
 import useLocalize from '@hooks/useLocalize';
 import useThemeStyles from '@hooks/useThemeStyles';
+import * as ErrorUtils from '@libs/ErrorUtils';
 import * as Session from '@userActions/Session';
 import ONYXKEYS from '@src/ONYXKEYS';
 import ChangeExpensifyLoginLink from './ChangeExpensifyLoginLink';
@@ -28,6 +30,10 @@ function SMSDeliveryFailurePage() {
 
     const SMSDeliveryFailureMessage = account?.smsDeliveryFailureStatus?.message;
     const hasSMSDeliveryFailure = account?.smsDeliveryFailureStatus?.hasSMSDeliveryFailure;
+    const isReset = account?.smsDeliveryFailureStatus?.isReset;
+
+    const errorText = useMemo(() => (account ? ErrorUtils.getLatestErrorMessage(account) : ''), [account]);
+    const shouldShowError = !!errorText;
 
     useEffect(() => {
         if (!isKeyboardShown) {
@@ -36,7 +42,7 @@ function SMSDeliveryFailurePage() {
         Keyboard.dismiss();
     }, [isKeyboardShown]);
 
-    if (hasSMSDeliveryFailure === true) {
+    if (hasSMSDeliveryFailure && isReset) {
         return (
             <>
                 <View style={[styles.mv3, styles.flexRow]}>
@@ -49,18 +55,24 @@ function SMSDeliveryFailurePage() {
                 <View style={[styles.mv4, styles.flexRow, styles.justifyContentBetween, styles.alignItemsEnd]}>
                     <Button
                         success
-                        medium
+                        large
                         text={translate('common.buttonConfirm')}
                         onPress={() => Session.clearSignInData()}
                         pressOnEnter
                         style={styles.w100}
                     />
                 </View>
+                <View style={[styles.mt3, styles.mb2]}>
+                    <ChangeExpensifyLoginLink onPress={() => Session.clearSignInData()} />
+                </View>
+                <View style={[styles.mt4, styles.signInPageWelcomeTextContainer]}>
+                    <Terms />
+                </View>
             </>
         );
     }
 
-    if (hasSMSDeliveryFailure === false) {
+    if (!hasSMSDeliveryFailure && isReset) {
         return (
             <>
                 <View style={[styles.mv3, styles.flexRow]}>
@@ -69,14 +81,20 @@ function SMSDeliveryFailurePage() {
                     </View>
                 </View>
                 <View style={[styles.mv4, styles.flexRow, styles.justifyContentBetween, styles.alignItemsEnd]}>
-                    <Button
-                        success
-                        medium
-                        text={translate('common.send')}
-                        onPress={() => Session.beginSignIn(login)}
-                        pressOnEnter
-                        style={styles.w100}
+                    <FormAlertWithSubmitButton
+                        buttonText={translate('common.send')}
+                        isLoading={account?.isLoading}
+                        onSubmit={() => Session.beginSignIn(login)}
+                        message={errorText}
+                        isAlertVisible={shouldShowError}
+                        containerStyles={[styles.w100, styles.mh0]}
                     />
+                </View>
+                <View style={[styles.mt3, styles.mb2]}>
+                    <ChangeExpensifyLoginLink onPress={() => Session.clearSignInData()} />
+                </View>
+                <View style={[styles.mt4, styles.signInPageWelcomeTextContainer]}>
+                    <Terms />
                 </View>
             </>
         );
@@ -90,13 +108,13 @@ function SMSDeliveryFailurePage() {
                 </View>
             </View>
             <View style={[styles.mv4, styles.flexRow, styles.justifyContentBetween, styles.alignItemsEnd]}>
-                <Button
-                    success
-                    medium
-                    text={translate('common.validate')}
-                    onPress={() => Session.resetSMSDeliveryFailure(login)}
-                    pressOnEnter
-                    style={styles.w100}
+                <FormAlertWithSubmitButton
+                    buttonText={translate('common.validate')}
+                    isLoading={account?.smsDeliveryFailureStatus?.isLoading}
+                    onSubmit={() => Session.resetSMSDeliveryFailure(login)}
+                    message={errorText}
+                    isAlertVisible={shouldShowError}
+                    containerStyles={[styles.w100, styles.mh0]}
                 />
             </View>
             <View style={[styles.mt3, styles.mb2]}>

--- a/src/pages/signin/SMSDeliveryFailurePage.tsx
+++ b/src/pages/signin/SMSDeliveryFailurePage.tsx
@@ -94,7 +94,7 @@ function SMSDeliveryFailurePage() {
                     success
                     medium
                     text={translate('common.validate')}
-                    onPress={() => console.log('resetSMSDeliveryFailure')}
+                    onPress={() => Session.resetSMSDeliveryFailure(login)}
                     pressOnEnter
                     style={styles.w100}
                 />

--- a/src/pages/signin/SignInPage.tsx
+++ b/src/pages/signin/SignInPage.tsx
@@ -94,7 +94,7 @@ function getRenderOptions({
     const isSAMLEnabled = !!account?.isSAMLEnabled;
     const isSAMLRequired = !!account?.isSAMLRequired;
     const hasEmailDeliveryFailure = !!account?.hasEmailDeliveryFailure;
-    const hasSMSDeliveryFailure = !!account?.smsDeliveryFailureStatus?.hasSMSDeliveryFailure;
+    const hasSMSDeliveryFailure = !!account?.smsDeliveryFailureStatus;
 
     // True, if the user has SAML required, and we haven't yet initiated SAML for their account
     const shouldInitiateSAMLLogin = hasAccount && hasLogin && isSAMLRequired && !hasInitiatedSAMLLogin && !!account.isLoading;

--- a/src/pages/signin/SignInPage.tsx
+++ b/src/pages/signin/SignInPage.tsx
@@ -49,7 +49,7 @@ type SignInPageRef = {
 type RenderOption = {
     shouldShowLoginForm: boolean;
     shouldShowEmailDeliveryFailurePage: boolean;
-    shouldShowSMSDeliveryFailurePage: boolean;
+    shouldShowSMSDeliveryFailurePage: boolean | undefined;
     shouldShowUnlinkLoginForm: boolean;
     shouldShowValidateCodeForm: boolean;
     shouldShowChooseSSOOrMagicCode: boolean;

--- a/src/pages/signin/SignInPage.tsx
+++ b/src/pages/signin/SignInPage.tsx
@@ -49,7 +49,7 @@ type SignInPageRef = {
 type RenderOption = {
     shouldShowLoginForm: boolean;
     shouldShowEmailDeliveryFailurePage: boolean;
-    shouldShowSMSDeliveryFailurePage: boolean | undefined;
+    shouldShowSMSDeliveryFailurePage: boolean;
     shouldShowUnlinkLoginForm: boolean;
     shouldShowValidateCodeForm: boolean;
     shouldShowChooseSSOOrMagicCode: boolean;
@@ -111,7 +111,7 @@ function getRenderOptions({
     const shouldShouldSignUpWelcomeForm = !!credentials?.login && !account?.validated && !account?.accountExists && !account?.domainControlled;
     const shouldShowLoginForm = !shouldShowAnotherLoginPageOpenedMessage && !hasLogin && !hasValidateCode;
     const shouldShowEmailDeliveryFailurePage = hasLogin && hasEmailDeliveryFailure && !shouldShowChooseSSOOrMagicCode && !shouldInitiateSAMLLogin;
-    const shouldShowSMSDeliveryFailurePage = hasLogin && hasSMSDeliveryFailure && !shouldShowChooseSSOOrMagicCode && !shouldInitiateSAMLLogin && account?.accountExists;
+    const shouldShowSMSDeliveryFailurePage = !!(hasLogin && hasSMSDeliveryFailure && !shouldShowChooseSSOOrMagicCode && !shouldInitiateSAMLLogin && account?.accountExists);
     const isUnvalidatedSecondaryLogin = hasLogin && !isPrimaryLogin && !account?.validated && !hasEmailDeliveryFailure && !hasSMSDeliveryFailure;
     const shouldShowValidateCodeForm =
         !shouldShouldSignUpWelcomeForm &&

--- a/src/pages/signin/SignInPage.tsx
+++ b/src/pages/signin/SignInPage.tsx
@@ -111,7 +111,7 @@ function getRenderOptions({
     const shouldShouldSignUpWelcomeForm = !!credentials?.login && !account?.validated && !account?.accountExists && !account?.domainControlled;
     const shouldShowLoginForm = !shouldShowAnotherLoginPageOpenedMessage && !hasLogin && !hasValidateCode;
     const shouldShowEmailDeliveryFailurePage = hasLogin && hasEmailDeliveryFailure && !shouldShowChooseSSOOrMagicCode && !shouldInitiateSAMLLogin;
-    const shouldShowSMSDeliveryFailurePage = hasLogin && hasSMSDeliveryFailure && !shouldShowChooseSSOOrMagicCode && !shouldInitiateSAMLLogin;
+    const shouldShowSMSDeliveryFailurePage = hasLogin && hasSMSDeliveryFailure && !shouldShowChooseSSOOrMagicCode && !shouldInitiateSAMLLogin && account?.accountExists;
     const isUnvalidatedSecondaryLogin = hasLogin && !isPrimaryLogin && !account?.validated && !hasEmailDeliveryFailure && !hasSMSDeliveryFailure;
     const shouldShowValidateCodeForm =
         !shouldShouldSignUpWelcomeForm &&

--- a/src/types/onyx/Account.ts
+++ b/src/types/onyx/Account.ts
@@ -69,7 +69,7 @@ type SMSDeliveryFailureStatus = {
     message: string;
 
     /** Indicates whether the SMS delivery failure status has been reset by an API call */
-    isReset: boolean;
+    isReset?: boolean;
 
     /** Whether a sign is loading */
     isLoading?: boolean;

--- a/src/types/onyx/Account.ts
+++ b/src/types/onyx/Account.ts
@@ -67,6 +67,12 @@ type SMSDeliveryFailureStatus = {
 
     /** The message associated with the SMS delivery failure */
     message: string;
+
+    /** Indicates whether the SMS delivery failure status has been reset by an API call */
+    isReset: boolean;
+
+    /** Whether a sign is loading */
+    isLoading?: boolean;
 };
 
 /** Model of user account */


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
<!-- Explain what your change does and how it addresses the linked issue -->

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/53980
PROPOSAL: https://github.com/Expensify/App/issues/53980#issuecomment-2537759035


### Tests
Same as QA Steps

- [x] Verify that no errors appear in the JS console

### Offline tests
Same as QA Steps

### QA Steps
**Test 1 (Simulate SMS Failure):**

1. Log in with an existing account.
2. On the login page with the magic code request, type `Onyx.merge("account", {smsDeliveryFailureStatus: {}});` in the console.
3. Verify that the `smsDeliveryFailurePage` is displayed correctly.

**Test 2 (Simulate Validate Fail):**

1. Repeat steps 1-3 on Test 1
2. Click the "Validate" button and type `Onyx.merge("account", {smsDeliveryFailureStatus: {isReset: true, hasSMSDeliveryFailure: true, message: "Please wait 23 hours and 37 minutes before trying again."}});` on the console
3. Verify that the message is displayed correctly
4. Click the "Got it" button
5. Verify that the user is navigated to the beginning of the sign-in flow

**Test 3 (Simulate Validate Success):**

1. Repeat steps 1-3 on Test 1
2. Click the "Validate" button and type `Onyx.merge("account", {smsDeliveryFailureStatus: {isReset: true, hasSMSDeliveryFailure: false}});` on the console
3. Verify that the message is displayed correctly
4. Click the "Send" button
5. Verify that the `BeginSignIn` API called
6. Type `Onyx.merge("account", {smsDeliveryFailureStatus: null});` on the console
7. Verify that the  user was able to continue the sign-in flow and navigate to the magic code request

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

https://github.com/user-attachments/assets/8bbba9dd-ba39-4d52-a7c0-6bef68d92a47

</details>

<details>
<summary>Android: mWeb Chrome</summary>

https://github.com/user-attachments/assets/d361cee4-7b32-4024-9bcc-8e55e95a45ec

</details>

<details>
<summary>iOS: Native</summary>

https://github.com/user-attachments/assets/6c09bd3a-6810-497f-88ba-2f15c4961529

</details>

<details>
<summary>iOS: mWeb Safari</summary>

https://github.com/user-attachments/assets/bc72e346-e618-4f78-a8b2-fb0782b02f2e

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

https://github.com/user-attachments/assets/979e13d9-fdeb-4cbe-9025-eabd501f58d9

</details>

<details>
<summary>MacOS: Desktop</summary>

https://github.com/user-attachments/assets/3d070eda-a621-4961-853b-d7d64d9d0784

</details>
