### PR TITLE
fix: Inconsistency on bottom padding for submit button in issue expensify card flow.

### DIFF
--- a/src/components/SubStepForms/ConfirmationStep.tsx
+++ b/src/components/SubStepForms/ConfirmationStep.tsx
@@ -38,9 +38,12 @@ type ConfirmationStepProps = SubStepProps & {
 
     /** The error message to display */
     error?: string;
+
+    /** Whether to apply safe area padding bottom */
+    shouldApplySafeAreaPaddingBottom?: boolean;
 };
 
-function ConfirmationStep({pageTitle, summaryItems, showOnfidoLinks, onfidoLinksTitle, isLoading, error, onNext}: ConfirmationStepProps) {
+function ConfirmationStep({pageTitle, summaryItems, showOnfidoLinks, onfidoLinksTitle, isLoading, error, onNext, shouldApplySafeAreaPaddingBottom = true}: ConfirmationStepProps) {
     const {translate} = useLocalize();
     const styles = useThemeStyles();
     const {isOffline} = useNetwork();
@@ -50,7 +53,7 @@ function ConfirmationStep({pageTitle, summaryItems, showOnfidoLinks, onfidoLinks
             {({safeAreaPaddingBottomStyle}) => (
                 <ScrollView
                     style={styles.pt0}
-                    contentContainerStyle={[styles.flexGrow1, safeAreaPaddingBottomStyle]}
+                    contentContainerStyle={[styles.flexGrow1, shouldApplySafeAreaPaddingBottom && safeAreaPaddingBottomStyle]}
                 >
                     <Text style={[styles.textHeadlineLineHeightXXL, styles.ph5, styles.mb3]}>{pageTitle}</Text>
                     {summaryItems.map(({description, title, shouldShowRightIcon, onPress}) => (

--- a/src/components/ValidateCodeActionModal/index.tsx
+++ b/src/components/ValidateCodeActionModal/index.tsx
@@ -75,7 +75,7 @@ function ValidateCodeActionModal({
                     onBackButtonPress={hide}
                 />
 
-                <View style={[themeStyles.ph5, themeStyles.mt3, themeStyles.mb7, themeStyles.flex1]}>
+                <View style={[themeStyles.ph5, themeStyles.mt3, themeStyles.mb5, themeStyles.flex1]}>
                     <Text style={[themeStyles.mb3]}>{descriptionPrimary}</Text>
                     {!!descriptionSecondary && <Text style={[themeStyles.mb3]}>{descriptionSecondary}</Text>}
                     <ValidateCodeForm

--- a/src/pages/ReimbursementAccount/PersonalInfo/substeps/Confirmation.tsx
+++ b/src/pages/ReimbursementAccount/PersonalInfo/substeps/Confirmation.tsx
@@ -68,6 +68,7 @@ function Confirmation({onNext, onMove, isEditing}: SubStepProps) {
             onfidoLinksTitle={`${translate('personalInfoStep.byAddingThisBankAccount')} `}
             isLoading={isLoading}
             error={error}
+            shouldApplySafeAreaPaddingBottom={false}
         />
     );
 }


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
<!-- Explain what your change does and how it addresses the linked issue -->

### Fixed Issues
$ https://github.com/Expensify/App/issues/53583
PROPOSAL: https://github.com/Expensify/App/issues/53583#issuecomment-2526541752


### Tests
1. Submit a physical card from expensify card page of a workspace
2. Notice the gap in the Issue Card button from the bottom
3. compare it with the Submit button on the validate magic code 
4. Go to workflows page > add bank account
5. Fill the details and proceed to confirmation page of personal info
6. Verify the gap is same as on all the other steps

- [x] Verify that no errors appear in the JS console

### Offline tests
- Can't add bank and expensify card in offline mode

### QA Steps
1. Submit a physical card from expensify card page of a workspace
2. Notice the gap in the Issue Card button from the bottom
3. compare it with the Submit button on the validate magic code 
4. Go to workflows page > add bank account
5. Fill the details and proceed to confirmation page of personal info
6. Verify the gap is same as on all the other steps


- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<img width="331" alt="android_native_varification_modal" src="https://github.com/user-attachments/assets/01aef167-4f54-4bf4-9e1d-f7fc3e08bfb0" />

<img width="331" alt="android_native_varification_modal_2" src="https://github.com/user-attachments/assets/38a654de-0820-4b40-9ff4-20fe559eedc4" />

<img width="329" alt="android_native_personal_info" src="https://github.com/user-attachments/assets/b0e39c0f-a389-43c4-b763-b16463c945c2" />

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<img width="327" alt="android_chrome_varification_modal" src="https://github.com/user-attachments/assets/04cb066a-38a5-429e-a436-d4a9bd4cc63c" />

<img width="330" alt="android_chrome_personal_info" src="https://github.com/user-attachments/assets/76c745e7-1c10-4214-9b69-4563f547dcb2" />

</details>

<details>
<summary>iOS: Native</summary>

<img width="352" alt="ios_native_varification_modal" src="https://github.com/user-attachments/assets/ff2cccb2-f923-4a1c-afcb-ffe465851491" />

<img width="350" alt="ios_native_personal_info" src="https://github.com/user-attachments/assets/7ef152b7-1697-46cb-815d-1fc293842525" />

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<img width="347" alt="ios_safari_varification_modal" src="https://github.com/user-attachments/assets/5e30c2be-33ad-4494-b483-2989bd18936b" />

<img width="350" alt="ios_safari_personal_info" src="https://github.com/user-attachments/assets/81275a3c-b9a8-456a-b92f-31f669e4a800" />

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<img width="1728" alt="web_chrome_validation_modal" src="https://github.com/user-attachments/assets/cf688d42-4f66-49e9-82bc-5a89648b7ad0" />

<img width="1728" alt="web_chrome_personal_step" src="https://github.com/user-attachments/assets/2578d21c-ba2b-41da-bb5b-a83116ccce33" />

</details>

<details>
<summary>MacOS: Desktop</summary>

<img width="1215" alt="desktop_app_personal_info" src="https://github.com/user-attachments/assets/01a24b75-0c77-40d3-8ecc-fc32e36c65cd" />

<img width="1214" alt="desktop_app_validation_modal" src="https://github.com/user-attachments/assets/604afada-55fb-4c01-85e2-619abdf406d8" />

</details>
