### PR TITLE
Revert "fix: "You no longer have access to your previous.." displayed when submit first expense via QAB"

### DIFF
--- a/src/pages/home/sidebar/SidebarScreen/FloatingActionButtonAndPopover.tsx
+++ b/src/pages/home/sidebar/SidebarScreen/FloatingActionButtonAndPopover.tsx
@@ -449,8 +449,8 @@ function FloatingActionButtonAndPopover({onHideCreateMenu, onShowCreateMenu}: Fl
                     onSelected: () =>
                         interceptAnonymousUser(() => {
                             selectOption(() => {
-                                const quickActionReportID = policyChatForActivePolicy?.reportID || ReportUtils.generateReportID();
-                                IOU.startMoneyRequest(CONST.IOU.TYPE.SUBMIT, quickActionReportID, CONST.IOU.REQUEST_TYPE.SCAN, true);
+                                const quickActionReportID = isValidReport ? policyChatForActivePolicy?.reportID ?? '-1' : ReportUtils.generateReportID();
+                                IOU.startMoneyRequest(CONST.IOU.TYPE.SUBMIT, quickActionReportID ?? '-1', CONST.IOU.REQUEST_TYPE.SCAN, true);
                             }, true);
                         }),
                     shouldShowSubscriptRightAvatar: true,
@@ -477,6 +477,7 @@ function FloatingActionButtonAndPopover({onHideCreateMenu, onShowCreateMenu}: Fl
         shouldShowProductTrainingTooltip,
         navigateToQuickAction,
         selectOption,
+        isValidReport,
         quickActionPolicy,
     ]);
 


### PR DESCRIPTION
Reverts Expensify/App#53746

This is blocking the app deploy, and is responsible for

![image](https://github.com/user-attachments/assets/8027508f-f7a9-4fd0-922c-8960306f0067)

https://github.com/Expensify/App/actions/runs/12350358982/job/34463064849

**Lint tests are failing, but they are already failing on** `main` (see https://github.com/Expensify/App/actions/runs/12353330258)