### PR TITLE
Revert "Merge pull request #53630 from FitseTLT/fix-showing-workspace…

### DIFF
--- a/src/libs/PolicyUtils.ts
+++ b/src/libs/PolicyUtils.ts
@@ -69,13 +69,11 @@ Onyx.connect({
 
 /**
  * Filter out the active policies, which will exclude policies with pending deletion
- * and policies the current user doesn't belong to.
  * These are policies that we can use to create reports with in NewDot.
  */
-function getActivePolicies(policies: OnyxCollection<Policy> | null, currentUserLogin: string | undefined): Policy[] {
+function getActivePolicies(policies: OnyxCollection<Policy> | null): Policy[] {
     return Object.values(policies ?? {}).filter<Policy>(
-        (policy): policy is Policy =>
-            !!policy && policy.pendingAction !== CONST.RED_BRICK_ROAD_PENDING_ACTION.DELETE && !!policy.name && !!policy.id && !!getPolicyRole(policy, currentUserLogin),
+        (policy): policy is Policy => !!policy && policy.pendingAction !== CONST.RED_BRICK_ROAD_PENDING_ACTION.DELETE && !!policy.name && !!policy.id,
     );
 }
 /**
@@ -638,7 +636,7 @@ function getPolicy(policyID: string | undefined): OnyxEntry<Policy> {
 
 /** Return active policies where current user is an admin */
 function getActiveAdminWorkspaces(policies: OnyxCollection<Policy> | null, currentUserLogin: string | undefined): Policy[] {
-    const activePolicies = getActivePolicies(policies, currentUserLogin);
+    const activePolicies = getActivePolicies(policies);
     return activePolicies.filter((policy) => shouldShowPolicy(policy, NetworkStore.isOffline(), currentUserLogin) && isPolicyAdmin(policy, currentUserLogin));
 }
 
@@ -654,7 +652,7 @@ function canSendInvoice(policies: OnyxCollection<Policy> | null, currentUserLogi
 }
 
 function hasWorkspaceWithInvoices(currentUserLogin: string | undefined): boolean {
-    const activePolicies = getActivePolicies(allPolicies, currentUserLogin);
+    const activePolicies = getActivePolicies(allPolicies);
     return activePolicies.some((policy) => shouldShowPolicy(policy, NetworkStore.isOffline(), currentUserLogin) && policy.areInvoicesEnabled);
 }
 

--- a/src/pages/workspace/WorkspaceNewRoomPage.tsx
+++ b/src/pages/workspace/WorkspaceNewRoomPage.tsx
@@ -64,14 +64,14 @@ function WorkspaceNewRoomPage() {
 
     const workspaceOptions = useMemo(
         () =>
-            PolicyUtils.getActivePolicies(policies, session?.email)
+            PolicyUtils.getActivePolicies(policies)
                 ?.filter((policy) => policy.type !== CONST.POLICY.TYPE.PERSONAL)
                 .map((policy) => ({
                     label: policy.name,
                     value: policy.id,
                 }))
                 .sort((a, b) => localeCompare(a.label, b.label)) ?? [],
-        [policies, session?.email],
+        [policies],
     );
     const [policyID, setPolicyID] = useState<string>(() => {
         if (!!activeWorkspaceOrDefaultID && workspaceOptions.some((option) => option.value === activeWorkspaceOrDefaultID)) {

--- a/tests/unit/PolicyUtilsTest.ts
+++ b/tests/unit/PolicyUtilsTest.ts
@@ -1,24 +1,10 @@
 import * as PolicyUtils from '@libs/PolicyUtils';
-import ONYXKEYS from '@src/ONYXKEYS';
-import type {Policy} from '@src/types/onyx';
-import createCollection from '../utils/collections/createCollection';
-import createRandomPolicy from '../utils/collections/policies';
 
 function toLocaleDigitMock(dot: string): string {
     return dot;
 }
 
 describe('PolicyUtils', () => {
-    describe('getActivePolicies', () => {
-        it("getActivePolicies should filter out policies that the current user doesn't belong to", () => {
-            const policies = createCollection<Policy>(
-                (item) => `${ONYXKEYS.COLLECTION.POLICY}${item.id}`,
-                (index) => ({...createRandomPolicy(index + 1), ...(!index && {role: null})} as Policy),
-                2,
-            );
-            expect(PolicyUtils.getActivePolicies(policies, undefined)).toHaveLength(1);
-        });
-    });
     describe('getRateDisplayValue', () => {
         it('should return an empty string for NaN', () => {
             const rate = PolicyUtils.getRateDisplayValue('invalid' as unknown as number, toLocaleDigitMock);


### PR DESCRIPTION
Reverts Expensify/App#53630

This is blocking the app deploy, and is responsible for

![image](https://github.com/user-attachments/assets/8027508f-f7a9-4fd0-922c-8960306f0067)

https://github.com/Expensify/App/actions/runs/12350358982/job/34463064849

**Lint tests are failing, but they are already failing on** `main` (see https://github.com/Expensify/App/actions/runs/12353330258)