### PR TITLE
Fix the step numbers in a doc page

### DIFF
--- a/docs/articles/expensify-classic/connections/Expensify-API.md
+++ b/docs/articles/expensify-classic/connections/Expensify-API.md
@@ -69,7 +69,7 @@ Many customers use Postman to help them build out their APIs. Below are some gui
 
 Find the ID by opening the expense report and clicking Details at the top right corner of the page. At the top of the menu, the ID is provided as the “Long ID.” 
 
-**Step 3: Export (generate) a "Report" as a CSV file**
+**Step 2: Export (generate) a "Report" as a CSV file**
 {% include info.html %} 
 For this you'll use the Documentation under [Report Exporter](https://integrations.expensify.com/Integration-Server/doc/#export). 
 {% include end-info.html %}
@@ -142,11 +142,11 @@ The template key will have the value like below:
 
 The template variable determines what information is saved in your CSV file. If you want more columns than merchant, amount, and transaction date, follow the syntax as defined in the export template format documentation.
 
-**Step 4: Save your generated file name**
+**Step 3: Save your generated file name**
 
-Expensify currently supports only the "onReceive":{"immediateResponse":["returnRandomFileName"]} option in step 3, so you should receive a random filename back from the API like "exportc111111d-a1a1-a1a1-a1a1-d1111111f.csv". You will need to document this filename if you plan on running the download command after this one.
+Expensify currently supports only the "onReceive":{"immediateResponse":["returnRandomFileName"]} option in step 2, so you should receive a random filename back from the API like "exportc111111d-a1a1-a1a1-a1a1-d1111111f.csv". You will need to document this filename if you plan on running the download command after this one.
 
-**Step 5: Download your exported report**
+**Step 4: Download your exported report**
 
 Set up another API call in almost the same way you did before. You don't need the template key in the Body anymore, so delete that and set the Body type to "none". Then modify your requestJobDescription to read like below, but with your own credentials and file name:
 

--- a/docs/articles/expensify-classic/connections/Expensify-API.md
+++ b/docs/articles/expensify-classic/connections/Expensify-API.md
@@ -11,46 +11,46 @@ To begin, review our [Integration Server Manual](https://integrations.expensify.
 
 We've compiled answers to some frequently asked questions to help you get started.
 
-**Should I give your support team my API credentials when I need help?**
+## Should I give your support team my API credentials when I need help?
  
 If you’re seeking help with Expensify's API, do not share your partnerUserSecret. If you do, immediately rotate your credentials on [this page](https://www.expensify.com/tools/integrations/).
 
-**Is there a rate limit?** 
+## Is there a rate limit?
 
 Yes, the rate limit is currently 50 requests per minute. If you exceed this limit, you'll receive an error message.
 
-**What is a Policy ID?** 
+## What is a Policy ID?
 
 This is also known as a Workspace ID. To find your Policy/Workspace ID, 
 Hover over Settings and click Workspaces. 
 Click the name of the Workspace. 
 Copy the ID number from the URL. For example, if the URL is https://www.expensify.com/policy?param={"policyID":"0810E551A5F2A9C2”}, then your workspace ID is 0810E551A5F2A9C2.
 
-**Can I use the parent type `file` to export workspace/policy data?**
+## Can I use the parent type `file` to export workspace/policy data?
 
 No. The parent type `file` can only be used to export expense and report data — not policy information. To export policy data (e.g., categories, tags), you must use the `get` type with `inputSettings.type` set to `policy`.
 
-**Can I use the API to create Domain Groups?**
+## Can I use the API to create Domain Groups?
  
 No, you cannot create domain groups. You can only assign users to them.
 
-**I’m exporting expense IDs `${expense.transactionID}` but when I open my CSV in Excel, it’s changing all the IDs and making them look the same. How can I prevent this?**
+## I’m exporting expense IDs `${expense.transactionID}` but when I open my CSV in Excel, it’s changing all the IDs and making them look the same. How can I prevent this?
  
 Try prepending a non-numeric character like a quote to force Excel to interpret the value as a string and not a number (i.e., `'${expense.transactionID}`).  
 
-**How can we export the person who will approve a report while the reports are still processing?** 
+## How can we export the person who will approve a report while the reports are still processing?
 
 Use the field ${report.managerEmail}.
 
-**Why won’t my boolean field return any data?** 
+## Why won’t my boolean field return any data?
 
 Boolean fields won't output values without a string. For example, instead of using `${expense.billable}`, use `${expense.billable?string("Yes", "No")}`. This will display "Yes" if the expense is billable and "No" if it is not.
 
-**Can I export the reports for just one user?** 
+## Can I export the reports for just one user?
 
 Not in a quick convenient way, as you would need to include the user in your template. The simplest approach is to export data for all users and then apply a filter in your preferred spreadsheet program.
 
-**Can I create expenses on behalf of users?** 
+## Can I create expenses on behalf of users?
 
 Yes. However, to access the Expense Creator API on behalf of employees, Expensify needs to verify the following setup:
 
@@ -59,11 +59,11 @@ Verify you have internal authorization to add data to other accounts within your
 
 If you need this access, contact concierge@expensify.com and reference this help page. 
 
-## Using Postman
+# Using Postman
 
 Many customers use Postman to help them build out their APIs. Below are some guides contributed by our customers. Please note, in all cases, you will need to first generate your authentication credentials, the steps for which can be found [here](https://integrations.expensify.com/Integration-Server/doc/#introduction) and have them ready:
 
-### Download expenses from a report as a CSV file
+## Download expenses from a report as a CSV file
 
 **Step 1: Get the ID of a report you want to export in Expensify**
 
@@ -166,7 +166,7 @@ Click Go and you should see the CSV in the response body.
 
 *Thank you to our customer Frederico Pettinella who originally wrote and shared this guide.*
 
-### Use Advanced Employee Updater API with Postman
+## Use Advanced Employee Updater API with Postman
 
 1. Create a new request.
 2. Select POST as the method.


### PR DESCRIPTION
### Explanation of Change
Some help docs use steps, but the step numbers go from 1 to 3 at the moment. 

### Fixed Issues
N/A, noticed while discussing doc changes internally in https://expensify.slack.com/archives/C07PP7QV8P5/p1734559832846429?thread_ts=1734371496.996889&cid=C07PP7QV8P5
PROPOSAL:

### Tests
1. Run `bundle exec jekyll serve`
1. Open http://127.0.0.1:4000/articles/expensify-classic/connections/Expensify-API
2. Scroll down to the section "Download expenses from a report as a CSV file"
3. Make sure the steps listed have coherent numbers

- [ ] Verify that no errors appear in the JS console

### Offline tests
N/A

### QA Steps
1. Open https://help.expensify.com/articles/expensify-classic/connections/Expensify-API
2. Scroll down to the section "Download expenses from a report as a CSV file"
3. Make sure the text reads "Step 1", ..., "Step 2", "Step 3", ... without skipping any step numbers

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos

<details>
<summary>Web / Chrome</summary>

<img width="1455" alt="image" src="https://github.com/user-attachments/assets/114cbf40-b321-492a-9beb-e11be1ef5a9e" />


</details>