### PR TITLE
Fix iOS Composer highlight flicker after closing attachment modal

### DIFF
--- a/src/hooks/useResetComposerFocus.ts
+++ b/src/hooks/useResetComposerFocus.ts
@@ -2,18 +2,23 @@ import {useIsFocused} from '@react-navigation/native';
 import type {MutableRefObject} from 'react';
 import {useEffect, useRef} from 'react';
 import type {TextInput} from 'react-native';
+import {useOnyx} from 'react-native-onyx';
+import ONYXKEYS from '@src/ONYXKEYS';
+import usePrevious from './usePrevious';
 
 export default function useResetComposerFocus(inputRef: MutableRefObject<TextInput | null>) {
     const isFocused = useIsFocused();
     const shouldResetFocusRef = useRef(false);
+    const [modal] = useOnyx(ONYXKEYS.MODAL);
+    const prevIsModalVisible = usePrevious(modal?.isVisible);
 
     useEffect(() => {
-        if (!isFocused || !shouldResetFocusRef.current) {
+        if (!isFocused || !shouldResetFocusRef.current || prevIsModalVisible) {
             return;
         }
         inputRef.current?.focus(); // focus input again
         shouldResetFocusRef.current = false;
-    }, [isFocused, inputRef]);
+    }, [isFocused, inputRef, prevIsModalVisible]);
 
     return {isFocused, shouldResetFocusRef};
 }

--- a/src/hooks/useResetComposerFocus.ts
+++ b/src/hooks/useResetComposerFocus.ts
@@ -1,24 +1,25 @@
 import {useIsFocused} from '@react-navigation/native';
 import type {MutableRefObject} from 'react';
 import {useEffect, useRef} from 'react';
+import {InteractionManager} from 'react-native';
 import type {TextInput} from 'react-native';
-import {useOnyx} from 'react-native-onyx';
-import ONYXKEYS from '@src/ONYXKEYS';
-import usePrevious from './usePrevious';
 
 export default function useResetComposerFocus(inputRef: MutableRefObject<TextInput | null>) {
     const isFocused = useIsFocused();
     const shouldResetFocusRef = useRef(false);
-    const [modal] = useOnyx(ONYXKEYS.MODAL);
-    const prevIsModalVisible = usePrevious(modal?.isVisible);
 
     useEffect(() => {
-        if (!isFocused || !shouldResetFocusRef.current || prevIsModalVisible) {
+        if (!isFocused || !shouldResetFocusRef.current) {
             return;
         }
-        inputRef.current?.focus(); // focus input again
-        shouldResetFocusRef.current = false;
-    }, [isFocused, inputRef, prevIsModalVisible]);
+        const interactionTask = InteractionManager.runAfterInteractions(() => {
+            inputRef.current?.focus(); // focus input again
+            shouldResetFocusRef.current = false;
+        });
+        return () => {
+            interactionTask.cancel();
+        };
+    }, [isFocused, inputRef]);
 
     return {isFocused, shouldResetFocusRef};
 }


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
<!-- Explain what your change does and how it addresses the linked issue -->

PR https://github.com/Expensify/App/pull/34404 introduced the `useResetComposerFocus` in order to deal with issuehttps://github.com/Expensify/App/issues/33466. Months after that we introduced `ComposeFocusManager` with PR https://github.com/Expensify/App/pull/35572 which was put place in for advanced focus management when opening / closing modals. Because of the 2 conflicting focus callers we got the issue which this PR fixes - the fix is adjusting `useResetComposerFocus` to only call focus when we're not coming back from a modal (see PR https://github.com/Expensify/App/pull/34404 test steps for details).

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/54615
PROPOSAL: https://github.com/Expensify/App/issues/54615#issuecomment-2564155244


### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

**Note**: This is a **Native** or **HybridApp** specific issue and fix.

1. Launch Native or HybridApp.
2. Go to DM.
3. Send an image to the DM.
4. Go back to LHN and reopen DM (so that composer is auto-focused without keyboard opening).
5. Tap on the image.
6. Tap app back button.
7. Verify that the composer is re-focused only once without any additional on/off flicker.

> [!caution]
> On **mWeb** step (7.) will fail because it didn't work like that before this PR either - this can be verified on staging / production before this PR is deployed on any of the two. On **mWeb** the current / expected behaviour is that the composer won't re-focus when returning back from attachment modal.

Additional test steps from PR https://github.com/Expensify/App/pull/34404 / https://github.com/Expensify/App/issues/33466 Issue :

1. Launch Native or HybridApp.
2. Tap on a report.
3. Long press any sent message and select Edit comment.
4. Note that the main composer will be hidden when the edit comment composer is displayed and focused.
5. Tap report header.
5. Tap back button.
6. Verify that when user is in edit comment mode, the main compose box should not be shown after tapping header and returning back.

> [!caution]
> On **mWeb** step (6.) will fail because it didn't work like that before this PR either - this can be verified on staging / production before this PR is deployed on any of the two. On **mWeb** the current / expected behaviour is that the main composer and the edit comment composer will both show at the same time and none of them will be focused when returning back report details screen.

- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

**N/A**.

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->

**Note**: This is a **Native** or **HybridApp** specific issue and fix.

1. Launch Native or HybridApp.
2. Go to DM.
3. Send an image to the DM.
4. Go back to LHN and reopen DM (so that composer is auto-focused without keyboard opening).
5. Tap on the image.
6. Tap app back button.
7. Verify that the composer is re-focused only once without any additional on/off flicker.

> [!caution]
> On **mWeb** step (7.) will fail because it didn't work like that before this PR either - this can be verified on staging / production before this PR is deployed on any of the two. On **mWeb** the current / expected behaviour is that the composer won't re-focus when returning back from attachment modal.

Additional test steps from PR https://github.com/Expensify/App/pull/34404 / https://github.com/Expensify/App/issues/33466 Issue :

1. Launch Native or HybridApp.
2. Tap on a report.
3. Long press any sent message and select Edit comment.
4. Note that the main composer will be hidden when the edit comment composer is displayed and focused.
5. Tap report header.
5. Tap back button.
6. Verify that when user is in edit comment mode, the main compose box should not be shown after tapping header and returning back.

> [!caution]
> On **mWeb** step (6.) will fail because it didn't work like that before this PR either - this can be verified on staging / production before this PR is deployed on any of the two. On **mWeb** the current / expected behaviour is that the main composer and the edit comment composer will both show at the same time and none of them will be focused when returning back report details screen.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/7723df0f-e7f2-4026-9682-3fa9983a9c8e


</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/00ee1b5b-be1e-4c80-b9a6-d3d3436a6acd


</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->
https://github.com/user-attachments/assets/e3d0a275-2a81-44d1-8eaa-97d288ffb3af

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/c4a9b310-b056-421f-b8d0-cfa1db0a2f93


</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/c2d151e3-81c1-4c04-b914-6acf916f362e


</details>

<details>
<summary>MacOS: Desktop</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/84e67801-e5cf-4a8d-9db1-55a2c33fd880


</details>
