### PR TITLE
Console error cleanup: patch react-native-render-html

### DIFF
--- a/patches/react-native-render-html+6.3.1+002+fix-console-warning.patch
+++ b/patches/react-native-render-html+6.3.1+002+fix-console-warning.patch
@@ -468,7 +468,7 @@ index d32140f..0804ba7 100644
    TDefaultBlockRenderer,
    TDefaultPhrasingRenderer,
 diff --git a/node_modules/react-native-render-html/src/TRenderEngineProvider.tsx b/node_modules/react-native-render-html/src/TRenderEngineProvider.tsx
-index 95b60df..56465c9 100644
+index 95b60df..db6fe0b 100644
 --- a/node_modules/react-native-render-html/src/TRenderEngineProvider.tsx
 +++ b/node_modules/react-native-render-html/src/TRenderEngineProvider.tsx
 @@ -1,7 +1,6 @@
@@ -561,7 +561,7 @@ index 95b60df..56465c9 100644
    ...config
  }: PropsWithChildren<TRenderEngineConfig>): ReactElement {
 -  const engine = useTRenderEngine(config);
-+  const engine = useTRenderEngine({enableUserAgentStyles, ...config});
++  const engine = useTRenderEngine({htmlParserOptions, emSize, ignoredDomTags, ignoredStyles, baseStyle, tagsStyles, classesStyles, enableUserAgentStyles, enableCSSInlineProcessing, customHTMLElementModels, fallbackFonts, systemFonts, ...config});
    return (
      <TRenderEngineContext.Provider value={engine}>
        {children}

--- a/patches/react-native-render-html+6.3.1+002+fix-console-warning.patch
+++ b/patches/react-native-render-html+6.3.1+002+fix-console-warning.patch
@@ -1,0 +1,719 @@
+diff --git a/node_modules/react-native-render-html/lib/commonjs/TChildrenRenderer.js b/node_modules/react-native-render-html/lib/commonjs/TChildrenRenderer.js
+index 9d16738..bbc66a0 100644
+--- a/node_modules/react-native-render-html/lib/commonjs/TChildrenRenderer.js
++++ b/node_modules/react-native-render-html/lib/commonjs/TChildrenRenderer.js
+@@ -3,7 +3,7 @@
+ Object.defineProperty(exports, "__esModule", {
+   value: true
+ });
+-exports.default = exports.tchildrenRendererDefaultProps = void 0;
++exports.default = void 0;
+ 
+ var _renderChildren = _interopRequireDefault(require("./renderChildren"));
+ 
+@@ -15,15 +15,6 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
+  */
+ const TChildrenRenderer = _renderChildren.default.bind(null);
+ 
+-const tchildrenRendererDefaultProps = {
+-  propsForChildren: {}
+-};
+-/**
+- * @ignore
+- */
+-
+-exports.tchildrenRendererDefaultProps = tchildrenRendererDefaultProps;
+-TChildrenRenderer.defaultProps = tchildrenRendererDefaultProps;
+ var _default = TChildrenRenderer;
+ exports.default = _default;
+ //# sourceMappingURL=TChildrenRenderer.js.map
+\ No newline at end of file
+diff --git a/node_modules/react-native-render-html/lib/commonjs/TNodeChildrenRenderer.js b/node_modules/react-native-render-html/lib/commonjs/TNodeChildrenRenderer.js
+index 50b43ca..5ecf4a4 100644
+--- a/node_modules/react-native-render-html/lib/commonjs/TNodeChildrenRenderer.js
++++ b/node_modules/react-native-render-html/lib/commonjs/TNodeChildrenRenderer.js
+@@ -8,8 +8,6 @@ exports.default = void 0;
+ 
+ var _SharedPropsProvider = require("./context/SharedPropsProvider");
+ 
+-var _TChildrenRenderer = require("./TChildrenRenderer");
+-
+ var _renderChildren = _interopRequireDefault(require("./renderChildren"));
+ 
+ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+@@ -78,12 +76,7 @@ function TNodeChildrenRenderer(props) {
+ 
+   return (0, _renderChildren.default)(useTNodeChildrenProps(props));
+ }
+-/**
+- * @ignore
+- */
+-
+ 
+-TNodeChildrenRenderer.defaultProps = _TChildrenRenderer.tchildrenRendererDefaultProps;
+ var _default = TNodeChildrenRenderer;
+ exports.default = _default;
+ //# sourceMappingURL=TNodeChildrenRenderer.js.map
+\ No newline at end of file
+diff --git a/node_modules/react-native-render-html/lib/commonjs/TNodeRenderer.js b/node_modules/react-native-render-html/lib/commonjs/TNodeRenderer.js
+index eafc942..e083941 100644
+--- a/node_modules/react-native-render-html/lib/commonjs/TNodeRenderer.js
++++ b/node_modules/react-native-render-html/lib/commonjs/TNodeRenderer.js
+@@ -57,7 +57,11 @@ const TNodeRenderer = /*#__PURE__*/(0, _react.memo)(function MemoizedTNodeRender
+   const sharedProps = (0, _SharedPropsProvider.useSharedProps)();
+   const renderRegistry = (0, _RenderRegistryProvider.useRendererRegistry)();
+   const TNodeChildrenRenderer = (0, _TChildrenRendererContext.useTNodeChildrenRenderer)();
+-  const tnodeProps = { ...props,
++  const tnodeProps = {
++    propsFromParent: {
++      collapsedMarginTop: null
++    },
++    ...props,
+     TNodeChildrenRenderer,
+     sharedProps
+   };
+@@ -109,13 +113,6 @@ const TNodeRenderer = /*#__PURE__*/(0, _react.memo)(function MemoizedTNodeRender
+   const renderFn = tnode.type === 'block' || tnode.type === 'document' ? _renderBlockContent.default : _renderTextualContent.default;
+   return Renderer === null ? renderFn(assembledProps) : /*#__PURE__*/_react.default.createElement(Renderer, assembledProps);
+ });
+-const defaultProps = {
+-  propsFromParent: {
+-    collapsedMarginTop: null
+-  }
+-}; // @ts-expect-error default props must be defined
+-
+-TNodeRenderer.defaultProps = defaultProps;
+ var _default = TNodeRenderer;
+ exports.default = _default;
+ //# sourceMappingURL=TNodeRenderer.js.map
+\ No newline at end of file
+diff --git a/node_modules/react-native-render-html/lib/commonjs/TRenderEngineProvider.js b/node_modules/react-native-render-html/lib/commonjs/TRenderEngineProvider.js
+index 3a700b6..4011a1b 100644
+--- a/node_modules/react-native-render-html/lib/commonjs/TRenderEngineProvider.js
++++ b/node_modules/react-native-render-html/lib/commonjs/TRenderEngineProvider.js
+@@ -5,7 +5,6 @@ Object.defineProperty(exports, "__esModule", {
+ });
+ exports.useAmbientTRenderEngine = useAmbientTRenderEngine;
+ exports.default = TRenderEngineProvider;
+-exports.defaultTRenderEngineProviderProps = exports.defaultFallbackFonts = exports.tRenderEngineProviderPropTypes = void 0;
+ 
+ var _react = _interopRequireDefault(require("react"));
+ 
+@@ -23,38 +22,6 @@ const defaultTRenderEngine = {};
+ 
+ const TRenderEngineContext = /*#__PURE__*/_react.default.createContext(defaultTRenderEngine);
+ 
+-const tRenderEngineProviderPropTypes = {
+-  customHTMLElementModels: _propTypes.default.object.isRequired,
+-  enableCSSInlineProcessing: _propTypes.default.bool,
+-  enableUserAgentStyles: _propTypes.default.bool,
+-  idsStyles: _propTypes.default.object,
+-  ignoredDomTags: _propTypes.default.array,
+-  ignoreDomNode: _propTypes.default.func,
+-  domVisitors: _propTypes.default.object,
+-  ignoredStyles: _propTypes.default.array.isRequired,
+-  allowedStyles: _propTypes.default.array,
+-  htmlParserOptions: _propTypes.default.object,
+-  tagsStyles: _propTypes.default.object,
+-  classesStyles: _propTypes.default.object,
+-  emSize: _propTypes.default.number.isRequired,
+-  baseStyle: _propTypes.default.object,
+-  systemFonts: _propTypes.default.arrayOf(_propTypes.default.string),
+-  fallbackFonts: _propTypes.default.shape({
+-    serif: _propTypes.default.string,
+-    'sans-serif': _propTypes.default.string,
+-    monospace: _propTypes.default.string
+-  }),
+-  setMarkersForTNode: _propTypes.default.func,
+-  dangerouslyDisableHoisting: _propTypes.default.bool,
+-  dangerouslyDisableWhitespaceCollapsing: _propTypes.default.bool,
+-  selectDomRoot: _propTypes.default.func
+-};
+-/**
+- * Default fallback font for special keys such as 'sans-serif', 'monospace',
+- * 'serif', based on current platform.
+- */
+-
+-exports.tRenderEngineProviderPropTypes = tRenderEngineProviderPropTypes;
+ const defaultFallbackFonts = {
+   'sans-serif': _reactNative.Platform.select({
+     ios: 'system',
+@@ -70,33 +37,6 @@ const defaultFallbackFonts = {
+   })
+ };
+ exports.defaultFallbackFonts = defaultFallbackFonts;
+-const defaultTRenderEngineProviderProps = {
+-  htmlParserOptions: {
+-    decodeEntities: true
+-  },
+-  emSize: 14,
+-  ignoredDomTags: [],
+-  ignoredStyles: [],
+-  baseStyle: {
+-    fontSize: 14
+-  },
+-  tagsStyles: {},
+-  classesStyles: {},
+-  enableUserAgentStyles: true,
+-  enableCSSInlineProcessing: true,
+-  customHTMLElementModels: {},
+-  fallbackFonts: defaultFallbackFonts,
+-  systemFonts: _defaultSystemFonts.default
+-};
+-/**
+- * Use the ambient transient render engine.
+- *
+- * @returns The ambient transient render engine.
+- *
+- * @public
+- */
+-
+-exports.defaultTRenderEngineProviderProps = defaultTRenderEngineProviderProps;
+ 
+ function useAmbientTRenderEngine() {
+   const engine = _react.default.useContext(TRenderEngineContext);
+@@ -119,22 +59,26 @@ function useAmbientTRenderEngine() {
+ 
+ function TRenderEngineProvider({
+   children,
++  htmlParserOptions = {
++    decodeEntities: true
++  },
++  emSize = 14,
++  ignoredDomTags = [],
++  ignoredStyles = [],
++  baseStyle = { fontSize: 14 },
++  tagsStyles = {},
++  classesStyles = {},
++  enableUserAgentStyles = true,
++  enableCSSInlineProcessing = true,
++  customHTMLElementModels = {},
++  fallbackFonts = defaultFallbackFonts,
++  systemFonts = defaultSystemFonts,
+   ...config
+ }) {
+-  const engine = (0, _useTRenderEngine.default)(config);
++  const engine = (0, _useTRenderEngine.default)({htmlParserOptions, emSize, ignoredDomTags, ignoredStyles, baseStyle, tagsStyles, classesStyles, enableUserAgentStyles, enableCSSInlineProcessing, customHTMLElementModels, fallbackFonts, systemFonts, ...config});
+   return /*#__PURE__*/_react.default.createElement(TRenderEngineContext.Provider, {
+     value: engine
+   }, children);
+ }
+-/**
+- * @ignore
+- */
+-
+-
+-TRenderEngineProvider.defaultProps = defaultTRenderEngineProviderProps;
+-/**
+- * @ignore
+- */
+ 
+-TRenderEngineProvider.propTypes = tRenderEngineProviderPropTypes;
+ //# sourceMappingURL=TRenderEngineProvider.js.map
+\ No newline at end of file
+diff --git a/node_modules/react-native-render-html/lib/commonjs/elements/IMGElement.js b/node_modules/react-native-render-html/lib/commonjs/elements/IMGElement.js
+index 1be151a..3a076d4 100644
+--- a/node_modules/react-native-render-html/lib/commonjs/elements/IMGElement.js
++++ b/node_modules/react-native-render-html/lib/commonjs/elements/IMGElement.js
+@@ -7,8 +7,6 @@ exports.default = void 0;
+ 
+ var _react = _interopRequireDefault(require("react"));
+ 
+-var _propTypes = _interopRequireDefault(require("prop-types"));
+-
+ var _useIMGElementState = _interopRequireDefault(require("./useIMGElementState"));
+ 
+ var _IMGElementContentSuccess = _interopRequireDefault(require("./IMGElementContentSuccess"));
+@@ -19,15 +17,10 @@ var _IMGElementContentLoading = _interopRequireDefault(require("./IMGElementCont
+ 
+ var _IMGElementContentError = _interopRequireDefault(require("./IMGElementContentError"));
+ 
+-var _defaultInitialImageDimensions = _interopRequireDefault(require("./defaultInitialImageDimensions"));
+-
+ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+ 
+ function _extends() { _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; }; return _extends.apply(this, arguments); }
+ 
+-function identity(arg) {
+-  return arg;
+-}
+ /**
+  * A component to render images based on an internal loading state.
+  *
+@@ -37,8 +30,6 @@ function identity(arg) {
+  * {@link IMGElementContentSuccess}, {@link IMGElementContentLoading}
+  * and {@link IMGElementContentError} for customization.
+  */
+-
+-
+ function IMGElement(props) {
+   const state = (0, _useIMGElementState.default)(props);
+   let content;
+@@ -59,43 +50,6 @@ function IMGElement(props) {
+   }), content);
+ }
+ 
+-const imgDimensionsType = _propTypes.default.shape({
+-  width: _propTypes.default.number,
+-  height: _propTypes.default.number
+-});
+-
+-const propTypes = {
+-  source: _propTypes.default.object.isRequired,
+-  alt: _propTypes.default.string,
+-  altColor: _propTypes.default.string,
+-  height: _propTypes.default.oneOfType([_propTypes.default.string, _propTypes.default.number]),
+-  width: _propTypes.default.oneOfType([_propTypes.default.string, _propTypes.default.number]),
+-  style: _propTypes.default.oneOfType([_propTypes.default.object, _propTypes.default.array]),
+-  computeMaxWidth: _propTypes.default.func.isRequired,
+-  contentWidth: _propTypes.default.number,
+-  enableExperimentalPercentWidth: _propTypes.default.bool,
+-  initialDimensions: imgDimensionsType,
+-  onPress: _propTypes.default.func,
+-  testID: _propTypes.default.string,
+-  objectFit: _propTypes.default.string,
+-  cachedNaturalDimensions: imgDimensionsType,
+-  containerProps: _propTypes.default.object
+-};
+-/**
+- * @ignore
+- */
+-
+-IMGElement.propTypes = propTypes;
+-/**
+- * @ignore
+- */
+-
+-IMGElement.defaultProps = {
+-  enableExperimentalPercentWidth: false,
+-  computeMaxWidth: identity,
+-  imagesInitialDimensions: _defaultInitialImageDimensions.default,
+-  style: {}
+-};
+ var _default = IMGElement;
+ exports.default = _default;
+ //# sourceMappingURL=IMGElement.js.map
+\ No newline at end of file
+diff --git a/node_modules/react-native-render-html/src/RenderHTMLConfigProvider.tsx b/node_modules/react-native-render-html/src/RenderHTMLConfigProvider.tsx
+index 0df5375..925062a 100644
+--- a/node_modules/react-native-render-html/src/RenderHTMLConfigProvider.tsx
++++ b/node_modules/react-native-render-html/src/RenderHTMLConfigProvider.tsx
+@@ -1,5 +1,4 @@
+ import React, { PropsWithChildren, ReactElement, useMemo } from 'react';
+-import PropTypes from 'prop-types';
+ import RenderersPropsProvider from './context/RenderersPropsProvider';
+ import SharedPropsProvider from './context/SharedPropsProvider';
+ import TChildrenRenderersContext from './context/TChildrenRendererContext';
+@@ -20,29 +19,6 @@ const childrenRendererContext = {
+   TNodeChildrenRenderer
+ };
+ 
+-export type RenderHTMLConfigPropTypes = Record<keyof RenderHTMLConfig, any>;
+-
+-export const renderHTMLConfigPropTypes: RenderHTMLConfigPropTypes = {
+-  bypassAnonymousTPhrasingNodes: PropTypes.bool,
+-  defaultTextProps: PropTypes.object,
+-  defaultViewProps: PropTypes.object,
+-  enableExperimentalBRCollapsing: PropTypes.bool,
+-  enableExperimentalGhostLinesPrevention: PropTypes.bool,
+-  enableExperimentalMarginCollapsing: PropTypes.bool,
+-  remoteErrorView: PropTypes.func,
+-  remoteLoadingView: PropTypes.func,
+-  debug: PropTypes.bool,
+-  computeEmbeddedMaxWidth: PropTypes.func,
+-  renderersProps: PropTypes.object,
+-  WebView: PropTypes.any,
+-  GenericPressable: PropTypes.any,
+-  defaultWebViewProps: PropTypes.object,
+-  pressableHightlightColor: PropTypes.string,
+-  customListStyleSpecs: PropTypes.object,
+-  renderers: PropTypes.object,
+-  provideEmbeddedHeaders: PropTypes.func
+-};
+-
+ /**
+  * A component to provide configuration for {@link RenderHTMLSource}
+  * descendants, to be used in conjunction with {@link TRenderEngineProvider}.
+@@ -85,8 +61,3 @@ export default function RenderHTMLConfigProvider(
+     </RenderRegistryProvider>
+   );
+ }
+-
+-/**
+- * @ignore
+- */
+-RenderHTMLConfigProvider.propTypes = renderHTMLConfigPropTypes;
+diff --git a/node_modules/react-native-render-html/src/RenderHTMLSource.tsx b/node_modules/react-native-render-html/src/RenderHTMLSource.tsx
+index c91da52..fd0e052 100644
+--- a/node_modules/react-native-render-html/src/RenderHTMLSource.tsx
++++ b/node_modules/react-native-render-html/src/RenderHTMLSource.tsx
+@@ -1,7 +1,6 @@
+ import equals from 'ramda/src/equals';
+ import React, { memo, ReactElement, useMemo } from 'react';
+ import { Dimensions } from 'react-native';
+-import PropTypes from 'prop-types';
+ import ttreeEventsContext from './context/ttreeEventsContext';
+ import isUriSource from './helpers/isUriSource';
+ import { SourceLoaderProps, TTreeEvents } from './internal-types';
+@@ -25,29 +24,6 @@ export type RenderHTMLSourcePropTypes = Record<
+   any
+ >;
+ 
+-export const renderSourcePropTypes: RenderHTMLSourcePropTypes = {
+-  source: PropTypes.oneOfType([
+-    PropTypes.shape({
+-      html: PropTypes.string.isRequired,
+-      baseUrl: PropTypes.string
+-    }),
+-    PropTypes.shape({
+-      dom: PropTypes.object.isRequired,
+-      baseUrl: PropTypes.string
+-    }),
+-    PropTypes.shape({
+-      uri: PropTypes.string.isRequired,
+-      method: PropTypes.string,
+-      body: PropTypes.any,
+-      headers: PropTypes.object
+-    })
+-  ]),
+-  onTTreeChange: PropTypes.func,
+-  onHTMLLoaded: PropTypes.func,
+-  onDocumentMetadataLoaded: PropTypes.func,
+-  contentWidth: PropTypes.number
+-};
+-
+ function isEmptySource(source: undefined | HTMLSource) {
+   return (
+     !source ||
+@@ -136,9 +112,4 @@ const RenderHTMLSource = memo(
+   }
+ );
+ 
+-/**
+- * @ignore
+- */
+-(RenderHTMLSource as any).propTypes = renderSourcePropTypes;
+-
+ export default RenderHTMLSource;
+diff --git a/node_modules/react-native-render-html/src/TChildrenRenderer.tsx b/node_modules/react-native-render-html/src/TChildrenRenderer.tsx
+index 618a592..e12888e 100644
+--- a/node_modules/react-native-render-html/src/TChildrenRenderer.tsx
++++ b/node_modules/react-native-render-html/src/TChildrenRenderer.tsx
+@@ -9,16 +9,4 @@ import renderChildren from './renderChildren';
+ const TChildrenRenderer: FunctionComponent<TChildrenRendererProps> =
+   renderChildren.bind(null);
+ 
+-export const tchildrenRendererDefaultProps: Pick<
+-  TChildrenRendererProps,
+-  'propsForChildren'
+-> = {
+-  propsForChildren: {}
+-};
+-
+-/**
+- * @ignore
+- */
+-TChildrenRenderer.defaultProps = tchildrenRendererDefaultProps;
+-
+ export default TChildrenRenderer;
+diff --git a/node_modules/react-native-render-html/src/TNodeChildrenRenderer.tsx b/node_modules/react-native-render-html/src/TNodeChildrenRenderer.tsx
+index bf5aef6..b820de0 100644
+--- a/node_modules/react-native-render-html/src/TNodeChildrenRenderer.tsx
++++ b/node_modules/react-native-render-html/src/TNodeChildrenRenderer.tsx
+@@ -1,7 +1,6 @@
+ import { ReactElement } from 'react';
+ import { TNode } from '@native-html/transient-render-engine';
+ import { useSharedProps } from './context/SharedPropsProvider';
+-import { tchildrenRendererDefaultProps } from './TChildrenRenderer';
+ import {
+   TChildrenRendererProps,
+   TNodeChildrenRendererProps
+@@ -73,9 +72,4 @@ function TNodeChildrenRenderer(
+   return renderChildren(useTNodeChildrenProps(props));
+ }
+ 
+-/**
+- * @ignore
+- */
+-TNodeChildrenRenderer.defaultProps = tchildrenRendererDefaultProps;
+-
+ export default TNodeChildrenRenderer;
+diff --git a/node_modules/react-native-render-html/src/TNodeRenderer.tsx b/node_modules/react-native-render-html/src/TNodeRenderer.tsx
+index d32140f..0804ba7 100644
+--- a/node_modules/react-native-render-html/src/TNodeRenderer.tsx
++++ b/node_modules/react-native-render-html/src/TNodeRenderer.tsx
+@@ -49,6 +49,7 @@ const TNodeRenderer = memo(function MemoizedTNodeRenderer(
+   const renderRegistry = useRendererRegistry();
+   const TNodeChildrenRenderer = useTNodeChildrenRenderer();
+   const tnodeProps = {
++    propsFromParent: { collapsedMarginTop: null },
+     ...props,
+     TNodeChildrenRenderer,
+     sharedProps
+@@ -120,16 +121,6 @@ const TNodeRenderer = memo(function MemoizedTNodeRenderer(
+     : React.createElement(Renderer as any, assembledProps);
+ });
+ 
+-const defaultProps: Required<Pick<TNodeRendererProps<any>, 'propsFromParent'>> =
+-  {
+-    propsFromParent: {
+-      collapsedMarginTop: null
+-    }
+-  };
+-
+-// @ts-expect-error default props must be defined
+-TNodeRenderer.defaultProps = defaultProps;
+-
+ export {
+   TDefaultBlockRenderer,
+   TDefaultPhrasingRenderer,
+diff --git a/node_modules/react-native-render-html/src/TRenderEngineProvider.tsx b/node_modules/react-native-render-html/src/TRenderEngineProvider.tsx
+index 95b60df..56465c9 100644
+--- a/node_modules/react-native-render-html/src/TRenderEngineProvider.tsx
++++ b/node_modules/react-native-render-html/src/TRenderEngineProvider.tsx
+@@ -1,7 +1,6 @@
+ import TRenderEngine from '@native-html/transient-render-engine';
+ import React, { PropsWithChildren, ReactElement } from 'react';
+ import { Platform } from 'react-native';
+-import PropTypes from 'prop-types';
+ import useTRenderEngine from './hooks/useTRenderEngine';
+ import { TRenderEngineConfig } from './shared-types';
+ import defaultSystemFonts from './defaultSystemFonts';
+@@ -11,36 +10,6 @@ const defaultTRenderEngine = {} as any;
+ const TRenderEngineContext =
+   React.createContext<TRenderEngine>(defaultTRenderEngine);
+ 
+-export const tRenderEngineProviderPropTypes: Record<
+-  keyof TRenderEngineConfig,
+-  any
+-> = {
+-  customHTMLElementModels: PropTypes.object.isRequired,
+-  enableCSSInlineProcessing: PropTypes.bool,
+-  enableUserAgentStyles: PropTypes.bool,
+-  idsStyles: PropTypes.object,
+-  ignoredDomTags: PropTypes.array,
+-  ignoreDomNode: PropTypes.func,
+-  domVisitors: PropTypes.object,
+-  ignoredStyles: PropTypes.array.isRequired,
+-  allowedStyles: PropTypes.array,
+-  htmlParserOptions: PropTypes.object,
+-  tagsStyles: PropTypes.object,
+-  classesStyles: PropTypes.object,
+-  emSize: PropTypes.number.isRequired,
+-  baseStyle: PropTypes.object,
+-  systemFonts: PropTypes.arrayOf(PropTypes.string),
+-  fallbackFonts: PropTypes.shape({
+-    serif: PropTypes.string,
+-    'sans-serif': PropTypes.string,
+-    monospace: PropTypes.string
+-  }),
+-  setMarkersForTNode: PropTypes.func,
+-  dangerouslyDisableHoisting: PropTypes.bool,
+-  dangerouslyDisableWhitespaceCollapsing: PropTypes.bool,
+-  selectDomRoot: PropTypes.func
+-};
+-
+ /**
+  * Default fallback font for special keys such as 'sans-serif', 'monospace',
+  * 'serif', based on current platform.
+@@ -51,23 +20,6 @@ export const defaultFallbackFonts = {
+   serif: Platform.select({ ios: 'Times New Roman', default: 'serif' })
+ };
+ 
+-export const defaultTRenderEngineProviderProps: TRenderEngineConfig = {
+-  htmlParserOptions: {
+-    decodeEntities: true
+-  },
+-  emSize: 14,
+-  ignoredDomTags: [],
+-  ignoredStyles: [],
+-  baseStyle: { fontSize: 14 },
+-  tagsStyles: {},
+-  classesStyles: {},
+-  enableUserAgentStyles: true,
+-  enableCSSInlineProcessing: true,
+-  customHTMLElementModels: {},
+-  fallbackFonts: defaultFallbackFonts,
+-  systemFonts: defaultSystemFonts
+-};
+-
+ /**
+  * Use the ambient transient render engine.
+  *
+@@ -97,22 +49,26 @@ export function useAmbientTRenderEngine() {
+  */
+ export default function TRenderEngineProvider({
+   children,
++  htmlParserOptions = {
++    decodeEntities: true
++  },
++  emSize = 14,
++  ignoredDomTags = [],
++  ignoredStyles = [],
++  baseStyle = { fontSize: 14 },
++  tagsStyles = {},
++  classesStyles = {},
++  enableUserAgentStyles = true,
++  enableCSSInlineProcessing = true,
++  customHTMLElementModels = {},
++  fallbackFonts = defaultFallbackFonts,
++  systemFonts = defaultSystemFonts,
+   ...config
+ }: PropsWithChildren<TRenderEngineConfig>): ReactElement {
+-  const engine = useTRenderEngine(config);
++  const engine = useTRenderEngine({enableUserAgentStyles, ...config});
+   return (
+     <TRenderEngineContext.Provider value={engine}>
+       {children}
+     </TRenderEngineContext.Provider>
+   );
+ }
+-
+-/**
+- * @ignore
+- */
+-TRenderEngineProvider.defaultProps = defaultTRenderEngineProviderProps;
+-
+-/**
+- * @ignore
+- */
+-TRenderEngineProvider.propTypes = tRenderEngineProviderPropTypes;
+diff --git a/node_modules/react-native-render-html/src/elements/IMGElement.tsx b/node_modules/react-native-render-html/src/elements/IMGElement.tsx
+index 573e7c1..a6fc90b 100644
+--- a/node_modules/react-native-render-html/src/elements/IMGElement.tsx
++++ b/node_modules/react-native-render-html/src/elements/IMGElement.tsx
+@@ -1,19 +1,13 @@
+ import React, { ReactElement, ReactNode } from 'react';
+-import PropTypes from 'prop-types';
+ import useIMGElementState from './useIMGElementState';
+ import IMGElementContentSuccess from './IMGElementContentSuccess';
+ import IMGElementContainer from './IMGElementContainer';
+ import IMGElementContentLoading from './IMGElementContentLoading';
+ import IMGElementContentError from './IMGElementContentError';
+ import type { IMGElementProps } from './img-types';
+-import defaultImageInitialDimensions from './defaultInitialImageDimensions';
+ 
+ export type { IMGElementProps } from './img-types';
+ 
+-function identity(arg: any) {
+-  return arg;
+-}
+-
+ /**
+  * A component to render images based on an internal loading state.
+  *
+@@ -44,42 +38,4 @@ function IMGElement(props: IMGElementProps): ReactElement {
+   );
+ }
+ 
+-const imgDimensionsType = PropTypes.shape({
+-  width: PropTypes.number,
+-  height: PropTypes.number
+-});
+-
+-const propTypes: Record<keyof IMGElementProps, any> = {
+-  source: PropTypes.object.isRequired,
+-  alt: PropTypes.string,
+-  altColor: PropTypes.string,
+-  height: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+-  width: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+-  style: PropTypes.oneOfType([PropTypes.object, PropTypes.array]),
+-  computeMaxWidth: PropTypes.func.isRequired,
+-  contentWidth: PropTypes.number,
+-  enableExperimentalPercentWidth: PropTypes.bool,
+-  initialDimensions: imgDimensionsType,
+-  onPress: PropTypes.func,
+-  testID: PropTypes.string,
+-  objectFit: PropTypes.string,
+-  cachedNaturalDimensions: imgDimensionsType,
+-  containerProps: PropTypes.object
+-};
+-
+-/**
+- * @ignore
+- */
+-IMGElement.propTypes = propTypes;
+-
+-/**
+- * @ignore
+- */
+-IMGElement.defaultProps = {
+-  enableExperimentalPercentWidth: false,
+-  computeMaxWidth: identity,
+-  imagesInitialDimensions: defaultImageInitialDimensions,
+-  style: {}
+-};
+-
+ export default IMGElement;
+diff --git a/node_modules/react-native-render-html/src/elements/useIMGElementState.ts b/node_modules/react-native-render-html/src/elements/useIMGElementState.ts
+index 6590d21..b603f26 100644
+--- a/node_modules/react-native-render-html/src/elements/useIMGElementState.ts
++++ b/node_modules/react-native-render-html/src/elements/useIMGElementState.ts
+@@ -63,6 +63,10 @@ function useImageNaturalDimensions<P extends UseIMGElementStateProps>(props: {
+   };
+ }
+ 
++function identity(arg: any) {
++  return arg;
++}
++
+ function useFetchedNaturalDimensions(props: {
+   cachedNaturalDimensions?: ImageDimensions;
+   source: ImageURISource;
+@@ -116,7 +120,7 @@ export default function useIMGElementState(
+     altColor,
+     source,
+     contentWidth,
+-    computeMaxWidth,
++    computeMaxWidth = identity,
+     objectFit,
+     initialDimensions = defaultImageInitialDimensions,
+     cachedNaturalDimensions
+diff --git a/node_modules/react-native-render-html/src/elements/useImageSpecifiedDimensions.ts b/node_modules/react-native-render-html/src/elements/useImageSpecifiedDimensions.ts
+index 5d6271b..710c73f 100644
+--- a/node_modules/react-native-render-html/src/elements/useImageSpecifiedDimensions.ts
++++ b/node_modules/react-native-render-html/src/elements/useImageSpecifiedDimensions.ts
+@@ -71,8 +71,7 @@ function deriveSpecifiedDimensionsFromProps({
+ export default function useImageSpecifiedDimensions(
+   props: UseIMGElementStateProps
+ ) {
+-  const { contentWidth, enableExperimentalPercentWidth, style, width, height } =
+-    props;
++  const { contentWidth, enableExperimentalPercentWidth = false, style = {}, width, height } = props
+   const flatStyle = useMemo(() => StyleSheet.flatten(style) || {}, [style]);
+   const specifiedDimensions = useMemo(
+     () =>
+diff --git a/node_modules/react-native-render-html/src/index.ts b/node_modules/react-native-render-html/src/index.ts
+index 8569583..b59ec49 100644
+--- a/node_modules/react-native-render-html/src/index.ts
++++ b/node_modules/react-native-render-html/src/index.ts
+@@ -128,7 +128,6 @@ export {
+ export { default as TNodeRenderer } from './TNodeRenderer';
+ export {
+   default as TRenderEngineProvider,
+-  defaultFallbackFonts,
+   useAmbientTRenderEngine
+ } from './TRenderEngineProvider';
+ export { default as RenderHTMLConfigProvider } from './RenderHTMLConfigProvider';
+diff --git a/node_modules/react-native-render-html/src/renderChildren.tsx b/node_modules/react-native-render-html/src/renderChildren.tsx
+index a669402..be9ffd6 100644
+--- a/node_modules/react-native-render-html/src/renderChildren.tsx
++++ b/node_modules/react-native-render-html/src/renderChildren.tsx
+@@ -4,8 +4,6 @@ import TNodeRenderer from './TNodeRenderer';
+ import { TChildrenRendererProps } from './shared-types';
+ import collapseTopMarginForChild from './helpers/collapseTopMarginForChild';
+ 
+-const empty = {};
+-
+ const mapCollapsibleChildren = (
+   propsForChildren: TChildrenRendererProps['propsForChildren'],
+   renderChild: TChildrenRendererProps['renderChild'],
+@@ -39,7 +37,7 @@ const mapCollapsibleChildren = (
+ 
+ export default function renderChildren({
+   tchildren,
+-  propsForChildren = empty,
++  propsForChildren = {},
+   disableMarginCollapsing,
+   renderChild
+ }: TChildrenRendererProps): ReactElement {


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
<!-- Explain what your change does and how it addresses the linked issue -->

A couple weeks ago we merged [this PR](https://github.com/Expensify/App/pull/52917) that introduced a patch to `react-native-render-html` that aimed to get rid of the console warning. The warning disappeared but it turned out there are some new problems with styling on the web (https://github.com/Expensify/App/issues/54304, https://github.com/Expensify/App/issues/54301).

I spent some time debugging these issues and figured it's becase the patch got rid of the default props that were originally passed to `TRenderEngineProvider.tsx/js` in the library. More specifically, `enableUserAgentStyles = true`, that prevented us from applying custom styles to certain elements. 

I created a new patch that addresses this exact problem and also gets rid of the console warning.

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/49035 https://github.com/Expensify/App/issues/51099 
PROPOSAL: N/A


### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

1. Log into the web app 
2. Open the console and make sure there is no console warning like _"TRenderEngineProvider: Support for defaultProps will be removed from function components in a future major release. Use JavaScript default parameters instead."_
3. Navigate to a workspace chat
4. Create an expense
5. Click on the expense preview.
6. Compare the expense status sentence "Waiting for You to approve expense(s)." style to the one in the staging app, make sure they are the same
7. Click on the report header.
8. Click Hold.
9. Enter a reason and save it.
10. Once again compare the styles with the staging app and make sure they are the same.
11. Go back to that chat
12. Send a link (google.com).
13. Send a heading markdown.
14. Make sure they look the same as in the staging app (link is underlined, heading markdown is bold)

You can also check out the screen recordings if something is unclear.

- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

N/A

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
6. Upload an image via copy paste
7. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->

Sameas **Tests** section above

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>MacOS: Chrome / Safari</summary>


https://github.com/user-attachments/assets/aed1a985-a981-4bcc-b9ff-94febb7eda58



</details>
