### PR TITLE
Make it possible to click the product training tooltip element

### DIFF
--- a/src/components/AutoCompleteSuggestions/AutoCompleteSuggestionsPortal/TransparentOverlay/TransparentOverlay.tsx
+++ b/src/components/AutoCompleteSuggestions/AutoCompleteSuggestionsPortal/TransparentOverlay/TransparentOverlay.tsx
@@ -1,6 +1,7 @@
 import React, {useCallback, useMemo} from 'react';
 import {View} from 'react-native';
 import type {PointerEvent} from 'react-native';
+import type {GestureResponderEvent} from 'react-native-modal';
 import type PressableProps from '@components/Pressable/GenericPressable/types';
 import PressableWithoutFeedback from '@components/Pressable/PressableWithoutFeedback';
 import useLocalize from '@hooks/useLocalize';
@@ -8,19 +9,23 @@ import useThemeStyles from '@hooks/useThemeStyles';
 import CONST from '@src/CONST';
 
 type TransparentOverlayProps = {
-    onPress: () => void;
+    onPress: (event?: GestureResponderEvent | MouseEvent | KeyboardEvent) => void;
+    holeX?: number;
+    holeY?: number;
+    holeWidth?: number;
+    holeHeight?: number;
 };
 
 type OnPressHandler = PressableProps['onPress'];
 
-function TransparentOverlay({onPress: onPressProp}: TransparentOverlayProps) {
+function TransparentOverlay({onPress: onPressProp, holeX = 0, holeY = 0, holeWidth = 0, holeHeight = 0}: TransparentOverlayProps) {
     const {translate} = useLocalize();
     const styles = useThemeStyles();
 
     const onPress = useCallback<NonNullable<OnPressHandler>>(
         (event) => {
             event?.preventDefault();
-            onPressProp();
+            onPressProp(event);
         },
         [onPressProp],
     );
@@ -38,6 +43,18 @@ function TransparentOverlay({onPress: onPressProp}: TransparentOverlayProps) {
         [],
     );
 
+    const holeStyle = useMemo(
+        () => ({
+            position: styles.pFixed,
+            top: holeY,
+            left: holeX,
+            width: holeWidth,
+            height: holeHeight,
+            zIndex: 1500,
+        }),
+        [holeX, holeY, holeWidth, holeHeight, styles.pFixed],
+    );
+
     return (
         <View
             onPointerDown={handlePointerDown}
@@ -48,7 +65,14 @@ function TransparentOverlay({onPress: onPressProp}: TransparentOverlayProps) {
                 style={[styles.flex1, styles.cursorDefault, overlay]}
                 accessibilityLabel={translate('common.close')}
                 role={CONST.ROLE.BUTTON}
-            />
+            >
+                <PressableWithoutFeedback
+                    onPress={onPress}
+                    style={holeStyle}
+                    accessibilityLabel={translate('common.close')}
+                    role={CONST.ROLE.BUTTON}
+                />
+            </PressableWithoutFeedback>
         </View>
     );
 }

--- a/src/components/FloatingActionButton.tsx
+++ b/src/components/FloatingActionButton.tsx
@@ -122,6 +122,7 @@ function FloatingActionButton({onPress, isActive, accessibilityLabel, role}: Flo
             renderTooltipContent={renderProductTrainingTooltip}
             wrapperStyle={styles.productTrainingTooltipWrapper}
             onHideTooltip={hideProductTrainingTooltip}
+            onChildrenElementPress={toggleFabAction}
         >
             <PressableWithoutFeedback
                 ref={(el) => {

--- a/src/components/LHNOptionsList/OptionRowLHN.tsx
+++ b/src/components/LHNOptionsList/OptionRowLHN.tsx
@@ -170,6 +170,15 @@ function OptionRowLHN({reportID, isFocused = false, onSelectRow = () => {}, opti
                 shiftVertical={isActiveWorkspaceChat ? 0 : variables.composerTooltipShiftVertical}
                 onHideTooltip={hideProductTrainingTooltip}
                 wrapperStyle={styles.productTrainingTooltipWrapper}
+                onChildrenElementPress={(event) => {
+                    Performance.markStart(CONST.TIMING.OPEN_REPORT);
+                    Timing.start(CONST.TIMING.OPEN_REPORT);
+
+                    event?.preventDefault();
+                    // Enable Composer to focus on clicking the same chat after opening the context menu.
+                    ReportActionComposeFocusManager.focus();
+                    onSelectRow(optionItem, popoverAnchor);
+                }}
             >
                 <View>
                     <Hoverable>

--- a/src/components/Search/SearchPageHeader.tsx
+++ b/src/components/Search/SearchPageHeader.tsx
@@ -367,6 +367,7 @@ function SearchPageHeader({queryJSON}: SearchPageHeaderProps) {
                         wrapperStyle={styles.productTrainingTooltipWrapper}
                         renderTooltipContent={renderProductTrainingTooltip}
                         onHideTooltip={hideProductTrainingTooltip}
+                        onChildrenElementPress={onFiltersButtonPress}
                     >
                         <Button
                             innerStyles={!isCannedQuery && [styles.searchRouterInputResults, styles.borderNone]}

--- a/src/components/Tooltip/BaseGenericTooltip/index.native.tsx
+++ b/src/components/Tooltip/BaseGenericTooltip/index.native.tsx
@@ -37,6 +37,7 @@ function BaseGenericTooltip({
     wrapperStyle = {},
     shouldUseOverlay = false,
     onHideTooltip = () => {},
+    onDismissTooltip = () => {},
     onChildrenElementPress = () => {},
 }: BaseGenericTooltipProps) {
     // The width of tooltip's inner content. Has to be undefined in the beginning
@@ -112,14 +113,16 @@ function BaseGenericTooltip({
         const isWithinTarget = !!pageX && !!pageY && pageX >= xOffset && pageX <= xOffset + targetWidth && pageY >= yOffset && pageY <= yOffset + targetHeight;
 
         console.log('handleOverlayClick', pageX, pageY, xOffset, targetWidth, yOffset, targetHeight, isWithinTarget);
+
         // Hide the tooltip
-        onHideTooltip();
+        onDismissTooltip();
 
         // If the click is within target bounds, trigger the children element's press callback
         requestAnimationFrame(() => {
             if (!isWithinTarget) {
                 return;
             }
+            onHideTooltip();
             onChildrenElementPress?.();
         });
     };

--- a/src/components/Tooltip/BaseGenericTooltip/index.native.tsx
+++ b/src/components/Tooltip/BaseGenericTooltip/index.native.tsx
@@ -129,7 +129,15 @@ function BaseGenericTooltip({
 
     return (
         <Portal hostName={!shouldUseOverlay ? 'modal' : undefined}>
-            {shouldUseOverlay && <TransparentOverlay onPress={handleOverlayClick} />}
+            {shouldUseOverlay && (
+                <TransparentOverlay
+                    onPress={handleOverlayClick}
+                    holeX={xOffset}
+                    holeY={yOffset}
+                    holeWidth={targetWidth}
+                    holeHeight={targetHeight}
+                />
+            )}
             <Animated.View
                 ref={rootWrapper}
                 style={[rootWrapperStyle, animationStyle]}

--- a/src/components/Tooltip/BaseGenericTooltip/index.tsx
+++ b/src/components/Tooltip/BaseGenericTooltip/index.tsx
@@ -141,7 +141,7 @@ function BaseGenericTooltip({
         const isWithinTarget = !!clickX && !!clickY && clickX >= xOffset && clickX <= xOffset + targetWidth && clickY >= yOffset && clickY <= yOffset + targetHeight;
 
         // Always hide the tooltip
-        onDismissTooltip();();
+        onDismissTooltip();;
 
         requestAnimationFrame(() => {
             if (!isWithinTarget) {

--- a/src/components/Tooltip/BaseGenericTooltip/index.tsx
+++ b/src/components/Tooltip/BaseGenericTooltip/index.tsx
@@ -38,6 +38,7 @@ function BaseGenericTooltip({
     },
     shouldUseOverlay = false,
     onHideTooltip = () => {},
+    onDismissTooltip = () => {},
     onChildrenElementPress = () => {},
 }: BaseGenericTooltipProps) {
     // The width of tooltip's inner content. Has to be undefined in the beginning
@@ -140,12 +141,14 @@ function BaseGenericTooltip({
         const isWithinTarget = !!clickX && !!clickY && clickX >= xOffset && clickX <= xOffset + targetWidth && clickY >= yOffset && clickY <= yOffset + targetHeight;
 
         // Always hide the tooltip
-        onHideTooltip();
+        onDismissTooltip();();
 
         requestAnimationFrame(() => {
             if (!isWithinTarget) {
                 return;
             }
+            // the tooltip should not be displayed again
+            onHideTooltip();
             onChildrenElementPress?.();
         });
     };

--- a/src/components/Tooltip/BaseGenericTooltip/index.tsx
+++ b/src/components/Tooltip/BaseGenericTooltip/index.tsx
@@ -38,6 +38,7 @@ function BaseGenericTooltip({
     },
     shouldUseOverlay = false,
     onHideTooltip = () => {},
+    onChildrenElementPress = () => {},
 }: BaseGenericTooltipProps) {
     // The width of tooltip's inner content. Has to be undefined in the beginning
     // as a width of 0 will cause the content to be rendered of a width of 0,
@@ -131,9 +132,27 @@ function BaseGenericTooltip({
         return null;
     }
 
+    const handleOverlayClick = (event?: MouseEvent | KeyboardEvent) => {
+        const clickX = event?.clientX;
+        const clickY = event?.clientY;
+
+        // Check if the click falls within the target element bounds
+        const isWithinTarget = !!clickX && !!clickY && clickX >= xOffset && clickX <= xOffset + targetWidth && clickY >= yOffset && clickY <= yOffset + targetHeight;
+
+        // Always hide the tooltip
+        onHideTooltip();
+
+        requestAnimationFrame(() => {
+            if (!isWithinTarget) {
+                return;
+            }
+            onChildrenElementPress?.();
+        });
+    };
+
     return ReactDOM.createPortal(
         <>
-            {shouldUseOverlay && <TransparentOverlay onPress={onHideTooltip} />}
+            {shouldUseOverlay && <TransparentOverlay onPress={handleOverlayClick} />}
             <Animated.View
                 ref={viewRef(rootWrapper)}
                 style={[rootWrapperStyle, animationStyle]}

--- a/src/components/Tooltip/BaseGenericTooltip/index.tsx
+++ b/src/components/Tooltip/BaseGenericTooltip/index.tsx
@@ -155,7 +155,15 @@ function BaseGenericTooltip({
 
     return ReactDOM.createPortal(
         <>
-            {shouldUseOverlay && <TransparentOverlay onPress={handleOverlayClick} />}
+            {shouldUseOverlay && (
+                <TransparentOverlay
+                    onPress={handleOverlayClick}
+                    holeX={xOffset}
+                    holeY={yOffset}
+                    holeWidth={targetWidth}
+                    holeHeight={targetHeight}
+                />
+            )}
             <Animated.View
                 ref={viewRef(rootWrapper)}
                 style={[rootWrapperStyle, animationStyle]}

--- a/src/components/Tooltip/BaseGenericTooltip/types.ts
+++ b/src/components/Tooltip/BaseGenericTooltip/types.ts
@@ -1,3 +1,4 @@
+import type {GestureResponderEvent} from 'react-native';
 import type {SharedValue} from 'react-native-reanimated';
 import type {SharedTooltipProps} from '@components/Tooltip/types';
 
@@ -30,6 +31,8 @@ type BaseGenericTooltipProps = {
 
     /** Handles what to do when hiding the tooltip */
     onHideTooltip?: () => void;
+
+    onChildrenElementPress?: (event: GestureResponderEvent | KeyboardEvent | undefined) => void;
 } & Pick<
     SharedTooltipProps,
     'renderTooltipContent' | 'maxWidth' | 'numberOfLines' | 'text' | 'shouldForceRenderingBelow' | 'wrapperStyle' | 'anchorAlignment' | 'shouldUseOverlay' | 'onHideTooltip'

--- a/src/components/Tooltip/BaseGenericTooltip/types.ts
+++ b/src/components/Tooltip/BaseGenericTooltip/types.ts
@@ -29,6 +29,8 @@ type BaseGenericTooltipProps = {
     A positive value shifts the tooltip down, and a negative value shifts it up. */
     shiftVertical?: number;
 
+    onDismissTooltip: () => void;
+
     /** Handles what to do when hiding the tooltip */
     onHideTooltip?: () => void;
 

--- a/src/components/Tooltip/EducationalTooltip/BaseEducationalTooltip.tsx
+++ b/src/components/Tooltip/EducationalTooltip/BaseEducationalTooltip.tsx
@@ -48,21 +48,6 @@ function BaseEducationalTooltip({children, onHideTooltip: onHideTooltipProp, sho
         [],
     );
 
-    // Automatically hide tooltip after 5 seconds
-    useEffect(() => {
-        if (!shouldAutoDismiss) {
-            return;
-        }
-
-        // Automatically hide tooltip after 5 seconds if shouldAutoDismiss is true
-        const timerID = setTimeout(() => {
-            closeTooltip();
-        }, 5000);
-        return () => {
-            clearTimeout(timerID);
-        };
-    }, [shouldAutoDismiss, closeTooltip]);
-
     useEffect(() => {
         if (!shouldMeasure || !shouldRender || didShow.current) {
             return;

--- a/src/components/Tooltip/GenericTooltip.tsx
+++ b/src/components/Tooltip/GenericTooltip.tsx
@@ -35,6 +35,7 @@ function GenericTooltip({
     shouldForceAnimate = false,
     shouldUseOverlay: shouldUseOverlayProp = false,
     onHideTooltip = () => {},
+    onChildrenElementPress = () => {},
 }: GenericTooltipProps) {
     const {preferredLocale} = useLocalize();
     const {windowWidth} = useWindowDimensions();
@@ -184,6 +185,7 @@ function GenericTooltip({
                     anchorAlignment={anchorAlignment}
                     shouldUseOverlay={shouldUseOverlay}
                     onHideTooltip={onPressOverlay}
+                    onChildrenElementPress={onChildrenElementPress}
                 />
             )}
             {/* eslint-disable-next-line react-compiler/react-compiler */}

--- a/src/components/Tooltip/GenericTooltip.tsx
+++ b/src/components/Tooltip/GenericTooltip.tsx
@@ -151,8 +151,7 @@ function GenericTooltip({
         }
         setShouldUseOverlay(false);
         hideTooltip();
-        onHideTooltip();
-    }, [shouldUseOverlay, onHideTooltip, hideTooltip]);
+    }, [shouldUseOverlay, hideTooltip]);
 
     // Skip the tooltip and return the children if the text is empty, we don't have a render function.
     if (StringUtils.isEmptyString(text) && renderTooltipContent == null) {
@@ -184,7 +183,8 @@ function GenericTooltip({
                     wrapperStyle={wrapperStyle}
                     anchorAlignment={anchorAlignment}
                     shouldUseOverlay={shouldUseOverlay}
-                    onHideTooltip={onPressOverlay}
+                    onDismissTooltip={onPressOverlay}
+                    onHideTooltip={onHideTooltip}
                     onChildrenElementPress={onChildrenElementPress}
                 />
             )}

--- a/src/components/Tooltip/types.ts
+++ b/src/components/Tooltip/types.ts
@@ -1,6 +1,6 @@
 import type {ReactNode} from 'react';
 import type React from 'react';
-import type {LayoutRectangle, StyleProp, ViewStyle} from 'react-native';
+import type {GestureResponderEvent, LayoutRectangle, StyleProp, ViewStyle} from 'react-native';
 import type {TooltipAnchorAlignment} from '@src/types/utils/AnchorAlignment';
 import type ChildrenProps from '@src/types/utils/ChildrenProps';
 
@@ -63,6 +63,8 @@ type GenericTooltipProps = SharedTooltipProps & {
 
     /** Whether to ignore TooltipSense activity and always triger animation */
     shouldForceAnimate?: boolean;
+
+    onChildrenElementPress?: (event: GestureResponderEvent | KeyboardEvent | undefined) => void;
 };
 
 type TooltipProps = ChildrenProps &
@@ -83,6 +85,7 @@ type EducationalTooltipProps = ChildrenProps &
 type TooltipExtendedProps = (EducationalTooltipProps | TooltipProps) & {
     /** Whether the actual Tooltip should be rendered. If false, it's just going to return the children */
     shouldRender?: boolean;
+    onChildrenElementPress?: (event?: GestureResponderEvent | KeyboardEvent | undefined) => void;
 };
 
 export default TooltipProps;

--- a/src/libs/Navigation/AppNavigator/createCustomBottomTabNavigator/BottomTabBar.tsx
+++ b/src/libs/Navigation/AppNavigator/createCustomBottomTabNavigator/BottomTabBar.tsx
@@ -157,6 +157,7 @@ function BottomTabBar({selectedTab}: BottomTabBarProps) {
                     renderTooltipContent={renderProductTrainingTooltip}
                     wrapperStyle={styles.productTrainingTooltipWrapper}
                     onHideTooltip={hideProductTrainingTooltip}
+                    onChildrenElementPress={navigateToChats}
                 >
                     <PressableWithFeedback
                         onPress={navigateToChats}

--- a/src/pages/Search/SearchTypeMenuNarrow.tsx
+++ b/src/pages/Search/SearchTypeMenuNarrow.tsx
@@ -221,6 +221,7 @@ function SearchTypeMenuNarrow({typeMenuItems, activeItemIndex, queryJSON, title,
                 renderTooltipContent={renderProductTrainingTooltip}
                 onHideTooltip={hideProductTrainingTooltip}
                 shouldUseOverlay
+                onChildrenElementPress={onPress}
             >
                 <Button
                     icon={Expensicons.Filters}


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
<!-- Explain what your change does and how it addresses the linked issue -->

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$
PROPOSAL:


### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

- [ ] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->
// TODO: These must be filled out, or the issue title must include "[No QA]."

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [ ] I linked the correct issue in the `### Fixed Issues` section above
- [ ] I wrote clear testing steps that cover the changes made in this PR
    - [ ] I added steps for local testing in the `Tests` section
    - [ ] I added steps for the expected offline behavior in the `Offline steps` section
    - [ ] I added steps for Staging and/or Production testing in the `QA steps` section
    - [ ] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [ ] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [ ] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [ ] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [ ] I ran the tests on **all platforms** & verified they passed on:
    - [ ] Android: Native
    - [ ] Android: mWeb Chrome
    - [ ] iOS: Native
    - [ ] iOS: mWeb Safari
    - [ ] MacOS: Chrome / Safari
    - [ ] MacOS: Desktop
- [ ] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [ ] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [ ] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [ ] I verified that comments were added to code that is not self explanatory
    - [ ] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [ ] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [ ] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [ ] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [ ] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [ ] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [ ] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [ ] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [ ] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [ ] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [ ] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [ ] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [ ] I verified that if a function's arguments changed that all usages have also been updated correctly
- [ ] If any new file was added I verified that:
    - [ ] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [ ] If a new CSS style is added I verified that:
    - [ ] A similar style doesn't already exist
    - [ ] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [ ] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [ ] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [ ] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [ ] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [ ] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [ ] I verified that all the inputs inside a form are aligned with each other.
    - [ ] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [ ] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [ ] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [ ] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Desktop</summary>

<!-- add screenshots or videos here -->

</details>
