### PR TITLE
Fix open app

### DIFF
--- a/src/ONYXKEYS.ts
+++ b/src/ONYXKEYS.ts
@@ -295,6 +295,9 @@ const ONYXKEYS = {
     /** Is report data loading? */
     IS_LOADING_APP: 'isLoadingApp',
 
+    /** Is the app loaded? */
+    HAS_LOADED_APP: 'hasLoadedApp',
+
     /** Is the test tools modal open? */
     IS_TEST_TOOLS_MODAL_OPEN: 'isTestToolsModalOpen',
 
@@ -1011,6 +1014,7 @@ type OnyxValuesMapping = {
     [ONYXKEYS.IS_TEST_TOOLS_MODAL_OPEN]: boolean;
     [ONYXKEYS.APP_PROFILING_IN_PROGRESS]: boolean;
     [ONYXKEYS.IS_LOADING_APP]: boolean;
+    [ONYXKEYS.HAS_LOADED_APP]: boolean;
     [ONYXKEYS.WALLET_TRANSFER]: OnyxTypes.WalletTransfer;
     [ONYXKEYS.LAST_ACCESSED_WORKSPACE_POLICY_ID]: string;
     [ONYXKEYS.SHOULD_SHOW_COMPOSE_INPUT]: boolean;

--- a/src/libs/actions/App.ts
+++ b/src/libs/actions/App.ts
@@ -106,6 +106,14 @@ Onyx.connect({
     },
 });
 
+let hasLoadedApp: boolean | undefined;
+Onyx.connect({
+    key: ONYXKEYS.HAS_LOADED_APP,
+    callback: (value) => {
+        hasLoadedApp = value;
+    },
+});
+
 const KEYS_TO_PRESERVE: OnyxKey[] = [
     ONYXKEYS.ACCOUNT,
     ONYXKEYS.IS_CHECKING_PUBLIC_ROOM,
@@ -239,7 +247,13 @@ function getOnyxDataForOpenOrReconnect(isOpenApp = false, isFullReconnect = fals
                 value: true,
             },
         ],
-        successData: [],
+        successData: [
+            {
+                onyxMethod: Onyx.METHOD.MERGE,
+                key: ONYXKEYS.HAS_LOADED_APP,
+                value: true,
+            },
+        ],
         finallyData: [
             {
                 onyxMethod: Onyx.METHOD.MERGE,
@@ -291,6 +305,10 @@ function openApp() {
  * @param [updateIDFrom] the ID of the Onyx update that we want to start fetching from
  */
 function reconnectApp(updateIDFrom: OnyxEntry<number> = 0) {
+    if (!hasLoadedApp) {
+        openApp();
+        return;
+    }
     console.debug(`[OnyxUpdates] App reconnecting with updateIDFrom: ${updateIDFrom}`);
     getPolicyParamsForOpenOrReconnect().then((policyParams) => {
         const params: ReconnectAppParams = policyParams;

--- a/src/libs/actions/Delegate.ts
+++ b/src/libs/actions/Delegate.ts
@@ -66,6 +66,7 @@ const KEYS_TO_PRESERVE_DELEGATE_ACCESS = [
     ONYXKEYS.SESSION,
     ONYXKEYS.STASHED_SESSION,
     ONYXKEYS.IS_LOADING_APP,
+    ONYXKEYS.HAS_LOADED_APP,
     ONYXKEYS.STASHED_CREDENTIALS,
 
     // We need to preserve the sidebar loaded state since we never unrender the sidebar when connecting as a delegate

--- a/src/libs/actions/QueuedOnyxUpdates.ts
+++ b/src/libs/actions/QueuedOnyxUpdates.ts
@@ -32,6 +32,7 @@ function flushQueue(): Promise<void> {
             ONYXKEYS.NVP_PREFERRED_LOCALE,
             ONYXKEYS.SESSION,
             ONYXKEYS.IS_LOADING_APP,
+            ONYXKEYS.HAS_LOADED_APP,
             ONYXKEYS.CREDENTIALS,
             ONYXKEYS.IS_SIDEBAR_LOADED,
             ONYXKEYS.ACCOUNT,

--- a/tests/actions/AppTest.ts
+++ b/tests/actions/AppTest.ts
@@ -38,6 +38,7 @@ describe('actions/App', () => {
 
     test('lastFullReconnectTime - full reconnectApp', async () => {
         // When a full ReconnectApp runs
+        await Onyx.set(ONYXKEYS.HAS_LOADED_APP, true);
         App.reconnectApp();
         App.confirmReadyToOpenApp();
         await waitForBatchedUpdates();
@@ -48,6 +49,7 @@ describe('actions/App', () => {
 
     test('lastFullReconnectTime - incremental reconnectApp', async () => {
         // When an incremental ReconnectApp runs
+        await Onyx.set(ONYXKEYS.HAS_LOADED_APP, true);
         App.reconnectApp(123);
         App.confirmReadyToOpenApp();
         await waitForBatchedUpdates();

--- a/tests/actions/SessionTest.ts
+++ b/tests/actions/SessionTest.ts
@@ -111,6 +111,7 @@ describe('Session', () => {
 
     test('ReconnectApp should push request to the queue', async () => {
         await TestHelper.signInWithTestUser();
+        await Onyx.set(ONYXKEYS.HAS_LOADED_APP, true);
         await Onyx.set(ONYXKEYS.NETWORK, {isOffline: true});
 
         App.confirmReadyToOpenApp();
@@ -128,8 +129,29 @@ describe('Session', () => {
         expect(PersistedRequests.getAll().length).toBe(0);
     });
 
+    test('ReconnectApp should open if app is not loaded', async () => {
+        await TestHelper.signInWithTestUser();
+        await Onyx.set(ONYXKEYS.HAS_LOADED_APP, false);
+        await Onyx.set(ONYXKEYS.NETWORK, {isOffline: true});
+
+        App.confirmReadyToOpenApp();
+        App.reconnectApp();
+
+        await waitForBatchedUpdates();
+
+        expect(PersistedRequests.getAll().length).toBe(1);
+        expect(PersistedRequests.getAll().at(0)?.command).toBe(WRITE_COMMANDS.OPEN_APP);
+
+        await Onyx.set(ONYXKEYS.NETWORK, {isOffline: false});
+
+        await waitForBatchedUpdates();
+
+        expect(PersistedRequests.getAll().length).toBe(0);
+    });
+
     test('ReconnectApp should replace same requests from the queue', async () => {
         await TestHelper.signInWithTestUser();
+        await Onyx.set(ONYXKEYS.HAS_LOADED_APP, true);
         await Onyx.set(ONYXKEYS.NETWORK, {isOffline: true});
 
         App.confirmReadyToOpenApp();

--- a/tests/actions/SessionTest.ts
+++ b/tests/actions/SessionTest.ts
@@ -1,14 +1,14 @@
 import {beforeEach, jest, test} from '@jest/globals';
 import Onyx from 'react-native-onyx';
 import type {OnyxEntry} from 'react-native-onyx';
-import * as App from '@libs/actions/App';
+import {confirmReadyToOpenApp, openApp, reconnectApp} from '@libs/actions/App';
 import OnyxUpdateManager from '@libs/actions/OnyxUpdateManager';
+import {getAll as getAllPersistedRequests} from '@libs/actions/PersistedRequests';
 import {WRITE_COMMANDS} from '@libs/API/types';
 import HttpUtils from '@libs/HttpUtils';
 import PushNotification from '@libs/Notification/PushNotification';
 // This lib needs to be imported, but it has nothing to export since all it contains is an Onyx connection
 import '@libs/Notification/PushNotification/subscribePushNotification';
-import * as PersistedRequests from '@userActions/PersistedRequests';
 import CONST from '@src/CONST';
 import * as SessionUtil from '@src/libs/actions/Session';
 import ONYXKEYS from '@src/ONYXKEYS';
@@ -88,8 +88,8 @@ describe('Session', () => {
             );
 
         // When we attempt to fetch the initial app data via the API
-        App.confirmReadyToOpenApp();
-        App.openApp();
+        confirmReadyToOpenApp();
+        openApp();
         await waitForBatchedUpdates();
 
         // Then it should fail and reauthenticate the user adding the new authToken to the session
@@ -114,19 +114,19 @@ describe('Session', () => {
         await Onyx.set(ONYXKEYS.HAS_LOADED_APP, true);
         await Onyx.set(ONYXKEYS.NETWORK, {isOffline: true});
 
-        App.confirmReadyToOpenApp();
-        App.reconnectApp();
+        confirmReadyToOpenApp();
+        reconnectApp();
 
         await waitForBatchedUpdates();
 
-        expect(PersistedRequests.getAll().length).toBe(1);
-        expect(PersistedRequests.getAll().at(0)?.command).toBe(WRITE_COMMANDS.RECONNECT_APP);
+        expect(getAllPersistedRequests().length).toBe(1);
+        expect(getAllPersistedRequests().at(0)?.command).toBe(WRITE_COMMANDS.RECONNECT_APP);
 
         await Onyx.set(ONYXKEYS.NETWORK, {isOffline: false});
 
         await waitForBatchedUpdates();
 
-        expect(PersistedRequests.getAll().length).toBe(0);
+        expect(getAllPersistedRequests().length).toBe(0);
     });
 
     test('ReconnectApp should open if app is not loaded', async () => {
@@ -134,19 +134,19 @@ describe('Session', () => {
         await Onyx.set(ONYXKEYS.HAS_LOADED_APP, false);
         await Onyx.set(ONYXKEYS.NETWORK, {isOffline: true});
 
-        App.confirmReadyToOpenApp();
-        App.reconnectApp();
+        confirmReadyToOpenApp();
+        reconnectApp();
 
         await waitForBatchedUpdates();
 
-        expect(PersistedRequests.getAll().length).toBe(1);
-        expect(PersistedRequests.getAll().at(0)?.command).toBe(WRITE_COMMANDS.OPEN_APP);
+        expect(getAllPersistedRequests().length).toBe(1);
+        expect(getAllPersistedRequests().at(0)?.command).toBe(WRITE_COMMANDS.OPEN_APP);
 
         await Onyx.set(ONYXKEYS.NETWORK, {isOffline: false});
 
         await waitForBatchedUpdates();
 
-        expect(PersistedRequests.getAll().length).toBe(0);
+        expect(getAllPersistedRequests().length).toBe(0);
     });
 
     test('ReconnectApp should replace same requests from the queue', async () => {
@@ -154,57 +154,57 @@ describe('Session', () => {
         await Onyx.set(ONYXKEYS.HAS_LOADED_APP, true);
         await Onyx.set(ONYXKEYS.NETWORK, {isOffline: true});
 
-        App.confirmReadyToOpenApp();
-        App.reconnectApp();
-        App.reconnectApp();
-        App.reconnectApp();
-        App.reconnectApp();
+        confirmReadyToOpenApp();
+        reconnectApp();
+        reconnectApp();
+        reconnectApp();
+        reconnectApp();
 
         await waitForBatchedUpdates();
 
-        expect(PersistedRequests.getAll().length).toBe(1);
-        expect(PersistedRequests.getAll().at(0)?.command).toBe(WRITE_COMMANDS.RECONNECT_APP);
+        expect(getAllPersistedRequests().length).toBe(1);
+        expect(getAllPersistedRequests().at(0)?.command).toBe(WRITE_COMMANDS.RECONNECT_APP);
 
         await Onyx.set(ONYXKEYS.NETWORK, {isOffline: false});
 
-        expect(PersistedRequests.getAll().length).toBe(0);
+        expect(getAllPersistedRequests().length).toBe(0);
     });
 
     test('OpenApp should push request to the queue', async () => {
         await TestHelper.signInWithTestUser();
         await Onyx.set(ONYXKEYS.NETWORK, {isOffline: true});
 
-        App.openApp();
+        openApp();
 
         await waitForBatchedUpdates();
 
-        expect(PersistedRequests.getAll().length).toBe(1);
-        expect(PersistedRequests.getAll().at(0)?.command).toBe(WRITE_COMMANDS.OPEN_APP);
+        expect(getAllPersistedRequests().length).toBe(1);
+        expect(getAllPersistedRequests().at(0)?.command).toBe(WRITE_COMMANDS.OPEN_APP);
 
         await Onyx.set(ONYXKEYS.NETWORK, {isOffline: false});
 
         await waitForBatchedUpdates();
 
-        expect(PersistedRequests.getAll().length).toBe(0);
+        expect(getAllPersistedRequests().length).toBe(0);
     });
 
     test('OpenApp should replace same requests from the queue', async () => {
         await TestHelper.signInWithTestUser();
         await Onyx.set(ONYXKEYS.NETWORK, {isOffline: true});
 
-        App.openApp();
-        App.openApp();
-        App.openApp();
-        App.openApp();
+        openApp();
+        openApp();
+        openApp();
+        openApp();
 
         await waitForBatchedUpdates();
 
-        expect(PersistedRequests.getAll().length).toBe(1);
-        expect(PersistedRequests.getAll().at(0)?.command).toBe(WRITE_COMMANDS.OPEN_APP);
+        expect(getAllPersistedRequests().length).toBe(1);
+        expect(getAllPersistedRequests().at(0)?.command).toBe(WRITE_COMMANDS.OPEN_APP);
 
         await Onyx.set(ONYXKEYS.NETWORK, {isOffline: false});
 
-        expect(PersistedRequests.getAll().length).toBe(0);
+        expect(getAllPersistedRequests().length).toBe(0);
     });
 
     test('LogOut should replace same requests from the queue instead of adding new one', async () => {
@@ -219,11 +219,11 @@ describe('Session', () => {
 
         await waitForBatchedUpdates();
 
-        expect(PersistedRequests.getAll().length).toBe(1);
-        expect(PersistedRequests.getAll().at(0)?.command).toBe(WRITE_COMMANDS.LOG_OUT);
+        expect(getAllPersistedRequests().length).toBe(1);
+        expect(getAllPersistedRequests().at(0)?.command).toBe(WRITE_COMMANDS.LOG_OUT);
 
         await Onyx.set(ONYXKEYS.NETWORK, {isOffline: false});
 
-        expect(PersistedRequests.getAll().length).toBe(0);
+        expect(getAllPersistedRequests().length).toBe(0);
     });
 });

--- a/tests/unit/NetworkTest.tsx
+++ b/tests/unit/NetworkTest.tsx
@@ -136,6 +136,7 @@ describe('NetworkTests', () => {
 
         // Sign in test user and wait for updates
         await TestHelper.signInWithTestUser(TEST_USER_ACCOUNT_ID, TEST_USER_LOGIN);
+        await Onyx.set(ONYXKEYS.HAS_LOADED_APP, true);
         await waitForBatchedUpdates();
 
         const initialAuthToken = sessionState?.authToken;

--- a/tests/unit/NetworkTest.tsx
+++ b/tests/unit/NetworkTest.tsx
@@ -4,7 +4,7 @@ import type {Mock} from 'jest-mock';
 import type {OnyxEntry} from 'react-native-onyx';
 import MockedOnyx from 'react-native-onyx';
 import TestToolMenu from '@components/TestToolMenu';
-import * as App from '@libs/actions/App';
+import {confirmReadyToOpenApp, reconnectApp} from '@libs/actions/App';
 import {resetReauthentication} from '@libs/Middleware/Reauthentication';
 import CONST from '@src/CONST';
 import * as NetworkActions from '@src/libs/actions/Network';
@@ -166,8 +166,8 @@ describe('NetworkTests', () => {
         await Onyx.set(ONYXKEYS.NETWORK, {isOffline: false});
 
         // Trigger reconnect which will fail due to expired token
-        App.confirmReadyToOpenApp();
-        App.reconnectApp();
+        confirmReadyToOpenApp();
+        reconnectApp();
         await waitForBatchedUpdates();
 
         // 4. First API Call Verification - Check ReconnectApp
@@ -184,8 +184,8 @@ describe('NetworkTests', () => {
         await Onyx.set(ONYXKEYS.NETWORK, {isOffline: false});
 
         // 7.Trigger another reconnect due to network change
-        App.confirmReadyToOpenApp();
-        App.reconnectApp();
+        confirmReadyToOpenApp();
+        reconnectApp();
 
         // 8. Now fail the pending authentication request
         resolveAuthRequest(Promise.reject(new Error('Network request failed')));


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
<!-- Explain what your change does and how it addresses the linked issue -->

If the call to openApp gets interrupted or fails for some reason, the app stays stuck in a loading state. This fixes is by saving a state in Onyx to check if the app successfully loaded previously, and if it didn't we call openApp instead of reconnectApp.

Before:

https://github.com/user-attachments/assets/1f7e3899-7348-402f-9941-49e9b9affd21

After:

https://github.com/user-attachments/assets/1874f2f1-1901-4841-a146-1e3f0c20f382

The easiest way to reproduce the issue is to interrupt the openApp call by reloading the page right after clearing the storage, it doesn't lead to the exact same state that we see in FullStory since no messages are loaded, but it is the same issue.

I was also able to reproduce the exact state I saw some users in on FullStory where their concierge chat only displays the first message. This state is harder to reproduce and I don't have a recording of it sadly. I was able to reproduce this state by interrupting the openApp when creating a new account, right at the same time as we display the onboarding (I am now blocked from creating new accounts because I made too many so I am not able to try again to get a recording of it).

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$
PROPOSAL:


### Tests

- [x] Verify that no errors appear in the JS console
- [x] Use the following steps to get the account in a bugged state and check that this fixes it

#### Simple repro

This is probably not what users do, but it does trigger the same bug.

1. Log into the app
2. Go to Settings -> Troubleshoot -> Clear cache and restart
3. As soon as you confirm the reload, reload the page (cmd + R)
4. Go to chats and see the app stuck in a loading state

#### Exact repro (optional)

This one is pretty difficult to reproduce, but matches what we are seeing in FullStory. I recommend opening chrome devtools in the network tab and use throttling "3G" to make it easier.

1. Create a new account
2. As soon as the onboarding appears, close the tab
3. Reopen the tab and see only the first message on concierge chat loaded

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->

Same as tests

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos

<details>
<summary>Android: Native</summary>

https://github.com/user-attachments/assets/46a4b6a6-e050-4dd3-9900-33882c5d72b4

</details>

<details>
<summary>Android: mWeb Chrome</summary>

https://github.com/user-attachments/assets/2403f486-942b-4fe5-b9da-b9fe8162291f

</details>

<details>
<summary>iOS: Native</summary>

https://github.com/user-attachments/assets/d0f269ac-d92a-4262-994d-f4ad14a206c7

</details>

<details>
<summary>iOS: mWeb Safari</summary>

https://github.com/user-attachments/assets/b2843d1f-3662-4dfe-97a4-d985d1c949e0

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

https://github.com/user-attachments/assets/8b3074a0-ae9e-47c6-90db-1a454cf82267

</details>

<details>
<summary>MacOS: Desktop</summary>

https://github.com/user-attachments/assets/78e47a78-3ec7-4d05-bba1-da0c888575e8

</details>
