### PR TITLE
[NO QA] Add YAPL build step to HybridApp builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -463,8 +463,6 @@ You can only build HybridApp if you have been granted access to [`Mobile-Expensi
     [url "https://github.com/"]
         insteadOf = ssh://git@github.com/
     ```
-3. The first time you build the app you will need to build YAPL (OldDot javascript logic). Simply run `npm run grunt:build:shared` from the `Mobile-Expensify` submodule
-    - The following runtime error often indicates that YAPL has not been built correctly: `undefined is not an object (evaluating'Store.ReportHistory.bindCacheClearingEvents')`
 
 At this point, the default behavior of some `npm` scripts will change to target HybridApp:
 - `npm run android` - build HybridApp for Android

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "postinstall": "./scripts/postInstall.sh",
     "clean": "./scripts/clean.sh",
     "clean-standalone": "STANDALONE_NEW_DOT=true ./scripts/clean.sh",
-    "android": "./scripts/set-pusher-suffix.sh && npm run grunt:build:shared && ./scripts/run-build.sh --android",
+    "android": "./scripts/set-pusher-suffix.sh && cd Mobile-Expensify && npm run grunt:build:shared && ../scripts/run-build.sh --android",
     "android-standalone": "./scripts/set-pusher-suffix.sh && STANDALONE_NEW_DOT=true ./scripts/run-build.sh --android",
     "ios": "./scripts/set-pusher-suffix.sh && ./scripts/run-build.sh --ios",
     "ios-standalone": "./scripts/set-pusher-suffix.sh && STANDALONE_NEW_DOT=true ./scripts/run-build.sh --ios",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "postinstall": "./scripts/postInstall.sh",
     "clean": "./scripts/clean.sh",
     "clean-standalone": "STANDALONE_NEW_DOT=true ./scripts/clean.sh",
-    "android": "./scripts/set-pusher-suffix.sh && ./scripts/run-build.sh --android",
+    "android": "./scripts/set-pusher-suffix.sh && npm run grunt:build:shared && ./scripts/run-build.sh --android",
     "android-standalone": "./scripts/set-pusher-suffix.sh && STANDALONE_NEW_DOT=true ./scripts/run-build.sh --android",
     "ios": "./scripts/set-pusher-suffix.sh && ./scripts/run-build.sh --ios",
     "ios-standalone": "./scripts/set-pusher-suffix.sh && STANDALONE_NEW_DOT=true ./scripts/run-build.sh --ios",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "postinstall": "./scripts/postInstall.sh",
     "clean": "./scripts/clean.sh",
     "clean-standalone": "STANDALONE_NEW_DOT=true ./scripts/clean.sh",
-    "android": "./scripts/set-pusher-suffix.sh && cd Mobile-Expensify && npm run grunt:build:shared && ../scripts/run-build.sh --android",
+    "android": "./scripts/set-pusher-suffix.sh && cd Mobile-Expensify && npm run grunt:build:shared && cd .. && ./scripts/run-build.sh --android",
     "android-standalone": "./scripts/set-pusher-suffix.sh && STANDALONE_NEW_DOT=true ./scripts/run-build.sh --android",
     "ios": "./scripts/set-pusher-suffix.sh && ./scripts/run-build.sh --ios",
     "ios-standalone": "./scripts/set-pusher-suffix.sh && STANDALONE_NEW_DOT=true ./scripts/run-build.sh --ios",


### PR DESCRIPTION
### Explanation of Change

Engineers building the Android HybridApp for the first time see a failure due to yapl code not being built. They they need to search slack and manually do this which is confusing and time-consuming. This change ensures it is done automatically.

Then I deleted step 3 from the HybridApp build instructions.

_I should be able to remove the manual step in our build workflows too, but I'll do that separately._

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
https://github.com/Expensify/App/issues/54877

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

**A) Script**
- `grunt build: shared` should run when an Android build is started
- <img width="875" alt="Screenshot 2025-01-17 at 11 10 23" src="https://github.com/user-attachments/assets/db21e36c-fddb-46a6-aba9-0ecabd8cf2f1" />

**B) Build**
- Clone a fresh App repo
- Clone the Mobile-Expensify submodule
- Build the android app
    - `cd app`
    - `git submodule update --init --progress --depth 100` 
    - `npm i`
    - `npm run android`
- It should build, and the app should not crash on start!

