### PR TITLE
Revert "Bump Onyx to 2.0.91 / Enable skippable collection member IDs in Onyx"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -98,7 +98,7 @@
         "react-native-launch-arguments": "^4.0.2",
         "react-native-localize": "^2.2.6",
         "react-native-modal": "^13.0.0",
-        "react-native-onyx": "2.0.91",
+        "react-native-onyx": "2.0.89",
         "react-native-pager-view": "6.5.1",
         "react-native-pdf": "6.7.3",
         "react-native-performance": "^5.1.0",
@@ -32318,9 +32318,9 @@
       }
     },
     "node_modules/react-native-onyx": {
-      "version": "2.0.91",
-      "resolved": "https://registry.npmjs.org/react-native-onyx/-/react-native-onyx-2.0.91.tgz",
-      "integrity": "sha512-tmRnU6+1DxL+Vbs+7fZWWx2plSDrgs/s6cR2XRamjScpqkeXaaTeajZUNpMImIHZQI5eSazRySNxO5zKnzCL1w==",
+      "version": "2.0.89",
+      "resolved": "https://registry.npmjs.org/react-native-onyx/-/react-native-onyx-2.0.89.tgz",
+      "integrity": "sha512-JzXjas0UNnYqTH4XD2Qfs64kBJBvHQ7HIIglieL1+Gto7eANyFRUpr0uRM3BlONinSPD/1xWZIurYAJtHuM5dg==",
       "license": "MIT",
       "dependencies": {
         "ascii-table": "0.0.9",

--- a/package.json
+++ b/package.json
@@ -163,7 +163,7 @@
     "react-native-launch-arguments": "^4.0.2",
     "react-native-localize": "^2.2.6",
     "react-native-modal": "^13.0.0",
-    "react-native-onyx": "2.0.91",
+    "react-native-onyx": "2.0.89",
     "react-native-pager-view": "6.5.1",
     "react-native-pdf": "6.7.3",
     "react-native-performance": "^5.1.0",

--- a/src/CONST.ts
+++ b/src/CONST.ts
@@ -16,8 +16,6 @@ import type PlaidBankAccount from './types/onyx/PlaidBankAccount';
 const EMPTY_ARRAY = Object.freeze([]);
 const EMPTY_OBJECT = Object.freeze({});
 
-const DEFAULT_NUMBER_ID = 0;
-
 const CLOUDFRONT_DOMAIN = 'cloudfront.net';
 const CLOUDFRONT_URL = `https://d2k5nsl2zxldvw.${CLOUDFRONT_DOMAIN}`;
 const ACTIVE_EXPENSIFY_URL = addTrailingForwardSlash(Config?.NEW_EXPENSIFY_URL ?? 'https://new.expensify.com');
@@ -914,7 +912,7 @@ const CONST = {
     CLOUDFRONT_URL,
     EMPTY_ARRAY,
     EMPTY_OBJECT,
-    DEFAULT_NUMBER_ID,
+    DEFAULT_NUMBER_ID: 0,
     USE_EXPENSIFY_URL,
     EXPENSIFY_URL,
     GOOGLE_MEET_URL_ANDROID: 'https://meet.google.com',
@@ -6562,7 +6560,6 @@ const CONST = {
             ERROR_PERMISSION_DENIED: 'permissionDenied',
         },
     },
-    SKIPPABLE_COLLECTION_MEMBER_IDS: [String(DEFAULT_NUMBER_ID), '-1', 'undefined', 'null', 'NaN'] as string[],
 } as const;
 
 type Country = keyof typeof CONST.ALL_COUNTRIES;

--- a/src/setup/index.ts
+++ b/src/setup/index.ts
@@ -1,7 +1,7 @@
 import {I18nManager} from 'react-native';
 import Onyx from 'react-native-onyx';
 import intlPolyfill from '@libs/IntlPolyfill';
-import {setDeviceID} from '@userActions/Device';
+import * as Device from '@userActions/Device';
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
 import addUtilsToWindow from './addUtilsToWindow';
@@ -42,10 +42,9 @@ export default function () {
             // Always open the home route on app startup for native platforms by clearing the lastVisitedPath
             [ONYXKEYS.LAST_VISITED_PATH]: initializeLastVisitedPath(),
         },
-        skippableCollectionMemberIDs: CONST.SKIPPABLE_COLLECTION_MEMBER_IDS,
     });
 
-    setDeviceID();
+    Device.setDeviceID();
 
     // Force app layout to work left to right because our design does not currently support devices using this mode
     I18nManager.allowRTL(false);


### PR DESCRIPTION
Reverts Expensify/App#54163. It's causing a test to fail consistently in GH actions on main.

# Fixed Issues
https://github.com/Expensify/App/issues/56001