### PR TITLE
[CP Staging] Revert "Show 'Report physical card loss/damage' option for physical cards, regardless of activation status"

### DIFF
--- a/src/pages/settings/Wallet/ExpensifyCardPage.tsx
+++ b/src/pages/settings/Wallet/ExpensifyCardPage.tsx
@@ -253,20 +253,17 @@ function ExpensifyCardPage({
                             </>
                         ))}
                         {physicalCards.map((card) => {
-                            if (card.state !== CONST.EXPENSIFY_CARD.STATE.OPEN && card.state !== CONST.EXPENSIFY_CARD.STATE.NOT_ACTIVATED) {
+                            if (card.state !== CONST.EXPENSIFY_CARD.STATE.OPEN) {
                                 return null;
                             }
-
                             return (
                                 <>
-                                    {card.state === CONST.EXPENSIFY_CARD.STATE.OPEN && (
-                                        <MenuItemWithTopDescription
-                                            description={translate('cardPage.physicalCardNumber')}
-                                            title={maskCard(card?.lastFourPAN)}
-                                            interactive={false}
-                                            titleStyle={styles.walletCardNumber}
-                                        />
-                                    )}
+                                    <MenuItemWithTopDescription
+                                        description={translate('cardPage.physicalCardNumber')}
+                                        title={maskCard(card?.lastFourPAN)}
+                                        interactive={false}
+                                        titleStyle={styles.walletCardNumber}
+                                    />
                                     <MenuItem
                                         title={translate('reportCardLostOrDamaged.report')}
                                         icon={Expensicons.Flag}


### PR DESCRIPTION
Reverts Expensify/App#55767

Fixes:
Fixes https://github.com/Expensify/App/issues/56148
Fixes https://github.com/Expensify/App/issues/56150
Fixes https://github.com/Expensify/App/issues/56155

### QA steps

Retest the linked blockers - they might not even be possible as you wont be able to report fraud for those cards