### PR TITLE
[WIP] Recursively translate templates

### DIFF
--- a/scripts/generateTranslations.ts
+++ b/scripts/generateTranslations.ts
@@ -1,214 +1,182 @@
 import {execSync} from 'child_process';
 import fs from 'fs';
-// import OpenAI from 'openai';
 import path from 'path';
-import type {StringLiteral, TemplateExpression} from 'typescript';
-import ts, {EmitHint} from 'typescript';
+import ts from 'typescript';
 
 const LANGUAGES_DIR = path.join(__dirname, '../src/languages');
-
-// Path to the English source file
 const SOURCE_FILE = `${LANGUAGES_DIR}/en.ts`;
-
 const TARGET_LANGUAGES = ['es'];
 
-// Initialize OpenAI API
-// const openai = new OpenAI({apiKey: process.env.OPENAI_API_KEY});
-
-// Temporary placeholder for actual translation function
 async function translate(text: string, targetLang: string): Promise<string> {
+    console.log(`🟢 Sending text for translation: "${text}" → ${targetLang}`);
     return Promise.resolve(`[${targetLang}] ${text}`);
 }
 
-const tsPrinter = ts.createPrinter();
-const debugFile = ts.createSourceFile('tempDebug.ts', '', ts.ScriptTarget.Latest);
-
-// Helper function to call OpenAI for translation
-// async function translateText(text: string, targetLang: string): Promise<string> {
-//     try {
-//         const response = await openai.chat.completions.create({
-//             model: 'gpt-4',
-//             messages: [
-//                 {
-//                     role: 'system',
-//                     content: `You are a professional translator. Translate the following text to ${targetLang}. It is either a plain string or a TypeScript function that returns a template string. Preserve placeholders like \${username}, \${count}, \${someBoolean ? 'valueIfTrue' : 'valueIfFalse'} etc without modifying their contents or removing the brackets. The contents of the placeholders are descriptive of what they represent in the phrase, but may include ternary expressions or other TypeScript code.`,
-//                 },
-//                 {role: 'user', content: text},
-//             ],
-//             temperature: 0.3,
-//         });
-//
-//         return response.choices.at(0)?.message?.content?.trim() ?? text;
-//     } catch (error) {
-//         console.error(`Error translating "${text}" to ${targetLang}:`, error);
-//         return text; // Fallback to English if translation fails
-//     }
-// }
-
-function isPlainStringNode(node: ts.Node): node is StringLiteral {
-    return (
-        ts.isStringLiteral(node) &&
-        !!node.parent && // Ensure the node has a parent
-        !ts.isImportDeclaration(node.parent) && // Ignore import paths
-        !ts.isExportDeclaration(node.parent) && // Ignore export paths
-        !ts.isCaseClause(node.parent)
-    ); // Ignore switch-case strings
+/** Checks if a node is a plain string literal */
+function isPlainStringNode(node: ts.Node): node is ts.StringLiteral {
+    return ts.isStringLiteral(node) && !!node.parent && !ts.isImportDeclaration(node.parent) && !ts.isExportDeclaration(node.parent) && !ts.isCaseClause(node.parent);
 }
 
-function isTemplateExpressionNode(node: ts.Node): node is TemplateExpression {
+/** Checks if a node is a template expression */
+function isTemplateExpressionNode(node: ts.Node): node is ts.TemplateExpression {
     return ts.isTemplateExpression(node) && !!node.parent;
 }
 
-function templateExpressionToString(node: TemplateExpression): string {
-    let result = node.head.text; // Start with TemplateHead text
+/** Determines if a template is "simple" (only identifiers) or "complex" */
+function isSimpleTemplate(node: ts.TemplateExpression): boolean {
+    return node.templateSpans.every((span) => ts.isIdentifier(span.expression));
+}
 
+/** Converts a `TemplateExpression` into a string */
+function templateExpressionToString(node: ts.TemplateExpression): string {
+    let result = node.head.text;
     node.templateSpans.forEach((span) => {
-        result += `\${${span.expression.getText()}}`; // Append placeholder
-        result += span.literal.text; // Append static text after placeholder
+        result += `\${${span.expression.getText()}}`;
+        result += span.literal.text;
     });
-
     return result;
 }
 
-function stringToTemplateExpression(input: string): ts.TemplateExpression {
+/** Converts a translated string back into a TemplateExpression */
+function stringToTemplateExpression(input: string, translations: Map<string, ts.TemplateExpression>): ts.TemplateExpression {
+    const tsPrinter = ts.createPrinter();
+    const debugFile = ts.createSourceFile('debug.ts', '', ts.ScriptTarget.Latest);
     const parts: Array<string | ts.Expression> = [];
-    const regex = /\$\{((?:[^{}]|\$\{[^{}]*})*)}/g;
+
+    // Updated regex to correctly extract multiple placeholders without merging them
+    const regex = /\$\{([^}]+)}/g;
     let lastIndex = 0;
 
     for (const match of input.matchAll(regex)) {
         const [fullMatch, expr] = match;
         const index = match.index ?? 0;
 
-        // Add static text before placeholder
+        // Capture static text before the placeholder
         if (index > lastIndex) {
             parts.push(input.slice(lastIndex, index));
         }
 
-        // Add the placeholder as an AST expression
-        parts.push(ts.factory.createIdentifier(expr));
+        // Ensure each placeholder is correctly translated or used as an identifier
+        const translatedExpression = translations.get(expr.trim());
+        if (translatedExpression) {
+            console.log(`🔄 Replacing placeholder with translated AST: "${expr}"`);
+            parts.push(translatedExpression);
+        } else {
+            parts.push(ts.factory.createIdentifier(expr.trim()));
+        }
 
         lastIndex = index + fullMatch.length;
     }
 
-    // Add remaining static text after last placeholder
+    // Capture any remaining static text after the last placeholder
     if (lastIndex < input.length) {
         parts.push(input.slice(lastIndex));
     }
 
-    // Ensure we have at least one static text part
+    // Ensure the first segment is a string
     const thingy = parts.at(0);
     const headText = typeof thingy === 'string' ? thingy : '';
     const templateHead = ts.factory.createTemplateHead(headText);
-
-    // Create template spans
     const spans: ts.TemplateSpan[] = [];
-    for (let i = 1; i < parts.length; i += 2) {
+
+    for (let i = 1; i < parts.length; i++) {
         const expr = parts.at(i) as ts.Expression;
-        const literalText = i + 1 < parts.length ? (parts.at(i + 1) as string) : '';
+        const literalText = i + 1 < parts.length && typeof parts.at(i + 1) === 'string' ? (parts.at(i + 1) as string) : '';
 
-        spans.push(ts.factory.createTemplateSpan(expr, i + 2 >= parts.length ? ts.factory.createTemplateTail(literalText) : ts.factory.createTemplateMiddle(literalText)));
+        spans.push(ts.factory.createTemplateSpan(expr, i + 1 >= parts.length ? ts.factory.createTemplateTail(literalText) : ts.factory.createTemplateMiddle(literalText)));
+
+        if (typeof parts.at(i + 1) === 'string') {
+            i++;
+        }
     }
 
-    return ts.factory.createTemplateExpression(templateHead, spans);
-}
-
-function extractStrings(node: ts.Node, strings: Map<string, string>) {
-    if (isPlainStringNode(node)) {
-        strings.set(node.text, node.text);
+    try {
+        const result = ts.factory.createTemplateExpression(templateHead, spans);
+        console.log(`✅ Successfully created TemplateExpression: ${tsPrinter.printNode(ts.EmitHint.Unspecified, result, debugFile)}`);
+        return result;
+    } catch (error) {
+        console.error(`❌ Error creating TemplateExpression:`, error);
+        console.error(`❌ Raw input string: ${input}`);
+        throw error;
     }
-    node.forEachChild((child) => extractStrings(child, strings));
 }
 
-function extractTemplateExpressions(node: ts.Node, templateExpressions: Map<string, TemplateExpression>) {
-    if (isTemplateExpressionNode(node)) {
-        templateExpressions.set(templateExpressionToString(node), node);
-    }
-    node.forEachChild((child) => extractTemplateExpressions(child, templateExpressions));
-}
+/** Processes all string literals and simple template literals in the AST */
+async function processLiterals(sourceFile: ts.SourceFile): Promise<ts.SourceFile> {
+    const translations = new Map<string, string>();
+    const nodesToTranslate: string[] = [];
 
-function createTransformer(translations: Map<string, string>): ts.TransformerFactory<ts.SourceFile> {
-    return (context: ts.TransformationContext) => {
-        const visit: ts.Visitor = (node) => {
-            if (isPlainStringNode(node)) {
-                const translatedText = translations.get(node.text);
-                // console.log(`🔵 Replacing String: "${node.text}" → "${translatedText}"`);
-                return translatedText ? ts.factory.createStringLiteral(translatedText) : node;
+    function collectLiterals(node: ts.Node) {
+        if (isPlainStringNode(node) && !translations.has(node.text)) {
+            nodesToTranslate.push(node.text);
+        }
+        if (isTemplateExpressionNode(node) && isSimpleTemplate(node)) {
+            const templateString = templateExpressionToString(node);
+            if (!translations.has(templateString)) {
+                nodesToTranslate.push(templateString);
             }
-            if (isTemplateExpressionNode(node)) {
-                const originalTemplateExpressionAsString = templateExpressionToString(node);
-                console.log(`🟡 Checking TemplateExpression: "${originalTemplateExpressionAsString}"`);
-                const translatedTemplate = translations.get(originalTemplateExpressionAsString);
-                if (translatedTemplate) {
-                    console.log(`🔹 Found Translation: "${translatedTemplate}"`);
-                    const translatedTemplateExpression = stringToTemplateExpression(translatedTemplate);
-                    try {
-                        // Try printing the expression to validate it
-                        const printedCode = tsPrinter.printNode(EmitHint.Unspecified, translatedTemplateExpression, debugFile);
-                        console.log(`🪇 Transforming translated template back to TemplateExpression: ${printedCode}`);
-                    } catch (e) {
-                        console.warn(`⚠️ Unhandled TemplateExpression: ${translatedTemplate}`);
-                        return node;
-                    }
+        }
+        node.forEachChild(collectLiterals);
+    }
+    collectLiterals(sourceFile);
 
-                    return translatedTemplateExpression;
-                }
-                console.warn('⚠️ No translation found for template expression', originalTemplateExpressionAsString);
-                return node;
-            }
-            return ts.visitEachChild(node, visit, context);
-        };
+    // Translate all collected strings and simple templates asynchronously
+    for (const text of nodesToTranslate) {
+        const translatedText = await translate(text, 'es');
+        translations.set(text, translatedText);
+    }
 
+    // Transformer function (synchronous now)
+    function transformLiterals(context: ts.TransformationContext) {
         return (node: ts.SourceFile) => {
-            const transformedNode = ts.visitNode(node, visit) ?? node; // Ensure we always return a valid node
-            return transformedNode as ts.SourceFile; // Safe cast since we always pass in a SourceFile
+            function visit(n: ts.Node): ts.Node {
+                if (isPlainStringNode(n) && translations.has(n.text)) {
+                    const translatedText = translations.get(n.text);
+                    if (translatedText) {
+                        console.log(`🔵 Replacing string: "${n.text}" → "${translations.get(n.text)}"`);
+                        return ts.factory.createStringLiteral(translatedText);
+                    }
+                }
+                if (isTemplateExpressionNode(n) && isSimpleTemplate(n)) {
+                    const templateString = templateExpressionToString(n);
+                    const translatedTemplateString = translations.get(templateString);
+                    if (translatedTemplateString) {
+                        console.log(`🟡 Replacing simple template: "${templateString}"`);
+                        return stringToTemplateExpression(translatedTemplateString, new Map());
+                    }
+                }
+                return ts.visitEachChild(n, visit, context);
+            }
+            return ts.visitNode(node, visit) as ts.SourceFile;
         };
-    };
+    }
+
+    const transformedResult = ts.transform(sourceFile, [transformLiterals]);
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const transformedSourceFile = transformedResult.transformed.at(0)!;
+    transformedResult.dispose();
+
+    return transformedSourceFile;
 }
 
-// Main function to process translations
+/** Main function to process translations */
 async function generateTranslatedFiles() {
     const sourceCode = fs.readFileSync(SOURCE_FILE, 'utf8');
     const sourceFile = ts.createSourceFile(SOURCE_FILE, sourceCode, ts.ScriptTarget.Latest, true);
 
     for (const lang of TARGET_LANGUAGES) {
-        // Extract strings
-        const stringsToTranslate = new Map<string, string>();
-        extractStrings(sourceFile, stringsToTranslate);
+        const transformedNode = await processLiterals(sourceFile);
 
-        // Extract templateExpressions
-        const templatesToTranslate = new Map<string, TemplateExpression>();
-        extractTemplateExpressions(sourceFile, templatesToTranslate);
-
-        // Transform the template expressions to strings and add them to the map
-        for (const [key, templateExpression] of templatesToTranslate) {
-            stringsToTranslate.set(key, templateExpressionToString(templateExpression));
-        }
-
-        const translations = new Map<string, string>();
-        for (const [originalText] of stringsToTranslate) {
-            const translatedText = await translate(originalText, lang);
-            translations.set(originalText, translatedText);
-        }
-
-        // Replace translated strings in the AST
-        const result = ts.transform(sourceFile, [createTransformer(translations)]);
-        const transformedNode = result.transformed.at(0) ?? sourceFile; // Ensure we always have a valid SourceFile
-        result.dispose();
-
-        // Generate translated TypeScript code
         const printer = ts.createPrinter();
         const translatedCode = printer.printFile(transformedNode);
 
-        // Write to file
         const outputPath = `${LANGUAGES_DIR}/${lang}.ts`;
         fs.writeFileSync(outputPath, translatedCode, 'utf8');
 
-        // Format the files using prettier
         execSync(`npx prettier --write ${LANGUAGES_DIR}`);
 
         console.log(`✅ Translated file created: ${outputPath}`);
     }
 }
 
-// Execute the translation process
 generateTranslatedFiles().catch(console.error);


### PR DESCRIPTION
### Explanation of Change
This is a WIP improvement that addresses the main known limitation of `scripts/generateTranslations.ts` - nested templates.

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$
PROPOSAL:


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

- [ ] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->
// TODO: These must be filled out, or the issue title must include "[No QA]."

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [ ] I linked the correct issue in the `### Fixed Issues` section above
- [ ] I wrote clear testing steps that cover the changes made in this PR
    - [ ] I added steps for local testing in the `Tests` section
    - [ ] I added steps for the expected offline behavior in the `Offline steps` section
    - [ ] I added steps for Staging and/or Production testing in the `QA steps` section
    - [ ] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [ ] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [ ] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [ ] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [ ] I ran the tests on **all platforms** & verified they passed on:
    - [ ] Android: Native
    - [ ] Android: mWeb Chrome
    - [ ] iOS: Native
    - [ ] iOS: mWeb Safari
    - [ ] MacOS: Chrome / Safari
    - [ ] MacOS: Desktop
- [ ] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [ ] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [ ] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [ ] I verified that comments were added to code that is not self explanatory
    - [ ] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [ ] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [ ] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [ ] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [ ] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [ ] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [ ] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [ ] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [ ] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [ ] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [ ] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [ ] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [ ] I verified that if a function's arguments changed that all usages have also been updated correctly
- [ ] If any new file was added I verified that:
    - [ ] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [ ] If a new CSS style is added I verified that:
    - [ ] A similar style doesn't already exist
    - [ ] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [ ] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [ ] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [ ] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [ ] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [ ] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [ ] I verified that all the inputs inside a form are aligned with each other.
    - [ ] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [ ] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [ ] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [ ] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Desktop</summary>

<!-- add screenshots or videos here -->

</details>
