### PR TITLE
Fix Distance label position on map

### DIFF
--- a/src/components/MapView/MapView.tsx
+++ b/src/components/MapView/MapView.tsx
@@ -228,18 +228,17 @@ const MapView = forwardRef<MapViewHandle, MapViewProps>(
         const initBounds = useMemo(() => (interactive ? undefined : waypointsBounds), [interactive, waypointsBounds]);
 
         const distanceSymbolCoorinate = useMemo(() => {
-            const length = directionCoordinates?.length;
-            // If the array is empty, return undefined
-            if (!length) {
-                return undefined;
+            if (!directionCoordinates?.length || !waypoints?.length) {
+                return;
             }
+            const {northEast, southWest} = utils.getBounds(
+                waypoints.map((waypoint) => waypoint.coordinate),
+                directionCoordinates,
+            );
+            const boundsCenter = utils.getBoundsCenter({northEast, southWest});
 
-            // Find the index of the middle element
-            const middleIndex = Math.floor(length / 2);
-
-            // Return the middle element
-            return directionCoordinates.at(middleIndex);
-        }, [directionCoordinates]);
+            return utils.findClosestCoordinateOnLineFromCenter(boundsCenter, directionCoordinates);
+        }, [waypoints, directionCoordinates]);
 
         return !isOffline && isAccessTokenSet && !!defaultSettings ? (
             <View style={[style, !interactive ? styles.pointerEventsNone : {}]}>

--- a/src/components/MapView/MapViewImpl.website.tsx
+++ b/src/components/MapView/MapViewImpl.website.tsx
@@ -250,18 +250,17 @@ const MapViewImpl = forwardRef<MapViewHandle, MapViewProps>(
         }, [waypoints, directionCoordinates, interactive, currentPosition, initialState.zoom]);
 
         const distanceSymbolCoorinate = useMemo(() => {
-            const length = directionCoordinates?.length;
-            // If the array is empty, return undefined
-            if (!length) {
-                return undefined;
+            if (!directionCoordinates?.length || !waypoints?.length) {
+                return;
             }
+            const {northEast, southWest} = utils.getBounds(
+                waypoints.map((waypoint) => waypoint.coordinate),
+                directionCoordinates,
+            );
+            const boundsCenter = utils.getBoundsCenter({northEast, southWest});
 
-            // Find the index of the middle element
-            const middleIndex = Math.floor(length / 2);
-
-            // Return the middle element
-            return directionCoordinates.at(middleIndex);
-        }, [directionCoordinates]);
+            return utils.findClosestCoordinateOnLineFromCenter(boundsCenter, directionCoordinates);
+        }, [waypoints, directionCoordinates]);
 
         return !isOffline && !!accessToken && !!initialViewState ? (
             <View
@@ -290,7 +289,7 @@ const MapViewImpl = forwardRef<MapViewHandle, MapViewProps>(
                     )}
                     {!!distanceSymbolCoorinate && !!distanceInMeters && !!distanceUnit && (
                         <Marker
-                            key="distance"
+                            key="distance-label"
                             longitude={distanceSymbolCoorinate.at(0) ?? 0}
                             latitude={distanceSymbolCoorinate.at(1) ?? 0}
                         >
@@ -298,7 +297,6 @@ const MapViewImpl = forwardRef<MapViewHandle, MapViewProps>(
                                 accessibilityLabel={CONST.ROLE.BUTTON}
                                 role={CONST.ROLE.BUTTON}
                                 onPress={toggleDistanceUnit}
-                                style={{marginRight: 100}}
                             >
                                 <View style={styles.distanceLabelWrapper}>
                                     <View style={styles.distanceLabelText}> {DistanceRequestUtils.getDistanceForDisplayLabel(distanceInMeters, distanceUnit)}</View>

--- a/src/components/MapView/MapViewTypes.ts
+++ b/src/components/MapView/MapViewTypes.ts
@@ -2,6 +2,8 @@ import type {ReactNode} from 'react';
 import type {StyleProp, ViewStyle} from 'react-native';
 import type {Unit} from '@src/types/onyx/Policy';
 
+type Coordinate = [number, number];
+
 type MapViewProps = {
     // Public access token to be used to fetch map data from Mapbox.
     accessToken: string;
@@ -18,7 +20,7 @@ type MapViewProps = {
     // Locations on which to put markers
     waypoints?: WayPoint[];
     // List of coordinates which together forms a direction.
-    directionCoordinates?: Array<[number, number]>;
+    directionCoordinates?: Coordinate[];
     // Callback to call when the map is idle / ready.
     onMapReady?: () => void;
     // Whether the map is interactable or not
@@ -33,7 +35,7 @@ type MapViewProps = {
 
 type DirectionProps = {
     // Coordinates of points that constitute the direction
-    coordinates: Array<[number, number]>;
+    coordinates: Coordinate[];
 };
 
 type PendingMapViewProps = {
@@ -53,14 +55,14 @@ type PendingMapViewProps = {
 // Initial state of the map
 type InitialState = {
     // Coordinate on which to center the map
-    location: [number, number];
+    location: Coordinate;
     zoom: number;
 };
 
 // Waypoint to be displayed on the map
 type WayPoint = {
     id: string;
-    coordinate: [number, number];
+    coordinate: Coordinate;
     markerComponent: () => ReactNode;
 };
 
@@ -73,9 +75,9 @@ type DirectionStyle = {
 // Represents a handle to interact with a map view.
 type MapViewHandle = {
     // Fly to a location on the map
-    flyTo: (location: [number, number], zoomLevel: number, animationDuration?: number) => void;
+    flyTo: (location: Coordinate, zoomLevel: number, animationDuration?: number) => void;
     // Fit the map view to a bounding box
-    fitBounds: (ne: [number, number], sw: [number, number], paddingConfig?: number | number[], animationDuration?: number) => void;
+    fitBounds: (ne: Coordinate, sw: Coordinate, paddingConfig?: number | number[], animationDuration?: number) => void;
 };
 
-export type {DirectionStyle, WayPoint, MapViewProps, DirectionProps, PendingMapViewProps, MapViewHandle};
+export type {DirectionStyle, WayPoint, MapViewProps, DirectionProps, PendingMapViewProps, MapViewHandle, Coordinate};

--- a/src/components/MapView/utils.ts
+++ b/src/components/MapView/utils.ts
@@ -1,3 +1,6 @@
+import type {LngLat} from 'react-map-gl';
+import type {Coordinate} from './MapViewTypes';
+
 function getBounds(waypoints: Array<[number, number]>, directionCoordinates: undefined | Array<[number, number]>): {southWest: [number, number]; northEast: [number, number]} {
     const lngs = waypoints.map((waypoint) => waypoint[0]);
     const lats = waypoints.map((waypoint) => waypoint[1]);
@@ -37,7 +40,86 @@ function areSameCoordinate(coordinate1: number[], coordinate2: number[]) {
     return haversineDistance(coordinate1, coordinate2) < 20;
 }
 
+function findClosestCoordinateOnLineFromCenter(center: LngLat, lineCoordinates: Coordinate[]): Coordinate | null {
+    if (!lineCoordinates || lineCoordinates.length < 2) {
+        return null;
+    }
+
+    let closestPointOnLine: Coordinate | null = null;
+    let minDistance = Infinity;
+
+    for (let i = 0; i < lineCoordinates.length - 1; i++) {
+        const startPoint = lineCoordinates.at(i);
+        const endPoint = lineCoordinates.at(i + 1);
+
+        if (!startPoint || !endPoint) {
+            break;
+        }
+
+        const closestPoint = closestPointOnSegment(center, startPoint, endPoint);
+
+        const distance = haversineDistance([center.lng, center.lat], [closestPoint.lng, closestPoint.lat]);
+
+        if (distance < minDistance) {
+            minDistance = distance;
+            closestPointOnLine = [closestPoint.lng, closestPoint.lat];
+        }
+    }
+
+    return closestPointOnLine;
+}
+
+/**
+ * Find the closest point on the line segment created by connecting start and endPoint
+ */
+function closestPointOnSegment(point: LngLat, startPoint: Coordinate, endPoint: Coordinate): LngLat {
+    const x0 = point.lng;
+    const y0 = point.lat;
+    const x1 = startPoint[0];
+    const y1 = startPoint[1];
+    const x2 = endPoint[0];
+    const y2 = endPoint[1];
+
+    const dx = x2 - x1;
+    const dy = y2 - y1;
+
+    if (dx === 0 && dy === 0) {
+        return {lng: x1, lat: y1};
+    }
+
+    const t = ((x0 - x1) * dx + (y0 - y1) * dy) / (dx * dx + dy * dy);
+
+    let closestX;
+    let closestY;
+    if (t < 0) {
+        closestX = x1;
+        closestY = y1;
+    } else if (t > 1) {
+        closestX = x2;
+        closestY = y2;
+    } else {
+        closestX = x1 + t * dx;
+        closestY = y1 + t * dy;
+    }
+
+    return {lng: closestX, lat: closestY};
+}
+
+function getBoundsCenter(bounds: {southWest: [number, number]; northEast: [number, number]}) {
+    const {
+        southWest: [south, west],
+        northEast: [north, east],
+    } = bounds;
+
+    const latitudeCenter = (north + south) / 2;
+    const longitudeCenter = (east + west) / 2;
+
+    return {lng: latitudeCenter, lat: longitudeCenter};
+}
+
 export default {
     getBounds,
     areSameCoordinate,
+    findClosestCoordinateOnLineFromCenter,
+    getBoundsCenter,
 };

--- a/src/components/MapView/utils.ts
+++ b/src/components/MapView/utils.ts
@@ -1,7 +1,7 @@
 import type {LngLat} from 'react-map-gl';
 import type {Coordinate} from './MapViewTypes';
 
-function getBounds(waypoints: Array<[number, number]>, directionCoordinates: undefined | Array<[number, number]>): {southWest: [number, number]; northEast: [number, number]} {
+function getBounds(waypoints: Coordinate[], directionCoordinates: undefined | Coordinate[]): {southWest: Coordinate; northEast: Coordinate} {
     const lngs = waypoints.map((waypoint) => waypoint[0]);
     const lats = waypoints.map((waypoint) => waypoint[1]);
     if (directionCoordinates) {
@@ -18,7 +18,7 @@ function getBounds(waypoints: Array<[number, number]>, directionCoordinates: und
 /**
  * Calculates the distance between two points on the Earth's surface given their latitude and longitude coordinates.
  */
-function haversineDistance(coordinate1: number[], coordinate2: number[]) {
+function haversineDistance(coordinate1: Coordinate, coordinate2: Coordinate) {
     // Radius of the Earth in meters
     const R = 6371e3;
     const lat1 = ((coordinate1.at(0) ?? 0) * Math.PI) / 180;
@@ -36,7 +36,7 @@ function haversineDistance(coordinate1: number[], coordinate2: number[]) {
     return R * angularDistance;
 }
 
-function areSameCoordinate(coordinate1: number[], coordinate2: number[]) {
+function areSameCoordinate(coordinate1: Coordinate, coordinate2: Coordinate) {
     return haversineDistance(coordinate1, coordinate2) < 20;
 }
 
@@ -105,7 +105,7 @@ function closestPointOnSegment(point: LngLat, startPoint: Coordinate, endPoint: 
     return {lng: closestX, lat: closestY};
 }
 
-function getBoundsCenter(bounds: {southWest: [number, number]; northEast: [number, number]}) {
+function getBoundsCenter(bounds: {southWest: Coordinate; northEast: Coordinate}) {
     const {
         southWest: [south, west],
         northEast: [north, east],


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
<!-- Explain what your change does and how it addresses the linked issue -->

The distance label position is now the closest point to the center of waypoints and directions bounds on the direction path.

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/56531
PROPOSAL: https://github.com/Expensify/App/issues/56531#issuecomment-2659111330


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests

1. Go to App.
2. Open FAB > Create expense > Distance.
3. Enter the following waypoints:
```
Start - 88 Kearny Street
First Stop - Golden Gate Bridge
Second stop - Telegraph Hill

```
4. Observe that distance label is fully visible on the map when map is centered.

- [x] Verify that no errors appear in the JS console

### Offline tests
Map does not render while offline. 

### QA Steps
same as tests.
- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.


### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->
![image](https://github.com/user-attachments/assets/4b6073e9-e3f5-4f17-b108-fe25af2870b6)

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->
![image](https://github.com/user-attachments/assets/fb6f8395-98d9-4d34-99ca-297b12de84ad)

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->
![image](https://github.com/user-attachments/assets/4469d7ca-b7f5-461f-8d42-afcae1ddd411)

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->
![image](https://github.com/user-attachments/assets/7e5c9fc3-1118-4c26-a858-0809b2a14b51)

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->
![image](https://github.com/user-attachments/assets/01a6836b-2ef4-43b3-87a8-6cc6f6b338d9)

</details>

<details>
<summary>MacOS: Desktop</summary>

<!-- add screenshots or videos here -->
![image](https://github.com/user-attachments/assets/36ba155a-b665-4a80-81e9-2e2235e8c488)

</details>
