### PR TITLE
[CP Staging] Revert "Adjust adaptStateIfNecessary to push a split navigator without a sidebar screen"

### DIFF
--- a/src/libs/Navigation/AppNavigator/createSplitNavigator/SplitRouter.ts
+++ b/src/libs/Navigation/AppNavigator/createSplitNavigator/SplitRouter.ts
@@ -26,7 +26,6 @@ function getRoutePolicyID(route: NavigationPartialRoute): string | undefined {
 
 function adaptStateIfNecessary({state, options: {sidebarScreen, defaultCentralScreen, parentRoute}}: AdaptStateIfNecessaryArgs) {
     const isNarrowLayout = getIsNarrowLayout();
-    const rootState = navigationRef.getRootState();
 
     const lastRoute = state.routes.at(-1) as NavigationPartialRoute;
     const routePolicyID = getRoutePolicyID(lastRoute);
@@ -38,14 +37,10 @@ function adaptStateIfNecessary({state, options: {sidebarScreen, defaultCentralSc
         }
     }
 
-    // When initializing the app on a small screen with the center screen as the initial screen, the sidebar must also be split to allow users to swipe back.
-    const isInitialRoute = !rootState || rootState.routes.length === 1;
-    const shouldSplitHaveSidebar = isInitialRoute || !isNarrowLayout;
-
     // If the screen is wide, there should be at least two screens inside:
     // - sidebarScreen to cover left pane.
     // - defaultCentralScreen to cover central pane.
-    if (!isAtLeastOneInState(state, sidebarScreen) && shouldSplitHaveSidebar) {
+    if (!isAtLeastOneInState(state, sidebarScreen)) {
         const paramsFromRoute = getParamsFromRoute(sidebarScreen);
         const copiedParams = pick(lastRoute?.params, paramsFromRoute);
 
@@ -70,6 +65,8 @@ function adaptStateIfNecessary({state, options: {sidebarScreen, defaultCentralSc
     // - defaultCentralScreen to cover central pane.
     if (!isNarrowLayout) {
         if (state.routes.length === 1 && state.routes[0].name === sidebarScreen) {
+            const rootState = navigationRef.getRootState();
+
             const previousSameNavigator = rootState?.routes.filter((route) => route.name === parentRoute.name).at(-2);
 
             // If we have optimization for not rendering all split navigators, then last selected option may not be in the state. In this case state has to be read from the preserved state.


### PR DESCRIPTION
Reverts Expensify/App#57110

Fixes https://github.com/Expensify/App/issues/57272