### PR TITLE
Define noop implementation of 11+ redirect for desktop app

### DIFF
--- a/src/libs/actions/Welcome/index.ts
+++ b/src/libs/actions/Welcome/index.ts
@@ -5,7 +5,6 @@ import * as API from '@libs/API';
 import {SIDE_EFFECT_REQUEST_COMMANDS, WRITE_COMMANDS} from '@libs/API/types';
 import DateUtils from '@libs/DateUtils';
 import Log from '@libs/Log';
-import CONST from '@src/CONST';
 import type {OnboardingCompanySize} from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
 import type {OnboardingPurpose} from '@src/types/onyx';
@@ -13,6 +12,7 @@ import type Onboarding from '@src/types/onyx/Onboarding';
 import type TryNewDot from '@src/types/onyx/TryNewDot';
 import {isEmptyObject} from '@src/types/utils/EmptyObject';
 import {clearInitialPath} from './OnboardingFlow';
+import switchToOldDotOnNonMicroCompanySize from './switchToOldDotOnNonMicroCompanySize';
 
 type OnboardingData = Onboarding | undefined;
 
@@ -148,29 +148,6 @@ function completeHybridAppOnboarding() {
         Log.info(`[HybridApp] Onboarding status has changed. Propagating new value to OldDot`, true);
         NativeModules.HybridAppModule.completeOnboarding(true);
     });
-}
-
-/*
- * Decides whether we should set dismissed key to `true` or `false` based on company size
- */
-function switchToOldDotOnNonMicroCompanySize(onboardingCompanySize: OnboardingCompanySize) {
-    if (onboardingCompanySize === CONST.ONBOARDING_COMPANY_SIZE.MICRO) {
-        return;
-    }
-
-    const optimisticData: OnyxUpdate[] = [
-        {
-            onyxMethod: Onyx.METHOD.MERGE,
-            key: ONYXKEYS.NVP_TRYNEWDOT,
-            value: {
-                classicRedirect: {
-                    dismissed: true,
-                },
-            },
-        },
-    ];
-
-    API.write(WRITE_COMMANDS.SWITCH_TO_OLD_DOT_ON_COMPANY_SIZE, {onboardingCompanySize}, {optimisticData});
 }
 
 Onyx.connect({

--- a/src/libs/actions/Welcome/switchToOldDotOnNonMicroCompanySize/index.desktop.ts
+++ b/src/libs/actions/Welcome/switchToOldDotOnNonMicroCompanySize/index.desktop.ts
@@ -1,0 +1,6 @@
+import type SwitchToOldDotOnNonMicroCompanySize from './types';
+
+// We don't want to use this API on desktop, so we just noop here
+const switchToOldDotOnNonMicroCompanySize: SwitchToOldDotOnNonMicroCompanySize = () => {};
+
+export default switchToOldDotOnNonMicroCompanySize;

--- a/src/libs/actions/Welcome/switchToOldDotOnNonMicroCompanySize/index.ts
+++ b/src/libs/actions/Welcome/switchToOldDotOnNonMicroCompanySize/index.ts
@@ -1,0 +1,29 @@
+import type {OnyxUpdate} from 'react-native-onyx';
+import Onyx from 'react-native-onyx';
+import * as API from '@libs/API';
+import {WRITE_COMMANDS} from '@libs/API/types';
+import CONST from '@src/CONST';
+import ONYXKEYS from '@src/ONYXKEYS';
+import type SwitchToOldDotOnNonMicroCompanySize from './types';
+
+const switchToOldDotOnNonMicroCompanySize: SwitchToOldDotOnNonMicroCompanySize = (onboardingCompanySize) => {
+    if (onboardingCompanySize === CONST.ONBOARDING_COMPANY_SIZE.MICRO) {
+        return;
+    }
+
+    const optimisticData: OnyxUpdate[] = [
+        {
+            onyxMethod: Onyx.METHOD.MERGE,
+            key: ONYXKEYS.NVP_TRYNEWDOT,
+            value: {
+                classicRedirect: {
+                    dismissed: true,
+                },
+            },
+        },
+    ];
+
+    API.write(WRITE_COMMANDS.SWITCH_TO_OLD_DOT_ON_COMPANY_SIZE, {onboardingCompanySize}, {optimisticData});
+};
+
+export default switchToOldDotOnNonMicroCompanySize;

--- a/src/libs/actions/Welcome/switchToOldDotOnNonMicroCompanySize/types.ts
+++ b/src/libs/actions/Welcome/switchToOldDotOnNonMicroCompanySize/types.ts
@@ -1,0 +1,5 @@
+import type {OnboardingCompanySize} from '@src/CONST';
+
+type SwitchToOldDotOnNonMicroCompanySize = (onboardingCompanySize: OnboardingCompanySize) => void;
+
+export default SwitchToOldDotOnNonMicroCompanySize;

--- a/src/pages/OnboardingEmployees/BaseOnboardingEmployees.tsx
+++ b/src/pages/OnboardingEmployees/BaseOnboardingEmployees.tsx
@@ -74,11 +74,7 @@ function BaseOnboardingEmployees({shouldUseNativeStyles, route}: BaseOnboardingE
                         return;
                     }
                     setOnboardingCompanySize(selectedCompanySize);
-
-                    // Redirect is disabled on desktop
-                    if (getPlatform() !== CONST.PLATFORM.DESKTOP) {
-                        switchToOldDotOnNonMicroCompanySize(selectedCompanySize);
-                    }
+                    switchToOldDotOnNonMicroCompanySize(selectedCompanySize);
 
                     const shouldCreateWorkspace = !onboardingPolicyID && !paidGroupPolicy;
 


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
<!-- Explain what your change does and how it addresses the linked issue -->

This is small follow up PR that addresses request from this comment https://github.com/Expensify/App/pull/55514#discussion_r1965926420 and creates noop function on desktop

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/53906
PROPOSAL:


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests

_Make sure the account you create is on the `hybridAppRedirect` beta! (`@applause` may not yet be added, so please try `+@trj.chat` if you are not initially being redirected to NewDot after account creation_

**A) Flow for 11+ accounts:**
- Create a new account, you should be redirected to NewDot
- On first onboarding modal press "Manage my team's expenses"
- Press any company size that includes 11+ employees
- After a short time redirect to Expensify Classic should happen
- `tryNewDot` NVP should have dismissed key set to `true`

**B) Flow for less than 11 employees:**
- Create a new account, you should be redirected to NewDot
- On first onboarding modal press "Manage my team's expenses"
- Press first option on the list (less than 11 employees)
- Onboarding accounting modal should be displayed
- `tryNewDot` NVP should have dismissed key set to `false`

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

-

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->

Same as tests, but last step in both flows can be omitted

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos

<details>
<summary>Android: Native</summary>

https://github.com/user-attachments/assets/8424c212-1261-4361-99ef-ccb43d872209

https://github.com/user-attachments/assets/85524d2d-538e-4270-95b6-5feedf13b6f0

</details>

<details>
<summary>Android: mWeb Chrome</summary>

https://github.com/user-attachments/assets/cfe1b9f4-bfa1-41b8-9842-eab2df335f10


https://github.com/user-attachments/assets/1a65513d-7adb-4dab-b956-57a7bf026404


</details>

<details>
<summary>iOS: Native</summary>

https://github.com/user-attachments/assets/6524a442-cc6a-4b7f-a576-e6fd810a584f


https://github.com/user-attachments/assets/08c89eca-e6e1-4fd7-bcd8-ab08ba001a9f

</details>

<details>
<summary>iOS: mWeb Safari</summary>

https://github.com/user-attachments/assets/fa5fbd86-8f37-4532-9ebe-7cc706e8d58a


https://github.com/user-attachments/assets/3a8ee1bc-7ff1-4b95-b7c4-d1c1e133689c


</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

https://github.com/user-attachments/assets/7475a8d9-2965-4abc-9048-e818bb16a8f5

https://github.com/user-attachments/assets/6683fc90-bed1-43b7-a13d-bb83f5d8b3f0

</details>

<details>
<summary>MacOS: Desktop</summary>


NOTE: We want to proceed further with onboarding on desktop. This PR just moved this noop to separate platform implementation.

https://github.com/user-attachments/assets/ce434d54-7c95-4aaa-b14f-b9317eab9df5

https://github.com/user-attachments/assets/13772b28-0a5c-4b9c-a9bf-e5c65cd95df0


</details>
