### PR TITLE
fix: no space between last selection and next button

### DIFF
--- a/src/pages/workspace/companyCards/assignCard/AssigneeStep.tsx
+++ b/src/pages/workspace/companyCards/assignCard/AssigneeStep.tsx
@@ -194,7 +194,7 @@ function AssigneeStep({policy, feed}: AssigneeStepProps) {
                 buttonText={translate(isEditing ? 'common.confirm' : 'common.next')}
                 onSubmit={submit}
                 isAlertVisible={shouldShowError}
-                containerStyles={styles.ph5}
+                containerStyles={[styles.ph5, !shouldShowError && styles.mt5]}
                 message={translate('common.error.pleaseSelectOne')}
                 buttonStyles={styles.mb5}
             />

--- a/src/pages/workspace/companyCards/assignCard/CardSelectionStep.tsx
+++ b/src/pages/workspace/companyCards/assignCard/CardSelectionStep.tsx
@@ -167,7 +167,7 @@ function CardSelectionStep({feed, policyID}: CardSelectionStepProps) {
                         buttonText={translate(isEditing ? 'common.confirm' : 'common.next')}
                         onSubmit={submit}
                         isAlertVisible={shouldShowError}
-                        containerStyles={styles.ph5}
+                        containerStyles={[styles.ph5, !shouldShowError && styles.mt5]}
                         message={translate('common.error.pleaseSelectOne')}
                         buttonStyles={styles.mb5}
                     />


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
<!-- Explain what your change does and how it addresses the linked issue -->
There is no spacing above the next button, causing the last item in the list and the button to appear too close together. This PR adds spacing between the 'Next' button and the last selected item.
### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/56963
PROPOSAL: https://github.com/Expensify/App/issues/56963#issuecomment-2664361739


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->
Preconditions:

- The user list and card list must be longer than the screen height(or have 10+ selections).

Steps to Reproduce:

1. Launch the app.
2. Tap on a company card and select "Assign Card."
3. Select the last user in the list.
4. Verify that there is spacing between the user selection and the "Next" button.
5. Tap "Next."
6. Select the last card in the list.
7. Verify that there is spacing between the card selection and the "Next" button.

- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->
Same as test above
### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->
Same as test above

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>
        <img
          src="https://github.com/user-attachments/assets/2981bb4b-fdd9-4329-83e2-975672f47a4d"
          width="100%" 
        >
        <img
          src="https://github.com/user-attachments/assets/4ea8a244-0365-4db1-b130-0f83522c9fd5"
          width="100%" 
        >     
   <img
          src="https://github.com/user-attachments/assets/8c4c9de6-8402-4855-902e-ac984c725f07"
          width="100%" 
        >  
      <img
          src="https://github.com/user-attachments/assets/54ec168d-c3b0-48de-8a1a-36139fefad30"
          width="100%" 
        >

</details>

<details>
<summary>Android: mWeb Chrome</summary>
        <img
          src="https://github.com/user-attachments/assets/8a7c2375-75cb-4774-8392-56d7c8ba69e1"
          width="100%" 
        >
        <img
          src="https://github.com/user-attachments/assets/e73b102e-aec0-4bf9-8495-181a6f671110"
          width="100%" 
        > 
       <img
          src="https://github.com/user-attachments/assets/94c3decf-ce9b-4257-9ea2-498b9b70d971"
          width="100%" 
        >    
    <img
          src="https://github.com/user-attachments/assets/723be1c3-ab88-4f0d-8053-3b0c7f118ced"
          width="100%" 
        >






</details>

<details>
<summary>iOS: Native</summary>
        <img
          src="https://github.com/user-attachments/assets/204fa2d4-e2f4-48e6-a9a0-8f4f70d4bab5"
          width="100%" 
        >        <img
          src="https://github.com/user-attachments/assets/71cc106a-7e05-4b9e-a581-4be6fa094ffd"
          width="100%" 
        >        <img
          src="https://github.com/user-attachments/assets/573687a0-36b8-47a0-b71b-787ddf9da27f"
          width="100%" 
        >        <img
          src="https://github.com/user-attachments/assets/fd33bdf8-a40e-49a6-9f9c-a3245d450d18"
          width="100%" 
        >


</details>

<details>
<summary>iOS: mWeb Safari</summary>
        <img
          src="https://github.com/user-attachments/assets/89cfe9e1-4a9e-46e2-81b6-0a8ece64f2be"
          width="100%" 
        >        <img
          src="https://github.com/user-attachments/assets/6766eb48-760a-4961-a627-4b9a60c7dcdb"
          width="100%" 
        >        <img
          src="https://github.com/user-attachments/assets/e2fb1104-e05e-4a12-8571-e0c3523fdbff"
          width="100%" 
        >        <img
          src="https://github.com/user-attachments/assets/ab36acc0-117f-4294-8499-53b4d3a5d27a"
          width="100%" 
        >


</details>

<details>
<summary>MacOS: Chrome / Safari</summary>
<img width="1499" alt="Screenshot 2025-02-24 at 15 16 13" src="https://github.com/user-attachments/assets/e2f6df5f-5815-420b-bdbe-6c38a92aa34c" />
<img width="1491" alt="Screenshot 2025-02-24 at 15 16 35" src="https://github.com/user-attachments/assets/f3f9d68f-dae3-428f-b1c8-3e807e927d1b" />
<img width="872" alt="Screenshot 2025-02-24 at 15 24 04" src="https://github.com/user-attachments/assets/428e32da-f739-447d-9de5-47e060dca464" />

<img width="868" alt="Screenshot 2025-02-24 at 15 24 17" src="https://github.com/user-attachments/assets/99660a5d-fb69-42d5-8101-5bffd13fdc26" />


</details>

<details>
<summary>MacOS: Desktop</summary>
<img width="1170" alt="Screenshot 2025-02-24 at 15 30 53" src="https://github.com/user-attachments/assets/d96c5bb9-3a0c-4fa6-8b8c-cb1d1a2443b9" />
<img width="1167" alt="Screenshot 2025-02-24 at 15 31 03" src="https://github.com/user-attachments/assets/1c9699cf-e751-4441-8bc2-17e925141acb" />

<img width="1162" alt="Screenshot 2025-02-24 at 15 31 15" src="https://github.com/user-attachments/assets/cec0d166-b06a-45f3-9655-1d075d2c4ac5" />
<img width="1165" alt="Screenshot 2025-02-24 at 15 31 23" src="https://github.com/user-attachments/assets/a79e82ab-383e-43ab-a9aa-9516a8aeba13" />


</details>
