### PR TITLE
Don't render expand icon when not needed

### DIFF
--- a/src/components/Composer/implementation/index.tsx
+++ b/src/components/Composer/implementation/index.tsx
@@ -47,6 +47,7 @@ function Composer(
             end: 0,
         },
         isComposerFullSize = false,
+        onContentSizeChange,
         shouldContainScroll = true,
         isGroupPolicyReport = false,
         ...props
@@ -362,6 +363,7 @@ function Composer(
             onSelectionChange={addCursorPositionToSelectionChange}
             onContentSizeChange={(e) => {
                 setPrevHeight(e.nativeEvent.contentSize.height);
+                onContentSizeChange?.(e);
             }}
             disabled={isDisabled}
             onKeyPress={handleKeyPress}

--- a/src/pages/home/report/ReportActionCompose/AttachmentPickerWithMenuItems.tsx
+++ b/src/pages/home/report/ReportActionCompose/AttachmentPickerWithMenuItems.tsx
@@ -43,6 +43,9 @@ type AttachmentPickerWithMenuItemsProps = {
     /** Callback to open the file in the modal */
     displayFileInModal: (url: FileObject) => void;
 
+    /** Whether or not the full size composer is available */
+    isFullComposerAvailable: boolean;
+
     /** Whether or not the composer is full size */
     isComposerFullSize: boolean;
 
@@ -96,6 +99,7 @@ function AttachmentPickerWithMenuItems({
     report,
     reportParticipantIDs,
     displayFileInModal,
+    isFullComposerAvailable,
     isComposerFullSize,
     reportID,
     isBlockedFromConcierge,
@@ -290,57 +294,59 @@ function AttachmentPickerWithMenuItems({
                                         </PressableWithFeedback>
                                     </Tooltip>
                                 </View>
-                                <View style={expandCollapseButtonContainerStyles}>
-                                    {isComposerFullSize ? (
-                                        <Tooltip
-                                            text={translate('reportActionCompose.collapse')}
-                                            key="composer-collapse"
-                                        >
-                                            <PressableWithFeedback
-                                                onPress={(e) => {
-                                                    e?.preventDefault();
-                                                    raiseIsScrollLikelyLayoutTriggered();
-                                                    setIsComposerFullSize(reportID, false);
-                                                }}
-                                                // Keep focus on the composer when Collapse button is clicked.
-                                                onMouseDown={(e) => e.preventDefault()}
-                                                style={styles.composerSizeButton}
-                                                disabled={isBlockedFromConcierge || disabled}
-                                                role={CONST.ROLE.BUTTON}
-                                                accessibilityLabel={translate('reportActionCompose.collapse')}
+                                {(isFullComposerAvailable || isComposerFullSize) && (
+                                    <View style={expandCollapseButtonContainerStyles}>
+                                        {isComposerFullSize ? (
+                                            <Tooltip
+                                                text={translate('reportActionCompose.collapse')}
+                                                key="composer-collapse"
                                             >
-                                                <Icon
-                                                    fill={theme.icon}
-                                                    src={Expensicons.Collapse}
-                                                />
-                                            </PressableWithFeedback>
-                                        </Tooltip>
-                                    ) : (
-                                        <Tooltip
-                                            text={translate('reportActionCompose.expand')}
-                                            key="composer-expand"
-                                        >
-                                            <PressableWithFeedback
-                                                onPress={(e) => {
-                                                    e?.preventDefault();
-                                                    raiseIsScrollLikelyLayoutTriggered();
-                                                    setIsComposerFullSize(reportID, true);
-                                                }}
-                                                // Keep focus on the composer when Expand button is clicked.
-                                                onMouseDown={(e) => e.preventDefault()}
-                                                style={styles.composerSizeButton}
-                                                disabled={isBlockedFromConcierge || disabled}
-                                                role={CONST.ROLE.BUTTON}
-                                                accessibilityLabel={translate('reportActionCompose.expand')}
+                                                <PressableWithFeedback
+                                                    onPress={(e) => {
+                                                        e?.preventDefault();
+                                                        raiseIsScrollLikelyLayoutTriggered();
+                                                        setIsComposerFullSize(reportID, false);
+                                                    }}
+                                                    // Keep focus on the composer when Collapse button is clicked.
+                                                    onMouseDown={(e) => e.preventDefault()}
+                                                    style={styles.composerSizeButton}
+                                                    disabled={isBlockedFromConcierge || disabled}
+                                                    role={CONST.ROLE.BUTTON}
+                                                    accessibilityLabel={translate('reportActionCompose.collapse')}
+                                                >
+                                                    <Icon
+                                                        fill={theme.icon}
+                                                        src={Expensicons.Collapse}
+                                                    />
+                                                </PressableWithFeedback>
+                                            </Tooltip>
+                                        ) : (
+                                            <Tooltip
+                                                text={translate('reportActionCompose.expand')}
+                                                key="composer-expand"
                                             >
-                                                <Icon
-                                                    fill={theme.icon}
-                                                    src={Expensicons.Expand}
-                                                />
-                                            </PressableWithFeedback>
-                                        </Tooltip>
-                                    )}
-                                </View>
+                                                <PressableWithFeedback
+                                                    onPress={(e) => {
+                                                        e?.preventDefault();
+                                                        raiseIsScrollLikelyLayoutTriggered();
+                                                        setIsComposerFullSize(reportID, true);
+                                                    }}
+                                                    // Keep focus on the composer when Expand button is clicked.
+                                                    onMouseDown={(e) => e.preventDefault()}
+                                                    style={styles.composerSizeButton}
+                                                    disabled={isBlockedFromConcierge || disabled}
+                                                    role={CONST.ROLE.BUTTON}
+                                                    accessibilityLabel={translate('reportActionCompose.expand')}
+                                                >
+                                                    <Icon
+                                                        fill={theme.icon}
+                                                        src={Expensicons.Expand}
+                                                    />
+                                                </PressableWithFeedback>
+                                            </Tooltip>
+                                        )}
+                                    </View>
+                                )}
                             </View>
                         </View>
                         <PopoverMenu

--- a/src/pages/home/report/ReportActionCompose/ComposerWithSuggestions/ComposerWithSuggestions.tsx
+++ b/src/pages/home/report/ReportActionCompose/ComposerWithSuggestions/ComposerWithSuggestions.tsx
@@ -12,8 +12,7 @@ import type {
     TextInputKeyPressEventData,
     TextInputScrollEventData,
 } from 'react-native';
-import {DeviceEventEmitter, findNodeHandle, InteractionManager, NativeModules, View} from 'react-native';
-import {StyleSheet} from 'react-native';
+import {DeviceEventEmitter, findNodeHandle, InteractionManager, NativeModules, StyleSheet, View} from 'react-native';
 import {useFocusedInputHandler} from 'react-native-keyboard-controller';
 import type {OnyxEntry} from 'react-native-onyx';
 import {useOnyx} from 'react-native-onyx';

--- a/src/pages/home/report/ReportActionCompose/ComposerWithSuggestions/ComposerWithSuggestions.tsx
+++ b/src/pages/home/report/ReportActionCompose/ComposerWithSuggestions/ComposerWithSuggestions.tsx
@@ -7,11 +7,13 @@ import type {
     MeasureInWindowOnSuccessCallback,
     NativeSyntheticEvent,
     TextInput,
+    TextInputContentSizeChangeEventData,
     TextInputFocusEventData,
     TextInputKeyPressEventData,
     TextInputScrollEventData,
 } from 'react-native';
 import {DeviceEventEmitter, findNodeHandle, InteractionManager, NativeModules, View} from 'react-native';
+import {StyleSheet} from 'react-native';
 import {useFocusedInputHandler} from 'react-native-keyboard-controller';
 import type {OnyxEntry} from 'react-native-onyx';
 import {useOnyx} from 'react-native-onyx';
@@ -86,6 +88,9 @@ type ComposerWithSuggestionsProps = Partial<ChildrenProps> & {
 
     /** Whether the composer is full size */
     isComposerFullSize: boolean;
+
+    /** Function to set whether the full composer is available */
+    setIsFullComposerAvailable: (isFullComposerAvailable: boolean) => void;
 
     /** Whether the menu is visible */
     isMenuVisible: boolean;
@@ -206,6 +211,7 @@ function ComposerWithSuggestions(
 
         // Composer
         isComposerFullSize,
+        setIsFullComposerAvailable,
         isMenuVisible,
         inputPlaceholder,
         displayFileInModal,
@@ -753,11 +759,23 @@ function ComposerWithSuggestions(
     );
 
     const isTouchEndedRef = useRef(false);
+    const containerComposeStyles = StyleSheet.flatten(StyleUtils.getContainerComposeStyles());
+
+    const updateIsFullComposerAvailable = useCallback(
+        (e: NativeSyntheticEvent<TextInputContentSizeChangeEventData>) => {
+            const paddingTopAndBottom = (containerComposeStyles.paddingVertical as number) * 2;
+            const inputHeight = e.nativeEvent.contentSize.height;
+            const totalHeight = inputHeight + paddingTopAndBottom;
+            const isFullComposerAvailable = totalHeight >= CONST.COMPOSER.FULL_COMPOSER_MIN_HEIGHT;
+            setIsFullComposerAvailable?.(isFullComposerAvailable);
+        },
+        [setIsFullComposerAvailable, containerComposeStyles],
+    );
 
     return (
         <>
             <View
-                style={[StyleUtils.getContainerComposeStyles(), styles.textInputComposeBorder]}
+                style={[containerComposeStyles, styles.textInputComposeBorder]}
                 onTouchEndCapture={() => {
                     isTouchEndedRef.current = true;
                 }}
@@ -790,6 +808,7 @@ function ComposerWithSuggestions(
                     selection={selection}
                     onSelectionChange={onSelectionChange}
                     isComposerFullSize={isComposerFullSize}
+                    onContentSizeChange={updateIsFullComposerAvailable}
                     value={value}
                     testID="composer"
                     shouldCalculateCaretPosition

--- a/src/pages/home/report/ReportActionCompose/ReportActionCompose.tsx
+++ b/src/pages/home/report/ReportActionCompose/ReportActionCompose.tsx
@@ -155,6 +155,7 @@ function ReportActionCompose({
         const initialModalState = getModalState();
         return shouldFocusInputOnScreenFocus && shouldShowComposeInput && !initialModalState?.isVisible && !initialModalState?.willAlertModalBecomeVisible;
     });
+    const [isFullComposerAvailable, setIsFullComposerAvailable] = useState(isComposerFullSize);
 
     // A flag to indicate whether the onScroll callback is likely triggered by a layout change (caused by text change) or not
     const isScrollLikelyLayoutTriggered = useRef(false);
@@ -470,6 +471,7 @@ function ReportActionCompose({
                                             reportID={reportID}
                                             report={report}
                                             reportParticipantIDs={reportParticipantIDs}
+                                            isFullComposerAvailable={isFullComposerAvailable}
                                             isComposerFullSize={isComposerFullSize}
                                             isBlockedFromConcierge={isBlockedFromConcierge}
                                             disabled={disabled}
@@ -507,6 +509,7 @@ function ReportActionCompose({
                                             isMenuVisible={isMenuVisible}
                                             inputPlaceholder={inputPlaceholder}
                                             isComposerFullSize={isComposerFullSize}
+                                            setIsFullComposerAvailable={setIsFullComposerAvailable}
                                             displayFileInModal={displayFileInModal}
                                             onCleared={submitForm}
                                             isBlockedFromConcierge={isBlockedFromConcierge}


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
<!-- Explain what your change does and how it addresses the linked issue -->

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/57019
PROPOSAL: https://github.com/Expensify/App/issues/57019#issuecomment-2666125818


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->
Same as QA Steps
- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->
Same as QA Steps
### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->

1. Open any chat and send a message
2. Click on the message
3. Press tab until you reach the add icon in the composer
4. Press tab once again
5. Verify the focus moves to the composer

There is no tab navigation on iOS/Android, so just verify the expand/collapse icon works normally
- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/31d7bb36-76ac-4f0d-b48e-91a7fbe34fe4


</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/7f40ba8e-83a8-4b5a-b6f4-86cfdbe4ecba


</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/be7ab8b1-b254-4611-92c2-5378d8cfcd49


</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/3c5ce8d3-674c-4275-972c-0aaa1d61c000


</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/b6129a6a-4df9-4fcf-9bcc-5af716653097


</details>

<details>
<summary>MacOS: Desktop</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/a9c71506-df4d-47ca-a68a-c49d90e97635


</details>
