### PR TITLE
update markdown rendering

### DIFF
--- a/src/libs/actions/Policy/Policy.ts
+++ b/src/libs/actions/Policy/Policy.ts
@@ -3853,7 +3853,6 @@ function setPolicyMaxExpenseAge(policyID: string, maxExpenseAge: string) {
                     pendingFields: {
                         maxExpenseAge: CONST.RED_BRICK_ROAD_PENDING_ACTION.UPDATE,
                     },
-                    isLoading: true,
                 },
             },
         ],
@@ -3865,7 +3864,6 @@ function setPolicyMaxExpenseAge(policyID: string, maxExpenseAge: string) {
                     pendingFields: {
                         maxExpenseAge: null,
                     },
-                    isLoading: false,
                 },
             },
         ],
@@ -3877,7 +3875,6 @@ function setPolicyMaxExpenseAge(policyID: string, maxExpenseAge: string) {
                     maxExpenseAge: originalMaxExpenseAge,
                     pendingFields: {maxExpenseAge: null},
                     errorFields: {maxExpenseAge: ErrorUtils.getMicroSecondOnyxErrorWithTranslationKey('common.genericErrorMessage')},
-                    isLoading: false,
                 },
             },
         ],
@@ -3911,6 +3908,7 @@ function updateCustomRules(policyID: string, customRules: string) {
                 key: `${ONYXKEYS.COLLECTION.POLICY}${policyID}`,
                 value: {
                     customRules: parsedCustomRules,
+                    isLoading: true,
                 },
             },
         ],
@@ -3923,6 +3921,7 @@ function updateCustomRules(policyID: string, customRules: string) {
                         // TODO
                         // maxExpenseAge: null,
                     },
+                    isLoading: false,
                 },
             },
         ],
@@ -3932,6 +3931,7 @@ function updateCustomRules(policyID: string, customRules: string) {
                 key: `${ONYXKEYS.COLLECTION.POLICY}${policyID}`,
                 value: {
                     customRules: originalCustomRules,
+                    isLoading: false,
                     // TODO
                     // pendingFields: {maxExpenseAge: null},
                     // errorFields: {maxExpenseAge: ErrorUtils.getMicroSecondOnyxErrorWithTranslationKey('common.genericErrorMessage')},

--- a/src/libs/actions/Policy/Policy.ts
+++ b/src/libs/actions/Policy/Policy.ts
@@ -3853,6 +3853,7 @@ function setPolicyMaxExpenseAge(policyID: string, maxExpenseAge: string) {
                     pendingFields: {
                         maxExpenseAge: CONST.RED_BRICK_ROAD_PENDING_ACTION.UPDATE,
                     },
+                    isLoading: true,
                 },
             },
         ],
@@ -3864,6 +3865,7 @@ function setPolicyMaxExpenseAge(policyID: string, maxExpenseAge: string) {
                     pendingFields: {
                         maxExpenseAge: null,
                     },
+                    isLoading: false,
                 },
             },
         ],
@@ -3875,6 +3877,7 @@ function setPolicyMaxExpenseAge(policyID: string, maxExpenseAge: string) {
                     maxExpenseAge: originalMaxExpenseAge,
                     pendingFields: {maxExpenseAge: null},
                     errorFields: {maxExpenseAge: ErrorUtils.getMicroSecondOnyxErrorWithTranslationKey('common.genericErrorMessage')},
+                    isLoading: false,
                 },
             },
         ],

--- a/src/pages/workspace/rules/CustomRulesSection.tsx
+++ b/src/pages/workspace/rules/CustomRulesSection.tsx
@@ -17,7 +17,12 @@ function CustomRulesSection({policyID}: CustomRulesSectionProps) {
     const {translate} = useLocalize();
     const styles = useThemeStyles();
     const policy = usePolicy(policyID);
-    const parsedRules = useMemo(() => getParsedComment(policy?.customRules ?? ''), [policy]);
+    const parsedRules = useMemo(() => {
+        const customRules = policy?.customRules ?? '';
+        const options = policy?.isLoading ? {shouldEscapeText: false} : undefined;
+
+        return getParsedComment(customRules, options);
+    }, [policy]);
     const rulesDescription = typeof parsedRules === 'string' ? parsedRules : '';
 
     return (


### PR DESCRIPTION
### Details

### Fixed Issues
$ https://github.com/Expensify/App/issues/56632
PROPOSAL: https://github.com/Expensify/App/issues/56632#issuecomment-2667586343

### Tests

Same QA step

- [x] Verify that no errors appear in the JS console

### Offline tests

### QA Steps

Precondition:

- Must have all betas enabled
- Ensure that Rules are enabled in Workspace settings > More features.

1. Launch the application.
2. Ensure that you are on all betas
3. Go to Workspace settings > Rules.
4. Scroll down and click Description under Custom rules.
5. Enter text with mark down and save it(ex: _hey_).
6. Wait for a while after saving it.
7. Verify that the text with Markdown formatting is rendered correctly after saving.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message: 
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

https://github.com/user-attachments/assets/bf1d5a5c-97bf-43a9-8c87-54b5c3836901

</details>

<details>
<summary>Android: mWeb Chrome</summary>

https://github.com/user-attachments/assets/cf97eeb9-45a9-4d5d-9cd7-022c34e31c46

</details>

<details>
<summary>iOS: Native</summary>

https://github.com/user-attachments/assets/951ee377-3e75-4d3c-a59d-084fcde4d104

</details>

<details>
<summary>iOS: mWeb Safari</summary>

https://github.com/user-attachments/assets/2952dc22-5848-4b68-8a2f-ea3d734ffd46

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

https://github.com/user-attachments/assets/faa83fab-6922-4f4b-a568-621dc803a304

</details>

<details>
<summary>MacOS: Desktop</summary>

https://github.com/user-attachments/assets/ce67bec4-2ba5-4e94-99cd-ca3cb9b44e85

</details>
