### PR TITLE
fix: Do not display errors in the Start screen of USD VBA flow

### DIFF
--- a/src/pages/ReimbursementAccount/VerifiedBankAccountFlowEntryPoint.tsx
+++ b/src/pages/ReimbursementAccount/VerifiedBankAccountFlowEntryPoint.tsx
@@ -18,7 +18,7 @@ import ValidateCodeActionModal from '@components/ValidateCodeActionModal';
 import useLocalize from '@hooks/useLocalize';
 import useTheme from '@hooks/useTheme';
 import useThemeStyles from '@hooks/useThemeStyles';
-import {getEarliestErrorField, getLatestErrorField} from '@libs/ErrorUtils';
+import {getEarliestErrorField, getLatestError, getLatestErrorField} from '@libs/ErrorUtils';
 import getPlaidDesktopMessage from '@libs/getPlaidDesktopMessage';
 import {REIMBURSEMENT_ACCOUNT_ROUTE_NAMES} from '@libs/ReimbursementAccountUtils';
 import WorkspaceResetBankAccountModal from '@pages/workspace/WorkspaceResetBankAccountModal';
@@ -221,7 +221,7 @@ function VerifiedBankAccountFlowEntryPoint({
                     )}
                     {shouldShowContinueSetupButton === true ? (
                         <OfflineWithFeedback
-                            errors={errors}
+                            errors={getLatestError(errors)}
                             shouldShowErrorMessages
                             onClose={resetReimbursementAccount}
                         >

--- a/src/pages/ReimbursementAccount/VerifiedBankAccountFlowEntryPoint.tsx
+++ b/src/pages/ReimbursementAccount/VerifiedBankAccountFlowEntryPoint.tsx
@@ -18,7 +18,7 @@ import ValidateCodeActionModal from '@components/ValidateCodeActionModal';
 import useLocalize from '@hooks/useLocalize';
 import useTheme from '@hooks/useTheme';
 import useThemeStyles from '@hooks/useThemeStyles';
-import {getEarliestErrorField, getLatestErrorField} from '@libs/ErrorUtils';
+import {getEarliestErrorField, getLatestError, getLatestErrorField} from '@libs/ErrorUtils';
 import getPlaidDesktopMessage from '@libs/getPlaidDesktopMessage';
 import {REIMBURSEMENT_ACCOUNT_ROUTE_NAMES} from '@libs/ReimbursementAccountUtils';
 import WorkspaceResetBankAccountModal from '@pages/workspace/WorkspaceResetBankAccountModal';
@@ -220,7 +220,7 @@ function VerifiedBankAccountFlowEntryPoint({
                         </View>
                     )}
                     <OfflineWithFeedback
-                        errors={errors}
+                        errors={getLatestError(errors)}
                         shouldShowErrorMessages
                         onClose={resetReimbursementAccount}
                     >

--- a/src/pages/ReimbursementAccount/VerifiedBankAccountFlowEntryPoint.tsx
+++ b/src/pages/ReimbursementAccount/VerifiedBankAccountFlowEntryPoint.tsx
@@ -18,7 +18,7 @@ import ValidateCodeActionModal from '@components/ValidateCodeActionModal';
 import useLocalize from '@hooks/useLocalize';
 import useTheme from '@hooks/useTheme';
 import useThemeStyles from '@hooks/useThemeStyles';
-import {getEarliestErrorField, getLatestError, getLatestErrorField} from '@libs/ErrorUtils';
+import {getEarliestErrorField, getLatestErrorField} from '@libs/ErrorUtils';
 import getPlaidDesktopMessage from '@libs/getPlaidDesktopMessage';
 import {REIMBURSEMENT_ACCOUNT_ROUTE_NAMES} from '@libs/ReimbursementAccountUtils';
 import WorkspaceResetBankAccountModal from '@pages/workspace/WorkspaceResetBankAccountModal';
@@ -219,57 +219,55 @@ function VerifiedBankAccountFlowEntryPoint({
                             </Text>
                         </View>
                     )}
-                    <OfflineWithFeedback
-                        errors={getLatestError(errors)}
-                        shouldShowErrorMessages
-                        onClose={resetReimbursementAccount}
-                    >
-                        {shouldShowContinueSetupButton === true ? (
-                            <>
+                    {shouldShowContinueSetupButton === true ? (
+                        <OfflineWithFeedback
+                            errors={errors}
+                            shouldShowErrorMessages
+                            onClose={resetReimbursementAccount}
+                        >
+                            <MenuItem
+                                title={translate('workspace.bankAccount.continueWithSetup')}
+                                icon={Connect}
+                                iconFill={theme.icon}
+                                onPress={onContinuePress}
+                                shouldShowRightIcon
+                                wrapperStyle={[styles.cardMenuItem, styles.mt4]}
+                                disabled={!!pendingAction || !isEmptyObject(errors)}
+                            />
+                            <MenuItem
+                                title={translate('workspace.bankAccount.startOver')}
+                                icon={RotateLeft}
+                                iconFill={theme.icon}
+                                // TODO add method for non USD accounts in next issue - https://github.com/Expensify/App/issues/50912
+                                onPress={requestResetFreePlanBankAccount}
+                                shouldShowRightIcon
+                                wrapperStyle={[styles.cardMenuItem, styles.mt4]}
+                                disabled={!!pendingAction || !isEmptyObject(errors)}
+                            />
+                        </OfflineWithFeedback>
+                    ) : (
+                        <>
+                            {!hasForeignCurrency && !shouldShowContinueSetupButton && (
                                 <MenuItem
-                                    title={translate('workspace.bankAccount.continueWithSetup')}
-                                    icon={Connect}
+                                    title={translate('bankAccount.connectOnlineWithPlaid')}
+                                    icon={Bank}
                                     iconFill={theme.icon}
-                                    onPress={onContinuePress}
-                                    shouldShowRightIcon
-                                    wrapperStyle={[styles.cardMenuItem, styles.mt4]}
-                                    disabled={!!pendingAction || !isEmptyObject(errors)}
-                                />
-                                <MenuItem
-                                    title={translate('workspace.bankAccount.startOver')}
-                                    icon={RotateLeft}
-                                    iconFill={theme.icon}
-                                    // TODO add method for non USD accounts in next issue - https://github.com/Expensify/App/issues/50912
-                                    onPress={requestResetFreePlanBankAccount}
-                                    shouldShowRightIcon
-                                    wrapperStyle={[styles.cardMenuItem, styles.mt4]}
-                                    disabled={!!pendingAction || !isEmptyObject(errors)}
-                                />
-                            </>
-                        ) : (
-                            <>
-                                {!hasForeignCurrency && !shouldShowContinueSetupButton && (
-                                    <MenuItem
-                                        title={translate('bankAccount.connectOnlineWithPlaid')}
-                                        icon={Bank}
-                                        iconFill={theme.icon}
-                                        disabled={!!isPlaidDisabled}
-                                        onPress={handleConnectPlaid}
-                                        shouldShowRightIcon
-                                        wrapperStyle={[styles.cardMenuItem, styles.mt4]}
-                                    />
-                                )}
-                                <MenuItem
-                                    title={translate('bankAccount.connectManually')}
-                                    icon={Connect}
-                                    iconFill={theme.icon}
-                                    onPress={handleConnectManually}
+                                    disabled={!!isPlaidDisabled}
+                                    onPress={handleConnectPlaid}
                                     shouldShowRightIcon
                                     wrapperStyle={[styles.cardMenuItem, styles.mt4]}
                                 />
-                            </>
-                        )}
-                    </OfflineWithFeedback>
+                            )}
+                            <MenuItem
+                                title={translate('bankAccount.connectManually')}
+                                icon={Connect}
+                                iconFill={theme.icon}
+                                onPress={handleConnectManually}
+                                shouldShowRightIcon
+                                wrapperStyle={[styles.cardMenuItem, styles.mt4]}
+                            />
+                        </>
+                    )}
                 </Section>
                 <View style={[styles.mv0, styles.mh5, styles.flexRow, styles.justifyContentBetween]}>
                     <TextLink href={CONST.OLD_DOT_PUBLIC_URLS.PRIVACY_URL}>{translate('common.privacy')}</TextLink>


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
<!-- Explain what your change does and how it addresses the linked issue -->

- Nested OfflineWithFeedback component deeper so it is only displayed when we show set of buttons for `Continue` scenario
- Pass only latest error to OfflineWithFeedback component

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/57768
PROPOSAL:
https://github.com/Expensify/App/issues/57768#issuecomment-2698500798


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->
Same as QA steps
- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->

- Create a new USD workspace.
- Go to workspace settings > Workflows.
- Click Connect bank account.
- Click Connect manually.
- Enter 011401533 for Routing number.
- Enter 111111111111111 for Account number.
- Click Next.
- Click RHP back button.
- No errors should be displayed
- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos

<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/75e27c75-6dda-4237-81d1-561b1ae4635e


</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/a4c550b5-2628-498b-b83d-ea6da6565f7a

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/f7593e7a-8003-43fb-974b-683d2cf18f7a


</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/29d3a023-e076-4be7-87ab-9f4b8ee12532


</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->
 https://github.com/user-attachments/assets/73b05f80-2e5a-486b-8048-36b67012e29a

</details>

<details>
<summary>MacOS: Desktop</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/b627595f-d6a6-4671-94b0-0defa62440ce


</details>
