### PR TITLE
[CP Staging] Fix: Scroll Issue on Reports Page, side pane appearing after language change

### DIFF
--- a/src/hooks/useSidePane.ts
+++ b/src/hooks/useSidePane.ts
@@ -27,7 +27,8 @@ function useSidePane() {
     const {windowWidth} = useWindowDimensions();
 
     const [sidePane] = useOnyx(ONYXKEYS.NVP_SIDE_PANE);
-    const isPaneHidden = isSidePaneHidden(sidePane, isExtraLargeScreenWidth);
+    const [language] = useOnyx(ONYXKEYS.NVP_PREFERRED_LOCALE);
+    const isPaneHidden = isSidePaneHidden(sidePane, isExtraLargeScreenWidth) || language !== CONST.LOCALES.EN;
 
     const sidePaneWidth = shouldUseNarrowLayout ? windowWidth : variables.sideBarWidth;
     const shouldApplySidePaneOffset = isExtraLargeScreenWidth && !isPaneHidden;

--- a/src/libs/Navigation/AppNavigator/useRootNavigatorScreenOptions.ts
+++ b/src/libs/Navigation/AppNavigator/useRootNavigatorScreenOptions.ts
@@ -81,9 +81,7 @@ const useRootNavigatorScreenOptions = () => {
             animation: Animations.NONE,
             web: {
                 cardStyleInterpolator: (props: StackCardInterpolationProps) => modalCardStyleInterpolator({props, isFullScreenModal: true}),
-                cardStyle: {
-                    ...StyleUtils.getNavigationModalCardStyle(),
-                },
+                cardStyle: StyleUtils.getNavigationModalCardStyle(),
             },
         },
         fullScreen: {
@@ -91,6 +89,9 @@ const useRootNavigatorScreenOptions = () => {
             // We need to turn off animation for the full screen to avoid delay when closing screens.
             animation: Animations.NONE,
             web: {
+                cardStyle: {
+                    height: '100%',
+                },
                 cardStyleInterpolator: (props: StackCardInterpolationProps) => modalCardStyleInterpolator({props, isFullScreenModal: true, shouldAnimateSidePane: true}),
             },
         },

--- a/src/libs/actions/App.ts
+++ b/src/libs/actions/App.ts
@@ -31,7 +31,6 @@ import {getAll, rollbackOngoingRequest, save} from './PersistedRequests';
 import {createDraftInitialWorkspace, createWorkspace, generatePolicyID} from './Policy/Policy';
 import {resolveDuplicationConflictAction} from './RequestConflictUtils';
 import {isAnonymousUser} from './Session';
-import {triggerSidePane} from './SidePane';
 import Timing from './Timing';
 
 type PolicyParamsForOpenOrReconnect = {
@@ -112,14 +111,6 @@ Onyx.connect({
     key: ONYXKEYS.HAS_LOADED_APP,
     callback: (value) => {
         hasLoadedApp = value;
-    },
-});
-
-let nvpSidePane: OnyxEntry<OnyxTypes.SidePane>;
-Onyx.connect({
-    key: ONYXKEYS.NVP_SIDE_PANE,
-    callback: (value) => {
-        nvpSidePane = value;
     },
 });
 
@@ -205,11 +196,6 @@ function setLocale(locale: Locale) {
 
 function setLocaleAndNavigate(locale: Locale) {
     setLocale(locale);
-
-    if (nvpSidePane) {
-        triggerSidePane(false, {shouldUpdateNarrowLayout: true});
-    }
-
     Navigation.goBack();
 }
 

--- a/src/libs/actions/App.ts
+++ b/src/libs/actions/App.ts
@@ -115,6 +115,14 @@ Onyx.connect({
     },
 });
 
+let nvpSidePane: OnyxEntry<OnyxTypes.SidePane>;
+Onyx.connect({
+    key: ONYXKEYS.NVP_SIDE_PANE,
+    callback: (value) => {
+        nvpSidePane = value;
+    },
+});
+
 const KEYS_TO_PRESERVE: OnyxKey[] = [
     ONYXKEYS.ACCOUNT,
     ONYXKEYS.IS_CHECKING_PUBLIC_ROOM,
@@ -197,7 +205,11 @@ function setLocale(locale: Locale) {
 
 function setLocaleAndNavigate(locale: Locale) {
     setLocale(locale);
-    triggerSidePane(false, {shouldUpdateNarrowLayout: true});
+
+    if (nvpSidePane) {
+        triggerSidePane(false, {shouldUpdateNarrowLayout: true});
+    }
+
     Navigation.goBack();
 }
 


### PR DESCRIPTION
### Explanation of Change

Issue was reported by @shawnborton on Slack [here](https://expensify.slack.com/archives/C05LX9D6E07/p1741156853495809). Fixing two big issues in one PR: 
- Unable to Scroll Down on Reports Page
- HelpButton was displayed for anyone that changed their langugage back and forth 

### Fixed Issues
$ https://github.com/Expensify/App/issues/56988
PROPOSAL: N/A

### Tests
1. Open Reports page on web (safari desktop, chrome desktop, safari ios, chrome android)
2. Verify that the page works well and user can scroll the reports

1. Make sure you have Help nvp disabled:
```ts
Onyx.set("nvp_sidePaneExpanded", null)
```
2. Change language from English to Spanish, and from Spanish to English
3. Verify that HelpButton isn't displayed in headers (for example on reports page)

### Offline tests

N/A

### QA Steps

Same as tests

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos

<details>
<summary>Android: mWeb Chrome</summary>

[and.webm](https://github.com/user-attachments/assets/e5f56fc9-f6cc-4f6d-a15a-34dbfcb7d7b3)


</details>

<details>
<summary>iOS: mWeb Safari</summary>


https://github.com/user-attachments/assets/3c30eb4a-08ad-4b83-93c6-69741d988949



</details>

<details>
<summary>MacOS: Chrome </summary>


https://github.com/user-attachments/assets/af435821-0c98-4ce7-bd4a-5f5d523548a0


</details>


<details>
<summary>MacOS: Safari</summary>

https://github.com/user-attachments/assets/c142bb3a-0b4c-423d-b214-a4ec0ec90933


</details>
