### PR TITLE
[NoQA] Revert "fix: Message Previews Always Include Sender Name"

### DIFF
--- a/src/libs/OptionsListUtils.ts
+++ b/src/libs/OptionsListUtils.ts
@@ -534,14 +534,10 @@ function uniqFast(items: string[]): string[] {
  * Get the last actor display name from last actor details.
  */
 function getLastActorDisplayName(lastActorDetails: Partial<PersonalDetails> | null, hasMultipleParticipants: boolean) {
-    if (!hasMultipleParticipants || !lastActorDetails) {
-        return '';
-    }
-
-    return lastActorDetails.accountID !== currentUserAccountID
+    return hasMultipleParticipants && lastActorDetails && lastActorDetails.accountID !== currentUserAccountID
         ? // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
           lastActorDetails.firstName || formatPhoneNumber(getDisplayNameOrDefault(lastActorDetails))
-        : translateLocal('common.you');
+        : '';
 }
 
 /**

--- a/tests/unit/OptionsListUtilsTest.ts
+++ b/tests/unit/OptionsListUtilsTest.ts
@@ -13,7 +13,6 @@ import {
     filterSelfDMChat,
     filterWorkspaceChats,
     formatMemberForList,
-    getLastActorDisplayName,
     getMemberInviteOptions,
     getSearchOptions,
     getShareDestinationOptions,
@@ -810,11 +809,6 @@ describe('OptionsListUtils', () => {
         expect(results.personalDetails.at(1)?.text).toBe('Black Widow');
         expect(results.personalDetails.at(2)?.text).toBe('Captain America');
         expect(results.personalDetails.at(3)?.text).toBe('Invisible Woman');
-    });
-
-    it('getLastActorDisplayName()', () => {
-        expect(getLastActorDisplayName(PERSONAL_DETAILS['2'], true)).toBe('You');
-        expect(getLastActorDisplayName(PERSONAL_DETAILS['3'], true)).toBe('Spider-Man');
     });
 
     it('formatMemberForList()', () => {


### PR DESCRIPTION
Reverts Expensify/App#57371

Straight revert for the unit tests failing in main