### PR TITLE
Remove reportID param from dismissModal function

### DIFF
--- a/contributingGuides/NAVIGATION.md
+++ b/contributingGuides/NAVIGATION.md
@@ -34,7 +34,7 @@ When creating RHP flows, you have to remember a couple of things:
 
 - We use a custom `goBack` function to handle the browser and the `react-navigation` history stack. Under the hood, it resolves to either replacing the current screen with the one we navigate to (deeplinking scenario) or just going back if we reached the current page by navigating in App (pops the screen). It ensures the requested behaviors on web, which is navigating back to the place from where you deeplinked when going into the RHP flow by it.
 
-- If you want to navigate to a certain report after completing a flow related to it, e.g. `RequestMoney` flow with a certain group/user, you should use `Navigation.dismissModal` with this `reportID` as an argument. If, in the future, we would like to navigate to something different than the report after such flows, the API should be rather easy to change. We do it like that in order to replace the RHP flow with the new report instead of pushing it, so pressing the back button does not navigate back to the ending page of the flow. If we were to navigate to the same report, we just pop the RHP modal.
+- If you want to navigate to a certain report after completing a flow related to it, e.g. `RequestMoney` flow with a certain group/user, you should use `Navigation.dismissModalWithReport` with this `reportID` as an argument. If, in the future, we would like to navigate to something different than the report after such flows, the API should be rather easy to change. We do it like that in order to replace the RHP flow with the new report instead of pushing it, so pressing the back button does not navigate back to the ending page of the flow. If we were to navigate to the same report, we just pop the RHP modal.
 
 ### Example of usage
 

--- a/src/libs/Navigation/AppNavigator/createRootStackNavigator/GetStateForActionHandlers.ts
+++ b/src/libs/Navigation/AppNavigator/createRootStackNavigator/GetStateForActionHandlers.ts
@@ -7,7 +7,7 @@ import type {RootNavigatorParamList, State} from '@libs/Navigation/types';
 import * as SearchQueryUtils from '@libs/SearchQueryUtils';
 import NAVIGATORS from '@src/NAVIGATORS';
 import SCREENS from '@src/SCREENS';
-import type {OpenWorkspaceSplitActionType, PushActionType, SwitchPolicyIdActionType} from './types';
+import type {OpenWorkspaceSplitActionType, PushActionType, ReplaceActionType, SwitchPolicyIdActionType} from './types';
 
 const MODAL_ROUTES_TO_DISMISS: string[] = [
     NAVIGATORS.WORKSPACE_SPLIT_NAVIGATOR,
@@ -237,6 +237,29 @@ function handlePushSearchPageAction(
     return stackRouter.getStateForAction(state, updatedAction, configOptions);
 }
 
+function handleReplaceReportsSplitNavigatorAction(
+    state: StackNavigationState<ParamListBase>,
+    action: ReplaceActionType,
+    configOptions: RouterConfigOptions,
+    stackRouter: Router<StackNavigationState<ParamListBase>, CommonActions.Action | StackActionType>,
+) {
+    const stateWithReportsSplitNavigator = stackRouter.getStateForAction(state, action, configOptions);
+
+    if (!stateWithReportsSplitNavigator) {
+        Log.hmmm('[handleReplaceReportsSplitNavigatorAction] ReportsSplitNavigator has not been found in the navigation state.');
+        return null;
+    }
+
+    const lastReportsSplitNavigator = stateWithReportsSplitNavigator.routes.at(-1);
+
+    // ReportScreen should always be opened with an animation when replacing the navigator
+    if (lastReportsSplitNavigator?.key) {
+        reportsSplitsWithEnteringAnimation.add(lastReportsSplitNavigator.key);
+    }
+
+    return stateWithReportsSplitNavigator;
+}
+
 /**
  * Handles the DISMISS_MODAL action.
  * If the last route is a modal route, it has to be popped from the navigation stack.
@@ -275,6 +298,7 @@ export {
     handleDismissModalAction,
     handlePushReportSplitAction,
     handlePushSearchPageAction,
+    handleReplaceReportsSplitNavigatorAction,
     handleSwitchPolicyIDAction,
     handleSwitchPolicyIDFromSearchAction,
     handleNavigatingToModalFromModal,

--- a/src/libs/Navigation/AppNavigator/createRootStackNavigator/RootStackRouter.ts
+++ b/src/libs/Navigation/AppNavigator/createRootStackNavigator/RootStackRouter.ts
@@ -14,10 +14,19 @@ import {
     handleOpenWorkspaceSplitAction,
     handlePushReportSplitAction,
     handlePushSearchPageAction,
+    handleReplaceReportsSplitNavigatorAction,
     handleSwitchPolicyIDAction,
 } from './GetStateForActionHandlers';
 import syncBrowserHistory from './syncBrowserHistory';
-import type {DismissModalActionType, OpenWorkspaceSplitActionType, PushActionType, RootStackNavigatorAction, RootStackNavigatorRouterOptions, SwitchPolicyIdActionType} from './types';
+import type {
+    DismissModalActionType,
+    OpenWorkspaceSplitActionType,
+    PushActionType,
+    ReplaceActionType,
+    RootStackNavigatorAction,
+    RootStackNavigatorRouterOptions,
+    SwitchPolicyIdActionType,
+} from './types';
 
 function isOpenWorkspaceSplitAction(action: RootStackNavigatorAction): action is OpenWorkspaceSplitActionType {
     return action.type === CONST.NAVIGATION.ACTION_TYPE.OPEN_WORKSPACE_SPLIT;
@@ -29,6 +38,10 @@ function isSwitchPolicyIdAction(action: RootStackNavigatorAction): action is Swi
 
 function isPushAction(action: RootStackNavigatorAction): action is PushActionType {
     return action.type === CONST.NAVIGATION.ACTION_TYPE.PUSH;
+}
+
+function isReplaceAction(action: RootStackNavigatorAction): action is ReplaceActionType {
+    return action.type === CONST.NAVIGATION.ACTION_TYPE.REPLACE;
 }
 
 function isDismissModalAction(action: RootStackNavigatorAction): action is DismissModalActionType {
@@ -80,6 +93,10 @@ function RootStackRouter(options: RootStackNavigatorRouterOptions) {
 
             if (isDismissModalAction(action)) {
                 return handleDismissModalAction(state, configOptions, stackRouter);
+            }
+
+            if (isReplaceAction(action) && action.payload.name === NAVIGATORS.REPORTS_SPLIT_NAVIGATOR) {
+                return handleReplaceReportsSplitNavigatorAction(state, action, configOptions, stackRouter);
             }
 
             if (isPushAction(action)) {

--- a/src/libs/Navigation/AppNavigator/createRootStackNavigator/types.ts
+++ b/src/libs/Navigation/AppNavigator/createRootStackNavigator/types.ts
@@ -29,6 +29,8 @@ type SwitchPolicyIdActionType = RootStackNavigatorActionType & {
 
 type PushActionType = StackActionType & {type: typeof CONST.NAVIGATION.ACTION_TYPE.PUSH};
 
+type ReplaceActionType = StackActionType & {type: typeof CONST.NAVIGATION.ACTION_TYPE.REPLACE};
+
 type DismissModalActionType = RootStackNavigatorActionType & {
     type: typeof CONST.NAVIGATION.ACTION_TYPE.DISMISS_MODAL;
 };
@@ -49,6 +51,7 @@ export type {
     OpenWorkspaceSplitActionType,
     SwitchPolicyIdActionType,
     PushActionType,
+    ReplaceActionType,
     DismissModalActionType,
     RootStackNavigatorAction,
     RootStackNavigatorActionType,

--- a/src/libs/Navigation/Navigation.ts
+++ b/src/libs/Navigation/Navigation.ts
@@ -24,6 +24,7 @@ import originalCloseRHPFlow from './helpers/closeRHPFlow';
 import getPolicyIDFromState from './helpers/getPolicyIDFromState';
 import getStateFromPath from './helpers/getStateFromPath';
 import getTopmostReportParams from './helpers/getTopmostReportParams';
+import {isFullScreenName} from './helpers/isNavigatorName';
 import isReportOpenInRHP from './helpers/isReportOpenInRHP';
 import isSideModalNavigator from './helpers/isSideModalNavigator';
 import linkTo from './helpers/linkTo';
@@ -469,20 +470,20 @@ function waitForProtectedRoutes() {
     });
 }
 
-type NavigateToReportWithPolicyCheckPayload = {report?: OnyxEntry<Report>; reportID?: string; reportActionID?: string; referrer?: string; policyIDToCheck?: string};
+type NavigateToReportWithPolicyCheckPayload = {report?: OnyxEntry<Report>; reportID?: string; reportActionID?: string; referrer?: string; policyIDToCheck?: string; forceReplace?: boolean};
 
 /**
  * Navigates to a report passed as a param (as an id or report object) and checks whether the target object belongs to the currently selected workspace.
  * If not, the current workspace is set to global.
  */
-function navigateToReportWithPolicyCheck({report, reportID, reportActionID, referrer, policyIDToCheck}: NavigateToReportWithPolicyCheckPayload, ref = navigationRef) {
+function navigateToReportWithPolicyCheck({report, reportID, reportActionID, referrer, policyIDToCheck}: NavigateToReportWithPolicyCheckPayload, forceReplace = false, ref = navigationRef) {
     const targetReport = reportID ? {reportID, ...allReports?.[`${ONYXKEYS.COLLECTION.REPORT}${reportID}`]} : report;
     const policyID = policyIDToCheck ?? getPolicyIDFromState(navigationRef.getRootState() as State<RootNavigatorParamList>);
     const policyMemberAccountIDs = getPolicyEmployeeAccountIDs(policyID);
     const shouldOpenAllWorkspace = isEmptyObject(targetReport) ? true : !doesReportBelongToWorkspace(targetReport, policyMemberAccountIDs, policyID);
 
     if ((shouldOpenAllWorkspace && !policyID) || !shouldOpenAllWorkspace) {
-        linkTo(ref.current, ROUTES.REPORT_WITH_ID.getRoute(targetReport?.reportID, reportActionID, referrer));
+        linkTo(ref.current, ROUTES.REPORT_WITH_ID.getRoute(targetReport?.reportID, reportActionID, referrer), {forceReplace: !!forceReplace});
         return;
     }
 
@@ -496,6 +497,17 @@ function navigateToReportWithPolicyCheck({report, reportID, reportActionID, refe
 
     if (referrer) {
         params.referrer = referrer;
+    }
+
+    if (forceReplace) {
+        ref.dispatch(
+            StackActions.replace(NAVIGATORS.REPORTS_SPLIT_NAVIGATOR, {
+                policyID: undefined,
+                screen: SCREENS.REPORT,
+                params,
+            }),
+        );
+        return;
     }
 
     ref.dispatch(
@@ -528,23 +540,31 @@ function getReportRouteByID(reportID?: string, routes: NavigationRoute[] = navig
 /**
  * Closes the modal navigator (RHP, LHP, onboarding).
  */
-const dismissModal = (reportID?: string, ref = navigationRef) => {
+const dismissModal = (ref = navigationRef) => {
     isNavigationReady().then(() => {
         ref.dispatch({type: CONST.NAVIGATION.ACTION_TYPE.DISMISS_MODAL});
-        if (!reportID) {
-            return;
-        }
-        navigateToReportWithPolicyCheck({reportID});
     });
 };
 
 /**
  * Dismisses the modal and opens the given report.
  */
-const dismissModalWithReport = (report: OnyxEntry<Report>, ref = navigationRef) => {
+const dismissModalWithReport = (navigateToReportPayload: NavigateToReportWithPolicyCheckPayload, ref = navigationRef) => {
     isNavigationReady().then(() => {
-        ref.dispatch({type: CONST.NAVIGATION.ACTION_TYPE.DISMISS_MODAL});
-        navigateToReportWithPolicyCheck({report});
+        if (getIsNarrowLayout()) {
+            const topmostReportID = getTopmostReportId();
+            const areReportsIDsDefined = !!topmostReportID && !!navigateToReportPayload.reportID;
+            const isReportsSplitTopmostFullScreen = ref.getRootState().routes.findLast((route) => isFullScreenName(route.name))?.name === NAVIGATORS.REPORTS_SPLIT_NAVIGATOR;
+            if (topmostReportID === navigateToReportPayload.reportID && areReportsIDsDefined && isReportsSplitTopmostFullScreen) {
+                dismissModal();
+                return;
+            }
+            const forceReplace = true;
+            navigateToReportWithPolicyCheck(navigateToReportPayload, forceReplace);
+            return;
+        }
+        dismissModal();
+        navigateToReportWithPolicyCheck(navigateToReportPayload);
     });
 };
 

--- a/src/libs/Navigation/Navigation.ts
+++ b/src/libs/Navigation/Navigation.ts
@@ -471,7 +471,7 @@ function waitForProtectedRoutes() {
 }
 
 // It should not be possible to pass a report and a reportID at the same time.
-type NavigateToReportWithPolicyCheckPayload = MergeExclusive<{report?: OnyxEntry<Report>}, {reportID?: string}> & {
+type NavigateToReportWithPolicyCheckPayload = MergeExclusive<{report: OnyxEntry<Report>}, {reportID: string}> & {
     reportActionID?: string;
     referrer?: string;
     policyIDToCheck?: string;

--- a/src/libs/Navigation/Navigation.ts
+++ b/src/libs/Navigation/Navigation.ts
@@ -5,7 +5,7 @@ import {CommonActions, getPathFromState, StackActions} from '@react-navigation/n
 import omit from 'lodash/omit';
 import type {OnyxCollection, OnyxEntry} from 'react-native-onyx';
 import Onyx from 'react-native-onyx';
-import type {Writable} from 'type-fest';
+import type {MergeExclusive, Writable} from 'type-fest';
 import getIsNarrowLayout from '@libs/getIsNarrowLayout';
 import Log from '@libs/Log';
 import {shallowCompare} from '@libs/ObjectUtils';
@@ -470,7 +470,12 @@ function waitForProtectedRoutes() {
     });
 }
 
-type NavigateToReportWithPolicyCheckPayload = {report?: OnyxEntry<Report>; reportID?: string; reportActionID?: string; referrer?: string; policyIDToCheck?: string; forceReplace?: boolean};
+// It should not be possible to pass a report and a reportID at the same time.
+type NavigateToReportWithPolicyCheckPayload = MergeExclusive<{report?: OnyxEntry<Report>}, {reportID?: string}> & {
+    reportActionID?: string;
+    referrer?: string;
+    policyIDToCheck?: string;
+};
 
 /**
  * Navigates to a report passed as a param (as an id or report object) and checks whether the target object belongs to the currently selected workspace.

--- a/src/libs/actions/IOU.ts
+++ b/src/libs/actions/IOU.ts
@@ -679,8 +679,11 @@ Onyx.connect({
     callback: (value) => (personalDetailsList = value),
 });
 
-// After finishing the action in RHP from the Inbox tab, besides dismissing the modal, we should open the report.
-// It is a helper function used only in this file.
+/**
+ * @private
+ * After finishing the action in RHP from the Inbox tab, besides dismissing the modal, we should open the report.
+ * It is a helper function used only in this file.
+ */
 function dismissModalAndOpenReportInInboxTab(reportID?: string) {
     if (isSearchTopmostFullScreenRoute() || !reportID) {
         Navigation.dismissModal();

--- a/src/libs/actions/IOU.ts
+++ b/src/libs/actions/IOU.ts
@@ -4758,7 +4758,7 @@ function requestMoney(requestMoneyInformation: RequestMoneyInformation) {
     }
 
     InteractionManager.runAfterInteractions(() => removeDraftTransaction(CONST.IOU.OPTIMISTIC_TRANSACTION_ID));
-    if (isSearchTopmostFullScreenRoute()) {
+    if (isSearchTopmostFullScreenRoute() || !activeReportID) {
         Navigation.dismissModal();
     } else {
         Navigation.dismissModalWithReport({reportID: activeReportID});
@@ -4846,7 +4846,7 @@ function submitPerDiemExpense(submitPerDiemExpenseInformation: PerDiemExpenseInf
     API.write(WRITE_COMMANDS.CREATE_PER_DIEM_REQUEST, parameters, onyxData);
 
     InteractionManager.runAfterInteractions(() => removeDraftTransaction(CONST.IOU.OPTIMISTIC_TRANSACTION_ID));
-    if (isSearchTopmostFullScreenRoute()) {
+    if (isSearchTopmostFullScreenRoute() || !activeReportID) {
         Navigation.dismissModal();
     } else {
         Navigation.dismissModalWithReport({reportID: activeReportID});
@@ -5144,7 +5144,7 @@ function trackExpense(params: CreateTrackExpenseParams) {
         }
     }
     InteractionManager.runAfterInteractions(() => removeDraftTransaction(CONST.IOU.OPTIMISTIC_TRANSACTION_ID));
-    if (isSearchTopmostFullScreenRoute()) {
+    if (isSearchTopmostFullScreenRoute() || !activeReportID) {
         Navigation.dismissModal();
     } else {
         Navigation.dismissModalWithReport({reportID: activeReportID});
@@ -5731,7 +5731,7 @@ function splitBill({
     API.write(WRITE_COMMANDS.SPLIT_BILL, parameters, onyxData);
     InteractionManager.runAfterInteractions(() => removeDraftTransaction(CONST.IOU.OPTIMISTIC_TRANSACTION_ID));
 
-    if (isSearchTopmostFullScreenRoute()) {
+    if (isSearchTopmostFullScreenRoute() || !existingSplitChatReportID) {
         Navigation.dismissModal();
     } else {
         Navigation.dismissModalWithReport({reportID: existingSplitChatReportID});
@@ -6581,7 +6581,7 @@ function createDistanceRequest(distanceRequestInformation: CreateDistanceRequest
     API.write(WRITE_COMMANDS.CREATE_DISTANCE_REQUEST, parameters, onyxData);
     InteractionManager.runAfterInteractions(() => removeDraftTransaction(CONST.IOU.OPTIMISTIC_TRANSACTION_ID));
     const activeReportID = isMoneyRequestReport && report?.reportID ? report.reportID : parameters.chatReportID;
-    if (isSearchTopmostFullScreenRoute()) {
+    if (isSearchTopmostFullScreenRoute() || !activeReportID) {
         Navigation.dismissModal();
     } else {
         Navigation.dismissModalWithReport({reportID: activeReportID});

--- a/src/libs/actions/IOU.ts
+++ b/src/libs/actions/IOU.ts
@@ -679,6 +679,16 @@ Onyx.connect({
     callback: (value) => (personalDetailsList = value),
 });
 
+// After finishing the action in RHP from the Inbox tab, besides dismissing the modal, we should open the report.
+// It is a helper function used only in this file.
+function dismissModalAndOpenReportInInboxTab(reportID?: string) {
+    if (isSearchTopmostFullScreenRoute() || !reportID) {
+        Navigation.dismissModal();
+        return;
+    }
+    Navigation.dismissModalWithReport({reportID});
+}
+
 /**
  * Find the report preview action from given chat report and iou report
  */
@@ -4758,11 +4768,7 @@ function requestMoney(requestMoneyInformation: RequestMoneyInformation) {
     }
 
     InteractionManager.runAfterInteractions(() => removeDraftTransaction(CONST.IOU.OPTIMISTIC_TRANSACTION_ID));
-    if (isSearchTopmostFullScreenRoute() || !activeReportID) {
-        Navigation.dismissModal();
-    } else {
-        Navigation.dismissModalWithReport({reportID: activeReportID});
-    }
+    dismissModalAndOpenReportInInboxTab(activeReportID);
 
     const trackReport = Navigation.getReportRouteByID(linkedTrackedExpenseReportAction?.childReportID);
     if (trackReport?.key) {
@@ -4846,11 +4852,7 @@ function submitPerDiemExpense(submitPerDiemExpenseInformation: PerDiemExpenseInf
     API.write(WRITE_COMMANDS.CREATE_PER_DIEM_REQUEST, parameters, onyxData);
 
     InteractionManager.runAfterInteractions(() => removeDraftTransaction(CONST.IOU.OPTIMISTIC_TRANSACTION_ID));
-    if (isSearchTopmostFullScreenRoute() || !activeReportID) {
-        Navigation.dismissModal();
-    } else {
-        Navigation.dismissModalWithReport({reportID: activeReportID});
-    }
+    dismissModalAndOpenReportInInboxTab(activeReportID);
 
     if (activeReportID) {
         notifyNewAction(activeReportID, payeeAccountID);
@@ -5144,11 +5146,7 @@ function trackExpense(params: CreateTrackExpenseParams) {
         }
     }
     InteractionManager.runAfterInteractions(() => removeDraftTransaction(CONST.IOU.OPTIMISTIC_TRANSACTION_ID));
-    if (isSearchTopmostFullScreenRoute() || !activeReportID) {
-        Navigation.dismissModal();
-    } else {
-        Navigation.dismissModalWithReport({reportID: activeReportID});
-    }
+    dismissModalAndOpenReportInInboxTab(activeReportID);
 
     if (action === CONST.IOU.ACTION.SHARE) {
         if (isSearchTopmostFullScreenRoute() && activeReportID) {
@@ -5731,11 +5729,7 @@ function splitBill({
     API.write(WRITE_COMMANDS.SPLIT_BILL, parameters, onyxData);
     InteractionManager.runAfterInteractions(() => removeDraftTransaction(CONST.IOU.OPTIMISTIC_TRANSACTION_ID));
 
-    if (isSearchTopmostFullScreenRoute() || !existingSplitChatReportID) {
-        Navigation.dismissModal();
-    } else {
-        Navigation.dismissModalWithReport({reportID: existingSplitChatReportID});
-    }
+    dismissModalAndOpenReportInInboxTab(existingSplitChatReportID);
 
     notifyNewAction(splitData.chatReportID, currentUserAccountID);
 }
@@ -5809,11 +5803,7 @@ function splitBillAndOpenReport({
     API.write(WRITE_COMMANDS.SPLIT_BILL_AND_OPEN_REPORT, parameters, onyxData);
     InteractionManager.runAfterInteractions(() => removeDraftTransaction(CONST.IOU.OPTIMISTIC_TRANSACTION_ID));
 
-    if (isSearchTopmostFullScreenRoute()) {
-        Navigation.dismissModal();
-    } else {
-        Navigation.dismissModalWithReport({reportID: splitData.chatReportID});
-    }
+    dismissModalAndOpenReportInInboxTab(splitData.chatReportID);
     notifyNewAction(splitData.chatReportID, currentUserAccountID);
 }
 
@@ -6394,11 +6384,7 @@ function completeSplitBill(
 
     API.write(WRITE_COMMANDS.COMPLETE_SPLIT_BILL, parameters, {optimisticData, successData, failureData});
     InteractionManager.runAfterInteractions(() => removeDraftTransaction(CONST.IOU.OPTIMISTIC_TRANSACTION_ID));
-    if (isSearchTopmostFullScreenRoute()) {
-        Navigation.dismissModal();
-    } else {
-        Navigation.dismissModalWithReport({reportID: chatReportID});
-    }
+    dismissModalAndOpenReportInInboxTab(chatReportID);
     notifyNewAction(chatReportID, sessionAccountID);
 }
 
@@ -6581,11 +6567,7 @@ function createDistanceRequest(distanceRequestInformation: CreateDistanceRequest
     API.write(WRITE_COMMANDS.CREATE_DISTANCE_REQUEST, parameters, onyxData);
     InteractionManager.runAfterInteractions(() => removeDraftTransaction(CONST.IOU.OPTIMISTIC_TRANSACTION_ID));
     const activeReportID = isMoneyRequestReport && report?.reportID ? report.reportID : parameters.chatReportID;
-    if (isSearchTopmostFullScreenRoute() || !activeReportID) {
-        Navigation.dismissModal();
-    } else {
-        Navigation.dismissModalWithReport({reportID: activeReportID});
-    }
+    dismissModalAndOpenReportInInboxTab(activeReportID);
     notifyNewAction(activeReportID, userAccountID);
 }
 
@@ -8286,11 +8268,7 @@ function sendMoneyElsewhere(report: OnyxEntry<OnyxTypes.Report>, amount: number,
 
     API.write(WRITE_COMMANDS.SEND_MONEY_ELSEWHERE, params, {optimisticData, successData, failureData});
 
-    if (isSearchTopmostFullScreenRoute()) {
-        Navigation.dismissModal();
-    } else {
-        Navigation.dismissModalWithReport({reportID: params.chatReportID});
-    }
+    dismissModalAndOpenReportInInboxTab(params.chatReportID);
     notifyNewAction(params.chatReportID, managerID);
 }
 
@@ -8303,11 +8281,7 @@ function sendMoneyWithWallet(report: OnyxEntry<OnyxTypes.Report>, amount: number
 
     API.write(WRITE_COMMANDS.SEND_MONEY_WITH_WALLET, params, {optimisticData, successData, failureData});
 
-    if (isSearchTopmostFullScreenRoute()) {
-        Navigation.dismissModal();
-    } else {
-        Navigation.dismissModalWithReport({reportID: params.chatReportID});
-    }
+    dismissModalAndOpenReportInInboxTab(params.chatReportID);
     notifyNewAction(params.chatReportID, managerID);
 }
 

--- a/src/libs/actions/IOU.ts
+++ b/src/libs/actions/IOU.ts
@@ -4758,7 +4758,11 @@ function requestMoney(requestMoneyInformation: RequestMoneyInformation) {
     }
 
     InteractionManager.runAfterInteractions(() => removeDraftTransaction(CONST.IOU.OPTIMISTIC_TRANSACTION_ID));
-    Navigation.dismissModal(isSearchTopmostFullScreenRoute() ? undefined : activeReportID);
+    if (isSearchTopmostFullScreenRoute()) {
+        Navigation.dismissModal();
+    } else {
+        Navigation.dismissModalWithReport({reportID: activeReportID});
+    }
 
     const trackReport = Navigation.getReportRouteByID(linkedTrackedExpenseReportAction?.childReportID);
     if (trackReport?.key) {
@@ -4842,7 +4846,12 @@ function submitPerDiemExpense(submitPerDiemExpenseInformation: PerDiemExpenseInf
     API.write(WRITE_COMMANDS.CREATE_PER_DIEM_REQUEST, parameters, onyxData);
 
     InteractionManager.runAfterInteractions(() => removeDraftTransaction(CONST.IOU.OPTIMISTIC_TRANSACTION_ID));
-    Navigation.dismissModal(isSearchTopmostFullScreenRoute() ? undefined : activeReportID);
+    if (isSearchTopmostFullScreenRoute()) {
+        Navigation.dismissModal();
+    } else {
+        Navigation.dismissModalWithReport({reportID: activeReportID});
+    }
+
     if (activeReportID) {
         notifyNewAction(activeReportID, payeeAccountID);
     }
@@ -4909,7 +4918,7 @@ function sendInvoice(
     if (isSearchTopmostFullScreenRoute()) {
         Navigation.dismissModal();
     } else {
-        Navigation.dismissModalWithReport(invoiceRoom);
+        Navigation.dismissModalWithReport({report: invoiceRoom});
     }
 
     notifyNewAction(invoiceRoom.reportID, receiver.accountID);
@@ -5135,7 +5144,11 @@ function trackExpense(params: CreateTrackExpenseParams) {
         }
     }
     InteractionManager.runAfterInteractions(() => removeDraftTransaction(CONST.IOU.OPTIMISTIC_TRANSACTION_ID));
-    Navigation.dismissModal(isSearchTopmostFullScreenRoute() ? undefined : activeReportID);
+    if (isSearchTopmostFullScreenRoute()) {
+        Navigation.dismissModal();
+    } else {
+        Navigation.dismissModalWithReport({reportID: activeReportID});
+    }
 
     if (action === CONST.IOU.ACTION.SHARE) {
         if (isSearchTopmostFullScreenRoute() && activeReportID) {
@@ -5718,7 +5731,12 @@ function splitBill({
     API.write(WRITE_COMMANDS.SPLIT_BILL, parameters, onyxData);
     InteractionManager.runAfterInteractions(() => removeDraftTransaction(CONST.IOU.OPTIMISTIC_TRANSACTION_ID));
 
-    Navigation.dismissModal(isSearchTopmostFullScreenRoute() ? undefined : existingSplitChatReportID);
+    if (isSearchTopmostFullScreenRoute()) {
+        Navigation.dismissModal();
+    } else {
+        Navigation.dismissModalWithReport({reportID: existingSplitChatReportID});
+    }
+
     notifyNewAction(splitData.chatReportID, currentUserAccountID);
 }
 
@@ -5791,7 +5809,11 @@ function splitBillAndOpenReport({
     API.write(WRITE_COMMANDS.SPLIT_BILL_AND_OPEN_REPORT, parameters, onyxData);
     InteractionManager.runAfterInteractions(() => removeDraftTransaction(CONST.IOU.OPTIMISTIC_TRANSACTION_ID));
 
-    Navigation.dismissModal(isSearchTopmostFullScreenRoute() ? undefined : splitData.chatReportID);
+    if (isSearchTopmostFullScreenRoute()) {
+        Navigation.dismissModal();
+    } else {
+        Navigation.dismissModalWithReport({reportID: splitData.chatReportID});
+    }
     notifyNewAction(splitData.chatReportID, currentUserAccountID);
 }
 
@@ -6110,7 +6132,7 @@ function startSplitBill({
 
     API.write(WRITE_COMMANDS.START_SPLIT_BILL, parameters, {optimisticData, successData, failureData});
 
-    Navigation.dismissModalWithReport(splitChatReport);
+    Navigation.dismissModalWithReport({report: splitChatReport});
     notifyNewAction(splitChatReport.reportID, currentUserAccountID);
 }
 
@@ -6372,7 +6394,11 @@ function completeSplitBill(
 
     API.write(WRITE_COMMANDS.COMPLETE_SPLIT_BILL, parameters, {optimisticData, successData, failureData});
     InteractionManager.runAfterInteractions(() => removeDraftTransaction(CONST.IOU.OPTIMISTIC_TRANSACTION_ID));
-    Navigation.dismissModal(isSearchTopmostFullScreenRoute() ? undefined : chatReportID);
+    if (isSearchTopmostFullScreenRoute()) {
+        Navigation.dismissModal();
+    } else {
+        Navigation.dismissModalWithReport({reportID: chatReportID});
+    }
     notifyNewAction(chatReportID, sessionAccountID);
 }
 
@@ -6555,7 +6581,11 @@ function createDistanceRequest(distanceRequestInformation: CreateDistanceRequest
     API.write(WRITE_COMMANDS.CREATE_DISTANCE_REQUEST, parameters, onyxData);
     InteractionManager.runAfterInteractions(() => removeDraftTransaction(CONST.IOU.OPTIMISTIC_TRANSACTION_ID));
     const activeReportID = isMoneyRequestReport && report?.reportID ? report.reportID : parameters.chatReportID;
-    Navigation.dismissModal(isSearchTopmostFullScreenRoute() ? undefined : activeReportID);
+    if (isSearchTopmostFullScreenRoute()) {
+        Navigation.dismissModal();
+    } else {
+        Navigation.dismissModalWithReport({reportID: activeReportID});
+    }
     notifyNewAction(activeReportID, userAccountID);
 }
 
@@ -8256,7 +8286,11 @@ function sendMoneyElsewhere(report: OnyxEntry<OnyxTypes.Report>, amount: number,
 
     API.write(WRITE_COMMANDS.SEND_MONEY_ELSEWHERE, params, {optimisticData, successData, failureData});
 
-    Navigation.dismissModal(isSearchTopmostFullScreenRoute() ? undefined : params.chatReportID);
+    if (isSearchTopmostFullScreenRoute()) {
+        Navigation.dismissModal();
+    } else {
+        Navigation.dismissModalWithReport({reportID: params.chatReportID});
+    }
     notifyNewAction(params.chatReportID, managerID);
 }
 
@@ -8269,7 +8303,11 @@ function sendMoneyWithWallet(report: OnyxEntry<OnyxTypes.Report>, amount: number
 
     API.write(WRITE_COMMANDS.SEND_MONEY_WITH_WALLET, params, {optimisticData, successData, failureData});
 
-    Navigation.dismissModal(isSearchTopmostFullScreenRoute() ? undefined : params.chatReportID);
+    if (isSearchTopmostFullScreenRoute()) {
+        Navigation.dismissModal();
+    } else {
+        Navigation.dismissModalWithReport({reportID: params.chatReportID});
+    }
     notifyNewAction(params.chatReportID, managerID);
 }
 

--- a/src/libs/actions/Report.ts
+++ b/src/libs/actions/Report.ts
@@ -66,6 +66,7 @@ import type EnvironmentType from '@libs/Environment/getEnvironment/types';
 import * as ErrorUtils from '@libs/ErrorUtils';
 import {getMicroSecondOnyxErrorWithTranslationKey} from '@libs/ErrorUtils';
 import fileDownload from '@libs/fileDownload';
+import getIsNarrowLayout from '@libs/getIsNarrowLayout';
 import HttpUtils from '@libs/HttpUtils';
 import isPublicScreenRoute from '@libs/isPublicScreenRoute';
 import * as Localize from '@libs/Localize';
@@ -1200,6 +1201,11 @@ function navigateToAndOpenReport(
     // We want to pass newChat here because if anything is passed in that param (even an existing chat), we will try to create a chat on the server
     openReport(report?.reportID, '', userLogins, newChat, undefined, undefined, undefined, avatarFile);
     if (shouldDismissModal) {
+        if (getIsNarrowLayout()) {
+            Navigation.dismissModalWithReport({report});
+            return;
+        }
+
         Navigation.dismissModal();
     }
 
@@ -2400,7 +2406,7 @@ function navigateToConciergeChat(shouldDismissModal = false, checkIfCurrentPageA
             navigateToAndOpenReport([CONST.EMAIL.CONCIERGE], shouldDismissModal);
         });
     } else if (shouldDismissModal) {
-        Navigation.dismissModal(conciergeChatReportID);
+        Navigation.dismissModalWithReport({reportID: conciergeChatReportID});
     } else {
         Navigation.navigate(ROUTES.REPORT_WITH_ID.getRoute(conciergeChatReportID), linkToOptions);
     }
@@ -2656,7 +2662,7 @@ function addPolicyReport(policyReport: OptimisticChatReport) {
     };
 
     API.write(WRITE_COMMANDS.ADD_WORKSPACE_ROOM, parameters, {optimisticData, successData, failureData});
-    Navigation.dismissModalWithReport(policyReport);
+    Navigation.dismissModalWithReport({report: policyReport});
 }
 
 /** Deletes a report, along with its reportActions, any linked reports, and any linked IOU report. */

--- a/src/libs/actions/Task.ts
+++ b/src/libs/actions/Task.ts
@@ -340,7 +340,7 @@ function createTaskAndNavigate(
         InteractionManager.runAfterInteractions(() => {
             clearOutTaskInfo();
         });
-        Navigation.dismissModal(parentReportID);
+        Navigation.dismissModalWithReport({reportID: parentReportID});
     }
     notifyNewAction(parentReportID, currentUserAccountID);
 }

--- a/src/libs/actions/TeachersUnite.ts
+++ b/src/libs/actions/TeachersUnite.ts
@@ -74,7 +74,7 @@ function referTeachersUniteVolunteer(partnerUserID: string, firstName: string, l
     };
 
     API.write(WRITE_COMMANDS.REFER_TEACHERS_UNITE_VOLUNTEER, parameters, {optimisticData});
-    Navigation.dismissModal(publicRoomReportID);
+    Navigation.dismissModalWithReport({reportID: publicRoomReportID});
 }
 
 /**
@@ -206,7 +206,7 @@ function addSchoolPrincipal(firstName: string, partnerUserID: string, lastName: 
     };
 
     API.write(WRITE_COMMANDS.ADD_SCHOOL_PRINCIPAL, parameters, {optimisticData, successData, failureData});
-    Navigation.dismissModal(expenseChatReportID);
+    Navigation.dismissModalWithReport({reportID: expenseChatReportID});
 }
 
 export default {referTeachersUniteVolunteer, addSchoolPrincipal};

--- a/src/pages/AddPersonalBankAccountPage.tsx
+++ b/src/pages/AddPersonalBankAccountPage.tsx
@@ -66,7 +66,7 @@ function AddPersonalBankAccountPage() {
             const onSuccessFallbackRoute = personalBankAccount?.onSuccessFallbackRoute ?? '';
 
             if (exitReportID) {
-                Navigation.dismissModal(exitReportID);
+                Navigation.dismissModalWithReport({reportID: exitReportID});
             } else if (shouldContinue && onSuccessFallbackRoute) {
                 continueSetup(onSuccessFallbackRoute);
             } else {

--- a/src/pages/EnablePayments/AddBankAccount/AddBankAccount.tsx
+++ b/src/pages/EnablePayments/AddBankAccount/AddBankAccount.tsx
@@ -8,10 +8,10 @@ import useLocalize from '@hooks/useLocalize';
 import useSubStep from '@hooks/useSubStep';
 import type {SubStepProps} from '@hooks/useSubStep/types';
 import useThemeStyles from '@hooks/useThemeStyles';
+import {addPersonalBankAccount, clearPersonalBankAccount} from '@libs/actions/BankAccounts';
+import {continueSetup} from '@libs/actions/PaymentMethods';
+import {updateCurrentStep} from '@libs/actions/Wallet';
 import Navigation from '@navigation/Navigation';
-import * as BankAccounts from '@userActions/BankAccounts';
-import * as PaymentMethods from '@userActions/PaymentMethods';
-import * as Wallet from '@userActions/Wallet';
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
 import ROUTES from '@src/ROUTES';
@@ -32,7 +32,7 @@ function AddBankAccount() {
         const selectedPlaidBankAccount = bankAccounts.find((bankAccount) => bankAccount.plaidAccountID === personalBankAccountDraft?.plaidAccountID);
 
         if (selectedPlaidBankAccount) {
-            BankAccounts.addPersonalBankAccount(selectedPlaidBankAccount);
+            addPersonalBankAccount(selectedPlaidBankAccount);
         }
     }, [personalBankAccountDraft?.plaidAccountID, plaidData?.bankAccounts]);
 
@@ -49,7 +49,7 @@ function AddBankAccount() {
             return;
         }
         if (shouldContinue && onSuccessFallbackRoute) {
-            PaymentMethods.continueSetup(onSuccessFallbackRoute);
+            continueSetup(onSuccessFallbackRoute);
             return;
         }
         Navigation.goBack(ROUTES.SETTINGS_WALLET);
@@ -61,8 +61,8 @@ function AddBankAccount() {
             return;
         }
         if (screenIndex === 0) {
-            BankAccounts.clearPersonalBankAccount();
-            Wallet.updateCurrentStep(null);
+            clearPersonalBankAccount();
+            updateCurrentStep(null);
             Navigation.goBack(ROUTES.SETTINGS_WALLET);
             return;
         }

--- a/src/pages/EnablePayments/AddBankAccount/AddBankAccount.tsx
+++ b/src/pages/EnablePayments/AddBankAccount/AddBankAccount.tsx
@@ -45,7 +45,7 @@ function AddBankAccount() {
         const onSuccessFallbackRoute = personalBankAccount?.onSuccessFallbackRoute ?? '';
 
         if (exitReportID) {
-            Navigation.dismissModal(exitReportID);
+            Navigation.dismissModalWithReport({reportID: exitReportID});
             return;
         }
         if (shouldContinue && onSuccessFallbackRoute) {

--- a/src/pages/NewChatPage.tsx
+++ b/src/pages/NewChatPage.tsx
@@ -229,6 +229,10 @@ function NewChatPage() {
     const selectOption = useCallback(
         (option?: Option) => {
             if (option?.isSelfDM) {
+                if (!option.reportID) {
+                    Navigation.dismissModal();
+                    return;
+                }
                 Navigation.dismissModalWithReport({reportID: option.reportID});
                 return;
             }

--- a/src/pages/NewChatPage.tsx
+++ b/src/pages/NewChatPage.tsx
@@ -229,7 +229,7 @@ function NewChatPage() {
     const selectOption = useCallback(
         (option?: Option) => {
             if (option?.isSelfDM) {
-                Navigation.dismissModal(option.reportID);
+                Navigation.dismissModalWithReport({reportID: option.reportID});
                 return;
             }
             if (selectedOptions.length && option) {

--- a/src/pages/RoomInvitePage.tsx
+++ b/src/pages/RoomInvitePage.tsx
@@ -215,7 +215,7 @@ function RoomInvitePage({
 
     const goBack = useCallback(() => {
         if (role === CONST.IOU.SHARE.ROLE.ACCOUNTANT) {
-            Navigation.dismissModal(reportID);
+            Navigation.dismissModalWithReport({reportID});
             return;
         }
         Navigation.goBack(backRoute);

--- a/src/pages/TransactionDuplicate/Confirmation.tsx
+++ b/src/pages/TransactionDuplicate/Confirmation.tsx
@@ -66,7 +66,11 @@ function Confirmation() {
 
     const resolveDuplicates = useCallback(() => {
         IOU.resolveDuplicates(transactionsMergeParams);
-        Navigation.dismissModalWithReport({reportID: reportAction?.childReportID});
+        if (!reportAction?.childReportID) {
+            Navigation.dismissModal();
+            return;
+        }
+        Navigation.dismissModalWithReport({reportID: reportAction.childReportID});
     }, [transactionsMergeParams, reportAction?.childReportID]);
 
     const contextValue = useMemo(

--- a/src/pages/TransactionDuplicate/Confirmation.tsx
+++ b/src/pages/TransactionDuplicate/Confirmation.tsx
@@ -66,7 +66,7 @@ function Confirmation() {
 
     const resolveDuplicates = useCallback(() => {
         IOU.resolveDuplicates(transactionsMergeParams);
-        Navigation.dismissModal(reportAction?.childReportID);
+        Navigation.dismissModalWithReport({reportID: reportAction?.childReportID});
     }, [transactionsMergeParams, reportAction?.childReportID]);
 
     const contextValue = useMemo(

--- a/src/pages/TransactionReceiptPage.tsx
+++ b/src/pages/TransactionReceiptPage.tsx
@@ -59,7 +59,7 @@ function TransactionReceipt({route}: TransactionReceiptProps) {
             Navigation.dismissModal();
         } else {
             const isOneTransactionThread = isOneTransactionThreadReportUtils(report?.reportID, report?.parentReportID, parentReportAction);
-            Navigation.dismissModal(isOneTransactionThread ? report?.parentReportID : report?.reportID);
+            Navigation.dismissModalWithReport({reportID: isOneTransactionThread ? report?.parentReportID : report?.reportID});
         }
     };
 

--- a/src/pages/TransactionReceiptPage.tsx
+++ b/src/pages/TransactionReceiptPage.tsx
@@ -59,7 +59,12 @@ function TransactionReceipt({route}: TransactionReceiptProps) {
             Navigation.dismissModal();
         } else {
             const isOneTransactionThread = isOneTransactionThreadReportUtils(report?.reportID, report?.parentReportID, parentReportAction);
-            Navigation.dismissModalWithReport({reportID: isOneTransactionThread ? report?.parentReportID : report?.reportID});
+            const reportID = isOneTransactionThread ? report?.parentReportID : report?.reportID;
+            if (!reportID) {
+                Navigation.dismissModal();
+                return;
+            }
+            Navigation.dismissModalWithReport({reportID});
         }
     };
 

--- a/src/pages/tasks/TaskAssigneeSelectorModal.tsx
+++ b/src/pages/tasks/TaskAssigneeSelectorModal.tsx
@@ -106,7 +106,7 @@ function TaskAssigneeSelectorModal() {
         const reportOnyx = reports?.[`${ONYXKEYS.COLLECTION.REPORT}${route.params?.reportID}`];
         if (reportOnyx && !ReportUtils.isTaskReport(reportOnyx)) {
             Navigation.isNavigationReady().then(() => {
-                Navigation.dismissModal(reportOnyx.reportID);
+                Navigation.dismissModalWithReport({reportID: reportOnyx.reportID});
             });
         }
         return reports?.[`${ONYXKEYS.COLLECTION.REPORT}${route.params?.reportID}`];
@@ -178,7 +178,7 @@ function TaskAssigneeSelectorModal() {
                     TaskActions.editTaskAssignee(report, session?.accountID ?? -1, option?.login ?? '', option?.accountID, assigneeChatReport);
                 }
                 InteractionManager.runAfterInteractions(() => {
-                    Navigation.dismissModal(report.reportID);
+                    Navigation.dismissModalWithReport({reportID: report?.reportID});
                 });
                 // If there's no report, we're creating a new task
             } else if (option.accountID) {

--- a/src/pages/tasks/TaskAssigneeSelectorModal.tsx
+++ b/src/pages/tasks/TaskAssigneeSelectorModal.tsx
@@ -18,15 +18,15 @@ import useCurrentUserPersonalDetails from '@hooks/useCurrentUserPersonalDetails'
 import useDebouncedState from '@hooks/useDebouncedState';
 import useLocalize from '@hooks/useLocalize';
 import useThemeStyles from '@hooks/useThemeStyles';
-import * as ReportActions from '@libs/actions/Report';
+import {searchInServer} from '@libs/actions/Report';
+import {canModifyTask, editTaskAssignee, setAssigneeValue} from '@libs/actions/Task';
 import {READ_COMMANDS} from '@libs/API/types';
 import HttpUtils from '@libs/HttpUtils';
 import Navigation from '@libs/Navigation/Navigation';
 import type {PlatformStackRouteProp} from '@libs/Navigation/PlatformStackNavigation/types';
-import * as OptionsListUtils from '@libs/OptionsListUtils';
-import * as ReportUtils from '@libs/ReportUtils';
+import {filterAndOrderOptions, getHeaderMessage, getValidOptions, isCurrentUser} from '@libs/OptionsListUtils';
+import {isOpenTaskReport, isTaskReport} from '@libs/ReportUtils';
 import type {TaskDetailsNavigatorParamList} from '@navigation/types';
-import * as TaskActions from '@userActions/Task';
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
 import ROUTES from '@src/ROUTES';
@@ -40,7 +40,7 @@ function useOptions() {
     const {options: optionsList, areOptionsInitialized} = useOptionsList();
 
     const defaultOptions = useMemo(() => {
-        const {recentReports, personalDetails, userToInvite, currentUserOption} = OptionsListUtils.getValidOptions(
+        const {recentReports, personalDetails, userToInvite, currentUserOption} = getValidOptions(
             {
                 reports: optionsList.reports,
                 personalDetails: optionsList.personalDetails,
@@ -51,7 +51,7 @@ function useOptions() {
             },
         );
 
-        const headerMessage = OptionsListUtils.getHeaderMessage((recentReports?.length || 0) + (personalDetails?.length || 0) !== 0 || !!currentUserOption, !!userToInvite, '');
+        const headerMessage = getHeaderMessage((recentReports?.length || 0) + (personalDetails?.length || 0) !== 0 || !!currentUserOption, !!userToInvite, '');
 
         if (isLoading) {
             // eslint-disable-next-line react-compiler/react-compiler
@@ -68,11 +68,11 @@ function useOptions() {
     }, [optionsList.reports, optionsList.personalDetails, betas, isLoading]);
 
     const options = useMemo(() => {
-        const filteredOptions = OptionsListUtils.filterAndOrderOptions(defaultOptions, debouncedSearchValue.trim(), {
+        const filteredOptions = filterAndOrderOptions(defaultOptions, debouncedSearchValue.trim(), {
             excludeLogins: CONST.EXPENSIFY_EMAILS_OBJECT,
             maxRecentReportsToShow: CONST.IOU.MAX_RECENT_REPORTS_TO_SHOW,
         });
-        const headerMessage = OptionsListUtils.getHeaderMessage(
+        const headerMessage = getHeaderMessage(
             (filteredOptions.recentReports?.length || 0) + (filteredOptions.personalDetails?.length || 0) !== 0 || !!filteredOptions.currentUserOption,
             !!filteredOptions.userToInvite,
             debouncedSearchValue,
@@ -104,7 +104,7 @@ function TaskAssigneeSelectorModal() {
             return;
         }
         const reportOnyx = reports?.[`${ONYXKEYS.COLLECTION.REPORT}${route.params?.reportID}`];
-        if (reportOnyx && !ReportUtils.isTaskReport(reportOnyx)) {
+        if (reportOnyx && !isTaskReport(reportOnyx)) {
             Navigation.isNavigationReady().then(() => {
                 Navigation.dismissModalWithReport({reportID: reportOnyx.reportID});
             });
@@ -167,27 +167,27 @@ function TaskAssigneeSelectorModal() {
             // Check to see if we're editing a task and if so, update the assignee
             if (report) {
                 if (option.accountID !== report.managerID) {
-                    const assigneeChatReport = TaskActions.setAssigneeValue(
+                    const assigneeChatReport = setAssigneeValue(
                         option?.login ?? '',
-                        option?.accountID ?? -1,
+                        option?.accountID ?? CONST.DEFAULT_NUMBER_ID,
                         report.reportID,
                         undefined, // passing null as report because for editing task the report will be task details report page not the actual report where task was created
-                        OptionsListUtils.isCurrentUser({...option, accountID: option?.accountID ?? -1, login: option?.login ?? ''}),
+                        isCurrentUser({...option, accountID: option?.accountID ?? CONST.DEFAULT_NUMBER_ID, login: option?.login ?? ''}),
                     );
                     // Pass through the selected assignee
-                    TaskActions.editTaskAssignee(report, session?.accountID ?? -1, option?.login ?? '', option?.accountID, assigneeChatReport);
+                    editTaskAssignee(report, session?.accountID ?? CONST.DEFAULT_NUMBER_ID, option?.login ?? '', option?.accountID, assigneeChatReport);
                 }
                 InteractionManager.runAfterInteractions(() => {
                     Navigation.dismissModalWithReport({reportID: report?.reportID});
                 });
                 // If there's no report, we're creating a new task
             } else if (option.accountID) {
-                TaskActions.setAssigneeValue(
+                setAssigneeValue(
                     option?.login ?? '',
-                    option.accountID ?? -1,
+                    option.accountID ?? CONST.DEFAULT_NUMBER_ID,
                     task?.shareDestination ?? '',
                     undefined, // passing null as report is null in this condition
-                    OptionsListUtils.isCurrentUser({...option, accountID: option?.accountID ?? -1, login: option?.login ?? undefined}),
+                    isCurrentUser({...option, accountID: option?.accountID ?? CONST.DEFAULT_NUMBER_ID, login: option?.login ?? undefined}),
                 );
                 InteractionManager.runAfterInteractions(() => {
                     Navigation.goBack(ROUTES.NEW_TASK.getRoute(backTo));
@@ -199,12 +199,12 @@ function TaskAssigneeSelectorModal() {
 
     const handleBackButtonPress = useCallback(() => Navigation.goBack(!route.params?.reportID ? ROUTES.NEW_TASK.getRoute(backTo) : backTo), [route.params, backTo]);
 
-    const isOpen = ReportUtils.isOpenTaskReport(report);
-    const canModifyTask = TaskActions.canModifyTask(report, currentUserPersonalDetails.accountID);
-    const isTaskNonEditable = ReportUtils.isTaskReport(report) && (!canModifyTask || !isOpen);
+    const isOpen = isOpenTaskReport(report);
+    const canModifyTaskValue = canModifyTask(report, currentUserPersonalDetails.accountID);
+    const isTaskNonEditable = isTaskReport(report) && (!canModifyTaskValue || !isOpen);
 
     useEffect(() => {
-        ReportActions.searchInServer(debouncedSearchValue);
+        searchInServer(debouncedSearchValue);
     }, [debouncedSearchValue]);
 
     return (

--- a/src/pages/tasks/TaskDescriptionPage.tsx
+++ b/src/pages/tasks/TaskDescriptionPage.tsx
@@ -59,14 +59,14 @@ function TaskDescriptionPage({report, currentUserPersonalDetails}: TaskDescripti
                 editTask(report, {description: values.description});
             }
 
-            Navigation.dismissModal(report?.reportID);
+            Navigation.dismissModalWithReport({reportID: report?.reportID});
         },
         [report],
     );
 
     if (!isTaskReport(report)) {
         Navigation.isNavigationReady().then(() => {
-            Navigation.dismissModal(report?.reportID);
+            Navigation.dismissModalWithReport({reportID: report?.reportID});
         });
     }
     const inputRef = useRef<AnimatedTextInputRef | null>(null);

--- a/src/pages/tasks/TaskTitlePage.tsx
+++ b/src/pages/tasks/TaskTitlePage.tsx
@@ -63,14 +63,14 @@ function TaskTitlePage({report, currentUserPersonalDetails}: TaskTitlePageProps)
                 editTask(report, {title: values.title});
             }
 
-            Navigation.dismissModal(report?.reportID);
+            Navigation.dismissModalWithReport({reportID: report?.reportID});
         },
         [report],
     );
 
     if (!isTaskReport(report)) {
         Navigation.isNavigationReady().then(() => {
-            Navigation.dismissModal(report?.reportID);
+            Navigation.dismissModalWithReport({reportID: report?.reportID});
         });
     }
 

--- a/src/pages/workspace/WorkspaceInviteMessagePage.tsx
+++ b/src/pages/workspace/WorkspaceInviteMessagePage.tsx
@@ -24,6 +24,7 @@ import {clearDraftValues} from '@libs/actions/FormActions';
 import {openExternalLink} from '@libs/actions/Link';
 import {addMembersToWorkspace} from '@libs/actions/Policy/Member';
 import {setWorkspaceInviteMessageDraft} from '@libs/actions/Policy/Policy';
+import getIsNarrowLayout from '@libs/getIsNarrowLayout';
 import Navigation from '@libs/Navigation/Navigation';
 import type {PlatformStackScreenProps} from '@libs/Navigation/PlatformStackNavigation/types';
 import {getAvatarsForAccountIDs} from '@libs/OptionsListUtils';
@@ -112,6 +113,12 @@ function WorkspaceInviteMessagePage({policy, route, currentUserPersonalDetails}:
             Navigation.setNavigationActionToMicrotaskQueue(() => Navigation.dismissModal());
             return;
         }
+
+        if (getIsNarrowLayout()) {
+            Navigation.navigate(ROUTES.WORKSPACE_MEMBERS.getRoute(route.params.policyID), {forceReplace: true});
+            return;
+        }
+
         Navigation.setNavigationActionToMicrotaskQueue(() => {
             Navigation.dismissModal();
             InteractionManager.runAfterInteractions(() => {

--- a/src/pages/workspace/WorkspaceNewRoomPage.tsx
+++ b/src/pages/workspace/WorkspaceNewRoomPage.tsx
@@ -132,6 +132,10 @@ function WorkspaceNewRoomPage() {
         if (!(((wasLoading && !isLoading) || (isOffline && isLoading)) && isEmptyObject(errorFields))) {
             return;
         }
+        if (!newRoomReportID) {
+            Navigation.dismissModal();
+            return;
+        }
         Navigation.dismissModalWithReport({reportID: newRoomReportID});
         // eslint-disable-next-line react-compiler/react-compiler, react-hooks/exhaustive-deps -- we just want this to update on changing the form State
     }, [isLoading, errorFields]);

--- a/src/pages/workspace/WorkspaceNewRoomPage.tsx
+++ b/src/pages/workspace/WorkspaceNewRoomPage.tsx
@@ -132,7 +132,7 @@ function WorkspaceNewRoomPage() {
         if (!(((wasLoading && !isLoading) || (isOffline && isLoading)) && isEmptyObject(errorFields))) {
             return;
         }
-        Navigation.dismissModal(newRoomReportID);
+        Navigation.dismissModalWithReport({reportID: newRoomReportID});
         // eslint-disable-next-line react-compiler/react-compiler, react-hooks/exhaustive-deps -- we just want this to update on changing the form State
     }, [isLoading, errorFields]);
 

--- a/src/pages/workspace/WorkspaceOverviewSharePage.tsx
+++ b/src/pages/workspace/WorkspaceOverviewSharePage.tsx
@@ -89,7 +89,7 @@ function WorkspaceOverviewSharePage({policy}: WithPolicyProps) {
                                         if (!adminRoom?.reportID) {
                                             return;
                                         }
-                                        Navigation.dismissModal(adminRoom.reportID);
+                                        Navigation.dismissModalWithReport({reportID: adminRoom.reportID});
                                     }}
                                 >
                                     {CONST.REPORT.WORKSPACE_CHAT_ROOMS.ADMINS}

--- a/src/pages/workspace/WorkspaceOverviewSharePage.tsx
+++ b/src/pages/workspace/WorkspaceOverviewSharePage.tsx
@@ -43,13 +43,13 @@ function WorkspaceOverviewSharePage({policy}: WithPolicyProps) {
     const adminEmail = session?.email ?? '';
     const urlWithTrailingSlash = addTrailingForwardSlash(environmentURL);
 
-    const url = `${urlWithTrailingSlash}${ROUTES.WORKSPACE_JOIN_USER.getRoute(policyID ?? '', adminEmail)}`;
+    const url = policyID ? `${urlWithTrailingSlash}${ROUTES.WORKSPACE_JOIN_USER.getRoute(policyID, adminEmail)}` : '';
 
     const hasAvatar = !!policy?.avatarURL;
     const logo = hasAvatar ? (policy?.avatarURL as ImageSourcePropType) : undefined;
 
     const defaultWorkspaceAvatar = getDefaultWorkspaceAvatar(policyName) || Expensicons.FallbackAvatar;
-    const defaultWorkspaceAvatarColors = StyleUtils.getDefaultWorkspaceAvatarColor(policyID ?? '');
+    const defaultWorkspaceAvatarColors = StyleUtils.getDefaultWorkspaceAvatarColor(policyID);
 
     const svgLogo = !hasAvatar ? defaultWorkspaceAvatar : undefined;
     const logoBackgroundColor = !hasAvatar ? defaultWorkspaceAvatarColors.backgroundColor?.toString() : undefined;

--- a/src/pages/workspace/WorkspaceOverviewSharePage.tsx
+++ b/src/pages/workspace/WorkspaceOverviewSharePage.tsx
@@ -20,9 +20,9 @@ import useStyleUtils from '@hooks/useStyleUtils';
 import useThemeStyles from '@hooks/useThemeStyles';
 import Clipboard from '@libs/Clipboard';
 import Navigation from '@libs/Navigation/Navigation';
-import * as ReportUtils from '@libs/ReportUtils';
+import {getDefaultWorkspaceAvatar, getRoom} from '@libs/ReportUtils';
 import shouldAllowDownloadQRCode from '@libs/shouldAllowDownloadQRCode';
-import * as Url from '@libs/Url';
+import {addTrailingForwardSlash} from '@libs/Url';
 import CONST from '@src/CONST';
 import ROUTES from '@src/ROUTES';
 import AccessOrNotFoundWrapper from './AccessOrNotFoundWrapper';
@@ -39,17 +39,17 @@ function WorkspaceOverviewSharePage({policy}: WithPolicyProps) {
     const session = useSession();
 
     const policyName = policy?.name ?? '';
-    const policyID = policy?.id ?? '-1';
+    const policyID = policy?.id;
     const adminEmail = session?.email ?? '';
-    const urlWithTrailingSlash = Url.addTrailingForwardSlash(environmentURL);
+    const urlWithTrailingSlash = addTrailingForwardSlash(environmentURL);
 
-    const url = `${urlWithTrailingSlash}${ROUTES.WORKSPACE_JOIN_USER.getRoute(policyID, adminEmail)}`;
+    const url = `${urlWithTrailingSlash}${ROUTES.WORKSPACE_JOIN_USER.getRoute(policyID ?? '', adminEmail)}`;
 
     const hasAvatar = !!policy?.avatarURL;
     const logo = hasAvatar ? (policy?.avatarURL as ImageSourcePropType) : undefined;
 
-    const defaultWorkspaceAvatar = ReportUtils.getDefaultWorkspaceAvatar(policyName) || Expensicons.FallbackAvatar;
-    const defaultWorkspaceAvatarColors = StyleUtils.getDefaultWorkspaceAvatarColor(policyID);
+    const defaultWorkspaceAvatar = getDefaultWorkspaceAvatar(policyName) || Expensicons.FallbackAvatar;
+    const defaultWorkspaceAvatarColors = StyleUtils.getDefaultWorkspaceAvatarColor(policyID ?? '');
 
     const svgLogo = !hasAvatar ? defaultWorkspaceAvatar : undefined;
     const logoBackgroundColor = !hasAvatar ? defaultWorkspaceAvatarColors.backgroundColor?.toString() : undefined;
@@ -59,7 +59,7 @@ function WorkspaceOverviewSharePage({policy}: WithPolicyProps) {
         if (!policy?.id) {
             return undefined;
         }
-        return ReportUtils.getRoom(CONST.REPORT.CHAT_TYPE.POLICY_ADMINS, policy?.id);
+        return getRoom(CONST.REPORT.CHAT_TYPE.POLICY_ADMINS, policy?.id);
     }, [policy?.id]);
 
     return (

--- a/src/pages/workspace/WorkspaceOverviewSharePage.tsx
+++ b/src/pages/workspace/WorkspaceOverviewSharePage.tsx
@@ -49,7 +49,7 @@ function WorkspaceOverviewSharePage({policy}: WithPolicyProps) {
     const logo = hasAvatar ? (policy?.avatarURL as ImageSourcePropType) : undefined;
 
     const defaultWorkspaceAvatar = getDefaultWorkspaceAvatar(policyName) || Expensicons.FallbackAvatar;
-    const defaultWorkspaceAvatarColors = StyleUtils.getDefaultWorkspaceAvatarColor(policyID);
+    const defaultWorkspaceAvatarColors = policyID ? StyleUtils.getDefaultWorkspaceAvatarColor(policyID) : StyleUtils.getDefaultWorkspaceAvatarColor('');
 
     const svgLogo = !hasAvatar ? defaultWorkspaceAvatar : undefined;
     const logoBackgroundColor = !hasAvatar ? defaultWorkspaceAvatarColors.backgroundColor?.toString() : undefined;

--- a/src/styles/utils/index.ts
+++ b/src/styles/utils/index.ts
@@ -276,8 +276,8 @@ function getAvatarBorderStyle(size: AvatarSizeName, type: string): ViewStyle {
 /**
  * Helper method to return workspace avatar color styles
  */
-function getDefaultWorkspaceAvatarColor(text?: string): ViewStyle {
-    const colorHash = hashText((text ?? '').trim(), workspaceColorOptions.length);
+function getDefaultWorkspaceAvatarColor(text: string): ViewStyle {
+    const colorHash = hashText(text.trim(), workspaceColorOptions.length);
     return workspaceColorOptions.at(colorHash) ?? {backgroundColor: colors.blue200, fill: colors.blue700};
 }
 

--- a/src/styles/utils/index.ts
+++ b/src/styles/utils/index.ts
@@ -276,8 +276,8 @@ function getAvatarBorderStyle(size: AvatarSizeName, type: string): ViewStyle {
 /**
  * Helper method to return workspace avatar color styles
  */
-function getDefaultWorkspaceAvatarColor(text: string): ViewStyle {
-    const colorHash = hashText(text.trim(), workspaceColorOptions.length);
+function getDefaultWorkspaceAvatarColor(text?: string): ViewStyle {
+    const colorHash = hashText((text ?? '').trim(), workspaceColorOptions.length);
     return workspaceColorOptions.at(colorHash) ?? {backgroundColor: colors.blue200, fill: colors.blue700};
 }
 


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
<!-- Explain what your change does and how it addresses the linked issue -->

This PR removes a reportID param from the `dismissModal` function.  Now `dismissModalWithReport` is responsible for closing the modal and navigating to a specific report. With this change, the responsibilities of both functions are well defined.

Changes introduced by this PR:
- now `dismissModal` is used only to close the modal without any additional actions.
- now when we want to close the modal and open the report we need to use the `dismissModalWithReport` function which accepts an options object as a parameter. We can pass either the `report` or the `reportID` field to this function (you can't pass both).
- Previously, when we closed a modal window on a small screen, we performed two actions: 
  1.  pop the modal from the navigation state 
  2. push a new screen to the split navigator below the removed modal navigator. 

 
  It works the same way on the wide layout, but on the narrow layout in this case only one action is performed: the modal navigator is replaced by a new split navigator. With this change only one animation is visible on the screen. It's possible after changes introduced by [this PR](https://github.com/Expensify/App/pull/57753), the split navigator on a narrow layout doesn't need to have a sidebar screen. 

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/56799
$ https://github.com/Expensify/App/issues/56871
PROPOSAL:


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

1. Chat - User lands on inbox before being redirected to new created chat or group.
  - Open the Expensify app
  - Tap on FAB and select "Create Chat"
  - Add some members to a group chat
  - Finish the creation flow
  - Verify that only one transition has been performed on screen
  
2. Workspace-Overview page is shown briefly before landing on members page when inviting a user
  - Login with any account
  - Create a new workspace
  - Go to workspace settings > Overview>Click Invite
  - Choose any account > Invite
  - Verify that only one transition has been performed on screen

- [ ] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->
Same as tests

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/0903105f-f2fe-4f75-abc0-9f2d90cb636a

https://github.com/user-attachments/assets/bc86a52a-4f92-43ee-8fa1-0db95538607b



</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/09b11d1f-6543-48c0-8690-0a9c091daa4e

https://github.com/user-attachments/assets/500834dc-e5b1-4a38-a3f7-36542b350fcb



</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/5a3545c7-98a6-4aed-b900-ec70884a61c3


</details>

<details>
<summary>MacOS: Desktop</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/fd0ceeff-abff-4c8f-a343-86f800484e74


</details>
