### PR TITLE
Fixes for change policy feature

### DIFF
--- a/src/components/ChangeWorkspaceMenuSectionList.tsx
+++ b/src/components/ChangeWorkspaceMenuSectionList.tsx
@@ -46,7 +46,7 @@ function ChangeWorkspaceMenuSectionList() {
                         src={section.icon}
                         additionalStyles={[styles.mr4]}
                     />
-                    <View style={[styles.flex1, styles.justifyContentCenter]}>
+                    <View style={[styles.flex1, styles.flexRow, styles.justifyContentCenter, styles.alignItemsCenter, styles.wAuto]}>
                         <RenderHTML html={`<comment>${convertToLTR(translate(section.titleTranslationKey))}</comment>`} />
                     </View>
                 </View>

--- a/src/hooks/useWorkspaceList.ts
+++ b/src/hooks/useWorkspaceList.ts
@@ -19,7 +19,7 @@ type WorkspaceListItem = {
 type UseWorkspaceListParams = {
     policies: OnyxCollection<Policy>;
     currentUserLogin: string | undefined;
-    isOffline: boolean;
+    shouldShowPendingDeletePolicy: boolean;
     selectedPolicyID: string | undefined;
     searchTerm: string;
     additionalFilter?: (policy: OnyxEntry<Policy>) => boolean;
@@ -41,7 +41,7 @@ function useWorkspaceList({
     currentUserLogin,
     selectedPolicyID,
     searchTerm,
-    isOffline,
+    shouldShowPendingDeletePolicy,
     isWorkspaceSwitcher = false,
     hasUnreadData,
     getIndicatorTypeForPolicy,
@@ -53,7 +53,7 @@ function useWorkspaceList({
         }
 
         return Object.values(policies)
-            .filter((policy) => !!policy && shouldShowPolicy(policy, !!isOffline, currentUserLogin) && !policy?.isJoinRequestPending && (additionalFilter ? additionalFilter(policy) : true))
+            .filter((policy) => !!policy && shouldShowPolicy(policy, shouldShowPendingDeletePolicy, currentUserLogin) && !policy?.isJoinRequestPending && (additionalFilter ? additionalFilter(policy) : true))
             .map((policy) => ({
                 text: policy?.name ?? '',
                 policyID: policy?.id,
@@ -76,7 +76,7 @@ function useWorkspaceList({
                         brickRoadIndicator: getIndicatorTypeForPolicy(policy?.id),
                     }),
             }));
-    }, [policies, isOffline, currentUserLogin, additionalFilter, selectedPolicyID, getIndicatorTypeForPolicy, hasUnreadData, isWorkspaceSwitcher]);
+    }, [policies, shouldShowPendingDeletePolicy, currentUserLogin, additionalFilter, selectedPolicyID, getIndicatorTypeForPolicy, hasUnreadData, isWorkspaceSwitcher]);
 
     const filteredAndSortedUserWorkspaces = useMemo<WorkspaceListItem[]>(
         () =>

--- a/src/hooks/useWorkspaceList.ts
+++ b/src/hooks/useWorkspaceList.ts
@@ -53,7 +53,13 @@ function useWorkspaceList({
         }
 
         return Object.values(policies)
-            .filter((policy) => !!policy && shouldShowPolicy(policy, shouldShowPendingDeletePolicy, currentUserLogin) && !policy?.isJoinRequestPending && (additionalFilter ? additionalFilter(policy) : true))
+            .filter(
+                (policy) =>
+                    !!policy &&
+                    shouldShowPolicy(policy, shouldShowPendingDeletePolicy, currentUserLogin) &&
+                    !policy?.isJoinRequestPending &&
+                    (additionalFilter ? additionalFilter(policy) : true),
+            )
             .map((policy) => ({
                 text: policy?.name ?? '',
                 policyID: policy?.id,

--- a/src/libs/actions/Report.ts
+++ b/src/libs/actions/Report.ts
@@ -5042,15 +5042,19 @@ function changeReportPolicy(reportID: string, policyID: string) {
         key: `${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${reportToMove.reportID}`,
         value: {
             [optimisticMovedReportAction.reportActionID]: {
-                ...optimisticMovedReportAction,
                 pendingAction: null,
+                errors: null,
             },
         },
     });
     failureData.push({
         onyxMethod: Onyx.METHOD.MERGE,
         key: `${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${reportToMove.reportID}`,
-        value: {[optimisticMovedReportAction.reportActionID]: null},
+        value: {
+            [optimisticMovedReportAction.reportActionID]: {
+                errors: getMicroSecondOnyxErrorWithTranslationKey('common.genericErrorMessage'),
+            },
+        },
     });
 
     // Call the ChangeReportPolicy API endpoint

--- a/src/libs/actions/Report.ts
+++ b/src/libs/actions/Report.ts
@@ -4942,7 +4942,9 @@ function changeReportPolicy(reportID: string, policyID: string) {
 
     // 2. If the old workspace had a workspace chat, mark the report preview action as deleted
     if (reportToMove?.parentReportID && reportToMove?.parentReportActionID) {
-        const oldReportPreviewAction = allReportActions?.[`${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${reportToMove?.parentReportID}`]?.[reportToMove?.parentReportActionID];
+        const workspaceChatReportID = reportToMove.parentReportID;
+        const reportPreviewActionID = reportToMove.parentReportActionID;
+        const oldReportPreviewAction = allReportActions?.[`${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${workspaceChatReportID}`]?.[reportPreviewActionID];
         const deletedTime = DateUtils.getDBTime();
         const firstMessage = Array.isArray(oldReportPreviewAction?.message) ? oldReportPreviewAction.message.at(0) : null;
         const updatedReportPreviewAction = {
@@ -4968,13 +4970,40 @@ function changeReportPolicy(reportID: string, policyID: string) {
 
         optimisticData.push({
             onyxMethod: Onyx.METHOD.MERGE,
-            key: `${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${reportToMove?.parentReportID}`,
-            value: {[reportToMove?.parentReportActionID]: updatedReportPreviewAction},
+            key: `${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${workspaceChatReportID}`,
+            value: {[reportPreviewActionID]: updatedReportPreviewAction},
         });
         failureData.push({
             onyxMethod: Onyx.METHOD.MERGE,
-            key: `${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${reportToMove?.parentReportID}`,
-            value: {[reportToMove?.parentReportActionID]: oldReportPreviewAction},
+            key: `${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${workspaceChatReportID}`,
+            value: {[reportPreviewActionID]: oldReportPreviewAction},
+        });
+
+        // Update the workspace chat report
+        const chatReport = allReports?.[`${ONYXKEYS.COLLECTION.REPORT}${workspaceChatReportID}`];
+        const lastMessageText = getLastVisibleMessage(
+            workspaceChatReportID,
+            {[reportPreviewActionID]: updatedReportPreviewAction as ReportAction},
+        )?.lastMessageText;
+        const lastVisibleActionCreated = getReportLastMessage(
+            workspaceChatReportID,
+            {[reportPreviewActionID]: updatedReportPreviewAction as ReportAction},
+        )?.lastVisibleActionCreated;
+
+        optimisticData.push({
+            onyxMethod: Onyx.METHOD.MERGE,
+            key: `${ONYXKEYS.COLLECTION.REPORT}${workspaceChatReportID}`,
+            value: {
+                hasOutstandingChildRequest: false,
+                iouReportID: null,
+                lastMessageText,
+                lastVisibleActionCreated,
+            },
+        });
+        failureData.push({
+            onyxMethod: Onyx.METHOD.MERGE,
+            key: `${ONYXKEYS.COLLECTION.REPORT}${workspaceChatReportID}`,
+            value: chatReport,
         });
     }
 

--- a/src/libs/actions/Report.ts
+++ b/src/libs/actions/Report.ts
@@ -4981,14 +4981,8 @@ function changeReportPolicy(reportID: string, policyID: string) {
 
         // Update the workspace chat report
         const chatReport = allReports?.[`${ONYXKEYS.COLLECTION.REPORT}${workspaceChatReportID}`];
-        const lastMessageText = getLastVisibleMessage(
-            workspaceChatReportID,
-            {[reportPreviewActionID]: updatedReportPreviewAction as ReportAction},
-        )?.lastMessageText;
-        const lastVisibleActionCreated = getReportLastMessage(
-            workspaceChatReportID,
-            {[reportPreviewActionID]: updatedReportPreviewAction as ReportAction},
-        )?.lastVisibleActionCreated;
+        const lastMessageText = getLastVisibleMessage(workspaceChatReportID, {[reportPreviewActionID]: updatedReportPreviewAction as ReportAction})?.lastMessageText;
+        const lastVisibleActionCreated = getReportLastMessage(workspaceChatReportID, {[reportPreviewActionID]: updatedReportPreviewAction as ReportAction})?.lastVisibleActionCreated;
 
         optimisticData.push({
             onyxMethod: Onyx.METHOD.MERGE,

--- a/src/pages/ReportChangeWorkspacePage.tsx
+++ b/src/pages/ReportChangeWorkspacePage.tsx
@@ -16,9 +16,11 @@ import Navigation from '@libs/Navigation/Navigation';
 import type {PlatformStackScreenProps} from '@libs/Navigation/PlatformStackNavigation/types';
 import type {ReportChangeWorkspaceNavigatorParamList} from '@libs/Navigation/types';
 import {isWorkspaceEligibleForReportChange} from '@libs/PolicyUtils';
+import {isExpenseReport} from '@libs/ReportUtils';
 import ONYXKEYS from '@src/ONYXKEYS';
 import ROUTES from '@src/ROUTES';
 import type SCREENS from '@src/SCREENS';
+import NotFoundPage from './ErrorPage/NotFoundPage';
 import type {WithReportOrNotFoundProps} from './home/report/withReportOrNotFound';
 import withReportOrNotFound from './home/report/withReportOrNotFound';
 
@@ -56,6 +58,10 @@ function ReportChangeWorkspacePage({report}: ReportChangeWorkspacePageProps) {
         searchTerm: debouncedSearchTerm,
         additionalFilter: (newPolicy) => isWorkspaceEligibleForReportChange(newPolicy, report, oldPolicy, currentUserLogin),
     });
+
+    if (!isExpenseReport(report)) {
+        return <NotFoundPage />;
+    }
 
     return (
         <ScreenWrapper

--- a/src/pages/ReportChangeWorkspacePage.tsx
+++ b/src/pages/ReportChangeWorkspacePage.tsx
@@ -51,7 +51,7 @@ function ReportChangeWorkspacePage({report}: ReportChangeWorkspacePageProps) {
     const {sections, shouldShowNoResultsFoundMessage, shouldShowSearchInput} = useWorkspaceList({
         policies,
         currentUserLogin,
-        isOffline,
+        shouldShowPendingDeletePolicy: false,
         selectedPolicyID: report.policyID,
         searchTerm: debouncedSearchTerm,
         additionalFilter: (newPolicy) => isWorkspaceEligibleForReportChange(newPolicy, report, oldPolicy, currentUserLogin),

--- a/src/pages/ReportChangeWorkspacePage.tsx
+++ b/src/pages/ReportChangeWorkspacePage.tsx
@@ -16,7 +16,7 @@ import Navigation from '@libs/Navigation/Navigation';
 import type {PlatformStackScreenProps} from '@libs/Navigation/PlatformStackNavigation/types';
 import type {ReportChangeWorkspaceNavigatorParamList} from '@libs/Navigation/types';
 import {isWorkspaceEligibleForReportChange} from '@libs/PolicyUtils';
-import {isExpenseReport} from '@libs/ReportUtils';
+import {isExpenseReport, isMoneyRequestReportPendingDeletion} from '@libs/ReportUtils';
 import ONYXKEYS from '@src/ONYXKEYS';
 import ROUTES from '@src/ROUTES';
 import type SCREENS from '@src/SCREENS';
@@ -59,7 +59,7 @@ function ReportChangeWorkspacePage({report}: ReportChangeWorkspacePageProps) {
         additionalFilter: (newPolicy) => isWorkspaceEligibleForReportChange(newPolicy, report, oldPolicy, currentUserLogin),
     });
 
-    if (!isExpenseReport(report)) {
+    if (!isExpenseReport(report) || isMoneyRequestReportPendingDeletion(report)) {
         return <NotFoundPage />;
     }
 

--- a/src/pages/ReportChangeWorkspacePage.tsx
+++ b/src/pages/ReportChangeWorkspacePage.tsx
@@ -59,7 +59,7 @@ function ReportChangeWorkspacePage({report}: ReportChangeWorkspacePageProps) {
         additionalFilter: (newPolicy) => isWorkspaceEligibleForReportChange(newPolicy, report, oldPolicy, currentUserLogin),
     });
 
-    if (!isExpenseReport(report) || isMoneyRequestReportPendingDeletion(report)) {
+    if (!isExpenseReport(report) || isMoneyRequestReportPendingDeletion(report) || (!report.total && !report.unheldTotal)) {
         return <NotFoundPage />;
     }
 

--- a/src/pages/WorkspaceSwitcherPage/index.tsx
+++ b/src/pages/WorkspaceSwitcherPage/index.tsx
@@ -70,7 +70,7 @@ function WorkspaceSwitcherPage() {
 
     const {sections, shouldShowNoResultsFoundMessage, shouldShowSearchInput, shouldShowCreateWorkspace} = useWorkspaceList({
         policies,
-        isOffline,
+        shouldShowPendingDeletePolicy: !!isOffline,
         currentUserLogin,
         selectedPolicyID: activeWorkspaceID,
         searchTerm: debouncedSearchTerm,


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
<!-- Explain what your change does and how it addresses the linked issue -->

Fixes for issues from this list: https://github.com/Expensify/App/issues/57464#issuecomment-2725262939
- This is a follow up to https://github.com/Expensify/App/pull/57553

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/58428
$ https://github.com/Expensify/App/issues/58432
$ https://github.com/Expensify/App/issues/58433
$ https://github.com/Expensify/App/issues/58451
$ https://github.com/Expensify/App/issues/58459
$ https://github.com/Expensify/App/issues/58462
$ https://github.com/Expensify/App/issues/58516

PROPOSAL:


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

#### Test 1

1. Precondition: Account has two workspaces.
2. Go to workspace chat of the first workspace.
3. Submit an expense.
4. Go offline.
5. Delete the second workspace.
6. Go to the expense report from Step 3.
7. Copy link to this report and add /change-workspace then send it in the chat and click on it
8. Verify that the deleted workspace is not included in the workspaces list

#### Test 2

1. Create a new workspace.
2. Go to workspace chat.
3. Submit two expenses.
4. Go to transaction thread of any expense.
5. Add /change-workspace to the end of the URL and navigate to it.
6. Expected Result: Not found page should open



#### Test 3

1. Precondition: Account has self DM and at least one workspace.
2. Go to self DM.
3. Track a manual expense.
4. Go to transaction thread.
5. Add /change-workspace to the end of the URL and navigate to it.
6. Expected Result: Not found page should open



#### Test 4

1. Test on android native app
2. Pre-condition: app language set to Spanish. Should have at least 2 workspaces
3. Open a workspace chat > Create expense
4. Copy the share url from details page
5. Paste the URL in report page and add /chage-workspace to it and send the URL
6. Open the link
7. Note a banner is shown
8. Expected Result: "Trabajo" word must be shown in the change workspace banner and must not be cut off.


#### Test 5

1. Prerequisite: Have at least two workspaces available.
2. Open any workspace chat.
3. Create an expense.
4. Open the expense report.
5. Tap on the header and select "Share"
6. Copy the URL.
7. Return to report and paste the URL.
8. At the end of it, add /change-workspace
9. Tap on header again and delete the expense.
10. Return to LHN and open the expense report thread.
11. Tap on the URL
12. Expected Result: Not found page should open


#### Test 6

1. Precondition: User is logged into two sessions. Account has two workspaces.
2. [Session A] Go to workspace chat and submit an expense.
3. [Session A] Go to expense report.
4. [Session A] Add /change-workspace to the end of the URL and send the link to the report.
5. [Session A] Go offline.
6. [Session B] Delete the second workspace.
7. [Session A] Click on the link in Step 4.
8. [Session A] Select the deleted workspace.
9. [Session A] Go online.
10. Expected Result: Session A should receive an error that the moving fails.


#### Test 7

1. Create two workspaces, create an expense report with 2 expenses in the workspace chat 1
2. Send the url of the report to any chat, append /change-workspace to the URL
3. Tap on the new link
4. From the workspace selection list select Workspace 2.
5. Tap "Got it" on the educational modal
6. Navigate to LHN and observe the messages displayed for the workspace 1 and 2
7. Expected Result: Owed amount for the expense report and GBR is shown only for workspace 2, where the report was moved to. workspace 1 chat should not have a GBR and should not show Owed amount message in LHN

- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->
Same as tests

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos

- [x] [[Change Policy] Report - Report workspace changed be changed to a deleted workspace in offline mode #58428](https://github.com/Expensify/App/issues/58428)
  <details>
  <summary>Screenshot/Video</summary>

  https://github.com/user-attachments/assets/1f19aafa-4874-4038-bc33-bc995b9945a2
  
  </details>

- [x]  [[Change Policy] Expense - Workspace page is blank when opened /change-workspace from individual expense #58432](https://github.com/Expensify/App/issues/58432)

  <details>
  <summary>Screenshot/Video</summary>
  
  <img width="1440" alt="Screenshot 2025-03-16 at 6 53 54 PM" src="https://github.com/user-attachments/assets/94a03a2b-18d5-4cc9-8c63-eafdea95b868" />
  
  
  </details>

- [x]  [[Change Policy] Track expense - Expense is not moved to workspace when navigate to /change-workspace #58433](https://github.com/Expensify/App/issues/58433)
  <details>
  <summary>Screenshot/Video</summary>
  
  <img width="1440" alt="Screenshot 2025-03-16 at 6 53 54 PM" src="https://github.com/user-attachments/assets/94a03a2b-18d5-4cc9-8c63-eafdea95b868" />
  
  
  </details>
- [x]  [[Change Policy] Android -expense-Trabajo word is missing in change workspace banner #58451](https://github.com/Expensify/App/issues/58451)

  <details>
  <summary>Screenshot/Video</summary>

  ![Screenshot_1742159517](https://github.com/user-attachments/assets/7c48bf72-7966-4c90-8705-5b57e4938593)
  
  </details>

- [x]  [[Change Policy] Expense - Deleted expense can still be moved to a different workspace. #58459](https://github.com/Expensify/App/issues/58459)
  <details>
  <summary>Screenshot/Video</summary>


  https://github.com/user-attachments/assets/a4132e2f-c8cd-47d7-ac1d-ac1c5f52a416



  </details>
- [x]  [[Change Policy] Expense - No error message when moving report fails #58462](https://github.com/Expensify/App/issues/58462)

  <details>
  <summary>Screenshot/Video</summary>
  
  https://github.com/user-attachments/assets/c7fa5acf-4c4e-4937-9f57-0c87f9c9843a
  
  
  </details>

- [x]  [[Change Policy] LHN - "Workspace owes.." is displayed for the old workspace after moving the report #58516](https://github.com/Expensify/App/issues/58516)

  <details>
  <summary>Screenshot/Video</summary>
  
  
  

  https://github.com/user-attachments/assets/e9ce3f7d-5607-4116-a0a2-72e2f45dbc3c


  
  
  </details>




<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Desktop</summary>

<!-- add screenshots or videos here -->

</details>
