### PR TITLE
[CP Staging] Revert "fix: always render the skeleton when fetching report actions"

### DIFF
--- a/src/pages/home/report/ReportActionsView.tsx
+++ b/src/pages/home/report/ReportActionsView.tsx
@@ -270,7 +270,7 @@ function ReportActionsView({
         };
     }, [isTheFirstReportActionIsLinked]);
 
-    if (isLoadingInitialReportActions && !isOffline) {
+    if (isLoadingInitialReportActions && visibleReportActions.length === 0 && !isOffline) {
         return <ReportActionsSkeletonView />;
     }
 


### PR DESCRIPTION
Reverts Expensify/App#58654

cc @adhorodyski @mountiny @ZhenjaHorbach 

For issue:
$ https://github.com/Expensify/App/issues/58771

Context https://expensify.slack.com/archives/C01GTK53T8Q/p1742485527549829