### PR TITLE
fix: autoGrow prop on mobile is handled by native platform

### DIFF
--- a/src/components/TextInput/BaseTextInput/implementation/index.native.tsx
+++ b/src/components/TextInput/BaseTextInput/implementation/index.native.tsx
@@ -2,7 +2,7 @@ import {Str} from 'expensify-common';
 import type {ForwardedRef} from 'react';
 import React, {forwardRef, useCallback, useEffect, useRef, useState} from 'react';
 import type {GestureResponderEvent, LayoutChangeEvent, NativeSyntheticEvent, StyleProp, TextInput, TextInputFocusEventData, ViewStyle} from 'react-native';
-import {ActivityIndicator, StyleSheet, View} from 'react-native';
+import {ActivityIndicator, Platform, StyleSheet, View} from 'react-native';
 import {useSharedValue, withSpring} from 'react-native-reanimated';
 import Checkbox from '@components/Checkbox';
 import FormHelpMessage from '@components/FormHelpMessage';
@@ -18,6 +18,7 @@ import type {BaseTextInputProps, BaseTextInputRef} from '@components/TextInput/B
 import * as styleConst from '@components/TextInput/styleConst';
 import TextInputClearButton from '@components/TextInput/TextInputClearButton';
 import TextInputLabel from '@components/TextInput/TextInputLabel';
+import TextInputMeasurement from '@components/TextInput/TextInputMeasurement';
 import useHtmlPaste from '@hooks/useHtmlPaste';
 import useLocalize from '@hooks/useLocalize';
 import useMarkdownStyle from '@hooks/useMarkdownStyle';
@@ -48,7 +49,7 @@ function BaseTextInput(
         forceActiveLabel = false,
         autoFocus = false,
         disableKeyboard = false,
-        autoGrow = false,
+        autoGrow: autoGrowProp = false,
         autoGrowExtraSpace = 0,
         autoGrowHeight = false,
         maxAutoGrowHeight,
@@ -80,6 +81,10 @@ function BaseTextInput(
     }: BaseTextInputProps,
     ref: ForwardedRef<BaseTextInputRef>,
 ) {
+    // For iOS, we don't need to measure the text input because it already has auto grow behavior
+    // See TextInputMeasurement.ios.tsx for more details
+    const autoGrow = Platform.OS !== 'ios' && autoGrowProp;
+
     const InputComponent = InputComponentMap.get(type) ?? RNTextInput;
     const isMarkdownEnabled = type === 'markdown';
     const isAutoGrowHeightMarkdown = isMarkdownEnabled && autoGrowHeight;
@@ -360,8 +365,8 @@ function BaseTextInput(
                                 placeholderTextColor={placeholderTextColor ?? theme.placeholderText}
                                 underlineColorAndroid="transparent"
                                 style={[
-                                    styles.flex1,
-                                    styles.w100,
+                                    autoGrow && styles.flex1,
+                                    autoGrow && styles.w100,
                                     inputStyle,
                                     (!hasLabel || isMultiline) && styles.pv0,
                                     inputPaddingLeft,
@@ -456,55 +461,21 @@ function BaseTextInput(
                     />
                 )}
             </View>
-            {!!contentWidth && isPrefixCharacterPaddingCalculated && (
-                <View
-                    style={[inputStyle as ViewStyle, styles.hiddenElementOutsideOfWindow, styles.visibilityHidden, styles.wAuto, inputPaddingLeft]}
-                    onLayout={(e) => {
-                        if (e.nativeEvent.layout.width === 0 && e.nativeEvent.layout.height === 0) {
-                            return;
-                        }
-                        setTextInputWidth(e.nativeEvent.layout.width);
-                        setTextInputHeight(e.nativeEvent.layout.height);
-                    }}
-                >
-                    <Text
-                        style={[
-                            inputStyle,
-                            autoGrowHeight && styles.autoGrowHeightHiddenInput(width ?? 0, typeof maxAutoGrowHeight === 'number' ? maxAutoGrowHeight : undefined),
-                            {width: contentWidth},
-                        ]}
-                    >
-                        {/* \u200B added to solve the issue of not expanding the text input enough when the value ends with '\n' (https://github.com/Expensify/App/issues/21271) */}
-                        {value ? `${value}${value.endsWith('\n') ? '\u200B' : ''}` : placeholder}
-                    </Text>
-                </View>
-            )}
-            {/*
-                 Text input component doesn't support auto grow by default.
-                 This text view is used to calculate width or height of the input value given textStyle in this component.
-                 This Text component is intentionally positioned out of the screen.
-             */}
-            {(!!autoGrow || autoGrowHeight) && !isAutoGrowHeightMarkdown && (
-                <Text
-                    style={[
-                        inputStyle,
-                        autoGrowHeight && styles.autoGrowHeightHiddenInput(width ?? 0, typeof maxAutoGrowHeight === 'number' ? maxAutoGrowHeight : undefined),
-                        styles.hiddenElementOutsideOfWindow,
-                        styles.visibilityHidden,
-                    ]}
-                    onLayout={(e) => {
-                        if (e.nativeEvent.layout.width === 0 && e.nativeEvent.layout.height === 0) {
-                            return;
-                        }
-                        // Add +2 to width so that cursor is not cut off / covered at the end of text content
-                        setTextInputWidth(e.nativeEvent.layout.width + 2);
-                        setTextInputHeight(e.nativeEvent.layout.height);
-                    }}
-                >
-                    {/* \u200B added to solve the issue of not expanding the text input enough when the value ends with '\n' (https://github.com/Expensify/App/issues/21271) */}
-                    {value ? `${value}${value.endsWith('\n') ? '\u200B' : ''}` : placeholder}
-                </Text>
-            )}
+            <TextInputMeasurement
+                value={value}
+                placeholder={placeholder}
+                contentWidth={contentWidth}
+                autoGrowHeight={autoGrowHeight}
+                maxAutoGrowHeight={maxAutoGrowHeight}
+                width={width}
+                inputStyle={inputStyle}
+                inputPaddingLeft={inputPaddingLeft}
+                autoGrow={autoGrow}
+                isAutoGrowHeightMarkdown={isAutoGrowHeightMarkdown}
+                onSetTextInputWidth={setTextInputWidth}
+                onSetTextInputHeight={setTextInputHeight}
+                isPrefixCharacterPaddingCalculated={isPrefixCharacterPaddingCalculated}
+            />
         </>
     );
 }

--- a/src/components/TextInput/BaseTextInput/implementation/index.native.tsx
+++ b/src/components/TextInput/BaseTextInput/implementation/index.native.tsx
@@ -2,7 +2,7 @@ import {Str} from 'expensify-common';
 import type {ForwardedRef} from 'react';
 import React, {forwardRef, useCallback, useEffect, useRef, useState} from 'react';
 import type {GestureResponderEvent, LayoutChangeEvent, NativeSyntheticEvent, StyleProp, TextInput, TextInputFocusEventData, ViewStyle} from 'react-native';
-import {ActivityIndicator, Platform, StyleSheet, View} from 'react-native';
+import {ActivityIndicator, StyleSheet, View} from 'react-native';
 import {useSharedValue, withSpring} from 'react-native-reanimated';
 import Checkbox from '@components/Checkbox';
 import FormHelpMessage from '@components/FormHelpMessage';
@@ -25,6 +25,7 @@ import useMarkdownStyle from '@hooks/useMarkdownStyle';
 import useStyleUtils from '@hooks/useStyleUtils';
 import useTheme from '@hooks/useTheme';
 import useThemeStyles from '@hooks/useThemeStyles';
+import getPlatform from '@libs/getPlatform';
 import isInputAutoFilled from '@libs/isInputAutoFilled';
 import variables from '@styles/variables';
 import CONST from '@src/CONST';
@@ -83,7 +84,7 @@ function BaseTextInput(
 ) {
     // For iOS, we don't need to measure the text input because it already has auto grow behavior
     // See TextInputMeasurement.ios.tsx for more details
-    const isExternalAutoGrowMeasurement = Platform.OS !== 'ios' && autoGrow;
+    const isExternalAutoGrowMeasurement = getPlatform() !== CONST.PLATFORM.IOS && autoGrow;
 
     const InputComponent = InputComponentMap.get(type) ?? RNTextInput;
     const isMarkdownEnabled = type === 'markdown';

--- a/src/components/TextInput/BaseTextInput/implementation/index.native.tsx
+++ b/src/components/TextInput/BaseTextInput/implementation/index.native.tsx
@@ -49,7 +49,7 @@ function BaseTextInput(
         forceActiveLabel = false,
         autoFocus = false,
         disableKeyboard = false,
-        autoGrow: autoGrowProp = false,
+        autoGrow = false,
         autoGrowExtraSpace = 0,
         autoGrowHeight = false,
         maxAutoGrowHeight,
@@ -83,7 +83,7 @@ function BaseTextInput(
 ) {
     // For iOS, we don't need to measure the text input because it already has auto grow behavior
     // See TextInputMeasurement.ios.tsx for more details
-    const autoGrow = Platform.OS !== 'ios' && autoGrowProp;
+    const isExternalAutoGrowMeasurement = Platform.OS !== 'ios' && autoGrow;
 
     const InputComponent = InputComponentMap.get(type) ?? RNTextInput;
     const isMarkdownEnabled = type === 'markdown';
@@ -266,7 +266,7 @@ function BaseTextInput(
         styles.textInputContainer,
         textInputContainerStyles,
         !!contentWidth && StyleUtils.getWidthStyle(textInputWidth),
-        autoGrow && StyleUtils.getAutoGrowWidthInputContainerStyles(textInputWidth, autoGrowExtraSpace),
+        isExternalAutoGrowMeasurement && StyleUtils.getAutoGrowWidthInputContainerStyles(textInputWidth, autoGrowExtraSpace),
         !hideFocusedState && isFocused && styles.borderColorFocus,
         (!!hasError || !!errorText) && styles.borderColorDanger,
         autoGrowHeight && {scrollPaddingTop: typeof maxAutoGrowHeight === 'number' ? 2 * maxAutoGrowHeight : undefined},
@@ -369,8 +369,8 @@ function BaseTextInput(
                                 placeholderTextColor={placeholderTextColor ?? theme.placeholderText}
                                 underlineColorAndroid="transparent"
                                 style={[
-                                    autoGrow && styles.flex1,
-                                    autoGrow && styles.w100,
+                                    !autoGrow && styles.flex1,
+                                    !autoGrow && styles.w100,
                                     inputStyle,
                                     (!hasLabel || isMultiline) && styles.pv0,
                                     inputPaddingLeft,

--- a/src/components/TextInput/BaseTextInput/implementation/index.native.tsx
+++ b/src/components/TextInput/BaseTextInput/implementation/index.native.tsx
@@ -278,6 +278,10 @@ function BaseTextInput(
 
     // Height fix is needed only for Text single line inputs
     const shouldApplyHeight = !isMultiline && !isMarkdownEnabled;
+
+    // Fix iOS cursor jumping when entering first character using HW keyboard https://github.com/Expensify/App/pull/59078#issuecomment-2802834037
+    const selection = inputProps.selection?.end === 0 && inputProps.selection?.start === 0 ? undefined : inputProps.selection;
+
     return (
         <>
             <View style={[containerStyles]}>
@@ -397,7 +401,7 @@ function BaseTextInput(
                                 keyboardType={inputProps.keyboardType}
                                 inputMode={!disableKeyboard ? inputProps.inputMode : CONST.INPUT_MODE.NONE}
                                 value={uncontrolled ? undefined : value}
-                                selection={inputProps.selection}
+                                selection={selection}
                                 readOnly={isReadOnly}
                                 defaultValue={defaultValue}
                                 markdownStyle={markdownStyle}

--- a/src/components/TextInput/BaseTextInput/implementation/index.tsx
+++ b/src/components/TextInput/BaseTextInput/implementation/index.tsx
@@ -19,13 +19,14 @@ import type {BaseTextInputProps, BaseTextInputRef} from '@components/TextInput/B
 import {ACTIVE_LABEL_SCALE, ACTIVE_LABEL_TRANSLATE_Y, INACTIVE_LABEL_SCALE, INACTIVE_LABEL_TRANSLATE_Y} from '@components/TextInput/styleConst';
 import TextInputClearButton from '@components/TextInput/TextInputClearButton';
 import TextInputLabel from '@components/TextInput/TextInputLabel';
+import TextInputMeasurement from '@components/TextInput/TextInputMeasurement';
 import useHtmlPaste from '@hooks/useHtmlPaste';
 import useLocalize from '@hooks/useLocalize';
 import useMarkdownStyle from '@hooks/useMarkdownStyle';
 import useStyleUtils from '@hooks/useStyleUtils';
 import useTheme from '@hooks/useTheme';
 import useThemeStyles from '@hooks/useThemeStyles';
-import {isMobileChrome, isMobileSafari, isSafari} from '@libs/Browser';
+import {isMobileChrome} from '@libs/Browser';
 import {scrollToRight} from '@libs/InputUtils';
 import isInputAutoFilled from '@libs/isInputAutoFilled';
 import variables from '@styles/variables';
@@ -472,63 +473,21 @@ function BaseTextInput(
                     />
                 )}
             </View>
-            {!!contentWidth && isPrefixCharacterPaddingCalculated && (
-                <View
-                    style={[inputStyle as ViewStyle, styles.hiddenElementOutsideOfWindow, styles.visibilityHidden, styles.wAuto, inputPaddingLeft]}
-                    onLayout={(e) => {
-                        if (e.nativeEvent.layout.width === 0 && e.nativeEvent.layout.height === 0) {
-                            return;
-                        }
-                        setTextInputWidth(e.nativeEvent.layout.width);
-                        setTextInputHeight(e.nativeEvent.layout.height);
-                    }}
-                >
-                    <Text
-                        style={[
-                            inputStyle,
-                            autoGrowHeight && styles.autoGrowHeightHiddenInput(width ?? 0, typeof maxAutoGrowHeight === 'number' ? maxAutoGrowHeight : undefined),
-                            {width: contentWidth},
-                        ]}
-                    >
-                        {/* \u200B added to solve the issue of not expanding the text input enough when the value ends with '\n' (https://github.com/Expensify/App/issues/21271) */}
-                        {value ? `${value}${value.endsWith('\n') ? '\u200B' : ''}` : placeholder}
-                    </Text>
-                </View>
-            )}
-            {/*
-                 Text input component doesn't support auto grow by default.
-                 We're using a hidden text input to achieve that.
-                 This text view is used to calculate width or height of the input value given textStyle in this component.
-                 This Text component is intentionally positioned out of the screen.
-             */}
-            {(!!autoGrow || autoGrowHeight) && !isAutoGrowHeightMarkdown && (
-                // Add +2 to width on Safari browsers so that text is not cut off due to the cursor or when changing the value
-                // Reference: https://github.com/Expensify/App/issues/8158, https://github.com/Expensify/App/issues/26628
-                // For mobile Chrome, ensure proper display of the text selection handle (blue bubble down).
-                // Reference: https://github.com/Expensify/App/issues/34921
-                <Text
-                    style={[
-                        inputStyle,
-                        autoGrowHeight && styles.autoGrowHeightHiddenInput(width ?? 0, typeof maxAutoGrowHeight === 'number' ? maxAutoGrowHeight : undefined),
-                        styles.hiddenElementOutsideOfWindow,
-                        styles.visibilityHidden,
-                    ]}
-                    onLayout={(e) => {
-                        if (e.nativeEvent.layout.width === 0 && e.nativeEvent.layout.height === 0) {
-                            return;
-                        }
-                        let additionalWidth = 0;
-                        if (isMobileSafari() || isSafari() || isMobileChrome()) {
-                            additionalWidth = 2;
-                        }
-                        setTextInputWidth(e.nativeEvent.layout.width + additionalWidth);
-                        setTextInputHeight(e.nativeEvent.layout.height);
-                    }}
-                >
-                    {/* \u200B added to solve the issue of not expanding the text input enough when the value ends with '\n' (https://github.com/Expensify/App/issues/21271) */}
-                    {value ? `${value}${value.endsWith('\n') ? '\u200B' : ''}` : placeholder}
-                </Text>
-            )}
+            <TextInputMeasurement
+                value={value}
+                placeholder={placeholder}
+                contentWidth={contentWidth}
+                autoGrowHeight={autoGrowHeight}
+                maxAutoGrowHeight={maxAutoGrowHeight}
+                width={width}
+                inputStyle={inputStyle}
+                inputPaddingLeft={inputPaddingLeft}
+                autoGrow={autoGrow}
+                isAutoGrowHeightMarkdown={isAutoGrowHeightMarkdown}
+                onSetTextInputWidth={setTextInputWidth}
+                onSetTextInputHeight={setTextInputHeight}
+                isPrefixCharacterPaddingCalculated={isPrefixCharacterPaddingCalculated}
+            />
         </>
     );
 }

--- a/src/components/TextInput/TextInputMeasurement/index.ios.tsx
+++ b/src/components/TextInput/TextInputMeasurement/index.ios.tsx
@@ -1,0 +1,7 @@
+function TextInputMeasurement() {
+    return null;
+}
+
+TextInputMeasurement.displayName = 'TextInputMeasurement';
+
+export default TextInputMeasurement;

--- a/src/components/TextInput/TextInputMeasurement/index.tsx
+++ b/src/components/TextInput/TextInputMeasurement/index.tsx
@@ -1,0 +1,91 @@
+import React from 'react';
+import type {ViewStyle} from 'react-native';
+import {View} from 'react-native';
+import Text from '@components/Text';
+import useThemeStyles from '@hooks/useThemeStyles';
+import {isMobileChrome, isMobileSafari, isSafari} from '@libs/Browser';
+import type TextInputMeasurementProps from './types';
+
+function TextInputMeasurement({
+    value,
+    placeholder,
+    contentWidth,
+    autoGrowHeight,
+    maxAutoGrowHeight,
+    width,
+    inputStyle,
+    inputPaddingLeft,
+    autoGrow,
+    isAutoGrowHeightMarkdown,
+    onSetTextInputWidth,
+    onSetTextInputHeight,
+    isPrefixCharacterPaddingCalculated,
+}: TextInputMeasurementProps) {
+    const styles = useThemeStyles();
+
+    return (
+        <>
+            {!!contentWidth && isPrefixCharacterPaddingCalculated && (
+                <View
+                    style={[inputStyle as ViewStyle, styles.hiddenElementOutsideOfWindow, styles.visibilityHidden, styles.wAuto, inputPaddingLeft]}
+                    onLayout={(e) => {
+                        if (e.nativeEvent.layout.width === 0 && e.nativeEvent.layout.height === 0) {
+                            return;
+                        }
+                        onSetTextInputWidth(e.nativeEvent.layout.width);
+                        onSetTextInputHeight(e.nativeEvent.layout.height);
+                    }}
+                >
+                    <Text
+                        style={[
+                            inputStyle,
+                            autoGrowHeight && styles.autoGrowHeightHiddenInput(width ?? 0, typeof maxAutoGrowHeight === 'number' ? maxAutoGrowHeight : undefined),
+                            {width: contentWidth},
+                        ]}
+                    >
+                        {/* \u200B added to solve the issue of not expanding the text input enough when the value ends with '\n' (https://github.com/Expensify/App/issues/21271) */}
+                        {value ? `${value}${value.endsWith('\n') ? '\u200B' : ''}` : placeholder}
+                    </Text>
+                </View>
+            )}
+            {/*
+                 Text input component doesn't support auto grow by default.
+                 We're using a hidden text input to achieve that.
+                 This text view is used to calculate width or height of the input value given textStyle in this component.
+                 This Text component is intentionally positioned out of the screen.
+             */}
+            {(!!autoGrow || !!autoGrowHeight) && !isAutoGrowHeightMarkdown && (
+                // Add +2 to width on Safari browsers so that text is not cut off due to the cursor or when changing the value
+                // Reference: https://github.com/Expensify/App/issues/8158, https://github.com/Expensify/App/issues/26628
+                // For mobile Chrome, ensure proper display of the text selection handle (blue bubble down).
+                // Reference: https://github.com/Expensify/App/issues/34921
+                <Text
+                    style={[
+                        inputStyle,
+                        autoGrowHeight && styles.autoGrowHeightHiddenInput(width ?? 0, typeof maxAutoGrowHeight === 'number' ? maxAutoGrowHeight : undefined),
+                        styles.hiddenElementOutsideOfWindow,
+                        styles.visibilityHidden,
+                    ]}
+                    onLayout={(e) => {
+                        if (e.nativeEvent.layout.width === 0 && e.nativeEvent.layout.height === 0) {
+                            return;
+                        }
+                        let additionalWidth = 0;
+                        if (isMobileSafari() || isSafari() || isMobileChrome()) {
+                            additionalWidth = 2;
+                        }
+                        onSetTextInputWidth(e.nativeEvent.layout.width + additionalWidth);
+                        onSetTextInputHeight(e.nativeEvent.layout.height);
+                    }}
+                >
+                    {/* \u200B added to solve the issue of not expanding the text input enough when the value ends with '\n' (https://github.com/Expensify/App/issues/21271) */}
+                    {value ? `${value}${value.endsWith('\n') ? '\u200B' : ''}` : placeholder}
+                </Text>
+            )}
+        </>
+    );
+}
+
+TextInputMeasurement.displayName = 'TextInputMeasurement';
+
+export default TextInputMeasurement;

--- a/src/components/TextInput/TextInputMeasurement/types.ts
+++ b/src/components/TextInput/TextInputMeasurement/types.ts
@@ -1,0 +1,44 @@
+import type {StyleProp, TextStyle, ViewStyle} from 'react-native';
+
+type TextInputMeasurementProps = {
+    /** The value to measure */
+    value?: string;
+
+    /** The placeholder to measure */
+    placeholder?: string;
+
+    /** The width to measure */
+    contentWidth?: number;
+
+    /** Whether to auto grow height */
+    autoGrowHeight?: boolean;
+
+    /** The maximum height for auto grow */
+    maxAutoGrowHeight?: number;
+
+    /** The width of the container */
+    width: number | null;
+
+    /** The input style */
+    inputStyle?: StyleProp<TextStyle>;
+
+    /** The input padding left */
+    inputPaddingLeft?: StyleProp<ViewStyle>;
+
+    /** Whether to auto grow */
+    autoGrow?: boolean;
+
+    /** Whether the input is markdown */
+    isAutoGrowHeightMarkdown?: boolean;
+
+    /** Callback to set the text input width */
+    onSetTextInputWidth: (width: number) => void;
+
+    /** Callback to set the text input height */
+    onSetTextInputHeight: (height: number) => void;
+
+    /** Whether the prefix character padding is calculated */
+    isPrefixCharacterPaddingCalculated: boolean;
+};
+
+export default TextInputMeasurementProps;


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
This PR is based on work from @hannojg in https://github.com/Expensify/App/pull/50238 and it's partially removing complicated `autoGrow` using layout events from `Text` to update dimension of `TextInput`. This is not necessary on native platforms because they can auto grow by default. 

Sadly on Android there is bug in RN that is causing component to be jumpy if I remove this autoGrow features that are adding some width buffer to Android component. For that reason I moved most of measuring logic into new component that is used only for Android + Web platforms so even more code is now reused across web and native.

### Fixed Issues

$ https://github.com/Expensify/App/issues/19961

### Tests

1. Sign in to any account
2. Go to any DM
3. Tap + in the compose box > Create Expense > Manual
4. Enter the amount
5. Verify that no jumpy behavior when entering the digits

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

### QA Steps

1. Sign in to any account
2. Go to any DM
3. Tap + in the compose box > Create Expense > Manual
4. Enter the amount
5. Verify that no jumpy behavior when entering the digits

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

[adndroid-text-input.webm](https://github.com/user-attachments/assets/8d47b309-61b6-4531-8b91-5f11f5bd80de)


</details>

<details>
<summary>Android: mWeb Chrome</summary>

[android-web.webm](https://github.com/user-attachments/assets/ca461057-36bd-4163-9cea-4f14b36803d8)


</details>

<details>
<summary>iOS: Native</summary>


https://github.com/user-attachments/assets/d21a0475-39c1-4c85-aa5b-12d0865d33b2



</details>

<details>
<summary>iOS: mWeb Safari</summary>


https://github.com/user-attachments/assets/691a8917-3561-447b-b86d-7456686d9b6d



</details>

<details>
<summary>MacOS: Chrome / Safari</summary>


https://github.com/user-attachments/assets/d630d8e4-cddd-4a5c-b528-5bebff2be149


</details>

<details>
<summary>MacOS: Desktop</summary>


https://github.com/user-attachments/assets/a12d490a-bddb-4765-8228-946c3ab3b8f7


</details>
