### PR TITLE
Fix "Add to group" button is present on team@expensify.com

### DIFF
--- a/src/CONST.ts
+++ b/src/CONST.ts
@@ -342,6 +342,7 @@ const EMAIL = {
     SVFG: 'svfg@expensify.com',
     EXPENSIFY_EMAIL_DOMAIN: '@expensify.com',
     EXPENSIFY_TEAM_EMAIL_DOMAIN: '@team.expensify.com',
+    TEAM: 'team@expensify.com',
     MANAGER_MCTEST: 'manager_mctest@expensify.com',
 };
 
@@ -3522,6 +3523,7 @@ const CONST = {
         EMAIL.RECEIPTS,
         EMAIL.STUDENT_AMBASSADOR,
         EMAIL.SVFG,
+        EMAIL.TEAM,
         EMAIL.MANAGER_MCTEST,
     ] as string[],
     get EXPENSIFY_ACCOUNT_IDS() {

--- a/tests/ui/NewChatPageTest.tsx
+++ b/tests/ui/NewChatPageTest.tsx
@@ -1,5 +1,5 @@
 import * as NativeNavigation from '@react-navigation/native';
-import {act, fireEvent, render, screen} from '@testing-library/react-native';
+import {act, fireEvent, render, screen, waitFor, within} from '@testing-library/react-native';
 import React from 'react';
 import {SectionList} from 'react-native';
 import Onyx from 'react-native-onyx';
@@ -9,12 +9,25 @@ import OptionsListContextProvider from '@components/OptionListContextProvider';
 import ScreenWrapper from '@components/ScreenWrapper';
 import {translateLocal} from '@libs/Localize';
 import NewChatPage from '@pages/NewChatPage';
+import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
 import type {NativeNavigationMock} from '../../__mocks__/@react-navigation/native';
 import {fakePersonalDetails} from '../utils/LHNTestUtils';
+import waitForBatchedUpdates from '../utils/waitForBatchedUpdates';
 import waitForBatchedUpdatesWithAct from '../utils/waitForBatchedUpdatesWithAct';
 
 jest.mock('@react-navigation/native');
+jest.mock('@src/libs/Navigation/navigationRef');
+
+const wrapper = ({children}: {children: React.ReactNode}) => (
+    <OnyxProvider>
+        <LocaleContextProvider>
+            <OptionsListContextProvider>
+                <ScreenWrapper testID="test">{children}</ScreenWrapper>
+            </OptionsListContextProvider>
+        </LocaleContextProvider>
+    </OnyxProvider>
+);
 
 describe('NewChatPage', () => {
     beforeAll(() => {
@@ -24,19 +37,15 @@ describe('NewChatPage', () => {
         jest.spyOn(NativeNavigation, 'useRoute').mockReturnValue({key: '', name: ''});
     });
 
+    afterEach(async () => {
+        jest.clearAllMocks();
+        await Onyx.clear();
+        await waitForBatchedUpdates();
+    });
+
     it('should scroll to top when adding a user to the group selection', async () => {
         await Onyx.merge(ONYXKEYS.PERSONAL_DETAILS_LIST, fakePersonalDetails);
-        render(
-            <OnyxProvider>
-                <LocaleContextProvider>
-                    <OptionsListContextProvider>
-                        <ScreenWrapper testID="test">
-                            <NewChatPage />
-                        </ScreenWrapper>
-                    </OptionsListContextProvider>
-                </LocaleContextProvider>
-            </OnyxProvider>,
-        );
+        render(<NewChatPage />, {wrapper});
         await waitForBatchedUpdatesWithAct();
         await act(() => {
             (NativeNavigation as NativeNavigationMock).triggerTransitionEnd();
@@ -48,5 +57,38 @@ describe('NewChatPage', () => {
             fireEvent.press(addButton);
             expect(spy).toHaveBeenCalledWith(expect.objectContaining({itemIndex: 0}));
         }
+    });
+
+    describe('should not display "Add to group" button on expensify emails', () => {
+        const excludedGroupEmails = CONST.EXPENSIFY_EMAILS.filter((value) => value !== CONST.EMAIL.CONCIERGE && value !== CONST.EMAIL.NOTIFICATIONS).map((email) => [email]);
+
+        it.each(excludedGroupEmails)('%s', async (email) => {
+            // Given that a personal details list is initialized in Onyx
+            await Onyx.merge(ONYXKEYS.PERSONAL_DETAILS_LIST, {
+                // eslint-disable-next-line @typescript-eslint/naming-convention
+                '1': {accountID: 1, login: email},
+            });
+
+            // And NewChatPage is opened
+            render(<NewChatPage />, {wrapper});
+            await waitForBatchedUpdatesWithAct();
+            await act(() => {
+                (NativeNavigation as NativeNavigationMock).triggerTransitionEnd();
+            });
+
+            // And email is entered into the search input
+            const input = screen.getByTestId('selection-list-text-input');
+            fireEvent.changeText(input, email);
+
+            // And waited for the user option to appear
+            await waitFor(() => {
+                expect(screen.getByLabelText(email)).toBeOnTheScreen();
+            });
+
+            // Then "Add to group" button should not appear
+            const userOption = screen.getByLabelText(email);
+            const addButton = within(userOption).queryByText(translateLocal('newChatPage.addToGroup'));
+            expect(addButton).not.toBeOnTheScreen();
+        });
     });
 });


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
<!-- Explain what your change does and how it addresses the linked issue -->

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/58920
PROPOSAL: https://github.com/Expensify/App/issues/58920#issuecomment-2743959290

<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

Same as QA Steps

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

Same as QA Steps

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->

1. Click on the FAB, then "Start Chat".
1. Search for `team@expensify.com` account.
1. Verify that the "Add to group" button is not displayed.

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

![image](https://github.com/user-attachments/assets/d9995784-b2b7-4bd1-8bbe-23c1877e2646)

</details>

<details>
<summary>Android: mWeb Chrome</summary>

![image](https://github.com/user-attachments/assets/60c40411-8d90-43d8-9e18-7ab7d1d22ccb)

</details>

<details>
<summary>iOS: Native</summary>

<img width="329" alt="Screenshot 2025-03-26 at 22 39 28" src="https://github.com/user-attachments/assets/57f01580-41e3-4fbd-a0b4-91d732ebb350" />

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<img width="329" alt="Screenshot 2025-03-26 at 22 53 00" src="https://github.com/user-attachments/assets/9cffc765-865b-44eb-b802-5fb51e40d2b4" />

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<img width="917" alt="Screenshot 2025-03-26 at 22 53 44" src="https://github.com/user-attachments/assets/4f7c46d1-fc6e-42c1-ab95-5e3de45e1404" />

</details>

<details>
<summary>MacOS: Desktop</summary>

<img width="1200" alt="Screenshot 2025-03-26 at 22 55 22" src="https://github.com/user-attachments/assets/b22173de-b318-43d1-bf59-717a6f474e9a" />

</details>
