### PR TITLE
fix: no preview message after switching priorities

### DIFF
--- a/src/libs/OptionsListUtils.ts
+++ b/src/libs/OptionsListUtils.ts
@@ -718,25 +718,6 @@ function getLastMessageTextForReport(report: OnyxEntry<Report>, lastActorDetails
         );
 
         lastMessageTextFromReport = formatReportLastMessageText(reportPreviewMessage);
-
-        // If lastIOUMoneyReportAction is empty, format the message with the actor's display name
-        if (!lastIOUMoneyReportAction) {
-            // Get the actor's display name instead of using email
-            const actorAccountID = lastReportAction?.actorAccountID;
-            const actorDetails = actorAccountID ? allPersonalDetails?.[actorAccountID] : null;
-
-            if (actorDetails) {
-                const actorDisplayName = getLastActorDisplayName(actorDetails);
-                const actorLastName = getLastActorLastName(actorDetails);
-
-                const actorName = actorLastName ? `${actorDisplayName} ${actorLastName}` : actorDisplayName;
-
-                // Format the message with the display name if available
-                if (actorDisplayName && actorDetails.login) {
-                    lastMessageTextFromReport = lastMessageTextFromReport.replace(actorDetails.login, actorName);
-                }
-            }
-        }
     } else if (isReimbursementQueuedAction(lastReportAction)) {
         lastMessageTextFromReport = getReimbursementQueuedActionMessage({reportAction: lastReportAction, reportOrID: report});
     } else if (isReimbursementDeQueuedAction(lastReportAction)) {

--- a/src/libs/OptionsListUtils.ts
+++ b/src/libs/OptionsListUtils.ts
@@ -552,20 +552,6 @@ function getLastActorDisplayName(lastActorDetails: Partial<PersonalDetails> | nu
 }
 
 /**
- * Get the last actor last name from last actor details.
- */
-function getLastActorLastName(lastActorDetails: Partial<PersonalDetails> | null) {
-    if (!lastActorDetails) {
-        return '';
-    }
-
-    return lastActorDetails.accountID !== currentUserAccountID
-        ? // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-          lastActorDetails.lastName || ''
-        : '';
-}
-
-/**
  * Update alternate text for the option when applicable
  */
 function getAlternateText(option: OptionData, {showChatPreviewLine = false, forcePolicyNamePreview = false}: PreviewConfig) {
@@ -716,7 +702,6 @@ function getLastMessageTextForReport(report: OnyxEntry<Report>, lastActorDetails
             true,
             lastReportAction,
         );
-
         lastMessageTextFromReport = formatReportLastMessageText(reportPreviewMessage);
     } else if (isReimbursementQueuedAction(lastReportAction)) {
         lastMessageTextFromReport = getReimbursementQueuedActionMessage({reportAction: lastReportAction, reportOrID: report});

--- a/src/libs/OptionsListUtils.ts
+++ b/src/libs/OptionsListUtils.ts
@@ -709,7 +709,7 @@ function getLastMessageTextForReport(report: OnyxEntry<Report>, lastActorDetails
             : undefined;
         const reportPreviewMessage = getReportPreviewMessage(
             !isEmptyObject(iouReport) ? iouReport : null,
-            lastIOUMoneyReportAction,
+            lastIOUMoneyReportAction ?? lastReportAction,
             true,
             reportUtilsIsChatReport(report),
             null,
@@ -719,11 +719,8 @@ function getLastMessageTextForReport(report: OnyxEntry<Report>, lastActorDetails
 
         lastMessageTextFromReport = formatReportLastMessageText(reportPreviewMessage);
 
-        // If lastMessageTextFromReport is empty, try to extract the message from the lastReportAction instead
-        if (!lastMessageTextFromReport) {
-            const lastReportActionMessage = getReportActionMessageText(lastReportAction);
-            lastMessageTextFromReport = lastReportActionMessage;
-
+        // If lastIOUMoneyReportAction is empty, format the message with the actor's display name
+        if (!lastIOUMoneyReportAction) {
             // Get the actor's display name instead of using email
             const actorAccountID = lastReportAction?.actorAccountID;
             const actorDetails = actorAccountID ? allPersonalDetails?.[actorAccountID] : null;

--- a/src/libs/ReportUtils.ts
+++ b/src/libs/ReportUtils.ts
@@ -4015,10 +4015,10 @@ function getReportPreviewMessage(
     const reportActionMessage = getReportActionHtml(iouReportAction);
 
     if (isEmptyObject(report) || !report?.reportID) {
-        // The IOU report associated with this action might not be loaded into the 'allReports'
-        // Alternatively, settled IOU reports might not be returned by the backend's OpenApp command.
-        // In either case, we lack the full report details needed for rich formatting,
-        // As a temporary solution until we know how to solve this the best, we just use the message that returned from BE
+        // This iouReport may be unavailable for one of the following reasons:
+        // 1. After SignIn, the OpenApp API won't return iouReports if they're settled.
+        // 2. The iouReport exists in local storage but hasn't been loaded into the allReports. It will be loaded automatically when the user opens the iouReport.
+        // Until we know how to solve this the best, we just display the report action message.
         return reportActionMessage;
     }
 

--- a/src/libs/ReportUtils.ts
+++ b/src/libs/ReportUtils.ts
@@ -4015,7 +4015,9 @@ function getReportPreviewMessage(
     const reportActionMessage = getReportActionHtml(iouReportAction);
 
     if (isEmptyObject(report) || !report?.reportID) {
-        // The iouReport is not found locally after SignIn because the OpenApp API won't return iouReports if they're settled
+        // The IOU report associated with this action might not be loaded into the 'allReports'
+        // Alternatively, settled IOU reports might not be returned by the backend's OpenApp command.
+        // In either case, we lack the full report details needed for rich formatting,
         // As a temporary solution until we know how to solve this the best, we just use the message that returned from BE
         return reportActionMessage;
     }

--- a/src/libs/ReportUtils.ts
+++ b/src/libs/ReportUtils.ts
@@ -4014,19 +4014,15 @@ function getReportPreviewMessage(
     const report = typeof reportOrID === 'string' ? getReport(reportOrID, allReports) : reportOrID;
     const reportActionMessage = getReportActionHtml(iouReportAction);
 
-    if (!report?.reportID) {
+    if (isEmptyObject(report) || !report?.reportID) {
+        // The iouReport is not found locally after SignIn because the OpenApp API won't return iouReports if they're settled
+        // As a temporary solution until we know how to solve this the best, we just use the message that returned from BE
         return reportActionMessage;
     }
 
     const allReportTransactions = getReportTransactions(report.reportID);
     const transactionsWithReceipts = allReportTransactions.filter(hasReceiptTransactionUtils);
     const numberOfScanningReceipts = transactionsWithReceipts.filter(isReceiptBeingScanned).length;
-
-    if (isEmptyObject(report) || !report?.reportID) {
-        // The iouReport is not found locally after SignIn because the OpenApp API won't return iouReports if they're settled
-        // As a temporary solution until we know how to solve this the best, we just use the message that returned from BE
-        return reportActionMessage;
-    }
 
     if (!isEmptyObject(iouReportAction) && !isIOUReport(report) && iouReportAction && isSplitBillReportAction(iouReportAction)) {
         // This covers group chats where the last action is a split expense action
@@ -4153,7 +4149,6 @@ function getReportPreviewMessage(
     // if we have the amount in the originalMessage and lastActorID, we can use that to display the preview message for the latest expense
     if (amount !== undefined && lastActorID && !isPreviewMessageForParentChatReport) {
         const amountToDisplay = convertToDisplayString(Math.abs(amount), currency);
-
         // We only want to show the actor name in the preview if it's not the current user who took the action
         const requestorName =
             lastActorID && lastActorID !== currentUserAccountID ? getDisplayNameForParticipant({accountID: lastActorID, shouldUseShortForm: !isPreviewMessageForParentChatReport}) : '';

--- a/src/libs/ReportUtils.ts
+++ b/src/libs/ReportUtils.ts
@@ -4149,6 +4149,7 @@ function getReportPreviewMessage(
     // if we have the amount in the originalMessage and lastActorID, we can use that to display the preview message for the latest expense
     if (amount !== undefined && lastActorID && !isPreviewMessageForParentChatReport) {
         const amountToDisplay = convertToDisplayString(Math.abs(amount), currency);
+
         // We only want to show the actor name in the preview if it's not the current user who took the action
         const requestorName =
             lastActorID && lastActorID !== currentUserAccountID ? getDisplayNameForParticipant({accountID: lastActorID, shouldUseShortForm: !isPreviewMessageForParentChatReport}) : '';


### PR DESCRIPTION
### Explanation of Change

The current solution tries to get the full report, but we can simplify it by just formatting the message from the lastReportAction object directly if there is no report. I need to get `actorDetails` because there is a user email instead of their name in the last message. Here's how we can modify the code:

```typescript
lastMessageTextFromReport = formatReportLastMessageText(reportPreviewMessage);

if (!lastMessageTextFromReport) {
    const lastReportActionMessage = getReportActionMessageText(lastReportAction);
    lastMessageTextFromReport = lastReportActionMessage;

    // Get the actor's display name instead of using email
    const actorAccountID = lastReportAction?.actorAccountID;
    const actorDetails = actorAccountID ? allPersonalDetails?.[actorAccountID] : null;

    if (actorDetails) {
        const actorDisplayName = getLastActorDisplayName(actorDetails);
        const actorLastName = getLastActorLastName(actorDetails);

        const actorName = actorLastName ? `${actorDisplayName} ${actorLastName}` : actorDisplayName;

        // Format the message with the display name if available
        if (actorDisplayName && actorDetails.login) {
            lastMessageTextFromReport = lastMessageTextFromReport.replace(actorDetails.login, actorName);
        }
    }
}
 ```

This solution uses two helper functions:

1. `getLastActorDisplayName` - Gets the first name or display name of the actor (Exists)
2. `getLastActorLastName` - Gets the last name of the actor (I added):
```typescript
function getLastActorLastName(lastActorDetails: Partial<PersonalDetails> | null) {
    if (!lastActorDetails) {
        return '';
    }

    return lastActorDetails.accountID !== currentUserAccountID
        ? // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
          lastActorDetails.lastName || ''
        : '';
}
 ```

Together, these functions ensure that when there's no formatted report preview message, we still get a properly formatted message with full names instead of email addresses.

### Fixed Issues

$ https://github.com/Expensify/App/issues/58879
PROPOSAL: $ https://github.com/Expensify/App/issues/58879#issuecomment-2744086647


### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

1. Open the Expensify app.
2. Tap on FAB and select "Create Chat"
3. Start an individual chat with another user.
4. Create an expense in it.
5. Repeat steps 2 to 5 with one or more chats.
6. Note that the preview on the individual chats, display the sent expense information.
7. Navigate to settings and select "Preferences"
8. Change the priority mode to "Focus"
9. Change it again to "Most Recent"
10. Return to inbox.
11. Check the message displayed on preview of individual chats after this last action.

- [x] Verify that no errors appear in the JS console


### Offline tests

Same as above

### QA Steps

Same as above

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x]  I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos

<details>
<summary>Android: Native</summary>

https://github.com/user-attachments/assets/9cbc4d6f-8632-4e2f-84f2-54b50a417bc8

</details>

<details>
<summary>Android: mWeb Chrome</summary>


https://github.com/user-attachments/assets/9cbc4d6f-8632-4e2f-84f2-54b50a417bc8

</details>


<details>
<summary>iOS: Native</summary>

https://github.com/user-attachments/assets/17a9b94c-4060-46d2-8a50-6eea6e86e717
</details>

<details>
<summary>iOS: mWeb Safari</summary>

https://github.com/user-attachments/assets/7a1b38a2-81cb-45f0-ba61-b625c4d1b5c1
</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

https://github.com/user-attachments/assets/4c5e0e58-88ea-4fab-9a62-406323806fcb
</details>

<details>
<summary>MacOS: Desktop</summary>

https://github.com/user-attachments/assets/5d8fbfc5-3a3f-4be8-a294-436d39820283
</details>


