### PR TITLE
Revert "[CP Staging] fix: auto focus input break navigator transition"

### DIFF
--- a/src/components/TextInput/index.tsx
+++ b/src/components/TextInput/index.tsx
@@ -59,7 +59,6 @@ function TextInput(props: BaseTextInputProps, ref: ForwardedRef<BaseTextInputRef
             // eslint-disable-next-line react/jsx-props-no-spreading
             {...props}
             autoFocus={isAutoFocusEnabled}
-            shouldDelayFocus={isAutoFocusEnabled}
             ref={(element) => {
                 textInputRef.current = element as HTMLFormElement;
 


### PR DESCRIPTION
Reverts Expensify/App#59251

See the comments starting from [here](https://github.com/Expensify/App/issues/59223#issuecomment-2760133910)