### PR TITLE
Revert "Change MarkAsUnread to pass reportActionID instead of time"

### DIFF
--- a/src/libs/API/parameters/MarkAsUnreadParams.ts
+++ b/src/libs/API/parameters/MarkAsUnreadParams.ts
@@ -1,7 +1,6 @@
 type MarkAsUnreadParams = {
     reportID: string;
     lastReadTime: string;
-    reportActionID: string;
 };
 
 export default MarkAsUnreadParams;

--- a/src/libs/actions/Report.ts
+++ b/src/libs/actions/Report.ts
@@ -1470,7 +1470,7 @@ function readNewestAction(reportID: string | undefined, shouldResetUnreadMarker 
 /**
  * Sets the last read time on a report
  */
-function markCommentAsUnread(reportID: string | undefined, reportAction: ReportAction) {
+function markCommentAsUnread(reportID: string | undefined, reportActionCreated: string) {
     if (!reportID) {
         Log.warn('7339cd6c-3263-4f89-98e5-730f0be15784 Invalid report passed to MarkCommentAsUnread. Not calling the API because it wil fail.');
         return;
@@ -1494,10 +1494,9 @@ function markCommentAsUnread(reportID: string | undefined, reportAction: ReportA
     const report = allReports?.[`${ONYXKEYS.COLLECTION.REPORT}${reportID}`];
     const transactionThreadReportID = ReportActionsUtils.getOneTransactionThreadReportID(reportID, reportActions ?? []);
     const transactionThreadReport = allReports?.[`${ONYXKEYS.COLLECTION.REPORT}${transactionThreadReportID}`];
-
     // If no action created date is provided, use the last action's from other user
     const actionCreationTime =
-        reportAction?.created || (latestReportActionFromOtherUsers?.created ?? getReportLastVisibleActionCreated(report, transactionThreadReport) ?? DateUtils.getDBTime(0));
+        reportActionCreated || (latestReportActionFromOtherUsers?.created ?? getReportLastVisibleActionCreated(report, transactionThreadReport) ?? DateUtils.getDBTime(0));
 
     // We subtract 1 millisecond so that the lastReadTime is updated to just before a given reportAction's created date
     // For example, if we want to mark a report action with ID 100 and created date '2014-04-01 16:07:02.999' unread, we set the lastReadTime to '2014-04-01 16:07:02.998'
@@ -1517,7 +1516,6 @@ function markCommentAsUnread(reportID: string | undefined, reportAction: ReportA
     const parameters: MarkAsUnreadParams = {
         reportID,
         lastReadTime,
-        reportActionID: reportAction?.reportActionID,
     };
 
     API.write(WRITE_COMMANDS.MARK_AS_UNREAD, parameters, {optimisticData});

--- a/src/pages/home/report/ContextMenu/ContextMenuActions.tsx
+++ b/src/pages/home/report/ContextMenu/ContextMenuActions.tsx
@@ -295,7 +295,7 @@ const ContextMenuActions: ContextMenuAction[] = [
         successIcon: Expensicons.Checkmark,
         shouldShow: ({type, isUnreadChat}) => type === CONST.CONTEXT_MENU_TYPES.REPORT_ACTION || (type === CONST.CONTEXT_MENU_TYPES.REPORT && !isUnreadChat),
         onPress: (closePopover, {reportAction, reportID}) => {
-            markCommentAsUnread(reportID, reportAction);
+            markCommentAsUnread(reportID, reportAction?.created);
             if (closePopover) {
                 hideContextMenu(true, ReportActionComposeFocusManager.focus);
             }

--- a/tests/actions/ReportTest.ts
+++ b/tests/actions/ReportTest.ts
@@ -317,7 +317,7 @@ describe('actions/Report', () => {
 
                 // When the user manually marks a message as "unread"
                 jest.advanceTimersByTime(10);
-                Report.markCommentAsUnread(REPORT_ID, reportActions['1']);
+                Report.markCommentAsUnread(REPORT_ID, reportActionCreatedDate);
                 return waitForBatchedUpdates();
             })
             .then(() => {
@@ -443,13 +443,13 @@ describe('actions/Report', () => {
                 expect(ReportUtils.isUnread(report, undefined)).toBe(false);
 
                 // When the user manually marks a message as "unread"
-                Report.markCommentAsUnread(REPORT_ID, reportActions[400]);
+                Report.markCommentAsUnread(REPORT_ID, reportActionCreatedDate);
                 return waitForBatchedUpdates();
             })
             .then(() => {
                 // Then we should expect the report to be to be unread
                 expect(ReportUtils.isUnread(report, undefined)).toBe(true);
-                expect(report?.lastReadTime).toBe(DateUtils.subtractMillisecondsFromDateTime(reportActions[400].created, 1));
+                expect(report?.lastReadTime).toBe(DateUtils.subtractMillisecondsFromDateTime(reportActionCreatedDate, 1));
 
                 // If the user deletes the last comment after the lastReadTime the lastMessageText will reflect the new last comment
                 Report.deleteReportComment(REPORT_ID, {...reportActions[400]});

--- a/tests/ui/UnreadIndicatorsTest.tsx
+++ b/tests/ui/UnreadIndicatorsTest.tsx
@@ -103,26 +103,6 @@ const USER_C_ACCOUNT_ID = 3;
 const USER_C_EMAIL = 'user_c@test.com';
 let reportAction3CreatedDate: string;
 let reportAction9CreatedDate: string;
-const TEN_MINUTES_AGO = subMinutes(new Date(), 10);
-const createdReportActionID = rand64().toString();
-const createdReportAction = {
-    actionName: CONST.REPORT.ACTIONS.TYPE.CREATED,
-    automatic: false,
-    created: format(TEN_MINUTES_AGO, CONST.DATE.FNS_DB_FORMAT_STRING),
-    reportActionID: createdReportActionID,
-    message: [
-        {
-            style: 'strong',
-            text: '__FAKE__',
-            type: 'TEXT',
-        },
-        {
-            style: 'normal',
-            text: 'created this report',
-            type: 'TEXT',
-        },
-    ],
-};
 
 /**
  * Sets up a test with a logged in user that has one unread chat from another user. Returns the <App/> test instance.
@@ -147,6 +127,7 @@ function signInAndGetAppWithUnreadChat(): Promise<void> {
             return waitForBatchedUpdates();
         })
         .then(async () => {
+            const TEN_MINUTES_AGO = subMinutes(new Date(), 10);
             reportAction3CreatedDate = format(addSeconds(TEN_MINUTES_AGO, 30), CONST.DATE.FNS_DB_FORMAT_STRING);
             reportAction9CreatedDate = format(addSeconds(TEN_MINUTES_AGO, 90), CONST.DATE.FNS_DB_FORMAT_STRING);
 
@@ -164,8 +145,26 @@ function signInAndGetAppWithUnreadChat(): Promise<void> {
                 lastActorAccountID: USER_B_ACCOUNT_ID,
                 type: CONST.REPORT.TYPE.CHAT,
             });
+            const createdReportActionID = rand64().toString();
             await Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${REPORT_ID}`, {
-                [createdReportActionID]: createdReportAction,
+                [createdReportActionID]: {
+                    actionName: CONST.REPORT.ACTIONS.TYPE.CREATED,
+                    automatic: false,
+                    created: format(TEN_MINUTES_AGO, CONST.DATE.FNS_DB_FORMAT_STRING),
+                    reportActionID: createdReportActionID,
+                    message: [
+                        {
+                            style: 'strong',
+                            text: '__FAKE__',
+                            type: 'TEXT',
+                        },
+                        {
+                            style: 'normal',
+                            text: 'created this report',
+                            type: 'TEXT',
+                        },
+                    ],
+                },
                 1: TestHelper.buildTestReportComment(format(addSeconds(TEN_MINUTES_AGO, 10), CONST.DATE.FNS_DB_FORMAT_STRING), USER_B_ACCOUNT_ID, '1'),
                 2: TestHelper.buildTestReportComment(format(addSeconds(TEN_MINUTES_AGO, 20), CONST.DATE.FNS_DB_FORMAT_STRING), USER_B_ACCOUNT_ID, '2'),
                 3: TestHelper.buildTestReportComment(reportAction3CreatedDate, USER_B_ACCOUNT_ID, '3'),
@@ -293,7 +292,7 @@ describe('Unread Indicators', () => {
                 const NEW_REPORT_ID = '2';
                 const NEW_REPORT_CREATED_DATE = subSeconds(new Date(), 5);
                 const NEW_REPORT_FIST_MESSAGE_CREATED_DATE = addSeconds(NEW_REPORT_CREATED_DATE, 1);
-                const createdReportActionIDLocal = rand64();
+                const createdReportActionID = rand64();
                 const commentReportActionID = rand64();
                 PusherHelper.emitOnyxUpdate([
                     {
@@ -317,11 +316,11 @@ describe('Unread Indicators', () => {
                         onyxMethod: Onyx.METHOD.MERGE,
                         key: `${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${NEW_REPORT_ID}`,
                         value: {
-                            [createdReportActionIDLocal]: {
+                            [createdReportActionID]: {
                                 actionName: CONST.REPORT.ACTIONS.TYPE.CREATED,
                                 automatic: false,
                                 created: format(NEW_REPORT_CREATED_DATE, CONST.DATE.FNS_DB_FORMAT_STRING),
-                                reportActionID: createdReportActionIDLocal,
+                                reportActionID: createdReportActionID,
                             },
                             [commentReportActionID]: {
                                 actionName: CONST.REPORT.ACTIONS.TYPE.ADD_COMMENT,
@@ -387,7 +386,7 @@ describe('Unread Indicators', () => {
             .then(() => {
                 // It's difficult to trigger marking a report comment as unread since we would have to mock the long press event and then
                 // another press on the context menu item so we will do it via the action directly and then test if the UI has updated properly
-                markCommentAsUnread(REPORT_ID, createdReportAction);
+                markCommentAsUnread(REPORT_ID, reportAction3CreatedDate);
                 return waitForBatchedUpdates();
             })
             .then(() => {
@@ -485,7 +484,7 @@ describe('Unread Indicators', () => {
                 expect(unreadIndicator).toHaveLength(0);
 
                 // Mark a previous comment as unread and verify the unread action indicator returns
-                markCommentAsUnread(REPORT_ID, createdReportAction);
+                markCommentAsUnread(REPORT_ID, reportAction9CreatedDate);
                 return waitForBatchedUpdates();
             })
             .then(() => {
@@ -567,7 +566,7 @@ describe('Unread Indicators', () => {
         const firstNewReportAction = reportActions ? lastItem(reportActions) : undefined;
 
         if (firstNewReportAction) {
-            markCommentAsUnread(REPORT_ID, firstNewReportAction);
+            markCommentAsUnread(REPORT_ID, firstNewReportAction?.created);
 
             await waitForBatchedUpdates();
 


### PR DESCRIPTION
Reverts Expensify/App#58758 to test fix for https://github.com/Expensify/App/issues/59393