### PR TITLE
[No QA] Cherry-pick Mobile-Expensify version bumps to Mobile-Expensify staging

### DIFF
--- a/.github/workflows/cherryPick.yml
+++ b/.github/workflows/cherryPick.yml
@@ -50,7 +50,7 @@ jobs:
           cd Mobile-Expensify
           git fetch origin main staging --no-tags --shallow-exclude ${{ steps.getPreviousVersion.outputs.PREVIOUS_VERSION }}
 
-      - name: Get version bump commit
+      - name: Get E/App version bump commit
         id: getVersionBumpCommit
         run: |
           git switch main
@@ -77,7 +77,7 @@ jobs:
           fi
           echo "VERSION_BUMP_SHA=$VERSION_BUMP_COMMIT" >> "$GITHUB_OUTPUT"
 
-      - name: Get merge commit for pull request to CP
+      - name: Get merge commit for E/App pull request to CP
         id: getCPMergeCommit
         uses: ./.github/actions/javascript/getPullRequestDetails
         with:
@@ -93,21 +93,15 @@ jobs:
           git cherry-pick -S -x --mainline 1 --strategy=recursive -Xtheirs ${{ steps.getMobileExpensifyVersionBumpCommit.outputs.VERSION_BUMP_SHA }}
           git push origin staging
 
-          # After being CP'd to staging, the version bump will have a new SHA. We'll need this to update the App submodule
-          echo "VERSION_BUMP_SHA=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+      - name: Update the Mobile-Expensify submodule on E/App staging
+        run: |
+          git add Mobile-Expensify
+          git commit -m "Update Mobile-Expensify submodule version to ${{ needs.createNewVersion.outputs.NEW_VERSION }}"
 
-      - name: Cherry-pick the version-bump to staging
+      - name: Cherry-pick the E/App version-bump to staging
         run: |
           git switch staging
           git cherry-pick -S -x --mainline 1 --strategy=recursive -Xtheirs ${{ steps.getVersionBumpCommit.outputs.VERSION_BUMP_SHA }}
-
-      - name: Update the Mobile-Expensify submodule on E/App staging
-        run: |
-          cd Mobile-Expensify
-          git checkout ${{ steps.cherryPickMobileExpensifyVersionBump.outputs.VERSION_BUMP_SHA }}
-          cd ..
-          git add Mobile-Expensify
-          git commit -m "Update Mobile-Expensify submodule version to ${{ needs.createNewVersion.outputs.NEW_VERSION }}"
 
       - name: Cherry-pick the merge commit of target PR
         id: cherryPick

--- a/.github/workflows/cherryPick.yml
+++ b/.github/workflows/cherryPick.yml
@@ -49,7 +49,7 @@ jobs:
         id: getVersionBumpCommit
         run: |
           git switch main
-          VERSION_BUMP_COMMIT="$(git log --format='%H' --author='OSBotify' --grep 'Update version to ${{ needs.createNewVersion.outputs.NEW_VERSION }}')"
+          VERSION_BUMP_COMMIT="$(git log -1 --format='%H' --author='OSBotify' --grep 'Update version to ${{ needs.createNewVersion.outputs.NEW_VERSION }}')"
           if [ -z "$VERSION_BUMP_COMMIT" ]; then
             echo "::error::❌ Could not find version bump commit for ${{ needs.createNewVersion.outputs.NEW_VERSION }}"
             git log --oneline
@@ -63,7 +63,7 @@ jobs:
         working-directory: Mobile-Expensify
         run: |
           git switch main
-          VERSION_BUMP_COMMIT="$(git log --format='%H' --author='OSBotify' --grep 'Update version to ${{ needs.createNewVersion.outputs.NEW_VERSION }}')"
+          VERSION_BUMP_COMMIT="$(git log -1 --format='%H' --author='OSBotify' --grep 'Update version to ${{ needs.createNewVersion.outputs.NEW_VERSION }}')"
           if [ -z "$VERSION_BUMP_COMMIT" ]; then
             echo "::error::❌ Could not find version bump commit for ${{ needs.createNewVersion.outputs.NEW_VERSION }}"
             git log --oneline

--- a/.github/workflows/cherryPick.yml
+++ b/.github/workflows/cherryPick.yml
@@ -51,10 +51,10 @@ jobs:
           git switch main
           VERSION_BUMP_COMMIT="$(git log -1 --format='%H' --author='OSBotify' --grep 'Update version to ${{ needs.createNewVersion.outputs.NEW_VERSION }}')"
           if [ -z "$VERSION_BUMP_COMMIT" ]; then
-            echo "::error::❌ Could not find version bump commit for ${{ needs.createNewVersion.outputs.NEW_VERSION }}"
+            echo "::error::❌ Could not find E/App version bump commit for ${{ needs.createNewVersion.outputs.NEW_VERSION }}"
             git log --oneline
           else
-            echo "::notice::👀 Found version bump commit $VERSION_BUMP_COMMIT"
+            echo "::notice::👀 Found E/App version bump commit $VERSION_BUMP_COMMIT"
           fi
           echo "VERSION_BUMP_SHA=$VERSION_BUMP_COMMIT" >> "$GITHUB_OUTPUT"
 
@@ -65,10 +65,10 @@ jobs:
           git switch main
           VERSION_BUMP_COMMIT="$(git log -1 --format='%H' --author='OSBotify' --grep 'Update version to ${{ needs.createNewVersion.outputs.NEW_VERSION }}')"
           if [ -z "$VERSION_BUMP_COMMIT" ]; then
-            echo "::error::❌ Could not find version bump commit for ${{ needs.createNewVersion.outputs.NEW_VERSION }}"
+            echo "::error::❌ Could not find Mobile-Expensify version bump commit for ${{ needs.createNewVersion.outputs.NEW_VERSION }}"
             git log --oneline
           else
-            echo "::notice::👀 Found version bump commit $VERSION_BUMP_COMMIT"
+            echo "::notice::👀 Found Mobile-Expensify version bump commit $VERSION_BUMP_COMMIT"
           fi
           echo "VERSION_BUMP_SHA=$VERSION_BUMP_COMMIT" >> "$GITHUB_OUTPUT"
 
@@ -86,11 +86,10 @@ jobs:
         run: |
           git switch staging
           git cherry-pick -S -x --mainline 1 --strategy=recursive -Xtheirs ${{ steps.getMobileExpensifyVersionBumpCommit.outputs.VERSION_BUMP_SHA }}
-
-          # After being CP'd to staging, the version bump will have a new SHA
-          echo "VERSION_BUMP_SHA=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
-
           git push origin staging
+
+          # After being CP'd to staging, the version bump will have a new SHA. We'll need this to update the App submodule
+          echo "VERSION_BUMP_SHA=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
       - name: Cherry-pick the version-bump to staging
         run: |

--- a/.github/workflows/cherryPick.yml
+++ b/.github/workflows/cherryPick.yml
@@ -40,10 +40,27 @@ jobs:
           SEMVER_LEVEL: "PATCH"
 
       - name: Fetch history of relevant refs
-        run: git fetch origin main staging --no-tags --shallow-exclude ${{ steps.getPreviousVersion.outputs.PREVIOUS_VERSION }}
+        run: |
+          git fetch origin main staging --no-tags --shallow-exclude ${{ steps.getPreviousVersion.outputs.PREVIOUS_VERSION }}
+          cd Mobile-Expensify
+          git fetch origin main staging --no-tags --shallow-exclude ${{ steps.getPreviousVersion.outputs.PREVIOUS_VERSION }}
 
       - name: Get version bump commit
         id: getVersionBumpCommit
+        run: |
+          git switch main
+          VERSION_BUMP_COMMIT="$(git log --format='%H' --author='OSBotify' --grep 'Update version to ${{ needs.createNewVersion.outputs.NEW_VERSION }}')"
+          if [ -z "$VERSION_BUMP_COMMIT" ]; then
+            echo "::error::❌ Could not find version bump commit for ${{ needs.createNewVersion.outputs.NEW_VERSION }}"
+            git log --oneline
+          else
+            echo "::notice::👀 Found version bump commit $VERSION_BUMP_COMMIT"
+          fi
+          echo "VERSION_BUMP_SHA=$VERSION_BUMP_COMMIT" >> "$GITHUB_OUTPUT"
+
+      - name: Get Mobile-Expensify version bump commit
+        id: getMobileExpensifyVersionBumpCommit
+        working-directory: Mobile-Expensify
         run: |
           git switch main
           VERSION_BUMP_COMMIT="$(git log --format='%H' --author='OSBotify' --grep 'Update version to ${{ needs.createNewVersion.outputs.NEW_VERSION }}')"
@@ -63,10 +80,28 @@ jobs:
           USER: ${{ github.actor }}
           PULL_REQUEST_NUMBER: ${{ github.event.inputs.PULL_REQUEST_NUMBER }}
 
+      - name: Cherry-pick the Mobile-Expensify version bump to Mobile-Expensify staging
+        working-directory: Mobile-Expensify
+        id: cherryPickMobileExpensifyVersionBump
+        run: |
+          git switch staging
+          git cherry-pick -S -x --mainline 1 --strategy=recursive -Xtheirs ${{ steps.getMobileExpensifyVersionBumpCommit.outputs.VERSION_BUMP_SHA }}
+
+          # After being CP'd to staging, the version bump will have a new SHA
+          echo "VERSION_BUMP_SHA=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
       - name: Cherry-pick the version-bump to staging
         run: |
           git switch staging
           git cherry-pick -S -x --mainline 1 --strategy=recursive -Xtheirs ${{ steps.getVersionBumpCommit.outputs.VERSION_BUMP_SHA }}
+
+      - name: Update the Mobile-Expensify submodule on E/App staging
+        run: |
+          cd Mobile-Expensify
+          git checkout ${{ steps.cherryPickMobileExpensifyVersionBump.outputs.VERSION_BUMP_SHA }}
+          cd ..
+          git add Mobile-Expensify
+          git commit -m "Update Mobile-Expensify submodule version to ${{ needs.createNewVersion.outputs.NEW_VERSION }}"
 
       - name: Cherry-pick the merge commit of target PR
         id: cherryPick

--- a/.github/workflows/cherryPick.yml
+++ b/.github/workflows/cherryPick.yml
@@ -87,7 +87,6 @@ jobs:
 
       - name: Cherry-pick the Mobile-Expensify version bump to Mobile-Expensify staging
         working-directory: Mobile-Expensify
-        id: cherryPickMobileExpensifyVersionBump
         run: |
           git switch staging
           git cherry-pick -S -x --mainline 1 --strategy=recursive -Xtheirs ${{ steps.getMobileExpensifyVersionBumpCommit.outputs.VERSION_BUMP_SHA }}

--- a/.github/workflows/cherryPick.yml
+++ b/.github/workflows/cherryPick.yml
@@ -24,6 +24,11 @@ jobs:
           token: ${{ secrets.OS_BOTIFY_TOKEN }}
           submodules: true
 
+      # This command is necessary to fetch any branch other than main in the submodule.
+      # See https://github.com/actions/checkout/issues/1815#issuecomment-2777836442 for further context.
+      - name: Enable branch-switching in submodules
+        run: git submodule foreach 'git config remote.origin.fetch "+refs/heads/*:refs/remotes/origin/*"'
+
       - name: Set up git for OSBotify
         id: setupGitForOSBotify
         uses: Expensify/GitHub-Actions/setupGitForOSBotify@main

--- a/.github/workflows/cherryPick.yml
+++ b/.github/workflows/cherryPick.yml
@@ -90,6 +90,8 @@ jobs:
           # After being CP'd to staging, the version bump will have a new SHA
           echo "VERSION_BUMP_SHA=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
+          git push origin staging
+
       - name: Cherry-pick the version-bump to staging
         run: |
           git switch staging

--- a/.github/workflows/createNewVersion.yml
+++ b/.github/workflows/createNewVersion.yml
@@ -120,8 +120,8 @@ jobs:
           NEW_VERSION: ${{ steps.bumpVersion.outputs.NEW_VERSION }}
 
       - name: Commit new Mobile-Expensify version
+        working-directory: Mobile-Expensify
         run: |
-          cd Mobile-Expensify
           git add \
             ./Android/AndroidManifest.xml \
             ./app/config/config.json \

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,6 +23,7 @@ jobs:
         uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608
         with:
           token: ${{ secrets.OS_BOTIFY_TOKEN }}
+          submodules: true
 
       - name: Validate actor
         id: validateActor
@@ -46,6 +47,9 @@ jobs:
       - name: Create and push tag
         if: ${{ github.ref == 'refs/heads/staging' }}
         run: |
+          git tag ${{ steps.getAppVersion.outputs.VERSION }}
+          git push origin --tags
+          cd Mobile-Expensify
           git tag ${{ steps.getAppVersion.outputs.VERSION }}
           git push origin --tags
 


### PR DESCRIPTION
### Explanation of Change
When CP'ing E/App PRs to staging, we create a new version in both E/App main and Mobile-Expensify main and update the Mobile-Expensify submodule in E/App main to contain the new version.

Then, we must cherry-pick the version bump to staging. However, we currently only cherry-pick the E/App version bump, and not the Mobile-Expensify version bump. This is the problem fixed by this PR.

To accomplish that, we:

1. Checkout the Mobile-Expensify submodule
1. Fetch history in the Mobile-Expensify submodule using the same commands as E/App
1. Find the version bump commit in Mobile-Expensify using the same commands as E/App.
1. Cherry-pick the Mobile-Expensify version bump from Mobile-Expensify main to Mobile-Expensify staging. Push that cherry-picked commit to Mobile-Expensify staging
1. CP the E/App version bump from main to staging as we do today - no changes there
1. Update the Mobile-Expensify submodule in E/App staging to point at the updated version of Mobile-Expensify staging, including the version bump.
1. Proceed with the CP as usual.

### Fixed Issues
$ https://expensify.slack.com/archives/C03V9A4TB/p1743718938055549
also related to https://github.com/Expensify/App/issues/58775. and https://github.com/Expensify/App/issues/58777

### Tests
I have not tested this in App-Test-Fork.

- [x] Verify that no errors appear in the JS console

### Offline tests
None.

### QA Steps
None.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Desktop</summary>

<!-- add screenshots or videos here -->

</details>
