### PR TITLE
[CP Staging] Revert "Fix no gbr/rbr shown when reopen the app"

### DIFF
--- a/src/components/Navigation/BottomTabBar/index.tsx
+++ b/src/components/Navigation/BottomTabBar/index.tsx
@@ -49,7 +49,6 @@ function BottomTabBar({selectedTab, isTooltipAllowed = false}: BottomTabBarProps
     const {orderedReportIDs} = useReportIDs();
     const [user] = useOnyx(ONYXKEYS.USER);
     const [reportActions] = useOnyx(ONYXKEYS.COLLECTION.REPORT_ACTIONS);
-    const [reports = []] = useOnyx(ONYXKEYS.COLLECTION.REPORT, {selector: (values) => orderedReportIDs.map((reportID) => values?.[`${ONYXKEYS.COLLECTION.REPORT}${reportID}`])});
     const {shouldUseNarrowLayout} = useResponsiveLayout();
     const [chatTabBrickRoad, setChatTabBrickRoad] = useState<BrickRoad>(undefined);
     const platform = getPlatform();
@@ -59,10 +58,10 @@ function BottomTabBar({selectedTab, isTooltipAllowed = false}: BottomTabBarProps
         isTooltipAllowed && selectedTab !== BOTTOM_TABS.HOME,
     );
     useEffect(() => {
-        setChatTabBrickRoad(getChatTabBrickRoad(activeWorkspaceID, reports));
+        setChatTabBrickRoad(getChatTabBrickRoad(activeWorkspaceID, orderedReportIDs));
         // We need to get a new brick road state when report actions are updated, otherwise we'll be showing an outdated brick road.
         // That's why reportActions is added as a dependency here
-    }, [activeWorkspaceID, reports, reportActions]);
+    }, [activeWorkspaceID, orderedReportIDs, reportActions]);
 
     const navigateToChats = useCallback(() => {
         if (selectedTab === BOTTOM_TABS.HOME) {

--- a/src/components/Navigation/DebugTabView.tsx
+++ b/src/components/Navigation/DebugTabView.tsx
@@ -107,7 +107,6 @@ function DebugTabView({selectedTab, chatTabBrickRoad, activeWorkspaceID}: DebugT
     const [reimbursementAccount] = useOnyx(ONYXKEYS.REIMBURSEMENT_ACCOUNT);
     const {status, indicatorColor, policyIDWithErrors} = useIndicatorStatus();
     const {orderedReportIDs} = useReportIDs();
-    const [reports = []] = useOnyx(ONYXKEYS.COLLECTION.REPORT, {selector: (values) => orderedReportIDs.map((reportID) => values?.[`${ONYXKEYS.COLLECTION.REPORT}${reportID}`])});
 
     const message = useMemo((): TranslationPaths | undefined => {
         if (selectedTab === BOTTOM_TABS.HOME) {
@@ -141,7 +140,7 @@ function DebugTabView({selectedTab, chatTabBrickRoad, activeWorkspaceID}: DebugT
 
     const navigateTo = useCallback(() => {
         if (selectedTab === BOTTOM_TABS.HOME && !!chatTabBrickRoad) {
-            const report = getChatTabBrickRoadReport(activeWorkspaceID, reports);
+            const report = getChatTabBrickRoadReport(activeWorkspaceID, orderedReportIDs);
 
             if (report) {
                 Navigation.navigate(ROUTES.DEBUG_REPORT.getRoute(report.reportID));
@@ -154,7 +153,7 @@ function DebugTabView({selectedTab, chatTabBrickRoad, activeWorkspaceID}: DebugT
                 Navigation.navigate(route);
             }
         }
-    }, [selectedTab, chatTabBrickRoad, activeWorkspaceID, reports, status, reimbursementAccount, policyIDWithErrors]);
+    }, [selectedTab, chatTabBrickRoad, activeWorkspaceID, orderedReportIDs, status, reimbursementAccount, policyIDWithErrors]);
 
     if (!([BOTTOM_TABS.HOME, BOTTOM_TABS.SETTINGS] as string[]).includes(selectedTab ?? '') || !indicator) {
         return null;

--- a/src/libs/WorkspacesSettingsUtils.ts
+++ b/src/libs/WorkspacesSettingsUtils.ts
@@ -137,13 +137,14 @@ function hasWorkspaceSettingsRBR(policy: Policy) {
     );
 }
 
-function getChatTabBrickRoadReport(policyID: string | undefined, orderedReports: Array<OnyxEntry<Report>> = []): OnyxEntry<Report> {
-    if (!orderedReports.length) {
+function getChatTabBrickRoadReport(policyID: string | undefined, orderedReportIDs: string[] = []): OnyxEntry<Report> {
+    if (!orderedReportIDs.length) {
         return undefined;
     }
 
+    const allReports = orderedReportIDs.map((reportID) => reportsCollection?.[`${ONYXKEYS.COLLECTION.REPORT}${reportID}`]);
     // If policyID is undefined, then all reports are checked whether they contain any brick road
-    const policyReports = policyID ? orderedReports.filter((report) => report?.policyID === policyID) : orderedReports;
+    const policyReports = policyID ? Object.values(allReports).filter((report) => report?.policyID === policyID) : Object.values(allReports);
 
     let reportWithGBR: OnyxEntry<Report>;
 
@@ -167,8 +168,8 @@ function getChatTabBrickRoadReport(policyID: string | undefined, orderedReports:
     return undefined;
 }
 
-function getChatTabBrickRoad(policyID: string | undefined, orderedReports: Array<OnyxEntry<Report>>): BrickRoad | undefined {
-    const report = getChatTabBrickRoadReport(policyID, orderedReports);
+function getChatTabBrickRoad(policyID: string | undefined, orderedReportIDs: string[]): BrickRoad | undefined {
+    const report = getChatTabBrickRoadReport(policyID, orderedReportIDs);
     return report ? getBrickRoadForPolicy(report) : undefined;
 }
 


### PR DESCRIPTION
Reverts Expensify/App#58652

Straight revert for performance reasons - this is causing iteration over the entire Reports collection that in case of heavy users can be 10k+ reports and slows down the entire app https://expensify.slack.com/archives/C05LX9D6E07/p1744125477572759?thread_ts=1743598259.881369&cid=C05LX9D6E07