### PR TITLE
Fix error modal sometimes when desktop tries to update in background

### DIFF
--- a/desktop/main.ts
+++ b/desktop/main.ts
@@ -128,6 +128,7 @@ process.argv.forEach((arg) => {
 let hasUpdate = false;
 let downloadedVersion: string;
 let isSilentUpdating = false;
+let isUpdateInProgress = false;
 
 // Note that we have to subscribe to this separately and cannot use translateLocal,
 // because the only way code can be shared between the main and renderer processes at runtime is via the context bridge
@@ -137,55 +138,103 @@ const preferredLocale: Locale = CONST.LOCALES.DEFAULT;
 const appProtocol = CONST.DEEPLINK_BASE_URL.replace('://', '');
 
 const quitAndInstallWithUpdate = () => {
+    console.debug('[dev] Attempting to quit and install update');
     if (!downloadedVersion) {
+        console.debug('[dev] No downloaded version available, skipping quit and install');
         return;
     }
+    console.debug(`[dev] Setting hasUpdate flag and installing version: ${downloadedVersion}`);
     hasUpdate = true;
     autoUpdater.quitAndInstall();
 };
 
 const verifyAndInstallLatestVersion = (browserWindow: BrowserWindow): void => {
+    console.debug('[dev] Starting verifyAndInstallLatestVersion process');
+
     if (!browserWindow || browserWindow.isDestroyed()) {
+        console.debug('[dev] Browser window is invalid or destroyed, skipping update check');
         return;
     }
+
+    // Prevent multiple simultaneous updates
+    if (isUpdateInProgress) {
+        console.debug('[dev] Update already in progress, skipping new update check');
+        return;
+    }
+
+    console.debug('[dev] Setting isUpdateInProgress flag and starting update check');
+    isUpdateInProgress = true;
 
     autoUpdater
         .checkForUpdates()
         .then((result) => {
+            console.debug('[dev] Update check completed', result?.updateInfo);
+
+            if (!browserWindow || browserWindow.isDestroyed()) {
+                console.debug('[dev] Browser window became invalid during update check, aborting');
+                isUpdateInProgress = false;
+                return;
+            }
+
             if (result?.updateInfo.version === downloadedVersion) {
+                console.debug(`[dev] Found matching version ${downloadedVersion}, proceeding with installation`);
                 return quitAndInstallWithUpdate();
             }
 
+            console.debug('[dev] New version found, starting download');
             return autoUpdater.downloadUpdate().then(() => {
+                console.debug('[dev] Download completed, proceeding with installation');
                 return quitAndInstallWithUpdate();
             });
         })
         .catch((error) => {
+            console.debug('[dev] Error during update check or download:', error);
             log.error('Error during update check or download:', error);
+        })
+        .finally(() => {
+            console.debug('[dev] Update process completed, resetting isUpdateInProgress flag');
+            isUpdateInProgress = false;
         });
 };
 
 /** Menu Item callback to trigger an update check */
 const manuallyCheckForUpdates = (menuItem?: MenuItem, browserWindow?: BaseWindow) => {
+    console.debug('[dev] Starting manual update check process');
+
+    // Prevent multiple simultaneous updates
+    if (isUpdateInProgress) {
+        console.debug('[dev] Update already in progress, skipping manual update check');
+        return;
+    }
+
     if (menuItem) {
+        console.debug('[dev] Disabling menu item during update check');
         // Disable item until the check (and download) is complete
         // eslint-disable-next-line no-param-reassign -- menu item flags like enabled or visible can be dynamically toggled by mutating the object
         menuItem.enabled = false;
     }
+
+    console.debug('[dev] Setting isUpdateInProgress flag and starting manual update check');
+    isUpdateInProgress = true;
+
     autoUpdater
         .checkForUpdates()
         .catch((error: unknown) => {
+            console.debug('[dev] Error during manual update check:', error);
             isSilentUpdating = false;
             return {error};
         })
         .then((result) => {
+            console.debug('[dev] Manual update check completed', result);
             const downloadPromise = result && 'downloadPromise' in result ? result.downloadPromise : undefined;
 
             if (!browserWindow) {
+                console.debug('[dev] No browser window available, skipping update dialogs');
                 return;
             }
 
             if (downloadPromise) {
+                console.debug('[dev] Update available, showing info dialog');
                 dialog.showMessageBox(browserWindow, {
                     type: 'info',
                     message: translate(preferredLocale, 'checkForUpdatesModal.available.title'),
@@ -193,6 +242,7 @@ const manuallyCheckForUpdates = (menuItem?: MenuItem, browserWindow?: BaseWindow
                     buttons: [translate(preferredLocale, 'checkForUpdatesModal.available.soundsGood')],
                 });
             } else if (result && 'error' in result && result.error) {
+                console.debug('[dev] Update check failed, showing error dialog');
                 dialog.showMessageBox(browserWindow, {
                     type: 'error',
                     message: translate(preferredLocale, 'checkForUpdatesModal.error.title'),
@@ -200,6 +250,7 @@ const manuallyCheckForUpdates = (menuItem?: MenuItem, browserWindow?: BaseWindow
                     buttons: [translate(preferredLocale, 'checkForUpdatesModal.notAvailable.okay')],
                 });
             } else {
+                console.debug('[dev] No update available, showing info dialog');
                 dialog.showMessageBox(browserWindow, {
                     type: 'info',
                     message: translate(preferredLocale, 'checkForUpdatesModal.notAvailable.title'),
@@ -213,10 +264,13 @@ const manuallyCheckForUpdates = (menuItem?: MenuItem, browserWindow?: BaseWindow
             return downloadPromise;
         })
         .finally(() => {
+            console.debug('[dev] Manual update check completed, resetting flags');
             isSilentUpdating = false;
+            isUpdateInProgress = false;
             if (!menuItem) {
                 return;
             }
+            console.debug('[dev] Re-enabling menu item');
             // eslint-disable-next-line no-param-reassign
             menuItem.enabled = true;
         });
@@ -632,11 +686,21 @@ const mainWindow = (): Promise<void> => {
                 });
 
                 app.on('before-quit', () => {
+                    console.debug('[dev] Application is preparing to quit');
                     // Adding __DEV__ check because we want links to be handled by dev app only while it's running
                     // https://github.com/Expensify/App/issues/15965#issuecomment-1483182952
                     if (__DEV__) {
+                        console.debug('[dev] Removing protocol client in dev mode');
                         app.removeAsDefaultProtocolClient(appProtocol);
                     }
+
+                    // Clean up update listeners and reset flags
+                    console.debug('[dev] Cleaning up update listeners and resetting flags');
+                    autoUpdater.removeAllListeners();
+                    isUpdateInProgress = false;
+                    isSilentUpdating = false;
+
+                    console.debug('[dev] Setting quitting flag to true');
                     quitting = true;
                 });
                 app.on('activate', () => {

--- a/desktop/main.ts
+++ b/desktop/main.ts
@@ -144,7 +144,11 @@ const quitAndInstallWithUpdate = () => {
     autoUpdater.quitAndInstall();
 };
 
-const verifyAndInstallLatestVersion = (): void => {
+const verifyAndInstallLatestVersion = (browserWindow: BrowserWindow): void => {
+    if (!browserWindow || browserWindow.isDestroyed()) {
+        return;
+    }
+
     autoUpdater
         .checkForUpdates()
         .then((result) => {
@@ -245,12 +249,12 @@ const electronUpdater = (browserWindow: BrowserWindow): PlatformSpecificUpdater 
             if (browserWindow.isVisible() && !isSilentUpdating) {
                 browserWindow.webContents.send(ELECTRON_EVENTS.UPDATE_DOWNLOADED, info.version);
             } else {
-                verifyAndInstallLatestVersion();
+                verifyAndInstallLatestVersion(browserWindow);
             }
         });
 
         ipcMain.on(ELECTRON_EVENTS.START_UPDATE, () => {
-            verifyAndInstallLatestVersion();
+            verifyAndInstallLatestVersion(browserWindow);
         });
         autoUpdater.checkForUpdates();
     },
@@ -398,7 +402,7 @@ const mainWindow = (): Promise<void> => {
                             {
                                 id: 'update',
                                 label: translate(preferredLocale, `desktopApplicationMenu.update`),
-                                click: verifyAndInstallLatestVersion,
+                                click: () => verifyAndInstallLatestVersion(browserWindow),
                                 visible: false,
                             },
                             {id: 'checkForUpdates', label: translate(preferredLocale, `desktopApplicationMenu.checkForUpdates`), click: manuallyCheckForUpdates},


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
<!-- Explain what your change does and how it addresses the linked issue -->
The core idea is simple: prevent multiple update processes from running at the same time by adding an `isUpdateInProgress` flag. When an update starts, we check and set this flag. When it finishes or fails, we reset it. This prevents race conditions that were likely causing the "Object has been destroyed" error, and we clean up all update listeners when the app quits.


### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/60108
PROPOSAL: N/A


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

- [x] Verify that no errors appear in the JS console

This PR can be tested only in staging or production.

**Precondition:** Be on an older version of the desktop app. (_v9.0.75-0 for example, when v9.0.75-1 is out_)

1. Login and you should get the ‘A new version is ready’ - if you don’t, check for updates to start the download.
2. Ignore the update until another, newer version is ready (_v9.0.75-2 in our example_).
3. Update the app.
4. Verify that it has been updated to the newest available version.
5. Additionally, you can verify logs in `~/Library/Logs/new.expensify.desktop/main.log`.

**Important:** Desktop users should not see an error modal with their desktop app seemingly failing to update in the background.

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

Same as tests.

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->
// TODO: These must be filled out, or the issue title must include "[No QA]."

- [x] Verify that no errors appear in the JS console
- [ ] 
Same as tests.

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Desktop</summary>

<!-- add screenshots or videos here -->

</details>
