### PR TITLE
Fix Take a tour of Expensify is not dynamic in the modal

### DIFF
--- a/src/languages/en.ts
+++ b/src/languages/en.ts
@@ -5103,11 +5103,13 @@ const translations = {
             },
             emptyExpenseResults: {
                 title: "You haven't created any expenses yet",
-                subtitle: 'Use the green button below to create an expense or take a tour of Expensify to learn more.',
+                subtitle: 'Create an expense or take a tour of Expensify to learn more.',
+                subtitleWithOnlyCreateButton: 'Use the green button below to create an expense.',
             },
             emptyInvoiceResults: {
                 title: "You haven't created any \ninvoices yet",
-                subtitle: 'Use the green button below to send an invoice or take a tour of Expensify to learn more.',
+                subtitle: 'Send an invoice or take a tour of Expensify to learn more.',
+                subtitleWithOnlyCreateButton: 'Use the green button below to send an invoice.',
             },
             emptyTripResults: {
                 title: 'No trips to display',

--- a/src/languages/es.ts
+++ b/src/languages/es.ts
@@ -5156,11 +5156,13 @@ const translations = {
             },
             emptyExpenseResults: {
                 title: 'Aún no has creado ningún gasto',
-                subtitle: 'Usa el botón verde de abajo para crear un gasto o haz un tour por Expensify para aprender más.',
+                subtitle: 'Crea un gasto o haz un tour por Expensify para aprender más.',
+                subtitleWithOnlyCreateButton: 'Usa el botón verde de abajo para crear un gasto.',
             },
             emptyInvoiceResults: {
                 title: 'Aún no has creado \nninguna factura',
-                subtitle: 'Usa el botón verde de abajo para crear una factura o haz un tour por Expensify para aprender más.',
+                subtitle: 'Envía una factura o haz un tour por Expensify para aprender más.',
+                subtitleWithOnlyCreateButton: 'Usa el botón verde de abajo para enviar una factura.',
             },
             emptyTripResults: {
                 title: 'No tienes viajes',

--- a/src/pages/Search/EmptySearchView.tsx
+++ b/src/pages/Search/EmptySearchView.tsx
@@ -129,10 +129,7 @@ function EmptySearchView({type, hasResults}: EmptySearchViewProps) {
                     return {
                         headerMedia: LottieAnimations.GenericEmptyState,
                         title: translate('search.searchResults.emptyExpenseResults.title'),
-                        subtitle: translate(hasSeenTour
-                            ? 'search.searchResults.emptyExpenseResults.subtitleWithOnlyCreateButton'
-                            : 'search.searchResults.emptyExpenseResults.subtitle'
-                        ),
+                        subtitle: translate(hasSeenTour ? 'search.searchResults.emptyExpenseResults.subtitleWithOnlyCreateButton' : 'search.searchResults.emptyExpenseResults.subtitle'),
                         buttons: [
                             ...(!hasSeenTour
                                 ? [
@@ -172,10 +169,7 @@ function EmptySearchView({type, hasResults}: EmptySearchViewProps) {
                     return {
                         headerMedia: LottieAnimations.GenericEmptyState,
                         title: translate('search.searchResults.emptyInvoiceResults.title'),
-                        subtitle: translate(hasSeenTour
-                            ? 'search.searchResults.emptyInvoiceResults.subtitleWithOnlyCreateButton'
-                            : 'search.searchResults.emptyInvoiceResults.subtitle'
-                        ),
+                        subtitle: translate(hasSeenTour ? 'search.searchResults.emptyInvoiceResults.subtitleWithOnlyCreateButton' : 'search.searchResults.emptyInvoiceResults.subtitle'),
                         buttons: [
                             ...(!hasSeenTour
                                 ? [

--- a/src/pages/Search/EmptySearchView.tsx
+++ b/src/pages/Search/EmptySearchView.tsx
@@ -129,7 +129,10 @@ function EmptySearchView({type, hasResults}: EmptySearchViewProps) {
                     return {
                         headerMedia: LottieAnimations.GenericEmptyState,
                         title: translate('search.searchResults.emptyExpenseResults.title'),
-                        subtitle: translate('search.searchResults.emptyExpenseResults.subtitle'),
+                        subtitle: translate(hasSeenTour
+                            ? 'search.searchResults.emptyExpenseResults.subtitleWithOnlyCreateButton'
+                            : 'search.searchResults.emptyExpenseResults.subtitle'
+                        ),
                         buttons: [
                             ...(!hasSeenTour
                                 ? [
@@ -169,7 +172,10 @@ function EmptySearchView({type, hasResults}: EmptySearchViewProps) {
                     return {
                         headerMedia: LottieAnimations.GenericEmptyState,
                         title: translate('search.searchResults.emptyInvoiceResults.title'),
-                        subtitle: translate('search.searchResults.emptyInvoiceResults.subtitle'),
+                        subtitle: translate(hasSeenTour
+                            ? 'search.searchResults.emptyInvoiceResults.subtitle'
+                            : 'search.searchResults.emptyInvoiceResults.subtitleWithOnlyCreateButton'
+                        ),
                         buttons: [
                             ...(!hasSeenTour
                                 ? [

--- a/src/pages/Search/EmptySearchView.tsx
+++ b/src/pages/Search/EmptySearchView.tsx
@@ -173,8 +173,8 @@ function EmptySearchView({type, hasResults}: EmptySearchViewProps) {
                         headerMedia: LottieAnimations.GenericEmptyState,
                         title: translate('search.searchResults.emptyInvoiceResults.title'),
                         subtitle: translate(hasSeenTour
-                            ? 'search.searchResults.emptyInvoiceResults.subtitle'
-                            : 'search.searchResults.emptyInvoiceResults.subtitleWithOnlyCreateButton'
+                            ? 'search.searchResults.emptyInvoiceResults.subtitleWithOnlyCreateButton'
+                            : 'search.searchResults.emptyInvoiceResults.subtitle'
                         ),
                         buttons: [
                             ...(!hasSeenTour

--- a/tests/ui/components/EmptySearchViewTest.tsx
+++ b/tests/ui/components/EmptySearchViewTest.tsx
@@ -1,8 +1,8 @@
 import {render, screen} from '@testing-library/react-native';
 import React from 'react';
 import Onyx from 'react-native-onyx';
-import OnyxProvider from '@components/OnyxProvider';
 import {LocaleContextProvider} from '@components/LocaleContextProvider';
+import OnyxProvider from '@components/OnyxProvider';
 import EmptySearchView from '@pages/Search/EmptySearchView';
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
@@ -13,9 +13,7 @@ jest.mock('@components/ConfirmedRoute.tsx');
 function Wrapper({children}: {children: React.ReactNode}) {
     return (
         <OnyxProvider>
-            <LocaleContextProvider>
-                {children}
-            </LocaleContextProvider>
+            <LocaleContextProvider>{children}</LocaleContextProvider>
         </OnyxProvider>
     );
 }
@@ -35,40 +33,39 @@ describe('EmptySearchView', () => {
         it('should display correct buttons and subtitle when user has not clicked on "Take a tour"', async () => {
             // Given user hasn't clicked on "Take a tour" yet
             await Onyx.merge(ONYXKEYS.NVP_ONBOARDING, {selfTourViewed: false});
-    
+
             // Render component
             render(
                 <Wrapper>
-                    <EmptySearchView 
-                        type={dataType} 
-                        hasResults={false} 
+                    <EmptySearchView
+                        type={dataType}
+                        hasResults={false}
                     />
-                </Wrapper>
+                </Wrapper>,
             );
-    
+
             // Then it should display create expenses and take a tour buttons
             expect(await screen.findByText('Create expense')).toBeVisible();
             expect(await screen.findByText('Take a tour')).toBeVisible();
 
             // And correct modal subtitle
             expect(screen.getByText('Create an expense or take a tour of Expensify to learn more.')).toBeVisible();
-
         });
-    
+
         it('should display correct buttons and subtitle when user already did "Take a tour"', async () => {
             // Given user clicked on "Take a tour"
             await Onyx.merge(ONYXKEYS.NVP_ONBOARDING, {selfTourViewed: true});
-    
+
             // Render component
             render(
                 <Wrapper>
-                    <EmptySearchView 
-                        type={dataType} 
-                        hasResults={false} 
+                    <EmptySearchView
+                        type={dataType}
+                        hasResults={false}
                     />
-                </Wrapper>
+                </Wrapper>,
             );
-    
+
             // Then it should display create expenses button
             expect(await screen.findByText('Create expense')).toBeVisible();
             expect(screen.queryByText('Take a tour')).not.toBeOnTheScreen();
@@ -76,7 +73,7 @@ describe('EmptySearchView', () => {
             // And correct modal subtitle
             expect(screen.getByText('Use the green button below to create an expense.')).toBeVisible();
         });
-    })
+    });
 
     describe('type is Invoice', () => {
         const dataType = CONST.SEARCH.DATA_TYPES.INVOICE;
@@ -84,40 +81,39 @@ describe('EmptySearchView', () => {
         it('should display correct buttons and subtitle when user has not clicked on "Take a tour"', async () => {
             // Given user hasn't clicked on "Take a tour" yet
             await Onyx.merge(ONYXKEYS.NVP_ONBOARDING, {selfTourViewed: false});
-    
+
             // Render component
             render(
                 <Wrapper>
-                    <EmptySearchView 
-                        type={dataType} 
-                        hasResults={false} 
+                    <EmptySearchView
+                        type={dataType}
+                        hasResults={false}
                     />
-                </Wrapper>
+                </Wrapper>,
             );
-    
+
             // Then it should display send invoice and take a tour buttons
             expect(await screen.findByText('Send invoice')).toBeVisible();
             expect(await screen.findByText('Take a tour')).toBeVisible();
 
             // And correct modal subtitle
             expect(screen.getByText('Send an invoice or take a tour of Expensify to learn more.')).toBeVisible();
-
         });
-    
+
         it('should display correct buttons and subtitle when user already did "Take a tour"', async () => {
             // Given user clicked on "Take a tour"
             await Onyx.merge(ONYXKEYS.NVP_ONBOARDING, {selfTourViewed: true});
-    
+
             // Render component
             render(
                 <Wrapper>
-                    <EmptySearchView 
-                        type={dataType} 
-                        hasResults={false} 
+                    <EmptySearchView
+                        type={dataType}
+                        hasResults={false}
                     />
-                </Wrapper>
+                </Wrapper>,
             );
-    
+
             // Then it should display Send invoice button
             expect(await screen.findByText('Send invoice')).toBeVisible();
             expect(screen.queryByText('Take a tour')).not.toBeOnTheScreen();
@@ -125,5 +121,5 @@ describe('EmptySearchView', () => {
             // And correct modal subtitle
             expect(screen.getByText('Use the green button below to send an invoice.')).toBeVisible();
         });
-    })
+    });
 });

--- a/tests/ui/components/EmptySearchViewTest.tsx
+++ b/tests/ui/components/EmptySearchViewTest.tsx
@@ -1,0 +1,129 @@
+import {render, screen} from '@testing-library/react-native';
+import React from 'react';
+import Onyx from 'react-native-onyx';
+import OnyxProvider from '@components/OnyxProvider';
+import {LocaleContextProvider} from '@components/LocaleContextProvider';
+import EmptySearchView from '@pages/Search/EmptySearchView';
+import CONST from '@src/CONST';
+import ONYXKEYS from '@src/ONYXKEYS';
+
+jest.mock('@components/ConfirmedRoute.tsx');
+
+// Wrapper component with OnyxProvider
+function Wrapper({children}: {children: React.ReactNode}) {
+    return (
+        <OnyxProvider>
+            <LocaleContextProvider>
+                {children}
+            </LocaleContextProvider>
+        </OnyxProvider>
+    );
+}
+
+describe('EmptySearchView', () => {
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    beforeAll(() => {
+        Onyx.init({keys: ONYXKEYS});
+    });
+
+    describe('type is Expense', () => {
+        const dataType = CONST.SEARCH.DATA_TYPES.EXPENSE;
+
+        it('should display correct buttons and subtitle when user has not clicked on "Take a tour"', async () => {
+            // Given user hasn't clicked on "Take a tour" yet
+            await Onyx.merge(ONYXKEYS.NVP_ONBOARDING, {selfTourViewed: false});
+    
+            // Render component
+            render(
+                <Wrapper>
+                    <EmptySearchView 
+                        type={dataType} 
+                        hasResults={false} 
+                    />
+                </Wrapper>
+            );
+    
+            // Then it should display create expenses and take a tour buttons
+            expect(await screen.findByText('Create expense')).toBeVisible();
+            expect(await screen.findByText('Take a tour')).toBeVisible();
+
+            // And correct modal subtitle
+            expect(screen.getByText('Create an expense or take a tour of Expensify to learn more.')).toBeVisible();
+
+        });
+    
+        it('should display correct buttons and subtitle when user already did "Take a tour"', async () => {
+            // Given user clicked on "Take a tour"
+            await Onyx.merge(ONYXKEYS.NVP_ONBOARDING, {selfTourViewed: true});
+    
+            // Render component
+            render(
+                <Wrapper>
+                    <EmptySearchView 
+                        type={dataType} 
+                        hasResults={false} 
+                    />
+                </Wrapper>
+            );
+    
+            // Then it should display create expenses button
+            expect(await screen.findByText('Create expense')).toBeVisible();
+            expect(screen.queryByText('Take a tour')).not.toBeOnTheScreen();
+
+            // And correct modal subtitle
+            expect(screen.getByText('Use the green button below to create an expense.')).toBeVisible();
+        });
+    })
+
+    describe('type is Invoice', () => {
+        const dataType = CONST.SEARCH.DATA_TYPES.INVOICE;
+
+        it('should display correct buttons and subtitle when user has not clicked on "Take a tour"', async () => {
+            // Given user hasn't clicked on "Take a tour" yet
+            await Onyx.merge(ONYXKEYS.NVP_ONBOARDING, {selfTourViewed: false});
+    
+            // Render component
+            render(
+                <Wrapper>
+                    <EmptySearchView 
+                        type={dataType} 
+                        hasResults={false} 
+                    />
+                </Wrapper>
+            );
+    
+            // Then it should display send invoice and take a tour buttons
+            expect(await screen.findByText('Send invoice')).toBeVisible();
+            expect(await screen.findByText('Take a tour')).toBeVisible();
+
+            // And correct modal subtitle
+            expect(screen.getByText('Send an invoice or take a tour of Expensify to learn more.')).toBeVisible();
+
+        });
+    
+        it('should display correct buttons and subtitle when user already did "Take a tour"', async () => {
+            // Given user clicked on "Take a tour"
+            await Onyx.merge(ONYXKEYS.NVP_ONBOARDING, {selfTourViewed: true});
+    
+            // Render component
+            render(
+                <Wrapper>
+                    <EmptySearchView 
+                        type={dataType} 
+                        hasResults={false} 
+                    />
+                </Wrapper>
+            );
+    
+            // Then it should display Send invoice button
+            expect(await screen.findByText('Send invoice')).toBeVisible();
+            expect(screen.queryByText('Take a tour')).not.toBeOnTheScreen();
+
+            // And correct modal subtitle
+            expect(screen.getByText('Use the green button below to send an invoice.')).toBeVisible();
+        });
+    })
+});


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
<!-- Explain what your change does and how it addresses the linked issue -->

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/59690
PROPOSAL: https://github.com/Expensify/App/issues/59690#issuecomment-2779889727


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->
Same as QA
- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->
Same as QA
### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->
// TODO: These must be filled out, or the issue title must include "[No QA]."

Prerequisite:
- Create a new account and choose manage my expense flow

1. Sign in to above account
2. Click Reports
3. Verify it shows an empty modal with a subtitle "Create an expense or take a tour of Expensify to learn more."
4. Tap on "Take a tour" action button on the modal
5. Click Reports again
6. Verify it now shows an empty modal with a subtitle "Use the green button below to create an expense."

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message: https://expensify.slack.com/archives/C01GTK53T8Q/p1744474798485389
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/14b09780-f904-4ee8-9cdd-b7157308dbe9


</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/a528fc4d-c3e6-4046-be65-d3f61eb770c5


</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/65c4325f-e4bd-4d29-af27-cfb877299bba


</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/13e82f79-c64e-4471-b16c-a8468eebe75c


</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/56cf85be-538d-440f-9870-9c55b602c222


</details>

<details>
<summary>MacOS: Desktop</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/fed64061-0275-401c-8f83-a59fee7d60dc


</details>
