### PR TITLE
[CP Staging] fix: Edge-to-edge bottom safe area padding fixes and `NewChatSelectorPage` refactoring

### DIFF
--- a/src/components/DatePicker/CalendarPicker/YearPickerModal.tsx
+++ b/src/components/DatePicker/CalendarPicker/YearPickerModal.tsx
@@ -55,11 +55,12 @@ function YearPickerModal({isVisible, years, currentYear = new Date().getFullYear
             hideModalContentWhileAnimating
             useNativeDriver
             shouldHandleNavigationBack
+            enableEdgeToEdgeBottomSafeAreaPadding
         >
             <ScreenWrapper
                 style={[styles.pb0]}
                 includePaddingTop={false}
-                includeSafeAreaPaddingBottom
+                enableEdgeToEdgeBottomSafeAreaPadding
                 testID={YearPickerModal.displayName}
             >
                 <HeaderWithBackButton
@@ -83,6 +84,7 @@ function YearPickerModal({isVisible, years, currentYear = new Date().getFullYear
                     shouldStopPropagation
                     shouldUseDynamicMaxToRenderPerBatch
                     ListItem={RadioListItem}
+                    addBottomSafeAreaPadding
                 />
             </ScreenWrapper>
         </Modal>

--- a/src/components/ScreenWrapper.tsx
+++ b/src/components/ScreenWrapper.tsx
@@ -79,6 +79,9 @@ type ScreenWrapperProps = {
      *  Search 'switch(behavior)' in ./node_modules/react-native/Libraries/Components/Keyboard/KeyboardAvoidingView.js for more context */
     keyboardAvoidingViewBehavior?: 'padding' | 'height' | 'position';
 
+    /** The vertical offset to pass to the KeyboardAvoidingView */
+    keyboardVerticalOffset?: number;
+
     /** Whether KeyboardAvoidingView should be enabled. Use false for screens where this functionality is not necessary */
     shouldEnableKeyboardAvoidingView?: boolean;
 
@@ -152,6 +155,7 @@ function ScreenWrapper(
         shouldEnableMinHeight = false,
         includePaddingTop = true,
         keyboardAvoidingViewBehavior = 'padding',
+        keyboardVerticalOffset,
         includeSafeAreaPaddingBottom: includeSafeAreaPaddingBottomProp = true,
         shouldEnableKeyboardAvoidingView = true,
         shouldEnablePickerAvoiding = true,
@@ -438,6 +442,7 @@ function ScreenWrapper(
                         // Whether the mobile offline indicator or the content in general
                         // should be offset by the bottom safe area padding when the keyboard is open.
                         shouldOffsetBottomSafeAreaPadding={shouldKeyboardOffsetBottomSafeAreaPadding || shouldOffsetMobileOfflineIndicator}
+                        keyboardVerticalOffset={keyboardVerticalOffset}
                     >
                         <PickerAvoidingView
                             style={isAvoidingViewportScroll ? [styles.h100, {marginTop: 1}] : styles.flex1}

--- a/src/hooks/useBottomSafeSafeAreaPaddingStyle.ts
+++ b/src/hooks/useBottomSafeSafeAreaPaddingStyle.ts
@@ -17,7 +17,7 @@ type UseBottomSafeAreaPaddingStyleParams = {
     style?: StyleProp<ViewStyle>;
 
     /** The style property to use for applying the bottom safe area padding. */
-    styleProperty?: 'paddingBottom' | 'bottom';
+    styleProperty?: 'paddingBottom' | 'marginBottom' | 'bottom';
 
     /** The additional padding to add to the bottom of the content. */
     additionalPaddingBottom?: number;

--- a/src/pages/NewChatPage.tsx
+++ b/src/pages/NewChatPage.tsx
@@ -4,9 +4,6 @@ import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import {Keyboard} from 'react-native';
 import {useOnyx} from 'react-native-onyx';
 import Button from '@components/Button';
-import ImportedStateIndicator from '@components/ImportedStateIndicator';
-import KeyboardAvoidingView from '@components/KeyboardAvoidingView';
-import OfflineIndicator from '@components/OfflineIndicator';
 import {useOptionsList} from '@components/OptionListContextProvider';
 import {PressableWithFeedback} from '@components/Pressable';
 import ReferralProgramCTA from '@components/ReferralProgramCTA';
@@ -20,9 +17,7 @@ import useDebouncedState from '@hooks/useDebouncedState';
 import useDismissedReferralBanners from '@hooks/useDismissedReferralBanners';
 import useLocalize from '@hooks/useLocalize';
 import useNetwork from '@hooks/useNetwork';
-import useResponsiveLayout from '@hooks/useResponsiveLayout';
 import useSafeAreaInsets from '@hooks/useSafeAreaInsets';
-import useSafeAreaPaddings from '@hooks/useSafeAreaPaddings';
 import useScreenWrapperTranstionStatus from '@hooks/useScreenWrapperTransitionStatus';
 import useThemeStyles from '@hooks/useThemeStyles';
 import {navigateToAndOpenReport, searchInServer, setGroupDraft} from '@libs/actions/Report';
@@ -144,11 +139,9 @@ function NewChatPage() {
     const {isOffline} = useNetwork();
     // We need to use isSmallScreenWidth instead of shouldUseNarrowLayout to show offline indicator on small screen only
     // eslint-disable-next-line rulesdir/prefer-shouldUseNarrowLayout-instead-of-isSmallScreenWidth
-    const {isSmallScreenWidth} = useResponsiveLayout();
     const styles = useThemeStyles();
     const personalData = useCurrentUserPersonalDetails();
     const {top} = useSafeAreaInsets();
-    const {insets, safeAreaPaddingBottomStyle} = useSafeAreaPaddings();
     const [isSearchingForReports] = useOnyx(ONYXKEYS.IS_SEARCHING_FOR_REPORTS, {initWithStoredValues: false});
     const selectionListRef = useRef<SelectionListHandle>(null);
 
@@ -339,50 +332,35 @@ function NewChatPage() {
 
     return (
         <ScreenWrapper
-            shouldEnableKeyboardAvoidingView={false}
-            includeSafeAreaPaddingBottom
-            shouldShowOfflineIndicator={false}
+            enableEdgeToEdgeBottomSafeAreaPadding
             includePaddingTop={false}
             shouldEnablePickerAvoiding={false}
-            testID={NewChatPage.displayName}
+            keyboardVerticalOffset={variables.contentHeaderHeight + top + variables.tabSelectorButtonHeight + variables.tabSelectorButtonPadding}
             // Disable the focus trap of this page to activate the parent focus trap in `NewChatSelectorPage`.
             focusTrapSettings={{active: false}}
+            testID={NewChatPage.displayName}
         >
-            <KeyboardAvoidingView
-                style={styles.flex1}
-                behavior="padding"
-                // Offset is needed as KeyboardAvoidingView in nested inside of TabNavigator instead of wrapping whole screen.
-                // This is because when wrapping whole screen the screen was freezing when changing Tabs.
-                keyboardVerticalOffset={variables.contentHeaderHeight + top + variables.tabSelectorButtonHeight + variables.tabSelectorButtonPadding}
-            >
-                <SelectionList<Option & ListItem>
-                    ref={selectionListRef}
-                    ListItem={UserListItem}
-                    sections={areOptionsInitialized ? sections : CONST.EMPTY_ARRAY}
-                    textInputValue={searchTerm}
-                    textInputHint={isOffline ? `${translate('common.youAppearToBeOffline')} ${translate('search.resultsAreLimited')}` : ''}
-                    onChangeText={setSearchTerm}
-                    textInputLabel={translate('selectionList.nameEmailOrPhoneNumber')}
-                    headerMessage={headerMessage}
-                    onSelectRow={selectOption}
-                    shouldSingleExecuteRowSelect
-                    onConfirm={(e, option) => (selectedOptions.length > 0 ? createGroup() : selectOption(option))}
-                    rightHandSideComponent={itemRightSideComponent}
-                    footerContent={footerContent}
-                    showLoadingPlaceholder={!areOptionsInitialized}
-                    shouldPreventDefaultFocusOnSelectRow={!canUseTouchScreen()}
-                    isLoadingNewOptions={!!isSearchingForReports}
-                    initiallyFocusedOptionKey={firstKeyForList}
-                    shouldTextInputInterceptSwipe
-                    confirmButtonStyles={insets.bottom ? [safeAreaPaddingBottomStyle, styles.mb5] : undefined}
-                />
-                {isSmallScreenWidth && (
-                    <>
-                        <OfflineIndicator />
-                        <ImportedStateIndicator />
-                    </>
-                )}
-            </KeyboardAvoidingView>
+            <SelectionList<Option & ListItem>
+                ref={selectionListRef}
+                ListItem={UserListItem}
+                sections={areOptionsInitialized ? sections : CONST.EMPTY_ARRAY}
+                textInputValue={searchTerm}
+                textInputHint={isOffline ? `${translate('common.youAppearToBeOffline')} ${translate('search.resultsAreLimited')}` : ''}
+                onChangeText={setSearchTerm}
+                textInputLabel={translate('selectionList.nameEmailOrPhoneNumber')}
+                headerMessage={headerMessage}
+                onSelectRow={selectOption}
+                shouldSingleExecuteRowSelect
+                onConfirm={(e, option) => (selectedOptions.length > 0 ? createGroup() : selectOption(option))}
+                rightHandSideComponent={itemRightSideComponent}
+                footerContent={footerContent}
+                showLoadingPlaceholder={!areOptionsInitialized}
+                shouldPreventDefaultFocusOnSelectRow={!canUseTouchScreen()}
+                isLoadingNewOptions={!!isSearchingForReports}
+                initiallyFocusedOptionKey={firstKeyForList}
+                shouldTextInputInterceptSwipe
+                addBottomSafeAreaPadding
+            />
         </ScreenWrapper>
     );
 }

--- a/src/pages/NewChatSelectorPage.tsx
+++ b/src/pages/NewChatSelectorPage.tsx
@@ -41,8 +41,8 @@ function NewChatSelectorPage() {
 
     return (
         <ScreenWrapper
+            enableEdgeToEdgeBottomSafeAreaPadding
             shouldEnableKeyboardAvoidingView={false}
-            includeSafeAreaPaddingBottom={false}
             shouldShowOfflineIndicator={false}
             shouldEnableMaxHeight
             testID={NewChatSelectorPage.displayName}

--- a/src/pages/workspace/WorkspaceNewRoomPage.tsx
+++ b/src/pages/workspace/WorkspaceNewRoomPage.tsx
@@ -9,19 +9,16 @@ import FormProvider from '@components/Form/FormProvider';
 import InputWrapper from '@components/Form/InputWrapper';
 import type {FormOnyxValues} from '@components/Form/types';
 import * as Illustrations from '@components/Icon/Illustrations';
-import ImportedStateIndicator from '@components/ImportedStateIndicator';
-import KeyboardAvoidingView from '@components/KeyboardAvoidingView';
-import OfflineIndicator from '@components/OfflineIndicator';
 import RoomNameInput from '@components/RoomNameInput';
 import ScreenWrapper from '@components/ScreenWrapper';
 import TextInput from '@components/TextInput';
 import ValuePicker from '@components/ValuePicker';
 import useActiveWorkspace from '@hooks/useActiveWorkspace';
 import useAutoFocusInput from '@hooks/useAutoFocusInput';
+import useBottomSafeSafeAreaPaddingStyle from '@hooks/useBottomSafeSafeAreaPaddingStyle';
 import useLocalize from '@hooks/useLocalize';
 import useNetwork from '@hooks/useNetwork';
 import usePrevious from '@hooks/usePrevious';
-import useResponsiveLayout from '@hooks/useResponsiveLayout';
 import useSafeAreaInsets from '@hooks/useSafeAreaInsets';
 import useThemeStyles from '@hooks/useThemeStyles';
 import {addErrorMessage} from '@libs/ErrorUtils';
@@ -51,7 +48,6 @@ function WorkspaceNewRoomPage() {
     const [activePolicyID] = useOnyx(ONYXKEYS.NVP_ACTIVE_POLICY_ID);
     // We need to use isSmallScreenWidth instead of shouldUseNarrowLayout to show offline indicator on small screen only
     // eslint-disable-next-line rulesdir/prefer-shouldUseNarrowLayout-instead-of-isSmallScreenWidth
-    const {isSmallScreenWidth} = useResponsiveLayout();
     const {top} = useSafeAreaInsets();
     const [visibility, setVisibility] = useState<ValueOf<typeof CONST.REPORT.VISIBILITY>>(CONST.REPORT.VISIBILITY.RESTRICTED);
     const [writeCapability, setWriteCapability] = useState<ValueOf<typeof CONST.REPORT.WRITE_CAPABILITIES>>(CONST.REPORT.WRITE_CAPABILITIES.ALL);
@@ -214,6 +210,8 @@ function WorkspaceNewRoomPage() {
 
     const {inputCallbackRef} = useAutoFocusInput();
 
+    const bottomSafeAreaPaddingStyle = useBottomSafeSafeAreaPaddingStyle({addBottomSafeAreaPadding: true, additionalPaddingBottom: styles.mb5.marginBottom, styleProperty: 'marginBottom'});
+
     const renderEmptyWorkspaceView = () => (
         <>
             <BlockingView
@@ -230,114 +228,93 @@ function WorkspaceNewRoomPage() {
                 large
                 text={translate('footer.learnMore')}
                 onPress={() => Navigation.navigate(ROUTES.SETTINGS_WORKSPACES.route)}
-                style={[styles.mh5, styles.mb5]}
+                style={[styles.mh5, bottomSafeAreaPaddingStyle]}
             />
-            {isSmallScreenWidth && (
-                <>
-                    <OfflineIndicator />
-                    <ImportedStateIndicator />
-                </>
-            )}
         </>
     );
 
     return (
         <ScreenWrapper
-            shouldEnableKeyboardAvoidingView={false}
             enableEdgeToEdgeBottomSafeAreaPadding
-            shouldShowOfflineIndicator={false}
             includePaddingTop={false}
             shouldEnablePickerAvoiding={false}
-            testID={WorkspaceNewRoomPage.displayName}
+            shouldEnableKeyboardAvoidingView={workspaceOptions.length !== 0}
+            keyboardVerticalOffset={variables.contentHeaderHeight + variables.tabSelectorButtonHeight + variables.tabSelectorButtonPadding + top}
             // Disable the focus trap of this page to activate the parent focus trap in `NewChatSelectorPage`.
             focusTrapSettings={{active: false}}
+            testID={WorkspaceNewRoomPage.displayName}
         >
             {workspaceOptions.length === 0 ? (
                 renderEmptyWorkspaceView()
             ) : (
-                <KeyboardAvoidingView
-                    style={styles.h100}
-                    behavior="padding"
-                    // Offset is needed as KeyboardAvoidingView in nested inside of TabNavigator instead of wrapping whole screen.
-                    // This is because when wrapping whole screen the screen was freezing when changing Tabs.
-                    shouldOffsetBottomSafeAreaPadding
-                    keyboardVerticalOffset={variables.contentHeaderHeight + variables.tabSelectorButtonHeight + variables.tabSelectorButtonPadding + top}
+                <FormProvider
+                    formID={ONYXKEYS.FORMS.NEW_ROOM_FORM}
+                    submitButtonText={translate('newRoomPage.createRoom')}
+                    style={[styles.h100, styles.mh5, styles.flexGrow1]}
+                    validate={validate}
+                    onSubmit={submit}
+                    enabledWhenOffline
+                    addBottomSafeAreaPadding
                 >
-                    <FormProvider
-                        formID={ONYXKEYS.FORMS.NEW_ROOM_FORM}
-                        submitButtonText={translate('newRoomPage.createRoom')}
-                        style={[styles.mh5, styles.flexGrow1]}
-                        validate={validate}
-                        onSubmit={submit}
-                        enabledWhenOffline
-                        addBottomSafeAreaPadding
-                    >
-                        <View style={styles.mb5}>
-                            <InputWrapper
-                                InputComponent={RoomNameInput}
-                                ref={inputCallbackRef}
-                                inputID={INPUT_IDS.ROOM_NAME}
-                                isFocused={isFocused}
-                                shouldDelayFocus
-                                autoFocus
-                            />
-                        </View>
-                        <View style={styles.mb5}>
-                            <InputWrapper
-                                InputComponent={TextInput}
-                                inputID={INPUT_IDS.REPORT_DESCRIPTION}
-                                label={translate('reportDescriptionPage.roomDescriptionOptional')}
-                                accessibilityLabel={translate('reportDescriptionPage.roomDescriptionOptional')}
-                                role={CONST.ROLE.PRESENTATION}
-                                autoGrowHeight
-                                maxAutoGrowHeight={variables.textInputAutoGrowMaxHeight}
-                                autoCapitalize="none"
-                                shouldInterceptSwipe
-                                type="markdown"
-                            />
-                        </View>
-                        <View style={[styles.mhn5]}>
-                            <InputWrapper
-                                InputComponent={ValuePicker}
-                                inputID={INPUT_IDS.POLICY_ID}
-                                label={translate('workspace.common.workspace')}
-                                items={workspaceOptions}
-                                value={policyID}
-                                onValueChange={(value) => setPolicyID(value as typeof policyID)}
-                            />
-                        </View>
-                        {isAdminPolicy && (
-                            <View style={styles.mhn5}>
-                                <InputWrapper
-                                    InputComponent={ValuePicker}
-                                    inputID={INPUT_IDS.WRITE_CAPABILITY}
-                                    label={translate('writeCapabilityPage.label')}
-                                    items={writeCapabilityOptions}
-                                    value={writeCapability}
-                                    onValueChange={(value) => setWriteCapability(value as typeof writeCapability)}
-                                />
-                            </View>
-                        )}
-                        <View style={[styles.mb1, styles.mhn5]}>
+                    <View style={styles.mb5}>
+                        <InputWrapper
+                            InputComponent={RoomNameInput}
+                            ref={inputCallbackRef}
+                            inputID={INPUT_IDS.ROOM_NAME}
+                            isFocused={isFocused}
+                            shouldDelayFocus
+                            autoFocus
+                        />
+                    </View>
+                    <View style={styles.mb5}>
+                        <InputWrapper
+                            InputComponent={TextInput}
+                            inputID={INPUT_IDS.REPORT_DESCRIPTION}
+                            label={translate('reportDescriptionPage.roomDescriptionOptional')}
+                            accessibilityLabel={translate('reportDescriptionPage.roomDescriptionOptional')}
+                            role={CONST.ROLE.PRESENTATION}
+                            autoGrowHeight
+                            maxAutoGrowHeight={variables.textInputAutoGrowMaxHeight}
+                            autoCapitalize="none"
+                            shouldInterceptSwipe
+                            type="markdown"
+                        />
+                    </View>
+                    <View style={[styles.mhn5]}>
+                        <InputWrapper
+                            InputComponent={ValuePicker}
+                            inputID={INPUT_IDS.POLICY_ID}
+                            label={translate('workspace.common.workspace')}
+                            items={workspaceOptions}
+                            value={policyID}
+                            onValueChange={(value) => setPolicyID(value as typeof policyID)}
+                        />
+                    </View>
+                    {isAdminPolicy && (
+                        <View style={styles.mhn5}>
                             <InputWrapper
                                 InputComponent={ValuePicker}
-                                inputID={INPUT_IDS.VISIBILITY}
-                                label={translate('newRoomPage.visibility')}
-                                items={visibilityOptions}
-                                onValueChange={(value) => setVisibility(value as typeof visibility)}
-                                value={visibility}
-                                furtherDetails={visibilityDescription}
-                                shouldShowTooltips={false}
+                                inputID={INPUT_IDS.WRITE_CAPABILITY}
+                                label={translate('writeCapabilityPage.label')}
+                                items={writeCapabilityOptions}
+                                value={writeCapability}
+                                onValueChange={(value) => setWriteCapability(value as typeof writeCapability)}
                             />
                         </View>
-                    </FormProvider>
-                    {isSmallScreenWidth && (
-                        <>
-                            <OfflineIndicator />
-                            <ImportedStateIndicator />
-                        </>
                     )}
-                </KeyboardAvoidingView>
+                    <View style={[styles.mb1, styles.mhn5]}>
+                        <InputWrapper
+                            InputComponent={ValuePicker}
+                            inputID={INPUT_IDS.VISIBILITY}
+                            label={translate('newRoomPage.visibility')}
+                            items={visibilityOptions}
+                            onValueChange={(value) => setVisibility(value as typeof visibility)}
+                            value={visibility}
+                            furtherDetails={visibilityDescription}
+                            shouldShowTooltips={false}
+                        />
+                    </View>
+                </FormProvider>
             )}
         </ScreenWrapper>
     );


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

@mountiny @lakchote 

### Explanation of Change
<!-- Explain what your change does and how it addresses the linked issue -->

This PR fixes regressions around bottom safe area handling and refactors the `NewChatSelectorPage` and tab switcher to use edge-to-edge bottom safe area handling.

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/60256
$ https://github.com/Expensify/App/issues/60230
PROPOSAL:


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

- [x] Verify that no errors appear in the JS console

**Learn more button in "New Workspace Room" page**

1. Launch app on an Android device with three-button navigation bar enabled
2. Login to app with a account with a fresh account with no workspaces
3. Click Floating-Action-Button ("+")
4. Click "Start chat"
5. Go to "Room"
6. Make sure the "Learn more" button is not covered by the navigation bar

**Too much bottom spacing in "YearPickerModal"**

1. Launch app
2. Tap fab - create expense
3. Enter amount and tap next
4. Select an user
5. Tap date - year
6. Scroll to the bottom
7. Make sure there is no extra space at the bottom of the list

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
8. Upload an image via copy paste
9. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->

- [ ] Verify that no errors appear in the JS console

Same as in Tests.

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

![Screenshot_20250415_123948_New Expensify Dev](https://github.com/user-attachments/assets/9f43f9e9-7110-4b36-b4d3-0b11464c948d)


https://github.com/user-attachments/assets/6e07d33f-e7b4-483a-8d0e-a4bf9edd35ef

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->


https://github.com/user-attachments/assets/9b0c60aa-fb09-468f-977b-2d2a31f38bdd


https://github.com/user-attachments/assets/8b694e34-8c3f-4544-9940-47f56638e083

![Simulator Screenshot - iPhone 16 Pro - 2025-04-15 at 13 53 04](https://github.com/user-attachments/assets/ee92ed2d-99e0-4c07-94e9-6eccde21913e)


</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Desktop</summary>

<!-- add screenshots or videos here -->

</details>
