### PR TITLE
Clock format error message overlaps clock format buttons

### DIFF
--- a/src/components/TimePicker/TimePicker.tsx
+++ b/src/components/TimePicker/TimePicker.tsx
@@ -126,7 +126,7 @@ function TimePicker(
     ref: ForwardedRef<TimePickerRef>,
 ) {
     const {numberFormat, translate} = useLocalize();
-    const {shouldUseNarrowLayout, isExtraSmallScreenHeight} = useResponsiveLayout();
+    const {isExtraSmallScreenHeight} = useResponsiveLayout();
     const styles = useThemeStyles();
     const StyleUtils = useStyleUtils();
     const value = DateUtils.extractTime12Hour(defaultValue, showFullFormat);
@@ -765,7 +765,7 @@ function TimePicker(
             <View style={[styles.flex1, styles.w100, styles.alignItemsCenter, styles.justifyContentCenter]}>
                 <View
                     nativeID={AMOUNT_VIEW_ID}
-                    style={[styles.flexRow, styles.w100, styles.justifyContentCenter, styles.timePickerInputsContainer, styles.mb6]}
+                    style={[styles.flexRow, styles.w100, styles.justifyContentCenter, styles.timePickerInputsContainer, styles.mb2]}
                 >
                     <AmountTextInput
                         placeholder={numberFormat(0)}
@@ -861,18 +861,18 @@ function TimePicker(
                         </>
                     )}
                 </View>
-                {!shouldUseNarrowLayout && renderedAmPmButtons}
+                {!canUseTouchScreen && renderedAmPmButtons}
             </View>
-            {shouldUseNarrowLayout && renderedAmPmButtons}
             {isError ? (
                 <FormHelpMessage
                     isError={isError}
                     message={errorMessage}
-                    style={[styles.ph5, styles.formHelperMessage]}
+                    style={[styles.ph5, styles.formHelperMessage, canUseTouchScreen && styles.mb5]}
                 />
             ) : (
-                <View style={[styles.formHelperMessage]} />
+                <View style={[styles.formHelperMessage, canUseTouchScreen && styles.mb5]} />
             )}
+            {canUseTouchScreen && renderedAmPmButtons}
             <View
                 style={[styles.numberPadWrapper, styles.pb4]}
                 nativeID={NUM_PAD_CONTAINER_VIEW_ID}

--- a/src/components/TimePicker/TimePicker.tsx
+++ b/src/components/TimePicker/TimePicker.tsx
@@ -126,7 +126,7 @@ function TimePicker(
     ref: ForwardedRef<TimePickerRef>,
 ) {
     const {numberFormat, translate} = useLocalize();
-    const {isSmallScreenWidth, isExtraSmallScreenHeight} = useResponsiveLayout();
+    const {shouldUseNarrowLayout, isExtraSmallScreenHeight} = useResponsiveLayout();
     const styles = useThemeStyles();
     const StyleUtils = useStyleUtils();
     const value = DateUtils.extractTime12Hour(defaultValue, showFullFormat);
@@ -728,33 +728,36 @@ function TimePicker(
         }
     };
 
-    const amPmButtons = (
-        <View style={styles.timePickerSwitcherContainer}>
-            <Button
-                shouldEnableHapticFeedback
-                innerStyles={styleForAM}
-                small
-                text={translate('common.am')}
-                onLongPress={() => {}}
-                onPress={() => {
-                    setAmPmValue(CONST.TIME_PERIOD.AM);
-                }}
-                onPressOut={() => {}}
-                onMouseDown={(e) => e.preventDefault()}
-            />
-            <Button
-                shouldEnableHapticFeedback
-                innerStyles={[styleForPM, styles.ml1]}
-                small
-                text={translate('common.pm')}
-                onLongPress={() => {}}
-                onPress={() => {
-                    setAmPmValue(CONST.TIME_PERIOD.PM);
-                }}
-                onPressOut={() => {}}
-                onMouseDown={(e) => e.preventDefault()}
-            />
-        </View>
+    const renderedAmPmButtons = useMemo(
+        () => (
+            <View style={styles.timePickerSwitcherContainer}>
+                <Button
+                    shouldEnableHapticFeedback
+                    innerStyles={styleForAM}
+                    small
+                    text={translate('common.am')}
+                    onLongPress={() => {}}
+                    onPress={() => {
+                        setAmPmValue(CONST.TIME_PERIOD.AM);
+                    }}
+                    onPressOut={() => {}}
+                    onMouseDown={(e) => e.preventDefault()}
+                />
+                <Button
+                    shouldEnableHapticFeedback
+                    innerStyles={[styleForPM, styles.ml1]}
+                    small
+                    text={translate('common.pm')}
+                    onLongPress={() => {}}
+                    onPress={() => {
+                        setAmPmValue(CONST.TIME_PERIOD.PM);
+                    }}
+                    onPressOut={() => {}}
+                    onMouseDown={(e) => e.preventDefault()}
+                />
+            </View>
+        ),
+        [styles, styleForAM, styleForPM, translate, setAmPmValue],
     );
 
     return (
@@ -858,9 +861,9 @@ function TimePicker(
                         </>
                     )}
                 </View>
-                {!isSmallScreenWidth && amPmButtons}
+                {!shouldUseNarrowLayout && renderedAmPmButtons}
             </View>
-            {isSmallScreenWidth && amPmButtons}
+            {shouldUseNarrowLayout && renderedAmPmButtons}
             {isError ? (
                 <FormHelpMessage
                     isError={isError}

--- a/src/components/TimePicker/TimePicker.tsx
+++ b/src/components/TimePicker/TimePicker.tsx
@@ -829,43 +829,41 @@ function TimePicker(
                         </>
                     )}
                 </View>
-                <View style={styles.timePickerSwitcherContainer}>
-                    <Button
-                        shouldEnableHapticFeedback
-                        innerStyles={styleForAM}
-                        medium={isExtraSmallScreenHeight}
-                        large={!isExtraSmallScreenHeight}
-                        text={translate('common.am')}
-                        onLongPress={() => {}}
-                        onPress={() => {
-                            setAmPmValue(CONST.TIME_PERIOD.AM);
-                        }}
-                        onPressOut={() => {}}
-                        onMouseDown={(e) => e.preventDefault()}
-                    />
-                    <Button
-                        shouldEnableHapticFeedback
-                        innerStyles={[styleForPM, styles.ml1]}
-                        medium={isExtraSmallScreenHeight}
-                        large={!isExtraSmallScreenHeight}
-                        text={translate('common.pm')}
-                        onLongPress={() => {}}
-                        onPress={() => {
-                            setAmPmValue(CONST.TIME_PERIOD.PM);
-                        }}
-                        onPressOut={() => {}}
-                        onMouseDown={(e) => e.preventDefault()}
-                    />
-                </View>
+            </View>
+            <View style={styles.timePickerSwitcherContainer}>
+                <Button
+                    shouldEnableHapticFeedback
+                    innerStyles={styleForAM}
+                    small
+                    text={translate('common.am')}
+                    onLongPress={() => {}}
+                    onPress={() => {
+                        setAmPmValue(CONST.TIME_PERIOD.AM);
+                    }}
+                    onPressOut={() => {}}
+                    onMouseDown={(e) => e.preventDefault()}
+                />
+                <Button
+                    shouldEnableHapticFeedback
+                    innerStyles={[styleForPM, styles.ml1]}
+                    small
+                    text={translate('common.pm')}
+                    onLongPress={() => {}}
+                    onPress={() => {
+                        setAmPmValue(CONST.TIME_PERIOD.PM);
+                    }}
+                    onPressOut={() => {}}
+                    onMouseDown={(e) => e.preventDefault()}
+                />
             </View>
             {isError ? (
                 <FormHelpMessage
                     isError={isError}
                     message={errorMessage}
-                    style={[styles.ph5]}
+                    style={[styles.ph5, styles.mb2, styles.mt5]}
                 />
             ) : (
-                <View style={styles.formHelperMessage} />
+                <View style={[styles.formHelperMessage, styles.mb2, styles.mt5]} />
             )}
             <View
                 style={[styles.numberPadWrapper, styles.pb4]}

--- a/src/components/TimePicker/TimePicker.tsx
+++ b/src/components/TimePicker/TimePicker.tsx
@@ -126,7 +126,7 @@ function TimePicker(
     ref: ForwardedRef<TimePickerRef>,
 ) {
     const {numberFormat, translate} = useLocalize();
-    const {isExtraSmallScreenHeight} = useResponsiveLayout();
+    const {isSmallScreenWidth, isExtraSmallScreenHeight} = useResponsiveLayout();
     const styles = useThemeStyles();
     const StyleUtils = useStyleUtils();
     const value = DateUtils.extractTime12Hour(defaultValue, showFullFormat);
@@ -728,12 +728,41 @@ function TimePicker(
         }
     };
 
+    const amPmButtons = (
+        <View style={styles.timePickerSwitcherContainer}>
+            <Button
+                shouldEnableHapticFeedback
+                innerStyles={styleForAM}
+                small
+                text={translate('common.am')}
+                onLongPress={() => {}}
+                onPress={() => {
+                    setAmPmValue(CONST.TIME_PERIOD.AM);
+                }}
+                onPressOut={() => {}}
+                onMouseDown={(e) => e.preventDefault()}
+            />
+            <Button
+                shouldEnableHapticFeedback
+                innerStyles={[styleForPM, styles.ml1]}
+                small
+                text={translate('common.pm')}
+                onLongPress={() => {}}
+                onPress={() => {
+                    setAmPmValue(CONST.TIME_PERIOD.PM);
+                }}
+                onPressOut={() => {}}
+                onMouseDown={(e) => e.preventDefault()}
+            />
+        </View>
+    );
+
     return (
         <View style={styles.flex1}>
             <View style={[styles.flex1, styles.w100, styles.alignItemsCenter, styles.justifyContentCenter]}>
                 <View
                     nativeID={AMOUNT_VIEW_ID}
-                    style={[styles.flexRow, styles.w100, styles.justifyContentCenter, styles.timePickerInputsContainer, styles.mb8]}
+                    style={[styles.flexRow, styles.w100, styles.justifyContentCenter, styles.timePickerInputsContainer, styles.mb6]}
                 >
                     <AmountTextInput
                         placeholder={numberFormat(0)}
@@ -829,41 +858,17 @@ function TimePicker(
                         </>
                     )}
                 </View>
+                {!isSmallScreenWidth && amPmButtons}
             </View>
-            <View style={styles.timePickerSwitcherContainer}>
-                <Button
-                    shouldEnableHapticFeedback
-                    innerStyles={styleForAM}
-                    small
-                    text={translate('common.am')}
-                    onLongPress={() => {}}
-                    onPress={() => {
-                        setAmPmValue(CONST.TIME_PERIOD.AM);
-                    }}
-                    onPressOut={() => {}}
-                    onMouseDown={(e) => e.preventDefault()}
-                />
-                <Button
-                    shouldEnableHapticFeedback
-                    innerStyles={[styleForPM, styles.ml1]}
-                    small
-                    text={translate('common.pm')}
-                    onLongPress={() => {}}
-                    onPress={() => {
-                        setAmPmValue(CONST.TIME_PERIOD.PM);
-                    }}
-                    onPressOut={() => {}}
-                    onMouseDown={(e) => e.preventDefault()}
-                />
-            </View>
+            {isSmallScreenWidth && amPmButtons}
             {isError ? (
                 <FormHelpMessage
                     isError={isError}
                     message={errorMessage}
-                    style={[styles.ph5, styles.mb2, styles.mt5]}
+                    style={[styles.ph5, styles.formHelperMessage]}
                 />
             ) : (
-                <View style={[styles.formHelperMessage, styles.mb2, styles.mt5]} />
+                <View style={[styles.formHelperMessage]} />
             )}
             <View
                 style={[styles.numberPadWrapper, styles.pb4]}

--- a/src/styles/index.ts
+++ b/src/styles/index.ts
@@ -4874,6 +4874,7 @@ const styles = (theme: ThemeColors) =>
             flexDirection: 'row',
             alignItems: 'flex-start',
             justifyContent: 'center',
+            marginBottom: 8,
         },
         selectionListRadioSeparator: {
             height: StyleSheet.hairlineWidth,
@@ -4928,8 +4929,8 @@ const styles = (theme: ThemeColors) =>
         },
         formHelperMessage: {
             height: 32,
-            marginBottom: 8,
-            marginTop: 20,
+            marginTop: 0,
+            marginBottom: 0,
         },
         timePickerInputExtraSmall: {
             fontSize: 50,

--- a/src/styles/index.ts
+++ b/src/styles/index.ts
@@ -4928,6 +4928,8 @@ const styles = (theme: ThemeColors) =>
         },
         formHelperMessage: {
             height: 32,
+            marginBottom: 8,
+            marginTop: 20,
         },
         timePickerInputExtraSmall: {
             fontSize: 50,

--- a/src/styles/index.ts
+++ b/src/styles/index.ts
@@ -4859,8 +4859,8 @@ const styles = (theme: ThemeColors) =>
             minWidth: 56,
             alignSelf: 'center',
         },
-        timePickerWidth100: {
-            width: 100,
+        timePickerWidth72: {
+            width: 72,
         },
         timePickerHeight100: {
             height: 100,

--- a/src/styles/utils/index.ts
+++ b/src/styles/utils/index.ts
@@ -1449,8 +1449,8 @@ const createStyleUtils = (theme: ThemeColors, styles: ThemeStyles) => ({
         const computedStyleForPM: ViewStyle = amPmValue !== CONST.TIME_PERIOD.PM ? {backgroundColor: theme.componentBG} : {};
 
         return {
-            styleForAM: [styles.timePickerWidth100, computedStyleForAM],
-            styleForPM: [styles.timePickerWidth100, computedStyleForPM],
+            styleForAM: [styles.timePickerWidth72, computedStyleForAM],
+            styleForPM: [styles.timePickerWidth72, computedStyleForPM],
         };
     },
 


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
<!-- Explain what your change does and how it addresses the linked issue -->

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/59787
PROPOSAL: https://github.com/Expensify/App/issues/59787#issuecomment-2785611439


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->
1. Navigate to Account settings > Profile
2. Tap the Status field
3. Tap the Clear after field
4. Select the Custom option
5. Tap the Time field
6. Change the time to 00:20
7. Tap the Save button
8. There is more space between the error message and clock format buttons

- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

Same as tests
### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->
Same as tests

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/4454c2e2-2cd3-4a27-8b7f-ef832c0db6ed


</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/ff0f4c0c-ed6b-4055-bd72-5c7b797ce333


</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/a1bb27af-b003-4296-ba48-03b0a677c286


</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

Before:
<img width="561" alt="Screenshot 2025-04-16 at 10 44 28" src="https://github.com/user-attachments/assets/b9e6724c-e162-4c16-8f60-ccdc03aff812" />

After:

https://github.com/user-attachments/assets/a41924ca-d33e-432b-a8da-284e9cb190a3

<img width="565" alt="Screenshot 2025-04-16 at 10 44 38" src="https://github.com/user-attachments/assets/3110704b-5d3b-4e1b-9ac4-1007ee2cde72" />

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->


https://github.com/user-attachments/assets/27386c3b-e7a9-467f-a8a2-f63433d93521



</details>

<details>
<summary>MacOS: Desktop</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/386832da-a756-48a5-8fed-4050981c6b44




</details>
