### PR TITLE
[No QA] Fix tag fetching in cherryPick.yml

### DIFF
--- a/.github/workflows/cherryPick.yml
+++ b/.github/workflows/cherryPick.yml
@@ -33,7 +33,7 @@ jobs:
         run: |
           git submodule foreach '\
             git config --add remote.origin.fetch "+refs/heads/staging:refs/remotes/origin/staging" && \
-            git config --add remote.origin.fetch "+refs/heads/production:refs/remotes/origin/production" && \
+            git config --add remote.origin.fetch "+refs/heads/production:refs/remotes/origin/production"'
 
       - name: Set up git for OSBotify
         id: setupGitForOSBotify

--- a/.github/workflows/cherryPick.yml
+++ b/.github/workflows/cherryPick.yml
@@ -34,7 +34,6 @@ jobs:
           git submodule foreach '\
             git config --add remote.origin.fetch "+refs/heads/staging:refs/remotes/origin/staging" && \
             git config --add remote.origin.fetch "+refs/heads/production:refs/remotes/origin/production" && \
-            git config --add remote.origin.fetch "+refs/tags/*:refs/tags/*"'
 
       - name: Set up git for OSBotify
         id: setupGitForOSBotify
@@ -53,9 +52,20 @@ jobs:
 
       - name: Fetch history of relevant refs
         run: |
-          git fetch origin main staging --no-tags --shallow-exclude ${{ steps.getPreviousVersion.outputs.PREVIOUS_VERSION }}
+          # Temporary hack during transition when -staging suffix is being added to tags
+          if git ls-remote origin refs/tags/${{ steps.getPreviousVersion.outputs.PREVIOUS_VERSION }} | grep -q . ; then
+            git fetch origin main staging --no-recurse-submodules --no-tags --shallow-exclude ${{ steps.getPreviousVersion.outputs.PREVIOUS_VERSION }}
+          else
+            git fetch origin main staging --no-recurse-submodules --no-tags --shallow-exclude ${{ steps.getPreviousVersion.outputs.PREVIOUS_VERSION }}-staging
+          fi
+
           cd Mobile-Expensify
-          git fetch origin main staging --no-tags --shallow-exclude ${{ steps.getPreviousVersion.outputs.PREVIOUS_VERSION }}
+          # Temporary hack during transition when -staging suffix is being added to tags
+          if git ls-remote origin refs/tags/${{ steps.getPreviousVersion.outputs.PREVIOUS_VERSION }} | grep -q . ; then
+            git fetch origin main staging --no-recurse-submodules --no-tags --shallow-exclude ${{ steps.getPreviousVersion.outputs.PREVIOUS_VERSION }}
+          else
+            git fetch origin main staging --no-recurse-submodules --no-tags --shallow-exclude ${{ steps.getPreviousVersion.outputs.PREVIOUS_VERSION }}-staging
+          fi
 
       - name: Get E/App version bump commit
         id: getVersionBumpCommit


### PR DESCRIPTION
### Explanation of Change
Ensure the ref used in `--shallow-exclude` is a real tag that exists by checking first and tacking on `-staging` if it's not found.

Also (dramatically) speed up fetching by adding `--no-recurse-submodules`.

### Fixed Issues
$ maybe https://expensify.slack.com/archives/C07J32337/p1744740685471859

### Tests
Tested locally with this script:

```bash
#!/bin/bash

mkdir ~/AppFetchTest
trap 'rm -rf ~/AppFetchTest' EXIT

echo "Initializing repo in ~/AppFetchTest"
cd ~/AppFetchTest
git init
git remote add origin git@github.com:Expensify/App.git
git config --local gc.auto 0

echo "Fetching parent repo"
time git fetch --no-tags --prune --no-recurse-submodules --depth=1 origin +refs/heads/staging*:refs/remotes/origin/staging* +refs/tags/staging*:refs/tags/staging*

echo "Initializing submodules"
git checkout --progress --force -B staging refs/remotes/origin/staging
git submodule sync
git submodule update --init --force --depth=1
git submodule foreach git config --local gc.auto 0

echo "Parent ref"
git log -1 --format='%H'

echo "Enabling branch switching in submodules"
git submodule foreach '\
    git config --add remote.origin.fetch "+refs/heads/staging:refs/remotes/origin/staging" && \
    git config --add remote.origin.fetch "+refs/heads/production:refs/remotes/origin/production"'

echo "Fetching history in parent repo"
# Temporary hack during transition when -staging suffix is being added to tags
if git ls-remote origin refs/tags/9.1.27-0 | grep -q . ; then
  time git fetch origin main staging --no-recurse-submodules --no-tags --shallow-exclude 9.1.27-0
else
  time git fetch origin main staging --no-recurse-submodules --no-tags --shallow-exclude 9.1.27-0-staging
fi


echo "Fetching history in submodule"
cd Mobile-Expensify
# Temp hack
if git ls-remote origin refs/tags/9.1.27-0 | grep -q . ; then
  time git fetch origin main staging --no-tags --shallow-exclude 9.1.27-0
else
  time git fetch origin main staging --no-tags --shallow-exclude 9.1.27-0-staging
fi
cd ..

git switch main
VERSION_BUMP_COMMIT="$(git log -1 --format='%H' --author='OSBotify' --grep 'Update version to 9.1.28-3')"
if [ -z "$VERSION_BUMP_COMMIT" ]; then
  echo "::error::❌ Could not find E/App version bump commit for 9.1.28-3"
  git log --oneline
else
  echo "::notice::👀 Found E/App version bump commit $VERSION_BUMP_COMMIT"
fi

cd Mobile-Expensify
git switch main
VERSION_BUMP_COMMIT="$(git log -1 --format='%H' --author='OSBotify' --grep 'Update version to 9.1.28-3')"
if [ -z "$VERSION_BUMP_COMMIT" ]; then
  echo "::error::❌ Could not find Mobile-Expensify version bump commit for 9.1.28-3"
  git log --oneline
else
  echo "::notice::👀 Found Mobile-Expensify version bump commit $VERSION_BUMP_COMMIT"
fi
```

### Offline tests
None.

### QA Steps
None

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Desktop</summary>

<!-- add screenshots or videos here -->

</details>
