### PR TITLE
Add stricter filtering to task reports

### DIFF
--- a/src/libs/SearchUIUtils.ts
+++ b/src/libs/SearchUIUtils.ts
@@ -443,53 +443,57 @@ function getAction(data: OnyxTypes.SearchResults['data'], key: string): SearchTr
  * Do not use directly, use only via `getSections()` facade.
  */
 function getTaskSections(data: OnyxTypes.SearchResults['data']): TaskListItemType[] {
-    return Object.keys(data)
-        .filter(isReportEntry)
-        .filter((key) => isTaskListItemType(data[key] as SearchListItem))
-        .map((key) => {
-            const taskItem = data[key] as SearchTask;
-            const personalDetails = data.personalDetailsList;
+    return (
+        Object.keys(data)
+            .filter(isReportEntry)
+            // Ensure that the reports that were passed are tasks, and not some other
+            // type of report that was sent as the parent
+            .filter((key) => isTaskListItemType(data[key] as SearchListItem))
+            .map((key) => {
+                const taskItem = data[key] as SearchTask;
+                const personalDetails = data.personalDetailsList;
 
-            const assignee = personalDetails?.[taskItem.managerID] ?? emptyPersonalDetails;
-            const createdBy = personalDetails?.[taskItem.accountID] ?? emptyPersonalDetails;
-            const formattedAssignee = formatPhoneNumber(getDisplayNameOrDefault(assignee));
-            const formattedCreatedBy = formatPhoneNumber(getDisplayNameOrDefault(createdBy));
+                const assignee = personalDetails?.[taskItem.managerID] ?? emptyPersonalDetails;
+                const createdBy = personalDetails?.[taskItem.accountID] ?? emptyPersonalDetails;
+                const formattedAssignee = formatPhoneNumber(getDisplayNameOrDefault(assignee));
+                const formattedCreatedBy = formatPhoneNumber(getDisplayNameOrDefault(createdBy));
 
-            const report = getReportOrDraftReport(taskItem.reportID) ?? taskItem;
-            const parentReport = getReportOrDraftReport(taskItem.parentReportID);
+                const report = getReportOrDraftReport(taskItem.reportID) ?? taskItem;
+                const parentReport = getReportOrDraftReport(taskItem.parentReportID);
 
-            const doesDataContainAPastYearTransaction = shouldShowYear(data);
-            const reportName = StringUtils.lineBreaksToSpaces(Parser.htmlToText(taskItem.reportName));
-            const description = StringUtils.lineBreaksToSpaces(Parser.htmlToText(taskItem.description));
+                const doesDataContainAPastYearTransaction = shouldShowYear(data);
+                const reportName = StringUtils.lineBreaksToSpaces(Parser.htmlToText(taskItem.reportName));
+                const description = StringUtils.lineBreaksToSpaces(Parser.htmlToText(taskItem.description));
 
-            const result: TaskListItemType = {
-                ...taskItem,
-                reportName,
-                description,
-                assignee,
-                formattedAssignee,
-                createdBy,
-                formattedCreatedBy,
-                keyForList: taskItem.reportID,
-                shouldShowYear: doesDataContainAPastYearTransaction,
-            };
+                const result: TaskListItemType = {
+                    ...taskItem,
+                    reportName,
+                    description,
+                    assignee,
+                    formattedAssignee,
+                    createdBy,
+                    formattedCreatedBy,
+                    keyForList: taskItem.reportID,
+                    shouldShowYear: doesDataContainAPastYearTransaction,
+                };
 
-            if (parentReport && personalDetails) {
-                const policy = getPolicy(parentReport.policyID);
-                const parentReportName = getReportName(parentReport, policy, undefined, undefined);
-                const icons = getIcons(parentReport, personalDetails, null, '', -1, policy);
-                const parentReportIcon = icons?.at(0);
+                if (parentReport && personalDetails) {
+                    const policy = getPolicy(parentReport.policyID);
+                    const parentReportName = getReportName(parentReport, policy, undefined, undefined);
+                    const icons = getIcons(parentReport, personalDetails, null, '', -1, policy);
+                    const parentReportIcon = icons?.at(0);
 
-                result.parentReportName = parentReportName;
-                result.parentReportIcon = parentReportIcon;
-            }
+                    result.parentReportName = parentReportName;
+                    result.parentReportIcon = parentReportIcon;
+                }
 
-            if (report) {
-                result.report = report;
-            }
+                if (report) {
+                    result.report = report;
+                }
 
-            return result;
-        });
+                return result;
+            })
+    );
 }
 
 /**

--- a/src/libs/SearchUIUtils.ts
+++ b/src/libs/SearchUIUtils.ts
@@ -445,8 +445,9 @@ function getAction(data: OnyxTypes.SearchResults['data'], key: string): SearchTr
 function getTaskSections(data: OnyxTypes.SearchResults['data']): TaskListItemType[] {
     return Object.keys(data)
         .filter(isReportEntry)
+        .filter((key) => isTaskListItemType(data[key] as SearchListItem))
         .map((key) => {
-            const taskItem = data[key] as SearchTask;
+            const taskItem = data[key] as TaskListItemType;
             const personalDetails = data.personalDetailsList;
 
             const assignee = personalDetails?.[taskItem.managerID] ?? emptyPersonalDetails;

--- a/src/libs/SearchUIUtils.ts
+++ b/src/libs/SearchUIUtils.ts
@@ -447,7 +447,7 @@ function getTaskSections(data: OnyxTypes.SearchResults['data']): TaskListItemTyp
         .filter(isReportEntry)
         .filter((key) => isTaskListItemType(data[key] as SearchListItem))
         .map((key) => {
-            const taskItem = data[key] as TaskListItemType;
+            const taskItem = data[key] as SearchTask;
             const personalDetails = data.personalDetailsList;
 
             const assignee = personalDetails?.[taskItem.managerID] ?? emptyPersonalDetails;


### PR DESCRIPTION

### Explanation of Change
For future backend changes, we need to account for reports being returned that are *not* tasks. To fix this, we need to properly filter out non-tasks before manipulating/accessing data.

### Fixed Issues
N/A

### Tests
Verify that task search in the Reports page works as expected. Play around with different filters/task locations.

- [x] Verify that no errors appear in the JS console

### Offline tests
N/A

### QA Steps
Same as tests

- [x] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [jsenyitko+shot_0@expensifail.com] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
N/A
