### PR TITLE
Add several UI fixes to MoneyRequestTransaction list

### DIFF
--- a/src/components/MoneyRequestReportView/MoneyRequestReportActionsList.tsx
+++ b/src/components/MoneyRequestReportView/MoneyRequestReportActionsList.tsx
@@ -437,7 +437,7 @@ function MoneyRequestReportActionsList({report, policy, reportActions = [], tran
     useLayoutEffect(parseFSAttributes, []);
 
     return (
-        <View style={[styles.flex1, styles.pv4]}>
+        <View style={[styles.flex1]}>
             {shouldUseNarrowLayout && !!selectionMode?.isEnabled && (
                 <>
                     <ButtonWithDropdownMenu
@@ -448,7 +448,7 @@ function MoneyRequestReportActionsList({report, policy, reportActions = [], tran
                         shouldAlwaysShowDropdownMenu
                         wrapperStyle={[styles.w100, styles.ph5]}
                     />
-                    <View style={[styles.searchListHeaderContainerStyle, styles.pt6, styles.ph8, styles.pb3]}>
+                    <View style={[styles.alignItemsCenter, styles.userSelectNone, styles.flexRow, styles.pt6, styles.ph8]}>
                         <Checkbox
                             accessibilityLabel={translate('workspace.people.selectAll')}
                             isChecked={selectedTransactionsID.length === transactions.length}
@@ -491,7 +491,7 @@ function MoneyRequestReportActionsList({report, policy, reportActions = [], tran
                     />
                 </>
             )}
-            <View style={[styles.flex1, styles.justifyContentEnd, styles.overflowHidden, styles.pb4]}>
+            <View style={[styles.flex1, styles.justifyContentEnd, styles.overflowHidden, styles.pv4]}>
                 <FloatingMessageCounter
                     isActive={isFloatingMessageCounterVisible}
                     onClick={scrollToBottomAndMarkReportAsRead}

--- a/src/components/MoneyRequestReportView/MoneyRequestReportTransactionList.tsx
+++ b/src/components/MoneyRequestReportView/MoneyRequestReportTransactionList.tsx
@@ -256,7 +256,6 @@ function MoneyRequestReportTransactionList({report, transactions, reportActions,
                                 shouldShowTooltip
                                 shouldUseNarrowLayout={shouldUseNarrowLayout || isMediumScreenWidth}
                                 shouldShowCheckbox={!!selectionMode?.isEnabled || isMediumScreenWidth}
-                                shouldShowChatBubbleComponent
                                 onCheckboxPress={toggleTransaction}
                             />
                         </PressableWithFeedback>

--- a/src/components/TransactionItemRow/DataCells/ChatBubbleCell.tsx
+++ b/src/components/TransactionItemRow/DataCells/ChatBubbleCell.tsx
@@ -25,9 +25,12 @@ function ChatBubbleCell({transaction, containerStyles}: {transaction: Transactio
     const {shouldUseNarrowLayout} = useResponsiveLayout();
     const [iouReportAction] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${transaction.reportID}`, {
         selector: (reportActions) => getIOUActionForTransactionID(Object.values(reportActions ?? {}), transaction.transactionID),
+        canBeMissing: false,
     });
 
-    const [transactionReport] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT}${iouReportAction?.childReportID}`);
+    const [transactionReport] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT}${iouReportAction?.childReportID}`, {
+        canBeMissing: false,
+    });
 
     const threadMessages = useMemo(
         () => ({

--- a/src/components/TransactionItemRow/DataCells/ChatBubbleCell.tsx
+++ b/src/components/TransactionItemRow/DataCells/ChatBubbleCell.tsx
@@ -1,5 +1,6 @@
 import React, {useMemo} from 'react';
 import {View} from 'react-native';
+import type {ViewStyle} from 'react-native';
 import {useOnyx} from 'react-native-onyx';
 import Icon from '@components/Icon';
 import {ChatBubbleCounter} from '@components/Icon/Expensicons';
@@ -18,7 +19,7 @@ import type Transaction from '@src/types/onyx/Transaction';
 const isReportUnread = ({lastReadTime = '', lastVisibleActionCreated = '', lastMentionedTime = ''}: Report): boolean =>
     lastReadTime < lastVisibleActionCreated || lastReadTime < (lastMentionedTime ?? '');
 
-function ChatBubbleCell({transaction}: {transaction: Transaction}) {
+function ChatBubbleCell({transaction, containerStyles}: {transaction: Transaction; containerStyles?: ViewStyle[]}) {
     const theme = useTheme();
     const styles = useThemeStyles();
     const {shouldUseNarrowLayout} = useResponsiveLayout();
@@ -38,18 +39,18 @@ function ChatBubbleCell({transaction}: {transaction: Transaction}) {
 
     const StyleUtils = useStyleUtils();
 
-    const elementSize = shouldUseNarrowLayout ? variables.iconSizeSmall : variables.iconSizeNormal;
+    const iconSize = shouldUseNarrowLayout ? variables.iconSizeSmall : variables.iconSizeNormal;
     const fontSize = shouldUseNarrowLayout ? variables.fontSizeXXSmall : variables.fontSizeExtraSmall;
 
     return (
         threadMessages.count > 0 && (
-            <View style={[styles.dFlex, styles.alignItemsCenter, styles.justifyContentCenter, styles.textAlignCenter, StyleUtils.getWidthAndHeightStyle(elementSize)]}>
+            <View style={[styles.dFlex, styles.alignItemsCenter, styles.justifyContentCenter, styles.textAlignCenter, StyleUtils.getWidthAndHeightStyle(iconSize), containerStyles]}>
                 <Icon
                     src={ChatBubbleCounter}
                     additionalStyles={[styles.pAbsolute]}
                     fill={threadMessages.isUnread ? theme.iconMenu : theme.icon}
-                    width={elementSize}
-                    height={elementSize}
+                    width={iconSize}
+                    height={iconSize}
                 />
                 <Text
                     style={[

--- a/src/components/TransactionItemRow/index.tsx
+++ b/src/components/TransactionItemRow/index.tsx
@@ -29,7 +29,6 @@ function TransactionItemRow({
     isSelected,
     shouldShowTooltip,
     dateColumnSize,
-    shouldShowChatBubbleComponent = false,
     onCheckboxPress,
     shouldShowCheckbox = false,
 }: {
@@ -38,7 +37,6 @@ function TransactionItemRow({
     isSelected: boolean;
     shouldShowTooltip: boolean;
     dateColumnSize: TableColumnSize;
-    shouldShowChatBubbleComponent?: boolean;
     onCheckboxPress: (transactionID: string) => void;
     shouldShowCheckbox: boolean;
 }) {
@@ -80,8 +78,8 @@ function TransactionItemRow({
         >
             {shouldUseNarrowLayout ? (
                 <Animated.View style={[animatedHighlightStyle]}>
-                    <View style={[styles.expenseWidgetRadius, styles.justifyContentEvenly, styles.gap3, bgActiveStyles]}>
-                        <View style={[styles.flexRow, styles.mt3, styles.mr3, styles.ml3]}>
+                    <View style={[styles.expenseWidgetRadius, styles.justifyContentEvenly, styles.p3, bgActiveStyles]}>
+                        <View style={[styles.flexRow]}>
                             {shouldShowCheckbox && (
                                 <View style={[styles.mr3, styles.justifyContentCenter]}>
                                     <Checkbox
@@ -138,10 +136,10 @@ function TransactionItemRow({
                                 )}
                             </View>
                         </View>
-                        <View style={[styles.flexRow, styles.justifyContentBetween, styles.mh3, styles.mb3]}>
-                            <View style={[styles.flexColumn, styles.gap2]}>
+                        <View style={[styles.flexRow, styles.justifyContentBetween, styles.alignItemsCenter]}>
+                            <View style={[styles.flexColumn]}>
                                 {hasCategoryOrTag && (
-                                    <View style={[styles.flexRow, styles.alignItemsCenter, styles.gap2]}>
+                                    <View style={[styles.flexRow, styles.alignItemsCenter, styles.gap2, styles.mt3]}>
                                         <CategoryCell
                                             transactionItem={transactionItem}
                                             shouldShowTooltip={shouldShowTooltip}
@@ -154,9 +152,15 @@ function TransactionItemRow({
                                         />
                                     </View>
                                 )}
-                                <TransactionItemRowRBR transaction={transactionItem} />
+                                <TransactionItemRowRBR
+                                    transaction={transactionItem}
+                                    containerStyles={[styles.mt3]}
+                                />
                             </View>
-                            {shouldShowChatBubbleComponent && <ChatBubbleCell transaction={transactionItem} />}
+                            <ChatBubbleCell
+                                transaction={transactionItem}
+                                containerStyles={[styles.mt3]}
+                            />
                         </View>
                     </View>
                 </Animated.View>
@@ -215,7 +219,7 @@ function TransactionItemRow({
                                 />
                             </View>
                             <View style={[StyleUtils.getReportTableColumnStyles(CONST.REPORT.TRANSACTION_LIST.COLUMNS.COMMENTS)]}>
-                                {shouldShowChatBubbleComponent && <ChatBubbleCell transaction={transactionItem} />}
+                                <ChatBubbleCell transaction={transactionItem} />
                             </View>
                             <View style={[StyleUtils.getReportTableColumnStyles(CONST.SEARCH.TABLE_COLUMNS.TOTAL_AMOUNT)]}>
                                 <TotalCell

--- a/src/pages/Search/SearchMoneyRequestReportPage.tsx
+++ b/src/pages/Search/SearchMoneyRequestReportPage.tsx
@@ -129,6 +129,7 @@ function SearchMoneyRequestReportPage({route}: SearchMoneyRequestPageProps) {
                                     breadcrumbLabel={translate('common.reports')}
                                     shouldDisplaySearch={false}
                                     shouldShowLoadingBar={false}
+                                    shouldDisplayHelpButton={false}
                                 />
                                 <SearchTypeMenu queryJSON={undefined} />
                             </View>

--- a/src/stories/TransactionItemRow.stories.tsx
+++ b/src/stories/TransactionItemRow.stories.tsx
@@ -65,7 +65,6 @@ function Template(
                         shouldUseNarrowLayout={shouldUseNarrowLayout}
                         isSelected={isSelected}
                         shouldShowTooltip={shouldShowTooltip}
-                        shouldShowChatBubbleComponent
                         dateColumnSize={CONST.SEARCH.TABLE_COLUMN_SIZES.NORMAL}
                         onCheckboxPress={() => {}}
                         shouldShowCheckbox={shouldShowCheckbox}


### PR DESCRIPTION
### Explanation of Change
This PR contains some minor UI tweaks that are mostly followups after other PRs.
Done:
 - https://github.com/Expensify/App/issues/61557 - extra space when selection mode header displayed is fixed
 - fixed unnecessary empty spacing in transactionItemRow: https://github.com/Expensify/App/pull/61159#issuecomment-2854769456
 - fixed Help Pane button wrongly displayed in SearchMoneyRequestReport page (see image) - no issue for this bug but its very small

#### wrong help pane button
<img width="900" alt="Screenshot 2025-05-08 at 12 33 43" src="https://github.com/user-attachments/assets/78a9adb0-1c68-4558-afb0-712a34e6222a" />


### Fixed Issues
$ https://github.com/Expensify/App/issues/61557
PROPOSAL:

### Tests
- go to money request report that has > 1 transactions
- verify that transaction rows on small screen have no extra spacing inside when: merchant and or tag/category are missing
- verify that transaction rows on small screen have no extra spacing inside when all the data is correct
- verify ☝️ the same where there are RBR violations
- on mobile longpress to go to mobile selection mode, and verify there is no extra spacing (issue 61557)

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

### QA Steps
Same as Tests.

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I verified there are no new alerts related to the `canBeMissing` param for `useOnyx`
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<img width="386" alt="rec-ios" src="https://github.com/user-attachments/assets/ca7db46b-8cef-4395-8957-8c8cd27fb308" />


</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>
<img width="550" alt="web-correct" src="https://github.com/user-attachments/assets/2e3cba41-1596-4986-b9c5-88e86e89fefa" />

<img width="550" alt="web-all" src="https://github.com/user-attachments/assets/a477ac97-84f7-4598-a96a-cac79ac120bc" />
<img width="565" alt="web2" src="https://github.com/user-attachments/assets/24e232f5-5013-4deb-b6fe-79c938b0f833" />

### help pane button

<img width="1000" alt="Screenshot 2025-05-08 at 12 53 25" src="https://github.com/user-attachments/assets/ec6bf0ad-d8be-4991-a71e-e2c6745ddfbc" />


</details>

<details>
<summary>MacOS: Desktop</summary>

<!-- add screenshots or videos here -->

</details>
