### PR TITLE
Fix workspace members page infinite render loop

### DIFF
--- a/src/hooks/useSearchResults.ts
+++ b/src/hooks/useSearchResults.ts
@@ -9,10 +9,8 @@ import usePrevious from './usePrevious';
  * the result of the filtering and sorting are deprioritized, allowing them to happen in the background.
  */
 function useSearchResults<TValue>(data: TValue[], filterData: (datum: TValue, searchInput: string) => boolean, sortData: (data: TValue[]) => TValue[] = (d) => d) {
-    // The text input value for the search bar this hook is meant to be used with
     const [inputValue, setInputValue] = useState('');
 
-    // The return result
     const [result, setResult] = useState(data);
 
     const [, startTransition] = useTransition();

--- a/src/hooks/useSearchResults.ts
+++ b/src/hooks/useSearchResults.ts
@@ -1,3 +1,4 @@
+import {deepEqual} from 'fast-equals';
 import {useEffect, useState, useTransition} from 'react';
 import CONST from '@src/CONST';
 import usePrevious from './usePrevious';
@@ -8,17 +9,27 @@ import usePrevious from './usePrevious';
  * the result of the filtering and sorting are deprioritized, allowing them to happen in the background.
  */
 function useSearchResults<TValue>(data: TValue[], filterData: (datum: TValue, searchInput: string) => boolean, sortData: (data: TValue[]) => TValue[] = (d) => d) {
+    // The text input value for the search bar this hook is meant to be used with
     const [inputValue, setInputValue] = useState('');
+
+    // The return result
     const [result, setResult] = useState(data);
+
     const [, startTransition] = useTransition();
     const prevData = usePrevious(data);
+
     useEffect(() => {
+        const filtered = inputValue.length ? data.filter((item) => filterData(item, inputValue)) : data;
+        const sorted = sortData(filtered);
+
+        if (deepEqual(result, sorted)) {
+            return;
+        }
+
         startTransition(() => {
-            const filtered = inputValue.length ? data.filter((item) => filterData(item, inputValue)) : data;
-            const sorted = sortData(filtered);
             setResult(sorted);
         });
-    }, [data, filterData, inputValue, sortData]);
+    }, [data, filterData, inputValue, result, sortData]);
 
     useEffect(() => {
         if (prevData.length <= CONST.SEARCH_ITEM_LIMIT || data.length > CONST.SEARCH_ITEM_LIMIT) {

--- a/src/hooks/useSearchResults.ts
+++ b/src/hooks/useSearchResults.ts
@@ -14,8 +14,7 @@ function useSearchResults<TValue>(data: TValue[], filterData: (datum: TValue, se
     const prevData = usePrevious(data);
     useEffect(() => {
         startTransition(() => {
-            const normalizedSearchQuery = inputValue.trim().toLowerCase();
-            const filtered = normalizedSearchQuery.length ? data.filter((item) => filterData(item, normalizedSearchQuery)) : data;
+            const filtered = inputValue.length ? data.filter((item) => filterData(item, inputValue)) : data;
             const sorted = sortData(filtered);
             setResult(sorted);
         });

--- a/src/hooks/useSearchResults.ts
+++ b/src/hooks/useSearchResults.ts
@@ -10,9 +10,7 @@ import usePrevious from './usePrevious';
  */
 function useSearchResults<TValue>(data: TValue[], filterData: (datum: TValue, searchInput: string) => boolean, sortData: (data: TValue[]) => TValue[] = (d) => d) {
     const [inputValue, setInputValue] = useState('');
-
     const [result, setResult] = useState(data);
-
     const [, startTransition] = useTransition();
     const prevData = usePrevious(data);
 

--- a/src/pages/workspace/WorkspaceMembersPage.tsx
+++ b/src/pages/workspace/WorkspaceMembersPage.tsx
@@ -224,9 +224,7 @@ function WorkspaceMembersPage({personalDetails, route, policy, currentUserPerson
         // eslint-disable-next-line react-compiler/react-compiler, react-hooks/exhaustive-deps
     }, [isFocused]);
 
-    useEffect(() => {
-        validateSelection();
-    }, [preferredLocale, validateSelection]);
+    useEffect(validateSelection, [preferredLocale, validateSelection]);
 
     useEffect(() => {
         if (removeMembersConfirmModalVisible && !deepEqual(accountIDs, prevAccountIDs)) {
@@ -415,6 +413,11 @@ function WorkspaceMembersPage({personalDetails, route, policy, currentUserPerson
     const policyOwner = policy?.owner;
     const currentUserLogin = currentUserPersonalDetails.login;
     const invitedPrimaryToSecondaryLogins = invertObject(policy?.primaryLoginsInvited ?? {});
+
+    const badgeOwner = useMemo(() => <Badge text={translate('common.owner')} />, [translate]);
+    const badgeAdmin = useMemo(() => <Badge text={translate('common.admin')} />, [translate]);
+    const badgeAuditor = useMemo(() => <Badge text={translate('common.auditor')} />, [translate]);
+
     const data: MemberOption[] = useMemo(() => {
         const result: MemberOption[] = [];
 
@@ -446,10 +449,12 @@ function WorkspaceMembersPage({personalDetails, route, policy, currentUserPerson
             const isAdmin = policyEmployee.role === CONST.POLICY.ROLE.ADMIN;
             const isAuditor = policyEmployee.role === CONST.POLICY.ROLE.AUDITOR;
             let roleBadge = null;
-            if (isOwner || isAdmin) {
-                roleBadge = <Badge text={isOwner ? translate('common.owner') : translate('common.admin')} />;
+            if (isOwner) {
+                roleBadge = badgeOwner;
+            } else if (isAdmin) {
+                roleBadge = badgeAdmin;
             } else if (isAuditor) {
-                roleBadge = <Badge text={translate('common.auditor')} />;
+                roleBadge = badgeAuditor;
             }
             const isPendingDeleteOrError = isPolicyAdmin && (policyEmployee.pendingAction === CONST.RED_BRICK_ROAD_PENDING_ACTION.DELETE || !isEmptyObject(policyEmployee.errors));
 
@@ -508,14 +513,20 @@ function WorkspaceMembersPage({personalDetails, route, policy, currentUserPerson
     const [inputValue, setInputValue, filteredData] = useSearchResults(data, filterMember, sortMembers);
 
     useEffect(() => {
+        // if (areSearchResultsPending) {
+        // console.log('RORY_DEBUG transition is pending, returning early');
+        // return;
+        // }
         if (!isFocused) {
             return;
         }
         if (isEmptyObject(invitedEmailsToAccountIDsDraft) || deepEqual(accountIDs, prevAccountIDs)) {
+            // console.log('RORY_DEBUG returning early', {invitedEmailsToAccountIDsDraft, accountIDs, prevAccountIDs});
             return;
         }
-        const invitedEmails = Object.values(invitedEmailsToAccountIDsDraft).map(String);
-        selectionListRef.current?.scrollAndHighlightItem?.(invitedEmails);
+        const invitedAccountIDs = Object.values(invitedEmailsToAccountIDsDraft).map(String);
+        // console.log('RORY_DEBUG scrolling and highlighting item', {invitedAccountIDs});
+        selectionListRef.current?.scrollAndHighlightItem?.(invitedAccountIDs);
         clearInviteDraft(route.params.policyID);
     }, [invitedEmailsToAccountIDsDraft, isFocused, accountIDs, prevAccountIDs, route.params.policyID]);
 
@@ -546,7 +557,6 @@ function WorkspaceMembersPage({personalDetails, route, policy, currentUserPerson
         if (selectionMode?.isEnabled) {
             return;
         }
-
         setSelectedEmployees([]);
     }, [setSelectedEmployees, selectionMode?.isEnabled]);
 

--- a/src/pages/workspace/WorkspaceMembersPage.tsx
+++ b/src/pages/workspace/WorkspaceMembersPage.tsx
@@ -513,19 +513,10 @@ function WorkspaceMembersPage({personalDetails, route, policy, currentUserPerson
     const [inputValue, setInputValue, filteredData] = useSearchResults(data, filterMember, sortMembers);
 
     useEffect(() => {
-        // if (areSearchResultsPending) {
-        // console.log('RORY_DEBUG transition is pending, returning early');
-        // return;
-        // }
-        if (!isFocused) {
-            return;
-        }
-        if (isEmptyObject(invitedEmailsToAccountIDsDraft) || deepEqual(accountIDs, prevAccountIDs)) {
-            // console.log('RORY_DEBUG returning early', {invitedEmailsToAccountIDsDraft, accountIDs, prevAccountIDs});
+        if (!isFocused || isEmptyObject(invitedEmailsToAccountIDsDraft) || deepEqual(accountIDs, prevAccountIDs)) {
             return;
         }
         const invitedAccountIDs = Object.values(invitedEmailsToAccountIDsDraft).map(String);
-        // console.log('RORY_DEBUG scrolling and highlighting item', {invitedAccountIDs});
         selectionListRef.current?.scrollAndHighlightItem?.(invitedAccountIDs);
         clearInviteDraft(route.params.policyID);
     }, [invitedEmailsToAccountIDsDraft, isFocused, accountIDs, prevAccountIDs, route.params.policyID]);

--- a/src/pages/workspace/WorkspaceMembersPage.tsx
+++ b/src/pages/workspace/WorkspaceMembersPage.tsx
@@ -501,6 +501,9 @@ function WorkspaceMembersPage({personalDetails, route, policy, currentUserPerson
         styles.cursorDefault,
         canSelectMultiple,
         isPolicyAdmin,
+        badgeAdmin,
+        badgeAuditor,
+        badgeOwner,
     ]);
 
     const filterMember = useCallback((memberOption: MemberOption, searchQuery: string) => {


### PR DESCRIPTION
### Explanation of Change
This fixes an infinite render loop in the workspace members page. There were two causes:

- unstable references to `Badge` components in the data was causing re-renders even if the sorted data didn't change.
- We were calling setState from inside an effect without a check to make sure data was changing first
- `useTransition` was called at the top-level of a `useEffect`, which schedules another render. We were misusing it before - it can't actually be used to make expensive computations like the filter and sort happen in the background, but it _does_ delay the render caused by `setResult`, so it does de-prioritize the more expensive render of the section list component itself.

### Fixed Issues
$ https://expensify.slack.com/archives/C01GTK53T8Q/p1746649333590639

### Tests
Prerequisite: have a workspace with >15 members.

1. Open the workspace members page
2. Validate that the page isn't rendering in an infinite loop (a clear symptom of this is infinite `Log` calls in the network tab).

- [x] Verify that no errors appear in the JS console

### Offline tests
Same as tests

### QA Steps
Same as tests.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.


### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

https://github.com/user-attachments/assets/82d98421-c527-46a3-be16-a26349907440

</details>

<details>
<summary>MacOS: Desktop</summary>

<!-- add screenshots or videos here -->

</details>
