### PR TITLE
Refactor report scroll visibility for chat and money reports

### DIFF
--- a/src/components/MoneyRequestReportView/MoneyRequestReportActionsList.tsx
+++ b/src/components/MoneyRequestReportView/MoneyRequestReportActionsList.tsx
@@ -44,6 +44,7 @@ import isSearchTopmostFullScreenRoute from '@navigation/helpers/isSearchTopmostF
 import FloatingMessageCounter from '@pages/home/report/FloatingMessageCounter';
 import ReportActionsListItemRenderer from '@pages/home/report/ReportActionsListItemRenderer';
 import shouldDisplayNewMarkerOnReportAction from '@pages/home/report/shouldDisplayNewMarkerOnReportAction';
+import useReportUnreadMessageScrollTracking from '@pages/home/report/useReportUnreadMessageScrollTracking';
 import {openReport, readNewestAction, subscribeToNewActionEvent} from '@userActions/Report';
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
@@ -114,7 +115,6 @@ function MoneyRequestReportActionsList({report, policy, reportActions = [], tran
     const [currentUserAccountID] = useOnyx(ONYXKEYS.SESSION, {canBeMissing: false, selector: (session) => session?.accountID});
 
     const canPerformWriteAction = canUserPerformWriteAction(report);
-    const [isFloatingMessageCounterVisible, setIsFloatingMessageCounterVisible] = useState(false);
 
     const {shouldUseNarrowLayout} = useResponsiveLayout();
 
@@ -183,22 +183,6 @@ function MoneyRequestReportActionsList({report, policy, reportActions = [], tran
     const onEndReached = useCallback(() => {
         loadNewerChats(false);
     }, [loadNewerChats]);
-
-    useEffect(() => {
-        if (
-            scrollingVerticalBottomOffset.current < AUTOSCROLL_TO_TOP_THRESHOLD &&
-            previousLastIndex.current !== lastActionIndex &&
-            reportActionSize.current > reportActions.length &&
-            hasNewestReportAction
-        ) {
-            setIsFloatingMessageCounterVisible(false);
-            reportScrollManager.scrollToEnd();
-        }
-
-        previousLastIndex.current = lastActionIndex;
-        reportActionSize.current = visibleReportActions.length;
-        hasNewestReportActionRef.current = hasNewestReportAction;
-    }, [lastActionIndex, reportActions, reportScrollManager, hasNewestReportAction, visibleReportActions.length]);
 
     const prevUnreadMarkerReportActionID = useRef<string | null>(null);
 
@@ -277,6 +261,40 @@ function MoneyRequestReportActionsList({report, policy, reportActions = [], tran
     }, [currentUserAccountID, earliestReceivedOfflineMessageIndex, prevVisibleActionsMap, visibleReportActions, unreadMarkerTime]);
     prevUnreadMarkerReportActionID.current = unreadMarkerReportActionID;
 
+    const {isFloatingMessageCounterVisible, setIsFloatingMessageCounterVisible, trackVerticalScrolling} = useReportUnreadMessageScrollTracking({
+        reportID: report.reportID,
+        currentVerticalScrollingOffsetRef: scrollingVerticalBottomOffset,
+        floatingMessageVisibleInitialValue: false,
+        readActionSkippedRef: readActionSkipped,
+        hasUnreadMarkerReportAction: !!unreadMarkerReportActionID,
+        onTrackScrolling: (event: NativeSyntheticEvent<NativeScrollEvent>) => {
+            const {layoutMeasurement, contentSize, contentOffset} = event.nativeEvent;
+            const fullContentHeight = contentSize.height;
+
+            /**
+             * Count the diff between current scroll position and the bottom of the list.
+             * Diff == (height of all items in the list) - (height of the layout with the list) - (how far user scrolled)
+             */
+            scrollingVerticalBottomOffset.current = fullContentHeight - layoutMeasurement.height - contentOffset.y;
+        },
+    });
+
+    useEffect(() => {
+        if (
+            scrollingVerticalBottomOffset.current < AUTOSCROLL_TO_TOP_THRESHOLD &&
+            previousLastIndex.current !== lastActionIndex &&
+            reportActionSize.current > reportActions.length &&
+            hasNewestReportAction
+        ) {
+            setIsFloatingMessageCounterVisible(false);
+            reportScrollManager.scrollToEnd();
+        }
+
+        previousLastIndex.current = lastActionIndex;
+        reportActionSize.current = visibleReportActions.length;
+        hasNewestReportActionRef.current = hasNewestReportAction;
+    }, [lastActionIndex, reportActions, reportScrollManager, hasNewestReportAction, visibleReportActions.length, setIsFloatingMessageCounterVisible]);
+
     /**
      * Subscribe to read/unread events and update our unreadMarkerTime
      */
@@ -330,7 +348,7 @@ function MoneyRequestReportActionsList({report, policy, reportActions = [], tran
                 }, DELAY_FOR_SCROLLING_TO_END);
             });
         },
-        [reportScrollManager],
+        [reportScrollManager, setIsFloatingMessageCounterVisible],
     );
 
     useEffect(() => {
@@ -399,37 +417,7 @@ function MoneyRequestReportActionsList({report, policy, reportActions = [], tran
         reportScrollManager.scrollToEnd();
         readActionSkipped.current = false;
         readNewestAction(report.reportID);
-    }, [report.reportID, reportScrollManager, hasNewestReportAction]);
-
-    /**
-     * Todo - extract to reusable logic - https://github.com/Expensify/App/issues/58891
-     * Show/hide the new floating message counter when user is scrolling back/forth in the history of messages.
-     */
-    const handleUnreadFloatingButton = () => {
-        if (scrollingVerticalBottomOffset.current > CONST.REPORT.ACTIONS.SCROLL_VERTICAL_OFFSET_THRESHOLD && !isFloatingMessageCounterVisible && !!unreadMarkerReportActionID) {
-            setIsFloatingMessageCounterVisible(true);
-        }
-
-        if (scrollingVerticalBottomOffset.current < CONST.REPORT.ACTIONS.SCROLL_VERTICAL_OFFSET_THRESHOLD && isFloatingMessageCounterVisible) {
-            if (readActionSkipped.current) {
-                readActionSkipped.current = false;
-                readNewestAction(report.reportID);
-            }
-            setIsFloatingMessageCounterVisible(false);
-        }
-    };
-
-    const trackVerticalScrolling = (event: NativeSyntheticEvent<NativeScrollEvent>) => {
-        const {layoutMeasurement, contentSize, contentOffset} = event.nativeEvent;
-        const fullContentHeight = contentSize.height;
-
-        /**
-         * Count the diff between current scroll position and the bottom of the list.
-         * Diff == (height of all items in the list) - (height of the layout with the list) - (how far user scrolled)
-         */
-        scrollingVerticalBottomOffset.current = fullContentHeight - layoutMeasurement.height - contentOffset.y;
-        handleUnreadFloatingButton();
-    };
+    }, [setIsFloatingMessageCounterVisible, hasNewestReportAction, reportScrollManager, report.reportID]);
 
     const reportHasComments = visibleReportActions.length > 0;
 

--- a/src/pages/home/report/ReportActionsList.tsx
+++ b/src/pages/home/report/ReportActionsList.tsx
@@ -62,6 +62,7 @@ import getInitialNumToRender from './getInitialNumReportActionsToRender';
 import ListBoundaryLoader from './ListBoundaryLoader';
 import ReportActionsListItemRenderer from './ReportActionsListItemRenderer';
 import shouldDisplayNewMarkerOnReportAction from './shouldDisplayNewMarkerOnReportAction';
+import useReportUnreadMessageScrollTracking from './useReportUnreadMessageScrollTracking';
 
 type ReportActionsListProps = {
     /** The report currently being looked at */
@@ -316,14 +317,25 @@ function ReportActionsList({
     const reportActionID = route?.params?.reportActionID;
     const indexOfLinkedAction = reportActionID ? sortedVisibleReportActions.findIndex((action) => action.reportActionID === reportActionID) : -1;
     const isLinkedActionCloseToNewest = indexOfLinkedAction < IS_CLOSE_TO_NEWEST_THRESHOLD;
-    const [isFloatingMessageCounterVisible, setIsFloatingMessageCounterVisible] = useState(!isLinkedActionCloseToNewest);
+
+    const {isFloatingMessageCounterVisible, setIsFloatingMessageCounterVisible, trackVerticalScrolling} = useReportUnreadMessageScrollTracking({
+        reportID: report.reportID,
+        currentVerticalScrollingOffsetRef: scrollingVerticalOffset,
+        floatingMessageVisibleInitialValue: !isLinkedActionCloseToNewest,
+        readActionSkippedRef: readActionSkipped,
+        hasUnreadMarkerReportAction: !!unreadMarkerReportActionID,
+        onTrackScrolling: (event: NativeSyntheticEvent<NativeScrollEvent>) => {
+            scrollingVerticalOffset.current = event.nativeEvent.contentOffset.y;
+            onScroll?.(event);
+        },
+    });
 
     useEffect(() => {
         if (isLinkedActionCloseToNewest) {
             return;
         }
         setIsFloatingMessageCounterVisible(true);
-    }, [isLinkedActionCloseToNewest, route]);
+    }, [isLinkedActionCloseToNewest, route, setIsFloatingMessageCounterVisible]);
 
     useEffect(() => {
         if (
@@ -337,7 +349,7 @@ function ReportActionsList({
         }
         previousLastIndex.current = lastActionIndex;
         reportActionSize.current = sortedVisibleReportActions.length;
-    }, [lastActionIndex, sortedVisibleReportActions, reportScrollManager, hasNewestReportAction, linkedReportActionID]);
+    }, [lastActionIndex, sortedVisibleReportActions, reportScrollManager, hasNewestReportAction, linkedReportActionID, setIsFloatingMessageCounterVisible]);
 
     useEffect(() => {
         userActiveSince.current = DateUtils.getDBTime();
@@ -414,7 +426,7 @@ function ReportActionsList({
                 setIsScrollToBottomEnabled(true);
             });
         },
-        [report.reportID, reportScrollManager],
+        [report.reportID, reportScrollManager, setIsFloatingMessageCounterVisible],
     );
     useEffect(() => {
         // Why are we doing this, when in the cleanup of the useEffect we are already calling the unsubscribe function?
@@ -463,29 +475,6 @@ function ReportActionsList({
         // eslint-disable-next-line react-compiler/react-compiler, react-hooks/exhaustive-deps
     }, [lastAction]);
 
-    /**
-     * Show/hide the new floating message counter when user is scrolling back/forth in the history of messages.
-     */
-    const handleUnreadFloatingButton = () => {
-        if (scrollingVerticalOffset.current > CONST.REPORT.ACTIONS.SCROLL_VERTICAL_OFFSET_THRESHOLD && !isFloatingMessageCounterVisible && !!unreadMarkerReportActionID) {
-            setIsFloatingMessageCounterVisible(true);
-        }
-
-        if (scrollingVerticalOffset.current < CONST.REPORT.ACTIONS.SCROLL_VERTICAL_OFFSET_THRESHOLD && isFloatingMessageCounterVisible) {
-            if (readActionSkipped.current) {
-                readActionSkipped.current = false;
-                readNewestAction(report.reportID);
-            }
-            setIsFloatingMessageCounterVisible(false);
-        }
-    };
-
-    const trackVerticalScrolling = (event: NativeSyntheticEvent<NativeScrollEvent>) => {
-        scrollingVerticalOffset.current = event.nativeEvent.contentOffset.y;
-        handleUnreadFloatingButton();
-        onScroll?.(event);
-    };
-
     const scrollToBottomAndMarkReportAsRead = useCallback(() => {
         setIsFloatingMessageCounterVisible(false);
 
@@ -498,7 +487,7 @@ function ReportActionsList({
         reportScrollManager.scrollToBottom();
         readActionSkipped.current = false;
         readNewestAction(report.reportID);
-    }, [report.reportID, reportScrollManager, hasNewestReportAction]);
+    }, [setIsFloatingMessageCounterVisible, hasNewestReportAction, reportScrollManager, report.reportID]);
 
     /**
      * Calculates the ideal number of report actions to render in the first render, based on the screen height and on

--- a/src/pages/home/report/useReportUnreadMessageScrollTracking.ts
+++ b/src/pages/home/report/useReportUnreadMessageScrollTracking.ts
@@ -1,0 +1,67 @@
+import {useState} from 'react';
+import type {MutableRefObject} from 'react';
+import type {NativeScrollEvent, NativeSyntheticEvent} from 'react-native';
+import {readNewestAction} from '@userActions/Report';
+import CONST from '@src/CONST';
+
+type Args = {
+    /** The report ID */
+    reportID: string;
+
+    /** The current offset of scrolling from either top or bottom of chat list */
+    currentVerticalScrollingOffsetRef: MutableRefObject<number>;
+
+    /** Ref for whether read action was skipped */
+    readActionSkippedRef: MutableRefObject<boolean>;
+
+    /** The initial value for visibility of floating message button */
+    floatingMessageVisibleInitialValue: boolean;
+
+    /** Whether the unread marker is displayed for any report action */
+    hasUnreadMarkerReportAction: boolean;
+
+    /** Callback to call on every scroll event */
+    onTrackScrolling: (event: NativeSyntheticEvent<NativeScrollEvent>) => void;
+};
+
+export default function useReportUnreadMessageScrollTracking({
+    reportID,
+    currentVerticalScrollingOffsetRef,
+    floatingMessageVisibleInitialValue,
+    hasUnreadMarkerReportAction,
+    readActionSkippedRef,
+    onTrackScrolling,
+}: Args) {
+    const [isFloatingMessageCounterVisible, setIsFloatingMessageCounterVisible] = useState(floatingMessageVisibleInitialValue);
+
+    /**
+     * On every scroll event we want to:
+     * Show/hide the new floating message counter when user is scrolling back/forth in the history of messages.
+     * Call any other callback that the component might need
+     */
+    const trackVerticalScrolling = (event: NativeSyntheticEvent<NativeScrollEvent>) => {
+        onTrackScrolling(event);
+
+        // display floating button if we're scrolled more than the offset
+        if (currentVerticalScrollingOffsetRef.current > CONST.REPORT.ACTIONS.SCROLL_VERTICAL_OFFSET_THRESHOLD && !isFloatingMessageCounterVisible && hasUnreadMarkerReportAction) {
+            setIsFloatingMessageCounterVisible(true);
+        }
+
+        // hide floating button if we're scrolled closer than the offset and mark message as read
+        if (currentVerticalScrollingOffsetRef.current < CONST.REPORT.ACTIONS.SCROLL_VERTICAL_OFFSET_THRESHOLD && isFloatingMessageCounterVisible) {
+            if (readActionSkippedRef.current) {
+                // eslint-disable-next-line react-compiler/react-compiler,no-param-reassign
+                readActionSkippedRef.current = false;
+                readNewestAction(reportID);
+            }
+
+            setIsFloatingMessageCounterVisible(false);
+        }
+    };
+
+    return {
+        isFloatingMessageCounterVisible,
+        setIsFloatingMessageCounterVisible,
+        trackVerticalScrolling,
+    };
+}

--- a/tests/unit/useReportUnreadMessageScrollTrackingTest.ts
+++ b/tests/unit/useReportUnreadMessageScrollTrackingTest.ts
@@ -1,0 +1,162 @@
+import {act, renderHook} from '@testing-library/react-native';
+import type {NativeScrollEvent, NativeSyntheticEvent} from 'react-native';
+import useReportUnreadMessageScrollTracking from '@pages/home/report/useReportUnreadMessageScrollTracking';
+import {readNewestAction} from '@userActions/Report';
+import CONST from '@src/CONST';
+
+jest.mock('@userActions/Report', () => {
+    return {
+        readNewestAction: jest.fn(),
+    };
+});
+
+const reportID = '12345';
+const readActionRefFalse = {current: false};
+const emptyScrollEventMock = {
+    nativeEvent: {layoutMeasurement: {height: 0, width: 0}, contentSize: {width: 100, height: 100}, contentOffset: {x: 0, y: 0}},
+} as NativeSyntheticEvent<NativeScrollEvent>;
+
+describe('useReportUnreadMessageScrollTracking', () => {
+    describe('on init and without any scrolling', () => {
+        const onTrackScrollingMockFn = jest.fn();
+
+        it('returns initial floatingMessage visibility and sets no state', () => {
+            // Given
+            const offsetRef = {current: 0};
+            const {result} = renderHook(() =>
+                useReportUnreadMessageScrollTracking({
+                    reportID,
+                    currentVerticalScrollingOffsetRef: offsetRef,
+                    readActionSkippedRef: readActionRefFalse,
+                    floatingMessageVisibleInitialValue: false,
+                    hasUnreadMarkerReportAction: false,
+                    onTrackScrolling: onTrackScrollingMockFn,
+                }),
+            );
+
+            // Then
+            expect(result.current.isFloatingMessageCounterVisible).toBe(false);
+            expect(onTrackScrollingMockFn).not.toBeCalled();
+        });
+
+        it('returns floatingMessage visibility that was set to a new value', () => {
+            // Given
+            const offsetRef = {current: 0};
+            const {result, rerender} = renderHook(() =>
+                useReportUnreadMessageScrollTracking({
+                    reportID,
+                    currentVerticalScrollingOffsetRef: offsetRef,
+                    readActionSkippedRef: readActionRefFalse,
+                    floatingMessageVisibleInitialValue: false,
+                    hasUnreadMarkerReportAction: false,
+                    onTrackScrolling: onTrackScrollingMockFn,
+                }),
+            );
+
+            // When
+            act(() => {
+                result.current.setIsFloatingMessageCounterVisible(true);
+            });
+            rerender({});
+
+            // Then
+            expect(result.current.isFloatingMessageCounterVisible).toBe(true);
+            expect(onTrackScrollingMockFn).not.toBeCalled();
+        });
+    });
+
+    describe('when scrolling', () => {
+        const onTrackScrollingMockFn = jest.fn();
+
+        it('returns floatingMessage visibility as true when scrolling outside of threshold', () => {
+            // Given
+            const offsetRef = {current: 0};
+            const {result, rerender} = renderHook(() =>
+                useReportUnreadMessageScrollTracking({
+                    reportID,
+                    currentVerticalScrollingOffsetRef: offsetRef,
+                    readActionSkippedRef: readActionRefFalse,
+                    floatingMessageVisibleInitialValue: false,
+                    hasUnreadMarkerReportAction: true,
+                    onTrackScrolling: onTrackScrollingMockFn,
+                }),
+            );
+
+            // When
+            act(() => {
+                offsetRef.current = CONST.REPORT.ACTIONS.SCROLL_VERTICAL_OFFSET_THRESHOLD + 100;
+                result.current.trackVerticalScrolling(emptyScrollEventMock);
+            });
+            rerender({});
+
+            // Then
+            expect(result.current.isFloatingMessageCounterVisible).toBe(true);
+            expect(onTrackScrollingMockFn).toBeCalledWith(emptyScrollEventMock);
+        });
+
+        it('returns floatingMessage visibility as false when scrolling inside the threshold', () => {
+            // Given
+            const offsetRef = {current: 0};
+            const {result, rerender} = renderHook(() =>
+                useReportUnreadMessageScrollTracking({
+                    reportID,
+                    currentVerticalScrollingOffsetRef: offsetRef,
+                    readActionSkippedRef: readActionRefFalse,
+                    floatingMessageVisibleInitialValue: false,
+                    hasUnreadMarkerReportAction: true,
+                    onTrackScrolling: onTrackScrollingMockFn,
+                }),
+            );
+
+            // When
+            act(() => {
+                offsetRef.current = CONST.REPORT.ACTIONS.SCROLL_VERTICAL_OFFSET_THRESHOLD - 100;
+                result.current.trackVerticalScrolling(emptyScrollEventMock);
+            });
+            rerender({});
+
+            // Then
+            expect(result.current.isFloatingMessageCounterVisible).toBe(false);
+            expect(onTrackScrollingMockFn).toBeCalledWith(emptyScrollEventMock);
+        });
+
+        it('calls readAction when scrolling inside the threshold and the message and read action skipped is true', () => {
+            // Given
+            const offsetRef = {current: 0};
+            const {result, rerender} = renderHook(() =>
+                useReportUnreadMessageScrollTracking({
+                    reportID,
+                    currentVerticalScrollingOffsetRef: offsetRef,
+                    readActionSkippedRef: {current: true},
+                    floatingMessageVisibleInitialValue: false,
+                    hasUnreadMarkerReportAction: true,
+                    onTrackScrolling: onTrackScrollingMockFn,
+                }),
+            );
+
+            // When
+            act(() => {
+                // offset greater, will set visible to true
+                offsetRef.current = CONST.REPORT.ACTIONS.SCROLL_VERTICAL_OFFSET_THRESHOLD + 100;
+                result.current.trackVerticalScrolling(emptyScrollEventMock);
+            });
+
+            expect(result.current.isFloatingMessageCounterVisible).toBe(true);
+            expect(readNewestAction).toBeCalledTimes(0);
+
+            rerender({});
+
+            act(() => {
+                // scrolling into the offset, should call readNewestAction
+                offsetRef.current = CONST.REPORT.ACTIONS.SCROLL_VERTICAL_OFFSET_THRESHOLD - 100;
+                result.current.trackVerticalScrolling(emptyScrollEventMock);
+            });
+
+            // Then
+            expect(readNewestAction).toBeCalledTimes(1);
+            expect(onTrackScrollingMockFn).toBeCalledWith(emptyScrollEventMock);
+            expect(readActionRefFalse.current).toBe(false);
+            expect(result.current.isFloatingMessageCounterVisible).toBe(false);
+        });
+    });
+});


### PR DESCRIPTION
### Explanation of Change
This is a pure code refactor, does not add any new functionalities, though needs usual testing, since it moves existing logic around.

- It modifies code related to setting visibility of unread message floating button. I could not abstract away 100% of this functionality, since there are differences between ReportScreen and table moneyRequestReport view that cannot be ignored.
- The two views (standard `ReportActionsList` and `MoneyRequestReportActionList`) are very similar, but ReportScreen handles much more cases (basically every possible report) than the newly added table view
- Even though the extraction is not perfect, the main achievement is moving out the logic of when the button is displayed while user scrolls through the view - that is now moved to a dedicated hook. Some other parts had to stay in their respective components
- added tests

### Fixed Issues

$ https://github.com/Expensify/App/issues/58891
PROPOSAL:

### Tests

- log in to the app as user A
- open another app and log in as user B
- write messages on a chat report and/or money request report between users A <---> B
- verify that scrolling and visibility of "new messages" button is correct

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

### QA Steps
same as Tests


### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I verified there are no new alerts related to the `canBeMissing` param for `useOnyx`
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

https://github.com/user-attachments/assets/a5af0c40-9534-4ad4-a5e6-01b0488103b0

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>


https://github.com/user-attachments/assets/4daebf9b-5e86-4036-9662-f486a5353454


https://github.com/user-attachments/assets/0c8a8bfb-faf2-42b3-87f2-82b64bd03ced

</details>

<details>
<summary>MacOS: Desktop</summary>

<!-- add screenshots or videos here -->

</details>
