### PR TITLE
[CP Staging] fix: search bar performance followup

### DIFF
--- a/src/components/SelectionListWithModal/index.tsx
+++ b/src/components/SelectionListWithModal/index.tsx
@@ -17,10 +17,11 @@ type SelectionListWithModalProps<TItem extends ListItem> = SelectionListProps<TI
     onTurnOnSelectionMode?: (item: TItem | null) => void;
     isSelected?: (item: TItem) => boolean;
     isScreenFocused?: boolean;
+    selectedItemKeys?: Array<string | number>;
 };
 
 function SelectionListWithModal<TItem extends ListItem>(
-    {turnOnSelectionModeOnLongPress, onTurnOnSelectionMode, onLongPressRow, isScreenFocused = false, sections, isSelected, ...rest}: SelectionListWithModalProps<TItem>,
+    {turnOnSelectionModeOnLongPress, onTurnOnSelectionMode, onLongPressRow, isScreenFocused = false, sections, isSelected, selectedItemKeys, ...rest}: SelectionListWithModalProps<TItem>,
     ref: ForwardedRef<SelectionListHandle>,
 ) {
     const [isModalVisible, setIsModalVisible] = useState(false);
@@ -40,12 +41,14 @@ function SelectionListWithModal<TItem extends ListItem>(
 
     useEffect(() => {
         // We can access 0 index safely as we are not displaying multiple sections in table view
-        const selectedItems = sections[0].data.filter((item) => {
-            if (isSelected) {
-                return isSelected(item);
-            }
-            return !!item.isSelected;
-        });
+        const selectedItems =
+            selectedItemKeys ??
+            sections[0].data.filter((item) => {
+                if (isSelected) {
+                    return isSelected(item);
+                }
+                return !!item.isSelected;
+            });
         selectionRef.current = selectedItems.length;
 
         if (!isSmallScreenWidth) {
@@ -66,7 +69,7 @@ function SelectionListWithModal<TItem extends ListItem>(
             turnOffMobileSelectionMode();
         }
         // eslint-disable-next-line react-compiler/react-compiler, react-hooks/exhaustive-deps
-    }, [sections, isSmallScreenWidth, isSelected, isFocused]);
+    }, [sections, selectedItemKeys, selectionMode, isSmallScreenWidth, isSelected, isFocused]);
 
     useEffect(
         () => () => {

--- a/src/hooks/useSearchResults.ts
+++ b/src/hooks/useSearchResults.ts
@@ -1,4 +1,4 @@
-import {startTransition, useEffect, useRef, useState} from 'react';
+import {useEffect, useRef, useState, useTransition} from 'react';
 import type {ListItem} from '@components/SelectionList/types';
 import CONST from '@src/CONST';
 import usePrevious from './usePrevious';
@@ -13,6 +13,7 @@ function useSearchResults<TValue extends ListItem>(data: TValue[], filterData: (
     const [result, setResult] = useState(data);
     const prevData = usePrevious(data);
     const prevInputValueRef = useRef<string | undefined>(undefined);
+    const [, startTransition] = useTransition();
     useEffect(() => {
         const normalizedSearchQuery = inputValue.trim().toLowerCase();
         const filtered = normalizedSearchQuery.length ? data.filter((item) => filterData(item, normalizedSearchQuery)) : data;

--- a/src/hooks/useSearchResults.ts
+++ b/src/hooks/useSearchResults.ts
@@ -1,4 +1,5 @@
-import {useEffect, useState, useTransition} from 'react';
+import {startTransition, useEffect, useRef, useState} from 'react';
+import type {ListItem} from '@components/SelectionList/types';
 import CONST from '@src/CONST';
 import usePrevious from './usePrevious';
 
@@ -7,15 +8,20 @@ import usePrevious from './usePrevious';
  * It utilizes `useTransition` to allow the searchQuery to change rapidly, while more expensive renders that occur using
  * the result of the filtering and sorting are deprioritized, allowing them to happen in the background.
  */
-function useSearchResults<TValue>(data: TValue[], filterData: (datum: TValue, searchInput: string) => boolean, sortData: (data: TValue[]) => TValue[] = (d) => d) {
+function useSearchResults<TValue extends ListItem>(data: TValue[], filterData: (datum: TValue, searchInput: string) => boolean, sortData: (data: TValue[]) => TValue[] = (d) => d) {
     const [inputValue, setInputValue] = useState('');
     const [result, setResult] = useState(data);
-    const [, startTransition] = useTransition();
     const prevData = usePrevious(data);
+    const prevInputValueRef = useRef<string | undefined>(undefined);
     useEffect(() => {
+        const normalizedSearchQuery = inputValue.trim().toLowerCase();
+        const filtered = normalizedSearchQuery.length ? data.filter((item) => filterData(item, normalizedSearchQuery)) : data;
+        if (prevInputValueRef.current === inputValue) {
+            setResult(filtered);
+            return;
+        }
+        prevInputValueRef.current = inputValue;
         startTransition(() => {
-            const normalizedSearchQuery = inputValue.trim().toLowerCase();
-            const filtered = normalizedSearchQuery.length ? data.filter((item) => filterData(item, normalizedSearchQuery)) : data;
             const sorted = sortData(filtered);
             setResult(sorted);
         });

--- a/src/pages/workspace/WorkspaceMembersPage.tsx
+++ b/src/pages/workspace/WorkspaceMembersPage.tsx
@@ -700,8 +700,6 @@ function WorkspaceMembersPage({personalDetails, route, policy, currentUserPerson
 
     const selectionModeHeader = selectionMode?.isEnabled && shouldUseNarrowLayout;
 
-    const sections = useMemo(() => [{data: filteredData, isDisabled: false}], [filteredData]);
-
     return (
         <WorkspacePageWithSections
             headerText={selectionModeHeader ? translate('common.selectMultiple') : translate('workspace.common.members')}
@@ -770,7 +768,7 @@ function WorkspaceMembersPage({personalDetails, route, policy, currentUserPerson
                         showsVerticalScrollIndicator={false}
                         contentContainerStyle={[styles.flexGrow1, styles.flexShrink0]}
                     >
-                        {shouldUseNarrowLayout && filteredData.length > 0 && <View style={[styles.pr5]}>{getHeaderContent()}</View>}
+                        {shouldUseNarrowLayout && data.length > 0 && <View style={[styles.pr5]}>{getHeaderContent()}</View>}
                         {!shouldUseNarrowLayout && (
                             <>
                                 {!!headerMessage && (
@@ -793,7 +791,8 @@ function WorkspaceMembersPage({personalDetails, route, policy, currentUserPerson
                             <SelectionListWithModal
                                 ref={selectionListRef}
                                 canSelectMultiple={canSelectMultiple}
-                                sections={sections}
+                                sections={[{data: filteredData, isDisabled: false}]}
+                                selectedItemKeys={selectedEmployees}
                                 ListItem={TableListItem}
                                 turnOnSelectionModeOnLongPress={isPolicyAdmin}
                                 onTurnOnSelectionMode={(item) => item && toggleUser(item?.accountID)}

--- a/src/pages/workspace/categories/WorkspaceCategoriesPage.tsx
+++ b/src/pages/workspace/categories/WorkspaceCategoriesPage.tsx
@@ -162,7 +162,7 @@ function WorkspaceCategoriesPage({route}: WorkspaceCategoriesPageProps) {
     }, []);
     const [inputValue, setInputValue, filteredCategoryList] = useSearchResults(categoryList, filterCategory, sortCategories);
 
-    useAutoTurnSelectionModeOffWhenHasNoActiveOption(filteredCategoryList);
+    useAutoTurnSelectionModeOffWhenHasNoActiveOption(categoryList);
 
     const sections = useMemo(() => [{data: filteredCategoryList, isDisabled: false}], [filteredCategoryList]);
 
@@ -467,6 +467,7 @@ function WorkspaceCategoriesPage({route}: WorkspaceCategoriesPageProps) {
                             turnOnSelectionModeOnLongPress={isSmallScreenWidth}
                             onTurnOnSelectionMode={(item) => item && toggleCategory(item)}
                             sections={sections}
+                            selectedItemKeys={selectedCategories}
                             onCheckboxPress={toggleCategory}
                             onSelectRow={navigateToCategorySettings}
                             shouldPreventDefaultFocusOnSelectRow={!canUseTouchScreen()}

--- a/src/pages/workspace/categories/WorkspaceCategoriesPage.tsx
+++ b/src/pages/workspace/categories/WorkspaceCategoriesPage.tsx
@@ -164,8 +164,6 @@ function WorkspaceCategoriesPage({route}: WorkspaceCategoriesPageProps) {
 
     useAutoTurnSelectionModeOffWhenHasNoActiveOption(categoryList);
 
-    const sections = useMemo(() => [{data: filteredCategoryList, isDisabled: false}], [filteredCategoryList]);
-
     const toggleCategory = useCallback(
         (category: PolicyOption) => {
             setSelectedCategories((prev) => {
@@ -466,7 +464,7 @@ function WorkspaceCategoriesPage({route}: WorkspaceCategoriesPageProps) {
                             canSelectMultiple={canSelectMultiple}
                             turnOnSelectionModeOnLongPress={isSmallScreenWidth}
                             onTurnOnSelectionMode={(item) => item && toggleCategory(item)}
-                            sections={sections}
+                            sections={[{data: filteredCategoryList, isDisabled: false}]}
                             selectedItemKeys={selectedCategories}
                             onCheckboxPress={toggleCategory}
                             onSelectRow={navigateToCategorySettings}

--- a/src/pages/workspace/distanceRates/PolicyDistanceRatesPage.tsx
+++ b/src/pages/workspace/distanceRates/PolicyDistanceRatesPage.tsx
@@ -410,7 +410,7 @@ function PolicyDistanceRatesPage({
                             canSelectMultiple={canSelectMultiple}
                             turnOnSelectionModeOnLongPress
                             onTurnOnSelectionMode={(item) => item && toggleRate(item)}
-                            sections={[{data: filteredDistanceRatesList, key: 'distanceRatesList'}]}
+                            sections={[{data: filteredDistanceRatesList, isDisabled: false}]}
                             selectedItemKeys={selectedDistanceRates}
                             onCheckboxPress={toggleRate}
                             onSelectRow={openRateDetails}

--- a/src/pages/workspace/distanceRates/PolicyDistanceRatesPage.tsx
+++ b/src/pages/workspace/distanceRates/PolicyDistanceRatesPage.tsx
@@ -187,7 +187,6 @@ function PolicyDistanceRatesPage({
     }, []);
     const sortRates = useCallback((rates: RateForList[]) => rates.sort((a, b) => (a.rate ?? 0) - (b.rate ?? 0)), []);
     const [inputValue, setInputValue, filteredDistanceRatesList] = useSearchResults(distanceRatesList, filterRate, sortRates);
-    const sections = useMemo(() => [{data: filteredDistanceRatesList, key: 'distanceRatesList'}], [filteredDistanceRatesList]);
 
     const addRate = () => {
         Navigation.navigate(ROUTES.WORKSPACE_CREATE_DISTANCE_RATE.getRoute(policyID));
@@ -411,7 +410,8 @@ function PolicyDistanceRatesPage({
                             canSelectMultiple={canSelectMultiple}
                             turnOnSelectionModeOnLongPress
                             onTurnOnSelectionMode={(item) => item && toggleRate(item)}
-                            sections={sections}
+                            sections={[{data: filteredDistanceRatesList, key: 'distanceRatesList'}]}
+                            selectedItemKeys={selectedDistanceRates}
                             onCheckboxPress={toggleRate}
                             onSelectRow={openRateDetails}
                             onSelectAll={toggleAllRates}

--- a/src/pages/workspace/perDiem/WorkspacePerDiemPage.tsx
+++ b/src/pages/workspace/perDiem/WorkspacePerDiemPage.tsx
@@ -135,12 +135,12 @@ function WorkspacePerDiemPage({route}: WorkspacePerDiemPageProps) {
     const [policyCategories] = useOnyx(`${ONYXKEYS.COLLECTION.POLICY_CATEGORIES}${policyID}`, {canBeMissing: false});
     const {selectionMode} = useMobileSelectionMode();
 
-    const customUnit = getPerDiemCustomUnit(policy);
+    const customUnit = useMemo(() => getPerDiemCustomUnit(policy), [policy]);
     const customUnitRates: Record<string, Rate> = useMemo(() => customUnit?.rates ?? {}, [customUnit]);
 
-    const allRatesArray = Object.values(customUnitRates);
+    const allRatesArray = useMemo(() => Object.values(customUnitRates), [customUnitRates]);
 
-    const allSubRates = getSubRatesData(allRatesArray);
+    const allSubRates = useMemo(() => getSubRatesData(allRatesArray), [allRatesArray]);
 
     const canSelectMultiple = shouldUseNarrowLayout ? selectionMode?.isEnabled : true;
 
@@ -201,9 +201,8 @@ function WorkspacePerDiemPage({route}: WorkspacePerDiemPageProps) {
         const normalizedSearchInput = StringUtils.normalize(searchInput.toLowerCase());
         return rateText.includes(normalizedSearchInput);
     }, []);
-    const sortRates = useCallback((rates: PolicyOption[]) => lodashSortBy(rates, 'text', localeCompare) as PolicyOption[], []);
+    const sortRates = useCallback((rates: PolicyOption[]) => lodashSortBy(rates, 'destination', localeCompare) as PolicyOption[], []);
     const [inputValue, setInputValue, filteredSubRatesList] = useSearchResults(subRatesList, filterRate, sortRates);
-    const sections = useMemo(() => [{data: filteredSubRatesList, isDisabled: false}], [filteredSubRatesList]);
 
     const toggleSubRate = (subRate: PolicyOption) => {
         if (selectedPerDiem.find((selectedSubRate) => selectedSubRate.subRateID === subRate.subRateID) !== undefined) {
@@ -229,19 +228,25 @@ function WorkspacePerDiemPage({route}: WorkspacePerDiemPageProps) {
         }
     };
 
-    const getCustomListHeader = () => (
-        <View style={[styles.flex1, styles.flexRow, styles.justifyContentBetween, canSelectMultiple && styles.pl3, !canSelectMultiple && [styles.ph9, styles.pv3, styles.pb5]]}>
-            <View style={styles.flex3}>
-                <Text style={[styles.textMicroSupporting, styles.alignSelfStart]}>{translate('common.destination')}</Text>
+    const getCustomListHeader = () => {
+        const header = (
+            <View style={[styles.flex1, styles.flexRow, styles.justifyContentBetween, canSelectMultiple && styles.pl3]}>
+                <View style={styles.flex3}>
+                    <Text style={[styles.textMicroSupporting, styles.alignSelfStart]}>{translate('common.destination')}</Text>
+                </View>
+                <View style={styles.flex2}>
+                    <Text style={[styles.textMicroSupporting, styles.alignItemsStart, styles.pl2]}>{translate('common.subrate')}</Text>
+                </View>
+                <View style={styles.flex2}>
+                    <Text style={[styles.textMicroSupporting, styles.alignSelfEnd]}>{translate('workspace.perDiem.amount')}</Text>
+                </View>
             </View>
-            <View style={styles.flex2}>
-                <Text style={[styles.textMicroSupporting, styles.alignItemsStart, styles.pl2]}>{translate('common.subrate')}</Text>
-            </View>
-            <View style={styles.flex2}>
-                <Text style={[styles.textMicroSupporting, styles.alignSelfEnd]}>{translate('workspace.perDiem.amount')}</Text>
-            </View>
-        </View>
-    );
+        );
+        if (canSelectMultiple) {
+            return header;
+        }
+        return <View style={!canSelectMultiple && [styles.ph9, styles.pv3, styles.pb5]}>{header}</View>;
+    };
 
     const openSettings = () => {
         Navigation.navigate(ROUTES.WORKSPACE_PER_DIEM_SETTINGS.getRoute(policyID));
@@ -446,7 +451,8 @@ function WorkspacePerDiemPage({route}: WorkspacePerDiemPageProps) {
                             canSelectMultiple={canSelectMultiple}
                             turnOnSelectionModeOnLongPress
                             onTurnOnSelectionMode={(item) => item && toggleSubRate(item)}
-                            sections={sections}
+                            sections={[{data: filteredSubRatesList, isDisabled: false}]}
+                            selectedItemKeys={selectedPerDiem.map((item) => item.subRateID)}
                             onCheckboxPress={toggleSubRate}
                             onSelectRow={openSubRateDetails}
                             shouldPreventDefaultFocusOnSelectRow={!canUseTouchScreen()}

--- a/src/pages/workspace/perDiem/WorkspacePerDiemPage.tsx
+++ b/src/pages/workspace/perDiem/WorkspacePerDiemPage.tsx
@@ -201,7 +201,7 @@ function WorkspacePerDiemPage({route}: WorkspacePerDiemPageProps) {
         const normalizedSearchInput = StringUtils.normalize(searchInput.toLowerCase());
         return rateText.includes(normalizedSearchInput);
     }, []);
-    const sortRates = useCallback((rates: PolicyOption[]) => lodashSortBy(rates, 'destination', localeCompare) as PolicyOption[], []);
+    const sortRates = useCallback((rates: PolicyOption[]) => lodashSortBy(rates, 'text', localeCompare) as PolicyOption[], []);
     const [inputValue, setInputValue, filteredSubRatesList] = useSearchResults(subRatesList, filterRate, sortRates);
 
     const toggleSubRate = (subRate: PolicyOption) => {

--- a/src/pages/workspace/tags/WorkspaceTagsPage.tsx
+++ b/src/pages/workspace/tags/WorkspaceTagsPage.tsx
@@ -25,6 +25,7 @@ import Text from '@components/Text';
 import TextLink from '@components/TextLink';
 import useCleanupSelectedOptions from '@hooks/useCleanupSelectedOptions';
 import useEnvironment from '@hooks/useEnvironment';
+import useFilteredSelection from '@hooks/useFilteredSelection';
 import useLocalize from '@hooks/useLocalize';
 import useMobileSelectionMode from '@hooks/useMobileSelectionMode';
 import useNetwork from '@hooks/useNetwork';
@@ -62,7 +63,6 @@ import ROUTES from '@src/ROUTES';
 import type SCREENS from '@src/SCREENS';
 import type {PendingAction} from '@src/types/onyx/OnyxCommon';
 import type DeepValueOf from '@src/types/utils/DeepValueOf';
-import {isEmptyObject} from '@src/types/utils/EmptyObject';
 import type {PolicyTag, PolicyTagList, TagListItem} from './types';
 
 type WorkspaceTagsPageProps = PlatformStackScreenProps<WorkspaceSplitNavigatorParamList, typeof SCREENS.WORKSPACE.TAGS>;
@@ -75,7 +75,6 @@ function WorkspaceTagsPage({route}: WorkspaceTagsPageProps) {
     const theme = useTheme();
     const {translate} = useLocalize();
     const threeDotsAnchorPosition = useThreeDotsAnchorPosition(styles.threeDotsPopoverOffsetNoCloseButton);
-    const [selectedTags, setSelectedTags] = useState<Record<string, boolean>>({});
     const [isDownloadFailureModalVisible, setIsDownloadFailureModalVisible] = useState(false);
     const [isDeleteTagsConfirmModalVisible, setIsDeleteTagsConfirmModalVisible] = useState(false);
     const [isOfflineModalVisible, setIsOfflineModalVisible] = useState(false);
@@ -98,6 +97,20 @@ function WorkspaceTagsPage({route}: WorkspaceTagsPageProps) {
     }, [policyID]);
     const isQuickSettingsFlow = !!backTo;
 
+    const tagsList = useMemo(() => {
+        if (isMultiLevelTags) {
+            return policyTagLists.reduce<Record<string, PolicyTagList>>((acc, policyTagList) => {
+                acc[policyTagList.name] = policyTagList;
+                return acc;
+            }, {});
+        }
+        return policyTagLists?.at(0)?.tags;
+    }, [isMultiLevelTags, policyTagLists]);
+
+    const filterTags = useCallback((tag?: PolicyTag | PolicyTagList) => !!tag && tag.pendingAction !== CONST.RED_BRICK_ROAD_PENDING_ACTION.DELETE, []);
+
+    const [selectedTags, setSelectedTags] = useFilteredSelection(tagsList, filterTags);
+
     const {isOffline} = useNetwork({onReconnect: fetchTags});
 
     useEffect(() => {
@@ -106,33 +119,12 @@ function WorkspaceTagsPage({route}: WorkspaceTagsPageProps) {
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
 
-    const cleanupSelectedOption = useCallback(() => setSelectedTags({}), []);
+    const cleanupSelectedOption = useCallback(() => setSelectedTags([]), [setSelectedTags]);
     useCleanupSelectedOptions(cleanupSelectedOption);
-
-    useEffect(() => {
-        if (isEmptyObject(selectedTags) || !canSelectMultiple) {
-            return;
-        }
-
-        setSelectedTags((prevSelectedTags) => {
-            const keys = Object.keys(prevSelectedTags);
-            const newSelectedTags: Record<string, boolean> = {};
-            const policyTagList = policyTagLists.at(0);
-
-            for (const key of keys) {
-                if (policyTagList?.tags?.[key] && policyTagList?.tags?.[key].pendingAction !== CONST.RED_BRICK_ROAD_PENDING_ACTION.DELETE) {
-                    newSelectedTags[key] = prevSelectedTags[key];
-                }
-            }
-
-            return newSelectedTags;
-        });
-        // eslint-disable-next-line react-compiler/react-compiler, react-hooks/exhaustive-deps
-    }, [policyTagLists]);
 
     useSearchBackPress({
         onClearSelection: () => {
-            setSelectedTags({});
+            setSelectedTags([]);
         },
         onNavigationCallBack: () => Navigation.goBack(backTo),
     });
@@ -175,7 +167,7 @@ function WorkspaceTagsPage({route}: WorkspaceTagsPageProps) {
                     orderWeight: policyTagList.orderWeight,
                     text: getCleanedTagName(policyTagList.name),
                     keyForList: String(policyTagList.orderWeight),
-                    isSelected: selectedTags[policyTagList.name] && canSelectMultiple,
+                    isSelected: selectedTags.includes(policyTagList.name) && canSelectMultiple,
                     pendingAction: getPendingAction(policyTagList),
                     enabled: true,
                     required: policyTagList.required,
@@ -194,7 +186,7 @@ function WorkspaceTagsPage({route}: WorkspaceTagsPageProps) {
             value: tag.name,
             text: getCleanedTagName(tag.name),
             keyForList: tag.name,
-            isSelected: selectedTags[tag.name] && canSelectMultiple,
+            isSelected: selectedTags.includes(tag.name) && canSelectMultiple,
             pendingAction: tag.pendingAction,
             errors: tag.errors ?? undefined,
             enabled: tag.enabled,
@@ -218,7 +210,6 @@ function WorkspaceTagsPage({route}: WorkspaceTagsPageProps) {
     }, []);
     const sortTags = useCallback((tags: TagListItem[]) => lodashSortBy(tags, 'value', localeCompare) as TagListItem[], []);
     const [inputValue, setInputValue, filteredTagList] = useSearchResults(tagList, filterTag, sortTags);
-    const sections = useMemo(() => [{data: filteredTagList, isDisabled: false}], [filteredTagList]);
 
     const filteredTagListKeyedByName = useMemo(
         () =>
@@ -230,15 +221,17 @@ function WorkspaceTagsPage({route}: WorkspaceTagsPageProps) {
     );
 
     const toggleTag = (tag: TagListItem) => {
-        setSelectedTags((prev) => ({
-            ...prev,
-            [tag.value]: !prev[tag.value],
-        }));
+        setSelectedTags((prev) => {
+            if (prev.includes(tag.value)) {
+                return prev.filter((item) => item !== tag.value);
+            }
+            return [...prev, tag.value];
+        });
     };
 
     const toggleAllTags = () => {
         const availableTags = filteredTagList.filter((tag) => tag.pendingAction !== CONST.RED_BRICK_ROAD_PENDING_ACTION.DELETE);
-        setSelectedTags(Object.keys(selectedTags).length > 0 ? {} : Object.fromEntries(availableTags.map((item) => [item.value, true])));
+        setSelectedTags(selectedTags.length > 0 ? [] : availableTags.map((item) => item.value));
     };
 
     const getCustomListHeader = () => {
@@ -273,14 +266,12 @@ function WorkspaceTagsPage({route}: WorkspaceTagsPageProps) {
         }
     };
 
-    const selectedTagsArray = Object.keys(selectedTags).filter((key) => selectedTags[key]);
-
     const deleteTags = () => {
-        deletePolicyTags(policyID, selectedTagsArray);
+        deletePolicyTags(policyID, selectedTags);
         setIsDeleteTagsConfirmModalVisible(false);
 
         InteractionManager.runAfterInteractions(() => {
-            setSelectedTags({});
+            setSelectedTags([]);
         });
     };
 
@@ -289,7 +280,7 @@ function WorkspaceTagsPage({route}: WorkspaceTagsPageProps) {
     const getHeaderButtons = () => {
         const hasAccountingConnections = hasAccountingConnectionsPolicyUtils(policy);
 
-        if (shouldUseNarrowLayout ? !selectionMode?.isEnabled : selectedTagsArray.length === 0) {
+        if (shouldUseNarrowLayout ? !selectionMode?.isEnabled : selectedTags.length === 0) {
             return (
                 <View style={[styles.flexRow, styles.gap2, shouldUseNarrowLayout && styles.mb3]}>
                     {!hasAccountingConnections && !isMultiLevelTags && (
@@ -316,7 +307,7 @@ function WorkspaceTagsPage({route}: WorkspaceTagsPageProps) {
         if (!hasAccountingConnections) {
             options.push({
                 icon: Expensicons.Trashcan,
-                text: translate(selectedTagsArray.length === 1 ? 'workspace.tags.deleteTag' : 'workspace.tags.deleteTags'),
+                text: translate(selectedTags.length === 1 ? 'workspace.tags.deleteTag' : 'workspace.tags.deleteTags'),
                 value: CONST.POLICY.BULK_ACTION_TYPES.DELETE,
                 onSelected: () => setIsDeleteTagsConfirmModalVisible(true),
             });
@@ -326,7 +317,7 @@ function WorkspaceTagsPage({route}: WorkspaceTagsPageProps) {
         const tagsToDisable: Record<string, {name: string; enabled: boolean}> = {};
         let disabledTagCount = 0;
         const tagsToEnable: Record<string, {name: string; enabled: boolean}> = {};
-        for (const tagName of selectedTagsArray) {
+        for (const tagName of selectedTags) {
             if (filteredTagListKeyedByName[tagName]?.enabled) {
                 enabledTagCount++;
                 tagsToDisable[tagName] = {
@@ -348,7 +339,7 @@ function WorkspaceTagsPage({route}: WorkspaceTagsPageProps) {
                 text: translate(enabledTagCount === 1 ? 'workspace.tags.disableTag' : 'workspace.tags.disableTags'),
                 value: CONST.POLICY.BULK_ACTION_TYPES.DISABLE,
                 onSelected: () => {
-                    setSelectedTags({});
+                    setSelectedTags([]);
                     setWorkspaceTagEnabled(policyID, tagsToDisable, 0);
                 },
             });
@@ -360,7 +351,7 @@ function WorkspaceTagsPage({route}: WorkspaceTagsPageProps) {
                 text: translate(disabledTagCount === 1 ? 'workspace.tags.enableTag' : 'workspace.tags.enableTags'),
                 value: CONST.POLICY.BULK_ACTION_TYPES.ENABLE,
                 onSelected: () => {
-                    setSelectedTags({});
+                    setSelectedTags([]);
                     setWorkspaceTagEnabled(policyID, tagsToEnable, 0);
                 },
             });
@@ -373,10 +364,10 @@ function WorkspaceTagsPage({route}: WorkspaceTagsPageProps) {
                 pressOnEnter
                 isSplitButton={false}
                 buttonSize={CONST.DROPDOWN_BUTTON_SIZE.MEDIUM}
-                customText={translate('workspace.common.selected', {count: selectedTagsArray.length})}
+                customText={translate('workspace.common.selected', {count: selectedTags.length})}
                 options={options}
                 style={[shouldUseNarrowLayout && styles.flexGrow1, shouldUseNarrowLayout && styles.mb3]}
-                isDisabled={!selectedTagsArray.length}
+                isDisabled={!selectedTags.length}
             />
         );
     };
@@ -447,7 +438,7 @@ function WorkspaceTagsPage({route}: WorkspaceTagsPageProps) {
                         shouldShowBackButton={shouldUseNarrowLayout}
                         onBackButtonPress={() => {
                             if (selectionMode?.isEnabled) {
-                                setSelectedTags({});
+                                setSelectedTags([]);
                                 turnOffMobileSelectionMode();
                                 return;
                             }
@@ -506,7 +497,8 @@ function WorkspaceTagsPage({route}: WorkspaceTagsPageProps) {
                                 canSelectMultiple={canSelectMultiple}
                                 turnOnSelectionModeOnLongPress={!isMultiLevelTags}
                                 onTurnOnSelectionMode={(item) => item && toggleTag(item)}
-                                sections={sections}
+                                sections={[{data: filteredTagList, isDisabled: false}]}
+                                selectedItemKeys={selectedTags}
                                 onCheckboxPress={toggleTag}
                                 onSelectRow={navigateToTagSettings}
                                 shouldSingleExecuteRowSelect={!canSelectMultiple}
@@ -560,8 +552,8 @@ function WorkspaceTagsPage({route}: WorkspaceTagsPageProps) {
                 isVisible={isDeleteTagsConfirmModalVisible}
                 onConfirm={deleteTags}
                 onCancel={() => setIsDeleteTagsConfirmModalVisible(false)}
-                title={translate(selectedTagsArray.length === 1 ? 'workspace.tags.deleteTag' : 'workspace.tags.deleteTags')}
-                prompt={translate(selectedTagsArray.length === 1 ? 'workspace.tags.deleteTagConfirmation' : 'workspace.tags.deleteTagsConfirmation')}
+                title={translate(selectedTags.length === 1 ? 'workspace.tags.deleteTag' : 'workspace.tags.deleteTags')}
+                prompt={translate(selectedTags.length === 1 ? 'workspace.tags.deleteTagConfirmation' : 'workspace.tags.deleteTagsConfirmation')}
                 confirmText={translate('common.delete')}
                 cancelText={translate('common.cancel')}
                 danger

--- a/src/pages/workspace/taxes/WorkspaceTaxesPage.tsx
+++ b/src/pages/workspace/taxes/WorkspaceTaxesPage.tsx
@@ -199,7 +199,6 @@ function WorkspaceTaxesPage({
         });
     }, []);
     const [inputValue, setInputValue, filteredTaxesList] = useSearchResults(taxesList, filterTax, sortTaxes);
-    const sections = useMemo(() => [{data: filteredTaxesList, isDisabled: false}], [filteredTaxesList]);
 
     const isLoading = !isOffline && taxesList === undefined;
 
@@ -410,7 +409,8 @@ function WorkspaceTaxesPage({
                         canSelectMultiple={canSelectMultiple}
                         turnOnSelectionModeOnLongPress
                         onTurnOnSelectionMode={(item) => item && toggleTax(item)}
-                        sections={sections}
+                        sections={[{data: filteredTaxesList, isDisabled: false}]}
+                        selectedItemKeys={selectedTaxesIDs}
                         onCheckboxPress={toggleTax}
                         onSelectRow={navigateToEditTaxRate}
                         onSelectAll={toggleAllTaxes}


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
<!-- Explain what your change does and how it addresses the linked issue -->

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/61820
$ https://github.com/Expensify/App/issues/61821
$ https://github.com/Expensify/App/issues/61833
PROPOSAL:

Also improves performance for https://github.com/Expensify/App/issues/61822, but it still needs more improvements

<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

Test 1:
Precondition: Workspace has at least 16 members.

1. Go to staging.new.expensify.com
2. Go to workspace settings > Members.
3. Tap on the search field.
4. Enter any term that will not return any result.
5. Verify that: The intro text "Directory of all workspace members" does not disappear

Test 2: 

Precondition: Workspace has imported a few per diem rates (5 per diem rates) (as long as per diem page is not scrollable).

1. Go to workspace settings.
3. Go to Per diem.
4. Verify that: There is no space between table header and content when there are a few per diem rates.

Test 3:

1. Go to workspace settings > Categories.
2. Long tap on any category.
3. Tap Select.
4. Tap on the search field.
7. Search for term that will not return any result.
8. Verify that: the selection mode is not turned off even if there's no search result

- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->
Test 1:
Precondition: Workspace has at least 16 members.

1. Go to staging.new.expensify.com
2. Go to workspace settings > Members.
3. Tap on the search field.
4. Enter any term that will not return any result.
5. Verify that: The intro text "Directory of all workspace members" does not disappear

Test 2: 

Precondition: Workspace has imported a few per diem rates (5 per diem rates) (as long as per diem page is not scrollable).

1. Go to workspace settings.
3. Go to Per diem.
4. Verify that: There is no space between table header and content when there are a few per diem rates.

Test 3:

1. Go to workspace settings > Categories.
2. Long tap on any category.
3. Tap Select.
4. Tap on the search field.
7. Search for term that will not return any result.
8. Verify that: the selection mode is not turned off even if there's no search result

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I verified there are no new alerts related to the `canBeMissing` param for `useOnyx`
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>
<img width="350" alt="Screenshot 2025-05-13 at 09 51 24" src="https://github.com/user-attachments/assets/31301c53-129b-47c6-b866-f6ad62890a0f" />
<img width="350" alt="Screenshot 2025-05-13 at 09 51 35" src="https://github.com/user-attachments/assets/7ac514dd-7296-435c-8c8c-ae3e58597055" />

https://github.com/user-attachments/assets/a0097a86-dfc5-4343-9b71-6dc04b963bd5


<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>
<img width="350" alt="Screenshot 2025-05-13 at 10 13 27" src="https://github.com/user-attachments/assets/c4cb9765-8753-4c8f-b821-9de5adc205bc" />
<img width="350" alt="Screenshot 2025-05-13 at 10 13 44" src="https://github.com/user-attachments/assets/d4599ba7-2cc4-4291-87bd-3c6803c8b9fe" />

https://github.com/user-attachments/assets/6c4881a9-37cf-4b9d-a809-de69afb534ec


<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>
<img width="363" alt="Screenshot 2025-05-13 at 10 14 15" src="https://github.com/user-attachments/assets/0cf47ae8-0cc1-46f6-97ca-ff86159c640f" />
<img width="363" alt="Screenshot 2025-05-13 at 10 14 26" src="https://github.com/user-attachments/assets/557a68e7-b40a-4902-ae6d-ff2d9851c67a" />

https://github.com/user-attachments/assets/cd7b1d8a-86b9-4570-af98-33eca4345c35


<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>
<img width="363" alt="Screenshot 2025-05-13 at 10 18 12" src="https://github.com/user-attachments/assets/d3fad32d-4204-4a67-b931-b8c6b9e990bc" />
<img width="363" alt="Screenshot 2025-05-13 at 10 18 21" src="https://github.com/user-attachments/assets/d687f3d1-70c4-4e54-804b-78ff9f32735e" />

https://github.com/user-attachments/assets/f509fa70-59ae-4fa1-a43a-0a150dcf7229


<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

https://github.com/user-attachments/assets/b03fc288-7453-425c-aa36-7c08f224b2f5


<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Desktop</summary>

https://github.com/user-attachments/assets/f6c80334-8b01-4d45-9e07-b1a0f3f7caa1


<!-- add screenshots or videos here -->

</details>
