### PR TITLE
perf: Refactor SearchTypeMenuPopover to improve bottom tabs switching

### DIFF
--- a/src/components/Search/SearchPageHeader/SearchTypeMenuPopover.tsx
+++ b/src/components/Search/SearchPageHeader/SearchTypeMenuPopover.tsx
@@ -1,40 +1,12 @@
-import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react';
-import type {TextStyle, ViewStyle} from 'react-native';
-import {useOnyx} from 'react-native-onyx';
+import React, {useRef} from 'react';
 import Button from '@components/Button';
-import type {MenuItemWithLink} from '@components/MenuItemList';
-import {usePersonalDetails} from '@components/OnyxProvider';
-import type {PopoverMenuItem} from '@components/PopoverMenu';
 import PopoverMenu from '@components/PopoverMenu';
 import type {SearchQueryJSON} from '@components/Search/types';
-import ThreeDotsMenu from '@components/ThreeDotsMenu';
-import useDeleteSavedSearch from '@hooks/useDeleteSavedSearch';
-import useLocalize from '@hooks/useLocalize';
 import useSafeAreaPaddings from '@hooks/useSafeAreaPaddings';
-import useSingleExecution from '@hooks/useSingleExecution';
+import useSearchTypeMenu from '@hooks/useSearchTypeMenu';
 import useTheme from '@hooks/useTheme';
 import useThemeStyles from '@hooks/useThemeStyles';
-import useWindowDimensions from '@hooks/useWindowDimensions';
-import {clearAllFilters} from '@libs/actions/Search';
-import {getCardFeedNamesWithType} from '@libs/CardFeedUtils';
-import {mergeCardListWithWorkspaceFeeds} from '@libs/CardUtils';
-import Navigation from '@libs/Navigation/Navigation';
-import {getAllTaxRates} from '@libs/PolicyUtils';
-import {buildSearchQueryJSON, buildUserReadableQueryString, isCannedSearchQuery} from '@libs/SearchQueryUtils';
-import {createBaseSavedSearchMenuItem, createTypeMenuItems, getOverflowMenu as getOverflowMenuUtil} from '@libs/SearchUIUtils';
-import variables from '@styles/variables';
 import * as Expensicons from '@src/components/Icon/Expensicons';
-import CONST from '@src/CONST';
-import ONYXKEYS from '@src/ONYXKEYS';
-import ROUTES from '@src/ROUTES';
-import type {SaveSearchItem} from '@src/types/onyx/SaveSearch';
-
-type SavedSearchMenuItem = MenuItemWithLink & {
-    key: string;
-    hash: string;
-    query: string;
-    styles?: Array<ViewStyle | TextStyle>;
-};
 
 type SearchTypeMenuNarrowProps = {
     queryJSON: SearchQueryJSON;
@@ -44,158 +16,10 @@ type SearchTypeMenuNarrowProps = {
 function SearchTypeMenuPopover({queryJSON, searchName}: SearchTypeMenuNarrowProps) {
     const theme = useTheme();
     const styles = useThemeStyles();
-    const {singleExecution} = useSingleExecution();
-    const {windowHeight} = useWindowDimensions();
-    const {translate} = useLocalize();
-    const {hash, groupBy} = queryJSON;
-    const {showDeleteModal, DeleteConfirmModal} = useDeleteSavedSearch();
-    const [allPolicies] = useOnyx(ONYXKEYS.COLLECTION.POLICY, {canBeMissing: true});
-    const [session] = useOnyx(ONYXKEYS.SESSION, {canBeMissing: false});
-    const personalDetails = usePersonalDetails();
-    const [reports = {}] = useOnyx(ONYXKEYS.COLLECTION.REPORT, {canBeMissing: true});
-    const taxRates = getAllTaxRates();
-    const [userCardList] = useOnyx(ONYXKEYS.CARD_LIST, {canBeMissing: true});
-    const [workspaceCardFeeds] = useOnyx(ONYXKEYS.COLLECTION.WORKSPACE_CARDS_LIST, {canBeMissing: true});
-    const allCards = useMemo(() => mergeCardListWithWorkspaceFeeds(workspaceCardFeeds ?? CONST.EMPTY_OBJECT, userCardList), [userCardList, workspaceCardFeeds]);
-    const {unmodifiedPaddings} = useSafeAreaPaddings();
-    const shouldGroupByReports = groupBy === CONST.SEARCH.GROUP_BY.REPORTS;
-    const cardFeedNamesWithType = useMemo(() => {
-        return getCardFeedNamesWithType({workspaceCardFeeds, translate});
-    }, [translate, workspaceCardFeeds]);
+    const {isPopoverVisible, delayPopoverMenuFirstRender, openMenu, closeMenu, allMenuItems, DeleteConfirmModal, windowHeight} = useSearchTypeMenu(queryJSON, searchName);
 
-    const [isPopoverVisible, setIsPopoverVisible] = useState(false);
     const buttonRef = useRef<HTMLDivElement>(null);
-    const openMenu = useCallback(() => {
-        setIsPopoverVisible(true);
-    }, []);
-    const closeMenu = useCallback(() => setIsPopoverVisible(false), []);
-
-    // this is a performance fix, rendering popover menu takes a lot of time and we don't need this component initially, that's why we postpone rendering it until everything else is rendered
-    const [delayPopoverMenuFirstRender, setDelayPopoverMenuFirstRender] = useState(true);
-    useEffect(() => {
-        setTimeout(() => {
-            setDelayPopoverMenuFirstRender(false);
-        }, 100);
-    }, []);
-
-    const typeMenuItems = useMemo(() => createTypeMenuItems(allPolicies, session?.email), [allPolicies, session?.email]);
-    const isCannedQuery = isCannedSearchQuery(queryJSON);
-    const title = searchName ?? (isCannedQuery ? undefined : buildUserReadableQueryString(queryJSON, personalDetails, reports, taxRates, allCards, cardFeedNamesWithType, allPolicies));
-    const activeItemIndex = isCannedQuery ? typeMenuItems.findIndex((item) => item.type === queryJSON.type) : -1;
-
-    const getOverflowMenu = useCallback(
-        (itemName: string, itemHash: number, itemQuery: string) => getOverflowMenuUtil(itemName, itemHash, itemQuery, showDeleteModal, true, closeMenu),
-        [closeMenu, showDeleteModal],
-    );
-    const [savedSearches] = useOnyx(ONYXKEYS.SAVED_SEARCHES, {canBeMissing: true});
-    const createSavedSearchMenuItem = useCallback(
-        (item: SaveSearchItem, key: string, index: number) => {
-            let savedSearchTitle = item.name;
-            if (savedSearchTitle === item.query) {
-                const jsonQuery = buildSearchQueryJSON(item.query) ?? ({} as SearchQueryJSON);
-                savedSearchTitle = buildUserReadableQueryString(jsonQuery, personalDetails, reports, taxRates, allCards, cardFeedNamesWithType, allPolicies);
-            }
-            const isItemFocused = Number(key) === hash;
-            const baseMenuItem: SavedSearchMenuItem = createBaseSavedSearchMenuItem(item, key, index, savedSearchTitle, isItemFocused);
-
-            return {
-                ...baseMenuItem,
-                onSelected: () => {
-                    clearAllFilters();
-                    Navigation.navigate(ROUTES.SEARCH_ROOT.getRoute({query: item?.query ?? '', name: item?.name}));
-                },
-                rightComponent: (
-                    <ThreeDotsMenu
-                        menuItems={getOverflowMenu(baseMenuItem.title ?? '', Number(baseMenuItem.hash ?? ''), item.query ?? '')}
-                        anchorPosition={{horizontal: 0, vertical: 380}}
-                        anchorAlignment={{
-                            horizontal: CONST.MODAL.ANCHOR_ORIGIN_HORIZONTAL.RIGHT,
-                            vertical: CONST.MODAL.ANCHOR_ORIGIN_VERTICAL.TOP,
-                        }}
-                        disabled={item.pendingAction === CONST.RED_BRICK_ROAD_PENDING_ACTION.DELETE}
-                    />
-                ),
-                styles: [styles.textSupporting],
-                isSelected: false,
-                shouldCallAfterModalHide: true,
-                icon: Expensicons.Bookmark,
-                iconWidth: variables.iconSizeNormal,
-                iconHeight: variables.iconSizeNormal,
-                shouldIconUseAutoWidthStyle: false,
-            };
-        },
-        [hash, getOverflowMenu, styles.textSupporting, personalDetails, reports, taxRates, allCards, cardFeedNamesWithType, allPolicies],
-    );
-
-    const savedSearchItems = useMemo(() => {
-        if (!savedSearches) {
-            return [];
-        }
-        return Object.entries(savedSearches).map(([key, item], index) => createSavedSearchMenuItem(item, key, index));
-    }, [createSavedSearchMenuItem, savedSearches]);
-
-    const currentSavedSearch = savedSearchItems.find((item) => Number(item.hash) === hash);
-
-    const popoverMenuItems = useMemo(() => {
-        const items = typeMenuItems.map((item, index) => {
-            let isSelected = false;
-            if (!title) {
-                if (shouldGroupByReports) {
-                    isSelected = item.translationPath === 'common.expenseReports';
-                } else {
-                    isSelected = index === activeItemIndex;
-                }
-            }
-
-            return {
-                text: translate(item.translationPath),
-                onSelected: singleExecution(() => {
-                    clearAllFilters();
-                    Navigation.navigate(item.getRoute());
-                }),
-                isSelected,
-                icon: item.icon,
-                iconFill: isSelected ? theme.iconSuccessFill : theme.icon,
-                iconRight: Expensicons.Checkmark,
-                shouldShowRightIcon: isSelected,
-                success: isSelected,
-                containerStyle: isSelected ? [{backgroundColor: theme.border}] : undefined,
-                shouldCallAfterModalHide: true,
-            };
-        });
-
-        if (title && !currentSavedSearch) {
-            items.push({
-                text: title,
-                onSelected: closeMenu,
-                isSelected: !currentSavedSearch,
-                icon: Expensicons.Filters,
-                iconFill: theme.iconSuccessFill,
-                success: true,
-                containerStyle: undefined,
-                iconRight: Expensicons.Checkmark,
-                shouldShowRightIcon: false,
-                shouldCallAfterModalHide: true,
-            });
-        }
-
-        return items;
-    }, [typeMenuItems, title, currentSavedSearch, activeItemIndex, translate, singleExecution, theme.iconSuccessFill, theme.icon, theme.border, closeMenu, shouldGroupByReports]);
-
-    const allMenuItems = useMemo(() => {
-        const items = [];
-        items.push(...popoverMenuItems);
-
-        if (savedSearchItems.length > 0) {
-            items.push({
-                text: translate('search.savedSearchesMenuItemTitle'),
-                styles: [styles.textSupporting],
-                disabled: true,
-            });
-            items.push(...savedSearchItems);
-        }
-        return items;
-    }, [popoverMenuItems, savedSearchItems, styles.textSupporting, translate]);
+    const {unmodifiedPaddings} = useSafeAreaPaddings();
 
     return (
         <>
@@ -206,7 +30,7 @@ function SearchTypeMenuPopover({queryJSON, searchName}: SearchTypeMenuNarrowProp
             />
             {!delayPopoverMenuFirstRender && (
                 <PopoverMenu
-                    menuItems={allMenuItems as PopoverMenuItem[]}
+                    menuItems={allMenuItems}
                     isVisible={isPopoverVisible}
                     anchorPosition={styles.createMenuPositionSidebar(windowHeight)}
                     onClose={closeMenu}

--- a/src/hooks/useSearchTypeMenu.tsx
+++ b/src/hooks/useSearchTypeMenu.tsx
@@ -1,0 +1,208 @@
+import React, {useCallback, useEffect, useMemo, useState} from 'react';
+import {InteractionManager} from 'react-native';
+import {useOnyx} from 'react-native-onyx';
+import {usePersonalDetails} from '@components/OnyxProvider';
+import type {PopoverMenuItem} from '@components/PopoverMenu';
+import type {SearchQueryJSON} from '@components/Search/types';
+import ThreeDotsMenu from '@components/ThreeDotsMenu';
+import {clearAllFilters} from '@libs/actions/Search';
+import {getCardFeedNamesWithType} from '@libs/CardFeedUtils';
+import {mergeCardListWithWorkspaceFeeds} from '@libs/CardUtils';
+import Navigation from '@libs/Navigation/Navigation';
+import {getAllTaxRates} from '@libs/PolicyUtils';
+import {buildSearchQueryJSON, buildUserReadableQueryString, isCannedSearchQuery} from '@libs/SearchQueryUtils';
+import type {SavedSearchMenuItem} from '@libs/SearchUIUtils';
+import {createBaseSavedSearchMenuItem, createTypeMenuItems, getOverflowMenu as getOverflowMenuUtil} from '@libs/SearchUIUtils';
+import variables from '@styles/variables';
+import * as Expensicons from '@src/components/Icon/Expensicons';
+import CONST from '@src/CONST';
+import ONYXKEYS from '@src/ONYXKEYS';
+import ROUTES from '@src/ROUTES';
+import useDeleteSavedSearch from './useDeleteSavedSearch';
+import useLocalize from './useLocalize';
+import useSingleExecution from './useSingleExecution';
+import useTheme from './useTheme';
+import useThemeStyles from './useThemeStyles';
+import useWindowDimensions from './useWindowDimensions';
+
+export default function useSearchTypeMenu(queryJSON: SearchQueryJSON, searchName?: string) {
+    const theme = useTheme();
+    const styles = useThemeStyles();
+    const {singleExecution} = useSingleExecution();
+    const {windowHeight} = useWindowDimensions();
+    const {translate} = useLocalize();
+    const {hash, groupBy} = queryJSON;
+    const {showDeleteModal, DeleteConfirmModal} = useDeleteSavedSearch();
+    const [allPolicies] = useOnyx(ONYXKEYS.COLLECTION.POLICY, {canBeMissing: true});
+    const [session] = useOnyx(ONYXKEYS.SESSION, {canBeMissing: false});
+    const personalDetails = usePersonalDetails();
+    const [reports = {}] = useOnyx(ONYXKEYS.COLLECTION.REPORT, {canBeMissing: true});
+    const taxRates = getAllTaxRates();
+    const [userCardList] = useOnyx(ONYXKEYS.CARD_LIST, {canBeMissing: true});
+    const [workspaceCardFeeds] = useOnyx(ONYXKEYS.COLLECTION.WORKSPACE_CARDS_LIST, {canBeMissing: true});
+    const [savedSearches] = useOnyx(ONYXKEYS.SAVED_SEARCHES, {canBeMissing: true});
+
+    const [isPopoverVisible, setIsPopoverVisible] = useState(false);
+    const [processedMenuItems, setProcessedMenuItems] = useState<PopoverMenuItem[]>([]);
+
+    const allCards = useMemo(() => mergeCardListWithWorkspaceFeeds(workspaceCardFeeds ?? CONST.EMPTY_OBJECT, userCardList), [userCardList, workspaceCardFeeds]);
+
+    const cardFeedNamesWithType = useMemo(() => getCardFeedNamesWithType({workspaceCardFeeds, translate}), [workspaceCardFeeds, translate]);
+
+    const typeMenuItems = useMemo(() => createTypeMenuItems(allPolicies, session?.email), [allPolicies, session?.email]);
+
+    const isCannedQuery = isCannedSearchQuery(queryJSON);
+    const shouldGroupByReports = groupBy === CONST.SEARCH.GROUP_BY.REPORTS;
+
+    // this is a performance fix, rendering popover menu takes a lot of time and we don't need this component initially, that's why we postpone rendering it until everything else is rendered
+    const [delayPopoverMenuFirstRender, setDelayPopoverMenuFirstRender] = useState(true);
+    useEffect(() => {
+        setTimeout(() => {
+            setDelayPopoverMenuFirstRender(false);
+        }, 100);
+    }, []);
+
+    const title = searchName ?? (isCannedQuery ? undefined : buildUserReadableQueryString(queryJSON, personalDetails, reports, taxRates, allCards, cardFeedNamesWithType, allPolicies));
+    const activeItemIndex = isCannedQuery ? typeMenuItems.findIndex((item) => item.type === queryJSON.type) : -1;
+
+    const closeMenu = useCallback(() => {
+        setIsPopoverVisible(false);
+    }, []);
+
+    const getOverflowMenu = useCallback(
+        (itemName: string, itemHash: number, itemQuery: string) => getOverflowMenuUtil(itemName, itemHash, itemQuery, showDeleteModal, true, closeMenu),
+        [showDeleteModal, closeMenu],
+    );
+
+    const currentSavedSearch = useMemo(() => {
+        if (!savedSearches) {
+            return undefined;
+        }
+        return Object.entries(savedSearches).find(([key]) => Number(key) === hash)?.[1];
+    }, [savedSearches, hash]);
+
+    const popoverMenuItems = useMemo(() => {
+        const items = typeMenuItems.map((item, index) => {
+            let isSelected = false;
+            if (!title) {
+                if (shouldGroupByReports) {
+                    isSelected = item.translationPath === 'common.expenseReports';
+                } else {
+                    isSelected = index === activeItemIndex;
+                }
+            }
+
+            return {
+                text: translate(item.translationPath),
+                onSelected: singleExecution(() => {
+                    clearAllFilters();
+                    Navigation.navigate(item.getRoute());
+                }),
+                isSelected,
+                icon: item.icon,
+                iconFill: isSelected ? theme.iconSuccessFill : theme.icon,
+                iconRight: Expensicons.Checkmark,
+                shouldShowRightIcon: isSelected,
+                success: isSelected,
+                containerStyle: isSelected ? [{backgroundColor: theme.border}] : undefined,
+                shouldCallAfterModalHide: true,
+            };
+        });
+
+        if (title && !currentSavedSearch) {
+            items.push({
+                text: title,
+                onSelected: closeMenu,
+                isSelected: !currentSavedSearch,
+                icon: Expensicons.Filters,
+                iconFill: theme.iconSuccessFill,
+                success: true,
+                containerStyle: undefined,
+                iconRight: Expensicons.Checkmark,
+                shouldShowRightIcon: false,
+                shouldCallAfterModalHide: true,
+            });
+        }
+
+        return items;
+    }, [typeMenuItems, title, currentSavedSearch, activeItemIndex, translate, singleExecution, theme, closeMenu, shouldGroupByReports]);
+
+    const processSavedSearches = useCallback(() => {
+        if (!savedSearches) {
+            setProcessedMenuItems(popoverMenuItems);
+            return;
+        }
+
+        const items = [];
+        items.push(...popoverMenuItems);
+
+        const savedSearchItems = Object.entries(savedSearches).map(([key, item], index) => {
+            let savedSearchTitle = item.name;
+
+            if (savedSearchTitle === item.query) {
+                const jsonQuery = buildSearchQueryJSON(item.query) ?? ({} as SearchQueryJSON);
+                savedSearchTitle = buildUserReadableQueryString(jsonQuery, personalDetails, reports, taxRates, allCards, cardFeedNamesWithType, allPolicies);
+            }
+
+            const isItemFocused = Number(key) === hash;
+            const baseMenuItem: SavedSearchMenuItem = createBaseSavedSearchMenuItem(item, key, index, savedSearchTitle, isItemFocused);
+
+            return {
+                ...baseMenuItem,
+                onSelected: () => {
+                    clearAllFilters();
+                    Navigation.navigate(ROUTES.SEARCH_ROOT.getRoute({query: item?.query ?? '', name: item?.name}));
+                },
+                rightComponent: (
+                    <ThreeDotsMenu
+                        menuItems={getOverflowMenu(baseMenuItem.title ?? '', Number(baseMenuItem.hash ?? ''), item.query ?? '')}
+                        anchorPosition={{horizontal: 0, vertical: 380}}
+                        anchorAlignment={{
+                            horizontal: CONST.MODAL.ANCHOR_ORIGIN_HORIZONTAL.RIGHT,
+                            vertical: CONST.MODAL.ANCHOR_ORIGIN_VERTICAL.TOP,
+                        }}
+                        disabled={item.pendingAction === CONST.RED_BRICK_ROAD_PENDING_ACTION.DELETE}
+                    />
+                ),
+                styles: [styles.textSupporting],
+                isSelected: false,
+                shouldCallAfterModalHide: true,
+                icon: Expensicons.Bookmark,
+                iconWidth: variables.iconSizeNormal,
+                iconHeight: variables.iconSizeNormal,
+                shouldIconUseAutoWidthStyle: false,
+            };
+        });
+
+        if (savedSearchItems.length > 0) {
+            items.push({
+                text: translate('search.savedSearchesMenuItemTitle'),
+                styles: [styles.textSupporting],
+                disabled: true,
+            });
+            items.push(...savedSearchItems);
+        }
+
+        setProcessedMenuItems(items as PopoverMenuItem[]);
+    }, [savedSearches, popoverMenuItems, hash, getOverflowMenu, styles.textSupporting, personalDetails, reports, taxRates, allCards, cardFeedNamesWithType, allPolicies, translate]);
+
+    const openMenu = useCallback(() => {
+        setIsPopoverVisible(true);
+        // Defer heavy processing until after interactions
+        InteractionManager.runAfterInteractions(() => {
+            processSavedSearches();
+        });
+    }, [processSavedSearches]);
+
+    return {
+        isPopoverVisible,
+        delayPopoverMenuFirstRender,
+        openMenu,
+        closeMenu,
+        allMenuItems: processedMenuItems,
+        DeleteConfirmModal,
+        theme,
+        styles,
+        windowHeight,
+    };
+}


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->
**Problem**

When switching between bottom tabs, the `SearchTypeMenuPopover` component re-renders unnecessarily. This triggers saved search and menu item processing logic even when the `PopoverMenu` component isn’t visible, which may lead to performance issues and slower tab switching.

**Solution**
We can improve this by:
- Moving the saved search and menu item processing logic into a useSearchTypeMenu hook to better separate logic from UI and avoid unnecessary re-renders.
- Using `InteractionManager.runAfterInteractions()` to postpone expensive operations until transition animations are complete.
- Delaying the processing of saved searches until the related UI is actually opened, so we avoid doing unnecessary work during tab switches.

Thanks to these changes, the render time of `SearchTypeMenuPopover` is much faster as it no longer performs heavy calculations unnecessarily.

Before:

`SearchTypeMenuPopover` rendered 3times, taking ~ 48ms in total. 
<img width="1889" alt="Screenshot 2025-05-06 at 15 34 05" src="https://github.com/user-attachments/assets/6cd02577-34f5-48bf-aaf4-0d7a2a63319b" />


After:
 It renders only once, taking around 20 ms
<img width="1900" alt="Screenshot 2025-05-06 at 15 33 57" src="https://github.com/user-attachments/assets/bc626311-b11a-4b59-a76d-13e29a1c3c2e" />

### Explanation of Change
<!-- Explain what your change does and how it addresses the linked issue -->

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/60007, https://github.com/Expensify/App/issues/61974
PROPOSAL:


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->
 The performance improvements might not be immediately noticeable since they’re focused on optimizing tab switching. To test, just make sure the Popover displays correctly and everything still works as expected.

1. Go to Reports.
2.  Tap the bookmark icon, then select Expense Reports, Tasks, Invoices, etc.
3. Confirm that results are filtered correctly and the search field shows a clean query
4. Tap the bookmark icon again
5. The selected saved search is highlighted.
- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
3. Upload an image via copy paste
4. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->
// TODO: These must be filled out, or the issue title must include "[No QA]."


Same as tests

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I verified there are no new alerts related to the `canBeMissing` param for `useOnyx`
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Desktop</summary>

<!-- add screenshots or videos here -->

</details>
