### PR TITLE
Revert "fix: get rid of redundant /Search API calls when opening report in RHN"

### DIFF
--- a/src/hooks/useSearchHighlightAndScroll.ts
+++ b/src/hooks/useSearchHighlightAndScroll.ts
@@ -1,4 +1,3 @@
-import {useNavigation} from '@react-navigation/native';
 import isEqual from 'lodash/isEqual';
 import {useCallback, useEffect, useRef, useState} from 'react';
 import type {OnyxCollection, OnyxEntry} from 'react-native-onyx';
@@ -34,12 +33,9 @@ function useSearchHighlightAndScroll({searchResults, transactions, previousTrans
     const highlightedIDs = useRef<Set<string>>(new Set());
     const initializedRef = useRef(false);
     const isChat = queryJSON.type === CONST.SEARCH.DATA_TYPES.CHAT;
-    const navigation = useNavigation();
 
     // Trigger search when a new report action is added while on chat or when a new transaction is added for the other search types.
     useEffect(() => {
-        const isNavigating = !navigation.isFocused();
-
         const previousTransactionsIDs = Object.keys(previousTransactions ?? {});
         const transactionsIDs = Object.keys(transactions ?? {});
 
@@ -50,10 +46,9 @@ function useSearchHighlightAndScroll({searchResults, transactions, previousTrans
             .map((actions) => Object.keys(actions ?? {}))
             .flat();
 
-        if (searchTriggeredRef.current || isNavigating) {
+        if (searchTriggeredRef.current) {
             return;
         }
-
         const hasTransactionsIDsChange = !isEqual(transactionsIDs, previousTransactionsIDs);
         const hasReportActionsIDsChange = !isEqual(reportActionsIDs, previousReportActionsIDs);
 
@@ -83,7 +78,7 @@ function useSearchHighlightAndScroll({searchResults, transactions, previousTrans
         return () => {
             searchTriggeredRef.current = false;
         };
-    }, [transactions, previousTransactions, queryJSON, offset, reportActions, previousReportActions, isChat, navigation]);
+    }, [transactions, previousTransactions, queryJSON, offset, reportActions, previousReportActions, isChat]);
 
     // Initialize the set with existing IDs only once
     useEffect(() => {

--- a/tests/unit/useSearchHighlightAndScrollTest.ts
+++ b/tests/unit/useSearchHighlightAndScrollTest.ts
@@ -1,6 +1,4 @@
 /* eslint-disable @typescript-eslint/naming-convention */
-import {useNavigation} from '@react-navigation/native';
-import type * as NativeNavigation from '@react-navigation/native';
 import {renderHook} from '@testing-library/react-native';
 import useSearchHighlightAndScroll from '@hooks/useSearchHighlightAndScroll';
 import type {UseSearchHighlightAndScroll} from '@hooks/useSearchHighlightAndScroll';
@@ -8,23 +6,12 @@ import {search} from '@libs/actions/Search';
 
 jest.mock('@libs/actions/Search');
 jest.mock('@src/components/ConfirmedRoute.tsx');
-jest.mock('@react-navigation/native', () => ({
-    ...jest.requireActual<typeof NativeNavigation>('@react-navigation/native'),
-    useNavigation: jest.fn(),
-}));
+
+afterEach(() => {
+    jest.clearAllMocks();
+});
 
 describe('useSearchHighlightAndScroll', () => {
-    beforeEach(() => {
-        // Default mock implementation
-        (useNavigation as jest.Mock).mockReturnValue({
-            isFocused: () => true,
-        });
-    });
-
-    afterEach(() => {
-        jest.clearAllMocks();
-    });
-
     it('should trigger Search when transactionIDs list change', () => {
         const initialProps: UseSearchHighlightAndScroll = {
             searchResults: {
@@ -207,12 +194,7 @@ describe('useSearchHighlightAndScroll', () => {
         expect(search).toHaveBeenCalled();
     });
 
-    it('should not trigger Search when navigation is not focused', () => {
-        // Mock navigation.isFocused to return false
-        (useNavigation as jest.Mock).mockReturnValue({
-            isFocused: () => false,
-        });
-
+    it('should trigger Search when report actions change', () => {
         const initialProps: UseSearchHighlightAndScroll = {
             searchResults: {
                 data: {personalDetailsList: {}},
@@ -230,84 +212,8 @@ describe('useSearchHighlightAndScroll', () => {
                     isLoading: false,
                 },
             },
-            transactions: {
-                transactions_1: {
-                    amount: -100,
-                    bank: '',
-                    billable: false,
-                    cardID: 0,
-                    cardName: 'Cash Expense',
-                    cardNumber: '',
-                    category: '',
-                    comment: {
-                        comment: '',
-                    },
-                    created: '2025-01-08',
-                    currency: 'ETB',
-                    filename: 'w_c989c343d834d48a4e004c38d03c90bff9434768.png',
-                    inserted: '2025-01-08 15:35:32',
-                    managedCard: false,
-                    merchant: 'g',
-                    modifiedAmount: 0,
-                    modifiedCreated: '',
-                    modifiedCurrency: '',
-                    modifiedMerchant: '',
-                    originalAmount: 0,
-                    originalCurrency: '',
-                    parentTransactionID: '',
-                    posted: '',
-                    receipt: {
-                        receiptID: 7409094723954473,
-                        state: 'SCANCOMPLETE',
-                        source: 'https://www.expensify.com/receipts/w_c989c343d834d48a4e004c38d03c90bff9434768.png',
-                    },
-                    reimbursable: true,
-                    reportID: '2309609540437471',
-                    status: 'Posted',
-                    tag: '',
-                    transactionID: '1',
-                    hasEReceipt: false,
-                },
-            },
-            previousTransactions: {
-                transactions_1: {
-                    amount: -100,
-                    bank: '',
-                    billable: false,
-                    cardID: 0,
-                    cardName: 'Cash Expense',
-                    cardNumber: '',
-                    category: '',
-                    comment: {
-                        comment: '',
-                    },
-                    created: '2025-01-08',
-                    currency: 'ETB',
-                    filename: 'w_c989c343d834d48a4e004c38d03c90bff9434768.png',
-                    inserted: '2025-01-08 15:35:32',
-                    managedCard: false,
-                    merchant: 'g',
-                    modifiedAmount: 0,
-                    modifiedCreated: '',
-                    modifiedCurrency: '',
-                    modifiedMerchant: '',
-                    originalAmount: 0,
-                    originalCurrency: '',
-                    parentTransactionID: '',
-                    posted: '',
-                    receipt: {
-                        receiptID: 7409094723954473,
-                        state: 'SCANCOMPLETE',
-                        source: 'https://www.expensify.com/receipts/w_c989c343d834d48a4e004c38d03c90bff9434768.png',
-                    },
-                    reimbursable: true,
-                    reportID: '2309609540437471',
-                    status: 'Posted',
-                    tag: '',
-                    transactionID: '1',
-                    hasEReceipt: false,
-                },
-            },
+            transactions: {},
+            previousTransactions: {},
             reportActions: {
                 reportActions_209647397999267: {
                     1: {
@@ -339,61 +245,34 @@ describe('useSearchHighlightAndScroll', () => {
             },
             offset: 0,
         };
-        const changedProp: UseSearchHighlightAndScroll = {
+
+        const changedProps: UseSearchHighlightAndScroll = {
             ...initialProps,
-            transactions: {
-                transactions_2: {
-                    amount: -100,
-                    bank: '',
-                    billable: false,
-                    cardID: 0,
-                    cardName: 'Cash Expense',
-                    cardNumber: '',
-                    category: '',
-                    comment: {
-                        comment: '',
+            reportActions: {
+                reportActions_209647397999268: {
+                    1: {
+                        actionName: 'POLICYCHANGELOG_CORPORATE_UPGRADE',
+                        reportActionID: '1',
+                        created: '',
                     },
-                    created: '2025-01-08',
-                    currency: 'ETB',
-                    filename: 'w_c989c343d834d48a4e004c38d03c90bff9434768.png',
-                    inserted: '2025-01-08 15:35:32',
-                    managedCard: false,
-                    merchant: 'g',
-                    modifiedAmount: 0,
-                    modifiedCreated: '',
-                    modifiedCurrency: '',
-                    modifiedMerchant: '',
-                    originalAmount: 0,
-                    originalCurrency: '',
-                    parentTransactionID: '',
-                    posted: '',
-                    receipt: {
-                        receiptID: 7409094723954473,
-                        state: 'SCANCOMPLETE',
-                        source: 'https://www.expensify.com/receipts/w_c989c343d834d48a4e004c38d03c90bff9434768.png',
+                    2: {
+                        actionName: 'ADDCOMMENT',
+                        reportActionID: '2',
+                        created: '',
                     },
-                    reimbursable: true,
-                    reportID: '2309609540437471',
-                    status: 'Posted',
-                    tag: '',
-                    transactionID: '2',
-                    hasEReceipt: false,
                 },
             },
         };
 
-        // Reset the mock to track new calls
-        jest.clearAllMocks();
-
-        const {rerender} = renderHook((prop: UseSearchHighlightAndScroll) => useSearchHighlightAndScroll(prop), {
+        const {rerender} = renderHook((props: UseSearchHighlightAndScroll) => useSearchHighlightAndScroll(props), {
             initialProps,
         });
         expect(search).not.toHaveBeenCalled();
 
-        // When the transaction ids list changes but navigation is not focused
-        rerender(changedProp);
+        // When report actions change
+        rerender(changedProps);
 
-        // Then Search should NOT be triggered
-        expect(search).not.toHaveBeenCalled();
+        // Then Search will be triggered
+        expect(search).toHaveBeenCalled();
     });
 });


### PR DESCRIPTION
Fix for https://github.com/Expensify/App/issues/62042.

The reverted PR adds `isNavigating` logic that prevents the search from happening after approving held expense.
It also removes the test used to catch this sort of bug, added in https://github.com/Expensify/App/pull/57887.
https://github.com/Expensify/App/blob/597101408171a66c5186ce6a15d0c7f096e999a3/src/hooks/useSearchHighlightAndScroll.ts#L41-L55


This is a straight revert of https://github.com/Expensify/App/pull/61499

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I verified there are no new alerts related to the `canBeMissing` param for `useOnyx`
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Desktop</summary>

<!-- add screenshots or videos here -->

</details>
