### PR TITLE
fix: Thread-Infinite Loading Occurs When Replying to a Deleted Parent Message

### DIFF
--- a/src/libs/ReportActionsUtils.ts
+++ b/src/libs/ReportActionsUtils.ts
@@ -1114,10 +1114,10 @@ function isMessageDeleted(reportAction: OnyxInputOrEntry<ReportAction>): boolean
     const originalMessage = getOriginalMessage(reportAction) as Message;
 
     return (
-        (message?.deleted !== undefined && message?.deleted !== '') ||
         (message?.isDeletedParentAction ?? false) ||
-        (originalMessage?.deleted !== undefined && originalMessage?.deleted !== '') ||
-        (originalMessage?.isDeletedParentAction ?? false)
+        (originalMessage?.isDeletedParentAction ?? false) ||
+        (message?.deleted !== undefined && message?.deleted !== '') ||
+        (originalMessage?.deleted !== undefined && originalMessage?.deleted !== '')
     );
 }
 

--- a/src/libs/ReportActionsUtils.ts
+++ b/src/libs/ReportActionsUtils.ts
@@ -1113,10 +1113,12 @@ function isMessageDeleted(reportAction: OnyxInputOrEntry<ReportAction>): boolean
     const message = getReportActionMessage(reportAction);
     const originalMessage = getOriginalMessage(reportAction) as Message;
 
-    return (message?.deleted && message?.deleted != "") ||
+    return (
+        (message?.deleted !== undefined && message?.deleted !== '') ||
         (message?.isDeletedParentAction ?? false) ||
-        (originalMessage?.deleted && originalMessage?.deleted != "") ||
-        (originalMessage?.isDeletedParentAction ?? false);
+        (originalMessage?.deleted !== undefined && originalMessage?.deleted !== '') ||
+        (originalMessage?.isDeletedParentAction ?? false)
+    );
 }
 
 /**
@@ -1810,7 +1812,7 @@ function getReportActionMessageFragments(action: ReportAction): Message[] {
     const actionMessage = action.previousMessage ?? action.message;
     if (Array.isArray(actionMessage)) {
         if (actionMessage?.length === 1) {
-            return [{...actionMessage.at(0), isDeletedParentAction: isMessageDeleted(action) } as Message];
+            return [{...actionMessage.at(0), isDeletedParentAction: isMessageDeleted(action)} as Message];
         }
         return actionMessage.filter((item): item is Message => !!item);
     }

--- a/src/libs/ReportActionsUtils.ts
+++ b/src/libs/ReportActionsUtils.ts
@@ -183,7 +183,7 @@ function getReportActionMessage(reportAction: PartialReportAction) {
 }
 
 function isDeletedParentAction(reportAction: OnyxInputOrEntry<ReportAction>): boolean {
-    return (getReportActionMessage(reportAction)?.isDeletedParentAction ?? false) && (reportAction?.childVisibleActionCount ?? 0) > 0;
+    return isMessageDeleted(reportAction) && (reportAction?.childVisibleActionCount ?? 0) > 0;
 }
 
 function isReversedTransaction(reportAction: OnyxInputOrEntry<ReportAction | OptimisticIOUReportAction>) {
@@ -1110,7 +1110,13 @@ function getIOUReportIDFromReportActionPreview(reportAction: OnyxEntry<ReportAct
  * A helper method to identify if the message is deleted or not.
  */
 function isMessageDeleted(reportAction: OnyxInputOrEntry<ReportAction>): boolean {
-    return getReportActionMessage(reportAction)?.isDeletedParentAction ?? false;
+    const message = getReportActionMessage(reportAction);
+    const originalMessage = getOriginalMessage(reportAction) as Message;
+
+    return (message?.deleted != null && message?.deleted != "") ||
+        (message?.isDeletedParentAction ?? false) ||
+        (originalMessage?.deleted != null && originalMessage?.deleted != "") ||
+        (originalMessage?.isDeletedParentAction ?? false);
 }
 
 /**
@@ -1803,6 +1809,9 @@ function getReportActionMessageFragments(action: ReportAction): Message[] {
 
     const actionMessage = action.previousMessage ?? action.message;
     if (Array.isArray(actionMessage)) {
+        if (actionMessage?.length === 1) {
+            return [{...actionMessage[0], isDeletedParentAction: isMessageDeleted(action) } as Message];
+        }
         return actionMessage.filter((item): item is Message => !!item);
     }
     return actionMessage ? [actionMessage] : [];

--- a/src/libs/ReportActionsUtils.ts
+++ b/src/libs/ReportActionsUtils.ts
@@ -1113,9 +1113,9 @@ function isMessageDeleted(reportAction: OnyxInputOrEntry<ReportAction>): boolean
     const message = getReportActionMessage(reportAction);
     const originalMessage = getOriginalMessage(reportAction) as Message;
 
-    return (message?.deleted != null && message?.deleted != "") ||
+    return (message?.deleted && message?.deleted != "") ||
         (message?.isDeletedParentAction ?? false) ||
-        (originalMessage?.deleted != null && originalMessage?.deleted != "") ||
+        (originalMessage?.deleted && originalMessage?.deleted != "") ||
         (originalMessage?.isDeletedParentAction ?? false);
 }
 
@@ -1810,7 +1810,7 @@ function getReportActionMessageFragments(action: ReportAction): Message[] {
     const actionMessage = action.previousMessage ?? action.message;
     if (Array.isArray(actionMessage)) {
         if (actionMessage?.length === 1) {
-            return [{...actionMessage[0], isDeletedParentAction: isMessageDeleted(action) } as Message];
+            return [{...actionMessage.at(0), isDeletedParentAction: isMessageDeleted(action) } as Message];
         }
         return actionMessage.filter((item): item is Message => !!item);
     }

--- a/src/libs/ReportActionsUtils.ts
+++ b/src/libs/ReportActionsUtils.ts
@@ -1115,8 +1115,8 @@ function isMessageDeleted(reportAction: OnyxInputOrEntry<ReportAction>): boolean
 
     return (
         (message?.isDeletedParentAction ?? false) ||
-        (originalMessage?.isDeletedParentAction ?? false) ||
         (message?.deleted !== undefined && message?.deleted !== '') ||
+        (originalMessage?.isDeletedParentAction ?? false) ||
         (originalMessage?.deleted !== undefined && originalMessage?.deleted !== '')
     );
 }

--- a/src/libs/ReportUtils.ts
+++ b/src/libs/ReportUtils.ts
@@ -4793,18 +4793,17 @@ function getSearchReportName(props: GetReportNameParams): string {
     return getReportNameInternal(props);
 }
 
-function isChatThreadDeleted(report: OnyxInputOrEntry<Report>, reportActionParam: OnyxInputOrEntry<ReportAction>): boolean
-{
+function isChatThreadDeleted(report: OnyxInputOrEntry<Report>, reportActionParam: OnyxInputOrEntry<ReportAction>): boolean {
     if (!isChatThread(report)) {
-        return false
+        return false;
     }
 
-    let reportAction = reportActionParam as OnyxEntry<ReportAction>
+    let reportAction = reportActionParam as OnyxEntry<ReportAction>;
     if (!reportAction) {
         reportAction = getReportAction(report?.parentReportID, report?.parentReportActionID);
     }
 
-    return isMessageDeleted(reportAction)
+    return isMessageDeleted(reportAction);
 }
 
 function getInvoiceReportName(report: OnyxEntry<Report>, policy?: OnyxEntry<Policy | SearchPolicy>, invoiceReceiverPolicy?: OnyxEntry<Policy | SearchPolicy>): string {

--- a/src/libs/ReportUtils.ts
+++ b/src/libs/ReportUtils.ts
@@ -4779,7 +4779,7 @@ function getReportName(
     const attributes = reportAttributes ?? reportAttributesDerivedValue;
     const derivedNameExists = report && !!attributes?.[report.reportID]?.reportName;
     // This doesn't apply to chat reports because last message (report name) can be changed and/or edited
-    if (canUseDerivedValue && derivedNameExists && !isChatReport(report)) {
+    if (canUseDerivedValue && derivedNameExists) {
         return attributes[report.reportID].reportName;
     }
     return getReportNameInternal({report, policy, parentReportActionParam, personalDetails, invoiceReceiverPolicy});

--- a/src/libs/ReportUtils.ts
+++ b/src/libs/ReportUtils.ts
@@ -177,6 +177,7 @@ import {
     isExportIntegrationAction,
     isIntegrationMessageAction,
     isMarkAsClosedAction,
+    isMessageDeleted,
     isModifiedExpenseAction,
     isMoneyRequestAction,
     isOldDotReportAction,
@@ -4777,7 +4778,8 @@ function getReportName(
     const canUseDerivedValue = report && policy === undefined && parentReportActionParam === undefined && personalDetails === undefined && invoiceReceiverPolicy === undefined;
     const attributes = reportAttributes ?? reportAttributesDerivedValue;
     const derivedNameExists = report && !!attributes?.[report.reportID]?.reportName;
-    if (canUseDerivedValue && derivedNameExists) {
+    // This doesn't apply to chat reports because last message (report name) can be changed and/or edited
+    if (canUseDerivedValue && derivedNameExists && !isChatReport(report)) {
         return attributes[report.reportID].reportName;
     }
     return getReportNameInternal({report, policy, parentReportActionParam, personalDetails, invoiceReceiverPolicy});
@@ -4789,6 +4791,20 @@ function getSearchReportName(props: GetReportNameParams): string {
         return policy.name;
     }
     return getReportNameInternal(props);
+}
+
+function isChatThreadDeleted(report: OnyxInputOrEntry<Report>, reportActionParam: OnyxInputOrEntry<ReportAction>): boolean
+{
+    if (!isChatThread(report)) {
+        return false
+    }
+
+    let reportAction = reportActionParam as OnyxEntry<ReportAction>
+    if (!reportAction) {
+        reportAction = getReportAction(report?.parentReportID, report?.parentReportActionID);
+    }
+
+    return isMessageDeleted(reportAction)
 }
 
 function getInvoiceReportName(report: OnyxEntry<Report>, policy?: OnyxEntry<Policy | SearchPolicy>, invoiceReceiverPolicy?: OnyxEntry<Policy | SearchPolicy>): string {
@@ -4956,7 +4972,7 @@ function getReportNameInternal({
             return getRenamedAction(parentReportAction, isExpenseReport(getReport(report.parentReportID, allReports)));
         }
 
-        if (parentReportActionMessage?.isDeletedParentAction) {
+        if (isChatThreadDeleted(report, parentReportActionParam)) {
             return translateLocal('parentReportAction.deletedMessage');
         }
 
@@ -11043,6 +11059,7 @@ export {
     isChatRoom,
     isTripRoom,
     isChatThread,
+    isChatThreadDeleted,
     isChildReport,
     isClosedExpenseReportWithNoExpenses,
     isCompletedTaskReport,

--- a/tests/unit/ReportActionsUtilsTest.ts
+++ b/tests/unit/ReportActionsUtilsTest.ts
@@ -5,7 +5,13 @@ import {actionR14932 as mockIOUAction, originalMessageR14932 as mockOriginalMess
 import {chatReportR14932 as mockChatReport, iouReportR14932 as mockIOUReport} from '../../__mocks__/reportData/reports';
 import CONST from '../../src/CONST';
 import * as ReportActionsUtils from '../../src/libs/ReportActionsUtils';
-import {getOneTransactionThreadReportID, getOriginalMessage, getSendMoneyFlowOneTransactionThreadID, isIOUActionMatchingTransactionList, isMessageDeleted} from '../../src/libs/ReportActionsUtils';
+import {
+    getOneTransactionThreadReportID,
+    getOriginalMessage,
+    getSendMoneyFlowOneTransactionThreadID,
+    isIOUActionMatchingTransactionList,
+    isMessageDeleted,
+} from '../../src/libs/ReportActionsUtils';
 import ONYXKEYS from '../../src/ONYXKEYS';
 import type {Report, ReportAction} from '../../src/types/onyx';
 import createRandomReport from '../utils/collections/reports';

--- a/tests/unit/ReportActionsUtilsTest.ts
+++ b/tests/unit/ReportActionsUtilsTest.ts
@@ -5,14 +5,13 @@ import {actionR14932 as mockIOUAction, originalMessageR14932 as mockOriginalMess
 import {chatReportR14932 as mockChatReport, iouReportR14932 as mockIOUReport} from '../../__mocks__/reportData/reports';
 import CONST from '../../src/CONST';
 import * as ReportActionsUtils from '../../src/libs/ReportActionsUtils';
-import {getOneTransactionThreadReportID, getOriginalMessage, getSendMoneyFlowOneTransactionThreadID, isIOUActionMatchingTransactionList} from '../../src/libs/ReportActionsUtils';
+import {getOneTransactionThreadReportID, getOriginalMessage, getSendMoneyFlowOneTransactionThreadID, isIOUActionMatchingTransactionList, isMessageDeleted} from '../../src/libs/ReportActionsUtils';
 import ONYXKEYS from '../../src/ONYXKEYS';
 import type {Report, ReportAction} from '../../src/types/onyx';
 import createRandomReport from '../utils/collections/reports';
 import * as LHNTestUtils from '../utils/LHNTestUtils';
 import waitForBatchedUpdates from '../utils/waitForBatchedUpdates';
 import wrapOnyxWithWaitForBatchedUpdates from '../utils/wrapOnyxWithWaitForBatchedUpdates';
-import { isMessageDeleted } from '../../src/libs/ReportActionsUtils';
 
 describe('ReportActionsUtils', () => {
     beforeAll(() =>
@@ -822,19 +821,19 @@ describe('ReportActionsUtils', () => {
                 actionName: CONST.REPORT.ACTIONS.TYPE.ADD_COMMENT,
                 originalMessage: {
                     html: 'Hello world',
-                    whisperedTo: []
+                    whisperedTo: [],
                 },
                 message: [
                     {
                         html: 'Hello world',
                         deleted: '2025-05-12 17:37:01.825',
                         type: CONST.REPORT.MESSAGE.TYPE.COMMENT,
-                        text: ''
+                        text: '',
                     },
                 ],
             };
             expect(isMessageDeleted(reportAction)).toBeTruthy();
-        })
+        });
         it('should return true if there is property isDeletedParentAction inside message', () => {
             const reportAction = {
                 created: '2025-05-12 17:27:01.825',
@@ -842,19 +841,19 @@ describe('ReportActionsUtils', () => {
                 actionName: CONST.REPORT.ACTIONS.TYPE.ADD_COMMENT,
                 originalMessage: {
                     html: 'Hello world',
-                    whisperedTo: []
+                    whisperedTo: [],
                 },
                 message: [
                     {
                         html: 'Hello world',
                         isDeletedParentAction: true,
                         type: CONST.REPORT.MESSAGE.TYPE.COMMENT,
-                        text: ''
+                        text: '',
                     },
                 ],
             };
             expect(isMessageDeleted(reportAction)).toBeTruthy();
-        })
+        });
         it('should return true if there is property deleted inside original message', () => {
             const reportAction = {
                 created: '2025-05-12 17:27:01.825',
@@ -863,18 +862,18 @@ describe('ReportActionsUtils', () => {
                 originalMessage: {
                     html: 'Hello world',
                     whisperedTo: [],
-                    deleted: '2025-05-12 17:37:01.825'
+                    deleted: '2025-05-12 17:37:01.825',
                 },
                 message: [
                     {
                         html: 'Hello world',
                         type: CONST.REPORT.MESSAGE.TYPE.COMMENT,
-                        text: ''
+                        text: '',
                     },
                 ],
             };
             expect(isMessageDeleted(reportAction)).toBeTruthy();
-        })
+        });
         it('should return true if there is property isDeletedParentAction inside original message', () => {
             const reportAction = {
                 created: '2025-05-12 17:27:01.825',
@@ -883,18 +882,18 @@ describe('ReportActionsUtils', () => {
                 originalMessage: {
                     html: 'Hello world',
                     whisperedTo: [],
-                    isDeletedParentAction: true
+                    isDeletedParentAction: true,
                 },
                 message: [
                     {
                         html: 'Hello world',
                         type: CONST.REPORT.MESSAGE.TYPE.COMMENT,
-                        text: ''
+                        text: '',
                     },
                 ],
             };
             expect(isMessageDeleted(reportAction)).toBeTruthy();
-        })
+        });
         it('should return false if there are no deletion properties in message and originalMessage', () => {
             const reportAction = {
                 created: '2025-05-12 17:27:01.825',
@@ -902,19 +901,19 @@ describe('ReportActionsUtils', () => {
                 actionName: CONST.REPORT.ACTIONS.TYPE.ADD_COMMENT,
                 originalMessage: {
                     html: 'Hello world',
-                    whisperedTo: []
+                    whisperedTo: [],
                 },
                 message: [
                     {
                         html: 'Hello world',
                         type: CONST.REPORT.MESSAGE.TYPE.COMMENT,
-                        text: ''
+                        text: '',
                     },
                 ],
             };
             expect(isMessageDeleted(reportAction)).toBeFalsy();
-        })
-    })
+        });
+    });
 
     describe('getReportActionMessageFragments', () => {
         it('should return the correct fragment for the REIMBURSED action', () => {
@@ -963,8 +962,8 @@ describe('ReportActionsUtils', () => {
                     {
                         type: CONST.REPORT.MESSAGE.TYPE.COMMENT,
                         text: '',
-                        deleted: '2025-05-12 17:27:01.825'
-                    }
+                        deleted: '2025-05-12 17:27:01.825',
+                    },
                 ],
             };
             const expectedFragments = ReportActionsUtils.getReportActionMessageFragments(action);

--- a/tests/unit/ReportActionsUtilsTest.ts
+++ b/tests/unit/ReportActionsUtilsTest.ts
@@ -12,6 +12,7 @@ import createRandomReport from '../utils/collections/reports';
 import * as LHNTestUtils from '../utils/LHNTestUtils';
 import waitForBatchedUpdates from '../utils/waitForBatchedUpdates';
 import wrapOnyxWithWaitForBatchedUpdates from '../utils/wrapOnyxWithWaitForBatchedUpdates';
+import { isMessageDeleted } from '../../src/libs/ReportActionsUtils';
 
 describe('ReportActionsUtils', () => {
     beforeAll(() =>
@@ -813,6 +814,108 @@ describe('ReportActionsUtils', () => {
         });
     });
 
+    describe('isMessageDeleted', () => {
+        it('should return true if there is property deleted inside message', () => {
+            const reportAction = {
+                created: '2025-05-12 17:27:01.825',
+                reportActionID: '8401445780099176',
+                actionName: CONST.REPORT.ACTIONS.TYPE.ADD_COMMENT,
+                originalMessage: {
+                    html: 'Hello world',
+                    whisperedTo: []
+                },
+                message: [
+                    {
+                        html: 'Hello world',
+                        deleted: '2025-05-12 17:37:01.825',
+                        type: CONST.REPORT.MESSAGE.TYPE.COMMENT,
+                        text: ''
+                    },
+                ],
+            };
+            expect(isMessageDeleted(reportAction)).toBeTruthy();
+        })
+        it('should return true if there is property isDeletedParentAction inside message', () => {
+            const reportAction = {
+                created: '2025-05-12 17:27:01.825',
+                reportActionID: '8401445780099176',
+                actionName: CONST.REPORT.ACTIONS.TYPE.ADD_COMMENT,
+                originalMessage: {
+                    html: 'Hello world',
+                    whisperedTo: []
+                },
+                message: [
+                    {
+                        html: 'Hello world',
+                        isDeletedParentAction: true,
+                        type: CONST.REPORT.MESSAGE.TYPE.COMMENT,
+                        text: ''
+                    },
+                ],
+            };
+            expect(isMessageDeleted(reportAction)).toBeTruthy();
+        })
+        it('should return true if there is property deleted inside original message', () => {
+            const reportAction = {
+                created: '2025-05-12 17:27:01.825',
+                reportActionID: '8401445780099176',
+                actionName: CONST.REPORT.ACTIONS.TYPE.ADD_COMMENT,
+                originalMessage: {
+                    html: 'Hello world',
+                    whisperedTo: [],
+                    deleted: '2025-05-12 17:37:01.825'
+                },
+                message: [
+                    {
+                        html: 'Hello world',
+                        type: CONST.REPORT.MESSAGE.TYPE.COMMENT,
+                        text: ''
+                    },
+                ],
+            };
+            expect(isMessageDeleted(reportAction)).toBeTruthy();
+        })
+        it('should return true if there is property isDeletedParentAction inside original message', () => {
+            const reportAction = {
+                created: '2025-05-12 17:27:01.825',
+                reportActionID: '8401445780099176',
+                actionName: CONST.REPORT.ACTIONS.TYPE.ADD_COMMENT,
+                originalMessage: {
+                    html: 'Hello world',
+                    whisperedTo: [],
+                    isDeletedParentAction: true
+                },
+                message: [
+                    {
+                        html: 'Hello world',
+                        type: CONST.REPORT.MESSAGE.TYPE.COMMENT,
+                        text: ''
+                    },
+                ],
+            };
+            expect(isMessageDeleted(reportAction)).toBeTruthy();
+        })
+        it('should return false if there are no deletion properties in message and originalMessage', () => {
+            const reportAction = {
+                created: '2025-05-12 17:27:01.825',
+                reportActionID: '8401445780099176',
+                actionName: CONST.REPORT.ACTIONS.TYPE.ADD_COMMENT,
+                originalMessage: {
+                    html: 'Hello world',
+                    whisperedTo: []
+                },
+                message: [
+                    {
+                        html: 'Hello world',
+                        type: CONST.REPORT.MESSAGE.TYPE.COMMENT,
+                        text: ''
+                    },
+                ],
+            };
+            expect(isMessageDeleted(reportAction)).toBeFalsy();
+        })
+    })
+
     describe('getReportActionMessageFragments', () => {
         it('should return the correct fragment for the REIMBURSED action', () => {
             const action = {
@@ -850,6 +953,22 @@ describe('ReportActionsUtils', () => {
             const expectedMessage = ReportActionsUtils.getReportActionMessageText(action);
             const expectedFragments = ReportActionsUtils.getReportActionMessageFragments(action);
             expect(expectedFragments).toEqual([{text: expectedMessage, html: `<muted-text>${expectedMessage}</muted-text>`, type: 'COMMENT'}]);
+        });
+        it('should return the correct fragment for the deleted message', () => {
+            const action = {
+                actionName: CONST.REPORT.ACTIONS.TYPE.ADD_COMMENT,
+                reportActionID: '1',
+                created: '1',
+                message: [
+                    {
+                        type: CONST.REPORT.MESSAGE.TYPE.COMMENT,
+                        text: '',
+                        deleted: '2025-05-12 17:27:01.825'
+                    }
+                ],
+            };
+            const expectedFragments = ReportActionsUtils.getReportActionMessageFragments(action);
+            expect(expectedFragments).toEqual([{text: '', type: CONST.REPORT.MESSAGE.TYPE.COMMENT, isDeletedParentAction: true, deleted: '2025-05-12 17:27:01.825'}]);
         });
     });
 

--- a/tests/unit/ReportUtilsTest.ts
+++ b/tests/unit/ReportUtilsTest.ts
@@ -458,6 +458,52 @@ describe('ReportUtils', () => {
                 ).toBe('floki@vikings.net');
             });
 
+            test('with deleted message and provided parent action param', () => {
+                const report = {
+                    type: CONST.REPORT.TYPE.CHAT,
+                    reportID: '4401445780099175',
+                    parentReportActionID: '8401445780099176',
+                    parentReportID: '4401445780099175'
+                }
+                const reportAction = { 
+                    created: '2025-05-12 17:27:01.825',
+                    reportActionID: '8401445780099176',
+                    actionName: CONST.REPORT.ACTIONS.TYPE.ADD_COMMENT,
+                    message: [
+                        { 
+                            deleted: '2025-05-12 17:27:01.825', 
+                            type: CONST.REPORT.MESSAGE.TYPE.COMMENT, 
+                            text: ''
+                        }
+                    ]
+                }
+                expect(getReportName(report, undefined, reportAction)).toEqual(translateLocal('parentReportAction.deletedMessage'));
+            });
+
+            test('with deleted message and not provided parent action param', async () => {
+                const report = {
+                    type: CONST.REPORT.TYPE.CHAT,
+                    parentReportActionID: '8401445780099176',
+                    parentReportID: '4401445780099175',
+                    reportID: '2401445780099174'
+                }
+                const reportAction = { 
+                    reportActionID: '8401445780099176', 
+                    parentReportID: '', 
+                    message: [
+                        { 
+                            deleted: '2025-05-12 17:27:01.825', 
+                            type: CONST.REPORT.MESSAGE.TYPE.COMMENT, 
+                            text: ''
+                        }
+                    ]
+                }
+                await Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${report.parentReportID}`, {
+                    [reportAction.reportActionID]: reportAction
+                })
+                expect(getReportName(report)).toEqual(translateLocal('parentReportAction.deletedMessage'));
+            });
+
             test('SMS', () => {
                 expect(
                     getReportName({

--- a/tests/unit/ReportUtilsTest.ts
+++ b/tests/unit/ReportUtilsTest.ts
@@ -463,20 +463,20 @@ describe('ReportUtils', () => {
                     type: CONST.REPORT.TYPE.CHAT,
                     reportID: '4401445780099175',
                     parentReportActionID: '8401445780099176',
-                    parentReportID: '4401445780099175'
-                }
-                const reportAction = { 
+                    parentReportID: '4401445780099175',
+                };
+                const reportAction = {
                     created: '2025-05-12 17:27:01.825',
                     reportActionID: '8401445780099176',
                     actionName: CONST.REPORT.ACTIONS.TYPE.ADD_COMMENT,
                     message: [
-                        { 
-                            deleted: '2025-05-12 17:27:01.825', 
-                            type: CONST.REPORT.MESSAGE.TYPE.COMMENT, 
-                            text: ''
-                        }
-                    ]
-                }
+                        {
+                            deleted: '2025-05-12 17:27:01.825',
+                            type: CONST.REPORT.MESSAGE.TYPE.COMMENT,
+                            text: '',
+                        },
+                    ],
+                };
                 expect(getReportName(report, undefined, reportAction)).toEqual(translateLocal('parentReportAction.deletedMessage'));
             });
 
@@ -485,22 +485,22 @@ describe('ReportUtils', () => {
                     type: CONST.REPORT.TYPE.CHAT,
                     parentReportActionID: '8401445780099176',
                     parentReportID: '4401445780099175',
-                    reportID: '2401445780099174'
-                }
-                const reportAction = { 
-                    reportActionID: '8401445780099176', 
-                    parentReportID: '', 
+                    reportID: '2401445780099174',
+                };
+                const reportAction = {
+                    reportActionID: '8401445780099176',
+                    parentReportID: '',
                     message: [
-                        { 
-                            deleted: '2025-05-12 17:27:01.825', 
-                            type: CONST.REPORT.MESSAGE.TYPE.COMMENT, 
-                            text: ''
-                        }
-                    ]
-                }
+                        {
+                            deleted: '2025-05-12 17:27:01.825',
+                            type: CONST.REPORT.MESSAGE.TYPE.COMMENT,
+                            text: '',
+                        },
+                    ],
+                };
                 await Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${report.parentReportID}`, {
-                    [reportAction.reportActionID]: reportAction
-                })
+                    [reportAction.reportActionID]: reportAction,
+                });
                 expect(getReportName(report)).toEqual(translateLocal('parentReportAction.deletedMessage'));
             });
 


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
Previously, we only checked whether the isDeletedParentAction flag was set to true to determine if a chat thread was deleted. However, we should introduce a utility function called isChatThreadDeleted in ReportUtils.ts that also checks whether the deleted property is null. If deleted is not null, we can treat the thread as deleted.
In the sidebar, "Deleted message" needs to be displayed instead of "Hidden" or empty message. In SidebarUtils.ts, this is handled through the reportName variable, which uses the getReportName function that now relies on our new isChatThreadDeleted function.

We can invoke the getReportAction function, providing report.parentReportActionID as the report action ID to retrieve the parent report action. From the parent report action, we can then extract the message and check for the presence of the deleted or isDeletedParentAction flags.

Additionally, when sending a message to a deleted thread, both the deleted and isDeletedParentAction flags may be missing from the message itself. Nevertheless, these flags are still available within reportAction.originalMessage. Consequently, we have also implemented a check for their presence in the originalMessage.

There is a useful function, IsDeletedMessage, located in ReportActionUtils.ts. By modifying it to check both the deleted and isDeletedParentAction flags on both the message and the originalMessage, we can reliably determine whether a message has actually been deleted. We can then reuse this improved function within the new isChatThreadDeleted function.

Furthermore, because a sent message is displayed as edited rather than deleted, we must adjust the way we retrieve message fragments. Specifically, a deleted chat thread scenario is identified when there is only a single message present in the message property. Therefore, an additional check for this condition has been incorporated when retrieving chat fragments within the getReportActionMessageFragments function.

With this approach, the HeaderView.tsx component will correctly display the title "Deleted message" instead of showing a loading skeleton.
<!-- Explain what your change does and how it addresses the linked issue -->

### Fixed Issues

$ https://github.com/Expensify/App/issues/59392
$ PROPOSAL: https://github.com/Expensify/App/issues/59392#issuecomment-2770995423



<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

I checked tests that are related to those enhancements, and no tests were failing.

Created new unit tests for functions I changed. There was no tests for function IsMessageDeleted so I added tests for whole function.



- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->
// TODO: These must be filled out, or the issue title must include "[No QA]."
We need 2 application instances and 2 users to test this. 
User A initiate a new chat, and provide User B’s email address.
Send a message to User B in the direct conversation.
Sign in with User B to access the message thread.
Return to User A, locate the sent message, right-click on it, remove it.
Switch back to User B and post a reply in the same thread.
Observe the following issues:
- The thread header gets stuck in a perpetual loading state. (Shouldn't happen)
- The message appears to have been edited rather than deleted. (Should be deleted)
- In the sidebar, the conversation is marked as “Hidden” instead of showing as a “Deleted” message. (should be deleted)

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I verified there are no new alerts related to the `canBeMissing` param for `useOnyx`
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

https://github.com/user-attachments/assets/c167bd51-86fc-4c90-af0a-73a232a2b04d

</details>

<details>
<summary>Android: mWeb Chrome</summary>

https://github.com/user-attachments/assets/f585e489-2482-4803-bc30-e7388388f205

</details>

<details>
<summary>iOS: Native</summary>

https://github.com/user-attachments/assets/1e3ec4f4-7767-4e7c-9407-8031678f39ae

</details>

<details>
<summary>iOS: mWeb Safari</summary>

https://github.com/user-attachments/assets/91a780a2-233d-4e37-b3f9-5cb2fca596b7

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

https://github.com/user-attachments/assets/ac1f71d9-9055-4fde-a6a5-4509915e555d

</details>

<details>
<summary>MacOS: Desktop</summary>

https://github.com/user-attachments/assets/4cca9e76-2eff-461a-bced-5f15ee1705d8

</details>
