### PR TITLE
fix: hide To recipient when From and To recipient are the same

### DIFF
--- a/src/components/SelectionList/Search/ExpenseItemHeaderNarrow.tsx
+++ b/src/components/SelectionList/Search/ExpenseItemHeaderNarrow.tsx
@@ -1,4 +1,4 @@
-import React, {memo} from 'react';
+import React, {memo, useMemo} from 'react';
 import {View} from 'react-native';
 import type {StyleProp, ViewStyle} from 'react-native';
 import {getButtonRole} from '@components/Button/utils';
@@ -9,7 +9,7 @@ import useStyleUtils from '@hooks/useStyleUtils';
 import useTheme from '@hooks/useTheme';
 import useThemeStyles from '@hooks/useThemeStyles';
 import {isCorrectSearchUserName} from '@libs/SearchUIUtils';
-import variables from '@styles/variables';
+import CONST from '@src/CONST';
 import type {SearchPersonalDetails, SearchTransactionAction} from '@src/types/onyx/SearchResults';
 import ActionCell from './ActionCell';
 import UserInfoCellsWithArrow from './UserInfoCellsWithArrow';
@@ -53,7 +53,7 @@ function ExpenseItemHeaderNarrow({
 
     // It might happen that we are missing display names for `From` or `To`, we only display arrow icon if both names exist
     const shouldDisplayArrowIcon = isCorrectSearchUserName(participantFromDisplayName) && isCorrectSearchUserName(participantToDisplayName);
-
+    const shouldShowAction = useMemo(() => action !== CONST.SEARCH.ACTION_TYPES.VIEW && action !== CONST.SEARCH.ACTION_TYPES.REVIEW, [action]);
     return (
         <View style={[styles.flex1, styles.flexRow, styles.alignItemsCenter, styles.justifyContentBetween, styles.mb3, styles.gap2, containerStyle]}>
             <View style={[styles.flexRow, styles.alignItemsCenter, styles.gap2, styles.flex1]}>
@@ -77,23 +77,28 @@ function ExpenseItemHeaderNarrow({
                         </View>
                     </PressableWithFeedback>
                 )}
-                <UserInfoCellsWithArrow
-                    shouldDisplayArrowIcon={!!shouldDisplayArrowIcon}
-                    participantFrom={participantFrom}
-                    participantFromDisplayName={participantFromDisplayName}
-                    participantTo={participantTo}
-                    participantToDisplayName={participantToDisplayName}
-                />
+                <View style={[styles.flex1, styles.flexRow, styles.alignItemsCenter, styles.gap2]}>
+                    <UserInfoCellsWithArrow
+                        shouldDisplayArrowIcon={!!shouldDisplayArrowIcon}
+                        participantFrom={participantFrom}
+                        participantFromDisplayName={participantFromDisplayName}
+                        participantTo={participantTo}
+                        participantToDisplayName={participantToDisplayName}
+                        fromRecipientStyle={!shouldDisplayArrowIcon ? styles.mw100 : {}}
+                    />
+                </View>
             </View>
-            <View style={[StyleUtils.getWidthStyle(variables.w80)]}>
-                <ActionCell
-                    action={action}
-                    goToItem={onButtonPress}
-                    isLargeScreenWidth={false}
-                    isSelected={isSelected}
-                    isLoading={isLoading}
-                />
-            </View>
+            {shouldShowAction && (
+                <View>
+                    <ActionCell
+                        action={action}
+                        goToItem={onButtonPress}
+                        isLargeScreenWidth={false}
+                        isSelected={isSelected}
+                        isLoading={isLoading}
+                    />
+                </View>
+            )}
         </View>
     );
 }

--- a/src/components/SelectionList/Search/ReportListItemHeader.tsx
+++ b/src/components/SelectionList/Search/ReportListItemHeader.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {useMemo} from 'react';
 import {View} from 'react-native';
 import type {OnyxEntry} from 'react-native-onyx';
 import Checkbox from '@components/Checkbox';
@@ -163,8 +163,11 @@ function ReportListItemHeader<TItem extends ListItem>({
     const {translate} = useLocalize();
     const {isLargeScreenWidth} = useResponsiveLayout();
     const thereIsFromAndTo = !!reportItem?.from && !!reportItem?.to;
-    const showArrowComponent = reportItem.type === CONST.REPORT.TYPE.IOU && thereIsFromAndTo;
-
+    const showArrowComponent = (reportItem.type === CONST.REPORT.TYPE.IOU && thereIsFromAndTo) || (reportItem.type === CONST.REPORT.TYPE.EXPENSE && !!reportItem?.from);
+    const shouldShowToRecipient = useMemo(
+        () => thereIsFromAndTo && reportItem?.from?.accountID !== reportItem?.to?.accountID,
+        [thereIsFromAndTo, reportItem?.from?.accountID, reportItem?.to?.accountID],
+    );
     const handleOnButtonPress = () => {
         handleActionButtonPress(currentSearchHash, reportItem, () => onSelectRow(item));
     };
@@ -178,19 +181,33 @@ function ReportListItemHeader<TItem extends ListItem>({
                 isDisabled={isDisabled}
                 canSelectMultiple={canSelectMultiple}
             />
-            <View style={[styles.pt0, styles.flexRow, styles.alignItemsCenter, showArrowComponent ? styles.justifyContentBetween : styles.justifyContentEnd, styles.pr3, styles.pl3]}>
-                {showArrowComponent && (
-                    <UserInfoCellsWithArrow
-                        shouldDisplayArrowIcon
-                        participantFrom={reportItem?.from}
-                        participantFromDisplayName={reportItem?.from?.displayName ?? reportItem?.from?.login ?? translate('common.hidden')}
-                        participantToDisplayName={reportItem?.to?.displayName ?? reportItem?.to?.login ?? translate('common.hidden')}
-                        participantTo={reportItem?.to}
-                        avatarSize="mid-subscript"
-                        infoCellsTextStyle={{...styles.textMicroBold, lineHeight: 14}}
-                        infoCellsAvatarStyle={styles.pr1}
-                    />
-                )}
+            <View
+                style={[
+                    styles.pt0,
+                    styles.flexRow,
+                    styles.alignItemsCenter,
+                    showArrowComponent ? styles.justifyContentBetween : styles.justifyContentEnd,
+                    styles.pr3,
+                    styles.pl3,
+                    styles.gap2,
+                ]}
+            >
+                <View style={[styles.flex1, styles.flexRow, styles.alignItemsCenter, styles.gap2]}>
+                    {showArrowComponent && (
+                        <UserInfoCellsWithArrow
+                            shouldDisplayArrowIcon={shouldShowToRecipient}
+                            shouldShowToRecipient={shouldShowToRecipient}
+                            participantFrom={reportItem?.from}
+                            participantFromDisplayName={reportItem?.from?.displayName ?? reportItem?.from?.login ?? translate('common.hidden')}
+                            participantToDisplayName={reportItem?.to?.displayName ?? reportItem?.to?.login ?? translate('common.hidden')}
+                            participantTo={reportItem?.to}
+                            avatarSize="mid-subscript"
+                            infoCellsTextStyle={{...styles.textMicroBold, lineHeight: 14}}
+                            infoCellsAvatarStyle={styles.pr1}
+                            fromRecipientStyle={!shouldShowToRecipient ? styles.mw100 : {}}
+                        />
+                    )}
+                </View>
                 <View>
                     <ActionCell
                         action={reportItem.action}

--- a/src/components/SelectionList/Search/UserInfoCellsWithArrow.tsx
+++ b/src/components/SelectionList/Search/UserInfoCellsWithArrow.tsx
@@ -13,6 +13,7 @@ import UserInfoCell from './UserInfoCell';
 
 function UserInfoCellsWithArrow({
     shouldDisplayArrowIcon,
+    shouldShowToRecipient = true,
     participantFrom,
     participantFromDisplayName,
     participantTo,
@@ -20,8 +21,10 @@ function UserInfoCellsWithArrow({
     avatarSize,
     infoCellsTextStyle,
     infoCellsAvatarStyle,
+    fromRecipientStyle,
 }: {
     shouldDisplayArrowIcon: boolean;
+    shouldShowToRecipient?: boolean;
     participantFrom: SearchPersonalDetails | PersonalDetails;
     participantFromDisplayName: string;
     participantTo: SearchPersonalDetails | PersonalDetails;
@@ -29,13 +32,14 @@ function UserInfoCellsWithArrow({
     avatarSize?: AvatarSizeName;
     infoCellsTextStyle?: TextStyle;
     infoCellsAvatarStyle?: ViewStyle;
+    fromRecipientStyle?: ViewStyle;
 }) {
     const styles = useThemeStyles();
     const theme = useTheme();
 
     return (
         <>
-            <View style={[styles.mw50]}>
+            <View style={[styles.mw50, fromRecipientStyle]}>
                 <UserInfoCell
                     accountID={participantFrom.accountID}
                     avatar={participantFrom.avatar}
@@ -53,16 +57,18 @@ function UserInfoCellsWithArrow({
                     fill={theme.icon}
                 />
             )}
-            <View style={[styles.flex1, styles.mw50]}>
-                <UserInfoCell
-                    accountID={participantTo.accountID}
-                    avatar={participantTo.avatar}
-                    displayName={participantToDisplayName}
-                    avatarSize={avatarSize}
-                    textStyle={infoCellsTextStyle}
-                    avatarStyle={infoCellsAvatarStyle}
-                />
-            </View>
+            {shouldShowToRecipient && (
+                <View style={[styles.flex1, styles.mw50]}>
+                    <UserInfoCell
+                        accountID={participantTo.accountID}
+                        avatar={participantTo.avatar}
+                        displayName={participantToDisplayName}
+                        avatarSize={avatarSize}
+                        textStyle={infoCellsTextStyle}
+                        avatarStyle={infoCellsAvatarStyle}
+                    />
+                </View>
+            )}
         </>
     );
 }


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
<!-- Explain what your change does and how it addresses the linked issue -->
This PR handles the condition to only show the "To" recipient for the expense type, and only when the "From" and "To" recipients are different. It also updates the UI accordingly.
### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/62109
PROPOSAL: https://github.com/Expensify/App/issues/62109#issuecomment-2887993925


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->
Pre-requisite: Use a mobile device, or make your screen narrow, or screen width less than 1024. 

1. Create a workspace
2. Create a couple of expenses
3. Submit the report.
4. Go to Reports > Expense Reports
5. Verify that the Submitter avatar and name are displayed correctly.
- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->
Same as test above
### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->
Same as test above

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I verified there are no new alerts related to the `canBeMissing` param for `useOnyx`
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>


https://github.com/user-attachments/assets/31de8bc4-39f3-4565-a7c8-8fa1268e10e4



</details>

<details>
<summary>Android: mWeb Chrome</summary>


https://github.com/user-attachments/assets/c87c65a6-e8f9-4348-b5b4-0d46ad6dbca6



</details>

<details>
<summary>iOS: Native</summary>


https://github.com/user-attachments/assets/9bdad11b-5d7b-4e81-89fa-8375a073eddf



</details>

<details>
<summary>iOS: mWeb Safari</summary>


https://github.com/user-attachments/assets/4ffec487-fb20-4909-806b-11f311e919db



</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

https://github.com/user-attachments/assets/eb086513-2be4-4082-b37f-8b089308ddd0


https://github.com/user-attachments/assets/93555945-7b89-4eea-8fb4-8aac27e33a2c




</details>

<details>
<summary>MacOS: Desktop</summary>


https://github.com/user-attachments/assets/f5eb71d1-ecc1-4965-84bb-28edb7f7a1c2



</details>
