### PR TITLE
fix: text focus is moved up after adding italic markdown at end. #61022

### DIFF
--- a/src/components/RNMarkdownTextInput.tsx
+++ b/src/components/RNMarkdownTextInput.tsx
@@ -1,7 +1,7 @@
 import type {MarkdownTextInputProps} from '@expensify/react-native-live-markdown';
 import {MarkdownTextInput} from '@expensify/react-native-live-markdown';
 import type {ForwardedRef} from 'react';
-import React, {forwardRef, useCallback, useEffect} from 'react';
+import React, {forwardRef, useCallback, useEffect, useRef} from 'react';
 import Animated, {useSharedValue} from 'react-native-reanimated';
 import useShortMentionsList from '@hooks/useShortMentionsList';
 import useTheme from '@hooks/useTheme';
@@ -25,6 +25,22 @@ function RNMarkdownTextInputWithRef({maxLength, parser, ...props}: RNMarkdownTex
 
     const {mentionsList, currentUserMentions} = useShortMentionsList();
     const mentionsSharedVal = useSharedValue<string[]>(mentionsList);
+    const inputRef = useRef<any>(null);
+
+    // Expose the ref to the parent component
+    React.useImperativeHandle(ref, () => inputRef.current);
+
+    // Check if the cursor is at the end of the text
+    const isCursorAtEnd = props.selection && props.value && props.selection.start === props.value.length;
+
+    // Automatically scroll to the end if the cursor was at the end after value changes
+    useEffect(() => {
+        if (inputRef.current && isCursorAtEnd) {
+            if ('scrollTop' in inputRef.current && 'scrollHeight' in inputRef.current) {
+                inputRef.current.scrollTop = inputRef.current.scrollHeight;
+            }
+        }
+    }, [props.value]);
 
     // If `parser` prop was passed down we use it directly, otherwise we default to parsing with ExpensiMark
     const parserWorklet = useCallback(
@@ -54,12 +70,7 @@ function RNMarkdownTextInputWithRef({maxLength, parser, ...props}: RNMarkdownTex
             textBreakStrategy="simple"
             keyboardAppearance={theme.colorScheme}
             parser={parserWorklet}
-            ref={(refHandle) => {
-                if (typeof ref !== 'function') {
-                    return;
-                }
-                ref(refHandle as AnimatedMarkdownTextInputRef);
-            }}
+            ref={inputRef}
             formatSelection={toggleSelectionFormat}
             // eslint-disable-next-line
             {...props}

--- a/src/components/RNMarkdownTextInput.tsx
+++ b/src/components/RNMarkdownTextInput.tsx
@@ -25,22 +25,25 @@ function RNMarkdownTextInputWithRef({maxLength, parser, ...props}: RNMarkdownTex
 
     const {mentionsList, currentUserMentions} = useShortMentionsList();
     const mentionsSharedVal = useSharedValue<string[]>(mentionsList);
-    const inputRef = useRef<any>(null);
+    const inputRef = useRef<AnimatedMarkdownTextInputRef>(null);
 
     // Expose the ref to the parent component
-    React.useImperativeHandle(ref, () => inputRef.current);
+    React.useImperativeHandle<AnimatedMarkdownTextInputRef | null, AnimatedMarkdownTextInputRef | null>(ref, () => inputRef.current);
 
     // Check if the cursor is at the end of the text
     const isCursorAtEnd = props.selection && props.value && props.selection.start === props.value.length;
 
     // Automatically scroll to the end if the cursor was at the end after value changes
     useEffect(() => {
-        if (inputRef.current && isCursorAtEnd) {
-            if ('scrollTop' in inputRef.current && 'scrollHeight' in inputRef.current) {
-                inputRef.current.scrollTop = inputRef.current.scrollHeight;
-            }
+        if (!inputRef.current || !isCursorAtEnd) {
+            return;
         }
-    }, [props.value]);
+
+        if ('scrollTop' in inputRef.current && 'scrollHeight' in inputRef.current) {
+            const currentRef = inputRef.current as unknown as {scrollTop: number; scrollHeight: number};
+            currentRef.scrollTop = currentRef.scrollHeight;
+        }
+    }, [props.value, isCursorAtEnd]);
 
     // If `parser` prop was passed down we use it directly, otherwise we default to parsing with ExpensiMark
     const parserWorklet = useCallback(


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
fix: text focus is moved up after adding italic markdown at end.

### Fixed Issues
$ [#61022](https://github.com/Expensify/App/issues/61022)
PROPOSAL: [#61022(comment)](https://github.com/Expensify/App/issues/61022#issuecomment-2877647947)

### Tests

1. Go to https://staging.new.expensify.com/home
2. Long press a workspace chat with no conversation & select onyx data
3. Paste the data in compose box
4. Add a bold markdown for the text
5. Note text shown in bold
6. Now add a _ at the end of the text
7. Note bold markdown removed after adding _
8. Add 5_ at the end of text
9. Verify text focus is not moved after adding italic markdown at end

- [x] Verify that no errors appear in the JS console

### Offline tests

Same

### QA Steps

1. Go to https://staging.new.expensify.com/home
2. Long press a workspace chat with no conversation & select onyx data
3. Paste the data in compose box
4. Add a bold markdown for the text
5. Note text shown in bold
6. Now add a _ at the end of the text
7. Note bold markdown removed after adding _
8. Add 5_ at the end of text
9. Verify text focus is not moved after adding italic markdown at end

- [x] Verify that no errors appear in the JS console

### PR Author Checklist


- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I verified there are no new alerts related to the `canBeMissing` param for `useOnyx`
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

https://private-user-images.githubusercontent.com/139571222/443362376-f353ed7a-a1d5-4501-952f-e191acfc06b8.mp4?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3NDc5MjY3OTQsIm5iZiI6MTc0NzkyNjQ5NCwicGF0aCI6Ii8xMzk1NzEyMjIvNDQzMzYyMzc2LWYzNTNlZDdhLWExZDUtNDUwMS05NTJmLWUxOTFhY2ZjMDZiOC5tcDQ_WC1BbXotQWxnb3JpdGhtPUFXUzQtSE1BQy1TSEEyNTYmWC1BbXotQ3JlZGVudGlhbD1BS0lBVkNPRFlMU0E1M1BRSzRaQSUyRjIwMjUwNTIyJTJGdXMtZWFzdC0xJTJGczMlMkZhd3M0X3JlcXVlc3QmWC1BbXotRGF0ZT0yMDI1MDUyMlQxNTA4MTRaJlgtQW16LUV4cGlyZXM9MzAwJlgtQW16LVNpZ25hdHVyZT0zNTZjYWY2Y2Q3MmE5N2FlMTQ2NTgzYjcwZWFhZGE1OTQ1NjQ3OWI2MWY5NDI3YjE5NjE4NzAwNjBmMzEzMjU5JlgtQW16LVNpZ25lZEhlYWRlcnM9aG9zdCJ9.wC4GdpFUDY54Uui8A5OGwVPcvp1Ike_M1QIEH88Q2IY

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Desktop</summary>

<!-- add screenshots or videos here -->

</details>
