### PR TITLE
fix: hide arrow icon if to recipient is invalid

### DIFF
--- a/src/components/ReportActionItem/TransactionPreview/TransactionPreviewContent.tsx
+++ b/src/components/ReportActionItem/TransactionPreview/TransactionPreviewContent.tsx
@@ -195,7 +195,7 @@ function TransactionPreviewContent({
                                 {shouldShowIOUHeader && (
                                     <View style={[styles.flex1, styles.dFlex, styles.alignItemsCenter, styles.gap2, styles.flexRow]}>
                                         <UserInfoCellsWithArrow
-                                            shouldDisplayArrowIcon
+                                            shouldShowToRecipient
                                             participantFrom={from}
                                             participantFromDisplayName={from.displayName ?? from.login ?? translate('common.hidden')}
                                             participantToDisplayName={to.displayName ?? to.login ?? translate('common.hidden')}

--- a/src/components/SelectionList/Search/ExpenseItemHeaderNarrow.tsx
+++ b/src/components/SelectionList/Search/ExpenseItemHeaderNarrow.tsx
@@ -52,7 +52,7 @@ function ExpenseItemHeaderNarrow({
     const theme = useTheme();
 
     // It might happen that we are missing display names for `From` or `To`, we only display arrow icon if both names exist
-    const shouldDisplayArrowIcon = isCorrectSearchUserName(participantFromDisplayName) && isCorrectSearchUserName(participantToDisplayName);
+    const shouldShowToRecipient = isCorrectSearchUserName(participantFromDisplayName) && isCorrectSearchUserName(participantToDisplayName);
     const shouldShowAction = useMemo(() => action !== CONST.SEARCH.ACTION_TYPES.VIEW && action !== CONST.SEARCH.ACTION_TYPES.REVIEW, [action]);
     return (
         <View style={[styles.flex1, styles.flexRow, styles.alignItemsCenter, styles.justifyContentBetween, styles.mb3, styles.gap2, containerStyle]}>
@@ -79,12 +79,12 @@ function ExpenseItemHeaderNarrow({
                 )}
                 <View style={[styles.flex1, styles.flexRow, styles.alignItemsCenter, styles.gap2]}>
                     <UserInfoCellsWithArrow
-                        shouldDisplayArrowIcon={!!shouldDisplayArrowIcon}
+                        shouldShowToRecipient={!!shouldShowToRecipient}
                         participantFrom={participantFrom}
                         participantFromDisplayName={participantFromDisplayName}
                         participantTo={participantTo}
                         participantToDisplayName={participantToDisplayName}
-                        fromRecipientStyle={!shouldDisplayArrowIcon ? styles.mw100 : {}}
+                        fromRecipientStyle={!shouldShowToRecipient ? styles.mw100 : {}}
                     />
                 </View>
             </View>

--- a/src/components/SelectionList/Search/ReportListItemHeader.tsx
+++ b/src/components/SelectionList/Search/ReportListItemHeader.tsx
@@ -13,6 +13,7 @@ import useStyleUtils from '@hooks/useStyleUtils';
 import useTheme from '@hooks/useTheme';
 import useThemeStyles from '@hooks/useThemeStyles';
 import {convertToDisplayString} from '@libs/CurrencyUtils';
+import {isCorrectSearchUserName} from '@libs/SearchUIUtils';
 import {handleActionButtonPress} from '@userActions/Search';
 import CONST from '@src/CONST';
 import type * as OnyxTypes from '@src/types/onyx';
@@ -181,9 +182,13 @@ function ReportListItemHeader<TItem extends ListItem>({
     const {isLargeScreenWidth} = useResponsiveLayout();
     const thereIsFromAndTo = !!reportItem?.from && !!reportItem?.to;
     const showArrowComponent = (reportItem.type === CONST.REPORT.TYPE.IOU && thereIsFromAndTo) || (reportItem.type === CONST.REPORT.TYPE.EXPENSE && !!reportItem?.from);
+    const participantToDisplayName = useMemo(
+        () => reportItem?.to?.displayName ?? reportItem?.to?.login ?? translate('common.hidden'),
+        [reportItem?.to?.displayName, reportItem?.to?.login, translate],
+    );
     const shouldShowToRecipient = useMemo(
-        () => thereIsFromAndTo && reportItem?.from?.accountID !== reportItem?.to?.accountID,
-        [thereIsFromAndTo, reportItem?.from?.accountID, reportItem?.to?.accountID],
+        () => thereIsFromAndTo && !!reportItem?.to?.accountID && reportItem?.from?.accountID !== reportItem?.to?.accountID && !!isCorrectSearchUserName(participantToDisplayName),
+        [thereIsFromAndTo, reportItem?.from?.accountID, reportItem?.to?.accountID, participantToDisplayName],
     );
     const avatarBorderColor =
         StyleUtils.getItemBackgroundColorStyle(!!item.isSelected, !!isFocused || !!isHovered, !!isDisabled, theme.activeComponentBG, theme.hoverComponentBG)?.backgroundColor ??
@@ -217,11 +222,10 @@ function ReportListItemHeader<TItem extends ListItem>({
                 <View style={[styles.flex1, styles.flexRow, styles.alignItemsCenter, styles.gap2]}>
                     {showArrowComponent && (
                         <UserInfoCellsWithArrow
-                            shouldDisplayArrowIcon={shouldShowToRecipient}
                             shouldShowToRecipient={shouldShowToRecipient}
                             participantFrom={reportItem?.from}
                             participantFromDisplayName={reportItem?.from?.displayName ?? reportItem?.from?.login ?? translate('common.hidden')}
-                            participantToDisplayName={reportItem?.to?.displayName ?? reportItem?.to?.login ?? translate('common.hidden')}
+                            participantToDisplayName={participantToDisplayName}
                             participantTo={reportItem?.to}
                             avatarSize="mid-subscript"
                             infoCellsTextStyle={{...styles.textMicroBold, lineHeight: 14}}

--- a/src/components/SelectionList/Search/UserInfoCellsWithArrow.tsx
+++ b/src/components/SelectionList/Search/UserInfoCellsWithArrow.tsx
@@ -12,8 +12,7 @@ import type {SearchPersonalDetails} from '@src/types/onyx/SearchResults';
 import UserInfoCell from './UserInfoCell';
 
 function UserInfoCellsWithArrow({
-    shouldDisplayArrowIcon,
-    shouldShowToRecipient = true,
+    shouldShowToRecipient,
     participantFrom,
     participantFromDisplayName,
     participantTo,
@@ -23,8 +22,7 @@ function UserInfoCellsWithArrow({
     infoCellsAvatarStyle,
     fromRecipientStyle,
 }: {
-    shouldDisplayArrowIcon: boolean;
-    shouldShowToRecipient?: boolean;
+    shouldShowToRecipient: boolean;
     participantFrom: SearchPersonalDetails | PersonalDetails;
     participantFromDisplayName: string;
     participantTo: SearchPersonalDetails | PersonalDetails;
@@ -49,25 +47,26 @@ function UserInfoCellsWithArrow({
                     avatarStyle={infoCellsAvatarStyle}
                 />
             </View>
-            {shouldDisplayArrowIcon && (
-                <Icon
-                    src={Expensicons.ArrowRightLong}
-                    width={variables.iconSizeXXSmall}
-                    height={variables.iconSizeXXSmall}
-                    fill={theme.icon}
-                />
-            )}
             {shouldShowToRecipient && (
-                <View style={[styles.flex1, styles.mw50]}>
-                    <UserInfoCell
-                        accountID={participantTo.accountID}
-                        avatar={participantTo.avatar}
-                        displayName={participantToDisplayName}
-                        avatarSize={avatarSize}
-                        textStyle={infoCellsTextStyle}
-                        avatarStyle={infoCellsAvatarStyle}
+                <>
+                    <Icon
+                        src={Expensicons.ArrowRightLong}
+                        width={variables.iconSizeXXSmall}
+                        height={variables.iconSizeXXSmall}
+                        fill={theme.icon}
+                        testID="ArrowRightLong Icon"
                     />
-                </View>
+                    <View style={[styles.flex1, styles.mw50]}>
+                        <UserInfoCell
+                            accountID={participantTo.accountID}
+                            avatar={participantTo.avatar}
+                            displayName={participantToDisplayName}
+                            avatarSize={avatarSize}
+                            textStyle={infoCellsTextStyle}
+                            avatarStyle={infoCellsAvatarStyle}
+                        />
+                    </View>
+                </>
             )}
         </>
     );

--- a/tests/ui/ReportListItemHeaderTest.tsx
+++ b/tests/ui/ReportListItemHeaderTest.tsx
@@ -1,0 +1,209 @@
+import {render, screen} from '@testing-library/react-native';
+import React from 'react';
+import Onyx from 'react-native-onyx';
+import type {ValueOf} from 'type-fest';
+import ComposeProviders from '@components/ComposeProviders';
+import {LocaleContextProvider} from '@components/LocaleContextProvider';
+import OnyxProvider from '@components/OnyxProvider';
+import {Context as SearchContext} from '@components/Search/SearchContext';
+import ReportListItemHeader from '@components/SelectionList/Search/ReportListItemHeader';
+import type {ReportListItemType} from '@components/SelectionList/types';
+import CONST from '@src/CONST';
+import ONYXKEYS from '@src/ONYXKEYS';
+import type {SearchPersonalDetails} from '@src/types/onyx/SearchResults';
+import createRandomPolicy from '../utils/collections/policies';
+import createRandomReport from '../utils/collections/reports';
+import waitForBatchedUpdates from '../utils/waitForBatchedUpdates';
+
+jest.mock('@components/ConfirmedRoute.tsx');
+jest.mock('@libs/Navigation/Navigation');
+jest.mock('@components/AvatarWithDisplayName.tsx');
+
+// Mock search context
+const mockSearchContext = {
+    currentSearchHash: 12345,
+    selectedReports: {},
+    setSelectedReports: jest.fn(),
+    selectedTransactionIDs: [],
+    setSelectedTransactionIDs: jest.fn(),
+    clearSelectedItems: jest.fn(),
+};
+
+const mockPersonalDetails: Record<string, SearchPersonalDetails> = {
+    john: {
+        accountID: 1,
+        displayName: 'John Doe',
+        login: 'john.doe@example.com',
+        avatar: 'https://example.com/avatar1.jpg',
+    },
+    jane: {
+        accountID: 2,
+        displayName: 'Jane Smith',
+        login: 'jane.smith@example.com',
+        avatar: 'https://example.com/avatar2.jpg',
+    },
+    fake: {
+        accountID: 0,
+        displayName: '',
+        login: '',
+        avatar: '',
+    },
+};
+
+const mockPolicy = createRandomPolicy(1);
+const createReportListItem = (type: ValueOf<typeof CONST.REPORT.TYPE>, from?: string, to?: string, options: Partial<ReportListItemType> = {}): ReportListItemType => ({
+    shouldAnimateInHighlight: false,
+    action: 'view' as const,
+    chatReportID: '123',
+    created: '2024-01-01',
+    currency: 'USD',
+    isOneTransactionReport: false,
+    isPolicyExpenseChat: false,
+    isWaitingOnBankAccount: false,
+    nonReimbursableTotal: 0,
+    policyID: mockPolicy.id,
+    private_isArchived: '',
+    reportID: '789',
+    reportName: 'Test Report',
+    stateNum: 1,
+    statusNum: 1,
+    total: 100,
+    type,
+    unheldTotal: 100,
+    keyForList: '789',
+    // @ts-expect-error - Intentionally allowing undefined for testing edge cases
+    from: from ? mockPersonalDetails[from] : undefined,
+    // @ts-expect-error - Intentionally allowing undefined for testing edge cases
+    to: to ? mockPersonalDetails[to] : undefined,
+    transactions: [],
+    ...options,
+});
+
+// Helper function to wrap component with context
+const renderReportListItemHeader = (reportItem: ReportListItemType) => {
+    const mockReport = createRandomReport(Number(reportItem.reportID));
+
+    return render(
+        <ComposeProviders components={[OnyxProvider, LocaleContextProvider]}>
+            {/* @ts-expect-error - Disable TypeScript errors to simplify the test */}
+            <SearchContext.Provider value={mockSearchContext}>
+                <ReportListItemHeader
+                    report={mockReport}
+                    policy={mockPolicy}
+                    item={reportItem}
+                    onSelectRow={jest.fn()}
+                    onCheckboxPress={jest.fn()}
+                    isDisabled={false}
+                    canSelectMultiple={false}
+                />
+            </SearchContext.Provider>
+        </ComposeProviders>,
+    );
+};
+
+describe('ReportListItemHeader', () => {
+    beforeAll(() =>
+        Onyx.init({
+            keys: ONYXKEYS,
+            evictableKeys: [ONYXKEYS.COLLECTION.REPORT_ACTIONS],
+        }),
+    );
+
+    afterEach(async () => {
+        await Onyx.clear();
+        jest.clearAllMocks();
+    });
+
+    describe('UserInfoCellsWithArrow', () => {
+        describe('when report type is IOU', () => {
+            it('should display both submitter and recipient if both are present', async () => {
+                const reportItem = createReportListItem(CONST.REPORT.TYPE.IOU, 'john', 'jane');
+                renderReportListItemHeader(reportItem);
+                await waitForBatchedUpdates();
+
+                expect(screen.getByText('John Doe')).toBeOnTheScreen();
+                expect(screen.getByText('Jane Smith')).toBeOnTheScreen();
+            });
+
+            it('should not display submitter and recipient if only submitter is present', async () => {
+                const reportItem = createReportListItem(CONST.REPORT.TYPE.IOU, 'john', undefined);
+                renderReportListItemHeader(reportItem);
+                await waitForBatchedUpdates();
+
+                expect(screen.queryByText('John Doe')).not.toBeOnTheScreen();
+                expect(screen.queryByTestId('ArrowRightLong Icon')).not.toBeOnTheScreen();
+            });
+
+            it('should only display submitter if submitter and recipient are the same', async () => {
+                const reportItem = createReportListItem(CONST.REPORT.TYPE.IOU, 'john', 'john');
+                renderReportListItemHeader(reportItem);
+                await waitForBatchedUpdates();
+
+                expect(screen.getByText('John Doe')).toBeOnTheScreen();
+                expect(screen.queryByTestId('ArrowRightLong Icon')).not.toBeOnTheScreen();
+            });
+
+            it('should not render anything if neither submitter nor recipient is present', async () => {
+                const reportItem = createReportListItem(CONST.REPORT.TYPE.IOU, undefined, undefined);
+                renderReportListItemHeader(reportItem);
+                await waitForBatchedUpdates();
+
+                expect(screen.queryByTestId('ArrowRightLong Icon')).not.toBeOnTheScreen();
+            });
+
+            it('should only display submitter if recipient is invalid', async () => {
+                const reportItem = createReportListItem(CONST.REPORT.TYPE.IOU, 'john', 'fake');
+                renderReportListItemHeader(reportItem);
+                await waitForBatchedUpdates();
+
+                expect(screen.getByText('John Doe')).toBeOnTheScreen();
+                expect(screen.queryByTestId('ArrowRightLong Icon')).not.toBeOnTheScreen();
+            });
+        });
+
+        describe('when report type is EXPENSE', () => {
+            it('should display both submitter and recipient if they are different', async () => {
+                const reportItem = createReportListItem(CONST.REPORT.TYPE.EXPENSE, 'john', 'jane');
+                renderReportListItemHeader(reportItem);
+                await waitForBatchedUpdates();
+
+                expect(screen.getByText('John Doe')).toBeOnTheScreen();
+                expect(screen.getByText('Jane Smith')).toBeOnTheScreen();
+            });
+
+            it('should display submitter if only submitter is present', async () => {
+                const reportItem = createReportListItem(CONST.REPORT.TYPE.EXPENSE, 'john', undefined);
+                renderReportListItemHeader(reportItem);
+                await waitForBatchedUpdates();
+
+                expect(screen.getByText('John Doe')).toBeOnTheScreen();
+                expect(screen.queryByTestId('ArrowRightLong Icon')).not.toBeOnTheScreen();
+            });
+
+            it('should only display submitter if submitter and recipient are the same', async () => {
+                const reportItem = createReportListItem(CONST.REPORT.TYPE.EXPENSE, 'john', 'john');
+                renderReportListItemHeader(reportItem);
+                await waitForBatchedUpdates();
+
+                expect(screen.getByText('John Doe')).toBeOnTheScreen();
+                expect(screen.queryByTestId('ArrowRightLong Icon')).not.toBeOnTheScreen();
+            });
+
+            it('should not render anything if no participants are present', async () => {
+                const reportItem = createReportListItem(CONST.REPORT.TYPE.EXPENSE, undefined, undefined);
+                renderReportListItemHeader(reportItem);
+                await waitForBatchedUpdates();
+
+                expect(screen.queryByTestId('ArrowRightLong Icon')).not.toBeOnTheScreen();
+            });
+            it('should only display submitter if recipient is invalid', async () => {
+                const reportItem = createReportListItem(CONST.REPORT.TYPE.EXPENSE, 'john', 'fake');
+                renderReportListItemHeader(reportItem);
+                await waitForBatchedUpdates();
+
+                expect(screen.getByText('John Doe')).toBeOnTheScreen();
+                expect(screen.queryByTestId('ArrowRightLong Icon')).not.toBeOnTheScreen();
+            });
+        });
+    });
+});


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
<!-- Explain what your change does and how it addresses the linked issue -->
In UserInfoCell, we render nothing when the user info is invalid. However, in UserInfoCellsWithArrow, we were still displaying the arrow icon even when the user info was invalid.

This PR updates the behavior to hide the arrow icon in such cases for consistency.

And add Unit tests to cover some scenario.
### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/62551
PROPOSAL:


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->
Precondition:

Log in with Expensifail account.

- Launch Expensify app.
- Go to workspace chat.
- Create an expense in the workspace chat.
- Create an empty report via + > Create report in the workspace chat.
- Go to Reports.
- Tap bookmark icon.
- Go to Expense Reports.
- Verify no arrow icon next to the submitter on the empty report when receiver is empty.
- Verify that other reports display the submitter’s avatar and name correctly.
- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->
Same as test above
### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->

Same as test above
- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I verified there are no new alerts related to the `canBeMissing` param for `useOnyx`
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

https://github.com/user-attachments/assets/f2e5271e-693a-4a1c-8195-a11062e92eee




</details>

<details>
<summary>Android: mWeb Chrome</summary>


https://github.com/user-attachments/assets/cf31b8d5-f433-4122-b34f-59a7c51d1bd1



</details>

<details>
<summary>iOS: Native</summary>

 

https://github.com/user-attachments/assets/4f327609-a2e6-4a5c-a10e-1059b34019cd



</details>

<details>
<summary>iOS: mWeb Safari</summary>


https://github.com/user-attachments/assets/8d074962-846e-4751-96b0-13b48a57b38b



</details>

<details>
<summary>MacOS: Chrome / Safari</summary>


https://github.com/user-attachments/assets/c87fc5ec-5ba5-4cd6-9192-fef9b31683c3



</details>

<details>
<summary>MacOS: Desktop</summary>


https://github.com/user-attachments/assets/6ad39b32-e697-4751-957a-6f6c3f790bea



</details>
