### PR TITLE
fix: iou description autofocus for mobile WebKit browsers

### DIFF
--- a/src/components/AddressForm.tsx
+++ b/src/components/AddressForm.tsx
@@ -194,6 +194,7 @@ function AddressForm({
                 defaultValue={street2}
                 spellCheck={false}
                 shouldSaveDraft={shouldSaveDraft}
+                autoFocus={false}
             />
             <View style={styles.formSpaceVertical} />
             <View style={styles.mhn5}>
@@ -227,6 +228,7 @@ function AddressForm({
                     spellCheck={false}
                     onValueChange={onAddressChanged}
                     shouldSaveDraft={shouldSaveDraft}
+                    autoFocus={false}
                 />
             )}
             <View style={styles.formSpaceVertical} />
@@ -240,6 +242,7 @@ function AddressForm({
                 spellCheck={false}
                 onValueChange={onAddressChanged}
                 shouldSaveDraft={shouldSaveDraft}
+                autoFocus={false}
             />
             <View style={styles.formSpaceVertical} />
             <InputWrapper
@@ -253,6 +256,7 @@ function AddressForm({
                 hint={zipFormat}
                 onValueChange={onAddressChanged}
                 shouldSaveDraft={shouldSaveDraft}
+                autoFocus={false}
             />
         </FormProvider>
     );

--- a/src/components/AddressSearch/index.tsx
+++ b/src/components/AddressSearch/index.tsx
@@ -79,6 +79,7 @@ function AddressSearch(
         value,
         locationBias,
         caretHidden,
+        autoFocus = true,
     }: AddressSearchProps,
     ref: ForwardedRef<HTMLElement>,
 ) {
@@ -446,6 +447,7 @@ function AddressSearch(
                             spellCheck: false,
                             selectTextOnFocus: true,
                             caretHidden,
+                            autoFocus,
                         }}
                         styles={{
                             textInputContainer: [styles.flexColumn],

--- a/src/components/AddressSearch/types.ts
+++ b/src/components/AddressSearch/types.ts
@@ -90,6 +90,9 @@ type AddressSearchProps = {
 
     /** If true, caret is hidden. The default value is false. */
     caretHidden?: boolean;
+
+    /** If true, the input is focused on mount. The default value is true. */
+    autoFocus?: boolean;
 };
 
 type IsCurrentTargetInsideContainerType = (event: FocusEvent | NativeSyntheticEvent<TextInputFocusEventData>, containerRef: RefObject<View | HTMLElement>) => boolean;

--- a/src/components/FocusTrap/FocusTrapForModal/index.web.tsx
+++ b/src/components/FocusTrap/FocusTrapForModal/index.web.tsx
@@ -10,7 +10,7 @@ function FocusTrapForModal({children, active, initialFocus = false, shouldPreven
         <FocusTrap
             active={active}
             focusTrapOptions={{
-                onActivate: blurActiveElement,
+                // onActivate: blurActiveElement,
                 preventScroll: shouldPreventScroll,
                 trapStack: sharedTrapStack,
                 clickOutsideDeactivates: true,

--- a/src/components/FocusTrap/FocusTrapForScreen/index.web.tsx
+++ b/src/components/FocusTrap/FocusTrapForScreen/index.web.tsx
@@ -46,7 +46,7 @@ function FocusTrapForScreen({children, focusTrapSettings}: FocusTrapProps) {
                     if (activeElement?.nodeName === CONST.ELEMENT_NAME.INPUT || activeElement?.nodeName === CONST.ELEMENT_NAME.TEXTAREA) {
                         return;
                     }
-                    activeElement?.blur();
+                    // activeElement?.blur();
                 },
                 trapStack: sharedTrapStack,
                 allowOutsideClick: true,

--- a/src/components/Form/InputWrapper.tsx
+++ b/src/components/Form/InputWrapper.tsx
@@ -72,12 +72,12 @@ type InputWrapperProps<TInput extends ValidInputs, TValue extends ValueTypeKey =
     };
 
 function InputWrapper<TInput extends ValidInputs, TValue extends ValueTypeKey>(props: InputWrapperProps<TInput, TValue>, ref: ForwardedRef<AnimatedTextInputRef>) {
-    const {InputComponent, inputID, valueType = 'string', shouldSubmitForm: propShouldSubmitForm, ...rest} = props as InputComponentBaseProps;
+    const {InputComponent, inputID, valueType = 'string', shouldSubmitForm: propShouldSubmitForm, autoFocus = true, ...rest} = props as InputComponentBaseProps;
     const {registerInput} = useContext(FormContext);
 
     const {shouldSetTouchedOnBlurOnly, blurOnSubmit, shouldSubmitForm} = computeComponentSpecificRegistrationParams(props as InputComponentBaseProps);
     // eslint-disable-next-line react-compiler/react-compiler
-    const {key, ...registerInputProps} = registerInput(inputID, shouldSubmitForm, {ref, valueType, ...rest, shouldSetTouchedOnBlurOnly, blurOnSubmit});
+    const {key, ...registerInputProps} = registerInput(inputID, shouldSubmitForm, {ref, valueType, ...rest, autoFocus, shouldSetTouchedOnBlurOnly, blurOnSubmit});
 
     return (
         <InputComponent

--- a/src/components/Form/types.ts
+++ b/src/components/Form/types.ts
@@ -103,6 +103,7 @@ type InputComponentBaseProps<TValue extends ValueTypeKey = ValueTypeKey> = Input
     errorText?: string;
     shouldSetTouchedOnBlurOnly?: boolean;
     isFocused?: boolean;
+    autoFocus?: boolean;
     measureLayout?: (ref: unknown, callback: MeasureLayoutOnSuccessCallback) => void;
     focus?: () => void;
     label?: string;

--- a/src/components/MenuItem.tsx
+++ b/src/components/MenuItem.tsx
@@ -610,7 +610,7 @@ function MenuItem(
         }
 
         if (event?.type === 'click') {
-            (event.currentTarget as HTMLElement).blur();
+            // (event.currentTarget as HTMLElement).blur();
         }
 
         if (onPress && event) {

--- a/src/components/SelectionList/BaseSelectionList.tsx
+++ b/src/components/SelectionList/BaseSelectionList.tsx
@@ -106,7 +106,7 @@ function BaseSelectionList<TItem extends ListItem>(
         shouldHideListOnInitialRender = true,
         textInputIconLeft,
         sectionTitleStyles,
-        textInputAutoFocus = true,
+        autoFocus = true,
         shouldShowTextInputAfterHeader = false,
         shouldShowHeaderMessageAfterHeader = false,
         includeSafeAreaPaddingBottom = true,
@@ -685,6 +685,7 @@ function BaseSelectionList<TItem extends ListItem>(
                     testID="selection-list-text-input"
                     shouldInterceptSwipe={shouldTextInputInterceptSwipe}
                     errorText={errorText}
+                    autoFocus={autoFocus}
                 />
             </View>
         );
@@ -737,7 +738,7 @@ function BaseSelectionList<TItem extends ListItem>(
     /** Focuses the text input when the component comes into focus and after any navigation animations finish. */
     useFocusEffect(
         useCallback(() => {
-            if (textInputAutoFocus && shouldShowTextInput) {
+            if (autoFocus && shouldShowTextInput) {
                 if (shouldDelayFocus) {
                     focusTimeoutRef.current = setTimeout(focusTextInput, CONST.ANIMATED_TRANSITION);
                 } else {
@@ -746,7 +747,7 @@ function BaseSelectionList<TItem extends ListItem>(
             }
 
             return () => focusTimeoutRef.current && clearTimeout(focusTimeoutRef.current);
-        }, [shouldShowTextInput, textInputAutoFocus, shouldDelayFocus, focusTextInput]),
+        }, [shouldShowTextInput, autoFocus, shouldDelayFocus, focusTextInput]),
     );
 
     const prevTextInputValue = usePrevious(textInputValue);

--- a/src/components/SelectionList/types.ts
+++ b/src/components/SelectionList/types.ts
@@ -562,7 +562,7 @@ type SelectionListProps<TItem extends ListItem> = Partial<ChildrenProps> & {
     textInputIconLeft?: IconAsset;
 
     /** Whether text input should be focused */
-    textInputAutoFocus?: boolean;
+    autoFocus?: boolean;
 
     /** Callback to fire when the text input changes */
     onChangeText?: (text: string) => void;

--- a/src/components/TextInput/index.tsx
+++ b/src/components/TextInput/index.tsx
@@ -30,7 +30,7 @@ function TextInput(props: BaseTextInputProps, ref: ForwardedRef<BaseTextInputRef
             if (!Browser.isMobileChrome() || !Visibility.isVisible() || !textInputRef.current || DomUtils.getActiveElement() !== textInputRef.current) {
                 return;
             }
-            textInputRef.current.blur();
+            // textInputRef.current.blur();
             textInputRef.current.focus();
         });
 
@@ -42,6 +42,21 @@ function TextInput(props: BaseTextInputProps, ref: ForwardedRef<BaseTextInputRef
         };
         // eslint-disable-next-line react-compiler/react-compiler, react-hooks/exhaustive-deps
     }, []);
+
+    useFocusEffect(() => {
+        // in focus
+        console.log('TextInput in focus');
+
+        return () => {
+            // out of focus
+            console.log('TextInput out of focus');
+        };
+    });
+
+    const onBlur = () => {
+        console.log(`TextInput onBlur - ${props.name}`);
+        props.onBlur?.();
+    };
 
     const isLabeledMultiline = !!props.label?.length && props.multiline;
     const labelAnimationStyle = {
@@ -57,6 +72,7 @@ function TextInput(props: BaseTextInputProps, ref: ForwardedRef<BaseTextInputRef
         <BaseTextInput
             // eslint-disable-next-line react/jsx-props-no-spreading
             {...props}
+            onBlur={onBlur}
             ref={(element) => {
                 textInputRef.current = element as HTMLFormElement;
 

--- a/src/libs/Navigation/PlatformStackNavigation/navigationOptions/buildPlatformSpecificNavigationOptions.ts
+++ b/src/libs/Navigation/PlatformStackNavigation/navigationOptions/buildPlatformSpecificNavigationOptions.ts
@@ -5,7 +5,7 @@ const getCommonNavigationOptions = (screenOptions: PlatformStackNavigationOption
     screenOptions === undefined ? {} : (({animation, keyboardHandlingEnabled, web, native, ...rest}: PlatformStackNavigationOptions) => rest)(screenOptions);
 
 const buildPlatformSpecificNavigationOptions = <NavigationOptions extends PlatformSpecificNavigationOptions>(screenOptions: PlatformStackNavigationOptions): NavigationOptions => ({
-    keyboardHandlingEnabled: screenOptions.keyboardHandlingEnabled,
+    keyboardHandlingEnabled: false, // screenOptions.keyboardHandlingEnabled,
     ...withAnimation<NavigationOptions>(screenOptions),
     ...getCommonNavigationOptions(screenOptions),
 });

--- a/src/pages/ReimbursementAccount/AddressFormFields.tsx
+++ b/src/pages/ReimbursementAccount/AddressFormFields.tsx
@@ -137,6 +137,7 @@ function AddressFormFields({
                 defaultValue={defaultValues?.city}
                 errorText={errors?.city ? translate('bankAccount.error.addressCity') : ''}
                 containerStyles={styles.mt6}
+                autoFocus={false}
             />
 
             {shouldDisplayStateSelector && (
@@ -168,6 +169,7 @@ function AddressFormFields({
                 errorText={errors?.zipCode ? translate('bankAccount.error.zipCode') : ''}
                 hint={translate('common.zipCodeExampleFormat', {zipSampleFormat: CONST.COUNTRY_ZIP_REGEX_DATA.US.samples})}
                 containerStyles={styles.mt3}
+                autoFocus={false}
             />
             {shouldDisplayCountrySelector && (
                 <View style={[styles.mt3, styles.mhn5]}>

--- a/src/pages/settings/Profile/DisplayNamePage.tsx
+++ b/src/pages/settings/Profile/DisplayNamePage.tsx
@@ -112,6 +112,7 @@ function DisplayNamePage({currentUserPersonalDetails}: DisplayNamePageProps) {
                             defaultValue={currentUserDetails.lastName ?? ''}
                             spellCheck={false}
                             autoCapitalize="words"
+                            autoFocus={false}
                         />
                     </View>
                 </FormProvider>

--- a/src/pages/settings/Profile/PersonalDetails/LegalNamePage.tsx
+++ b/src/pages/settings/Profile/PersonalDetails/LegalNamePage.tsx
@@ -123,6 +123,7 @@ function LegalNamePage() {
                                 defaultValue={legalLastName}
                                 spellCheck={false}
                                 autoCapitalize="words"
+                                autoFocus={false}
                             />
                         </View>
                     </FormProvider>

--- a/src/pages/settings/Profile/PersonalDetails/PersonalAddressPage.tsx
+++ b/src/pages/settings/Profile/PersonalDetails/PersonalAddressPage.tsx
@@ -9,7 +9,7 @@ import {updateAddress as updateAddressPersonalDetails} from '@src/libs/actions/P
 import ONYXKEYS from '@src/ONYXKEYS';
 
 /**
- * Submit form to update user's first and last legal name
+ * Submit form to update user's personal address
  * @param values - form input values
  */
 function updateAddress(values: FormOnyxValues<typeof ONYXKEYS.FORMS.HOME_ADDRESS_FORM>) {


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
This change adds the `autoFocus` option to `InputWrapper` component, and defaults it to `true`.  It fixes the original issue of the IOU Description field not auto-focusing in iOS Webkit browsers and showing the software keyboard.  But it also fixes the issue for all fields that use `InputWrapper`, which is used almost exclusively with `useAutoFocusInput` hook and single-input forms/modals.

Setting `autoFocus={false}` on the `InputWrapper` will now be required for fields on a multi-field form that should not be focused upon load.

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/52414
PROPOSAL:


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->
1. FAB
2. Create Expense, Manual, $1, Next
3. Click Description
- The Description field should be auto-focused, with green underline
- The device's software keyboard should appear on mobile apps/browsers

- [ ] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
6. Upload an image via copy paste
7. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->
Same as tests

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [ ] I linked the correct issue in the `### Fixed Issues` section above
- [ ] I wrote clear testing steps that cover the changes made in this PR
    - [ ] I added steps for local testing in the `Tests` section
    - [ ] I added steps for the expected offline behavior in the `Offline steps` section
    - [ ] I added steps for Staging and/or Production testing in the `QA steps` section
    - [ ] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [ ] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [ ] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [ ] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [ ] I ran the tests on **all platforms** & verified they passed on:
    - [ ] Android: Native
    - [ ] Android: mWeb Chrome
    - [ ] iOS: Native
    - [ ] iOS: mWeb Safari
    - [ ] MacOS: Chrome / Safari
    - [ ] MacOS: Desktop
- [ ] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [ ] I verified there are no new alerts related to the `canBeMissing` param for `useOnyx`
- [ ] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [ ] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [ ] I verified that comments were added to code that is not self explanatory
    - [ ] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [ ] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [ ] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [ ] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [ ] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [ ] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [ ] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [ ] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [ ] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [ ] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [ ] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [ ] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [ ] I verified that if a function's arguments changed that all usages have also been updated correctly
- [ ] If any new file was added I verified that:
    - [ ] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [ ] If a new CSS style is added I verified that:
    - [ ] A similar style doesn't already exist
    - [ ] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [ ] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [ ] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [ ] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [ ] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [ ] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [ ] I verified that all the inputs inside a form are aligned with each other.
    - [ ] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [ ] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [ ] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [ ] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Desktop</summary>

<!-- add screenshots or videos here -->

</details>
