### PR TITLE
Improving logic to avoid multiple iterations

### DIFF
--- a/src/hooks/useLoadReportActions.ts
+++ b/src/hooks/useLoadReportActions.ts
@@ -66,7 +66,7 @@ function useLoadReportActions({reportID, reportActionID, reportActions, allRepor
                 }
                 // Oldest = last matching action we encounter
                 currentReportOldestAction = action;
-            } else if (targetReportID === transactionThreadReport?.reportID) {
+            } else if (!isEmptyObject(transactionThreadReport) && transactionThreadReport?.reportID === targetReportID) {
                 // Same logic for transaction thread
                 if (!transactionThreadNewestAction) {
                     transactionThreadNewestAction = action;

--- a/src/hooks/useLoadReportActions.ts
+++ b/src/hooks/useLoadReportActions.ts
@@ -44,11 +44,43 @@ function useLoadReportActions({reportID, reportActionID, reportActions, allRepor
     const newestReportAction = useMemo(() => reportActions?.at(0), [reportActions]);
     const oldestReportAction = useMemo(() => reportActions?.at(-1), [reportActions]);
 
-    const reportActionIDMap = useMemo(() => {
-        return reportActions.map((action) => ({
-            reportActionID: action.reportActionID,
-            reportID: allReportActionIDs?.includes(action.reportActionID) ? reportID : transactionThreadReport?.reportID,
-        }));
+    // Track oldest/newest actions per report in a single pass
+    const {currentReportOldest, currentReportNewest, transactionThreadOldest, transactionThreadNewest} = useMemo(() => {
+        let currentReportNewestAction = null;
+        let currentReportOldestAction = null;
+        let transactionThreadNewestAction = null;
+        let transactionThreadOldestAction = null;
+
+        const allReportActionIDsSet = new Set(allReportActionIDs);
+
+        for (const action of reportActions) {
+            // Determine which report this action belongs to
+            const isCurrentReport = allReportActionIDsSet.has(action.reportActionID);
+            const targetReportID = isCurrentReport ? reportID : transactionThreadReport?.reportID;
+
+            // Track newest/oldest per report
+            if (targetReportID === reportID) {
+                // Newest = first matching action we encounter
+                if (!currentReportNewestAction) {
+                    currentReportNewestAction = action;
+                }
+                // Oldest = last matching action we encounter
+                currentReportOldestAction = action;
+            } else if (targetReportID === transactionThreadReport?.reportID) {
+                // Same logic for transaction thread
+                if (!transactionThreadNewestAction) {
+                    transactionThreadNewestAction = action;
+                }
+                transactionThreadOldestAction = action;
+            }
+        }
+
+        return {
+            currentReportOldest: currentReportOldestAction,
+            currentReportNewest: currentReportNewestAction,
+            transactionThreadOldest: transactionThreadOldestAction,
+            transactionThreadNewest: transactionThreadNewestAction,
+        };
     }, [reportActions, allReportActionIDs, reportID, transactionThreadReport?.reportID]);
 
     /**
@@ -70,19 +102,13 @@ function useLoadReportActions({reportID, reportActionID, reportActions, allRepor
             didLoadOlderChats.current = true;
 
             if (!isEmptyObject(transactionThreadReport)) {
-                // Get older actions based on the oldest reportAction for the current report
-                const oldestActionCurrentReport = reportActionIDMap.findLast((item) => item.reportID === reportID);
-                getOlderActions(oldestActionCurrentReport?.reportID, oldestActionCurrentReport?.reportActionID);
-
-                // Get older actions based on the oldest reportAction for the transaction thread report
-                const oldestActionTransactionThreadReport = reportActionIDMap.findLast((item) => item.reportID === transactionThreadReport.reportID);
-                getOlderActions(oldestActionTransactionThreadReport?.reportID, oldestActionTransactionThreadReport?.reportActionID);
+                getOlderActions(reportID, currentReportOldest?.reportActionID);
+                getOlderActions(transactionThreadReport.reportID, transactionThreadOldest?.reportActionID);
             } else {
-                // Retrieve the next REPORT.ACTIONS.LIMIT sized page of comments
-                getOlderActions(reportID, oldestReportAction.reportActionID);
+                getOlderActions(reportID, currentReportOldest?.reportActionID);
             }
         },
-        [isOffline, oldestReportAction, reportID, reportActionIDMap, transactionThreadReport, hasOlderActions],
+        [isOffline, oldestReportAction, hasOlderActions, transactionThreadReport, reportID, currentReportOldest?.reportActionID, transactionThreadOldest?.reportActionID],
     );
 
     const loadNewerChats = useCallback(
@@ -104,20 +130,24 @@ function useLoadReportActions({reportID, reportActionID, reportActions, allRepor
 
             didLoadNewerChats.current = true;
 
-            // If this is a one transaction report, ensure we load newer actions for both this report and the report associated with the transaction
             if (!isEmptyObject(transactionThreadReport)) {
-                // Get newer actions based on the newest reportAction for the current report
-                const newestActionCurrentReport = reportActionIDMap.find((item) => item.reportID === reportID);
-                getNewerActions(newestActionCurrentReport?.reportID, newestActionCurrentReport?.reportActionID);
-
-                // Get newer actions based on the newest reportAction for the transaction thread report
-                const newestActionTransactionThreadReport = reportActionIDMap.find((item) => item.reportID === transactionThreadReport.reportID);
-                getNewerActions(newestActionTransactionThreadReport?.reportID, newestActionTransactionThreadReport?.reportActionID);
+                getNewerActions(reportID, currentReportNewest?.reportActionID);
+                getNewerActions(transactionThreadReport.reportID, transactionThreadNewest?.reportActionID);
             } else if (newestReportAction) {
                 getNewerActions(reportID, newestReportAction.reportActionID);
             }
         },
-        [reportActionID, isFocused, newestReportAction, hasNewerActions, isOffline, transactionThreadReport, reportActionIDMap, reportID],
+        [
+            reportActionID,
+            isFocused,
+            newestReportAction,
+            hasNewerActions,
+            isOffline,
+            transactionThreadReport,
+            reportID,
+            currentReportNewest?.reportActionID,
+            transactionThreadNewest?.reportActionID,
+        ],
     );
 
     return {

--- a/src/hooks/useLoadReportActions.ts
+++ b/src/hooks/useLoadReportActions.ts
@@ -81,7 +81,7 @@ function useLoadReportActions({reportID, reportActionID, reportActions, allRepor
             transactionThreadOldest: transactionThreadOldestAction,
             transactionThreadNewest: transactionThreadNewestAction,
         };
-    }, [reportActions, allReportActionIDs, reportID, transactionThreadReport?.reportID]);
+    }, [reportActions, allReportActionIDs, reportID, transactionThreadReport]);
 
     /**
      * Retrieves the next set of reportActions for the chat once we are nearing the end of what we are currently

--- a/tests/unit/useLoadReportActionsTest.tsx
+++ b/tests/unit/useLoadReportActionsTest.tsx
@@ -1,0 +1,179 @@
+import {renderHook} from '@testing-library/react-native';
+import useLoadReportActions from '@hooks/useLoadReportActions';
+import type Navigation from '@libs/Navigation/Navigation';
+
+jest.mock('@hooks/useNetwork', () => jest.fn(() => ({isOffline: false})));
+
+jest.mock('@react-navigation/native', () => {
+    const actualNav = jest.requireActual<typeof Navigation>('@react-navigation/native');
+    return {
+        ...actualNav,
+        useNavigationState: () => true,
+        useRoute: jest.fn(),
+        useFocusEffect: jest.fn(),
+        useIsFocused: () => true,
+        useNavigation: () => ({
+            navigate: jest.fn(),
+            addListener: jest.fn(),
+        }),
+        createNavigationContainerRef: jest.fn(),
+    };
+});
+
+describe('useLoadReportActions', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    // Base test data from your example
+    const baseProps = {
+        reportID: '6549335221793525',
+        reportActions: [
+            /* your 4 reportActions array here */
+        ],
+        allReportActionIDs: ['8759152536123291182', '2034215190990675144', '186758379215594799'],
+        transactionThreadReport: undefined,
+        hasOlderActions: true,
+        hasNewerActions: false,
+    };
+
+    describe('Base cases', () => {
+        test('correctly identifies current report actions', () => {
+            jest.doMock('@userActions/Report', () => ({
+                getNewerActions: (_: string | undefined, reportActionID: string | undefined) => {
+                    expect(reportActionID).toBe('186758379215594799');
+                },
+                getOlderActions: (_: string | undefined, reportActionID: string | undefined) => {
+                    expect(reportActionID).toBe('8759152536123291182');
+                },
+            }));
+            const {result} = renderHook(() => useLoadReportActions(baseProps));
+
+            result.current.loadOlderChats();
+            result.current.loadNewerChats();
+        });
+
+        test('handles transaction thread report actions', () => {
+            jest.doMock('@userActions/Report', () => ({
+                getNewerActions: (_: string | undefined, reportActionID: string | undefined) => {
+                    expect(reportActionID).toBe('186758379215594799');
+                },
+                getOlderActions: (_: string | undefined, reportActionID: string | undefined) => {
+                    expect(reportActionID).toBe('2034215190990675144');
+                },
+            }));
+
+            const propsWithTransaction = {
+                ...baseProps,
+                transactionThreadReport: {reportID: '186758379215594798'},
+                allReportActionIDs: ['8759152536123291182'], // Only first action belongs to main report
+            };
+
+            const {result} = renderHook(() => useLoadReportActions(propsWithTransaction));
+
+            result.current.loadOlderChats();
+            result.current.loadNewerChats();
+        });
+    });
+
+    describe('loadOlderChats behavior', () => {
+        test('loads older actions for current report', () => {
+            jest.doMock('@userActions/Report', () => ({
+                getNewerActions: jest.fn(),
+                getOlderActions: (reportID: string | undefined, reportActionID: string | undefined) => {
+                    expect(reportID).toBe('6549335221793525');
+                    expect(reportActionID).toBe('186758379215594799');
+                },
+            }));
+            const {result} = renderHook(() => useLoadReportActions(baseProps));
+            result.current.loadOlderChats();
+        });
+
+        test('loads actions for both reports when transaction thread exists', () => {
+            jest.doMock('@userActions/Report', () => ({
+                getNewerActions: jest.fn(),
+                getOlderActions: (reportID: string | undefined, reportActionID: string | undefined) => {
+                    if (reportID !== 'TRANSACTION_THREAD_REPORT') {
+                        expect(reportID).toBe('8759152536123291182');
+                        expect(reportActionID).toBe('6549335221793525');
+                    } else {
+                        expect(reportID).toBe('TRANSACTION_THREAD_REPORT');
+                        expect(reportActionID).toBe('186758379215594799');
+                    }
+                },
+            }));
+            const props = {
+                ...baseProps,
+                transactionThreadReport: {reportID: 'TRANSACTION_THREAD_REPORT'},
+            };
+
+            const {result} = renderHook(() => useLoadReportActions(props));
+            result.current.loadOlderChats();
+        });
+    });
+
+    describe('loadNewerChats behavior', () => {
+        test('loads newer actions when conditions met', () => {
+            jest.doMock('@userActions/Report', () => ({
+                getNewerActions: (reportID: string | undefined, reportActionID: string | undefined) => {
+                    expect(reportID).toBe('6549335221793525');
+                    expect(reportActionID).toBe('8759152536123291182');
+                },
+                getOlderActions: jest.fn(),
+            }));
+            const props = {
+                ...baseProps,
+                hasNewerActions: true,
+                reportActionID: 'EXISTING_ACTION_ID',
+            };
+
+            const {result} = renderHook(() => useLoadReportActions(props));
+            result.current.loadNewerChats();
+        });
+
+        test('handles transaction thread newer actions', () => {
+            jest.doMock('@userActions/Report', () => ({
+                getNewerActions: (reportID: string | undefined, reportActionID: string | undefined) => {
+                    if (reportID !== 'TRANSACTION_THREAD_REPORT') {
+                        expect(reportID).toBe('6549335221793525');
+                        expect(reportActionID).toBe('8759152536123291182');
+                    } else {
+                        expect(reportID).toBe('TRANSACTION_THREAD_REPORT');
+                        expect(reportActionID).toBe('2034215190990675144');
+                    }
+                },
+                getOlderActions: jest.fn(),
+            }));
+            const props = {
+                ...baseProps,
+                transactionThreadReport: {reportID: 'TRANSACTION_THREAD_REPORT'},
+                hasNewerActions: true,
+            };
+
+            const {result} = renderHook(() => useLoadReportActions(props));
+            result.current.loadNewerChats();
+        });
+    });
+
+    describe('Edge cases', () => {
+        test('handles empty reportActions', () => {
+            const mockGetOlderActions = jest.fn();
+            const mockGetNewerActions = jest.fn();
+            jest.doMock('@userActions/Report', () => ({
+                getNewerActions: mockGetNewerActions,
+                getOlderActions: mockGetOlderActions,
+            }));
+            const props = {
+                ...baseProps,
+                reportActions: [],
+            };
+
+            const {result} = renderHook(() => useLoadReportActions(props));
+            result.current.loadOlderChats();
+            result.current.loadNewerChats();
+
+            expect(mockGetOlderActions).not.toHaveBeenCalled();
+            expect(mockGetNewerActions).not.toHaveBeenCalled();
+        });
+    });
+});


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
<!-- Explain what your change does and how it addresses the linked issue -->
Replace the current O(n²) Array.map + Array.includes pattern with O(1) 
Eliminate redundant iterations by processing all report actions in a single pass.

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/63026
PROPOSAL: -


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

- [x] Verify that no errors appear in the JS console

1. Sign in with a valid user
2. on web click CMD+K, on native click the search icon
3. The modal should open and show the content

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

1. Sign in with a valid user
2. on web click CMD+K, on native click the search icon
3. The modal should open and show the content

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
4. Upload an image via copy paste
5. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->
Same as tests

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I verified there are no new alerts related to the `canBeMissing` param for `useOnyx`
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/e7738813-eebe-4536-b1ca-c4668f0a2b60




</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/ba5dfa1f-257e-4364-82dd-1e5d83014747




</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->


https://github.com/user-attachments/assets/7b690ab6-1f73-43ee-b212-36b5204aeb5b



</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->


https://github.com/user-attachments/assets/23774b4c-8826-4e24-93e5-93d6e334dad9



</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/5d071824-fe44-4a43-ae9e-ea4c0da2750b


https://github.com/user-attachments/assets/f78497ae-a41b-40d9-843c-7d559a118065




</details>

<details>
<summary>MacOS: Desktop</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/c40f4b34-c423-4e23-88cf-bd9b09d8b6dd




</details>
