### PR TITLE
[No QA] fix: add open_app and splash_screen metrics tracking

### DIFF
--- a/src/CONST.ts
+++ b/src/CONST.ts
@@ -1614,6 +1614,8 @@ const CONST = {
     TIMING: {
         GET_ORDERED_REPORT_IDS: 'get_ordered_report_ids',
         CALCULATE_MOST_RECENT_LAST_MODIFIED_ACTION: 'calc_most_recent_last_modified_action',
+        OPEN_APP: 'open_app',
+        SPLASH_SCREEN: 'splash_screen',
         OPEN_SEARCH: 'open_search',
         OPEN_REPORT: 'open_report',
         OPEN_REPORT_FROM_PREVIEW: 'open_report_from_preview',

--- a/src/SplashScreenStateContext.tsx
+++ b/src/SplashScreenStateContext.tsx
@@ -1,5 +1,6 @@
-import React, {useContext, useMemo, useState} from 'react';
+import React, {useContext, useEffect, useMemo, useState} from 'react';
 import type {ValueOf} from 'type-fest';
+import Timing from './libs/actions/Timing';
 import CONST from './CONST';
 import type ChildrenProps from './types/utils/ChildrenProps';
 
@@ -22,6 +23,14 @@ function SplashScreenStateContextProvider({children}: ChildrenProps) {
         }),
         [splashScreenState],
     );
+
+  useEffect(() => {
+      if (splashScreenState !== "hidden") {
+        return;
+      }
+
+      Timing.end(CONST.TIMING.SPLASH_SCREEN);
+  }, [splashScreenState]);
 
     return <SplashScreenStateContext.Provider value={splashScreenStateContext}>{children}</SplashScreenStateContext.Provider>;
 }

--- a/src/SplashScreenStateContext.tsx
+++ b/src/SplashScreenStateContext.tsx
@@ -1,7 +1,7 @@
 import React, {useContext, useEffect, useMemo, useState} from 'react';
 import type {ValueOf} from 'type-fest';
-import Timing from './libs/actions/Timing';
 import CONST from './CONST';
+import Timing from './libs/actions/Timing';
 import type ChildrenProps from './types/utils/ChildrenProps';
 
 type SplashScreenStateContextType = {
@@ -24,13 +24,13 @@ function SplashScreenStateContextProvider({children}: ChildrenProps) {
         [splashScreenState],
     );
 
-  useEffect(() => {
-      if (splashScreenState !== "hidden") {
-        return;
-      }
+    useEffect(() => {
+        if (splashScreenState !== 'hidden') {
+            return;
+        }
 
-      Timing.end(CONST.TIMING.SPLASH_SCREEN);
-  }, [splashScreenState]);
+        Timing.end(CONST.TIMING.SPLASH_SCREEN);
+    }, [splashScreenState]);
 
     return <SplashScreenStateContext.Provider value={splashScreenStateContext}>{children}</SplashScreenStateContext.Provider>;
 }

--- a/src/libs/actions/App.ts
+++ b/src/libs/actions/App.ts
@@ -162,6 +162,7 @@ const isReadyToOpenApp = new Promise<void>((resolve) => {
 });
 
 function confirmReadyToOpenApp() {
+    Timing.end(CONST.TIMING.OPEN_APP);
     resolveIsReadyPromise();
 }
 

--- a/src/libs/actions/App.ts
+++ b/src/libs/actions/App.ts
@@ -216,7 +216,6 @@ function setSidebarLoaded() {
 
     Onyx.set(ONYXKEYS.IS_SIDEBAR_LOADED, true);
     Performance.markEnd(CONST.TIMING.SIDEBAR_LOADED);
-    Timing.end(CONST.TIMING.SIDEBAR_LOADED);
 }
 
 function setAppLoading(isLoading: boolean) {

--- a/src/pages/Search/SearchPage.tsx
+++ b/src/pages/Search/SearchPage.tsx
@@ -54,6 +54,7 @@ import ROUTES from '@src/ROUTES';
 import type SCREENS from '@src/SCREENS';
 import type {SearchResults} from '@src/types/onyx';
 import SearchPageNarrow from './SearchPageNarrow';
+import { confirmReadyToOpenApp } from '@libs/actions/App';
 
 type SearchPageProps = PlatformStackScreenProps<SearchFullscreenNavigatorParamList, typeof SCREENS.SEARCH.ROOT>;
 
@@ -89,6 +90,10 @@ function SearchPage({route}: SearchPageProps) {
     // eslint-disable-next-line rulesdir/no-default-id-values
     const [currentSearchResults] = useOnyx(`${ONYXKEYS.COLLECTION.SNAPSHOT}${queryJSON?.hash ?? CONST.DEFAULT_NUMBER_ID}`, {canBeMissing: true});
     const [lastNonEmptySearchResults, setLastNonEmptySearchResults] = useState<SearchResults | undefined>(undefined);
+
+    useEffect(() => {
+      confirmReadyToOpenApp();
+    }, []);
 
     useEffect(() => {
         if (!currentSearchResults?.search?.type) {

--- a/src/pages/Search/SearchPage.tsx
+++ b/src/pages/Search/SearchPage.tsx
@@ -26,6 +26,7 @@ import usePermissions from '@hooks/usePermissions';
 import useResponsiveLayout from '@hooks/useResponsiveLayout';
 import useTheme from '@hooks/useTheme';
 import useThemeStyles from '@hooks/useThemeStyles';
+import {confirmReadyToOpenApp} from '@libs/actions/App';
 import {searchInServer} from '@libs/actions/Report';
 import {
     approveMoneyRequestOnSearch,
@@ -53,7 +54,6 @@ import ONYXKEYS from '@src/ONYXKEYS';
 import ROUTES from '@src/ROUTES';
 import type SCREENS from '@src/SCREENS';
 import type {SearchResults} from '@src/types/onyx';
-import { confirmReadyToOpenApp } from '@libs/actions/App';
 import SearchPageNarrow from './SearchPageNarrow';
 
 type SearchPageProps = PlatformStackScreenProps<SearchFullscreenNavigatorParamList, typeof SCREENS.SEARCH.ROOT>;
@@ -92,7 +92,7 @@ function SearchPage({route}: SearchPageProps) {
     const [lastNonEmptySearchResults, setLastNonEmptySearchResults] = useState<SearchResults | undefined>(undefined);
 
     useEffect(() => {
-      confirmReadyToOpenApp();
+        confirmReadyToOpenApp();
     }, []);
 
     useEffect(() => {

--- a/src/pages/Search/SearchPage.tsx
+++ b/src/pages/Search/SearchPage.tsx
@@ -53,8 +53,8 @@ import ONYXKEYS from '@src/ONYXKEYS';
 import ROUTES from '@src/ROUTES';
 import type SCREENS from '@src/SCREENS';
 import type {SearchResults} from '@src/types/onyx';
-import SearchPageNarrow from './SearchPageNarrow';
 import { confirmReadyToOpenApp } from '@libs/actions/App';
+import SearchPageNarrow from './SearchPageNarrow';
 
 type SearchPageProps = PlatformStackScreenProps<SearchFullscreenNavigatorParamList, typeof SCREENS.SEARCH.ROOT>;
 

--- a/src/pages/home/sidebar/BaseSidebarScreen.tsx
+++ b/src/pages/home/sidebar/BaseSidebarScreen.tsx
@@ -21,7 +21,6 @@ function BaseSidebarScreen() {
 
     useEffect(() => {
         Performance.markStart(CONST.TIMING.SIDEBAR_LOADED);
-        Timing.start(CONST.TIMING.SIDEBAR_LOADED);
     }, []);
 
     return (

--- a/src/pages/home/sidebar/BaseSidebarScreen.tsx
+++ b/src/pages/home/sidebar/BaseSidebarScreen.tsx
@@ -9,7 +9,6 @@ import useResponsiveLayout from '@hooks/useResponsiveLayout';
 import useThemeStyles from '@hooks/useThemeStyles';
 import {isMobile} from '@libs/Browser';
 import Performance from '@libs/Performance';
-import Timing from '@userActions/Timing';
 import CONST from '@src/CONST';
 import SidebarLinksData from './SidebarLinksData';
 

--- a/src/setup/index.ts
+++ b/src/setup/index.ts
@@ -8,8 +8,11 @@ import ONYXKEYS from '@src/ONYXKEYS';
 import addUtilsToWindow from './addUtilsToWindow';
 import initializeLastVisitedPath from './initializeLastVisitedPath';
 import platformSetup from './platformSetup';
+import telemetry from './telemetry';
 
 export default function () {
+    telemetry();
+
     /*
      * Initialize the Onyx store when the app loads for the first time.
      *

--- a/src/setup/telemetry/index.native.ts
+++ b/src/setup/telemetry/index.native.ts
@@ -4,14 +4,14 @@ import Timing from '@userActions/Timing';
 import CONST from '@src/CONST';
 
 export default function () {
-  Timing.start(CONST.TIMING.SPLASH_SCREEN);
-  Timing.start(CONST.TIMING.OPEN_APP);
+    Timing.start(CONST.TIMING.SPLASH_SCREEN);
+    Timing.start(CONST.TIMING.OPEN_APP);
 
-  AppState.addEventListener('change', (nextState: AppStateStatus) => {
-    if (nextState !== "active") {
-      return;
-    }
+    AppState.addEventListener('change', (nextState: AppStateStatus) => {
+        if (nextState !== 'active') {
+            return;
+        }
 
-    Timing.clearData();
-  });
+        Timing.clearData();
+    });
 }

--- a/src/setup/telemetry/index.native.ts
+++ b/src/setup/telemetry/index.native.ts
@@ -1,0 +1,17 @@
+import {AppState} from 'react-native';
+import type {AppStateStatus} from 'react-native';
+import Timing from '@userActions/Timing';
+import CONST from '@src/CONST';
+
+export default function () {
+  Timing.start(CONST.TIMING.SPLASH_SCREEN);
+  Timing.start(CONST.TIMING.OPEN_APP);
+
+  AppState.addEventListener('change', (nextState: AppStateStatus) => {
+    if (nextState !== "active") {
+      return;
+    }
+
+    Timing.clearData();
+  });
+}

--- a/src/setup/telemetry/index.ts
+++ b/src/setup/telemetry/index.ts
@@ -1,0 +1,15 @@
+import CONST from '@src/CONST';
+import Timing from '@userActions/Timing';
+
+export default function () {
+  Timing.start(CONST.TIMING.SPLASH_SCREEN);
+  Timing.start(CONST.TIMING.OPEN_APP);
+
+  document.addEventListener('visibilitychange', () => {
+    if (!document.hidden) {
+      return;
+    }
+
+    Timing.clearData();
+  });
+}

--- a/src/setup/telemetry/index.ts
+++ b/src/setup/telemetry/index.ts
@@ -1,15 +1,15 @@
-import CONST from '@src/CONST';
 import Timing from '@userActions/Timing';
+import CONST from '@src/CONST';
 
 export default function () {
-  Timing.start(CONST.TIMING.SPLASH_SCREEN);
-  Timing.start(CONST.TIMING.OPEN_APP);
+    Timing.start(CONST.TIMING.SPLASH_SCREEN);
+    Timing.start(CONST.TIMING.OPEN_APP);
 
-  document.addEventListener('visibilitychange', () => {
-    if (!document.hidden) {
-      return;
-    }
+    document.addEventListener('visibilitychange', () => {
+        if (!document.hidden) {
+            return;
+        }
 
-    Timing.clearData();
-  });
+        Timing.clearData();
+    });
 }


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
<!-- Explain what your change does and how it addresses the linked issue -->
This PR corrects our performance metrics in the following way:
- `splash_screen` was introduced, measuring the time from when we initiate the JS until we hide the splash.
- `open_app` was introduced, measuring the time from when we initiate the JS until the app declares `confirmReadyToOpenApp()` on any of the main navigators.
- `sidebar_loaded` was removed, because it serves no purpose to continue measuring sidebar's layout time. It contains less of the 'app opening' process than the ones above.
- `Timing.clearData()` was introduced as a global cleanup every time we background the app on any platform. This is to fix outliers that were clearly reported after we revisited the app after leaving it in the middle of the measurement.

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/62185
PROPOSAL: N/A


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

- Put console logs in `start/end/clearData` functions inside of the `src/libs/actions/Timing.ts` module and observe if the events are being reported correctly or cleared when we interrupt them with backgrounding the app/switching tabs (web).

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->
// TODO: These must be filled out, or the issue title must include "[No QA]."

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I verified there are no new alerts related to the `canBeMissing` param for `useOnyx`
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Desktop</summary>

<!-- add screenshots or videos here -->

</details>