### PR TITLE
Fix approve action on Search

### DIFF
--- a/src/libs/SearchUIUtils.ts
+++ b/src/libs/SearchUIUtils.ts
@@ -547,8 +547,7 @@ function getAction(data: OnyxTypes.SearchResults['data'], key: string): SearchTr
     const hasOnlyPendingCardOrScanningTransactions = allReportTransactions.length > 0 && allReportTransactions.every(isPendingCardOrScanningTransaction);
 
     const isAllowedToApproveExpenseReport = isAllowedToApproveExpenseReportUtils(report, undefined, policy);
-
-    if (canApproveIOU(report, policy) && isAllowedToApproveExpenseReport && !hasOnlyPendingCardOrScanningTransactions) {
+    if (canApproveIOU(report, policy, allReportTransactions) && isAllowedToApproveExpenseReport && !hasOnlyPendingCardOrScanningTransactions) {
         return CONST.SEARCH.ACTION_TYPES.APPROVE;
     }
 

--- a/src/libs/actions/IOU.ts
+++ b/src/libs/actions/IOU.ts
@@ -9133,8 +9133,7 @@ function canIOUBePaid(
 
     const {reimbursableSpend} = getMoneyRequestSpendBreakdown(iouReport);
     const isAutoReimbursable = policy?.reimbursementChoice === CONST.POLICY.REIMBURSEMENT_CHOICES.REIMBURSEMENT_YES ? false : canBeAutoReimbursed(iouReport, policy);
-    const shouldBeApproved = canApproveIOU(iouReport, policy);
-
+    const shouldBeApproved = canApproveIOU(iouReport, policy, transactions);
     const isPayAtEndExpenseReport = isPayAtEndExpenseReportReportUtils(iouReport?.reportID, transactions);
     return (
         isPayer &&

--- a/tests/unit/Search/SearchUIUtilsTest.ts
+++ b/tests/unit/Search/SearchUIUtilsTest.ts
@@ -995,6 +995,133 @@ describe('SearchUIUtils', () => {
         });
     });
 
+    test('Should show `Approve` for report', () => {
+        Onyx.merge(ONYXKEYS.SESSION, {accountID: adminAccountID});
+
+        const result: OnyxTypes.SearchResults = {
+            data: {
+                personalDetailsList: {
+                    adminAccountID: {
+                        accountID: adminAccountID,
+                        avatar: 'https://d1wpcgnaa73g0y.cloudfront.net/fake.jpeg',
+                        displayName: 'You',
+                        login: 'you@expensifail.com',
+                    },
+                    // eslint-disable-next-line @typescript-eslint/naming-convention
+                    '2074551': {
+                        accountID: 2074551,
+                        avatar: 'https://d1wpcgnaa73g0y.cloudfront.net/fake2.jpeg',
+                        displayName: 'Jason',
+                        login: 'jason@expensifail.com',
+                    },
+                },
+                // eslint-disable-next-line @typescript-eslint/naming-convention
+                policy_137DA25D273F2423: {
+                    approvalMode: 'ADVANCED',
+                    approver: '',
+                    autoReimbursement: {
+                        limit: 500000,
+                    },
+                    autoReimbursementLimit: 500000,
+                    autoReporting: true,
+                    autoReportingFrequency: 'immediate',
+                    harvesting: {
+                        enabled: true,
+                    },
+                    id: '137DA25D273F2423',
+                    name: 'Expenses - Expensify US',
+                    owner: 'accounting@expensifail.com',
+                    preventSelfApproval: true,
+                    reimbursementChoice: 'reimburseYes',
+                    role: 'user',
+                    rules: {
+                        approvalRules: [],
+                        expenseRules: [],
+                    },
+                    type: 'corporate',
+                },
+                // eslint-disable-next-line @typescript-eslint/naming-convention
+                report_6523565988285061: {
+                    accountID: 2074551,
+                    chatReportID: '4128157185472356',
+                    created: '2025-05-26 19:49:56',
+                    currency: 'USD',
+                    isOneTransactionReport: true,
+                    isOwnPolicyExpenseChat: false,
+                    isPolicyExpenseChat: false,
+                    isWaitingOnBankAccount: false,
+                    managerID: adminAccountID,
+                    nonReimbursableTotal: 0,
+                    oldPolicyName: '',
+                    ownerAccountID: 2074551,
+                    parentReportActionID: '5568426544518647396',
+                    parentReportID: '4128157185472356',
+                    policyID: '137DA25D273F2423',
+                    private_isArchived: '',
+                    reportID: '6523565988285061',
+                    reportName: 'Expense Report #6523565988285061',
+                    stateNum: 1,
+                    statusNum: 1,
+                    total: -1000,
+                    type: 'expense',
+                    unheldTotal: -1000,
+                },
+                // eslint-disable-next-line @typescript-eslint/naming-convention
+                transactions_1805965960759424086: {
+                    accountID: 2074551,
+                    amount: 0,
+                    canDelete: false,
+                    canHold: true,
+                    canUnhold: false,
+                    category: 'Employee Meals Remote (Fringe Benefit)',
+                    action: 'approve',
+                    comment: {
+                        comment: '',
+                    },
+                    created: '2025-05-26',
+                    currency: 'USD',
+                    hasEReceipt: false,
+                    isFromOneTransactionReport: true,
+                    managerID: adminAccountID,
+                    merchant: '(none)',
+                    modifiedAmount: -1000,
+                    modifiedCreated: '2025-05-22',
+                    modifiedCurrency: 'USD',
+                    modifiedMerchant: 'Costco Wholesale',
+                    parentTransactionID: '',
+                    policyID: '137DA25D273F2423',
+                    receipt: {
+                        source: 'https://www.expensify.com/receipts/fake.jpg',
+                        state: 'SCANCOMPLETE',
+                    },
+                    reportID: '6523565988285061',
+                    reportType: 'expense',
+                    tag: '',
+                    transactionID: '1805965960759424086',
+                    transactionThreadReportID: '4139222832581831',
+                    transactionType: 'cash',
+                },
+            },
+            search: {
+                type: 'expense',
+                status: 'all',
+                offset: 0,
+                hasMoreResults: false,
+                hasResults: true,
+                isLoading: false,
+                columnsToShow: {
+                    shouldShowCategoryColumn: true,
+                    shouldShowTagColumn: true,
+                    shouldShowTaxColumn: true,
+                },
+            },
+        };
+        return waitForBatchedUpdates().then(() => {
+            const action = SearchUIUtils.getAction(result.data, 'report_6523565988285061');
+            expect(action).toEqual(CONST.SEARCH.ACTION_TYPES.APPROVE);
+        });
+    });
+
     test('Should return true if the search result has valid type', () => {
         expect(SearchUIUtils.shouldShowEmptyState(false, reportsListItems.length, searchResults.search.type)).toBe(true);
         expect(SearchUIUtils.shouldShowEmptyState(true, 0, searchResults.search.type)).toBe(true);


### PR DESCRIPTION
### Explanation of Change
In [this PR](https://github.com/Expensify/App/pull/61355), we added a new `iouTransactions` param to [canApproveIOU](https://github.com/Expensify/App/pull/61355/files#diff-9c07b44e092fd3d975806649be46d76b75a377c16e32ed86597b630a84c290d0R8756), but we never passed the report transactions from the Search page. So computing the approve action failed when the user had some results in Search without transactions being present in their local Onyx store.

### Fixed Issues
$ https://github.com/Expensify/App/issues/63184

### Tests
Note: test on web only

1. Navigate to the `Reports > Expense reports` page
2. Get the current user accountID
2.1. Open the browser console
2.2. Navigate to the `Application` tab
2.3. Search for `session`
2.4. Get the `accountID`
3. Open this file [testData.txt](https://github.com/user-attachments/files/20524268/testData.txt)
4. Replace all instances of `<accountID>` with the accountID from step 2.4
5. Copy the contents of the file
6. Paste the contents in the browser console
7. Verify that you see one report and the action is `Approve`

- [x] Verify that no errors appear in the JS console

### Offline tests
N/A

### QA Steps
Same as tests

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I verified there are no new alerts related to the `canBeMissing` param for `useOnyx`
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos

https://github.com/user-attachments/assets/26ecce35-086c-4929-bc83-1c1fefe88d5d


<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Desktop</summary>

<!-- add screenshots or videos here -->

</details>
