### PR TITLE
Revert "fix: redundant `/Search` API calls when opening report in RHN"

### DIFF
--- a/src/hooks/useSearchHighlightAndScroll.ts
+++ b/src/hooks/useSearchHighlightAndScroll.ts
@@ -1,6 +1,5 @@
-import {useIsFocused} from '@react-navigation/native';
 import isEqual from 'lodash/isEqual';
-import {useCallback, useEffect, useMemo, useRef, useState} from 'react';
+import {useCallback, useEffect, useRef, useState} from 'react';
 import type {OnyxCollection, OnyxEntry} from 'react-native-onyx';
 import type {SearchQueryJSON} from '@components/Search/types';
 import type {ReportListItemType, SearchListItem, SelectionListHandle, TransactionListItemType} from '@components/SelectionList/types';
@@ -25,7 +24,6 @@ type UseSearchHighlightAndScroll = {
  * Hook used to trigger a search when a new transaction or report action is added and handle highlighting and scrolling.
  */
 function useSearchHighlightAndScroll({searchResults, transactions, previousTransactions, reportActions, previousReportActions, queryJSON, offset}: UseSearchHighlightAndScroll) {
-    const isFocused = useIsFocused();
     // Ref to track if the search was triggered by this hook
     const triggeredByHookRef = useRef(false);
     const searchTriggeredRef = useRef(false);
@@ -35,13 +33,6 @@ function useSearchHighlightAndScroll({searchResults, transactions, previousTrans
     const highlightedIDs = useRef<Set<string>>(new Set());
     const initializedRef = useRef(false);
     const isChat = queryJSON.type === CONST.SEARCH.DATA_TYPES.CHAT;
-
-    const existingSearchResultIDs = useMemo(() => {
-        if (!searchResults?.data) {
-            return [];
-        }
-        return isChat ? extractReportActionIDsFromSearchResults(searchResults.data) : extractTransactionIDsFromSearchResults(searchResults.data);
-    }, [searchResults?.data, isChat]);
 
     // Trigger search when a new report action is added while on chat or when a new transaction is added for the other search types.
     useEffect(() => {
@@ -55,33 +46,19 @@ function useSearchHighlightAndScroll({searchResults, transactions, previousTrans
             .map((actions) => Object.keys(actions ?? {}))
             .flat();
 
-        // Only proceed if we have previous data to compare against
-        // This prevents triggering on initial data load
-        if (previousTransactionsIDs.length === 0 && previousReportActionsIDs.length === 0) {
+        if (searchTriggeredRef.current) {
             return;
         }
-
         const hasTransactionsIDsChange = !isEqual(transactionsIDs, previousTransactionsIDs);
         const hasReportActionsIDsChange = !isEqual(reportActionsIDs, previousReportActionsIDs);
 
+        // NOTE: This if statement should NOT assume report actions can only change
+        // in one type, i.e.: isChat && hasReportActionsIDsChange
+        // because they can also change in other types such as CONST.SEARCH.DATA_TYPES.EXPENSE.
+        // Assuming they can only change in one type leads to issues such as
+        // https://github.com/Expensify/App/issues/57605
         // Check if there is a change in the transactions or report actions list
         if ((!isChat && hasTransactionsIDsChange) || hasReportActionsIDsChange) {
-            // If we're not focused, don't trigger search
-            if (!isFocused) {
-                return;
-            }
-
-            const newIDs = isChat ? reportActionsIDs : transactionsIDs;
-            const hasAGenuinelyNewID = newIDs.some((id) => !existingSearchResultIDs.includes(id));
-
-            // Only skip search if there are no new items AND search results aren't empty
-            // This ensures deletions that result in empty data still trigger search
-            if (!hasAGenuinelyNewID && existingSearchResultIDs.length > 0) {
-                const hasDeletedID = existingSearchResultIDs.some((id) => !newIDs.includes(id));
-                if (!hasDeletedID) {
-                    return;
-                }
-            }
             // We only want to highlight new items if the addition of transactions or report actions triggered the search.
             // This is because, on deletion of items, the backend sometimes returns old items in place of the deleted ones.
             // We don't want to highlight these old items, even if they appear new in the current search results.
@@ -96,7 +73,12 @@ function useSearchHighlightAndScroll({searchResults, transactions, previousTrans
             // Set the ref to prevent further triggers until reset
             searchTriggeredRef.current = true;
         }
-    }, [isFocused, transactions, previousTransactions, queryJSON, offset, reportActions, previousReportActions, isChat, searchResults?.data, existingSearchResultIDs]);
+
+        // Reset the ref when transactions or report actions in chat search type are updated
+        return () => {
+            searchTriggeredRef.current = false;
+        };
+    }, [transactions, previousTransactions, queryJSON, offset, reportActions, previousReportActions, isChat]);
 
     // Initialize the set with existing IDs only once
     useEffect(() => {
@@ -104,9 +86,10 @@ function useSearchHighlightAndScroll({searchResults, transactions, previousTrans
             return;
         }
 
-        highlightedIDs.current = new Set(existingSearchResultIDs);
+        const existingIDs = isChat ? extractReportActionIDsFromSearchResults(searchResults.data) : extractTransactionIDsFromSearchResults(searchResults.data);
+        highlightedIDs.current = new Set(existingIDs);
         initializedRef.current = true;
-    }, [searchResults?.data, isChat, existingSearchResultIDs]);
+    }, [searchResults?.data, isChat]);
 
     // Detect new items (transactions or report actions)
     useEffect(() => {

--- a/tests/unit/useSearchHighlightAndScrollTest.ts
+++ b/tests/unit/useSearchHighlightAndScrollTest.ts
@@ -3,153 +3,277 @@ import {renderHook} from '@testing-library/react-native';
 import useSearchHighlightAndScroll from '@hooks/useSearchHighlightAndScroll';
 import type {UseSearchHighlightAndScroll} from '@hooks/useSearchHighlightAndScroll';
 import {search} from '@libs/actions/Search';
+import CONST from '@src/CONST';
 
 jest.mock('@libs/actions/Search');
-jest.mock('@react-navigation/native', () => ({
-    useIsFocused: jest.fn(() => true),
-    createNavigationContainerRef: () => ({}),
-}));
-jest.mock('@rnmapbox/maps', () => ({
-    __esModule: true,
-    default: {},
-    MarkerView: {},
-    setAccessToken: jest.fn(),
-}));
-jest.mock('@react-native-community/geolocation', () => ({
-    setRNConfiguration: jest.fn(),
-    getCurrentPosition: jest.fn(),
-    watchPosition: jest.fn(),
-    clearWatch: jest.fn(),
-}));
-
-const mockUseIsFocused = jest.fn().mockReturnValue(true);
+jest.mock('@src/components/ConfirmedRoute.tsx');
 
 afterEach(() => {
     jest.clearAllMocks();
 });
 
 describe('useSearchHighlightAndScroll', () => {
-    const baseProps: UseSearchHighlightAndScroll = {
-        searchResults: {
-            data: {
-                personalDetailsList: {},
+    it('should trigger Search when transactionIDs list change', () => {
+        const initialProps: UseSearchHighlightAndScroll = {
+            searchResults: {
+                data: {personalDetailsList: {}},
+                search: {
+                    columnsToShow: {
+                        shouldShowCategoryColumn: true,
+                        shouldShowTagColumn: true,
+                        shouldShowTaxColumn: true,
+                    },
+                    hasMoreResults: false,
+                    hasResults: true,
+                    offset: 0,
+                    status: 'all',
+                    type: 'expense',
+                    isLoading: false,
+                },
             },
-            search: {
-                columnsToShow: {shouldShowCategoryColumn: true, shouldShowTagColumn: true, shouldShowTaxColumn: true},
-                hasMoreResults: false,
-                hasResults: true,
-                offset: 0,
-                status: 'all',
-                type: 'expense',
-                isLoading: false,
-            },
-        },
-        transactions: {},
-        previousTransactions: {},
-        reportActions: {},
-        previousReportActions: {},
-        queryJSON: {
-            type: 'expense',
-            status: 'all',
-            sortBy: 'date',
-            sortOrder: 'desc',
-            filters: {operator: 'and', left: 'tag', right: ''},
-            inputQuery: 'type:expense status:all',
-            flatFilters: [],
-            hash: 123,
-            recentSearchHash: 456,
-        },
-        offset: 0,
-    };
-
-    it('should not trigger search when collections are empty', () => {
-        renderHook(() => useSearchHighlightAndScroll(baseProps));
-        expect(search).not.toHaveBeenCalled();
-    });
-
-    it('should trigger search when new transaction added and focused', () => {
-        const initialProps = {
-            ...baseProps,
-            transactions: {'1': {transactionID: '1'}},
-            previousTransactions: {'1': {transactionID: '1'}},
-        };
-
-        const {rerender} = renderHook((props: UseSearchHighlightAndScroll) => useSearchHighlightAndScroll(props), {
-            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-            // @ts-expect-error
-            initialProps,
-        });
-
-        const updatedProps = {
-            ...baseProps,
             transactions: {
-                '1': {transactionID: '1'},
-                '2': {transactionID: '2'},
+                transactions_1: {
+                    amount: -100,
+                    bank: '',
+                    billable: false,
+                    cardID: 0,
+                    cardName: 'Cash Expense',
+                    cardNumber: '',
+                    category: '',
+                    comment: {
+                        comment: '',
+                    },
+                    created: '2025-01-08',
+                    currency: 'ETB',
+                    filename: 'w_c989c343d834d48a4e004c38d03c90bff9434768.png',
+                    inserted: '2025-01-08 15:35:32',
+                    managedCard: false,
+                    merchant: 'g',
+                    modifiedAmount: 0,
+                    modifiedCreated: '',
+                    modifiedCurrency: '',
+                    modifiedMerchant: '',
+                    originalAmount: 0,
+                    originalCurrency: '',
+                    parentTransactionID: '',
+                    posted: '',
+                    receipt: {
+                        receiptID: 7409094723954473,
+                        state: CONST.IOU.RECEIPT_STATE.SCAN_COMPLETE,
+                        source: 'https://www.expensify.com/receipts/w_c989c343d834d48a4e004c38d03c90bff9434768.png',
+                    },
+                    reimbursable: true,
+                    reportID: '2309609540437471',
+                    status: 'Posted',
+                    tag: '',
+                    transactionID: '1',
+                    hasEReceipt: false,
+                },
             },
-            previousTransactions: {'1': {transactionID: '1'}},
-        };
-
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // @ts-expect-error
-        rerender(updatedProps);
-        expect(search).toHaveBeenCalledWith({queryJSON: baseProps.queryJSON, offset: 0});
-    });
-
-    it('should not trigger search when not focused', () => {
-        mockUseIsFocused.mockReturnValue(false);
-
-        const {rerender} = renderHook((props: UseSearchHighlightAndScroll) => useSearchHighlightAndScroll(props), {
-            initialProps: baseProps,
-        });
-
-        const updatedProps = {
-            ...baseProps,
-            transactions: {'1': {transactionID: '1'}},
-        };
-
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // @ts-expect-error
-        rerender(updatedProps);
-        expect(search).not.toHaveBeenCalled();
-    });
-
-    it('should trigger search for chat when report actions change', () => {
-        mockUseIsFocused.mockReturnValue(true);
-
-        const chatProps = {
-            ...baseProps,
-            queryJSON: {...baseProps.queryJSON, type: 'chat' as const},
+            previousTransactions: {
+                transactions_1: {
+                    amount: -100,
+                    bank: '',
+                    billable: false,
+                    cardID: 0,
+                    cardName: 'Cash Expense',
+                    cardNumber: '',
+                    category: '',
+                    comment: {
+                        comment: '',
+                    },
+                    created: '2025-01-08',
+                    currency: 'ETB',
+                    filename: 'w_c989c343d834d48a4e004c38d03c90bff9434768.png',
+                    inserted: '2025-01-08 15:35:32',
+                    managedCard: false,
+                    merchant: 'g',
+                    modifiedAmount: 0,
+                    modifiedCreated: '',
+                    modifiedCurrency: '',
+                    modifiedMerchant: '',
+                    originalAmount: 0,
+                    originalCurrency: '',
+                    parentTransactionID: '',
+                    posted: '',
+                    receipt: {
+                        receiptID: 7409094723954473,
+                        state: CONST.IOU.RECEIPT_STATE.SCAN_COMPLETE,
+                        source: 'https://www.expensify.com/receipts/w_c989c343d834d48a4e004c38d03c90bff9434768.png',
+                    },
+                    reimbursable: true,
+                    reportID: '2309609540437471',
+                    status: 'Posted',
+                    tag: '',
+                    transactionID: '1',
+                    hasEReceipt: false,
+                },
+            },
             reportActions: {
-                reportActions_1: {
-                    '1': {actionName: 'EXISTING', reportActionID: '1'},
+                reportActions_209647397999267: {
+                    1: {
+                        actionName: CONST.REPORT.ACTIONS.TYPE.POLICY_CHANGE_LOG.CORPORATE_UPGRADE,
+                        reportActionID: '1',
+                        created: '',
+                    },
                 },
             },
             previousReportActions: {
-                reportActions_1: {
-                    '1': {actionName: 'EXISTING', reportActionID: '1'},
+                reportActions_209647397999267: {
+                    1: {
+                        actionName: CONST.REPORT.ACTIONS.TYPE.POLICY_CHANGE_LOG.CORPORATE_UPGRADE,
+                        reportActionID: '1',
+                        created: '',
+                    },
+                },
+            },
+            queryJSON: {
+                type: 'expense',
+                status: 'all',
+                sortBy: 'date',
+                sortOrder: 'desc',
+                filters: {operator: 'and', left: 'tag', right: ''},
+                inputQuery: 'type:expense status:all sortBy:date sortOrder:desc',
+                flatFilters: [],
+                hash: 243428839,
+                recentSearchHash: 422547233,
+            },
+            offset: 0,
+        };
+        const changedProp: UseSearchHighlightAndScroll = {
+            ...initialProps,
+            transactions: {
+                transactions_2: {
+                    amount: -100,
+                    bank: '',
+                    billable: false,
+                    cardID: 0,
+                    cardName: 'Cash Expense',
+                    cardNumber: '',
+                    category: '',
+                    comment: {
+                        comment: '',
+                    },
+                    created: '2025-01-08',
+                    currency: 'ETB',
+                    filename: 'w_c989c343d834d48a4e004c38d03c90bff9434768.png',
+                    inserted: '2025-01-08 15:35:32',
+                    managedCard: false,
+                    merchant: 'g',
+                    modifiedAmount: 0,
+                    modifiedCreated: '',
+                    modifiedCurrency: '',
+                    modifiedMerchant: '',
+                    originalAmount: 0,
+                    originalCurrency: '',
+                    parentTransactionID: '',
+                    posted: '',
+                    receipt: {
+                        receiptID: 7409094723954473,
+                        state: CONST.IOU.RECEIPT_STATE.SCAN_COMPLETE,
+                        source: 'https://www.expensify.com/receipts/w_c989c343d834d48a4e004c38d03c90bff9434768.png',
+                    },
+                    reimbursable: true,
+                    reportID: '2309609540437471',
+                    status: 'Posted',
+                    tag: '',
+                    transactionID: '2',
+                    hasEReceipt: false,
+                },
+            },
+        };
+
+        const {rerender} = renderHook((prop: UseSearchHighlightAndScroll) => useSearchHighlightAndScroll(prop), {
+            initialProps,
+        });
+        expect(search).not.toHaveBeenCalled();
+
+        // When the transaction ids list change though it has the same length as previous value
+        rerender(changedProp);
+
+        // Then Search will be triggered.
+        expect(search).toHaveBeenCalled();
+    });
+
+    it('should trigger Search when report actions change', () => {
+        const initialProps: UseSearchHighlightAndScroll = {
+            searchResults: {
+                data: {personalDetailsList: {}},
+                search: {
+                    columnsToShow: {
+                        shouldShowCategoryColumn: true,
+                        shouldShowTagColumn: true,
+                        shouldShowTaxColumn: true,
+                    },
+                    hasMoreResults: false,
+                    hasResults: true,
+                    offset: 0,
+                    status: 'all',
+                    type: 'expense',
+                    isLoading: false,
+                },
+            },
+            transactions: {},
+            previousTransactions: {},
+            reportActions: {
+                reportActions_209647397999267: {
+                    1: {
+                        actionName: CONST.REPORT.ACTIONS.TYPE.POLICY_CHANGE_LOG.CORPORATE_UPGRADE,
+                        reportActionID: '1',
+                        created: '',
+                    },
+                },
+            },
+            previousReportActions: {
+                reportActions_209647397999267: {
+                    1: {
+                        actionName: CONST.REPORT.ACTIONS.TYPE.POLICY_CHANGE_LOG.CORPORATE_UPGRADE,
+                        reportActionID: '1',
+                        created: '',
+                    },
+                },
+            },
+            queryJSON: {
+                type: 'expense',
+                status: 'all',
+                sortBy: 'date',
+                sortOrder: 'desc',
+                filters: {operator: 'and', left: 'tag', right: ''},
+                inputQuery: 'type:expense status:all sortBy:date sortOrder:desc',
+                flatFilters: [],
+                hash: 243428839,
+                recentSearchHash: 422547233,
+            },
+            offset: 0,
+        };
+
+        const changedProps: UseSearchHighlightAndScroll = {
+            ...initialProps,
+            reportActions: {
+                reportActions_209647397999268: {
+                    1: {
+                        actionName: CONST.REPORT.ACTIONS.TYPE.POLICY_CHANGE_LOG.CORPORATE_UPGRADE,
+                        reportActionID: '1',
+                        created: '',
+                    },
+                    2: {
+                        actionName: CONST.REPORT.ACTIONS.TYPE.ADD_COMMENT,
+                        reportActionID: '2',
+                        created: '',
+                    },
                 },
             },
         };
 
         const {rerender} = renderHook((props: UseSearchHighlightAndScroll) => useSearchHighlightAndScroll(props), {
-            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-            // @ts-expect-error
-            initialProps: chatProps,
+            initialProps,
         });
+        expect(search).not.toHaveBeenCalled();
 
-        const updatedProps = {
-            ...chatProps,
-            reportActions: {
-                reportActions_1: {
-                    '1': {actionName: 'EXISTING', reportActionID: '1'},
-                    '2': {actionName: 'ADDCOMMENT', reportActionID: '2'},
-                },
-            },
-        };
+        // When report actions change
+        rerender(changedProps);
 
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // @ts-expect-error
-        rerender(updatedProps);
-        expect(search).toHaveBeenCalledWith({queryJSON: chatProps.queryJSON, offset: 0});
+        // Then Search will be triggered
+        expect(search).toHaveBeenCalled();
     });
 });


### PR DESCRIPTION
Reverts Expensify/App#62352

Just hanging out on the Reports page seems to be calling search repeatedly https://expensify.slack.com/archives/C05LX9D6E07/p1748943025662389