### PR TITLE
Revert "fix: redundant `/Search` API calls when opening report in RHN"

### DIFF
--- a/src/hooks/useSearchHighlightAndScroll.ts
+++ b/src/hooks/useSearchHighlightAndScroll.ts
@@ -1,6 +1,5 @@
-import {useIsFocused} from '@react-navigation/native';
 import isEqual from 'lodash/isEqual';
-import {useCallback, useEffect, useMemo, useRef, useState} from 'react';
+import {useCallback, useEffect, useRef, useState} from 'react';
 import type {OnyxCollection, OnyxEntry} from 'react-native-onyx';
 import type {SearchQueryJSON} from '@components/Search/types';
 import type {ReportListItemType, SearchListItem, SelectionListHandle, TransactionListItemType} from '@components/SelectionList/types';
@@ -25,7 +24,6 @@ type UseSearchHighlightAndScroll = {
  * Hook used to trigger a search when a new transaction or report action is added and handle highlighting and scrolling.
  */
 function useSearchHighlightAndScroll({searchResults, transactions, previousTransactions, reportActions, previousReportActions, queryJSON, offset}: UseSearchHighlightAndScroll) {
-    const isFocused = useIsFocused();
     // Ref to track if the search was triggered by this hook
     const triggeredByHookRef = useRef(false);
     const searchTriggeredRef = useRef(false);
@@ -35,13 +33,6 @@ function useSearchHighlightAndScroll({searchResults, transactions, previousTrans
     const highlightedIDs = useRef<Set<string>>(new Set());
     const initializedRef = useRef(false);
     const isChat = queryJSON.type === CONST.SEARCH.DATA_TYPES.CHAT;
-
-    const existingSearchResultIDs = useMemo(() => {
-        if (!searchResults?.data) {
-            return [];
-        }
-        return isChat ? extractReportActionIDsFromSearchResults(searchResults.data) : extractTransactionIDsFromSearchResults(searchResults.data);
-    }, [searchResults?.data, isChat]);
 
     // Trigger search when a new report action is added while on chat or when a new transaction is added for the other search types.
     useEffect(() => {
@@ -55,33 +46,19 @@ function useSearchHighlightAndScroll({searchResults, transactions, previousTrans
             .map((actions) => Object.keys(actions ?? {}))
             .flat();
 
-        // Only proceed if we have previous data to compare against
-        // This prevents triggering on initial data load
-        if (previousTransactionsIDs.length === 0 && previousReportActionsIDs.length === 0) {
+        if (searchTriggeredRef.current) {
             return;
         }
-
         const hasTransactionsIDsChange = !isEqual(transactionsIDs, previousTransactionsIDs);
         const hasReportActionsIDsChange = !isEqual(reportActionsIDs, previousReportActionsIDs);
 
+        // NOTE: This if statement should NOT assume report actions can only change
+        // in one type, i.e.: isChat && hasReportActionsIDsChange
+        // because they can also change in other types such as CONST.SEARCH.DATA_TYPES.EXPENSE.
+        // Assuming they can only change in one type leads to issues such as
+        // https://github.com/Expensify/App/issues/57605
         // Check if there is a change in the transactions or report actions list
         if ((!isChat && hasTransactionsIDsChange) || hasReportActionsIDsChange) {
-            // If we're not focused, don't trigger search
-            if (!isFocused) {
-                return;
-            }
-
-            const newIDs = isChat ? reportActionsIDs : transactionsIDs;
-            const hasAGenuinelyNewID = newIDs.some((id) => !existingSearchResultIDs.includes(id));
-
-            // Only skip search if there are no new items AND search results aren't empty
-            // This ensures deletions that result in empty data still trigger search
-            if (!hasAGenuinelyNewID && existingSearchResultIDs.length > 0) {
-                const hasDeletedID = existingSearchResultIDs.some((id) => !newIDs.includes(id));
-                if (!hasDeletedID) {
-                    return;
-                }
-            }
             // We only want to highlight new items if the addition of transactions or report actions triggered the search.
             // This is because, on deletion of items, the backend sometimes returns old items in place of the deleted ones.
             // We don't want to highlight these old items, even if they appear new in the current search results.
@@ -96,7 +73,12 @@ function useSearchHighlightAndScroll({searchResults, transactions, previousTrans
             // Set the ref to prevent further triggers until reset
             searchTriggeredRef.current = true;
         }
-    }, [isFocused, transactions, previousTransactions, queryJSON, offset, reportActions, previousReportActions, isChat, searchResults?.data, existingSearchResultIDs]);
+
+        // Reset the ref when transactions or report actions in chat search type are updated
+        return () => {
+            searchTriggeredRef.current = false;
+        };
+    }, [transactions, previousTransactions, queryJSON, offset, reportActions, previousReportActions, isChat]);
 
     // Initialize the set with existing IDs only once
     useEffect(() => {
@@ -104,9 +86,10 @@ function useSearchHighlightAndScroll({searchResults, transactions, previousTrans
             return;
         }
 
-        highlightedIDs.current = new Set(existingSearchResultIDs);
+        const existingIDs = isChat ? extractReportActionIDsFromSearchResults(searchResults.data) : extractTransactionIDsFromSearchResults(searchResults.data);
+        highlightedIDs.current = new Set(existingIDs);
         initializedRef.current = true;
-    }, [searchResults?.data, isChat, existingSearchResultIDs]);
+    }, [searchResults?.data, isChat]);
 
     // Detect new items (transactions or report actions)
     useEffect(() => {

--- a/tests/unit/useSearchHighlightAndScrollTest.ts
+++ b/tests/unit/useSearchHighlightAndScrollTest.ts
@@ -3,153 +3,277 @@ import {renderHook} from '@testing-library/react-native';
 import useSearchHighlightAndScroll from '@hooks/useSearchHighlightAndScroll';
 import type {UseSearchHighlightAndScroll} from '@hooks/useSearchHighlightAndScroll';
 import {search} from '@libs/actions/Search';
+import CONST from '@src/CONST';
 
 jest.mock('@libs/actions/Search');
-jest.mock('@react-navigation/native', () => ({
-    useIsFocused: jest.fn(() => true),
-    createNavigationContainerRef: () => ({}),
-}));
-jest.mock('@rnmapbox/maps', () => ({
-    __esModule: true,
-    default: {},
-    MarkerView: {},
-    setAccessToken: jest.fn(),
-}));
-jest.mock('@react-native-community/geolocation', () => ({
-    setRNConfiguration: jest.fn(),
-    getCurrentPosition: jest.fn(),
-    watchPosition: jest.fn(),
-    clearWatch: jest.fn(),
-}));
-
-const mockUseIsFocused = jest.fn().mockReturnValue(true);
+jest.mock('@src/components/ConfirmedRoute.tsx');
 
 afterEach(() => {
     jest.clearAllMocks();
 });
 
 describe('useSearchHighlightAndScroll', () => {
-    const baseProps: UseSearchHighlightAndScroll = {
-        searchResults: {
-            data: {
-                personalDetailsList: {},
+    it('should trigger Search when transactionIDs list change', () => {
+        const initialProps: UseSearchHighlightAndScroll = {
+            searchResults: {
+                data: {personalDetailsList: {}},
+                search: {
+                    columnsToShow: {
+                        shouldShowCategoryColumn: true,
+                        shouldShowTagColumn: true,
+                        shouldShowTaxColumn: true,
+                    },
+                    hasMoreResults: false,
+                    hasResults: true,
+                    offset: 0,
+                    status: 'all',
+                    type: 'expense',
+                    isLoading: false,
+                },
             },
-            search: {
-                columnsToShow: {shouldShowCategoryColumn: true, shouldShowTagColumn: true, shouldShowTaxColumn: true},
-                hasMoreResults: false,
-                hasResults: true,
-                offset: 0,
-                status: 'all',
-                type: 'expense',
-                isLoading: false,
-            },
-        },
-        transactions: {},
-        previousTransactions: {},
-        reportActions: {},
-        previousReportActions: {},
-        queryJSON: {
-            type: 'expense',
-            status: 'all',
-            sortBy: 'date',
-            sortOrder: 'desc',
-            filters: {operator: 'and', left: 'tag', right: ''},
-            inputQuery: 'type:expense status:all',
-            flatFilters: [],
-            hash: 123,
-            recentSearchHash: 456,
-        },
-        offset: 0,
-    };
-
-    it('should not trigger search when collections are empty', () => {
-        renderHook(() => useSearchHighlightAndScroll(baseProps));
-        expect(search).not.toHaveBeenCalled();
-    });
-
-    it('should trigger search when new transaction added and focused', () => {
-        const initialProps = {
-            ...baseProps,
-            transactions: {'1': {transactionID: '1'}},
-            previousTransactions: {'1': {transactionID: '1'}},
-        };
-
-        const {rerender} = renderHook((props: UseSearchHighlightAndScroll) => useSearchHighlightAndScroll(props), {
-            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-            // @ts-expect-error
-            initialProps,
-        });
-
-        const updatedProps = {
-            ...baseProps,
             transactions: {
-                '1': {transactionID: '1'},
-                '2': {transactionID: '2'},
+                transactions_1: {
+                    amount: -100,
+                    bank: '',
+                    billable: false,
+                    cardID: 0,
+                    cardName: 'Cash Expense',
+                    cardNumber: '',
+                    category: '',
+                    comment: {
+                        comment: '',
+                    },
+                    created: '2025-01-08',
+                    currency: 'ETB',
+                    filename: 'w_c989c343d834d48a4e004c38d03c90bff9434768.png',
+                    inserted: '2025-01-08 15:35:32',
+                    managedCard: false,
+                    merchant: 'g',
+                    modifiedAmount: 0,
+                    modifiedCreated: '',
+                    modifiedCurrency: '',
+                    modifiedMerchant: '',
+                    originalAmount: 0,
+                    originalCurrency: '',
+                    parentTransactionID: '',
+                    posted: '',
+                    receipt: {
+                        receiptID: 7409094723954473,
+                        state: CONST.IOU.RECEIPT_STATE.SCAN_COMPLETE,
+                        source: 'https://www.expensify.com/receipts/w_c989c343d834d48a4e004c38d03c90bff9434768.png',
+                    },
+                    reimbursable: true,
+                    reportID: '2309609540437471',
+                    status: 'Posted',
+                    tag: '',
+                    transactionID: '1',
+                    hasEReceipt: false,
+                },
             },
-            previousTransactions: {'1': {transactionID: '1'}},
-        };
-
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // @ts-expect-error
-        rerender(updatedProps);
-        expect(search).toHaveBeenCalledWith({queryJSON: baseProps.queryJSON, offset: 0});
-    });
-
-    it('should not trigger search when not focused', () => {
-        mockUseIsFocused.mockReturnValue(false);
-
-        const {rerender} = renderHook((props: UseSearchHighlightAndScroll) => useSearchHighlightAndScroll(props), {
-            initialProps: baseProps,
-        });
-
-        const updatedProps = {
-            ...baseProps,
-            transactions: {'1': {transactionID: '1'}},
-        };
-
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // @ts-expect-error
-        rerender(updatedProps);
-        expect(search).not.toHaveBeenCalled();
-    });
-
-    it('should trigger search for chat when report actions change', () => {
-        mockUseIsFocused.mockReturnValue(true);
-
-        const chatProps = {
-            ...baseProps,
-            queryJSON: {...baseProps.queryJSON, type: 'chat' as const},
+            previousTransactions: {
+                transactions_1: {
+                    amount: -100,
+                    bank: '',
+                    billable: false,
+                    cardID: 0,
+                    cardName: 'Cash Expense',
+                    cardNumber: '',
+                    category: '',
+                    comment: {
+                        comment: '',
+                    },
+                    created: '2025-01-08',
+                    currency: 'ETB',
+                    filename: 'w_c989c343d834d48a4e004c38d03c90bff9434768.png',
+                    inserted: '2025-01-08 15:35:32',
+                    managedCard: false,
+                    merchant: 'g',
+                    modifiedAmount: 0,
+                    modifiedCreated: '',
+                    modifiedCurrency: '',
+                    modifiedMerchant: '',
+                    originalAmount: 0,
+                    originalCurrency: '',
+                    parentTransactionID: '',
+                    posted: '',
+                    receipt: {
+                        receiptID: 7409094723954473,
+                        state: CONST.IOU.RECEIPT_STATE.SCAN_COMPLETE,
+                        source: 'https://www.expensify.com/receipts/w_c989c343d834d48a4e004c38d03c90bff9434768.png',
+                    },
+                    reimbursable: true,
+                    reportID: '2309609540437471',
+                    status: 'Posted',
+                    tag: '',
+                    transactionID: '1',
+                    hasEReceipt: false,
+                },
+            },
             reportActions: {
-                reportActions_1: {
-                    '1': {actionName: 'EXISTING', reportActionID: '1'},
+                reportActions_209647397999267: {
+                    1: {
+                        actionName: CONST.REPORT.ACTIONS.TYPE.POLICY_CHANGE_LOG.CORPORATE_UPGRADE,
+                        reportActionID: '1',
+                        created: '',
+                    },
                 },
             },
             previousReportActions: {
-                reportActions_1: {
-                    '1': {actionName: 'EXISTING', reportActionID: '1'},
+                reportActions_209647397999267: {
+                    1: {
+                        actionName: CONST.REPORT.ACTIONS.TYPE.POLICY_CHANGE_LOG.CORPORATE_UPGRADE,
+                        reportActionID: '1',
+                        created: '',
+                    },
+                },
+            },
+            queryJSON: {
+                type: 'expense',
+                status: 'all',
+                sortBy: 'date',
+                sortOrder: 'desc',
+                filters: {operator: 'and', left: 'tag', right: ''},
+                inputQuery: 'type:expense status:all sortBy:date sortOrder:desc',
+                flatFilters: [],
+                hash: 243428839,
+                recentSearchHash: 422547233,
+            },
+            offset: 0,
+        };
+        const changedProp: UseSearchHighlightAndScroll = {
+            ...initialProps,
+            transactions: {
+                transactions_2: {
+                    amount: -100,
+                    bank: '',
+                    billable: false,
+                    cardID: 0,
+                    cardName: 'Cash Expense',
+                    cardNumber: '',
+                    category: '',
+                    comment: {
+                        comment: '',
+                    },
+                    created: '2025-01-08',
+                    currency: 'ETB',
+                    filename: 'w_c989c343d834d48a4e004c38d03c90bff9434768.png',
+                    inserted: '2025-01-08 15:35:32',
+                    managedCard: false,
+                    merchant: 'g',
+                    modifiedAmount: 0,
+                    modifiedCreated: '',
+                    modifiedCurrency: '',
+                    modifiedMerchant: '',
+                    originalAmount: 0,
+                    originalCurrency: '',
+                    parentTransactionID: '',
+                    posted: '',
+                    receipt: {
+                        receiptID: 7409094723954473,
+                        state: CONST.IOU.RECEIPT_STATE.SCAN_COMPLETE,
+                        source: 'https://www.expensify.com/receipts/w_c989c343d834d48a4e004c38d03c90bff9434768.png',
+                    },
+                    reimbursable: true,
+                    reportID: '2309609540437471',
+                    status: 'Posted',
+                    tag: '',
+                    transactionID: '2',
+                    hasEReceipt: false,
+                },
+            },
+        };
+
+        const {rerender} = renderHook((prop: UseSearchHighlightAndScroll) => useSearchHighlightAndScroll(prop), {
+            initialProps,
+        });
+        expect(search).not.toHaveBeenCalled();
+
+        // When the transaction ids list change though it has the same length as previous value
+        rerender(changedProp);
+
+        // Then Search will be triggered.
+        expect(search).toHaveBeenCalled();
+    });
+
+    it('should trigger Search when report actions change', () => {
+        const initialProps: UseSearchHighlightAndScroll = {
+            searchResults: {
+                data: {personalDetailsList: {}},
+                search: {
+                    columnsToShow: {
+                        shouldShowCategoryColumn: true,
+                        shouldShowTagColumn: true,
+                        shouldShowTaxColumn: true,
+                    },
+                    hasMoreResults: false,
+                    hasResults: true,
+                    offset: 0,
+                    status: 'all',
+                    type: 'expense',
+                    isLoading: false,
+                },
+            },
+            transactions: {},
+            previousTransactions: {},
+            reportActions: {
+                reportActions_209647397999267: {
+                    1: {
+                        actionName: CONST.REPORT.ACTIONS.TYPE.POLICY_CHANGE_LOG.CORPORATE_UPGRADE,
+                        reportActionID: '1',
+                        created: '',
+                    },
+                },
+            },
+            previousReportActions: {
+                reportActions_209647397999267: {
+                    1: {
+                        actionName: CONST.REPORT.ACTIONS.TYPE.POLICY_CHANGE_LOG.CORPORATE_UPGRADE,
+                        reportActionID: '1',
+                        created: '',
+                    },
+                },
+            },
+            queryJSON: {
+                type: 'expense',
+                status: 'all',
+                sortBy: 'date',
+                sortOrder: 'desc',
+                filters: {operator: 'and', left: 'tag', right: ''},
+                inputQuery: 'type:expense status:all sortBy:date sortOrder:desc',
+                flatFilters: [],
+                hash: 243428839,
+                recentSearchHash: 422547233,
+            },
+            offset: 0,
+        };
+
+        const changedProps: UseSearchHighlightAndScroll = {
+            ...initialProps,
+            reportActions: {
+                reportActions_209647397999268: {
+                    1: {
+                        actionName: CONST.REPORT.ACTIONS.TYPE.POLICY_CHANGE_LOG.CORPORATE_UPGRADE,
+                        reportActionID: '1',
+                        created: '',
+                    },
+                    2: {
+                        actionName: CONST.REPORT.ACTIONS.TYPE.ADD_COMMENT,
+                        reportActionID: '2',
+                        created: '',
+                    },
                 },
             },
         };
 
         const {rerender} = renderHook((props: UseSearchHighlightAndScroll) => useSearchHighlightAndScroll(props), {
-            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-            // @ts-expect-error
-            initialProps: chatProps,
+            initialProps,
         });
+        expect(search).not.toHaveBeenCalled();
 
-        const updatedProps = {
-            ...chatProps,
-            reportActions: {
-                reportActions_1: {
-                    '1': {actionName: 'EXISTING', reportActionID: '1'},
-                    '2': {actionName: 'ADDCOMMENT', reportActionID: '2'},
-                },
-            },
-        };
+        // When report actions change
+        rerender(changedProps);
 
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // @ts-expect-error
-        rerender(updatedProps);
-        expect(search).toHaveBeenCalledWith({queryJSON: chatProps.queryJSON, offset: 0});
+        // Then Search will be triggered
+        expect(search).toHaveBeenCalled();
     });
 });


### PR DESCRIPTION
Reverts Expensify/App#62352

### Explanation of Change
We stopped making a call to Search to refresh the list after an action was taken in the RHP

### Fixed Issues
$ https://github.com/Expensify/App/issues/63380

### Tests
Prerequisite: Account has at least one workspace.
Prerequisite 2: Delayed submissions and approvals enabled.

1. Open the staging.new.expensify.com website.
2. Open any workspace chat.
3. Submit a manual expense to it.
4. Tap on "Submit" on expense preview.
5. Navigate to "Reports".
6. Note that an "Approve" button can be seen on the preview of the just submitted expense.
7. Open the expense and tap on "More"
8. Hold the expense.
9. Return to expenses list.
10. Note that you see a `Review` button now


- [x] Verify that no errors appear in the JS console

### Offline tests
N/A

### QA Steps
Same as above

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I verified there are no new alerts related to the `canBeMissing` param for `useOnyx`
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos

<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Desktop</summary>

<!-- add screenshots or videos here -->

</details>
