### PR TITLE
perf: move screen focus to LHNOptionsList

### DIFF
--- a/src/components/LHNOptionsList/LHNOptionsList.tsx
+++ b/src/components/LHNOptionsList/LHNOptionsList.tsx
@@ -1,4 +1,4 @@
-import {useRoute} from '@react-navigation/native';
+import {useIsFocused, useRoute} from '@react-navigation/native';
 import type {FlashListProps} from '@shopify/flash-list';
 import {FlashList} from '@shopify/flash-list';
 import type {ReactElement} from 'react';
@@ -42,6 +42,7 @@ function LHNOptionsList({style, contentContainerStyles, data, onSelectRow, optio
     const {isOffline} = useNetwork();
     const flashListRef = useRef<FlashList<Report>>(null);
     const route = useRoute();
+    const isScreenFocused = useIsFocused();
 
     const [reports] = useOnyx(ONYXKEYS.COLLECTION.REPORT, {canBeMissing: false});
     const [reportAttributes] = useOnyx(ONYXKEYS.DERIVED.REPORT_ATTRIBUTES, {selector: (attributes) => attributes?.reports, canBeMissing: false});
@@ -225,7 +226,7 @@ function LHNOptionsList({style, contentContainerStyles, data, onSelectRow, optio
                     lastReportActionTransaction={lastReportActionTransaction}
                     receiptTransactions={transactions}
                     viewMode={optionMode}
-                    isFocused={!shouldDisableFocusOptions}
+                    isOptionFocused={!shouldDisableFocusOptions}
                     lastMessageTextFromReport={lastMessageTextFromReport}
                     onSelectRow={onSelectRow}
                     preferredLocale={preferredLocale}
@@ -233,6 +234,7 @@ function LHNOptionsList({style, contentContainerStyles, data, onSelectRow, optio
                     transactionViolations={transactionViolations}
                     onLayout={onLayoutItem}
                     shouldShowRBRorGBRTooltip={shouldShowRBRorGBRTooltip}
+                    isScreenFocused={isScreenFocused}
                 />
             );
         },
@@ -253,6 +255,7 @@ function LHNOptionsList({style, contentContainerStyles, data, onSelectRow, optio
             onLayoutItem,
             isOffline,
             firstReportIDWithGBRorRBR,
+            isScreenFocused,
         ],
     );
 
@@ -271,6 +274,7 @@ function LHNOptionsList({style, contentContainerStyles, data, onSelectRow, optio
             preferredLocale,
             transactions,
             isOffline,
+            isScreenFocused,
         ],
         [
             reportActions,
@@ -286,6 +290,7 @@ function LHNOptionsList({style, contentContainerStyles, data, onSelectRow, optio
             preferredLocale,
             transactions,
             isOffline,
+            isScreenFocused,
         ],
     );
 

--- a/src/components/LHNOptionsList/OptionRowLHN.tsx
+++ b/src/components/LHNOptionsList/OptionRowLHN.tsx
@@ -1,5 +1,4 @@
-import {useFocusEffect} from '@react-navigation/native';
-import React, {useCallback, useMemo, useRef, useState} from 'react';
+import React, {useMemo, useRef, useState} from 'react';
 import type {GestureResponderEvent, ViewStyle} from 'react-native';
 import {StyleSheet, View} from 'react-native';
 import {useOnyx} from 'react-native-onyx';
@@ -51,7 +50,7 @@ import type {OptionRowLHNProps} from './types';
 
 function OptionRowLHN({
     reportID,
-    isFocused = false,
+    isOptionFocused = false,
     onSelectRow = () => {},
     optionItem,
     viewMode = 'default',
@@ -59,12 +58,12 @@ function OptionRowLHN({
     onLayout = () => {},
     hasDraftComment,
     shouldShowRBRorGBRTooltip,
+    isScreenFocused = false,
 }: OptionRowLHNProps) {
     const theme = useTheme();
     const styles = useThemeStyles();
     const popoverAnchor = useRef<View>(null);
     const StyleUtils = useStyleUtils();
-    const [isScreenFocused, setIsScreenFocused] = useState(false);
     const {shouldUseNarrowLayout} = useResponsiveLayout();
 
     const [report] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT}${optionItem?.reportID}`, {canBeMissing: true});
@@ -105,15 +104,6 @@ function OptionRowLHN({
     const {translate} = useLocalize();
     const [isContextMenuActive, setIsContextMenuActive] = useState(false);
 
-    useFocusEffect(
-        useCallback(() => {
-            setIsScreenFocused(true);
-            return () => {
-                setIsScreenFocused(false);
-            };
-        }, []),
-    );
-
     const isInFocusMode = viewMode === CONST.OPTION_MODE.COMPACT;
     const sidebarInnerRowStyle = StyleSheet.flatten<ViewStyle>(
         isInFocusMode
@@ -121,7 +111,7 @@ function OptionRowLHN({
             : [styles.chatLinkRowPressable, styles.flexGrow1, styles.optionItemAvatarNameWrapper, styles.optionRow, styles.justifyContentCenter],
     );
 
-    if (!optionItem && !isFocused) {
+    if (!optionItem && !isOptionFocused) {
         // rendering null as a render item causes the FlashList to render all
         // its children and consume significant memory on the first render. We can avoid this by
         // rendering a placeholder view instead. This behaviour is only observed when we
@@ -140,7 +130,7 @@ function OptionRowLHN({
     }
 
     const brickRoadIndicator = optionItem.brickRoadIndicator;
-    const textStyle = isFocused ? styles.sidebarLinkActiveText : styles.sidebarLinkText;
+    const textStyle = isOptionFocused ? styles.sidebarLinkActiveText : styles.sidebarLinkText;
     const textUnreadStyle = shouldUseBoldText(optionItem) ? [textStyle, styles.sidebarLinkTextBold] : [textStyle];
     const displayNameStyle = [styles.optionDisplayName, styles.optionDisplayNameCompact, styles.pre, textUnreadStyle, style];
     const alternateTextStyle = isInFocusMode
@@ -188,7 +178,7 @@ function OptionRowLHN({
     const statusContent = formattedDate ? `${statusText ? `${statusText} ` : ''}(${formattedDate})` : statusText;
     const isStatusVisible = !!emojiCode && isOneOnOneChat(!isEmptyObject(report) ? report : undefined);
 
-    const subscriptAvatarBorderColor = isFocused ? focusedBackgroundColor : theme.sidebar;
+    const subscriptAvatarBorderColor = isOptionFocused ? focusedBackgroundColor : theme.sidebar;
     const firstIcon = optionItem.icons?.at(0);
 
     const onOptionPress = (event: GestureResponderEvent | KeyboardEvent | undefined) => {
@@ -256,8 +246,8 @@ function OptionRowLHN({
                                     styles.sidebarLink,
                                     styles.sidebarLinkInnerLHN,
                                     StyleUtils.getBackgroundColorStyle(theme.sidebar),
-                                    isFocused ? styles.sidebarLinkActive : null,
-                                    (hovered || isContextMenuActive) && !isFocused ? styles.sidebarLinkHover : null,
+                                    isOptionFocused ? styles.sidebarLinkActive : null,
+                                    (hovered || isContextMenuActive) && !isOptionFocused ? styles.sidebarLinkHover : null,
                                 ]}
                                 role={CONST.ROLE.BUTTON}
                                 accessibilityLabel={`${translate('accessibilityHints.navigatesToChat')} ${optionItem.text}. ${optionItem.isUnread ? `${translate('common.unread')}.` : ''} ${
@@ -272,7 +262,7 @@ function OptionRowLHN({
                                             firstIcon &&
                                             (optionItem.shouldShowSubscript ? (
                                                 <SubscriptAvatar
-                                                    backgroundColor={hovered && !isFocused ? hoveredBackgroundColor : subscriptAvatarBorderColor}
+                                                    backgroundColor={hovered && !isOptionFocused ? hoveredBackgroundColor : subscriptAvatarBorderColor}
                                                     mainAvatar={firstIcon}
                                                     secondaryAvatar={optionItem.icons.at(1)}
                                                     size={isInFocusMode ? CONST.AVATAR_SIZE.SMALL : CONST.AVATAR_SIZE.DEFAULT}
@@ -284,8 +274,8 @@ function OptionRowLHN({
                                                     size={isInFocusMode ? CONST.AVATAR_SIZE.SMALL : CONST.AVATAR_SIZE.DEFAULT}
                                                     secondAvatarStyle={[
                                                         StyleUtils.getBackgroundAndBorderStyle(theme.sidebar),
-                                                        isFocused ? StyleUtils.getBackgroundAndBorderStyle(focusedBackgroundColor) : undefined,
-                                                        hovered && !isFocused ? StyleUtils.getBackgroundAndBorderStyle(hoveredBackgroundColor) : undefined,
+                                                        isOptionFocused ? StyleUtils.getBackgroundAndBorderStyle(focusedBackgroundColor) : undefined,
+                                                        hovered && !isOptionFocused ? StyleUtils.getBackgroundAndBorderStyle(hoveredBackgroundColor) : undefined,
                                                     ]}
                                                     shouldShowTooltip={shouldOptionShowTooltip(optionItem)}
                                                 />

--- a/src/components/LHNOptionsList/OptionRowLHNData.tsx
+++ b/src/components/LHNOptionsList/OptionRowLHNData.tsx
@@ -14,7 +14,7 @@ import type {OptionRowLHNDataProps} from './types';
  * re-render if the data really changed.
  */
 function OptionRowLHNData({
-    isFocused = false,
+    isOptionFocused = false,
     fullReport,
     reportAttributes,
     oneTransactionThreadReport,
@@ -35,7 +35,7 @@ function OptionRowLHNData({
 }: OptionRowLHNDataProps) {
     const reportID = propsToForward.reportID;
     const currentReportIDValue = useCurrentReportID();
-    const isReportFocused = isFocused && currentReportIDValue?.currentReportID === reportID;
+    const isReportFocused = isOptionFocused && currentReportIDValue?.currentReportID === reportID;
 
     const optionItemRef = useRef<OptionData | undefined>(undefined);
     const optionItem = useMemo(() => {
@@ -88,7 +88,7 @@ function OptionRowLHNData({
         <OptionRowLHN
             // eslint-disable-next-line react/jsx-props-no-spreading
             {...propsToForward}
-            isFocused={isReportFocused}
+            isOptionFocused={isReportFocused}
             optionItem={optionItem}
         />
     );

--- a/src/components/LHNOptionsList/types.ts
+++ b/src/components/LHNOptionsList/types.ts
@@ -37,7 +37,7 @@ type LHNOptionsListProps = CustomLHNOptionsListProps;
 
 type OptionRowLHNDataProps = {
     /** Whether row should be focused */
-    isFocused?: boolean;
+    isOptionFocused?: boolean;
 
     /** List of users' personal details */
     personalDetails?: PersonalDetailsList;
@@ -109,6 +109,9 @@ type OptionRowLHNDataProps = {
 
     /** Whether to show the educational tooltip for the GBR or RBR */
     shouldShowRBRorGBRTooltip: boolean;
+
+    /** Whether the screen is focused */
+    isScreenFocused?: boolean;
 };
 
 type OptionRowLHNProps = {
@@ -116,7 +119,7 @@ type OptionRowLHNProps = {
     reportID: string;
 
     /** Whether this option is currently in focus so we can modify its style */
-    isFocused?: boolean;
+    isOptionFocused?: boolean;
 
     /** A function that is called when an option is selected. Selected option is passed as a param */
     onSelectRow?: (optionItem: OptionData, popoverAnchor: RefObject<View>) => void;
@@ -137,6 +140,9 @@ type OptionRowLHNProps = {
 
     /** Whether to show the educational tooltip on the GBR or RBR */
     shouldShowRBRorGBRTooltip: boolean;
+
+    /** Whether the screen is focused */
+    isScreenFocused?: boolean;
 };
 
 type RenderItemProps = {item: Report};

--- a/tests/ui/components/LHNOptionsListTest.tsx
+++ b/tests/ui/components/LHNOptionsListTest.tsx
@@ -1,0 +1,174 @@
+import {NavigationContainer} from '@react-navigation/native';
+import type * as ReactNavigation from '@react-navigation/native';
+import {render, screen, userEvent, waitFor} from '@testing-library/react-native';
+import React from 'react';
+import Onyx from 'react-native-onyx';
+import ComposeProviders from '@components/ComposeProviders';
+import LHNOptionsList from '@components/LHNOptionsList/LHNOptionsList';
+import type {LHNOptionsListProps} from '@components/LHNOptionsList/types';
+import {LocaleContextProvider} from '@components/LocaleContextProvider';
+import OnyxProvider from '@components/OnyxProvider';
+import {showContextMenu} from '@pages/home/report/ContextMenu/ReportActionContextMenu';
+import CONST from '@src/CONST';
+import ONYXKEYS from '@src/ONYXKEYS';
+import {getFakeReport} from '../../utils/LHNTestUtils';
+
+// Mock the context menu
+jest.mock('@pages/home/report/ContextMenu/ReportActionContextMenu', () => ({
+    showContextMenu: jest.fn(),
+}));
+
+// Mock the useRootNavigationState hook
+jest.mock('@src/hooks/useRootNavigationState');
+
+// Mock navigation hooks
+const mockUseIsFocused = jest.fn().mockReturnValue(false);
+jest.mock('@react-navigation/native', () => {
+    const actualNav = jest.requireActual<typeof ReactNavigation>('@react-navigation/native');
+    return {
+        ...actualNav,
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+        useIsFocused: () => mockUseIsFocused(),
+        useRoute: jest.fn(),
+        useNavigationState: jest.fn(),
+        createNavigationContainerRef: () => ({
+            getState: () => jest.fn(),
+        }),
+    };
+});
+
+const getReportItem = (reportID: string) => {
+    return screen.findByTestId(reportID);
+};
+
+const getReportItemButton = () => {
+    return userEvent.setup();
+};
+
+describe('LHNOptionsList', () => {
+    const mockReport = getFakeReport([1, 2], 0, false);
+
+    const defaultProps: LHNOptionsListProps = {
+        data: [mockReport],
+        onSelectRow: jest.fn(),
+        optionMode: CONST.OPTION_MODE.DEFAULT,
+        onFirstItemRendered: jest.fn(),
+    };
+
+    const getLHNOptionsListElement = (props: Partial<LHNOptionsListProps> = {}) => {
+        const mergedProps = {
+            data: props.data ?? defaultProps.data,
+            onSelectRow: props.onSelectRow ?? defaultProps.onSelectRow,
+            optionMode: props.optionMode ?? defaultProps.optionMode,
+            onFirstItemRendered: props.onFirstItemRendered ?? defaultProps.onFirstItemRendered,
+        };
+
+        return (
+            <NavigationContainer>
+                <ComposeProviders components={[OnyxProvider, LocaleContextProvider]}>
+                    <LHNOptionsList
+                        data={mergedProps.data}
+                        onSelectRow={mergedProps.onSelectRow}
+                        optionMode={mergedProps.optionMode}
+                        onFirstItemRendered={mergedProps.onFirstItemRendered}
+                    />
+                </ComposeProviders>
+            </NavigationContainer>
+        );
+    };
+
+    beforeEach(() => {
+        Onyx.init({
+            keys: ONYXKEYS,
+        });
+
+        jest.clearAllMocks();
+    });
+
+    afterEach(() => {
+        return Onyx.clear();
+    });
+
+    it('shows context menu on long press', async () => {
+        // Given the screen is focused.
+        mockUseIsFocused.mockReturnValue(true);
+
+        // Given the LHNOptionsList is rendered with a report.
+        render(getLHNOptionsListElement());
+
+        // Then wait for the report to be displayed in the LHNOptionsList.
+        const reportItem = await waitFor(() => getReportItem(mockReport.reportID));
+        expect(reportItem).toBeTruthy();
+
+        // When the user long presses the report item.
+        const user = getReportItemButton();
+        await user.longPress(reportItem);
+
+        // Then wait for all state updates to complete and verify the context menu is shown
+        await waitFor(() => {
+            expect(showContextMenu).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    type: CONST.CONTEXT_MENU_TYPES.REPORT,
+                    report: expect.objectContaining({
+                        reportID: mockReport.reportID,
+                    }),
+                }),
+            );
+        });
+    });
+
+    it('does not show context menu when screen is not focused', async () => {
+        // Given the screen is not focused.
+        mockUseIsFocused.mockReturnValue(false);
+
+        // When the LHNOptionsList is rendered.
+        render(getLHNOptionsListElement());
+
+        // Then wait for the report to be displayed in the LHNOptionsList.
+        const reportItem = await waitFor(() => getReportItem(mockReport.reportID));
+        expect(reportItem).toBeTruthy();
+
+        // When the user long presses the report item.
+        const user = getReportItemButton();
+        await user.longPress(reportItem);
+
+        // Then wait for all state updates to complete and verify the context menu is not shown
+        await waitFor(() => {
+            expect(showContextMenu).not.toHaveBeenCalled();
+        });
+    });
+
+    it('shows context menu after returning from chat', async () => {
+        // Given the screen is focused.
+        mockUseIsFocused.mockReturnValue(true);
+
+        // When the LHNOptionsList is rendered.
+        const {rerender} = render(getLHNOptionsListElement());
+
+        // Then wait for the report to be displayed in the LHNOptionsList.
+        const reportItem = await waitFor(() => getReportItem(mockReport.reportID));
+        expect(reportItem).toBeTruthy();
+
+        // When the user navigates to chat and back by re-rendering with different focus state
+        rerender(getLHNOptionsListElement());
+
+        // When the user re-renders again to simulate returning to the screen
+        rerender(getLHNOptionsListElement());
+
+        // When the user long presses the report item.
+        const user = getReportItemButton();
+        await user.longPress(reportItem);
+
+        // Then wait for all state updates to complete and verify the context menu is shown
+        await waitFor(() => {
+            expect(showContextMenu).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    type: CONST.CONTEXT_MENU_TYPES.REPORT,
+                    report: expect.objectContaining({
+                        reportID: mockReport.reportID,
+                    }),
+                }),
+            );
+        });
+    });
+});


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
<!-- Explain what your change does and how it addresses the linked issue -->

**Problem**

`OptionRowLHN` use the`useFocusEffect` hook locally inside each row component. This means that every time the screen focus changed (e.g., navigating between Inbox → Reports), all instances of OptionRowLHN triggered re-renders — even if nothing else changed.
In large lists (e.g., LHN with hundreds/thousands of rows), this caused significant performance hits and longer render durations.

**Solution**

Move the screen focus logic to the parent component (`LHNOptionsList`) and passed `isScreenFocused` value as a prop to each `OptionRowLHN` instead of using `useFocusEffect` within the row. Replace the custom focus hook with React Navigation’s built-in `useIsFocused()` in the parent for better clarity and simplicity. This avoided each row setting up its own focus listener and prevented cascading re-renders on screen transitions. This change preserves the required focus-based behavior while minimizing redundant work across many list items.

**Performance gain**

- Android 
- Commit count dropped from 17 → 14, total render time down by ~29% ( from`8941ms` down to` 6328ms` -> Total Duration Difference: `2613.470 ms`)
-  iOS - Commit count dropped from 25 → 22, total render time down by ~14% ( from `3297ms` down to `2820ms` -> Total Duration Difference:` -477.069 ms`)

Before:

<img width="1189" alt="Image" src="https://github.com/user-attachments/assets/cc02c0ee-72e6-4e64-bf20-3a7080a751db" />

After:

<img width="877" alt="Image" src="https://github.com/user-attachments/assets/af3ab9b9-c014-412e-b232-947af3e5923b" />

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/60007
PROPOSAL:


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->
This change is performance-related only — no functionality is expected to change. The goal is to avoid unnecessary re-renders in long LHN lists by lifting useFocusEffect `out of each row and managing focus state at the parent level. 
Please check that there are no regressions in the behavior tied to screen focus :

**Tooltip**:
1. Create a new account A and start some chats
2. Verify that a tooltip is displayed for one of the reports in LHN that have RBR/GBR

**Context Menu**:
1. Long-press a chat in the LHN.
2. Verify that the context menu appears correctly with the expected options.

- [ ] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
4. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->
// TODO: These must be filled out, or the issue title must include "[No QA]."
same as tests 

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I verified there are no new alerts related to the `canBeMissing` param for `useOnyx`
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

[untitled1.webm](https://github.com/user-attachments/assets/3e8ff8b5-91c3-4e08-93da-c1c8e20791ab)


![android_native](https://github.com/user-attachments/assets/00b3d309-24ae-4c42-807c-e5c29cfd456b)


<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

[untitled.webm](https://github.com/user-attachments/assets/0d201ce6-0f65-4edd-96c9-0ee4706380b2)

![android_mweb](https://github.com/user-attachments/assets/32698241-4b5e-4a09-92ee-e92d89a96038)


</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->


https://github.com/user-attachments/assets/711cdadb-c224-4fde-bcb5-52376c21ff0f

![ios](https://github.com/user-attachments/assets/60dc3abc-5052-4949-9752-f2eb74a1f1fd)


</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->


https://github.com/user-attachments/assets/a5505390-765a-44bd-ae06-e60067b0505c

![iOS_mWeb](https://github.com/user-attachments/assets/9f799200-1404-4216-b800-9d356514cadd)




</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->
<img width="1901" alt="web" src="https://github.com/user-attachments/assets/609070ad-d7f5-46c6-80b0-bd683950e39b" />
</details>



<details>
<summary>MacOS: Desktop</summary>

<!-- add screenshots or videos here -->
<img width="1211" alt="desktop" src="https://github.com/user-attachments/assets/c37bcafc-9f69-446a-8e9a-cd487f0b5cb6" />

</details>
