### PR TITLE
Remove a call to getReportNameValuePairs when checking if a thread is disabled

### DIFF
--- a/src/libs/ReportUtils.ts
+++ b/src/libs/ReportUtils.ts
@@ -9089,23 +9089,19 @@ function getNonHeldAndFullAmount(iouReport: OnyxEntry<Report>, shouldExcludeNonR
  * - The action is a whisper action and it's neither a report preview nor IOU action
  * - The action is the thread's first chat
  */
-function shouldDisableThread(reportAction: OnyxInputOrEntry<ReportAction>, reportID: string, isThreadReportParentAction: boolean): boolean {
+function shouldDisableThread(reportAction: OnyxInputOrEntry<ReportAction>, reportID: string, isThreadReportParentAction: boolean, isReportArchived = false): boolean {
     const isSplitBillAction = isSplitBillReportAction(reportAction);
     const isDeletedActionLocal = isDeletedAction(reportAction);
     const isReportPreviewActionLocal = isReportPreviewAction(reportAction);
     const isIOUAction = isMoneyRequestAction(reportAction);
     const isWhisperActionLocal = isWhisperAction(reportAction) || isActionableTrackExpense(reportAction);
-
-    // This will get removed as part of https://github.com/Expensify/App/issues/59961
-    // eslint-disable-next-line deprecation/deprecation
-    const isArchived = isArchivedNonExpenseReport(getReportOrDraftReport(reportID), getReportNameValuePairs(reportID));
     const isActionDisabled = CONST.REPORT.ACTIONS.THREAD_DISABLED.some((action: string) => action === reportAction?.actionName);
 
     return (
         isActionDisabled ||
         isSplitBillAction ||
         (isDeletedActionLocal && !reportAction?.childVisibleActionCount) ||
-        (isArchived && !reportAction?.childVisibleActionCount) ||
+        (isReportArchived && !reportAction?.childVisibleActionCount) ||
         (isWhisperActionLocal && !isReportPreviewActionLocal && !isIOUAction) ||
         isThreadReportParentAction
     );

--- a/src/libs/ReportUtils.ts
+++ b/src/libs/ReportUtils.ts
@@ -8380,71 +8380,6 @@ function canLeaveInvoiceRoom(report: OnyxEntry<Report>): boolean {
     return true;
 }
 
-/**
- * Allows a user to leave a policy room according to the following conditions of the visibility or chatType rNVP:
- * `public` - Anyone can leave (because anybody can join)
- * `public_announce` - Only non-policy members can leave (it's auto-shared with policy members)
- * `policy_admins` - Nobody can leave (it's auto-shared with all policy admins)
- * `policy_announce` - Nobody can leave (it's auto-shared with all policy members)
- * `policyExpenseChat` - Nobody can leave (it's auto-shared with all policy members)
- * `policy` - Anyone can leave (though only policy members can join)
- * `domain` - Nobody can leave (it's auto-shared with domain members)
- * `dm` - Nobody can leave (it's auto-shared with users)
- * `private` - Anybody can leave (though you can only be invited to join)
- * `invoice` - Invoice sender, invoice receiver and auto-invited admins cannot leave
- */
-function canLeaveRoom(report: OnyxEntry<Report>, isPolicyEmployee: boolean): boolean {
-    if (isInvoiceRoom(report)) {
-        // This will get removed as part of https://github.com/Expensify/App/issues/59961
-        // eslint-disable-next-line deprecation/deprecation
-        if (isArchivedNonExpenseReport(report, getReportNameValuePairs(report?.reportID))) {
-            return false;
-        }
-
-        const invoiceReport = getReportOrDraftReport(report?.iouReportID);
-
-        if (invoiceReport?.ownerAccountID === currentUserAccountID) {
-            return false;
-        }
-
-        if (invoiceReport?.managerID === currentUserAccountID) {
-            return false;
-        }
-
-        const isSenderPolicyAdmin = getPolicy(report?.policyID)?.role === CONST.POLICY.ROLE.ADMIN;
-
-        if (isSenderPolicyAdmin) {
-            return false;
-        }
-
-        const isReceiverPolicyAdmin =
-            report?.invoiceReceiver?.type === CONST.REPORT.INVOICE_RECEIVER_TYPE.BUSINESS ? getPolicy(report?.invoiceReceiver?.policyID)?.role === CONST.POLICY.ROLE.ADMIN : false;
-
-        if (isReceiverPolicyAdmin) {
-            return false;
-        }
-
-        return true;
-    }
-
-    if (!report?.visibility) {
-        if (
-            report?.chatType === CONST.REPORT.CHAT_TYPE.POLICY_ADMINS ||
-            report?.chatType === CONST.REPORT.CHAT_TYPE.POLICY_ANNOUNCE ||
-            report?.chatType === CONST.REPORT.CHAT_TYPE.POLICY_EXPENSE_CHAT ||
-            report?.chatType === CONST.REPORT.CHAT_TYPE.DOMAIN_ALL ||
-            report?.chatType === CONST.REPORT.CHAT_TYPE.SELF_DM ||
-            !report?.chatType
-        ) {
-            // DM chats don't have a chatType
-            return false;
-        }
-    } else if (isPublicAnnounceRoom(report) && isPolicyEmployee) {
-        return false;
-    }
-    return true;
-}
-
 function isCurrentUserTheOnlyParticipant(participantAccountIDs?: number[]): boolean {
     return !!(participantAccountIDs?.length === 1 && participantAccountIDs?.at(0) === currentUserAccountID);
 }
@@ -10816,7 +10751,6 @@ export {
     canEditWriteCapability,
     canFlagReportAction,
     isNonAdminOrOwnerOfPolicyExpenseChat,
-    canLeaveRoom,
     canJoinChat,
     canLeaveChat,
     canReportBeMentionedWithinPolicy,

--- a/src/pages/home/report/ContextMenu/ContextMenuActions.tsx
+++ b/src/pages/home/report/ContextMenu/ContextMenuActions.tsx
@@ -269,11 +269,11 @@ const ContextMenuActions: ContextMenuAction[] = [
         isAnonymousAction: false,
         textTranslateKey: 'reportActionContextMenu.replyInThread',
         icon: Expensicons.ChatBubbleReply,
-        shouldShow: ({type, reportAction, reportID, isThreadReportParentAction}) => {
+        shouldShow: ({type, reportAction, reportID, isThreadReportParentAction, isArchivedRoom}) => {
             if (type !== CONST.CONTEXT_MENU_TYPES.REPORT_ACTION || !reportID) {
                 return false;
             }
-            return !shouldDisableThread(reportAction, reportID, isThreadReportParentAction);
+            return !shouldDisableThread(reportAction, reportID, isThreadReportParentAction, isArchivedRoom);
         },
         onPress: (closePopover, {reportAction, reportID}) => {
             const originalReportID = getOriginalReportID(reportID, reportAction);

--- a/tests/unit/ReportUtilsTest.ts
+++ b/tests/unit/ReportUtilsTest.ts
@@ -1234,27 +1234,8 @@ describe('ReportUtils', () => {
             expect(shouldDisableThread(reportAction, reportID, false)).toBeTruthy();
         });
 
-        it('should disable on deleted and not-thread actions', () => {
-            const reportAction = {
-                message: [
-                    {
-                        translationKey: '',
-                        type: 'COMMENT',
-                        html: '',
-                        text: '',
-                        isEdited: true,
-                    },
-                ],
-                childVisibleActionCount: 1,
-            } as ReportAction;
-            expect(shouldDisableThread(reportAction, reportID, false)).toBeFalsy();
-
-            reportAction.childVisibleActionCount = 0;
-            expect(shouldDisableThread(reportAction, reportID, false)).toBeTruthy();
-        });
-
         it('should disable on archived reports and not-thread actions', () => {
-            Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT}${reportID}`, {
+            return Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT}${reportID}`, {
                 statusNum: CONST.REPORT.STATUS_NUM.CLOSED,
                 stateNum: CONST.REPORT.STATE_NUM.APPROVED,
             })
@@ -1263,10 +1244,10 @@ describe('ReportUtils', () => {
                     const reportAction = {
                         childVisibleActionCount: 1,
                     } as ReportAction;
-                    expect(shouldDisableThread(reportAction, reportID, false)).toBeFalsy();
+                    expect(shouldDisableThread(reportAction, reportID, false, false)).toBeFalsy();
 
                     reportAction.childVisibleActionCount = 0;
-                    expect(shouldDisableThread(reportAction, reportID, false)).toBeTruthy();
+                    expect(shouldDisableThread(reportAction, reportID, false, false)).toBeTruthy();
                 });
         });
 
@@ -1285,6 +1266,91 @@ describe('ReportUtils', () => {
                 childReportID: reportID,
             } as ReportAction;
             expect(shouldDisableThread(reportAction, reportID, true)).toBeTruthy();
+        });
+
+        describe('only deleted actions with a child visible count of 0 should be disabled', () => {
+            it('should be enabled if the report action is not-deleted and visible action count is 1', () => {
+                // Given a normal report action with one child visible action count
+                const reportAction = {
+                    message: [
+                        {
+                            translationKey: '',
+                            type: 'COMMENT',
+                            html: 'test',
+                            text: 'test',
+                        },
+                    ],
+                    childVisibleActionCount: 1,
+                } as ReportAction;
+
+                // When it's checked to see if the thread should be disabled
+                const result = shouldDisableThread(reportAction, reportID, false);
+
+                // Then the thread should be enabled
+                expect(result).toBeFalsy();
+            });
+
+            it('thread should be enabled if the report action is not-deleted and visible action count is 0', () => {
+                // Given a normal report action with zero child visible action count
+                const reportAction = {
+                    message: [
+                        {
+                            translationKey: '',
+                            type: 'COMMENT',
+                            html: 'test',
+                            text: 'test',
+                        },
+                    ],
+                    childVisibleActionCount: 0,
+                } as ReportAction;
+
+                // When it's checked to see if the thread should be disabled
+                const result = shouldDisableThread(reportAction, reportID, false);
+
+                // Then the thread should be enabled
+                expect(result).toBeFalsy();
+            });
+            it('thread should be enabled if the report action is deleted and visible action count is 1', () => {
+                // Given a normal report action with one child visible action count
+                const reportAction = {
+                    message: [
+                        {
+                            translationKey: '',
+                            type: 'COMMENT',
+                            html: '',
+                            text: '',
+                        },
+                    ],
+                    childVisibleActionCount: 1,
+                } as ReportAction;
+
+                // When it's checked to see if the thread should be disabled
+                const result = shouldDisableThread(reportAction, reportID, false);
+
+                // Then the thread should be enabled
+                expect(result).toBeFalsy();
+            });
+
+            it('thread should be disabled if the report action is deleted and visible action count is 0', () => {
+                // Given a normal report action with zero child visible action count
+                const reportAction = {
+                    message: [
+                        {
+                            translationKey: '',
+                            type: 'COMMENT',
+                            html: '',
+                            text: '',
+                        },
+                    ],
+                    childVisibleActionCount: 0,
+                } as ReportAction;
+
+                // When it's checked to see if the thread should be disabled
+                const result = shouldDisableThread(reportAction, reportID, false);
+
+                // Then the thread should be disabled
+                expect(result).toBeTruthy();
+            });
         });
     });
 

--- a/tests/unit/ReportUtilsTest.ts
+++ b/tests/unit/ReportUtilsTest.ts
@@ -1234,23 +1234,6 @@ describe('ReportUtils', () => {
             expect(shouldDisableThread(reportAction, reportID, false)).toBeTruthy();
         });
 
-        it('should disable on archived reports and not-thread actions', () => {
-            return Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT}${reportID}`, {
-                statusNum: CONST.REPORT.STATUS_NUM.CLOSED,
-                stateNum: CONST.REPORT.STATE_NUM.APPROVED,
-            })
-                .then(() => waitForBatchedUpdates())
-                .then(() => {
-                    const reportAction = {
-                        childVisibleActionCount: 1,
-                    } as ReportAction;
-                    expect(shouldDisableThread(reportAction, reportID, false, false)).toBeFalsy();
-
-                    reportAction.childVisibleActionCount = 0;
-                    expect(shouldDisableThread(reportAction, reportID, false, false)).toBeTruthy();
-                });
-        });
-
         it("should disable on a whisper action and it's neither a report preview nor IOU action", () => {
             const reportAction = {
                 actionName: CONST.REPORT.ACTIONS.TYPE.MODIFIED_EXPENSE,

--- a/tests/unit/ReportUtilsTest.ts
+++ b/tests/unit/ReportUtilsTest.ts
@@ -1269,7 +1269,7 @@ describe('ReportUtils', () => {
         });
 
         describe('deleted threads', () => {
-            it('should be enabled if the report action is not-deleted and visible action count is 1', () => {
+            it('should be enabled if the report action is not-deleted and child visible action count is 1', () => {
                 // Given a normal report action with one child visible action count
                 const reportAction = {
                     message: [
@@ -1284,13 +1284,13 @@ describe('ReportUtils', () => {
                 } as ReportAction;
 
                 // When it's checked to see if the thread should be disabled
-                const result = shouldDisableThread(reportAction, reportID, false);
+                const isThreadDisabled = shouldDisableThread(reportAction, reportID, false);
 
                 // Then the thread should be enabled
-                expect(result).toBeFalsy();
+                expect(isThreadDisabled).toBeFalsy();
             });
 
-            it('should be enabled if the report action is not-deleted and visible action count is 0', () => {
+            it('should be enabled if the report action is not-deleted and child visible action count is 0', () => {
                 // Given a normal report action with zero child visible action count
                 const reportAction = {
                     message: [
@@ -1305,12 +1305,12 @@ describe('ReportUtils', () => {
                 } as ReportAction;
 
                 // When it's checked to see if the thread should be disabled
-                const result = shouldDisableThread(reportAction, reportID, false);
+                const isThreadDisabled = shouldDisableThread(reportAction, reportID, false);
 
                 // Then the thread should be enabled
-                expect(result).toBeFalsy();
+                expect(isThreadDisabled).toBeFalsy();
             });
-            it('should be enabled if the report action is deleted and visible action count is 1', () => {
+            it('should be enabled if the report action is deleted and child visible action count is 1', () => {
                 // Given a normal report action with one child visible action count
                 const reportAction = {
                     message: [
@@ -1325,13 +1325,13 @@ describe('ReportUtils', () => {
                 } as ReportAction;
 
                 // When it's checked to see if the thread should be disabled
-                const result = shouldDisableThread(reportAction, reportID, false);
+                const isThreadDisabled = shouldDisableThread(reportAction, reportID, false);
 
                 // Then the thread should be enabled
-                expect(result).toBeFalsy();
+                expect(isThreadDisabled).toBeFalsy();
             });
 
-            it('should be disabled if the report action is deleted and visible action count is 0', () => {
+            it('should be disabled if the report action is deleted and child visible action count is 0', () => {
                 // Given a normal report action with zero child visible action count
                 const reportAction = {
                     message: [
@@ -1346,10 +1346,105 @@ describe('ReportUtils', () => {
                 } as ReportAction;
 
                 // When it's checked to see if the thread should be disabled
-                const result = shouldDisableThread(reportAction, reportID, false);
+                const isThreadDisabled = shouldDisableThread(reportAction, reportID, false);
 
                 // Then the thread should be disabled
-                expect(result).toBeTruthy();
+                expect(isThreadDisabled).toBeTruthy();
+            });
+        });
+
+        describe('archived report threads', () => {
+            it('should be enabled if the report is not-archived and child visible action count is 1', () => {
+                // Given a normal report action with one child visible action count
+                const reportAction = {
+                    message: [
+                        {
+                            translationKey: '',
+                            type: 'COMMENT',
+                            html: 'test',
+                            text: 'test',
+                        },
+                    ],
+                    childVisibleActionCount: 1,
+                } as ReportAction;
+
+                // And a report that is not archived
+                const isReportArchived = false;
+
+                // When it's checked to see if the thread should be disabled
+                const isThreadDisabled = shouldDisableThread(reportAction, reportID, false, isReportArchived);
+
+                // Then the thread should be enabled
+                expect(isThreadDisabled).toBeFalsy();
+            });
+            it('should be enabled if the report is not-archived and child visible action count is 0', () => {
+                // Given a normal report action with zero child visible action counts
+                const reportAction = {
+                    message: [
+                        {
+                            translationKey: '',
+                            type: 'COMMENT',
+                            html: 'test',
+                            text: 'test',
+                        },
+                    ],
+                    childVisibleActionCount: 1,
+                } as ReportAction;
+
+                // And a report that is not archived
+                const isReportArchived = false;
+
+                // When it's checked to see if the thread should be disabled
+                const isThreadDisabled = shouldDisableThread(reportAction, reportID, false, isReportArchived);
+
+                // Then the thread should be enabled
+                expect(isThreadDisabled).toBeFalsy();
+            });
+            it('should be enabled if the report is archived and child visible action count is 1', () => {
+                // Given a normal report action with one child visible action count
+                const reportAction = {
+                    message: [
+                        {
+                            translationKey: '',
+                            type: 'COMMENT',
+                            html: 'test',
+                            text: 'test',
+                        },
+                    ],
+                    childVisibleActionCount: 1,
+                } as ReportAction;
+
+                // And a report that is not archived
+                const isReportArchived = true;
+
+                // When it's checked to see if the thread should be disabled
+                const isThreadDisabled = shouldDisableThread(reportAction, reportID, false, isReportArchived);
+
+                // Then the thread should be enabled
+                expect(isThreadDisabled).toBeFalsy();
+            });
+            it('should be disabled if the report is archived and child visible action count is 0', () => {
+                // Given a normal report action with zero child visible action counts
+                const reportAction = {
+                    message: [
+                        {
+                            translationKey: '',
+                            type: 'COMMENT',
+                            html: 'test',
+                            text: 'test',
+                        },
+                    ],
+                    childVisibleActionCount: 0,
+                } as ReportAction;
+
+                // And a report that is not archived
+                const isReportArchived = true;
+
+                // When it's checked to see if the thread should be disabled
+                const isThreadDisabled = shouldDisableThread(reportAction, reportID, false, isReportArchived);
+
+                // Then the thread should be disabled
+                expect(isThreadDisabled).toBeTruthy();
             });
         });
     });

--- a/tests/unit/ReportUtilsTest.ts
+++ b/tests/unit/ReportUtilsTest.ts
@@ -1268,7 +1268,7 @@ describe('ReportUtils', () => {
             expect(shouldDisableThread(reportAction, reportID, true)).toBeTruthy();
         });
 
-        describe('only deleted actions with a child visible count of 0 should be disabled', () => {
+        describe('deleted threads', () => {
             it('should be enabled if the report action is not-deleted and visible action count is 1', () => {
                 // Given a normal report action with one child visible action count
                 const reportAction = {
@@ -1290,7 +1290,7 @@ describe('ReportUtils', () => {
                 expect(result).toBeFalsy();
             });
 
-            it('thread should be enabled if the report action is not-deleted and visible action count is 0', () => {
+            it('should be enabled if the report action is not-deleted and visible action count is 0', () => {
                 // Given a normal report action with zero child visible action count
                 const reportAction = {
                     message: [
@@ -1310,7 +1310,7 @@ describe('ReportUtils', () => {
                 // Then the thread should be enabled
                 expect(result).toBeFalsy();
             });
-            it('thread should be enabled if the report action is deleted and visible action count is 1', () => {
+            it('should be enabled if the report action is deleted and visible action count is 1', () => {
                 // Given a normal report action with one child visible action count
                 const reportAction = {
                     message: [
@@ -1331,7 +1331,7 @@ describe('ReportUtils', () => {
                 expect(result).toBeFalsy();
             });
 
-            it('thread should be disabled if the report action is deleted and visible action count is 0', () => {
+            it('should be disabled if the report action is deleted and visible action count is 0', () => {
                 // Given a normal report action with zero child visible action count
                 const reportAction = {
                     message: [


### PR DESCRIPTION
### Explanation of Change
The call to `getReportNameValuePairs()` was removed, which required passing `isArchivedReport` through the params.

### Fixed Issues
Part of https://github.com/Expensify/App/issues/59961

### Tests

1. Create a workspace
2. Send several messages to #announce room
3. Hover over a message (message A) >> Reply in thread
4. Send a reply message
5. Delete the workspace
6. Go to the archived #announce room from step 2
7. Hover over message A from step 3
8. Verify Reply in thread option shows
9. Press Reply in thread
10. Verify user navigates to the thread report
11. Hover over any message that has no reply in #announce room above
12. Verify Reply in thread option does not show

- [x] Verify that no errors appear in the JS console

### Offline tests
Same as tests

### QA Steps
Same as tests

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I verified there are no new alerts related to the `canBeMissing` param for `useOnyx`
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Desktop</summary>

<!-- add screenshots or videos here -->

</details>
