### PR TITLE
Fix: Prevent deleted unreported expenses from being added to report in offline mode

### DIFF
--- a/src/components/SelectionList/types.ts
+++ b/src/components/SelectionList/types.ts
@@ -822,6 +822,12 @@ type FlattenedSectionsReturn<TItem extends ListItem> = {
     someSelected: boolean;
 };
 
+type UnreportedExpenseListItemType = Transaction & {
+    isDisabled: boolean;
+    keyForList: string;
+    errors?: Errors;
+};
+
 type ButtonOrCheckBoxRoles = 'button' | 'checkbox';
 
 type ExtendedSectionListData<TItem extends ListItem, TSection extends SectionWithIndexOffset<TItem>> = SectionListData<TItem, TSection> & {
@@ -867,4 +873,5 @@ export type {
     SplitListItemProps,
     SplitListItemType,
     SearchListItem,
+    UnreportedExpenseListItemType,
 };

--- a/src/libs/TransactionUtils/index.ts
+++ b/src/libs/TransactionUtils/index.ts
@@ -6,6 +6,7 @@ import lodashSet from 'lodash/set';
 import type {OnyxCollection, OnyxEntry} from 'react-native-onyx';
 import Onyx from 'react-native-onyx';
 import type {ValueOf} from 'type-fest';
+import type {UnreportedExpenseListItemType} from '@components/SelectionList/types';
 import {getPolicyCategoriesData} from '@libs/actions/Policy/Category';
 import {getPolicyTagsData} from '@libs/actions/Policy/Tag';
 import type {MergeDuplicatesParams} from '@libs/API/parameters';
@@ -1601,23 +1602,17 @@ function isTransactionPendingDelete(transaction: OnyxEntry<Transaction>): boolea
     return getTransactionPendingAction(transaction) === CONST.RED_BRICK_ROAD_PENDING_ACTION.DELETE;
 }
 
-type UnreportedExpenseListItem = Transaction & {
-    isDisabled: boolean;
-    keyForList: string;
-    errors?: Errors;
-};
-
 /**
  * Creates sections data for unreported expenses, marking transactions with DELETE pending action as disabled
  */
-function createUnreportedExpenseSections(transactions: Array<Transaction | undefined>): Array<{shouldShow: boolean; data: UnreportedExpenseListItem[]}> {
+function createUnreportedExpenseSections(transactions: Array<Transaction | undefined>): Array<{shouldShow: boolean; data: UnreportedExpenseListItemType[]}> {
     return [
         {
             shouldShow: true,
             data: transactions
                 .filter((t): t is Transaction => t !== undefined)
                 .map(
-                    (transaction): UnreportedExpenseListItem => ({
+                    (transaction): UnreportedExpenseListItemType => ({
                         ...transaction,
                         isDisabled: isTransactionPendingDelete(transaction),
                         keyForList: transaction.transactionID,

--- a/src/libs/TransactionUtils/index.ts
+++ b/src/libs/TransactionUtils/index.ts
@@ -1601,6 +1601,23 @@ function isTransactionPendingDelete(transaction: OnyxEntry<Transaction>): boolea
     return getTransactionPendingAction(transaction) === CONST.RED_BRICK_ROAD_PENDING_ACTION.DELETE;
 }
 
+/**
+ * Creates sections data for unreported expenses, marking transactions with DELETE pending action as disabled
+ */
+function createUnreportedExpenseSections<T extends Transaction>(transactions: Array<T | undefined>): Array<{shouldShow: boolean; data: Array<T & {isDisabled: boolean}>}> {
+    return [
+        {
+            shouldShow: true,
+            data: transactions
+                .filter((t): t is T => t !== undefined)
+                .map((transaction) => ({
+                    ...transaction,
+                    isDisabled: isTransactionPendingDelete(transaction),
+                })),
+        },
+    ];
+}
+
 export {
     buildOptimisticTransaction,
     calculateTaxAmount,
@@ -1705,6 +1722,7 @@ export {
     getOriginalTransactionWithSplitInfo,
     getTransactionPendingAction,
     isTransactionPendingDelete,
+    createUnreportedExpenseSections,
 };
 
 export type {TransactionChanges};

--- a/src/pages/AddUnreportedExpense.tsx
+++ b/src/pages/AddUnreportedExpense.tsx
@@ -16,7 +16,7 @@ import {fetchUnreportedExpenses} from '@libs/actions/UnreportedExpenses';
 import interceptAnonymousUser from '@libs/interceptAnonymousUser';
 import type {AddUnreportedExpensesParamList} from '@libs/Navigation/types';
 import {shouldRestrictUserBillableActions} from '@libs/SubscriptionUtils';
-import {isTransactionPendingDelete} from '@libs/TransactionUtils';
+import {createUnreportedExpenseSections} from '@libs/TransactionUtils';
 import Navigation from '@navigation/Navigation';
 import type {PlatformStackScreenProps} from '@navigation/PlatformStackNavigation/types';
 import {startMoneyRequest} from '@userActions/IOU';
@@ -70,17 +70,7 @@ function AddUnreportedExpense({route}: AddUnreportedExpensePageType) {
     const styles = useThemeStyles();
     const selectionListRef = useRef<SelectionListHandle>(null);
     const sections: Array<SectionListDataType<Transaction & ListItem>> = useMemo(
-        () => [
-            {
-                shouldShow: true,
-                data: transactions
-                    .filter((t): t is Transaction & ListItem => t !== undefined)
-                    .map((transaction) => ({
-                        ...transaction,
-                        isDisabled: isTransactionPendingDelete(transaction),
-                    })),
-            },
-        ],
+        () => createUnreportedExpenseSections(transactions as Array<(Transaction & ListItem) | undefined>),
         [transactions],
     );
 

--- a/src/pages/AddUnreportedExpense.tsx
+++ b/src/pages/AddUnreportedExpense.tsx
@@ -69,10 +69,7 @@ function AddUnreportedExpense({route}: AddUnreportedExpensePageType) {
 
     const styles = useThemeStyles();
     const selectionListRef = useRef<SelectionListHandle>(null);
-    const sections: Array<SectionListDataType<Transaction & ListItem>> = useMemo(
-        () => createUnreportedExpenseSections(transactions as Array<(Transaction & ListItem) | undefined>),
-        [transactions],
-    );
+    const sections: Array<SectionListDataType<Transaction & ListItem>> = useMemo(() => createUnreportedExpenseSections(transactions), [transactions]);
 
     const thereIsNoUnreportedTransaction = !((sections.at(0)?.data.length ?? 0) > 0);
 

--- a/tests/unit/AddUnreportedExpenseTest.ts
+++ b/tests/unit/AddUnreportedExpenseTest.ts
@@ -1,0 +1,115 @@
+import {createUnreportedExpenseSections} from '@libs/TransactionUtils';
+import CONST from '@src/CONST';
+import type Transaction from '@src/types/onyx/Transaction';
+
+function generateTransaction(values: Partial<Transaction> = {}): Transaction {
+    const baseTransaction: Transaction = {
+        transactionID: `transaction_${Math.random()}`,
+        reportID: CONST.REPORT.UNREPORTED_REPORT_ID,
+        amount: 1000,
+        currency: 'USD',
+        merchant: 'Test Merchant',
+        category: '',
+        comment: {comment: ''},
+        created: '2025-06-12',
+        tag: '',
+        billable: false,
+        receipt: {},
+        filename: '',
+        taxCode: '',
+        taxAmount: 0,
+        pendingAction: undefined,
+        ...values,
+    };
+    return baseTransaction;
+}
+
+describe('AddUnreportedExpense', () => {
+    describe('createUnreportedExpenseSections', () => {
+        it('should mark transactions with DELETE pendingAction as disabled', () => {
+            const normalTransaction = generateTransaction({
+                transactionID: '123',
+                pendingAction: undefined,
+                amount: 1000,
+                merchant: 'Normal Merchant',
+            });
+
+            const deletedTransaction = generateTransaction({
+                transactionID: '456',
+                pendingAction: CONST.RED_BRICK_ROAD_PENDING_ACTION.DELETE,
+                amount: 2000,
+                merchant: 'Deleted Merchant',
+            });
+
+            const transactions = [normalTransaction, deletedTransaction];
+            const sections = createUnreportedExpenseSections(transactions);
+
+            // Should create one section
+            expect(sections).toHaveLength(1);
+            expect(sections.at(0)?.shouldShow).toBe(true);
+            expect(sections.at(0)?.data).toHaveLength(2);
+
+            const processedNormalTransaction = sections.at(0)?.data.find((t) => t.transactionID === '123');
+            expect(processedNormalTransaction?.isDisabled).toBe(false);
+
+            const processedDeletedTransaction = sections.at(0)?.data.find((t) => t.transactionID === '456');
+            expect(processedDeletedTransaction?.isDisabled).toBe(true);
+        });
+
+        it('should not mark transactions without DELETE pendingAction as disabled', () => {
+            const normalTransaction = generateTransaction({
+                transactionID: '123',
+                pendingAction: undefined,
+                amount: 1000,
+                merchant: 'Normal Merchant',
+            });
+
+            const updateTransaction = generateTransaction({
+                transactionID: '456',
+                pendingAction: CONST.RED_BRICK_ROAD_PENDING_ACTION.UPDATE,
+                amount: 2000,
+                merchant: 'Update Merchant',
+            });
+
+            const addTransaction = generateTransaction({
+                transactionID: '789',
+                pendingAction: CONST.RED_BRICK_ROAD_PENDING_ACTION.ADD,
+                amount: 3000,
+                merchant: 'Add Merchant',
+            });
+
+            const transactions = [normalTransaction, updateTransaction, addTransaction];
+            const sections = createUnreportedExpenseSections(transactions);
+
+            expect(sections.at(0)?.data).toHaveLength(3);
+            sections.at(0)?.data.forEach((transaction) => {
+                expect(transaction.isDisabled).toBe(false);
+            });
+        });
+
+        it('should handle transaction list with only deleted transactions', () => {
+            const deletedTransaction1 = generateTransaction({
+                transactionID: '123',
+                pendingAction: CONST.RED_BRICK_ROAD_PENDING_ACTION.DELETE,
+                amount: 1000,
+                merchant: 'Deleted Merchant 1',
+            });
+
+            const deletedTransaction2 = generateTransaction({
+                transactionID: '456',
+                pendingAction: CONST.RED_BRICK_ROAD_PENDING_ACTION.DELETE,
+                amount: 2000,
+                merchant: 'Deleted Merchant 2',
+            });
+
+            const transactions = [deletedTransaction1, deletedTransaction2];
+            const sections = createUnreportedExpenseSections(transactions);
+
+            expect(sections.at(0)?.data).toHaveLength(2);
+            sections.at(0)?.data.forEach((transaction) => {
+                expect(transaction.isDisabled).toBe(true);
+                expect(transaction.pendingAction).toBe(CONST.RED_BRICK_ROAD_PENDING_ACTION.DELETE);
+            });
+        });
+    });
+});


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
<!-- Explain what your change does and how it addresses the linked issue -->

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/63858
PROPOSAL: https://github.com/Expensify/App/issues/63858#issuecomment-2959517973


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
Same as QA Steps

- [x] Verify that no errors appear in the JS console

### Offline tests
Same as QA Steps

### QA Steps
Precondition:
- Account has self DM and a workspace

1. Go to workspace chat
2. Click + > Create report
3. Go to self DM
4. Track a manual expense in self DM
5. Go offline
6. Delete the track expense from Step 4
7. Go to workspace chat
8. On the empty report preview, click Add expense > Add unreported expense
9. Verify that the deleted tracked expense is disabled in the unreported expense list while offline

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I verified there are no new alerts related to the `canBeMissing` param for `useOnyx`
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

https://github.com/user-attachments/assets/b22d9cfd-8b6c-4b97-9426-991d8be9d7ea

</details>

<details>
<summary>Android: mWeb Chrome</summary>

https://github.com/user-attachments/assets/5c27c213-5c61-4c68-aee5-872197e8b6eb

</details>

<details>
<summary>iOS: Native</summary>

https://github.com/user-attachments/assets/295b8722-05b0-4375-9850-b5b84113913e

</details>

<details>
<summary>iOS: mWeb Safari</summary>

https://github.com/user-attachments/assets/08ea7c5d-0409-421e-bc65-33c2c61d8e0f

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

https://github.com/user-attachments/assets/ca144029-8b1d-41e8-9339-051b4d28f917

</details>

<details>
<summary>MacOS: Desktop</summary>

https://github.com/user-attachments/assets/13a2c0c4-9a94-4dc5-b2c1-3fccd52002f2

</details>
