### PR TITLE
fix: missing backTo params on split screen

### DIFF
--- a/src/ROUTES.ts
+++ b/src/ROUTES.ts
@@ -5,6 +5,8 @@ import type {IOUAction, IOUType} from './CONST';
 import type {IOURequestType} from './libs/actions/IOU';
 import Log from './libs/Log';
 import type {ReimbursementAccountStepToOpen} from './libs/ReimbursementAccountUtils';
+import SCREENS from './SCREENS';
+import type {Screen} from './SCREENS';
 import type {ExitReason} from './types/form/ExitSurveyReasonForm';
 import type {ConnectionName, SageIntacctMappingName} from './types/onyx/Policy';
 import type {CustomFieldType} from './types/onyx/PolicyEmployee';
@@ -2616,7 +2618,20 @@ const HYBRID_APP_ROUTES = {
     MONEY_REQUEST_CREATE_TAB_DISTANCE: '/submit/new/distance',
 } as const;
 
-export {HYBRID_APP_ROUTES, getUrlWithBackToParam, PUBLIC_SCREENS_ROUTES};
+/**
+ * Configuration for shared parameters that can be passed between routes.
+ * These parameters are commonly used across multiple screens and are preserved
+ * during navigation state transitions.
+ *
+ * Currently includes:
+ * - `backTo`: Specifies the route to return to when navigating back, preserving
+ *   navigation context in split-screen and central screen
+ */
+const SHARED_ROUTE_PARAMS: Partial<Record<Screen, string[]>> = {
+    [SCREENS.WORKSPACE.INITIAL]: ['backTo'],
+} as const;
+
+export {HYBRID_APP_ROUTES, getUrlWithBackToParam, PUBLIC_SCREENS_ROUTES, SHARED_ROUTE_PARAMS};
 export default ROUTES;
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/libs/Navigation/AppNavigator/createSplitNavigator/SplitRouter.ts
+++ b/src/libs/Navigation/AppNavigator/createSplitNavigator/SplitRouter.ts
@@ -59,7 +59,7 @@ function adaptStateIfNecessary({state, options: {sidebarScreen, defaultCentralSc
     // - sidebarScreen to cover left pane.
     // - defaultCentralScreen to cover central pane.
     if (!isAtLeastOneInState(state, sidebarScreen) && shouldSplitHaveSidebar) {
-        const paramsFromRoute = getParamsFromRoute(sidebarScreen);
+        const paramsFromRoute = getParamsFromRoute(sidebarScreen, true);
         const copiedParams = pick(lastRoute?.params, paramsFromRoute);
 
         // We don't want to get an empty object as params because it breaks some navigation logic when comparing if routes are the same.

--- a/src/libs/Navigation/AppNavigator/createSplitNavigator/SplitRouter.ts
+++ b/src/libs/Navigation/AppNavigator/createSplitNavigator/SplitRouter.ts
@@ -59,7 +59,7 @@ function adaptStateIfNecessary({state, options: {sidebarScreen, defaultCentralSc
     // - sidebarScreen to cover left pane.
     // - defaultCentralScreen to cover central pane.
     if (!isAtLeastOneInState(state, sidebarScreen) && shouldSplitHaveSidebar) {
-        const paramsFromRoute = getParamsFromRoute(sidebarScreen, true);
+        const paramsFromRoute = getParamsFromRoute(sidebarScreen, !isNarrowLayout);
         const copiedParams = pick(lastRoute?.params, paramsFromRoute);
 
         // We don't want to get an empty object as params because it breaks some navigation logic when comparing if routes are the same.

--- a/src/libs/Navigation/helpers/getParamsFromRoute.ts
+++ b/src/libs/Navigation/helpers/getParamsFromRoute.ts
@@ -1,12 +1,26 @@
 import {normalizedConfigs} from '@libs/Navigation/linkingConfig/config';
+import {SHARED_ROUTE_PARAMS} from '@src/ROUTES';
 import type {Screen} from '@src/SCREENS';
 
-function getParamsFromRoute(screenName: string): string[] {
+function getParamsFromRoute(screenName: string, includeSharedParams?: boolean): string[] {
     const routeConfig = normalizedConfigs[screenName as Screen];
 
-    const route = routeConfig.pattern;
+    if (!routeConfig?.pattern) {
+        return [];
+    }
 
-    return route.match(/(?<=[:?&])(\w+)(?=[/=?&]|$)/g) ?? [];
+    const route = routeConfig.pattern;
+    const pathParams = route.match(/(?<=[:?&])(\w+)(?=[/=?&]|$)/g) ?? [];
+
+    if (!includeSharedParams) {
+        return pathParams;
+    }
+
+    // Get shared parameters from the configuration
+    const sharedParams = SHARED_ROUTE_PARAMS[screenName as Screen] ?? [];
+
+    // Combine both path parameters and shared parameters, removing duplicates
+    return [...new Set([...pathParams, ...sharedParams])];
 }
 
 export default getParamsFromRoute;

--- a/tests/navigation/GoBackTests.tsx
+++ b/tests/navigation/GoBackTests.tsx
@@ -457,6 +457,7 @@ describe('Go back on the narrow layout', () => {
 });
 describe('Go back on the wide layout', () => {
     beforeEach(() => {
+        mockedGetIsNarrowLayout.mockReturnValue(false);
         mockedUseResponsiveLayout.mockReturnValue({
             ...CONST.NAVIGATION_TESTS.DEFAULT_USE_RESPONSIVE_LAYOUT_VALUE,
             shouldUseNarrowLayout: false,

--- a/tests/navigation/GoBackTests.tsx
+++ b/tests/navigation/GoBackTests.tsx
@@ -26,7 +26,8 @@ jest.mock('@src/components/Navigation/TopLevelNavigationTabBar');
 
 const mockedGetIsNarrowLayout = getIsNarrowLayout as jest.MockedFunction<typeof getIsNarrowLayout>;
 const mockedUseResponsiveLayout = useResponsiveLayout as jest.MockedFunction<typeof useResponsiveLayout>;
-
+const mockedPolicyID = 'test-policy';
+const mockedBackToRoute = '/test';
 describe('Go back on the narrow layout', () => {
     beforeEach(() => {
         mockedGetIsNarrowLayout.mockReturnValue(true);
@@ -451,6 +452,51 @@ describe('Go back on the narrow layout', () => {
             expect(reportsSplitAfterGoBack?.state?.index).toBe(3);
             expect(reportsSplitAfterGoBack?.state?.routes.at(-1)?.name).toBe(SCREENS.REPORT);
             expect(reportsSplitAfterGoBack?.state?.routes.at(-1)?.params).toMatchObject({reportID: '1'});
+        });
+    });
+});
+describe('Go back on the wide layout', () => {
+    beforeEach(() => {
+        mockedUseResponsiveLayout.mockReturnValue({
+            ...CONST.NAVIGATION_TESTS.DEFAULT_USE_RESPONSIVE_LAYOUT_VALUE,
+            shouldUseNarrowLayout: false,
+            isSmallScreenWidth: false,
+            isLargeScreenWidth: true,
+        });
+    });
+
+    it('should preserved backTo params between central screen and side bar screen', () => {
+        // Given the initialized navigation with workspaces split navigator
+        render(
+            <TestNavigationContainer
+                initialState={{
+                    index: 0,
+                    routes: [
+                        {
+                            name: NAVIGATORS.WORKSPACE_SPLIT_NAVIGATOR,
+                            state: {
+                                index: 0,
+                                routes: [
+                                    {
+                                        name: SCREENS.WORKSPACE.PER_DIEM,
+                                        params: {policyID: mockedPolicyID, backTo: mockedBackToRoute},
+                                    },
+                                ],
+                            },
+                        },
+                    ],
+                }}
+            />,
+        );
+
+        // Then the backTo params should be preserved in the sidebar route
+        const initialRootState = navigationRef.current?.getRootState();
+        const initialWorkspaceNavigator = initialRootState?.routes.at(0);
+        const initialRoutes = initialWorkspaceNavigator?.state?.routes ?? [];
+        const initialSidebarRoute = initialRoutes.find((route) => route.name === SCREENS.WORKSPACE.INITIAL);
+        expect(initialSidebarRoute?.params).toMatchObject({
+            policyID: mockedPolicyID,
+            backTo: mockedBackToRoute,
         });
     });
 });

--- a/tests/utils/TestNavigationContainer.tsx
+++ b/tests/utils/TestNavigationContainer.tsx
@@ -49,6 +49,10 @@ function TestWorkspaceSplitNavigator() {
                 name={SCREENS.WORKSPACE.CATEGORIES}
                 getComponent={getEmptyComponent}
             />
+            <WorkspaceSplit.Screen
+                name={SCREENS.WORKSPACE.PER_DIEM}
+                getComponent={getEmptyComponent}
+            />
         </WorkspaceSplit.Navigator>
     );
 }


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
When navigating from the report RHP page to the Per Diem page, we pass the `backTo` parameter to the route. However, in the `Workspace Initial `page, the `backTo` parameter is undefined. The function `getParamsFromRoute` is used to extract parameters that match a regex and pass them to the sidebarScreen page. Since `backTo` is not part of the workspace initial `path`, it is not included in this process, resulting in the `backTo` parameter being missing.
https://github.com/Expensify/App/blob/1cd33a2fc969ccf5ad97acd9cef4d11902b327b2/src/libs/Navigation/AppNavigator/createSplitNavigator/SplitRouter.ts#L62-L63
In this PR, we fixed the issue described above by adding a new configuration to accept the `backTo` parameter.
### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/63483
PROPOSAL: https://github.com/Expensify/App/issues/63483#issuecomment-2952355780


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

- Verify the test from NAVIGATION_TESTS
- Verify the test from QA steps

- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->
Same as QA steps
### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->

1. Navigate to https://staging.new.expensify.com/
2. Log in with any account
3. Create a workspace
4. Navigate to Workspace settings - More features
5. Enable "Per diem"
6. Navigate to the workspace chat
7. Navigate to "+" - Create expense - Per diem
8. Click on the "Edit per diem rates" button
9. Click on the "<" button => Verify the app navigate to Create expense  - Per diem page
10. Repeat step 8
11. Refresh the page
12. Click on the '<" button => Verify that the app opens the "Create Expense - Per Diem" page with the workspace list page in the background.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I verified there are no new alerts related to the `canBeMissing` param for `useOnyx`
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>


https://github.com/user-attachments/assets/65335f0e-5824-492e-ad4a-ffe431fb8e2f



</details>

<details>
<summary>Android: mWeb Chrome</summary>


https://github.com/user-attachments/assets/c1066384-6b13-425e-b510-0897b80605ee



</details>

<details>
<summary>iOS: Native</summary>

https://github.com/user-attachments/assets/beafc5fe-d1c5-4264-a9d6-ffb0466006cc

</details>

<details>
<summary>iOS: mWeb Safari</summary>


https://github.com/user-attachments/assets/c80e190f-5b35-40cb-97c8-19a07da72520



</details>

<details>
<summary>MacOS: Chrome / Safari</summary>


https://github.com/user-attachments/assets/11a9642a-8240-406a-9964-627ddacfbadb



</details>

<details>
<summary>MacOS: Desktop</summary>

https://github.com/user-attachments/assets/029753a6-b0bd-4aef-8614-1963885ff19e




</details>
