### PR TITLE
Always use currency symbol on left of number

### DIFF
--- a/src/components/TextInputWithCurrencySymbol/BaseTextInputWithCurrencySymbol.tsx
+++ b/src/components/TextInputWithCurrencySymbol/BaseTextInputWithCurrencySymbol.tsx
@@ -31,7 +31,6 @@ function BaseTextInputWithCurrencySymbol(
     const currencySymbol = getLocalizedCurrencySymbol(selectedCurrencyCode);
     const styles = useThemeStyles();
 
-
     /**
      * Set a new amount value properly formatted
      *
@@ -44,11 +43,13 @@ function BaseTextInputWithCurrencySymbol(
 
     return (
         <>
-            {!hideCurrencySymbol && <CurrencySymbolButton
-                currencySymbol={currencySymbol ?? ''}
-                onCurrencyButtonPress={onCurrencyButtonPress}
-                isCurrencyPressable={isCurrencyPressable}
-            />}
+            {!hideCurrencySymbol && (
+                <CurrencySymbolButton
+                    currencySymbol={currencySymbol ?? ''}
+                    onCurrencyButtonPress={onCurrencyButtonPress}
+                    isCurrencyPressable={isCurrencyPressable}
+                />
+            )}
             <AmountTextInput
                 formattedAmount={formattedAmount}
                 onChangeAmount={setFormattedAmount}

--- a/src/components/TextInputWithCurrencySymbol/BaseTextInputWithCurrencySymbol.tsx
+++ b/src/components/TextInputWithCurrencySymbol/BaseTextInputWithCurrencySymbol.tsx
@@ -4,8 +4,8 @@ import AmountTextInput from '@components/AmountTextInput';
 import CurrencySymbolButton from '@components/CurrencySymbolButton';
 import useLocalize from '@hooks/useLocalize';
 import useThemeStyles from '@hooks/useThemeStyles';
-import * as CurrencyUtils from '@libs/CurrencyUtils';
-import * as MoneyRequestUtils from '@libs/MoneyRequestUtils';
+import {getLocalizedCurrencySymbol} from '@libs/CurrencyUtils';
+import {addLeadingZero, replaceAllDigits} from '@libs/MoneyRequestUtils';
 import type {BaseTextInputRef} from '@src/components/TextInput/BaseTextInput/types';
 import type BaseTextInputWithCurrencySymbolProps from './types';
 
@@ -28,7 +28,7 @@ function BaseTextInputWithCurrencySymbol(
     ref: React.ForwardedRef<BaseTextInputRef>,
 ) {
     const {fromLocaleDigit} = useLocalize();
-    const currencySymbol = CurrencyUtils.getLocalizedCurrencySymbol(selectedCurrencyCode);
+    const currencySymbol = getLocalizedCurrencySymbol(selectedCurrencyCode);
     const styles = useThemeStyles();
 
 
@@ -38,7 +38,7 @@ function BaseTextInputWithCurrencySymbol(
      * @param text - Changed text from user input
      */
     const setFormattedAmount = (text: string) => {
-        const newAmount = MoneyRequestUtils.addLeadingZero(MoneyRequestUtils.replaceAllDigits(text, fromLocaleDigit));
+        const newAmount = addLeadingZero(replaceAllDigits(text, fromLocaleDigit));
         onChangeAmount(newAmount);
     };
 

--- a/src/components/TextInputWithCurrencySymbol/BaseTextInputWithCurrencySymbol.tsx
+++ b/src/components/TextInputWithCurrencySymbol/BaseTextInputWithCurrencySymbol.tsx
@@ -29,16 +29,8 @@ function BaseTextInputWithCurrencySymbol(
 ) {
     const {fromLocaleDigit} = useLocalize();
     const currencySymbol = CurrencyUtils.getLocalizedCurrencySymbol(selectedCurrencyCode);
-    const isCurrencySymbolLTR = CurrencyUtils.isCurrencySymbolLTR(selectedCurrencyCode);
     const styles = useThemeStyles();
 
-    const currencySymbolButton = !hideCurrencySymbol && (
-        <CurrencySymbolButton
-            currencySymbol={currencySymbol ?? ''}
-            onCurrencyButtonPress={onCurrencyButtonPress}
-            isCurrencyPressable={isCurrencyPressable}
-        />
-    );
 
     /**
      * Set a new amount value properly formatted
@@ -50,37 +42,27 @@ function BaseTextInputWithCurrencySymbol(
         onChangeAmount(newAmount);
     };
 
-    const amountTextInput = (
-        <AmountTextInput
-            formattedAmount={formattedAmount}
-            onChangeAmount={setFormattedAmount}
-            placeholder={placeholder}
-            ref={ref}
-            selection={selection}
-            onSelectionChange={(event: NativeSyntheticEvent<TextInputSelectionChangeEventData>) => {
-                onSelectionChange(event);
-            }}
-            onKeyPress={onKeyPress}
-            style={[styles.pr1, style]}
-            // eslint-disable-next-line react/jsx-props-no-spreading
-            {...rest}
-        />
-    );
-
-    if (isCurrencySymbolLTR) {
-        return (
-            <>
-                {currencySymbolButton}
-                {amountTextInput}
-                {extraSymbol}
-            </>
-        );
-    }
-
     return (
         <>
-            {amountTextInput}
-            {currencySymbolButton}
+            {!hideCurrencySymbol && <CurrencySymbolButton
+                currencySymbol={currencySymbol ?? ''}
+                onCurrencyButtonPress={onCurrencyButtonPress}
+                isCurrencyPressable={isCurrencyPressable}
+            />}
+            <AmountTextInput
+                formattedAmount={formattedAmount}
+                onChangeAmount={setFormattedAmount}
+                placeholder={placeholder}
+                ref={ref}
+                selection={selection}
+                onSelectionChange={(event: NativeSyntheticEvent<TextInputSelectionChangeEventData>) => {
+                    onSelectionChange(event);
+                }}
+                onKeyPress={onKeyPress}
+                style={[styles.pr1, style]}
+                // eslint-disable-next-line react/jsx-props-no-spreading
+                {...rest}
+            />
             {extraSymbol}
         </>
     );

--- a/src/libs/CurrencyUtils.ts
+++ b/src/libs/CurrencyUtils.ts
@@ -65,19 +65,6 @@ function getCurrencySymbol(currencyCode: string): string | undefined {
 }
 
 /**
- * Whether the currency symbol is left-to-right.
- */
-function isCurrencySymbolLTR(currencyCode: string): boolean {
-    const parts = formatToParts(TranslationStore.getCurrentLocale(), 0, {
-        style: 'currency',
-        currency: currencyCode,
-    });
-
-    // Currency is LTR when the first part is of currency type.
-    return parts.at(0)?.type === 'currency';
-}
-
-/**
  * Takes an amount as a floating point number and converts it to an integer equivalent to the amount in "cents".
  * This is because the backend always stores amounts in "cents". The backend works in integer cents to avoid precision errors
  * when doing math operations.
@@ -213,7 +200,6 @@ export {
     getCurrencyUnit,
     getLocalizedCurrencySymbol,
     getCurrencySymbol,
-    isCurrencySymbolLTR,
     convertToBackendAmount,
     convertToFrontendAmountAsInteger,
     convertToFrontendAmountAsString,

--- a/tests/unit/CurrencyUtilsTest.ts
+++ b/tests/unit/CurrencyUtilsTest.ts
@@ -48,18 +48,6 @@ describe('CurrencyUtils', () => {
         );
     });
 
-    describe('isCurrencySymbolLTR', () => {
-        test.each([
-            [true, CONST.LOCALES.EN, 'USD'],
-            [false, CONST.LOCALES.ES, 'USD'],
-        ])('Returns %s for preferredLocale %s and currencyCode %s', (isLeft, locale, currencyCode) =>
-            TranslationStore.load(locale).then(() => {
-                const isSymbolLeft = CurrencyUtils.isCurrencySymbolLTR(currencyCode);
-                expect(isSymbolLeft).toBe(isLeft);
-            }),
-        );
-    });
-
     describe('getCurrencyDecimals', () => {
         test('Currency decimals smaller than or equal 2', () => {
             expect(CurrencyUtils.getCurrencyDecimals('JPY')).toBe(0);


### PR DESCRIPTION
### Explanation of Change
Changes the BNP to always have the currency to the left of the number so that's standardized across the different locales.

### Fixed Issues
$ https://github.com/Expensify/App/issues/64349

### Tests
1. Click Settings > Preferences > Languages > Pick `Deutsh`
2. Go to + > Create expense
3. Click the manual tab
4. Observe the orientation of the currency selector on the BNP, the currency symbol should be to the left of the amount

NOTE: This is the new expected behavior for all locales (including Spanish). This ONLY applies to the BNP, other places in App still use the locale preferences to display currency and amounts.

- [x] Verify that no errors appear in the JS console

### Offline tests
N/A

### QA Steps
Same as test steps


- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I verified there are no new alerts related to the `canBeMissing` param for `useOnyx`
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos

https://github.com/user-attachments/assets/e5df3cf4-4296-497c-96e0-c9d6d9ae6899


<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Desktop</summary>

<!-- add screenshots or videos here -->

</details>
