### PR TITLE
Update pending field for prohibited expense toggle

### DIFF
--- a/src/CONST/index.ts
+++ b/src/CONST/index.ts
@@ -3065,6 +3065,13 @@ const CONST = {
             PREVENT_SELF_APPROVAL: 'preventSelfApproval',
             MAX_EXPENSE_AGE: 'maxExpenseAge',
         },
+        PROHIBITED_EXPENSES: {
+            ALCOHOL: 'alcohol',
+            HOTEL_INCIDENTALS: 'hotelIncidentals',
+            GAMBLING: 'gambling',
+            TOBACCO: 'tobacco',
+            ADULT_ENTERTAINMENT: 'adultEntertainment',
+        },
         CONNECTIONS: {
             NAME: {
                 // Here we will add other connections names when we add support for them

--- a/src/libs/actions/Policy/Policy.ts
+++ b/src/libs/actions/Policy/Policy.ts
@@ -4088,15 +4088,19 @@ function setPolicyMaxExpenseAmount(policyID: string, maxExpenseAmount: string) {
 /**
  *
  * @param policyID
- * @param prohibitedExpenses
+ * @param prohibitedExpense
  */
-function setPolicyProhibitedExpenses(policyID: string, prohibitedExpense: keyof ProhibitedExpenses) {
+function setPolicyProhibitedExpense(policyID: string, prohibitedExpense: keyof ProhibitedExpenses) {
     // This will be fixed as part of https://github.com/Expensify/Expensify/issues/507850
     // eslint-disable-next-line deprecation/deprecation
     const policy = getPolicy(policyID);
     const originalProhibitedExpenses = policy?.prohibitedExpenses;
     const prohibitedExpenses = {
-        ...originalProhibitedExpenses,
+        [CONST.POLICY.PROHIBITED_EXPENSES.ADULT_ENTERTAINMENT]: originalProhibitedExpenses?.[CONST.POLICY.PROHIBITED_EXPENSES.ADULT_ENTERTAINMENT],
+        [CONST.POLICY.PROHIBITED_EXPENSES.ALCOHOL]: originalProhibitedExpenses?.[CONST.POLICY.PROHIBITED_EXPENSES.ALCOHOL],
+        [CONST.POLICY.PROHIBITED_EXPENSES.GAMBLING]: originalProhibitedExpenses?.[CONST.POLICY.PROHIBITED_EXPENSES.GAMBLING],
+        [CONST.POLICY.PROHIBITED_EXPENSES.HOTEL_INCIDENTALS]: originalProhibitedExpenses?.[CONST.POLICY.PROHIBITED_EXPENSES.HOTEL_INCIDENTALS],
+        [CONST.POLICY.PROHIBITED_EXPENSES.TOBACCO]: originalProhibitedExpenses?.[CONST.POLICY.PROHIBITED_EXPENSES.TOBACCO],
         [prohibitedExpense]: !originalProhibitedExpenses?.[prohibitedExpense],
     };
 
@@ -5448,7 +5452,7 @@ export {
     setPolicyMaxExpenseAmount,
     setPolicyMaxExpenseAge,
     updateCustomRules,
-    setPolicyProhibitedExpenses,
+    setPolicyProhibitedExpense,
     setPolicyBillableMode,
     disableWorkspaceBillableExpenses,
     setWorkspaceEReceiptsEnabled,

--- a/src/libs/actions/Policy/Policy.ts
+++ b/src/libs/actions/Policy/Policy.ts
@@ -4096,11 +4096,7 @@ function setPolicyProhibitedExpense(policyID: string, prohibitedExpense: keyof P
     const policy = getPolicy(policyID);
     const originalProhibitedExpenses = policy?.prohibitedExpenses;
     const prohibitedExpenses = {
-        [CONST.POLICY.PROHIBITED_EXPENSES.ADULT_ENTERTAINMENT]: originalProhibitedExpenses?.[CONST.POLICY.PROHIBITED_EXPENSES.ADULT_ENTERTAINMENT],
-        [CONST.POLICY.PROHIBITED_EXPENSES.ALCOHOL]: originalProhibitedExpenses?.[CONST.POLICY.PROHIBITED_EXPENSES.ALCOHOL],
-        [CONST.POLICY.PROHIBITED_EXPENSES.GAMBLING]: originalProhibitedExpenses?.[CONST.POLICY.PROHIBITED_EXPENSES.GAMBLING],
-        [CONST.POLICY.PROHIBITED_EXPENSES.HOTEL_INCIDENTALS]: originalProhibitedExpenses?.[CONST.POLICY.PROHIBITED_EXPENSES.HOTEL_INCIDENTALS],
-        [CONST.POLICY.PROHIBITED_EXPENSES.TOBACCO]: originalProhibitedExpenses?.[CONST.POLICY.PROHIBITED_EXPENSES.TOBACCO],
+        ...originalProhibitedExpenses,
         [prohibitedExpense]: !originalProhibitedExpenses?.[prohibitedExpense],
     };
 
@@ -4145,9 +4141,11 @@ function setPolicyProhibitedExpense(policyID: string, prohibitedExpense: keyof P
         ],
     };
 
+    // Remove pendingFields before sending to the API
+    const {pendingFields, ...prohibitedExpensesWithoutPendingFields} = prohibitedExpenses;
     const parameters: SetPolicyProhibitedExpensesParams = {
         policyID,
-        prohibitedExpenses: JSON.stringify(prohibitedExpenses),
+        prohibitedExpenses: JSON.stringify(prohibitedExpensesWithoutPendingFields),
     };
 
     API.write(WRITE_COMMANDS.SET_POLICY_PROHIBITED_EXPENSES, parameters, onyxData);

--- a/src/libs/actions/Policy/Policy.ts
+++ b/src/libs/actions/Policy/Policy.ts
@@ -4098,9 +4098,6 @@ function setPolicyProhibitedExpenses(policyID: string, prohibitedExpense: keyof 
     const prohibitedExpenses = {
         ...originalProhibitedExpenses,
         [prohibitedExpense]: !originalProhibitedExpenses?.[prohibitedExpense],
-        pendingFields: {
-            [prohibitedExpense]: CONST.RED_BRICK_ROAD_PENDING_ACTION.UPDATE,
-        },
     };
 
     const onyxData: OnyxData = {
@@ -4109,7 +4106,12 @@ function setPolicyProhibitedExpenses(policyID: string, prohibitedExpense: keyof 
                 onyxMethod: Onyx.METHOD.MERGE,
                 key: `${ONYXKEYS.COLLECTION.POLICY}${policyID}`,
                 value: {
-                    prohibitedExpenses,
+                    prohibitedExpenses: {
+                        ...prohibitedExpenses,
+                        pendingFields: {
+                            [prohibitedExpense]: CONST.RED_BRICK_ROAD_PENDING_ACTION.UPDATE,
+                        },
+                    },
                 },
             },
         ],

--- a/src/libs/actions/Policy/Policy.ts
+++ b/src/libs/actions/Policy/Policy.ts
@@ -4090,11 +4090,19 @@ function setPolicyMaxExpenseAmount(policyID: string, maxExpenseAmount: string) {
  * @param policyID
  * @param prohibitedExpenses
  */
-function setPolicyProhibitedExpenses(policyID: string, prohibitedExpenses: ProhibitedExpenses) {
+function setPolicyProhibitedExpenses(policyID: string, prohibitedExpense: keyof ProhibitedExpenses) {
     // This will be fixed as part of https://github.com/Expensify/Expensify/issues/507850
     // eslint-disable-next-line deprecation/deprecation
     const policy = getPolicy(policyID);
     const originalProhibitedExpenses = policy?.prohibitedExpenses;
+    const prohibitedExpenses = {
+        ...originalProhibitedExpenses,
+        [prohibitedExpense]: !originalProhibitedExpenses?.[prohibitedExpense],
+        pendingFields: {
+            [prohibitedExpense]: CONST.RED_BRICK_ROAD_PENDING_ACTION.UPDATE,
+        },
+    };
+
     const onyxData: OnyxData = {
         optimisticData: [
             {
@@ -4102,9 +4110,6 @@ function setPolicyProhibitedExpenses(policyID: string, prohibitedExpenses: Prohi
                 key: `${ONYXKEYS.COLLECTION.POLICY}${policyID}`,
                 value: {
                     prohibitedExpenses,
-                    pendingFields: {
-                        prohibitedExpenses: CONST.RED_BRICK_ROAD_PENDING_ACTION.UPDATE,
-                    },
                 },
             },
         ],
@@ -4113,7 +4118,11 @@ function setPolicyProhibitedExpenses(policyID: string, prohibitedExpenses: Prohi
                 onyxMethod: Onyx.METHOD.MERGE,
                 key: `${ONYXKEYS.COLLECTION.POLICY}${policyID}`,
                 value: {
-                    pendingFields: {prohibitedExpenses: null},
+                    prohibitedExpenses: {
+                        pendingFields: {
+                            [prohibitedExpense]: null,
+                        },
+                    },
                     errorFields: null,
                 },
             },
@@ -4124,7 +4133,6 @@ function setPolicyProhibitedExpenses(policyID: string, prohibitedExpenses: Prohi
                 key: `${ONYXKEYS.COLLECTION.POLICY}${policyID}`,
                 value: {
                     prohibitedExpenses: originalProhibitedExpenses,
-                    pendingFields: {prohibitedExpenses: null},
                     errorFields: {prohibitedExpenses: ErrorUtils.getMicroSecondOnyxErrorWithTranslationKey('common.genericErrorMessage')},
                 },
             },

--- a/src/pages/workspace/rules/IndividualExpenseRulesSection.tsx
+++ b/src/pages/workspace/rules/IndividualExpenseRulesSection.tsx
@@ -20,6 +20,7 @@ import type {TranslationPaths} from '@src/languages/types';
 import ROUTES from '@src/ROUTES';
 import type {Policy} from '@src/types/onyx';
 import type {PendingAction} from '@src/types/onyx/OnyxCommon';
+import {isEmptyObject} from '@src/types/utils/EmptyObject';
 
 type IndividualExpenseRulesSectionProps = {
     policyID: string;
@@ -175,7 +176,7 @@ function IndividualExpenseRulesSection({policyID}: IndividualExpenseRulesSection
         title: prohibitedExpenses,
         descriptionTranslationKey: 'workspace.rules.individualExpenseRules.prohibitedExpenses',
         action: () => Navigation.navigate(ROUTES.RULES_PROHIBITED_DEFAULT.getRoute(policyID)),
-        pendingAction: policy?.pendingFields?.prohibitedExpenses,
+        pendingAction: !isEmptyObject(policy?.prohibitedExpenses?.pendingFields) ? CONST.RED_BRICK_ROAD_PENDING_ACTION.UPDATE : undefined,
     });
 
     const areEReceiptsEnabled = policy?.eReceipts ?? false;

--- a/src/pages/workspace/rules/RulesProhibitedDefaultPage.tsx
+++ b/src/pages/workspace/rules/RulesProhibitedDefaultPage.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import {View} from 'react-native';
 import HeaderWithBackButton from '@components/HeaderWithBackButton';
+import OfflineWithFeedback from '@components/OfflineWithFeedback';
 import ScreenWrapper from '@components/ScreenWrapper';
 import ScrollView from '@components/ScrollView';
 import Switch from '@components/Switch';
@@ -49,76 +50,20 @@ function RulesProhibitedDefaultPage({
                         <Text style={[styles.textNormal, styles.colorMuted]}>{translate('workspace.rules.individualExpenseRules.prohibitedDefaultDescription')}</Text>
                     </Text>
 
-                    <View style={[styles.flexRow, styles.alignItemsCenter, styles.justifyContentBetween, styles.mt3, styles.mh5, styles.mb5]}>
-                        <Text>{translate('workspace.rules.individualExpenseRules.adultEntertainment')}</Text>
-                        <Switch
-                            isOn={policy?.prohibitedExpenses?.adultEntertainment ?? false}
-                            accessibilityLabel={translate('workspace.rules.individualExpenseRules.adultEntertainment')}
-                            onToggle={() => {
-                                const prohibitedExpenses: ProhibitedExpenses = {
-                                    ...policy?.prohibitedExpenses,
-                                    adultEntertainment: !policy?.prohibitedExpenses?.adultEntertainment,
-                                };
-                                setPolicyProhibitedExpenses(policyID, prohibitedExpenses);
-                            }}
-                        />
-                    </View>
-                    <View style={[styles.flexRow, styles.alignItemsCenter, styles.justifyContentBetween, styles.mt3, styles.mh5, styles.mb5]}>
-                        <Text>{translate('workspace.rules.individualExpenseRules.alcohol')}</Text>
-                        <Switch
-                            isOn={policy?.prohibitedExpenses?.alcohol ?? false}
-                            accessibilityLabel={translate('workspace.rules.individualExpenseRules.alcohol')}
-                            onToggle={() => {
-                                const prohibitedExpenses: ProhibitedExpenses = {
-                                    ...policy?.prohibitedExpenses,
-                                    alcohol: !policy?.prohibitedExpenses?.alcohol,
-                                };
-                                setPolicyProhibitedExpenses(policyID, prohibitedExpenses);
-                            }}
-                        />
-                    </View>
-                    <View style={[styles.flexRow, styles.alignItemsCenter, styles.justifyContentBetween, styles.mt3, styles.mh5, styles.mb5]}>
-                        <Text>{translate('workspace.rules.individualExpenseRules.gambling')}</Text>
-                        <Switch
-                            isOn={policy?.prohibitedExpenses?.gambling ?? false}
-                            accessibilityLabel={translate('workspace.rules.individualExpenseRules.gambling')}
-                            onToggle={() => {
-                                const prohibitedExpenses: ProhibitedExpenses = {
-                                    ...policy?.prohibitedExpenses,
-                                    gambling: !policy?.prohibitedExpenses?.gambling,
-                                };
-                                setPolicyProhibitedExpenses(policyID, prohibitedExpenses);
-                            }}
-                        />
-                    </View>
-                    <View style={[styles.flexRow, styles.alignItemsCenter, styles.justifyContentBetween, styles.mt3, styles.mh5, styles.mb5]}>
-                        <Text>{translate('workspace.rules.individualExpenseRules.hotelIncidentals')}</Text>
-                        <Switch
-                            isOn={policy?.prohibitedExpenses?.hotelIncidentals ?? false}
-                            accessibilityLabel={translate('workspace.rules.individualExpenseRules.hotelIncidentals')}
-                            onToggle={() => {
-                                const prohibitedExpenses: ProhibitedExpenses = {
-                                    ...policy?.prohibitedExpenses,
-                                    hotelIncidentals: !policy?.prohibitedExpenses?.hotelIncidentals,
-                                };
-                                setPolicyProhibitedExpenses(policyID, prohibitedExpenses);
-                            }}
-                        />
-                    </View>
-                    <View style={[styles.flexRow, styles.alignItemsCenter, styles.justifyContentBetween, styles.mt3, styles.mh5, styles.mb5]}>
-                        <Text>{translate('workspace.rules.individualExpenseRules.tobacco')}</Text>
-                        <Switch
-                            isOn={policy?.prohibitedExpenses?.tobacco ?? false}
-                            accessibilityLabel={translate('workspace.rules.individualExpenseRules.tobacco')}
-                            onToggle={() => {
-                                const prohibitedExpenses: ProhibitedExpenses = {
-                                    ...policy?.prohibitedExpenses,
-                                    tobacco: !policy?.prohibitedExpenses?.tobacco,
-                                };
-                                setPolicyProhibitedExpenses(policyID, prohibitedExpenses);
-                            }}
-                        />
-                    </View>
+                    {Object.values(CONST.POLICY.PROHIBITED_EXPENSES).map((prohibitedExpense) => (
+                        <OfflineWithFeedback pendingAction={policy?.prohibitedExpenses?.pendingFields?.[prohibitedExpense]}>
+                            <View style={[styles.flexRow, styles.alignItemsCenter, styles.justifyContentBetween, styles.mt3, styles.mh5, styles.mb5]}>
+                                <Text>{translate(`workspace.rules.individualExpenseRules.${prohibitedExpense}`)}</Text>
+                                <Switch
+                                    isOn={policy?.prohibitedExpenses?.[prohibitedExpense] ?? false}
+                                    accessibilityLabel={translate('workspace.rules.individualExpenseRules.adultEntertainment')}
+                                    onToggle={() => {
+                                        setPolicyProhibitedExpenses(policyID, prohibitedExpense);
+                                    }}
+                                />
+                            </View>
+                        </OfflineWithFeedback>
+                    ))}
                 </ScrollView>
             </ScreenWrapper>
         </AccessOrNotFoundWrapper>

--- a/src/pages/workspace/rules/RulesProhibitedDefaultPage.tsx
+++ b/src/pages/workspace/rules/RulesProhibitedDefaultPage.tsx
@@ -16,7 +16,6 @@ import AccessOrNotFoundWrapper from '@pages/workspace/AccessOrNotFoundWrapper';
 import {setPolicyProhibitedExpenses} from '@userActions/Policy/Policy';
 import CONST from '@src/CONST';
 import type SCREENS from '@src/SCREENS';
-import type {ProhibitedExpenses} from '@src/types/onyx/Policy';
 
 type ProhibitedExpensesProps = PlatformStackScreenProps<SettingsNavigatorParamList, typeof SCREENS.WORKSPACE.RULES_PROHIBITED_DEFAULT>;
 

--- a/src/pages/workspace/rules/RulesProhibitedDefaultPage.tsx
+++ b/src/pages/workspace/rules/RulesProhibitedDefaultPage.tsx
@@ -13,7 +13,7 @@ import Navigation from '@libs/Navigation/Navigation';
 import type {PlatformStackScreenProps} from '@libs/Navigation/PlatformStackNavigation/types';
 import type {SettingsNavigatorParamList} from '@libs/Navigation/types';
 import AccessOrNotFoundWrapper from '@pages/workspace/AccessOrNotFoundWrapper';
-import {setPolicyProhibitedExpenses} from '@userActions/Policy/Policy';
+import {setPolicyProhibitedExpense} from '@userActions/Policy/Policy';
 import CONST from '@src/CONST';
 import type SCREENS from '@src/SCREENS';
 
@@ -50,14 +50,17 @@ function RulesProhibitedDefaultPage({
                     </Text>
 
                     {Object.values(CONST.POLICY.PROHIBITED_EXPENSES).map((prohibitedExpense) => (
-                        <OfflineWithFeedback pendingAction={policy?.prohibitedExpenses?.pendingFields?.[prohibitedExpense]}>
+                        <OfflineWithFeedback
+                            pendingAction={policy?.prohibitedExpenses?.pendingFields?.[prohibitedExpense]}
+                            key={translate(`workspace.rules.individualExpenseRules.${prohibitedExpense}`)}
+                        >
                             <View style={[styles.flexRow, styles.alignItemsCenter, styles.justifyContentBetween, styles.mt3, styles.mh5, styles.mb5]}>
                                 <Text>{translate(`workspace.rules.individualExpenseRules.${prohibitedExpense}`)}</Text>
                                 <Switch
                                     isOn={policy?.prohibitedExpenses?.[prohibitedExpense] ?? false}
-                                    accessibilityLabel={translate('workspace.rules.individualExpenseRules.adultEntertainment')}
+                                    accessibilityLabel={translate(`workspace.rules.individualExpenseRules.${prohibitedExpense}`)}
                                     onToggle={() => {
-                                        setPolicyProhibitedExpenses(policyID, prohibitedExpense);
+                                        setPolicyProhibitedExpense(policyID, prohibitedExpense);
                                     }}
                                 />
                             </View>

--- a/src/types/onyx/Policy.ts
+++ b/src/types/onyx/Policy.ts
@@ -1433,7 +1433,7 @@ type ACHAccount = {
 };
 
 /** Prohibited expense types */
-type ProhibitedExpenses = {
+type ProhibitedExpenses = OnyxCommon.OnyxValueWithOfflineFeedback<{
     /** Whether the policy prohibits alcohol expenses */
     alcohol?: boolean;
 
@@ -1448,7 +1448,7 @@ type ProhibitedExpenses = {
 
     /** Whether the policy prohibits adult entertainment expenses */
     adultEntertainment?: boolean;
-};
+}>;
 
 /** Day of the month to schedule submission  */
 type AutoReportingOffset = number | ValueOf<typeof CONST.POLICY.AUTO_REPORTING_OFFSET>;


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
<!-- Explain what your change does and how it addresses the linked issue -->

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/63870
PROPOSAL: https://github.com/Expensify/App/issues/63870#issuecomment-2961132079


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->
1. Launch app
2. Go to workspace settings - enable rules
3. Turn off internet
4. Toggle on/off/on prohibited expenses
5. Prohibited expenses toggle on must be greyed out in offline
- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->
// TODO: These must be filled out, or the issue title must include "[No QA]."
1. Launch app
2. Go to workspace settings - enable rules
3. Turn off internet
4. Toggle on/off/on prohibited expenses
5. Prohibited expenses toggle on must be greyed out in offline
- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I verified there are no new alerts related to the `canBeMissing` param for `useOnyx`
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/91d449b0-3edb-4574-92ec-4f0bf1fdf16c


</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/b6209f55-d930-4524-a5d8-3046221e98ab



</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/76d303f5-74eb-4a7f-b562-5021a39a94ab



</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/82485f57-bc7c-4de3-9412-d1a6c8f97635


</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

https://github.com/user-attachments/assets/3d37ed38-343f-4be7-8f66-c53d6336f72e


<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Desktop</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/557565ae-7888-41e7-afa5-71f14c3b488f



</details>
