### PR TITLE
[No QA] Run generateTranslations dry run on every pull request

### DIFF
--- a/.github/workflows/generateTranslations.yml
+++ b/.github/workflows/generateTranslations.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       # v4
       - name: Checkout
-        uses: 8ade135a41bc03ea155e62e844d188df1ea18608
+        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608
 
       - name: Setup Node
         uses: ./.github/actions/composite/setupNode

--- a/.github/workflows/generateTranslations.yml
+++ b/.github/workflows/generateTranslations.yml
@@ -21,7 +21,6 @@ jobs:
 
       - name: Run generateTranslations dry run
         run: npx ts-node ./scripts/generateTranslations.ts --dry-run
-        continue-on-error: true
 
       - name: Explain failure
         if: failure()

--- a/.github/workflows/generateTranslations.yml
+++ b/.github/workflows/generateTranslations.yml
@@ -1,0 +1,23 @@
+name: Generate static translations
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+jobs:
+  # We always run dry-run the script to verify that it still works.
+  # The generateTranslations script runs with ts-node, which can't handle Flow
+  # (the specialized JS that React Native is written in).
+  # Therefore, adding an import in the wrong place could break the script, even if you didn't modify the script.
+  dryRun:
+    runs-on: ubuntu-latest
+    steps:
+      # v4
+      - name: Checkout
+        uses: 8ade135a41bc03ea155e62e844d188df1ea18608
+
+      - name: Setup Node
+        uses: ./.github/actions/composite/setupNode
+
+      - name: Run generateTranslations dry run
+        run: npx ts-node ./scripts/generateTranslations.ts --dry-run

--- a/.github/workflows/generateTranslations.yml
+++ b/.github/workflows/generateTranslations.yml
@@ -25,5 +25,5 @@ jobs:
       - name: Explain failure
         if: failure()
         run: |
-          echo '😦Something you did broke scripts/generateTranslations.ts. Most likely, this means you added an import that caused react-native to be directly or indirectly imported into the script.'
+          echo '::error:: 😦 Something you did broke scripts/generateTranslations.ts. Most likely, this means you added an import that caused react-native to be directly or indirectly imported into the script.'
           exit 1

--- a/.github/workflows/generateTranslations.yml
+++ b/.github/workflows/generateTranslations.yml
@@ -21,3 +21,10 @@ jobs:
 
       - name: Run generateTranslations dry run
         run: npx ts-node ./scripts/generateTranslations.ts --dry-run
+        continue-on-error: true
+
+      - name: Explain failure
+        if: failure()
+        run: |
+          echo '😦Something you did broke scripts/generateTranslations.ts. Most likely, this means you added an import that caused react-native to be directly or indirectly imported into the script.'
+          exit 1

--- a/scripts/generateTranslations.ts
+++ b/scripts/generateTranslations.ts
@@ -32,7 +32,7 @@ const GENERATED_FILE_PREFIX = dedent(`
      * This file was automatically generated. Please consider these alternatives before manually editing it:
      *
      * - Improve the prompts in prompts/translation, or
-     * - Improve context annotations in src/languages/en.ts
+     * - Improve context annotations in src/languages/${CONST.LOCALES.EN}.ts
      */
 `);
 

--- a/scripts/generateTranslations.ts
+++ b/scripts/generateTranslations.ts
@@ -11,6 +11,7 @@ import ts from 'typescript';
 import decodeUnicode from '@libs/StringUtils/decodeUnicode';
 import dedent from '@libs/StringUtils/dedent';
 import hashStr from '@libs/StringUtils/hash';
+import CONST from '@src/CONST';
 import {isTranslationTargetLocale, LOCALES, TRANSLATION_TARGET_LOCALES} from '@src/CONST/LOCALES';
 import type {TranslationTargetLocale} from '@src/CONST/LOCALES';
 import CLI from './utils/CLI';

--- a/scripts/generateTranslations.ts
+++ b/scripts/generateTranslations.ts
@@ -11,7 +11,6 @@ import ts from 'typescript';
 import decodeUnicode from '@libs/StringUtils/decodeUnicode';
 import dedent from '@libs/StringUtils/dedent';
 import hashStr from '@libs/StringUtils/hash';
-import CONST from '@src/CONST';
 import {isTranslationTargetLocale, LOCALES, TRANSLATION_TARGET_LOCALES} from '@src/CONST/LOCALES';
 import type {TranslationTargetLocale} from '@src/CONST/LOCALES';
 import CLI from './utils/CLI';
@@ -32,7 +31,7 @@ const GENERATED_FILE_PREFIX = dedent(`
      * This file was automatically generated. Please consider these alternatives before manually editing it:
      *
      * - Improve the prompts in prompts/translation, or
-     * - Improve context annotations in src/languages/${CONST.LOCALES.EN}.ts
+     * - Improve context annotations in src/languages/en.ts
      */
 `);
 


### PR DESCRIPTION
### Explanation of Change
Errant imports could break ts-node scripts. Since `scripts/generateTranslations.ts` is now mission-critical, it's important it isn't accidentally broken. This PR adds a PR check to validate that it isn't broken.

### Fixed Issues
$ https://github.com/Expensify/App/issues/64192

### Tests
1. Import `src/CONST.ts` to `scripts/generateTranslations.ts`.
1. Push that change, and validate that the check fails
    - ✅ https://github.com/Expensify/App/actions/runs/15767867358/job/44447522348?pr=64611
1. Then remove that change, push again, and validate that the check passes.
    - ✅ https://github.com/Expensify/App/actions/runs/15767932520/job/44447689246?pr=64611

- [x] Verify that no errors appear in the JS console

### Offline tests
None.

### QA Steps
None.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I verified there are no new alerts related to the `canBeMissing` param for `useOnyx`
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Desktop</summary>

<!-- add screenshots or videos here -->

</details>
