### PR TITLE
fix incorrect values shown on the date field in reportFields

### DIFF
--- a/src/libs/WorkspaceReportFieldUtils.ts
+++ b/src/libs/WorkspaceReportFieldUtils.ts
@@ -80,7 +80,7 @@ function getReportFieldInitialValue(reportField: PolicyReportField | null): stri
     }
 
     if (reportField.type === CONST.REPORT_FIELD_TYPES.DATE) {
-        return Localize.translateLocal('common.initialValue');
+        return Localize.translateLocal('common.currentDate');
     }
 
     return reportField.value ?? reportField.defaultValue;

--- a/src/libs/WorkspaceReportFieldUtils.ts
+++ b/src/libs/WorkspaceReportFieldUtils.ts
@@ -4,9 +4,9 @@ import type {TranslationPaths} from '@src/languages/types';
 import type ONYXKEYS from '@src/ONYXKEYS';
 import type {InputID} from '@src/types/form/WorkspaceReportFieldForm';
 import type {PolicyReportField, PolicyReportFieldType} from '@src/types/onyx/Policy';
-import * as ErrorUtils from './ErrorUtils';
-import * as Localize from './Localize';
-import * as ValidationUtils from './ValidationUtils';
+import {addErrorMessage} from './ErrorUtils';
+import {translateLocal} from './Localize';
+import {isRequiredFulfilled} from './ValidationUtils';
 
 /**
  * Gets the translation key for the report field type.
@@ -45,17 +45,13 @@ function validateReportFieldListValueName(
 ): FormInputErrors<typeof ONYXKEYS.FORMS.WORKSPACE_REPORT_FIELDS_FORM> {
     const errors: FormInputErrors<typeof ONYXKEYS.FORMS.WORKSPACE_REPORT_FIELDS_FORM> = {};
 
-    if (!ValidationUtils.isRequiredFulfilled(valueName)) {
-        errors[inputID] = Localize.translateLocal('workspace.reportFields.listValueRequiredError');
+    if (!isRequiredFulfilled(valueName)) {
+        errors[inputID] = translateLocal('workspace.reportFields.listValueRequiredError');
     } else if (priorValueName !== valueName && listValues.some((currentValueName) => currentValueName === valueName)) {
-        errors[inputID] = Localize.translateLocal('workspace.reportFields.existingListValueError');
+        errors[inputID] = translateLocal('workspace.reportFields.existingListValueError');
     } else if ([...valueName].length > CONST.WORKSPACE_REPORT_FIELD_POLICY_MAX_LENGTH) {
         // Uses the spread syntax to count the number of Unicode code points instead of the number of UTF-16 code units.
-        ErrorUtils.addErrorMessage(
-            errors,
-            inputID,
-            Localize.translateLocal('common.error.characterLimitExceedCounter', {length: [...valueName].length, limit: CONST.WORKSPACE_REPORT_FIELD_POLICY_MAX_LENGTH}),
-        );
+        addErrorMessage(errors, inputID, translateLocal('common.error.characterLimitExceedCounter', {length: [...valueName].length, limit: CONST.WORKSPACE_REPORT_FIELD_POLICY_MAX_LENGTH}));
     }
 
     return errors;
@@ -80,7 +76,7 @@ function getReportFieldInitialValue(reportField: PolicyReportField | null): stri
     }
 
     if (reportField.type === CONST.REPORT_FIELD_TYPES.DATE) {
-        return Localize.translateLocal('common.currentDate');
+        return translateLocal('common.currentDate');
     }
 
     return reportField.value ?? reportField.defaultValue;

--- a/src/pages/workspace/reportFields/CreateReportFieldsPage.tsx
+++ b/src/pages/workspace/reportFields/CreateReportFieldsPage.tsx
@@ -43,7 +43,7 @@ function WorkspaceCreateReportFieldsPage({
     const styles = useThemeStyles();
     const {translate} = useLocalize();
     const formRef = useRef<FormRef>(null);
-    const [formDraft] = useOnyx(ONYXKEYS.FORMS.WORKSPACE_REPORT_FIELDS_FORM_DRAFT);
+    const [formDraft] = useOnyx(ONYXKEYS.FORMS.WORKSPACE_REPORT_FIELDS_FORM_DRAFT, {canBeMissing: true});
 
     const availableListValuesLength = (formDraft?.[INPUT_IDS.DISABLED_LIST_VALUES] ?? []).filter((disabledListValue) => !disabledListValue).length;
 
@@ -103,7 +103,7 @@ function WorkspaceCreateReportFieldsPage({
         setInitialCreateReportFieldsForm();
     }, []);
 
-    const [modal] = useOnyx(ONYXKEYS.MODAL);
+    const [modal] = useOnyx(ONYXKEYS.MODAL, {canBeMissing: true});
 
     const listValues = [...(formDraft?.[INPUT_IDS.LIST_VALUES] ?? [])].sort(localeCompare).join(', ');
 

--- a/src/pages/workspace/reportFields/CreateReportFieldsPage.tsx
+++ b/src/pages/workspace/reportFields/CreateReportFieldsPage.tsx
@@ -186,8 +186,8 @@ function WorkspaceCreateReportFieldsPage({
 
                             {inputValues[INPUT_IDS.TYPE] === CONST.REPORT_FIELD_TYPES.DATE && (
                                 <MenuItemWithTopDescription
-                                    title={translate('common.initialValue')}
-                                    description={translate('common.date')}
+                                    title={translate('common.currentDate')}
+                                    description={translate('common.initialValue')}
                                     rightLabel={translate('common.required')}
                                     interactive={false}
                                 />

--- a/src/pages/workspace/reportFields/ReportFieldsSettingsPage.tsx
+++ b/src/pages/workspace/reportFields/ReportFieldsSettingsPage.tsx
@@ -113,7 +113,7 @@ function ReportFieldsSettingsPage({
                             style={[styles.moneyRequestMenuItem]}
                             titleStyle={styles.flex1}
                             title={WorkspaceReportFieldUtils.getReportFieldInitialValue(reportField)}
-                            description={isDateFieldType ? translate('common.date') : translate('common.initialValue')}
+                            description={translate('common.initialValue')}
                             shouldShowRightIcon={!isDateFieldType && !hasAccountingConnections}
                             interactive={!isDateFieldType && !hasAccountingConnections}
                             onPress={() => Navigation.navigate(ROUTES.WORKSPACE_EDIT_REPORT_FIELDS_INITIAL_VALUE.getRoute(policyID, reportFieldID))}

--- a/src/pages/workspace/reportFields/ReportFieldsSettingsPage.tsx
+++ b/src/pages/workspace/reportFields/ReportFieldsSettingsPage.tsx
@@ -12,15 +12,15 @@ import useThemeStyles from '@hooks/useThemeStyles';
 import localeCompare from '@libs/LocaleCompare';
 import Navigation from '@libs/Navigation/Navigation';
 import type {PlatformStackScreenProps} from '@libs/Navigation/PlatformStackNavigation/types';
-import * as PolicyUtils from '@libs/PolicyUtils';
-import * as ReportUtils from '@libs/ReportUtils';
-import * as WorkspaceReportFieldUtils from '@libs/WorkspaceReportFieldUtils';
+import {hasAccountingConnections as hasAccountingConnectionsPolicyUtils} from '@libs/PolicyUtils';
+import {getReportFieldKey} from '@libs/ReportUtils';
+import {getReportFieldInitialValue, getReportFieldTypeTranslationKey} from '@libs/WorkspaceReportFieldUtils';
 import type {SettingsNavigatorParamList} from '@navigation/types';
 import NotFoundPage from '@pages/ErrorPage/NotFoundPage';
 import AccessOrNotFoundWrapper from '@pages/workspace/AccessOrNotFoundWrapper';
 import type {WithPolicyAndFullscreenLoadingProps} from '@pages/workspace/withPolicyAndFullscreenLoading';
 import withPolicyAndFullscreenLoading from '@pages/workspace/withPolicyAndFullscreenLoading';
-import * as ReportField from '@userActions/Policy/ReportField';
+import {deleteReportFields} from '@userActions/Policy/ReportField';
 import CONST from '@src/CONST';
 import ROUTES from '@src/ROUTES';
 import type SCREENS from '@src/SCREENS';
@@ -37,8 +37,8 @@ function ReportFieldsSettingsPage({
     const {translate} = useLocalize();
     const [isDeleteModalVisible, setIsDeleteModalVisible] = useState(false);
 
-    const hasAccountingConnections = PolicyUtils.hasAccountingConnections(policy);
-    const reportFieldKey = ReportUtils.getReportFieldKey(reportFieldID);
+    const hasAccountingConnections = hasAccountingConnectionsPolicyUtils(policy);
+    const reportFieldKey = getReportFieldKey(reportFieldID);
     const reportField = policy?.fieldList?.[reportFieldKey] ?? null;
 
     if (!reportField) {
@@ -51,7 +51,7 @@ function ReportFieldsSettingsPage({
     const listValues = Object.values(policy?.fieldList?.[reportFieldKey]?.values ?? {})?.sort(localeCompare);
 
     const deleteReportFieldAndHideModal = () => {
-        ReportField.deleteReportFields(policyID, [reportFieldKey]);
+        deleteReportFields(policyID, [reportFieldKey]);
         setIsDeleteModalVisible(false);
         Navigation.goBack();
     };
@@ -93,7 +93,7 @@ function ReportFieldsSettingsPage({
                     <MenuItemWithTopDescription
                         style={[styles.moneyRequestMenuItem]}
                         titleStyle={styles.flex1}
-                        title={Str.recapitalize(translate(WorkspaceReportFieldUtils.getReportFieldTypeTranslationKey(reportField.type)))}
+                        title={Str.recapitalize(translate(getReportFieldTypeTranslationKey(reportField.type)))}
                         description={translate('common.type')}
                         interactive={false}
                     />
@@ -112,7 +112,7 @@ function ReportFieldsSettingsPage({
                         <MenuItemWithTopDescription
                             style={[styles.moneyRequestMenuItem]}
                             titleStyle={styles.flex1}
-                            title={WorkspaceReportFieldUtils.getReportFieldInitialValue(reportField)}
+                            title={getReportFieldInitialValue(reportField)}
                             description={translate('common.initialValue')}
                             shouldShowRightIcon={!isDateFieldType && !hasAccountingConnections}
                             interactive={!isDateFieldType && !hasAccountingConnections}


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
<!-- Explain what your change does and how it addresses the linked issue -->

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/64428
PROPOSAL: https://github.com/Expensify/App/issues/64428#issuecomment-2983706614


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->
1. Create a Workspace
2. Go to reports > Click Add Field
3. Enter any name > Select type as Date

Verify that As seen in OldDot, the 3rd row should have a heading as Initial Value like other fields List and Name and the value should be Current Date.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I verified there are no new alerts related to the `canBeMissing` param for `useOnyx`
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>
Build error, android is fckedddddd right now
<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

![Screenshot 2025-06-20 at 10 52 01 AM](https://github.com/user-attachments/assets/d4182ea9-d07c-460d-9322-81966b6d8f0e)

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

![Screenshot 2025-06-20 at 10 48 02 AM](https://github.com/user-attachments/assets/b6345a7d-e046-4665-85f9-c2295494d449)

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

![Screenshot 2025-06-20 at 10 49 01 AM](https://github.com/user-attachments/assets/68027d41-e88f-4f56-ae1d-890f4a2fe497)

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

![Screenshot 2025-06-20 at 10 32 03 AM](https://github.com/user-attachments/assets/08ffc894-5cef-4db4-afd3-a9b0b86a2831)

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Desktop</summary>

![Screenshot 2025-06-20 at 10 32 34 AM](https://github.com/user-attachments/assets/73f8a3e1-98e5-4025-ac8f-5a04dcadeba3)

<!-- add screenshots or videos here -->

</details>
