### PR TITLE
fix: cards filter with old ui

### DIFF
--- a/src/components/SelectionList/Search/CardListItem.tsx
+++ b/src/components/SelectionList/Search/CardListItem.tsx
@@ -2,10 +2,9 @@ import {Str} from 'expensify-common';
 import React, {useCallback} from 'react';
 import {View} from 'react-native';
 import Avatar from '@components/Avatar';
+import Checkbox from '@components/Checkbox';
 import Icon from '@components/Icon';
 import {FallbackAvatar} from '@components/Icon/Expensicons';
-import PressableWithFeedback from '@components/Pressable/PressableWithFeedback';
-import SelectCircle from '@components/SelectCircle';
 import BaseListItem from '@components/SelectionList/BaseListItem';
 import type {BaseListItemProps, ListItem} from '@components/SelectionList/types';
 import TextWithTooltip from '@components/TextWithTooltip';
@@ -50,7 +49,7 @@ function CardListItem<TItem extends ListItem>({
 
     const ownersAvatar = {
         source: item.cardOwnerPersonalDetails?.avatar ?? FallbackAvatar,
-        id: item.cardOwnerPersonalDetails?.accountID ?? -1,
+        id: item.cardOwnerPersonalDetails?.accountID ?? CONST.DEFAULT_NUMBER_ID,
         type: CONST.ICON_TYPE_AVATAR,
         name: item.cardOwnerPersonalDetails?.displayName ?? '',
         fallbackIcon: item.cardOwnerPersonalDetails?.fallbackIcon,
@@ -85,7 +84,7 @@ function CardListItem<TItem extends ListItem>({
                             <View>
                                 <UserDetailsTooltip
                                     shouldRender={showTooltip}
-                                    accountID={Number(item.cardOwnerPersonalDetails?.accountID ?? -1)}
+                                    accountID={Number(item.cardOwnerPersonalDetails?.accountID ?? CONST.DEFAULT_NUMBER_ID)}
                                     icon={ownersAvatar}
                                     fallbackUserDetails={{
                                         displayName: item.cardOwnerPersonalDetails?.displayName,
@@ -144,18 +143,14 @@ function CardListItem<TItem extends ListItem>({
                     </View>
                 </View>
                 {!!canSelectMultiple && !item.isDisabled && (
-                    <PressableWithFeedback
-                        onPress={handleCheckboxPress}
-                        disabled={isDisabled}
-                        role={CONST.ROLE.BUTTON}
+                    <Checkbox
+                        shouldSelectOnPressEnter
+                        isChecked={item.isSelected ?? false}
                         accessibilityLabel={item.text ?? ''}
-                        style={[styles.ml2, styles.optionSelectCircle]}
-                    >
-                        <SelectCircle
-                            isChecked={item.isSelected ?? false}
-                            selectCircleStyles={styles.ml0}
-                        />
-                    </PressableWithFeedback>
+                        onPress={handleCheckboxPress}
+                        disabled={!!isDisabled}
+                        style={styles.ml3}
+                    />
                 )}
             </>
         </BaseListItem>

--- a/src/pages/Search/SearchAdvancedFiltersPage/SearchFiltersCardPage.tsx
+++ b/src/pages/Search/SearchAdvancedFiltersPage/SearchFiltersCardPage.tsx
@@ -1,10 +1,10 @@
 import React, {useCallback, useEffect, useMemo, useState} from 'react';
 import {View} from 'react-native';
 import {useOnyx} from 'react-native-onyx';
-import Button from '@components/Button';
 import HeaderWithBackButton from '@components/HeaderWithBackButton';
 import {usePersonalDetails} from '@components/OnyxProvider';
 import ScreenWrapper from '@components/ScreenWrapper';
+import SearchFilterPageFooterButtons from '@components/Search/SearchFilterPageFooterButtons';
 import SelectionList from '@components/SelectionList';
 import CardListItem from '@components/SelectionList/Search/CardListItem';
 import useDebouncedState from '@hooks/useDebouncedState';
@@ -25,10 +25,10 @@ function SearchFiltersCardPage() {
     const {translate} = useLocalize();
     const illustrations = useThemeIllustrations();
 
-    const [userCardList, userCardListMetadata] = useOnyx(ONYXKEYS.CARD_LIST);
-    const [workspaceCardFeeds, workspaceCardFeedsMetadata] = useOnyx(ONYXKEYS.COLLECTION.WORKSPACE_CARDS_LIST);
+    const [userCardList, userCardListMetadata] = useOnyx(ONYXKEYS.CARD_LIST, {canBeMissing: true});
+    const [workspaceCardFeeds, workspaceCardFeedsMetadata] = useOnyx(ONYXKEYS.COLLECTION.WORKSPACE_CARDS_LIST, {canBeMissing: true});
     const [searchTerm, debouncedSearchTerm, setSearchTerm] = useDebouncedState('');
-    const [searchAdvancedFiltersForm, searchAdvancedFiltersFormMetadata] = useOnyx(ONYXKEYS.FORMS.SEARCH_ADVANCED_FILTERS_FORM);
+    const [searchAdvancedFiltersForm, searchAdvancedFiltersFormMetadata] = useOnyx(ONYXKEYS.FORMS.SEARCH_ADVANCED_FILTERS_FORM, {canBeMissing: true});
     const personalDetails = usePersonalDetails();
 
     const [selectedCards, setSelectedCards] = useState<string[]>([]);
@@ -147,17 +147,18 @@ function SearchFiltersCardPage() {
 
     const headerMessage = debouncedSearchTerm.trim() && sections.every((section) => !section.data.length) ? translate('common.noResultsFound') : '';
 
+    const resetChanges = useCallback(() => {
+        setSelectedCards([]);
+    }, [setSelectedCards]);
+
     const footerContent = useMemo(
         () => (
-            <Button
-                success
-                text={translate('common.save')}
-                pressOnEnter
-                onPress={handleConfirmSelection}
-                large
+            <SearchFilterPageFooterButtons
+                applyChanges={handleConfirmSelection}
+                resetChanges={resetChanges}
             />
         ),
-        [translate, handleConfirmSelection],
+        [resetChanges, handleConfirmSelection],
     );
 
     return (


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
<!-- Explain what your change does and how it addresses the linked issue -->

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/64976
PROPOSAL: https://github.com/Expensify/App/issues/64976#issuecomment-3014856636


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->
1. Open ND
2. Run console code
<details>
 <summary>Onyx</summary>

```js
Onyx.merge('cardList', {
    '12345': {
        cardID: 12345,
        accountID: 1,
        bank: 'Expensify Card',
        domainName: 'test-domain.exfy',
        lastFourPAN: '1234',
        cardName: '455594XXXXXX1234',
        nameValuePairs: {
            cardTitle: 'John Doe Card',
            isVirtual: false,
        },
        state: 3,
        fraud: 'none',
        lastUpdated: '2025-01-01',
    },
    '12346': {
        cardID: 12346,
        accountID: 2,
        bank: 'Expensify Card',
        domainName: 'test-domain.exfy',
        lastFourPAN: '5678',
        cardName: '455594XXXXXX5678',
        nameValuePairs: {
            cardTitle: 'Jane Smith Card',
            isVirtual: true,
        },
        state: 3,
        fraud: 'none',
        lastUpdated: '2025-01-01',
    },
    '12347': {
        cardID: 12347,
        accountID: 3,
        bank: 'Expensify Card',
        domainName: 'workspace-test.exfy',
        lastFourPAN: '1111',
        cardName: '455594XXXXXX1111',
        nameValuePairs: {
            cardTitle: 'Alice Lee Card',
            isVirtual: false,
        },
        state: 3,
        fraud: 'none',
        lastUpdated: '2025-02-01',
    },
    '12348': {
        cardID: 12348,
        accountID: 4,
        bank: 'Expensify Card',
        domainName: 'workspace-test.exfy',
        lastFourPAN: '2222',
        cardName: '455594XXXXXX2222',
        nameValuePairs: {
            cardTitle: 'Bob Brown Card',
            isVirtual: true,
        },
        state: 2,
        fraud: 'none',
        lastUpdated: '2025-02-05',
    },
    '12349': {
        cardID: 12349,
        accountID: 5,
        bank: 'Expensify Card',
        domainName: 'alpha-domain.exfy',
        lastFourPAN: '3333',
        cardName: '455594XXXXXX3333',
        nameValuePairs: {
            cardTitle: 'Charlie Davis Card',
            isVirtual: false,
        },
        state: 1,
        fraud: 'suspected',
        lastUpdated: '2025-03-01',
    },
    '12350': {
        cardID: 12350,
        accountID: 6,
        bank: 'Expensify Card',
        domainName: 'beta-domain.exfy',
        lastFourPAN: '4444',
        cardName: '455594XXXXXX4444',
        nameValuePairs: {
            cardTitle: 'Diana Evans Card',
            isVirtual: true,
        },
        state: 3,
        fraud: 'none',
        lastUpdated: '2025-03-10',
    },
    '12351': {
        cardID: 12351,
        accountID: 7,
        bank: 'Expensify Card',
        domainName: 'gamma-domain.exfy',
        lastFourPAN: '5555',
        cardName: '455594XXXXXX5555',
        nameValuePairs: {
            cardTitle: 'Ethan Foster Card',
            isVirtual: false,
        },
        state: 4,
        fraud: 'none',
        lastUpdated: '2025-03-20',
    },
    '12352': {
        cardID: 12352,
        accountID: 8,
        bank: 'Expensify Card',
        domainName: 'delta-domain.exfy',
        lastFourPAN: '6666',
        cardName: '455594XXXXXX6666',
        nameValuePairs: {
            cardTitle: 'Fiona Green Card',
            isVirtual: true,
        },
        state: 3,
        fraud: 'investigation',
        lastUpdated: '2025-04-01',
    },
    '12353': {
        cardID: 12353,
        accountID: 9,
        bank: 'Expensify Card',
        domainName: 'epsilon-domain.exfy',
        lastFourPAN: '7777',
        cardName: '455594XXXXXX7777',
        nameValuePairs: {
            cardTitle: 'George Hill Card',
            isVirtual: false,
        },
        state: 1,
        fraud: 'none',
        lastUpdated: '2025-04-05',
    },
    '12354': {
        cardID: 12354,
        accountID: 10,
        bank: 'Expensify Card',
        domainName: 'zeta-domain.exfy',
        lastFourPAN: '8888',
        cardName: '455594XXXXXX8888',
        nameValuePairs: {
            cardTitle: 'Hannah Irwin Card',
            isVirtual: true,
        },
        state: 2,
        fraud: 'none',
        lastUpdated: '2025-04-10',
    },
    '12355': {
        cardID: 12355,
        accountID: 11,
        bank: 'Expensify Card',
        domainName: 'theta-domain.exfy',
        lastFourPAN: '9999',
        cardName: '455594XXXXXX9999',
        nameValuePairs: {
            cardTitle: 'Isaac Johnson Card',
            isVirtual: false,
        },
        state: 3,
        fraud: 'none',
        lastUpdated: '2025-04-15',
    },
    '12356': {
        cardID: 12356,
        accountID: 12,
        bank: 'Expensify Card',
        domainName: 'iota-domain.exfy',
        lastFourPAN: '0001',
        cardName: '455594XXXXXX0001',
        nameValuePairs: {
            cardTitle: 'Jenna King Card',
            isVirtual: true,
        },
        state: 3,
        fraud: 'none',
        lastUpdated: '2025-04-20',
    },
    '12357': {
        cardID: 12357,
        accountID: 13,
        bank: 'Expensify Card',
        domainName: 'kappa-domain.exfy',
        lastFourPAN: '0002',
        cardName: '455594XXXXXX0002',
        nameValuePairs: {
            cardTitle: 'Kevin Lee Card',
            isVirtual: false,
        },
        state: 3,
        fraud: 'none',
        lastUpdated: '2025-05-01',
    },
    '12358': {
        cardID: 12358,
        accountID: 14,
        bank: 'Expensify Card',
        domainName: 'lambda-domain.exfy',
        lastFourPAN: '0003',
        cardName: '455594XXXXXX0003',
        nameValuePairs: {
            cardTitle: 'Linda Moore Card',
            isVirtual: true,
        },
        state: 1,
        fraud: 'none',
        lastUpdated: '2025-05-10',
    },
    '12359': {
        cardID: 12359,
        accountID: 15,
        bank: 'Expensify Card',
        domainName: 'mu-domain.exfy',
        lastFourPAN: '0004',
        cardName: '455594XXXXXX0004',
        nameValuePairs: {
            cardTitle: 'Michael Nguyen Card',
            isVirtual: false,
        },
        state: 3,
        fraud: 'none',
        lastUpdated: '2025-05-15',
    }
});
Onyx.merge('cards_18755165_Expensify Card',  {
        '12347': {
            accountID: 3,
            bank: 'Expensify Card',
            fundID: '18755165',
            cardID: 12347,
            cardName: '455594XXXXXX9999',
            domainName: 'workspace-test-very-very-long.exfy',
            lastFourPAN: '9999',
            nameValuePairs: {
                cardTitle: 'Team Card 1',
            },
            state: 3, // OPEN
            fraud: 'none',
            lastUpdated: '2025-01-01',
        },
        '12348': {
            accountID: 4,
            bank: 'Expensify Card',
            fundID: '18755165',
            cardID: 12348,
            cardName: '455594XXXXXX8888',
            domainName: 'workspace-test.exfy',
            lastFourPAN: '8888',
            nameValuePairs: {
                cardTitle: 'Team Card 2',
            },
            state: 3, // OPEN
            fraud: 'none',
            lastUpdated: '2025-01-01',
        },
    });
```

</details>

3. Open search/filters/card page
4. Verify the Card UI has square checkboxes and Reset button
- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->
Same as test above
### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->
Precondition: Use account with several cards.

1. Go to Reports
2. Click on Filters
3. Choose Card
Verify the Card UI has square checkboxes and Reset button

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I verified there are no new alerts related to the `canBeMissing` param for `useOnyx`
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

![Screenshot_1751358108](https://github.com/user-attachments/assets/970e176c-9390-4ed8-a846-78e7f9730dd0)


</details>

<details>
<summary>Android: mWeb Chrome</summary>

![Screenshot_1751358171](https://github.com/user-attachments/assets/c6cf81d0-28b7-4aa9-af0d-e60324b48f4a)


</details>

<details>
<summary>iOS: Native</summary>

![Simulator Screenshot - iPhone 16 Pro Max - 2025-07-01 at 15 16 23](https://github.com/user-attachments/assets/3965d1ab-e246-424d-b465-3e1c524b48c4)


</details>

<details>
<summary>iOS: mWeb Safari</summary>

![Simulator Screenshot - iPhone 16 Pro Max - 2025-07-01 at 15 14 36](https://github.com/user-attachments/assets/f3fe403e-e972-4e27-b177-adaddc98d494)


</details>

<details>
<summary>MacOS: Chrome / Safari</summary>


https://github.com/user-attachments/assets/f7300a09-f74b-41f9-a7e3-510bafcf44b1



</details>

<details>
<summary>MacOS: Desktop</summary>


https://github.com/user-attachments/assets/5f9a83f6-480c-4df3-89c3-b04fa3b6a8d6



</details>
