### PR TITLE
[No QA] Revert "fix: Persist troubleshooting flags across login sessions"

### DIFF
--- a/src/libs/actions/SignInRedirect.ts
+++ b/src/libs/actions/SignInRedirect.ts
@@ -34,20 +34,11 @@ function clearStorageAndRedirect(errorMessage?: string): Promise<void> {
         keysToPreserve.push(ONYXKEYS.NETWORK);
     }
 
-    // Preserve troubleshooting flags
-    keysToPreserve.push(ONYXKEYS.APP_PROFILING_IN_PROGRESS);
-    keysToPreserve.push(ONYXKEYS.SHOULD_STORE_LOGS);
-    keysToPreserve.push(ONYXKEYS.SHOULD_MASK_ONYX_STATE);
-
-    // Preserve account settings (staging server, debug mode, etc.) across logout
-    keysToPreserve.push(ONYXKEYS.ACCOUNT);
-
     return Onyx.clear(keysToPreserve).then(() => {
         if (CONFIG.IS_HYBRID_APP) {
             resetSignInFlow();
         }
         clearAllPolicies();
-
         if (!errorMessage) {
             return;
         }

--- a/src/pages/signin/SignInPage.tsx
+++ b/src/pages/signin/SignInPage.tsx
@@ -108,8 +108,7 @@ function getRenderOptions({
     // SAML required users may reload the login page after having already entered their login details, in which
     // case we want to clear their sign in data so they don't end up in an infinite loop redirecting back to their
     // SSO provider's login page
-    // Don't clear if we don't have account data - this prevents clearing during app resets when state is inconsistent
-    if (hasAccount && hasLogin && isSAMLRequired && !shouldInitiateSAMLLogin && !hasInitiatedSAMLLogin && !account.isLoading) {
+    if (hasLogin && isSAMLRequired && !shouldInitiateSAMLLogin && !hasInitiatedSAMLLogin && !account.isLoading) {
         clearSignInData();
     }
 


### PR DESCRIPTION
Reverts Expensify/App#63650

Reverts because it doesn't fix the linked [issue](https://github.com/Expensify/App/issues/62496).