### PR TITLE
[No QA] Revert "After deleting expense and returning to Chats messages display fallback avatar"

### DIFF
--- a/src/components/Search/index.tsx
+++ b/src/components/Search/index.tsx
@@ -175,12 +175,9 @@ function Search({queryJSON, currentSearchResults, lastNonEmptySearchResults, onS
     const searchListRef = useRef<SelectionListHandle | null>(null);
 
     useEffect(() => {
-        if (!isFocused) {
-            return;
-        }
         clearSelectedTransactions(hash);
         setCurrentSearchHash(hash);
-    }, [hash, clearSelectedTransactions, setCurrentSearchHash, isFocused]);
+    }, [hash, clearSelectedTransactions, setCurrentSearchHash]);
 
     const searchResults = currentSearchResults?.data ? currentSearchResults : lastNonEmptySearchResults;
     const isSearchResultsEmpty = !searchResults?.data || isSearchResultsEmptyUtil(searchResults);
@@ -218,11 +215,12 @@ function Search({queryJSON, currentSearchResults, lastNonEmptySearchResults, onS
     }, [isSmallScreenWidth, selectedTransactions, selectionMode?.isEnabled]);
 
     useEffect(() => {
-        if (isOffline || !isFocused) {
+        if (isOffline) {
             return;
         }
+
         handleSearch({queryJSON, offset});
-    }, [handleSearch, isOffline, offset, queryJSON, isFocused]);
+    }, [handleSearch, isOffline, offset, queryJSON]);
 
     useEffect(() => {
         openSearch();


### PR DESCRIPTION
Reverts Expensify/App#64403 because it adds an extra API call. Details [here](https://github.com/Expensify/App/issues/63300#issuecomment-2991247336). We'll go with the other [solution](https://github.com/Expensify/App/issues/63300#issuecomment-2933373895).