### PR TITLE
fix: replace dropdown menu when only one option

### DIFF
--- a/src/components/ButtonWithDropdownMenu/index.tsx
+++ b/src/components/ButtonWithDropdownMenu/index.tsx
@@ -51,6 +51,7 @@ function ButtonWithDropdownMenu<IValueType>({
     secondLineText = '',
     icon,
     shouldUseModalPaddingStyle = true,
+    shouldUseOptionIcon = false,
 }: ButtonWithDropdownMenuProps<IValueType>) {
     const theme = useTheme();
     const styles = useThemeStyles();
@@ -72,7 +73,7 @@ function ButtonWithDropdownMenu<IValueType>({
     const innerStyleDropButton = StyleUtils.getDropDownButtonHeight(buttonSize);
     const isButtonSizeLarge = buttonSize === CONST.DROPDOWN_BUTTON_SIZE.LARGE;
     const nullCheckRef = (ref: RefObject<View | null>) => ref ?? null;
-    const shouldShowRightIcon = !!options.at(0)?.iconRight;
+    const shouldShowRightIcon = !!options.at(0)?.shouldShowRightIcon;
 
     useEffect(() => {
         if (!dropdownAnchor.current) {
@@ -215,8 +216,8 @@ function ButtonWithDropdownMenu<IValueType>({
                     iconRightStyles={shouldShowRightIcon && styles.ml2}
                     enterKeyEventListenerPriority={enterKeyEventListenerPriority}
                     secondLineText={secondLineText}
-                    icon={icon ?? options.at(0)?.iconLeft}
-                    iconRight={options.at(0)?.iconRight}
+                    icon={shouldUseOptionIcon ? options.at(0)?.icon : icon}
+                    iconRight={shouldShowRightIcon ? options.at(0)?.icon : undefined}
                     shouldShowRightIcon={shouldShowRightIcon}
                 />
             )}

--- a/src/components/ButtonWithDropdownMenu/index.tsx
+++ b/src/components/ButtonWithDropdownMenu/index.tsx
@@ -245,6 +245,7 @@ function ButtonWithDropdownMenu<IValueType>({
                     headerText={menuHeaderText}
                     menuItems={options.map((item, index) => ({
                         ...item,
+                        shouldShowRightIcon: undefined,
                         onSelected: item.onSelected
                             ? () => item.onSelected?.()
                             : () => {

--- a/src/components/ButtonWithDropdownMenu/index.tsx
+++ b/src/components/ButtonWithDropdownMenu/index.tsx
@@ -72,6 +72,7 @@ function ButtonWithDropdownMenu<IValueType>({
     const innerStyleDropButton = StyleUtils.getDropDownButtonHeight(buttonSize);
     const isButtonSizeLarge = buttonSize === CONST.DROPDOWN_BUTTON_SIZE.LARGE;
     const nullCheckRef = (ref: RefObject<View | null>) => ref ?? null;
+    const shouldShowRightIcon = !!options.at(0)?.iconRight;
 
     useEffect(() => {
         if (!dropdownAnchor.current) {
@@ -210,10 +211,13 @@ function ButtonWithDropdownMenu<IValueType>({
                     large={buttonSize === CONST.DROPDOWN_BUTTON_SIZE.LARGE}
                     medium={buttonSize === CONST.DROPDOWN_BUTTON_SIZE.MEDIUM}
                     small={buttonSize === CONST.DROPDOWN_BUTTON_SIZE.SMALL}
-                    innerStyles={[innerStyleDropButton]}
+                    innerStyles={[innerStyleDropButton, shouldShowRightIcon && styles.dropDownButtonCartIconView]}
+                    iconRightStyles={shouldShowRightIcon && styles.ml2}
                     enterKeyEventListenerPriority={enterKeyEventListenerPriority}
                     secondLineText={secondLineText}
-                    icon={icon}
+                    icon={icon ?? options.at(0)?.iconLeft}
+                    iconRight={options.at(0)?.iconRight}
+                    shouldShowRightIcon={shouldShowRightIcon}
                 />
             )}
             {(shouldAlwaysShowDropdownMenu || options.length > 1) && !!popoverAnchorPosition && (

--- a/src/components/ButtonWithDropdownMenu/index.tsx
+++ b/src/components/ButtonWithDropdownMenu/index.tsx
@@ -216,7 +216,7 @@ function ButtonWithDropdownMenu<IValueType>({
                     iconRightStyles={shouldShowRightIcon && styles.ml2}
                     enterKeyEventListenerPriority={enterKeyEventListenerPriority}
                     secondLineText={secondLineText}
-                    icon={shouldUseOptionIcon ? options.at(0)?.icon : icon}
+                    icon={shouldUseOptionIcon && !shouldShowRightIcon ? options.at(0)?.icon : icon}
                     iconRight={shouldShowRightIcon ? options.at(0)?.icon : undefined}
                     shouldShowRightIcon={shouldShowRightIcon}
                 />

--- a/src/components/ButtonWithDropdownMenu/types.ts
+++ b/src/components/ButtonWithDropdownMenu/types.ts
@@ -25,8 +25,7 @@ type DropdownOption<TValueType> = {
     value: TValueType;
     text: string;
     icon?: IconAsset;
-    iconLeft?: IconAsset;
-    iconRight?: IconAsset;
+    shouldShowRightIcon?: boolean;
     iconWidth?: number;
     iconHeight?: number;
     iconDescription?: string;
@@ -144,6 +143,9 @@ type ButtonWithDropdownMenuProps<TValueType> = {
 
     /** Whether to use modal padding style for the popover menu */
     shouldUseModalPaddingStyle?: boolean;
+
+    /** Whether to display the option icon when only one option is available */
+    shouldUseOptionIcon?: boolean;
 };
 
 export type {

--- a/src/components/ButtonWithDropdownMenu/types.ts
+++ b/src/components/ButtonWithDropdownMenu/types.ts
@@ -25,6 +25,8 @@ type DropdownOption<TValueType> = {
     value: TValueType;
     text: string;
     icon?: IconAsset;
+    iconLeft?: IconAsset;
+    iconRight?: IconAsset;
     iconWidth?: number;
     iconHeight?: number;
     iconDescription?: string;

--- a/src/components/OnboardingHelpDropdownButton.tsx
+++ b/src/components/OnboardingHelpDropdownButton.tsx
@@ -1,5 +1,4 @@
 import {addMinutes} from 'date-fns';
-import noop from 'lodash/noop';
 import React from 'react';
 import {useOnyx} from 'react-native-onyx';
 import useCurrentUserPersonalDetails from '@hooks/useCurrentUserPersonalDetails';

--- a/src/components/OnboardingHelpDropdownButton.tsx
+++ b/src/components/OnboardingHelpDropdownButton.tsx
@@ -57,6 +57,7 @@ function OnboardingHelpDropdownButton({reportID, shouldUseNarrowLayout, shouldSh
         options.push({
             text: translate('getAssistancePage.scheduleACall'),
             icon: CalendarSolid,
+            iconLeft: CalendarSolid,
             value: CONST.ONBOARDING_HELP.SCHEDULE_CALL,
             onSelected: () => {
                 clearBookingDraft();
@@ -106,6 +107,7 @@ function OnboardingHelpDropdownButton({reportID, shouldUseNarrowLayout, shouldSh
         options.push({
             text: translate('getAssistancePage.registerForWebinar'),
             icon: Monitor,
+            iconRight: Monitor,
             value: CONST.ONBOARDING_HELP.REGISTER_FOR_WEBINAR,
             onSelected: () => {
                 openExternalLink(CONST.REGISTER_FOR_WEBINAR_URL);
@@ -119,8 +121,10 @@ function OnboardingHelpDropdownButton({reportID, shouldUseNarrowLayout, shouldSh
 
     return (
         <ButtonWithDropdownMenu
-            onPress={noop}
-            shouldAlwaysShowDropdownMenu
+            onPress={(_event, value) => {
+                const option = options.find((opt) => opt.value === value);
+                option?.onSelected?.();
+            }}
             pressOnEnter
             success={!!hasActiveScheduledCall}
             buttonSize={CONST.DROPDOWN_BUTTON_SIZE.MEDIUM}

--- a/src/components/OnboardingHelpDropdownButton.tsx
+++ b/src/components/OnboardingHelpDropdownButton.tsx
@@ -127,6 +127,7 @@ function OnboardingHelpDropdownButton({reportID, shouldUseNarrowLayout, shouldSh
             success={!!hasActiveScheduledCall}
             buttonSize={CONST.DROPDOWN_BUTTON_SIZE.MEDIUM}
             options={options}
+            shouldUseOptionIcon
             isSplitButton={false}
             customText={hasActiveScheduledCall ? translate('scheduledCall.callScheduled') : translate('getAssistancePage.onboardingHelp')}
             wrapperStyle={shouldUseNarrowLayout && styles.earlyDiscountButton}

--- a/src/components/OnboardingHelpDropdownButton.tsx
+++ b/src/components/OnboardingHelpDropdownButton.tsx
@@ -56,7 +56,6 @@ function OnboardingHelpDropdownButton({reportID, shouldUseNarrowLayout, shouldSh
         options.push({
             text: translate('getAssistancePage.scheduleACall'),
             icon: CalendarSolid,
-            iconLeft: CalendarSolid,
             value: CONST.ONBOARDING_HELP.SCHEDULE_CALL,
             onSelected: () => {
                 clearBookingDraft();
@@ -106,7 +105,7 @@ function OnboardingHelpDropdownButton({reportID, shouldUseNarrowLayout, shouldSh
         options.push({
             text: translate('getAssistancePage.registerForWebinar'),
             icon: Monitor,
-            iconRight: Monitor,
+            shouldShowRightIcon: true,
             value: CONST.ONBOARDING_HELP.REGISTER_FOR_WEBINAR,
             onSelected: () => {
                 openExternalLink(CONST.REGISTER_FOR_WEBINAR_URL);

--- a/tests/ui/components/OnboardingHelpDropdownButtonTest.tsx
+++ b/tests/ui/components/OnboardingHelpDropdownButtonTest.tsx
@@ -1,0 +1,263 @@
+import {fireEvent, render, screen} from '@testing-library/react-native';
+import React from 'react';
+import Onyx from 'react-native-onyx';
+import ComposeProviders from '@components/ComposeProviders';
+import {LocaleContextProvider} from '@components/LocaleContextProvider';
+import OnboardingHelpDropdownButton from '@components/OnboardingHelpDropdownButton';
+import OnyxProvider from '@components/OnyxProvider';
+import {openExternalLink} from '@libs/actions/Link';
+import {cancelBooking, clearBookingDraft, rescheduleBooking} from '@libs/actions/ScheduleCall';
+import Navigation from '@libs/Navigation/Navigation';
+import CONST from '@src/CONST';
+import ONYXKEYS from '@src/ONYXKEYS';
+import ROUTES from '@src/ROUTES';
+import waitForBatchedUpdates from '../../utils/waitForBatchedUpdates';
+import waitForBatchedUpdatesWithAct from '../../utils/waitForBatchedUpdatesWithAct';
+
+// Mock the dependencies
+jest.mock('@libs/actions/Link', () => ({
+    openExternalLink: jest.fn(),
+}));
+jest.mock('@libs/Navigation/Navigation', () => ({
+    navigate: jest.fn(),
+}));
+jest.mock('@libs/actions/ScheduleCall', () => ({
+    clearBookingDraft: jest.fn(),
+    rescheduleBooking: jest.fn(),
+    cancelBooking: jest.fn(),
+}));
+
+const mockOpenExternalLink = jest.mocked(openExternalLink);
+const mockNavigate = jest.mocked(Navigation.navigate);
+const mockClearBookingDraft = jest.mocked(clearBookingDraft);
+const mockRescheduleBooking = jest.mocked(rescheduleBooking);
+const mockCancelBooking = jest.mocked(cancelBooking);
+
+// Helper function to create mock events for PopoverMenuItem fireEvent.press
+function createMockPressEvent(target: unknown) {
+    return {
+        nativeEvent: {},
+        type: 'press',
+        target,
+        currentTarget: target,
+    };
+}
+
+// Helper function to render OnboardingHelpDropdownButton with props
+function renderOnboardingHelpDropdownButton(props: {
+    reportID: string;
+    shouldUseNarrowLayout: boolean;
+    shouldShowRegisterForWebinar: boolean;
+    shouldShowGuideBooking: boolean;
+    hasActiveScheduledCall: boolean;
+}) {
+    return render(
+        <ComposeProviders components={[OnyxProvider, LocaleContextProvider]}>
+            <OnboardingHelpDropdownButton
+                reportID={props.reportID}
+                shouldUseNarrowLayout={props.shouldUseNarrowLayout}
+                shouldShowRegisterForWebinar={props.shouldShowRegisterForWebinar}
+                shouldShowGuideBooking={props.shouldShowGuideBooking}
+                hasActiveScheduledCall={props.hasActiveScheduledCall}
+            />
+        </ComposeProviders>,
+    );
+}
+
+const mockScheduledCall = {
+    eventTime: '2025-07-05 10:00:00',
+    id: 'call-id-123',
+    status: CONST.SCHEDULE_CALL_STATUS.CREATED,
+    host: 123,
+    eventURI: 'test-uri',
+    inserted: '2025-07-04 09:00:00',
+};
+const currentUserAccountID = 1;
+
+describe('OnboardingHelpDropdownButton', () => {
+    beforeAll(() => {
+        Onyx.init({
+            keys: ONYXKEYS,
+        });
+    });
+
+    beforeEach(() => {
+        Onyx.merge(ONYXKEYS.SESSION, {accountID: currentUserAccountID});
+        return waitForBatchedUpdates();
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
+        Onyx.clear();
+        return waitForBatchedUpdates();
+    });
+
+    it('should display the schedule call option when guide booking is enabled', async () => {
+        // Given component configured to show schedule call option only
+        const props = {
+            reportID: '1',
+            shouldUseNarrowLayout: false,
+            shouldShowRegisterForWebinar: false,
+            shouldShowGuideBooking: true,
+            hasActiveScheduledCall: false,
+        };
+
+        // When component is rendered
+        renderOnboardingHelpDropdownButton(props);
+        await waitForBatchedUpdatesWithAct();
+
+        // Then only schedule call option is visible
+        const scheduleCallOption = screen.getByText('getAssistancePage.scheduleACall');
+        expect(scheduleCallOption).toBeOnTheScreen();
+        expect(screen.queryByText('getAssistancePage.registerForWebinar')).not.toBeOnTheScreen();
+        expect(screen.queryByText('common.reschedule')).not.toBeOnTheScreen();
+        expect(screen.queryByText('common.cancel')).not.toBeOnTheScreen();
+
+        // When schedule call option is pressed
+        fireEvent.press(scheduleCallOption);
+
+        // Then booking draft is cleared and navigation occurs
+        expect(mockClearBookingDraft).toHaveBeenCalledTimes(1);
+        expect(mockNavigate).toHaveBeenCalledWith(ROUTES.SCHEDULE_CALL_BOOK.getRoute(props.reportID));
+    });
+
+    it('should only display the registerForWebinar option when webinar is enabled', async () => {
+        // Given component configured to display the registerForWebinar
+        const props = {
+            reportID: '1',
+            shouldUseNarrowLayout: false,
+            shouldShowRegisterForWebinar: true,
+            shouldShowGuideBooking: false,
+            hasActiveScheduledCall: false,
+        };
+
+        // When component is rendered
+        renderOnboardingHelpDropdownButton(props);
+        await waitForBatchedUpdatesWithAct();
+
+        // Then only webinar registration option is visible
+        const registerOption = screen.getByText('getAssistancePage.registerForWebinar');
+        expect(registerOption).toBeOnTheScreen();
+        expect(screen.queryByText('getAssistancePage.scheduleACall')).not.toBeOnTheScreen();
+        expect(screen.queryByText('common.reschedule')).not.toBeOnTheScreen();
+        expect(screen.queryByText('common.cancel')).not.toBeOnTheScreen();
+
+        // When webinar registration option is pressed
+        fireEvent.press(registerOption);
+
+        // Then webinar registration URL is opened
+        expect(mockOpenExternalLink).toHaveBeenCalledTimes(1);
+        expect(mockOpenExternalLink).toHaveBeenCalledWith(CONST.REGISTER_FOR_WEBINAR_URL);
+    });
+
+    it('should display dropdown menu with all options when user has active scheduled call', async () => {
+        // Given component configured with active scheduled call and webinar registration
+        const props = {
+            reportID: '1',
+            shouldUseNarrowLayout: false,
+            shouldShowRegisterForWebinar: true,
+            shouldShowGuideBooking: false,
+            hasActiveScheduledCall: true,
+        };
+        // Given scheduled call data exists in Onyx
+        await Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT_NAME_VALUE_PAIRS}${props.reportID}`, {
+            calendlyCalls: [mockScheduledCall],
+        });
+
+        // When component is rendered
+        renderOnboardingHelpDropdownButton(props);
+        await waitForBatchedUpdatesWithAct();
+
+        // Then dropdown button displays "Call scheduled" text
+        const dropdownButton = screen.getByText('scheduledCall.callScheduled');
+        expect(dropdownButton).toBeOnTheScreen();
+
+        // When dropdown menu is opened
+        fireEvent.press(dropdownButton);
+        await waitForBatchedUpdatesWithAct();
+
+        // Then all expected menu options are present
+        expect(screen.getByText('common.reschedule')).toBeOnTheScreen();
+        expect(screen.getByText('common.cancel')).toBeOnTheScreen();
+        expect(screen.getByText('getAssistancePage.registerForWebinar')).toBeOnTheScreen();
+        expect(screen.queryByText('getAssistancePage.scheduleACall')).not.toBeOnTheScreen();
+    });
+
+    describe('dropdown actions with active scheduled call', () => {
+        // Given component configured with active scheduled call and webinar registration enabled
+        const props = {
+            reportID: '1',
+            shouldUseNarrowLayout: false,
+            shouldShowRegisterForWebinar: true,
+            shouldShowGuideBooking: false,
+            hasActiveScheduledCall: true,
+        };
+        beforeEach(() => {
+            Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT_NAME_VALUE_PAIRS}${props.reportID}`, {
+                calendlyCalls: [mockScheduledCall],
+            });
+            return waitForBatchedUpdates();
+        });
+        it('should open webinar registration URL when webinar option is pressed', async () => {
+            // Given scheduled call data exists in Onyx
+            await Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT_NAME_VALUE_PAIRS}${props.reportID}`, {
+                calendlyCalls: [mockScheduledCall],
+            });
+
+            // When component is rendered and dropdown is opened
+            renderOnboardingHelpDropdownButton(props);
+            await waitForBatchedUpdatesWithAct();
+
+            const dropdownButton = screen.getByText('scheduledCall.callScheduled');
+            fireEvent.press(dropdownButton);
+            await waitForBatchedUpdatesWithAct();
+
+            // When webinar menu item is pressed
+            const webinarMenuItem = screen.getByText('getAssistancePage.registerForWebinar');
+            fireEvent.press(webinarMenuItem, createMockPressEvent(webinarMenuItem));
+            await waitForBatchedUpdatesWithAct();
+
+            // Then webinar registration URL is opened
+            expect(mockOpenExternalLink).toHaveBeenCalledTimes(1);
+            expect(mockOpenExternalLink).toHaveBeenCalledWith(CONST.REGISTER_FOR_WEBINAR_URL);
+        });
+
+        it('should call reschedule booking when reschedule option is pressed', async () => {
+            // When component is rendered and dropdown is opened
+            renderOnboardingHelpDropdownButton(props);
+            await waitForBatchedUpdatesWithAct();
+
+            const dropdownButton = screen.getByText('scheduledCall.callScheduled');
+            fireEvent.press(dropdownButton);
+            await waitForBatchedUpdatesWithAct();
+
+            // When reschedule option is pressed
+            const rescheduleMenuItem = screen.getByText('common.reschedule');
+            fireEvent.press(rescheduleMenuItem, createMockPressEvent(rescheduleMenuItem));
+            await waitForBatchedUpdatesWithAct();
+
+            // Then reschedule booking action is called with scheduled call data
+            expect(mockRescheduleBooking).toHaveBeenCalledTimes(1);
+            expect(mockRescheduleBooking).toHaveBeenCalledWith(mockScheduledCall);
+        });
+
+        it('should call cancel booking when cancel option is pressed', async () => {
+            // When component is rendered and dropdown is opened
+            renderOnboardingHelpDropdownButton(props);
+            await waitForBatchedUpdatesWithAct();
+
+            const dropdownButton = screen.getByText('scheduledCall.callScheduled');
+            fireEvent.press(dropdownButton);
+            await waitForBatchedUpdatesWithAct();
+
+            // When cancel option is pressed
+            const cancelMenuItem = screen.getByText('common.cancel');
+            fireEvent.press(cancelMenuItem, createMockPressEvent(cancelMenuItem));
+            await waitForBatchedUpdatesWithAct();
+
+            // Then cancel booking action is called with scheduled call data
+            expect(mockCancelBooking).toHaveBeenCalledTimes(1);
+            expect(mockCancelBooking).toHaveBeenCalledWith(mockScheduledCall);
+        });
+    });
+});


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
This PR updated the OnboardingHelpDropdownButton to display as single button when only one option

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/65325
PROPOSAL:  https://github.com/Expensify/App/issues/65325#issuecomment-3027363190


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->
#### Test 1: Verify that the "Schedule call" button is displayed as a single button.
1. Open admin room
2. Run console log

<details>
 <summary>Code</summary>

```js
Onyx.merge(
    'account',
    {
        guideDetails: {
            email: 'fake@gmail.com',
            calendarLink: 'fakeLink.com',
            eventURI: '123'
        }
    }
);

Onyx.merge(
    'nvp_introSelected',
    {
        companySize: '11-50'
    }
);
```

</details>

3. Verify that the "Schedule call" button is displayed as a single button.
#### Test 2: Verify that the "Register for webinar" button is displayed as a single button.
1. Open admin room
2. Run console log

<details>
 <summary>Code</summary>

```js
Onyx.merge(
    'account',
    {
        guideDetails: {
            email: 'fake@gmail.com',
            calendarLink: 'fakeLink.com',
            eventURI: '123'
        }
    }
);

Onyx.merge(
    'nvp_introSelected',
    {
        companySize: '1-10'
    }
);

```

</details>

3. Verify that the "Register for webinar" button is displayed as a single button.

- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->
Same test above
### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
5. Upload an image via copy paste
6. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->
Precondition:
- Log in with an account that only has the "Register for webinar" or "Schedule call" option available in the admin room.

Steps:

1. Open the admin room.
2. Verify that if the header button has only one option, it is displayed as a single button instead of a dropdown button.

Note: If you don't have an account with these options, you can use the steps from the test step above.
- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I verified there are no new alerts related to the `canBeMissing` param for `useOnyx`
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

![Screenshot_1751542517](https://github.com/user-attachments/assets/c7b89014-cfa6-4d4b-88e4-7a1b2baa9e07)

![Screenshot_1751542544](https://github.com/user-attachments/assets/2c0627bf-22e8-4016-b5a7-9ce64c2d68ff)

![Screenshot_1751542635](https://github.com/user-attachments/assets/f9effc77-03be-4b80-a4ff-e463c7e91dcc)


</details>

<details>
<summary>Android: mWeb Chrome</summary>

![Screenshot_1751542724](https://github.com/user-attachments/assets/68f47ac1-4493-4bea-beed-93991188df96)

![Screenshot_1751542774](https://github.com/user-attachments/assets/0282fb07-58e3-4640-ad21-69738164f1cd)

![Screenshot_1751542814](https://github.com/user-attachments/assets/ba0fcc76-a3fb-4e56-9563-f4469baa69ef)

![Screenshot_1751542947](https://github.com/user-attachments/assets/c0b875a4-427c-4fd5-9f9d-e9ce4c6d156d)


</details>

<details>
<summary>iOS: Native</summary>

![Simulator Screenshot - iPhone 16 Pro Max - 2025-07-03 at 18 19 32](https://github.com/user-attachments/assets/a54c9971-7fad-4dac-944f-32b87a16fc23)

![Simulator Screenshot - iPhone 16 Pro Max - 2025-07-03 at 18 20 04](https://github.com/user-attachments/assets/2321d794-489b-42da-a4c0-d275e753f7ea)

![Simulator Screenshot - iPhone 16 Pro Max - 2025-07-03 at 18 22 37](https://github.com/user-attachments/assets/0afb0d82-d7ab-4098-b861-98849f45e730)


</details>

<details>
<summary>iOS: mWeb Safari</summary>

![Simulator Screenshot - iPhone 16 Pro Max - 2025-07-03 at 18 25 05](https://github.com/user-attachments/assets/cc9ce214-50c3-43e8-86a5-44626c1a2644)

![Simulator Screenshot - iPhone 16 Pro Max - 2025-07-03 at 18 25 27](https://github.com/user-attachments/assets/933c3073-168c-4c12-a408-2a7e993a763b)

![Simulator Screenshot - iPhone 16 Pro Max - 2025-07-03 at 18 26 05](https://github.com/user-attachments/assets/44b0bf1f-eac6-4513-aea5-5a62849d93ed)


</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<img width="1103" alt="Screenshot 2025-07-03 at 17 52 04" src="https://github.com/user-attachments/assets/f2e91642-dfe4-4be0-bb50-5ff5a0b5b82a" />

<img width="1103" alt="Screenshot 2025-07-03 at 17 51 23" src="https://github.com/user-attachments/assets/687aee96-7adf-4940-b71f-787574e890e2" />

<img width="1127" alt="Screenshot 2025-07-03 at 18 50 05" src="https://github.com/user-attachments/assets/d9398b5f-5238-4a56-87ef-ac31091ac242" />



</details>

<details>
<summary>MacOS: Desktop</summary>


https://github.com/user-attachments/assets/baecbdf8-a3f0-4a28-8a39-e4f8ca6bc83e

<img width="1202" alt="Screenshot 2025-07-03 at 18 09 44" src="https://github.com/user-attachments/assets/398d9d7d-2429-4037-9b33-2493b5886a44" />

<img width="1205" alt="Screenshot 2025-07-03 at 18 09 26" src="https://github.com/user-attachments/assets/4a088571-2c56-4cb6-be3d-9816182cb6e5" />


<img width="1220" alt="Screenshot 2025-07-03 at 17 53 50" src="https://github.com/user-attachments/assets/fb127c4e-8f56-4288-8a99-684eb384a428" />

</details>
