### PR TITLE
[CP Staging] Revert "Fix: New message marker is not displayed on the first message in expense report"

### DIFF
--- a/src/components/MoneyRequestReportView/MoneyRequestReportActionsList.tsx
+++ b/src/components/MoneyRequestReportView/MoneyRequestReportActionsList.tsx
@@ -328,7 +328,7 @@ function MoneyRequestReportActionsList({
         // Scan through each visible report action until we find the appropriate action to show the unread marker
         for (let index = startIndex; index >= endIndex; index--) {
             const reportAction = visibleReportActions.at(index);
-            const nextAction = index > 0 ? visibleReportActions.at(index - 1) : undefined;
+            const nextAction = visibleReportActions.at(index - 1);
             const isEarliestReceivedOfflineMessage = index === earliestReceivedOfflineMessageIndex;
 
             const shouldDisplayNewMarker =


### PR DESCRIPTION
Reverts Expensify/App#64859

Straight revert

Fixes https://github.com/Expensify/App/issues/65487

Please test the regression from the linked PR