### PR TITLE
Perf: Limit previous Search screens mounted

### DIFF
--- a/contributingGuides/NAVIGATION.md
+++ b/contributingGuides/NAVIGATION.md
@@ -654,7 +654,7 @@ function useCustomRootStackNavigatorState({state}: CustomStateHookProps) {
 }
 ```
 
-To optimize the number of routes rendered in `RootStackNavigator` we limit the number of `FullScreenNavigators` rendered to 2 (we need to render the previous fullscreen too for the transition animations to work well). 
+To optimize the number of routes rendered in `RootStackNavigator` we limit the number of `FullScreenNavigators` rendered to 2 (we need to render the previous fullscreen too for the transition animations to work well). There's an exception for `SearchFullscreenNavigator` where we render only last route when possible due to performance implications. The idea stays the same.
 
 -   `src/libs/Navigation/AppNavigator/createSearchFullscreenNavigator/index.tsx`
 
@@ -664,10 +664,9 @@ function useCustomEffects(props: CustomEffectsHookProps) {
     usePreserveNavigatorState(props.state, props.parentRoute);
 }
 
-// This is a custom state hook that is used to render the last two routes in the stack.
-// We do this to improve the performance of the search results screen.
-function useCustomState({state}: CustomStateHookProps) {
-    const routesToRender = [...state.routes.slice(-2)];
+// For web we only render last route in SearchFullscreenNavigator. Other navigators are keep last two routes mounted. The idea stays the same.
+export default function useCustomState({state}: CustomStateHookProps) {
+    const routesToRender = state.routes.slice(-1);
     return {...state, routes: routesToRender, index: routesToRender.length - 1};
 }
 ```

--- a/src/libs/Navigation/AppNavigator/createSearchFullscreenNavigator/index.tsx
+++ b/src/libs/Navigation/AppNavigator/createSearchFullscreenNavigator/index.tsx
@@ -5,25 +5,13 @@ import usePreserveNavigatorState from '@libs/Navigation/AppNavigator/createSplit
 import useNavigationResetOnLayoutChange from '@libs/Navigation/AppNavigator/useNavigationResetOnLayoutChange';
 import createPlatformStackNavigatorComponent from '@navigation/PlatformStackNavigation/createPlatformStackNavigatorComponent';
 import defaultPlatformStackScreenOptions from '@navigation/PlatformStackNavigation/defaultPlatformStackScreenOptions';
-import type {
-    CustomEffectsHookProps,
-    CustomStateHookProps,
-    PlatformStackNavigationEventMap,
-    PlatformStackNavigationOptions,
-    PlatformStackNavigationState,
-} from '@navigation/PlatformStackNavigation/types';
+import type {CustomEffectsHookProps, PlatformStackNavigationEventMap, PlatformStackNavigationOptions, PlatformStackNavigationState} from '@navigation/PlatformStackNavigation/types';
 import SearchFullscreenRouter from './SearchFullscreenRouter';
+import useCustomState from './useCustomState';
 
 function useCustomEffects(props: CustomEffectsHookProps) {
     useNavigationResetOnLayoutChange(props);
     usePreserveNavigatorState(props.state, props.parentRoute);
-}
-
-// This is a custom state hook that is used to render the last two routes in the stack.
-// We do this to improve the performance of the search results screen.
-function useCustomState({state}: CustomStateHookProps) {
-    const routesToRender = [...state.routes.slice(-2)];
-    return {...state, routes: routesToRender, index: routesToRender.length - 1};
 }
 
 const SearchFullscreenNavigatorComponent = createPlatformStackNavigatorComponent('SearchFullscreenNavigator', {

--- a/src/libs/Navigation/AppNavigator/createSearchFullscreenNavigator/useCustomState/index.native.ts
+++ b/src/libs/Navigation/AppNavigator/createSearchFullscreenNavigator/useCustomState/index.native.ts
@@ -2,8 +2,9 @@ import type {CustomStateHookProps} from '@libs/Navigation/PlatformStackNavigatio
 import SCREENS from '@src/SCREENS';
 
 /**
- * This is a custom state hook that is used to render the last two search routes in the stack.
+ * This is a custom state hook for SearchFullscreenNavigator that is used to render the last two search routes in the stack.
  * For native platforms, we render the last two routes to allow users to return by swiping left.
+ * @see SearchFullscreenNavigator use only!
  */
 export default function useCustomState({state}: CustomStateHookProps) {
     const lastSearchNavigatorIndex = state.routes.findLastIndex((route) => route.name === SCREENS.SEARCH.ROOT);

--- a/src/libs/Navigation/AppNavigator/createSearchFullscreenNavigator/useCustomState/index.native.ts
+++ b/src/libs/Navigation/AppNavigator/createSearchFullscreenNavigator/useCustomState/index.native.ts
@@ -1,0 +1,12 @@
+import type {CustomStateHookProps} from '@libs/Navigation/PlatformStackNavigation/types';
+import SCREENS from '@src/SCREENS';
+
+/**
+ * This is a custom state hook that is used to render the last two search routes in the stack.
+ * For native platforms, we render the last two routes to allow users to return by swiping left.
+ */
+export default function useCustomState({state}: CustomStateHookProps) {
+    const lastSearchNavigatorIndex = state.routes.findLastIndex((route) => route.name === SCREENS.SEARCH.ROOT);
+    const routesToRender = state.routes.slice(Math.max(0, lastSearchNavigatorIndex), state.routes.length);
+    return {...state, routes: routesToRender, index: routesToRender.length - 1};
+}

--- a/src/libs/Navigation/AppNavigator/createSearchFullscreenNavigator/useCustomState/index.ts
+++ b/src/libs/Navigation/AppNavigator/createSearchFullscreenNavigator/useCustomState/index.ts
@@ -1,0 +1,10 @@
+import type {CustomStateHookProps} from '@libs/Navigation/PlatformStackNavigation/types';
+
+/**
+ * This is a custom state hook that is used to render the last search route in the stack.
+ * We do this to improve the performance of the search results screen by avoiding unnecessary re-renders of underneath routes.
+ */
+export default function useCustomState({state}: CustomStateHookProps) {
+    const routesToRender = state.routes.slice(-1);
+    return {...state, routes: routesToRender, index: routesToRender.length - 1};
+}

--- a/src/libs/Navigation/AppNavigator/createSearchFullscreenNavigator/useCustomState/index.ts
+++ b/src/libs/Navigation/AppNavigator/createSearchFullscreenNavigator/useCustomState/index.ts
@@ -1,8 +1,9 @@
 import type {CustomStateHookProps} from '@libs/Navigation/PlatformStackNavigation/types';
 
 /**
- * This is a custom state hook that is used to render the last search route in the stack.
+ * This is a custom state hook for SearchFullscreenNavigator that is used to render the last search route in the stack.
  * We do this to improve the performance of the search results screen by avoiding unnecessary re-renders of underneath routes.
+ * @see SearchFullscreenNavigator use only!
  */
 export default function useCustomState({state}: CustomStateHookProps) {
     const routesToRender = state.routes.slice(-1);


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
<!-- Explain what your change does and how it addresses the linked issue -->

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/65582
PROPOSAL: https://expensify.slack.com/archives/C05LX9D6E07/p1751863693154849


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

- [ ] Verify that no errors appear in the JS console

1. Open `Reports` tab from bottom tabs
3. Go to `Reports` from `Expenses` in `Explore panel`
4. Go to `Chats` from `Expenses`
5. Change `Status` filter to `unread`
7. Swipe back / go back until original `Reports` are visible

If none of this steps resulted in any bugs/visual regressions we should be fine 👍 

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
9. Upload an image via copy paste
10. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->
// TODO: These must be filled out, or the issue title must include "[No QA]."

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I verified there are no new alerts related to the `canBeMissing` param for `useOnyx`
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/a8c83b2f-e89c-4c68-9e4e-fa2f8bf78877


</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/8e59f669-c612-486d-adc8-56d1ca85d221


</details>

<details>
<summary>iOS: Native</summary>

https://github.com/user-attachments/assets/fce74f54-15a3-440f-b88b-c2e583d995e7


<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

https://github.com/user-attachments/assets/754e9346-79ba-4d39-96d0-cccb3c49849b


<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/87b9c7fd-1892-4ad1-b39b-d5af4d24268a


</details>

<details>
<summary>MacOS: Desktop</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/d54d678b-6885-4eb7-aa04-1099241940e0


</details>
