### PR TITLE
[CP Staging] Revert "Remove `NAVIGATE_DEPRECATED` and use `POP_TO` instead"

### DIFF
--- a/src/CONST/index.ts
+++ b/src/CONST/index.ts
@@ -5075,15 +5075,15 @@ const CONST = {
             REPLACE: 'REPLACE',
             PUSH: 'PUSH',
             NAVIGATE: 'NAVIGATE',
+            NAVIGATE_DEPRECATED: 'NAVIGATE_DEPRECATED',
             SET_PARAMS: 'SET_PARAMS',
-            PRELOAD: 'PRELOAD',
-            POP_TO: 'POP_TO',
 
             /** These action types are custom for RootNavigator */
             DISMISS_MODAL: 'DISMISS_MODAL',
             OPEN_WORKSPACE_SPLIT: 'OPEN_WORKSPACE_SPLIT',
             SET_HISTORY_PARAM: 'SET_HISTORY_PARAM',
             REPLACE_PARAMS: 'REPLACE_PARAMS',
+            PRELOAD: 'PRELOAD',
         },
     },
     TIME_PERIOD: {

--- a/src/libs/Navigation/Navigation.ts
+++ b/src/libs/Navigation/Navigation.ts
@@ -305,6 +305,15 @@ function goUp(backToRoute: Route, options?: GoBackOptions) {
         return;
     }
 
+    /**
+     * In react-navigation 7 the behavior of the `navigate` function has slightly changed.
+     * If it detects that a screen that we want to navigate to is already in the stack, it doesn't go back anymore.
+     * More: https://reactnavigation.org/docs/upgrading-from-6.x#the-navigate-method-no-longer-goes-back-use-popto-instead
+     */
+    if (minimalAction.type === CONST.NAVIGATION.ACTION_TYPE.NAVIGATE) {
+        minimalAction.type = CONST.NAVIGATION.ACTION_TYPE.NAVIGATE_DEPRECATED;
+    }
+
     const indexOfBackToRoute = targetState.routes.findLastIndex((route) => doesRouteMatchToMinimalActionPayload(route, minimalAction, compareParams));
     const distanceToPop = targetState.routes.length - indexOfBackToRoute - 1;
 
@@ -316,10 +325,11 @@ function goUp(backToRoute: Route, options?: GoBackOptions) {
     }
 
     /**
-     * If we are not comparing params, we want to use popTo action because it will replace params in the route already existing in the state if necessary.
+     * If we are not comparing params, we want to use navigate action because it will replace params in the route already existing in the state if necessary.
+     * This part will need refactor after migrating to react-navigation 7. We will use popTo instead.
      */
     if (!compareParams) {
-        navigationRef.current.dispatch({...minimalAction, type: CONST.NAVIGATION.ACTION_TYPE.POP_TO});
+        navigationRef.current.dispatch(minimalAction);
         return;
     }
 


### PR DESCRIPTION
Reverts Expensify/App#65258 cc @WojtekBoman 

Fixes https://github.com/Expensify/App/pull/65258

Same tests as in the linked issue