### PR TITLE
Fix: Expense Split for 3 Participants Only Divides Amount Between 2

### DIFF
--- a/src/components/ReportActionItem/TransactionPreview/TransactionPreviewContent.tsx
+++ b/src/components/ReportActionItem/TransactionPreview/TransactionPreviewContent.tsx
@@ -184,17 +184,7 @@ function TransactionPreviewContent({
         }
 
         return calculateAmount(isReportAPolicyExpenseChat ? 1 : originalParticipantCount - 1, amount ?? 0, requestCurrency ?? '', action?.actorAccountID === sessionAccountID);
-    }, [
-        shouldShowSplitShare,
-        isReportAPolicyExpenseChat,
-        participantAccountIDs.length,
-        transaction?.comment?.splits,
-        amount,
-        requestCurrency,
-        sessionAccountID,
-        isBillSplit,
-        action,
-    ]);
+    }, [shouldShowSplitShare, isReportAPolicyExpenseChat, participantAccountIDs.length, transaction?.comment?.splits, amount, requestCurrency, sessionAccountID, isBillSplit, action]);
 
     const shouldWrapDisplayAmount = !(isBillSplit || shouldShowMerchantOrDescription || isTransactionScanning);
     const previewTextViewGap = (shouldShowCategoryOrTag || !shouldWrapDisplayAmount) && styles.gap2;

--- a/src/components/ReportActionItem/TransactionPreview/TransactionPreviewContent.tsx
+++ b/src/components/ReportActionItem/TransactionPreview/TransactionPreviewContent.tsx
@@ -161,6 +161,7 @@ function TransactionPreviewContent({
     const shouldShowIOUHeader = !!from && !!to;
 
     // If available, retrieve the split share from the splits object of the transaction, if not, display an even share.
+    const actorAccountID = action?.actorAccountID;
     const splitShare = useMemo(() => {
         if (!shouldShowSplitShare) {
             return 0;
@@ -183,8 +184,19 @@ function TransactionPreviewContent({
             }
         }
 
-        return calculateAmount(isReportAPolicyExpenseChat ? 1 : originalParticipantCount - 1, amount ?? 0, requestCurrency ?? '', action?.actorAccountID === sessionAccountID);
-    }, [shouldShowSplitShare, isReportAPolicyExpenseChat, participantAccountIDs.length, transaction?.comment?.splits, amount, requestCurrency, sessionAccountID, isBillSplit, action]);
+        return calculateAmount(isReportAPolicyExpenseChat ? 1 : originalParticipantCount - 1, amount ?? 0, requestCurrency ?? '', actorAccountID === sessionAccountID);
+    }, [
+        shouldShowSplitShare,
+        isReportAPolicyExpenseChat,
+        participantAccountIDs.length,
+        transaction?.comment?.splits,
+        amount,
+        requestCurrency,
+        sessionAccountID,
+        isBillSplit,
+        action,
+        actorAccountID,
+    ]);
 
     const shouldWrapDisplayAmount = !(isBillSplit || shouldShowMerchantOrDescription || isTransactionScanning);
     const previewTextViewGap = (shouldShowCategoryOrTag || !shouldWrapDisplayAmount) && styles.gap2;

--- a/src/components/ReportActionItem/TransactionPreview/TransactionPreviewContent.tsx
+++ b/src/components/ReportActionItem/TransactionPreview/TransactionPreviewContent.tsx
@@ -161,14 +161,41 @@ function TransactionPreviewContent({
     const shouldShowIOUHeader = !!from && !!to;
 
     // If available, retrieve the split share from the splits object of the transaction, if not, display an even share.
-    const splitShare = useMemo(
-        () =>
-            shouldShowSplitShare
-                ? (transaction?.comment?.splits?.find((split) => split.accountID === sessionAccountID)?.amount ??
-                  calculateAmount(isReportAPolicyExpenseChat ? 1 : participantAccountIDs.length - 1, amount ?? 0, requestCurrency ?? '', action?.actorAccountID === sessionAccountID))
-                : 0,
-        [shouldShowSplitShare, isReportAPolicyExpenseChat, action?.actorAccountID, participantAccountIDs.length, transaction?.comment?.splits, amount, requestCurrency, sessionAccountID],
-    );
+    const splitShare = useMemo(() => {
+        if (!shouldShowSplitShare) {
+            return 0;
+        }
+
+        const splitAmount = transaction?.comment?.splits?.find((split) => split.accountID === sessionAccountID)?.amount;
+        if (splitAmount !== undefined) {
+            return splitAmount;
+        }
+
+        let originalParticipantCount = participantAccountIDs.length;
+
+        if (isBillSplit) {
+            // Try to get the participant count from transaction splits data
+            const transactionSplitsCount = transaction?.comment?.splits?.length;
+            if (transactionSplitsCount && transactionSplitsCount > 0) {
+                originalParticipantCount = transactionSplitsCount;
+            } else if (isMoneyRequestAction(action)) {
+                originalParticipantCount = getOriginalMessage(action)?.participantAccountIDs?.length ?? participantAccountIDs.length;
+            }
+        }
+
+        return calculateAmount(isReportAPolicyExpenseChat ? 1 : originalParticipantCount - 1, amount ?? 0, requestCurrency ?? '', action?.actorAccountID === sessionAccountID);
+    }, [
+        shouldShowSplitShare,
+        isReportAPolicyExpenseChat,
+        action?.actorAccountID,
+        participantAccountIDs.length,
+        transaction?.comment?.splits,
+        amount,
+        requestCurrency,
+        sessionAccountID,
+        isBillSplit,
+        action,
+    ]);
 
     const shouldWrapDisplayAmount = !(isBillSplit || shouldShowMerchantOrDescription || isTransactionScanning);
     const previewTextViewGap = (shouldShowCategoryOrTag || !shouldWrapDisplayAmount) && styles.gap2;

--- a/src/components/ReportActionItem/TransactionPreview/TransactionPreviewContent.tsx
+++ b/src/components/ReportActionItem/TransactionPreview/TransactionPreviewContent.tsx
@@ -187,7 +187,6 @@ function TransactionPreviewContent({
     }, [
         shouldShowSplitShare,
         isReportAPolicyExpenseChat,
-        action?.actorAccountID,
         participantAccountIDs.length,
         transaction?.comment?.splits,
         amount,


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
<!-- Explain what your change does and how it addresses the linked issue -->

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/65231
PROPOSAL: https://github.com/Expensify/App/issues/65231#issuecomment-3022259499


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
Same as QA Steps

- [x] Verify that no errors appear in the JS console

### Offline tests
Same as QA Steps

### QA Steps
1. Tap FAB → tap "Start Chat"
2. Create a group chat with 3 members
3. Tap the “+” button near the compose box → Choose “Split Expense”
4. Tap “Scan” → Select “Take Photo” (simulate a failed scan or provide invalid receipt input)
5. Tap "Split expense"
6. While scanning observe the amount displayed "0", Manually edit the amount (e.g., enter $12.00 USD) and tap “Save”
7. Tap "Split" button , user redirected to the group chat.
8. Open the Split Expense Details → Verify it’s split evenly among 3 members ($4 per person)
9. Navigate to DMs with any of the other 2 participants
10. In the Split Expense Preview in DM, verify the split amount is correctly displayed ($4 per person)
11. Tap into the Split Expense Details → Verify the split amount is correctly displayed ($4 per person)

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I verified there are no new alerts related to the `canBeMissing` param for `useOnyx`
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

https://github.com/user-attachments/assets/8d13e414-4949-4ffd-9cae-b2d2c9157c22

</details>

<details>
<summary>Android: mWeb Chrome</summary>

https://github.com/user-attachments/assets/0cc2f9ad-4001-43cd-bb89-8140c0865c92

</details>

<details>
<summary>iOS: Native</summary>

https://github.com/user-attachments/assets/d1397854-e13e-49ec-9e33-4db986829766

</details>

<details>
<summary>iOS: mWeb Safari</summary>

https://github.com/user-attachments/assets/64e99e23-94fc-4cb7-9396-327dae14077b

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

https://github.com/user-attachments/assets/61c517eb-ce5b-477f-b350-2af6e83984e2

</details>

<details>
<summary>MacOS: Desktop</summary>

https://github.com/user-attachments/assets/f97d9eb6-b657-40ed-a288-91c916f207a4

</details>