### PR TITLE
Change withOnyx to useOnyx in createOnyxContext

### DIFF
--- a/src/components/createOnyxContext.tsx
+++ b/src/components/createOnyxContext.tsx
@@ -2,32 +2,23 @@ import {Str} from 'expensify-common';
 import type {ComponentType, ReactNode} from 'react';
 import React, {createContext, useContext} from 'react';
 import type {OnyxValue} from 'react-native-onyx';
-import {withOnyx} from 'react-native-onyx';
+import useOnyx from '@hooks/useOnyx';
 import type {OnyxKey} from '@src/ONYXKEYS';
 import type ChildrenProps from '@src/types/utils/ChildrenProps';
 
-// Provider types
-type ProviderOnyxProps<TOnyxKey extends OnyxKey> = Record<TOnyxKey, OnyxValue<TOnyxKey>>;
-
-type ProviderPropsWithOnyx<TOnyxKey extends OnyxKey> = ChildrenProps & ProviderOnyxProps<TOnyxKey>;
-
 // createOnyxContext return type
-type CreateOnyxContext<TOnyxKey extends OnyxKey> = [ComponentType<Omit<ProviderPropsWithOnyx<TOnyxKey>, TOnyxKey>>, React.Context<OnyxValue<TOnyxKey>>, () => OnyxValue<TOnyxKey>];
+type CreateOnyxContext<TOnyxKey extends OnyxKey> = [ComponentType<ChildrenProps>, React.Context<OnyxValue<TOnyxKey>>, () => OnyxValue<TOnyxKey>];
 
 export default <TOnyxKey extends OnyxKey>(onyxKeyName: TOnyxKey): CreateOnyxContext<TOnyxKey> => {
     const Context = createContext<OnyxValue<TOnyxKey>>(null as OnyxValue<TOnyxKey>);
-    function Provider(props: ProviderPropsWithOnyx<TOnyxKey>): ReactNode {
-        return <Context.Provider value={props[onyxKeyName]}>{props.children}</Context.Provider>;
+    function Provider(props: ChildrenProps): ReactNode {
+        const [value] = useOnyx(onyxKeyName, {
+            canBeMissing: true,
+        });
+        return <Context.Provider value={value as OnyxValue<TOnyxKey>}>{props.children}</Context.Provider>;
     }
 
     Provider.displayName = `${Str.UCFirst(onyxKeyName)}Provider`;
-    // eslint-disable-next-line
-    const ProviderWithOnyx = withOnyx<ProviderPropsWithOnyx<TOnyxKey>, ProviderOnyxProps<TOnyxKey>>({
-        [onyxKeyName]: {
-            key: onyxKeyName,
-        },
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    } as Record<TOnyxKey, any>)(Provider);
 
     const useOnyxContext = () => {
         const value = useContext(Context);
@@ -37,5 +28,5 @@ export default <TOnyxKey extends OnyxKey>(onyxKeyName: TOnyxKey): CreateOnyxCont
         return value as OnyxValue<TOnyxKey>;
     };
 
-    return [ProviderWithOnyx, Context, useOnyxContext];
+    return [Provider, Context, useOnyxContext];
 };

--- a/tests/unit/SidebarOrderTest.ts
+++ b/tests/unit/SidebarOrderTest.ts
@@ -58,8 +58,9 @@ describe('Sidebar', () => {
             // When it is rendered
             LHNTestUtils.getDefaultRenderedSidebarLinks();
 
-            // Then it should render with an empty state since personal details are loaded by beforeEach
-            expect(screen.toJSON()).not.toBe(null);
+            // Then it should render with the empty state message and not show the reports list
+            expect(screen.getByText(translateLocal('common.emptyLHN.title'))).toBeOnTheScreen();
+            expect(screen.queryByTestId('lhn-options-list')).not.toBeOnTheScreen();
         });
 
         it('is rendered with an empty list when personal details exist', () =>

--- a/tests/unit/SidebarOrderTest.ts
+++ b/tests/unit/SidebarOrderTest.ts
@@ -53,14 +53,13 @@ describe('Sidebar', () => {
     });
 
     describe('in default mode', () => {
-        it('is not rendered when there are no props passed to it', () => {
+        it('is rendered with empty state when no reports are available', () => {
             // Given all the default props are passed to SidebarLinks
             // When it is rendered
             LHNTestUtils.getDefaultRenderedSidebarLinks();
 
-            // Then it should render nothing and be null
-            // This is expected because there is an early return when there are no personal details
-            expect(screen.toJSON()).toBe(null);
+            // Then it should render with an empty state since personal details are loaded by beforeEach
+            expect(screen.toJSON()).not.toBe(null);
         });
 
         it('is rendered with an empty list when personal details exist', () =>


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
<!-- Explain what your change does and how it addresses the linked issue -->

Change the deprecated `withOnyx` inside createOnyxContext.tsx to `useOnyx`


### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/62300


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

## Tests

1. **Verify context providers work correctly after refactor:**
   - Navigate to any screen that uses a context created by `createOnyxContext` (e.g., settings screen, report screen)
   - Verify that the screen loads without errors and displays the expected data
   - Verify that the context provider is correctly passing data to consuming components

2. **Test data reactivity and updates:**
   - Navigate to a screen that uses a context created by `createOnyxContext`
   - Trigger an action that updates the Onyx data for that context (e.g., update user settings, change report data)
   - Verify that the UI updates immediately to reflect the new data

3. **Test multiple context consumers:**
   - Navigate to a screen with multiple components that consume the same context
   - Verify that all components receive the same data and update simultaneously when the Onyx data changes

4. **Test context hook functionality:**
   - Navigate to screens that use the context hook returned by `createOnyxContext`
   - Verify that components can successfully read data using the hook
   - Verify that the hook throws appropriate errors when used outside the provider

5. **Test initial data loading:**
   - Clear app data/cache and restart the app
   - Navigate to screens using contexts created by `createOnyxContext`
   - Verify that initial data loads correctly and displays properly

6. **Test error scenarios:**
   - Navigate to a screen that uses a context created by `createOnyxContext`
   - Simulate network errors or invalid data scenarios
   - Verify that error handling works as expected and no crashes occur

## Offline tests

1. **Test offline data availability:**
   - Go offline
   - Navigate to screens that use contexts created by `createOnyxContext`
   - Verify that cached data is still available and displayed correctly

2. **Test data synchronization when going back online:**
   - While offline, navigate to screens using the affected contexts
   - Go back online
   - Verify that data syncs properly and any pending updates are reflected

## QA Steps

### Test 1: Personal Details Context (usePersonalDetails)
**Screens to test:**
- Search functionality and filters
- Money request flows
- Task management screens
- Report participant lists

**Steps:**
1. Navigate to Search → Advanced Filters → "From" field
2. Verify: User names and avatars load correctly
3. Create a money request and select participants
4. Verify: Personal details display correctly in participant selection
5. View any group chat participant list
6. Verify: All participant names and avatars display correctly

### Test 2: Session Context (useSession) 
**Screens to test:**
- Authentication-dependent features
- Task assignment flows
- Image components requiring auth

**Steps:**

1. Press + button → Assign Task
2. In "Assign to" field, type your own name/email
3. Verify: You can find and select yourself
4. Create the task
5. Verify: Task is created successfully (proving session works for task creation)
6. Expected Result: Task assignment works and shows you have proper session access

### Test 3: Policy Categories/Tags Context
**Screens to test:**
- MoneyRequestView
- Expense categorization flows

**Steps:**
1. Create a new expense request
2. Select categories and tags (if available)
3. Verify: Categories and tags load and save correctly
4. View expense details
5. Verify: Selected categories/tags display correctly


### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I verified there are no new alerts related to the `canBeMissing` param for `useOnyx`
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/dc8b5aaf-b529-48b4-9341-d12e3c79688d




</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/b37e2566-9a3e-4224-8c18-b8f37ff3012a


</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->


https://github.com/user-attachments/assets/8bbdffae-c3b1-4ffe-b892-337268f61134



</details>

<details>
<summary>MacOS: Desktop</summary>

<!-- add screenshots or videos here -->

</details>
