### PR TITLE
[No QA] Update Set-Custom-Report-Names.md

### DIFF
--- a/docs/articles/expensify-classic/reports/Set-Custom-Report-Names.md
+++ b/docs/articles/expensify-classic/reports/Set-Custom-Report-Names.md
@@ -5,28 +5,99 @@ keywords: [Expensify Classic, default report title, report naming, enforce repor
 ---
 <div id="expensify-classic" markdown="1">
 
-Workspace Admins can automatically apply a custom report title to all reports created within a specific workspace. You can also enforce this setting so members can't update it.
+Automatically generate standardized report titles across your workspace using formulas. Admins can pull in dynamic data like report type or member name, and even lock naming rules to prevent edits.
 
 ---
 
-# Set a Default Report Title
+# Customize Report Titles Using Formulas
 
+**Navigation:**
 1. Head to **Settings > Workspace > [Workspace Name] > Rules**.
 2. Scroll to **Custom Report Names**.
-3. Configure the title formula:
-   - Use the example on the **Rules Settings page**, or refer to more [report formula options](https://help.expensify.com/articles/expensify-classic/spending-insights/Custom-Templates).
-   - Some formulas automatically update the report title as changes are made. For example, the title will update before submission if the formula includes the report date, total amount, or workspace name.
-   - Changes to Report Field values (e.g., `{field:Customer}`) won't update the title until the report is submitted. After submission and before approval, updates will apply automatically. Once a report is Approved or Reimbursed, the title will not update retroactively.
+3. Configure the title formula using your preferred formulas (see below).
 4. To prevent members from editing the title, enable the **Enforce Custom Report Names** toggle.
+
+**Example formula:**  
+`{report:type} - {report:submit:from:firstname} {report:startdate}`  
+**Result:** `Expense Report - Alice 2025-05-15`
 
 ---
 
-# FAQ
+# How Dynamic Titles Work
 
-## Can I stop team members from changing the report name?
-Yes! Just turn on the **Enforce Default Report Title** option, and the title will be locked in based on the formula you set.
+- Custom report names update automatically when the value of the fields they reference is updated. For example:
+    - {report:total} will update when new expenses are added to the report.
+    - {report:workspaceName} will update when the workspace name changes.
+- Report titles freeze once a report is **Approved** or **Reimbursed**.
+- Fields related to report submission are snapshots of the data at the time the report was submitted. For example:
+    - {report:submit:from:firstName} may capture the first name of Joanne and won't be updated if Joanne changes her first name to "Jo" in Expensify
+    - The report title will need to be manually edited by an admin, or the report unapproved and submitted again
 
-## What if my formula doesn't show the correct title immediately?
-Some formula fields, like `{field:Customer}`, only update after submission. Others, like dates and amounts, update in realtime before submitting the report.
+---
+
+# Report Title Formula Reference
+
+## Report-level data
+
+| Formula | Example | Description |
+| -- | -- | -- |
+| `{report:id}` | R00I7J3xs5fn | Unique report ID in a base 62 representation |
+| `{report:oldID}` | R3513250790654885 | unique report ID |
+| `{report:total}` | $325.34 | Total amount on report |
+| `{report:type}` | Expense Report | Report type (Expense Report, Invoice, Bill) |
+| `{report:reimbursable}` | $143.43 | Reimbursable amount |
+| `{report:currency}` | USD | Currency used |
+| `{field:Employee ID}` | 123456 | Custom field from the report |
+| `{report:created}` | 2024-09-15 12:00:00 | When report was created |
+| `{report:created:yyyy-MM-dd}` | 2024-09-15 | Created date (custom format - see below for more formats) |
+| `{report:startdate}` | 2024-09-15 | Earliest expense date |
+| `{report:enddate}` | 2024-09-26 | Latest expense date |
+| `{report:submit:date}` | 2023-09-15 12:00:00 | Submission time |
+| `{report:submit:date:yyyy-MM-dd}` | 2023-09-15 | Submission date (formatted) |
+| `{report:approve:date}` | 2011-09-25 12:00:00 | Approval timestamp |
+| `{report:approve:date:yyyy-MM-dd}` | 2011-09-25 | Approval date (formatted) |
+| `{report:expensescount}` | 10 | Number of expenses |
+| `{report:workspaceName}` | Sales | Name of the workspace |
+| `{report:status}` | Approved | Current report status |
+| `{report:submit:to}` | alice@email.com | Approver’s email |
+| `{report:submit:from}` | Sally Ride | Submitter full name |
+| `{report:submit:from:firstname}` | Sally | Submitter’s first name |
+| `{report:submit:from:lastname}` | Ride | Submitter’s last name |
+| `{report:submit:from:fullname}` | Sally Ride | Submitter full name |
+| `{report:submit:from:email}` | sride@email.com | Submitter email |
+| `{report:submit:from:customfield1}` | 100 | Submitter custom field 1 |
+| `{report:submit:from:customfield2}` | 1234 | Submitter custom field 2 |
+
+---
+
+# Date Format Options
+
+Customize date appearance with these formats:
+
+| Format | Example |
+| -- | -- |
+| M/dd/yyyy | 5/23/2024 |
+| MMMM dd, yyyy | May 23, 2024 |
+| dd MMM yyyy | 23 May 2024 |
+| yyyy/MM/dd | 2024/05/23 |
+| MMMM, yyyy | May, 2024 |
+| yy/MM/dd | 24/05/23 |
+| dd/MM/yy | 23/05/24 |
+| yyyy | 2024 |
+
+---
+
+# Advanced Formula Functions
+
+Add `|` functions to format results:
+
+| Function | Example | Description |
+| -- | -- | -- |
+| `frontpart` | `{report:submit:from:email|frontpart}` → alice | Gets first word or string before `@` |
+| `substr:x` | `{report:policyname|substr:20}` → Sales Expenses | Trims to first `x` characters |
+| `substr:x:y` | `{report:policyname|substr:20|frontpart}` → Sales | Chains multiple functions |
+| `domain` | `{report:submit:from:email|domain}` → email.com | Returns email domain |
+
+---
 
 </div>

--- a/docs/articles/expensify-classic/reports/Set-Custom-Report-Names.md
+++ b/docs/articles/expensify-classic/reports/Set-Custom-Report-Names.md
@@ -98,6 +98,4 @@ Add `|` functions to format results:
 | `substr:x:y` | `{report:policyname|substr:20|frontpart}` → Sales | Chains multiple functions |
 | `domain` | `{report:submit:from:email|domain}` → email.com | Returns email domain |
 
----
-
 </div>


### PR DESCRIPTION
### Explanation of Change
Updated to add report fields in to help doc itself, and remove reference to custom exports page. Also updated in like with new NewDot article. 

### Fixed Issues

https://github.com/Expensify/Expensify/issues/505552

### Tests
N/A

### Offline tests
N/A

### QA Steps
N/A

### PR Author Checklist
### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->
- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] If we are not using the full Onyx data that we loaded, I've added the proper selector in order to ensure the component only re-renders when the data it is using changes
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.
