### PR TITLE
[NoQA] Revert "Fix: Reset Background to Workspace on Page Reload in Track Expense"

### DIFF
--- a/src/ROUTES.ts
+++ b/src/ROUTES.ts
@@ -602,11 +602,10 @@ const ROUTES = {
     },
     MONEY_REQUEST_STEP_CONFIRMATION: {
         route: ':action/:iouType/confirmation/:transactionID/:reportID/:backToReport?',
-        getRoute: (action: IOUAction, iouType: IOUType, transactionID: string, reportID: string | undefined, backToReport?: string, participantsAutoAssigned?: boolean, backTo?: string) =>
-            getUrlWithBackToParam(
-                `${action as string}/${iouType as string}/confirmation/${transactionID}/${reportID}/${backToReport ?? ''}${participantsAutoAssigned ? '?participantsAutoAssigned=true' : ''}`,
-                backTo,
-            ),
+        getRoute: (action: IOUAction, iouType: IOUType, transactionID: string, reportID: string | undefined, backToReport?: string, participantsAutoAssigned?: boolean) =>
+            `${action as string}/${iouType as string}/confirmation/${transactionID}/${reportID}/${backToReport ?? ''}${
+                participantsAutoAssigned ? '?participantsAutoAssigned=true' : ''
+            }` as const,
     },
     MONEY_REQUEST_STEP_AMOUNT: {
         route: ':action/:iouType/amount/:transactionID/:reportID/:pageIndex?/:backToReport?',

--- a/src/libs/Navigation/types.ts
+++ b/src/libs/Navigation/types.ts
@@ -1410,7 +1410,7 @@ type MoneyRequestNavigatorParamList = {
         transactionID: string;
         reportID: string;
         pageIndex?: string;
-        backTo?: Routes;
+        backTo?: string;
         participantsAutoAssigned?: string;
         backToReport?: string;
     };

--- a/src/libs/ReportUtils.ts
+++ b/src/libs/ReportUtils.ts
@@ -9925,7 +9925,7 @@ function createDraftTransactionAndNavigateToParticipantSelector(
     }
 
     if (actionName === CONST.IOU.ACTION.SHARE) {
-        Navigation.navigate(ROUTES.MONEY_REQUEST_ACCOUNTANT.getRoute(actionName, CONST.IOU.TYPE.SUBMIT, transactionID, reportID, Navigation.getActiveRoute()));
+        Navigation.navigate(ROUTES.MONEY_REQUEST_ACCOUNTANT.getRoute(actionName, CONST.IOU.TYPE.SUBMIT, transactionID, reportID, undefined));
         return;
     }
 

--- a/src/pages/iou/request/step/IOURequestStepAccountant.tsx
+++ b/src/pages/iou/request/step/IOURequestStepAccountant.tsx
@@ -38,7 +38,8 @@ function IOURequestStepAccountant({
             createDraftWorkspaceAndNavigateToConfirmationScreen(transactionID, action);
             return;
         }
-        Navigation.navigate(ROUTES.MONEY_REQUEST_STEP_PARTICIPANTS.getRoute(iouType, transactionID, reportID, Navigation.getActiveRoute(), action));
+
+        Navigation.navigate(ROUTES.MONEY_REQUEST_STEP_PARTICIPANTS.getRoute(iouType, transactionID, reportID, undefined, action));
     }, [iouType, transactionID, reportID, action, currentUserLogin]);
 
     const navigateBack = useCallback(() => {

--- a/src/pages/iou/request/step/IOURequestStepConfirmation.tsx
+++ b/src/pages/iou/request/step/IOURequestStepConfirmation.tsx
@@ -81,7 +81,7 @@ function IOURequestStepConfirmation({
     report: reportReal,
     reportDraft,
     route: {
-        params: {iouType, reportID, transactionID: initialTransactionID, action, participantsAutoAssigned: participantsAutoAssignedFromRoute, backToReport, backTo},
+        params: {iouType, reportID, transactionID: initialTransactionID, action, participantsAutoAssigned: participantsAutoAssignedFromRoute, backToReport},
     },
     transaction: initialTransaction,
     isLoadingTransaction,
@@ -299,11 +299,6 @@ function IOURequestStepConfirmation({
     }, [transactionIDs, requestType, defaultCategory, policy?.id]);
 
     const navigateBack = useCallback(() => {
-        if (backTo) {
-            Navigation.goBack(backTo);
-            return;
-        }
-
         // If the action is categorize and there's no policies other than personal one, we simply call goBack(), i.e: dismiss the whole flow together
         // We don't need to subscribe to policy_ collection as we only need to check on the latest collection value
         if (action === CONST.IOU.ACTION.CATEGORIZE) {
@@ -358,7 +353,6 @@ function IOURequestStepConfirmation({
         reportID,
         participantsAutoAssignedFromRoute,
         isMovingTransactionFromTrackExpense,
-        backTo,
     ]);
 
     const navigateToAddReceipt = useCallback(() => {

--- a/src/pages/iou/request/step/IOURequestStepParticipants.tsx
+++ b/src/pages/iou/request/step/IOURequestStepParticipants.tsx
@@ -253,9 +253,6 @@ function IOURequestStepParticipants({
             iouType === CONST.IOU.TYPE.CREATE ? CONST.IOU.TYPE.SUBMIT : iouType,
             initialTransactionID,
             newReportID,
-            undefined,
-            undefined,
-            Navigation.getActiveRoute(),
         );
 
         const route = isCategorizing


### PR DESCRIPTION
Reverts Expensify/App#65514

It breaks the navigation handling in auto-assigning flow of Create Expense - after auto-assigning the active policy and then changing the assignment in the confirmation step it doesn't get back to the Scan step but to the Participants Step

Current behavior:

https://github.com/user-attachments/assets/3c123ab1-d77a-4d92-8f58-52863ed28bb2

Before introducing the change:

https://github.com/user-attachments/assets/5a281792-a334-4928-98fc-156ab060cb2a

