### PR TITLE
fix: Web - Subscription- The top of explore plans does not scroll if the screen size is increased.

### DIFF
--- a/src/pages/settings/Subscription/SubscriptionPlan/ComparePlansModal.tsx
+++ b/src/pages/settings/Subscription/SubscriptionPlan/ComparePlansModal.tsx
@@ -3,12 +3,14 @@ import {View} from 'react-native';
 import HeaderWithBackButton from '@components/HeaderWithBackButton';
 import Modal from '@components/Modal';
 import type {AnimationOut} from '@components/Modal/ReanimatedModal/types';
+import SafeAreaConsumer from '@components/SafeAreaConsumer';
 import ScrollView from '@components/ScrollView';
 import Text from '@components/Text';
 import TextLink from '@components/TextLink';
 import useLocalize from '@hooks/useLocalize';
 import useResponsiveLayout from '@hooks/useResponsiveLayout';
 import useThemeStyles from '@hooks/useThemeStyles';
+import useWindowDimensions from '@hooks/useWindowDimensions';
 import CONST from '@src/CONST';
 import SubscriptionPlanCard from './SubscriptionPlanCard';
 
@@ -23,6 +25,7 @@ type ComparePlansModalProps = {
 function ComparePlansModal({isModalVisible, setIsModalVisible}: ComparePlansModalProps) {
     const styles = useThemeStyles();
     const {translate} = useLocalize();
+    const {windowHeight} = useWindowDimensions();
     // We need to use isSmallScreenWidth instead of shouldUseNarrowLayout to be consistent with BaseModal component
     // eslint-disable-next-line rulesdir/prefer-shouldUseNarrowLayout-instead-of-isSmallScreenWidth
     const {isSmallScreenWidth} = useResponsiveLayout();
@@ -60,22 +63,33 @@ function ComparePlansModal({isModalVisible, setIsModalVisible}: ComparePlansModa
     );
 
     return (
-        <Modal
-            isVisible={isModalVisible}
-            type={isSmallScreenWidth ? CONST.MODAL.MODAL_TYPE.CENTERED : CONST.MODAL.MODAL_TYPE.CENTERED_SMALL}
-            onClose={() => setIsModalVisible(false)}
-            animationOut={isSmallScreenWidth ? animationOut : undefined}
-            innerContainerStyle={isSmallScreenWidth ? undefined : styles.workspaceSection}
-        >
-            <HeaderWithBackButton
-                title={translate('subscription.compareModal.comparePlans')}
-                shouldShowCloseButton
-                onCloseButtonPress={() => setIsModalVisible(false)}
-                shouldShowBackButton={false}
-                style={isSmallScreenWidth ? styles.pl4 : [styles.pr3, styles.pl8]}
-            />
-            {isSmallScreenWidth ? <ScrollView addBottomSafeAreaPadding>{renderPlans()}</ScrollView> : renderPlans()}
-        </Modal>
+        <SafeAreaConsumer>
+            {({safeAreaPaddingBottomStyle}) => (
+                <Modal
+                    isVisible={isModalVisible}
+                    type={isSmallScreenWidth ? CONST.MODAL.MODAL_TYPE.CENTERED : CONST.MODAL.MODAL_TYPE.CENTERED_SMALL}
+                    onClose={() => setIsModalVisible(false)}
+                    animationOut={isSmallScreenWidth ? animationOut : undefined}
+                    innerContainerStyle={isSmallScreenWidth ? undefined : styles.workspaceSection}
+                >
+                    <View
+                        style={{
+                            maxHeight: isSmallScreenWidth ? windowHeight : windowHeight - 20,
+                            ...safeAreaPaddingBottomStyle,
+                        }}
+                    >
+                        <HeaderWithBackButton
+                            title={translate('subscription.compareModal.comparePlans')}
+                            shouldShowCloseButton
+                            onCloseButtonPress={() => setIsModalVisible(false)}
+                            shouldShowBackButton={false}
+                            style={isSmallScreenWidth ? styles.pl4 : [styles.pr3, styles.pl8]}
+                        />
+                        <ScrollView addBottomSafeAreaPadding>{renderPlans()}</ScrollView>
+                    </View>
+                </Modal>
+            )}
+        </SafeAreaConsumer>
     );
 }
 

--- a/src/pages/settings/Subscription/SubscriptionPlan/ComparePlansModal.tsx
+++ b/src/pages/settings/Subscription/SubscriptionPlan/ComparePlansModal.tsx
@@ -62,6 +62,8 @@ function ComparePlansModal({isModalVisible, setIsModalVisible}: ComparePlansModa
         </View>
     );
 
+    const maxHeight = isSmallScreenWidth ? undefined : windowHeight - 20;
+
     return (
         <SafeAreaConsumer>
             {({safeAreaPaddingBottomStyle}) => (
@@ -70,23 +72,16 @@ function ComparePlansModal({isModalVisible, setIsModalVisible}: ComparePlansModa
                     type={isSmallScreenWidth ? CONST.MODAL.MODAL_TYPE.CENTERED : CONST.MODAL.MODAL_TYPE.CENTERED_SMALL}
                     onClose={() => setIsModalVisible(false)}
                     animationOut={isSmallScreenWidth ? animationOut : undefined}
-                    innerContainerStyle={isSmallScreenWidth ? undefined : styles.workspaceSection}
+                    innerContainerStyle={isSmallScreenWidth ? {...safeAreaPaddingBottomStyle, maxHeight} : {...styles.workspaceSection, ...safeAreaPaddingBottomStyle, maxHeight}}
                 >
-                    <View
-                        style={{
-                            maxHeight: isSmallScreenWidth ? windowHeight : windowHeight - 20,
-                            ...safeAreaPaddingBottomStyle,
-                        }}
-                    >
-                        <HeaderWithBackButton
-                            title={translate('subscription.compareModal.comparePlans')}
-                            shouldShowCloseButton
-                            onCloseButtonPress={() => setIsModalVisible(false)}
-                            shouldShowBackButton={false}
-                            style={isSmallScreenWidth ? styles.pl4 : [styles.pr3, styles.pl8]}
-                        />
-                        <ScrollView addBottomSafeAreaPadding>{renderPlans()}</ScrollView>
-                    </View>
+                    <HeaderWithBackButton
+                        title={translate('subscription.compareModal.comparePlans')}
+                        shouldShowCloseButton
+                        onCloseButtonPress={() => setIsModalVisible(false)}
+                        shouldShowBackButton={false}
+                        style={isSmallScreenWidth ? styles.pl4 : [styles.pr3, styles.pl8]}
+                    />
+                    <ScrollView>{renderPlans()}</ScrollView>
                 </Modal>
             )}
         </SafeAreaConsumer>

--- a/src/pages/settings/Subscription/SubscriptionPlan/ComparePlansModal.tsx
+++ b/src/pages/settings/Subscription/SubscriptionPlan/ComparePlansModal.tsx
@@ -62,7 +62,7 @@ function ComparePlansModal({isModalVisible, setIsModalVisible}: ComparePlansModa
         </View>
     );
 
-    const maxHeight = isSmallScreenWidth ? undefined : windowHeight - 20;
+    const maxHeight = isSmallScreenWidth ? undefined : windowHeight - 40;
 
     return (
         <SafeAreaConsumer>


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
<!-- Explain what your change does and how it addresses the linked issue -->

### Fixed Issues
$ https://github.com/Expensify/App/issues/64948
PROPOSAL: https://github.com/Expensify/App/issues/64948#issuecomment-3005712899

### Tests
1. Click Account tab
2. Click on "Subscription"
3. Click on "Explore all plans"
4. Increase the screen zoom to 150% or 175% (or adjust until the modal content overflows).
5. Verify the modal is scrollable when content overflows


- [x] Verify that no errors appear in the JS console

### Offline tests
1. Click Account tab
2. Click on "Subscription"
3. Click on "Explore all plans"
4. Increase the screen zoom to 150% or 175% (or adjust until the modal content overflows).
5. Verify the modal is scrollable when content overflows

### QA Steps
1. Click Account tab
2. Click on "Subscription"
3. Click on "Explore all plans"
4. Increase the screen zoom to 150% or 175% (or adjust until the modal content overflows).
5. Verify the modal is scrollable when content overflows

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.


### Screenshots/Videos
<details>
<summary>Android: Native</summary>

https://github.com/user-attachments/assets/e47ca526-a4ea-45d4-a9f5-df740ab35681

</details>

<details>
<summary>Android: mWeb Chrome</summary>

https://github.com/user-attachments/assets/bf0c190e-3ab9-43eb-bc64-bff03f11322e

</details>

<details>
<summary>iOS: Native</summary>

https://github.com/user-attachments/assets/31daad2d-c6f1-46a8-ae9c-65720bc90d76

</details>

<details>
<summary>iOS: mWeb Safari</summary>

https://github.com/user-attachments/assets/2f3e2c63-5605-420f-acfd-8df6f290be32

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

https://github.com/user-attachments/assets/0bf35823-3258-4287-bf8d-02c9a1803481

</details>

<details>
<summary>MacOS: Desktop</summary>

https://github.com/user-attachments/assets/78319d7c-fc4b-496d-abac-846f81d2aaff

</details>
