### PR TITLE
65501 update dropdown to show only button in case of single option

### DIFF
--- a/src/CONST/index.ts
+++ b/src/CONST/index.ts
@@ -5125,6 +5125,7 @@ const CONST = {
     },
     SELECTION_LIST_WITH_MODAL_TEST_ID: 'selectionListWithModalMenuItem',
 
+    ICON_TEST_ID: 'Icon',
     IMAGE_TEST_ID: 'Image',
     IMAGE_SVG_TEST_ID: 'ImageSVG',
     VIDEO_PLAYER_TEST_ID: 'VideoPlayer',

--- a/src/components/ButtonWithDropdownMenu/index.tsx
+++ b/src/components/ButtonWithDropdownMenu/index.tsx
@@ -116,9 +116,14 @@ function ButtonWithDropdownMenu<IValueType>({
                 }
             } else {
                 const option = options.at(0);
-                if (option?.value) {
-                    onPress(e, option.value);
+                               if (!option) return;
+                if (option.onSelected) {
+                    option.onSelected(); // Call the same callbacks that would be called if this was a dropdown item
+                } else {
+                    onOptionSelected?.(option);
                 }
+                onSubItemSelected?.(option, 0, e);  // Call onSubItemSelected if it exists (for nested menu items)
+                onPress(e, option.value); // Finally call the main onPress
             }
         },
         {
@@ -207,7 +212,14 @@ function ButtonWithDropdownMenu<IValueType>({
                     text={selectedItem?.text}
                     onPress={(event) => {
                         const option = options.at(0);
-                        return option ? onPress(event, option.value) : undefined;
+                        if (!option) return;
+                        if (option.onSelected) {
+                            option.onSelected();  // Call the same callbacks that would be called if this was a dropdown item
+                        } else {
+                            onOptionSelected?.(option);
+                        }
+                        onSubItemSelected?.(option, 0, event); // Call onSubItemSelected if it exists (for nested menu items)
+                        onPress(event, option.value);  // Finally call the main onPress
                     }}
                     large={buttonSize === CONST.DROPDOWN_BUTTON_SIZE.LARGE}
                     medium={buttonSize === CONST.DROPDOWN_BUTTON_SIZE.MEDIUM}

--- a/src/components/ButtonWithDropdownMenu/index.tsx
+++ b/src/components/ButtonWithDropdownMenu/index.tsx
@@ -114,10 +114,10 @@ function ButtonWithDropdownMenu<IValueType>({
                 option.onSelected();
             } else {
                 onOptionSelected?.(option);
+                onPress(event, option.value);
             }
-
+            
             onSubItemSelected?.(option, 0, event);
-            onPress(event, option.value);
         },
         [options, onPress, onOptionSelected, onSubItemSelected],
     );

--- a/src/components/ButtonWithDropdownMenu/index.tsx
+++ b/src/components/ButtonWithDropdownMenu/index.tsx
@@ -103,6 +103,25 @@ function ButtonWithDropdownMenu<IValueType>({
         }
     }, [windowWidth, windowHeight, isMenuVisible, anchorAlignment.vertical, popoverHorizontalOffsetType]);
 
+    const handleSingleOptionPress = useCallback(
+        (event: GestureResponderEvent | KeyboardEvent | undefined) => {
+            const option = options.at(0);
+            if (!option) {
+                return;
+            }
+
+            if (option.onSelected) {
+                option.onSelected();
+            } else {
+                onOptionSelected?.(option);
+            }
+
+            onSubItemSelected?.(option, 0, event);
+            onPress(event, option.value);
+        },
+        [options, onPress, onOptionSelected, onSubItemSelected],
+    );
+
     useKeyboardShortcut(
         CONST.KEYBOARD_SHORTCUTS.CTRL_ENTER,
         (e) => {
@@ -115,15 +134,7 @@ function ButtonWithDropdownMenu<IValueType>({
                     onPress(e, selectedItem.value);
                 }
             } else {
-                const option = options.at(0);
-                               if (!option) return;
-                if (option.onSelected) {
-                    option.onSelected(); // Call the same callbacks that would be called if this was a dropdown item
-                } else {
-                    onOptionSelected?.(option);
-                }
-                onSubItemSelected?.(option, 0, e);  // Call onSubItemSelected if it exists (for nested menu items)
-                onPress(e, option.value); // Finally call the main onPress
+                handleSingleOptionPress(e);
             }
         },
         {
@@ -210,17 +221,7 @@ function ButtonWithDropdownMenu<IValueType>({
                     disabledStyle={disabledStyle}
                     isLoading={isLoading}
                     text={selectedItem?.text}
-                    onPress={(event) => {
-                        const option = options.at(0);
-                        if (!option) return;
-                        if (option.onSelected) {
-                            option.onSelected();  // Call the same callbacks that would be called if this was a dropdown item
-                        } else {
-                            onOptionSelected?.(option);
-                        }
-                        onSubItemSelected?.(option, 0, event); // Call onSubItemSelected if it exists (for nested menu items)
-                        onPress(event, option.value);  // Finally call the main onPress
-                    }}
+                    onPress={handleSingleOptionPress}
                     large={buttonSize === CONST.DROPDOWN_BUTTON_SIZE.LARGE}
                     medium={buttonSize === CONST.DROPDOWN_BUTTON_SIZE.MEDIUM}
                     small={buttonSize === CONST.DROPDOWN_BUTTON_SIZE.SMALL}
@@ -231,6 +232,7 @@ function ButtonWithDropdownMenu<IValueType>({
                     icon={shouldUseOptionIcon && !shouldShowButtonRightIcon ? options.at(0)?.icon : icon}
                     iconRight={shouldShowButtonRightIcon ? options.at(0)?.icon : undefined}
                     shouldShowRightIcon={shouldShowButtonRightIcon}
+                    testID={testID}
                 />
             )}
             {(shouldAlwaysShowDropdownMenu || options.length > 1) && !!popoverAnchorPosition && (

--- a/src/components/ButtonWithDropdownMenu/index.tsx
+++ b/src/components/ButtonWithDropdownMenu/index.tsx
@@ -116,7 +116,7 @@ function ButtonWithDropdownMenu<IValueType>({
                 onOptionSelected?.(option);
                 onPress(event, option.value);
             }
-            
+
             onSubItemSelected?.(option, 0, event);
         },
         [options, onPress, onOptionSelected, onSubItemSelected],

--- a/src/pages/workspace/companyCards/WorkspaceCompanyCardsListHeaderButtons.tsx
+++ b/src/pages/workspace/companyCards/WorkspaceCompanyCardsListHeaderButtons.tsx
@@ -134,7 +134,7 @@ function WorkspaceCompanyCardsListHeaderButtons({policyID, selectedFeed, shouldS
                     <ButtonWithDropdownMenu
                         success={false}
                         onPress={() => {}}
-                        shouldAlwaysShowDropdownMenu
+                        shouldUseOptionIcon
                         customText={translate('common.more')}
                         options={secondaryActions}
                         isSplitButton={false}

--- a/src/pages/workspace/distanceRates/PolicyDistanceRatesPage.tsx
+++ b/src/pages/workspace/distanceRates/PolicyDistanceRatesPage.tsx
@@ -337,7 +337,7 @@ function PolicyDistanceRatesPage({
                     <ButtonWithDropdownMenu
                         success={false}
                         onPress={() => {}}
-                        shouldAlwaysShowDropdownMenu
+                        shouldUseOptionIcon
                         customText={translate('common.more')}
                         options={secondaryActions}
                         isSplitButton={false}

--- a/src/pages/workspace/taxes/WorkspaceTaxesPage.tsx
+++ b/src/pages/workspace/taxes/WorkspaceTaxesPage.tsx
@@ -335,7 +335,7 @@ function WorkspaceTaxesPage({
             <ButtonWithDropdownMenu
                 success={false}
                 onPress={() => {}}
-                shouldAlwaysShowDropdownMenu
+                shouldUseOptionIcon
                 customText={translate('common.more')}
                 options={secondaryActions}
                 isSplitButton={false}

--- a/tests/ui/components/ButtonWithDropdownMenuTest.tsx
+++ b/tests/ui/components/ButtonWithDropdownMenuTest.tsx
@@ -47,7 +47,7 @@ describe('ButtonWithDropdownMenu (single option)', () => {
         expect(mockOnSelected).toHaveBeenCalled();
         expect(mockOnOptionSelected).not.toHaveBeenCalled(); // onSelected takes precedence
         expect(mockOnSubItemSelected).toHaveBeenCalledWith(expect.objectContaining(option), 0, undefined);
-        expect(mockOnPress).toHaveBeenCalledWith(undefined, 'test');
+        expect(mockOnPress).not.toHaveBeenCalled(); // onPress should not be called when onSelected exists to prevent double execution
     });
 
     it('renders the icon from the option along with the text', () => {

--- a/tests/ui/components/ButtonWithDropdownMenuTest.tsx
+++ b/tests/ui/components/ButtonWithDropdownMenuTest.tsx
@@ -1,0 +1,77 @@
+import React from 'react';
+import {render, fireEvent, RenderAPI} from '@testing-library/react-native';
+import type {ReactTestInstance} from 'react-test-renderer';
+import ButtonWithDropdownMenu from '@components/ButtonWithDropdownMenu';
+import * as Expensicons from '@components/Icon/Expensicons';
+
+describe('ButtonWithDropdownMenu (single option)', () => {
+    const mockOnSelected = jest.fn();
+    const mockOnOptionSelected = jest.fn();
+    const mockOnSubItemSelected = jest.fn();
+    const mockOnPress = jest.fn();
+    const option = {
+        value: 'test',
+        text: 'Test Option',
+        icon: Expensicons.Checkbox,
+        onSelected: mockOnSelected,
+    };
+
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('renders a button (not a dropdown) when only one option is present', () => {
+        // Given a single option
+        const {getByText} = render(
+            <ButtonWithDropdownMenu
+                options={[option]}
+                onPress={mockOnPress}
+                onOptionSelected={mockOnOptionSelected}
+                onSubItemSelected={mockOnSubItemSelected}
+                shouldUseOptionIcon
+            />
+        );
+        // When the component is rendered
+        // Then it should render a button with the option text
+        expect(getByText('Test Option')).toBeTruthy();
+    });
+
+    it('calls all relevant callbacks when the button is pressed', () => {
+        // Given a single option with all callbacks
+        const {getByText} = render(
+            <ButtonWithDropdownMenu
+                options={[option]}
+                onPress={mockOnPress}
+                onOptionSelected={mockOnOptionSelected}
+                onSubItemSelected={mockOnSubItemSelected}
+                shouldUseOptionIcon
+            />
+        );
+        // When the button is pressed
+        fireEvent.press(getByText('Test Option'));
+        // Then all relevant callbacks should be called
+        expect(mockOnSelected).toHaveBeenCalled();
+        expect(mockOnOptionSelected).not.toHaveBeenCalled(); // onSelected takes precedence
+        expect(mockOnSubItemSelected).toHaveBeenCalledWith(expect.objectContaining(option), 0, undefined);
+        expect(mockOnPress).toHaveBeenCalledWith(undefined, 'test');
+    });
+
+    it('renders the icon from the option along with the text', () => {
+        // Given a single option with an icon
+        const {getByText, UNSAFE_getAllByProps}: RenderAPI = render(
+            <ButtonWithDropdownMenu
+                options={[option]}
+                onPress={mockOnPress}
+                onOptionSelected={mockOnOptionSelected}
+                onSubItemSelected={mockOnSubItemSelected}
+                shouldUseOptionIcon
+            />
+        );
+        // When the component is rendered
+        // Then the icon should be present in the tree by props
+        const iconNodes: ReactTestInstance[] = UNSAFE_getAllByProps({src: Expensicons.Checkbox});
+        expect(iconNodes.length).toBeGreaterThan(0);
+        // And the button text should still be present
+        expect(getByText('Test Option')).toBeTruthy();
+    });
+}); 

--- a/tests/ui/components/ButtonWithDropdownMenuTest.tsx
+++ b/tests/ui/components/ButtonWithDropdownMenuTest.tsx
@@ -58,6 +58,7 @@ describe('ButtonWithDropdownMenu (single option)', () => {
                 onOptionSelected={mockOnOptionSelected}
                 onSubItemSelected={mockOnSubItemSelected}
                 shouldUseOptionIcon
+                testID={CONST.ICON_TEST_ID}
             />,
         );
         const iconNodes = screen.getAllByTestId(CONST.ICON_TEST_ID);
@@ -65,74 +66,3 @@ describe('ButtonWithDropdownMenu (single option)', () => {
         expect(screen.getByText('Test Option')).toBeTruthy();
     });
 });
-describe('ButtonWithDropdownMenu (single option)', () => {
-    const mockOnSelected = jest.fn();
-    const mockOnOptionSelected = jest.fn();
-    const mockOnSubItemSelected = jest.fn();
-    const mockOnPress = jest.fn();
-    const option = {
-        value: 'test',
-        text: 'Test Option',
-        icon: Expensicons.Checkbox,
-        onSelected: mockOnSelected,
-    };
-
-    afterEach(() => {
-        jest.clearAllMocks();
-    });
-
-    it('renders a button (not a dropdown) when only one option is present', () => {
-        // Given a single option
-        const {getByText} = render(
-            <ButtonWithDropdownMenu
-                options={[option]}
-                onPress={mockOnPress}
-                onOptionSelected={mockOnOptionSelected}
-                onSubItemSelected={mockOnSubItemSelected}
-                shouldUseOptionIcon
-            />
-        );
-        // When the component is rendered
-        // Then it should render a button with the option text
-        expect(getByText('Test Option')).toBeTruthy();
-    });
-
-    it('calls all relevant callbacks when the button is pressed', () => {
-        // Given a single option with all callbacks
-        const {getByText} = render(
-            <ButtonWithDropdownMenu
-                options={[option]}
-                onPress={mockOnPress}
-                onOptionSelected={mockOnOptionSelected}
-                onSubItemSelected={mockOnSubItemSelected}
-                shouldUseOptionIcon
-            />
-        );
-        // When the button is pressed
-        fireEvent.press(getByText('Test Option'));
-        // Then all relevant callbacks should be called
-        expect(mockOnSelected).toHaveBeenCalled();
-        expect(mockOnOptionSelected).not.toHaveBeenCalled(); // onSelected takes precedence
-        expect(mockOnSubItemSelected).toHaveBeenCalledWith(expect.objectContaining(option), 0, undefined);
-        expect(mockOnPress).toHaveBeenCalledWith(undefined, 'test');
-    });
-
-    it('renders the icon from the option along with the text', () => {
-        // Given a single option with an icon
-        const {getByText, UNSAFE_getAllByProps}: RenderAPI = render(
-            <ButtonWithDropdownMenu
-                options={[option]}
-                onPress={mockOnPress}
-                onOptionSelected={mockOnOptionSelected}
-                onSubItemSelected={mockOnSubItemSelected}
-                shouldUseOptionIcon
-            />
-        );
-        // When the component is rendered
-        // Then the icon should be present in the tree by props
-        const iconNodes: ReactTestInstance[] = UNSAFE_getAllByProps({src: Expensicons.Checkbox});
-        expect(iconNodes.length).toBeGreaterThan(0);
-        // And the button text should still be present
-        expect(getByText('Test Option')).toBeTruthy();
-    });
-}); 

--- a/tests/ui/components/ButtonWithDropdownMenuTest.tsx
+++ b/tests/ui/components/ButtonWithDropdownMenuTest.tsx
@@ -1,9 +1,70 @@
+import {fireEvent, render, screen} from '@testing-library/react-native';
 import React from 'react';
-import {render, fireEvent, RenderAPI} from '@testing-library/react-native';
-import type {ReactTestInstance} from 'react-test-renderer';
 import ButtonWithDropdownMenu from '@components/ButtonWithDropdownMenu';
 import * as Expensicons from '@components/Icon/Expensicons';
+import CONST from '@src/CONST';
 
+describe('ButtonWithDropdownMenu (single option)', () => {
+    const mockOnSelected = jest.fn();
+    const mockOnOptionSelected = jest.fn();
+    const mockOnSubItemSelected = jest.fn();
+    const mockOnPress = jest.fn();
+    const option = {
+        value: 'test',
+        text: 'Test Option',
+        icon: Expensicons.Checkbox,
+        onSelected: mockOnSelected,
+    };
+
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('renders a button (not a dropdown) when only one option is present', () => {
+        render(
+            <ButtonWithDropdownMenu
+                options={[option]}
+                onPress={mockOnPress}
+                onOptionSelected={mockOnOptionSelected}
+                onSubItemSelected={mockOnSubItemSelected}
+                shouldUseOptionIcon
+            />,
+        );
+        expect(screen.getByText('Test Option')).toBeTruthy();
+    });
+
+    it('calls all relevant callbacks when the button is pressed', () => {
+        render(
+            <ButtonWithDropdownMenu
+                options={[option]}
+                onPress={mockOnPress}
+                onOptionSelected={mockOnOptionSelected}
+                onSubItemSelected={mockOnSubItemSelected}
+                shouldUseOptionIcon
+            />,
+        );
+        fireEvent.press(screen.getByText('Test Option'));
+        expect(mockOnSelected).toHaveBeenCalled();
+        expect(mockOnOptionSelected).not.toHaveBeenCalled(); // onSelected takes precedence
+        expect(mockOnSubItemSelected).toHaveBeenCalledWith(expect.objectContaining(option), 0, undefined);
+        expect(mockOnPress).toHaveBeenCalledWith(undefined, 'test');
+    });
+
+    it('renders the icon from the option along with the text', () => {
+        render(
+            <ButtonWithDropdownMenu
+                options={[option]}
+                onPress={mockOnPress}
+                onOptionSelected={mockOnOptionSelected}
+                onSubItemSelected={mockOnSubItemSelected}
+                shouldUseOptionIcon
+            />,
+        );
+        const iconNodes = screen.getAllByTestId(CONST.ICON_TEST_ID);
+        expect(iconNodes.length).toBeGreaterThan(0);
+        expect(screen.getByText('Test Option')).toBeTruthy();
+    });
+});
 describe('ButtonWithDropdownMenu (single option)', () => {
     const mockOnSelected = jest.fn();
     const mockOnOptionSelected = jest.fn();


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
<!-- Explain what your change does and how it addresses the linked issue -->

The changes in this PR Address two Issues. More Dropdowns  having Single Option in Taxes , Distance Rates and Company Cards Screen in Workspace Settings will Now Show as a Single Button with the Only Item available's name and Icon. 

The Second Change is that the Behavior of the Button should be same as it was when that item was when it was in the dropdown. It should perform the same functionality that it did while being an option in the dropdown.

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ [#65501](https://github.com/Expensify/App/issues/65501)
PROPOSAL: [#65501 (Comment)](https://github.com/Expensify/App/issues/65501#issuecomment-3037029000)


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

- **Test 1:** Taxes (dropdown button More shows only Settings as an option)

  1. Go To Workspace Settings
  2. Click on Taxes
  3. Verify that the button Next to Add Rate in the Top App Bar is Not a Dropdown button Saying More but is a Settings Button.
  4. Verify the Icon on the Button is a Settings Icon place on the left Side of the Icon
  5. Verify that clicking on that Button Actually opens the setting right hand settings menu.

- **Test 2:** Distance rates (dropdown button More shows only Settings as an option) 

  1. Go To Workspace Settings
  2. Click on Distance Rates
  3. Verify that the button Next to Add Rate in the Top App Bar is Not a Dropdown button Saying More but is a Settings Button.
  4. Verify the Icon on the Button is a Settings Icon place on the left Side of the Icon
  5. Verify that clicking on that Button Actually opens the setting right hand settings menu.

- **Test 3:** Company cards (dropdown button More shows only Settings as an option)

  1. Go To Workspace Settings
  2. Click on Company Cards
  3. Verify that the button in the Top App Bar is Not a Dropdown button Saying More but is a Settings Button.
  4. Verify the Icon on the Button is a Settings Icon place on the left Side of the Icon
  5. Verify that clicking on that Button Actually opens the setting right hand settings menu.

- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

Same as Tests Above

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
3. Upload an image via copy paste
4. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->

Precondition:

- Log in with an account that has the atleast 1 Company card added in any of the workspace to test on Company cards Screen.

Tests

Same as Tests Above


- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I verified there are no new alerts related to the `canBeMissing` param for `useOnyx`
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/9582d3fe-4f6b-4f91-b3da-c0a398cd282a

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->


https://github.com/user-attachments/assets/ec51c7b6-6ab2-47ac-afee-529f3b889eb6


</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/9395b8cd-9cd5-4162-9910-a29633f7b046

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/d7186e79-1584-44e2-8648-96d90952a802

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/3569d1e3-8d0c-4e5e-9c75-06141ed73f6c

</details>

<details>
<summary>MacOS: Desktop</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/153eadae-7cc6-4a6f-acf6-06b4130a49a6




</details>
