### PR TITLE
Fix the logic used to display help content for IOU expenses

### DIFF
--- a/src/components/SidePanel/HelpComponents/HelpContent.tsx
+++ b/src/components/SidePanel/HelpComponents/HelpContent.tsx
@@ -50,12 +50,13 @@ function HelpContent({closeSidePanel}: HelpContentProps) {
         selector: (actions) =>
             Object.values(actions ?? {})
                 .filter((action) => action.reportActionID === report?.parentReportActionID)
+                .filter(isMoneyRequestAction)
                 .at(0),
     });
 
     const transactionID = useMemo(() => {
         const transactionThreadReportAction = getOneTransactionThreadReportAction(report, chatReport, reportActions ?? []);
-        return getOriginalMessage(isMoneyRequestAction(parentIOUReportAction) ? parentIOUReportAction : transactionThreadReportAction)?.IOUTransactionID;
+        return getOriginalMessage(parentIOUReportAction ?? transactionThreadReportAction)?.IOUTransactionID;
     }, [report, chatReport, reportActions, parentIOUReportAction]);
     const [transaction] = useOnyx(`${ONYXKEYS.COLLECTION.TRANSACTION}${transactionID}`, {canBeMissing: true});
 

--- a/src/components/SidePanel/HelpComponents/HelpContent.tsx
+++ b/src/components/SidePanel/HelpComponents/HelpContent.tsx
@@ -14,7 +14,7 @@ import useResponsiveLayout from '@hooks/useResponsiveLayout';
 import useRootNavigationState from '@hooks/useRootNavigationState';
 import useThemeStyles from '@hooks/useThemeStyles';
 import {normalizedConfigs} from '@libs/Navigation/linkingConfig/config';
-import {getOriginalMessage, isMoneyRequestAction} from '@libs/ReportActionsUtils';
+import {getOneTransactionThreadReportAction, getOriginalMessage, isMoneyRequestAction} from '@libs/ReportActionsUtils';
 import {getHelpPaneReportType} from '@libs/ReportUtils';
 import {getExpenseType} from '@libs/TransactionUtils';
 import CONST from '@src/CONST';
@@ -43,14 +43,21 @@ function HelpContent({closeSidePanel}: HelpContentProps) {
     });
 
     const [report] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT}${params?.reportID || String(CONST.DEFAULT_NUMBER_ID)}`, {canBeMissing: true});
-    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-    const [parentReportActions] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${report?.parentReportID}`, {
-        canEvict: false,
+    const [reportActions] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${report?.reportID}`, {canBeMissing: true});
+    const [chatReport] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT}${report?.parentReportID}`, {canBeMissing: true});
+    const [parentIOUReportAction] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${report?.parentReportID}`, {
         canBeMissing: true,
+        selector: (actions) =>
+            Object.values(actions ?? {})
+                .filter((action) => action.reportActionID === report?.parentReportActionID)
+                .at(0),
     });
-    const parentReportAction = report?.parentReportActionID ? parentReportActions?.[report.parentReportActionID] : undefined;
-    const linkedTransactionID = useMemo(() => (isMoneyRequestAction(parentReportAction) ? getOriginalMessage(parentReportAction)?.IOUTransactionID : undefined), [parentReportAction]);
-    const [transaction] = useOnyx(`${ONYXKEYS.COLLECTION.TRANSACTION}${linkedTransactionID}`, {canBeMissing: true});
+
+    const transactionID = useMemo(() => {
+        const transactionThreadReportAction = getOneTransactionThreadReportAction(report, chatReport, reportActions ?? []);
+        return getOriginalMessage(isMoneyRequestAction(parentIOUReportAction) ? parentIOUReportAction : transactionThreadReportAction)?.IOUTransactionID;
+    }, [report, chatReport, reportActions, parentIOUReportAction]);
+    const [transaction] = useOnyx(`${ONYXKEYS.COLLECTION.TRANSACTION}${transactionID}`, {canBeMissing: true});
 
     const route = useMemo(() => {
         const path = normalizedConfigs[routeName]?.path;
@@ -61,13 +68,14 @@ function HelpContent({closeSidePanel}: HelpContentProps) {
 
         const cleanedPath = path.replaceAll('?', '');
         const expenseType = getExpenseType(transaction);
-
-        if (expenseType) {
+        const reportType = getHelpPaneReportType(report);
+        
+        if (expenseType && reportType !== CONST.REPORT.HELP_TYPE.EXPENSE_REPORT) {
             return cleanedPath.replaceAll(':reportID', `:${CONST.REPORT.HELP_TYPE.EXPENSE}/:${expenseType}`);
         }
 
-        if (report) {
-            return cleanedPath.replaceAll(':reportID', `:${getHelpPaneReportType(report)}`);
+        if (reportType) {
+            return cleanedPath.replaceAll(':reportID', `:${reportType}`);
         }
 
         return cleanedPath;

--- a/src/components/SidePanel/HelpComponents/HelpContent.tsx
+++ b/src/components/SidePanel/HelpComponents/HelpContent.tsx
@@ -69,7 +69,7 @@ function HelpContent({closeSidePanel}: HelpContentProps) {
         const cleanedPath = path.replaceAll('?', '');
         const expenseType = getExpenseType(transaction);
         const reportType = getHelpPaneReportType(report);
-        
+
         if (expenseType && reportType !== CONST.REPORT.HELP_TYPE.EXPENSE_REPORT) {
             return cleanedPath.replaceAll(':reportID', `:${CONST.REPORT.HELP_TYPE.EXPENSE}/:${expenseType}`);
         }

--- a/src/hooks/useRootNavigationState.ts
+++ b/src/hooks/useRootNavigationState.ts
@@ -20,8 +20,9 @@ function useRootNavigationState<T>(selector: Selector<T>): T {
     });
 
     useEffect(() => {
-        const unsubscribe = navigationRef.addListener('state', (e) => {
-            setResult(selectorRef.current(e.data.state as NavigationState));
+        const unsubscribe = navigationRef.addListener('state', () => {
+            // State from the event data may be incomplete. (defined params but no nested state for the route)
+            setResult(selectorRef.current(navigationRef.getRootState()));
         });
 
         return unsubscribe;

--- a/src/libs/ReportActionsUtils.ts
+++ b/src/libs/ReportActionsUtils.ts
@@ -1198,7 +1198,7 @@ function isTagModificationAction(actionName: string): boolean {
  * Used for Send Money flow, which is a special case where we have no IOU create action and only one IOU pay action.
  * In other reports, pay actions do not count as a transactions, but this is an exception to this rule.
  */
-function getSendMoneyFlowOneTransactionReportAction(actions: OnyxEntry<ReportActions> | ReportAction[], chatReport: OnyxEntry<Report>): ReportAction<'IOU'> | undefined {
+function getSendMoneyFlowAction(actions: OnyxEntry<ReportActions> | ReportAction[], chatReport: OnyxEntry<Report>): ReportAction<'IOU'> | undefined {
     if (!chatReport) {
         return undefined;
     }
@@ -1273,7 +1273,7 @@ function getOneTransactionThreadReportAction(
         return;
     }
 
-    const sendMoneyFlow = getSendMoneyFlowOneTransactionReportAction(reportActions, chatReport);
+    const sendMoneyFlow = getSendMoneyFlowAction(reportActions, chatReport);
 
     if (sendMoneyFlow?.childReportID) {
         return sendMoneyFlow;
@@ -3099,7 +3099,7 @@ export {
     getWorkspaceDescriptionUpdatedMessage,
     getWorkspaceReportFieldAddMessage,
     getWorkspaceCustomUnitRateAddedMessage,
-    getSendMoneyFlowOneTransactionReportAction,
+    getSendMoneyFlowAction,
     getWorkspaceTagUpdateMessage,
     getWorkspaceReportFieldUpdateMessage,
     getWorkspaceReportFieldDeleteMessage,

--- a/src/libs/ReportActionsUtils.ts
+++ b/src/libs/ReportActionsUtils.ts
@@ -1253,8 +1253,8 @@ const isIOUActionMatchingTransactionList = (
 };
 
 /**
- * Gets the reportID for the transaction thread associated with a report by iterating over the reportActions and identifying the IOU report actions.
- * Returns a reportID if there is exactly one transaction thread for the report, and null otherwise.
+ * Gets the report action for the transaction thread associated with a report by iterating over the reportActions and identifying the IOU report actions.
+ * Returns a report action if there is exactly one transaction thread for the report, and undefined otherwise.
  */
 function getOneTransactionThreadReportAction(
     report: OnyxEntry<Report>,
@@ -1321,10 +1321,13 @@ function getOneTransactionThreadReportAction(
         return;
     }
 
-    // Ensure we have a childReportID associated with the IOU report action
     return singleAction;
 }
 
+/**
+ * Gets the reportID for the transaction thread associated with a report by iterating over the reportActions and identifying the IOU report actions.
+ * Returns a reportID if there is exactly one transaction thread for the report, and undefined otherwise.
+ */
 function getOneTransactionThreadReportID(...args: Parameters<typeof getOneTransactionThreadReportAction>): string | undefined {
     return getOneTransactionThreadReportAction(...args)?.childReportID;
 }

--- a/tests/unit/ReportActionsUtilsTest.ts
+++ b/tests/unit/ReportActionsUtilsTest.ts
@@ -6,7 +6,7 @@ import {actionR14932 as mockIOUAction, originalMessageR14932 as mockOriginalMess
 import {chatReportR14932 as mockChatReport, iouReportR14932 as mockIOUReport} from '../../__mocks__/reportData/reports';
 import CONST from '../../src/CONST';
 import * as ReportActionsUtils from '../../src/libs/ReportActionsUtils';
-import {getOneTransactionThreadReportID, getOriginalMessage, getSendMoneyFlowOneTransactionThreadID, isIOUActionMatchingTransactionList} from '../../src/libs/ReportActionsUtils';
+import {getOneTransactionThreadReportID, getOriginalMessage, getSendMoneyFlowOneTransactionReportAction, isIOUActionMatchingTransactionList} from '../../src/libs/ReportActionsUtils';
 import ONYXKEYS from '../../src/ONYXKEYS';
 import type {Report, ReportAction} from '../../src/types/onyx';
 import {createRandomReport} from '../utils/collections/reports';
@@ -856,7 +856,7 @@ describe('ReportActionsUtils', () => {
         });
     });
 
-    describe('getSendMoneyFlowOneTransactionThreadID', () => {
+    describe('getSendMoneyFlowOneTransactionReportAction', () => {
         const mockChatReportID = `${ONYXKEYS.COLLECTION.REPORT}REPORT` as const;
         const mockDMChatReportID = `${ONYXKEYS.COLLECTION.REPORT}REPORT_DM` as const;
         const childReportID = `${ONYXKEYS.COLLECTION.REPORT}childReport123` as const;
@@ -891,27 +891,27 @@ describe('ReportActionsUtils', () => {
         };
 
         it('should return undefined for a single non-IOU action', () => {
-            expect(getSendMoneyFlowOneTransactionThreadID([nonIOUAction], mockedReports[mockDMChatReportID])).toBeUndefined();
+            expect(getSendMoneyFlowOneTransactionReportAction([nonIOUAction], mockedReports[mockDMChatReportID])?.childReportID).toBeUndefined();
         });
 
         it('should return undefined for multiple IOU actions regardless of type', () => {
-            expect(getSendMoneyFlowOneTransactionThreadID([payAction, payAction], mockedReports[mockDMChatReportID])).toBeUndefined();
+            expect(getSendMoneyFlowOneTransactionReportAction([payAction, payAction], mockedReports[mockDMChatReportID])?.childReportID).toBeUndefined();
         });
 
         it('should return undefined for a single IOU action that is not `Pay`', () => {
-            expect(getSendMoneyFlowOneTransactionThreadID([createAction], mockedReports[mockDMChatReportID])).toBeUndefined();
+            expect(getSendMoneyFlowOneTransactionReportAction([createAction], mockedReports[mockDMChatReportID])?.childReportID).toBeUndefined();
         });
 
         it('should return the appropriate childReportID for a valid single `Pay` IOU action in DM chat', () => {
-            expect(getSendMoneyFlowOneTransactionThreadID([payAction], mockedReports[mockDMChatReportID])).toEqual(childReportID);
+            expect(getSendMoneyFlowOneTransactionReportAction([payAction], mockedReports[mockDMChatReportID])?.childReportID).toEqual(childReportID);
         });
 
         it('should return undefined for a valid single `Pay` IOU action in a chat that is not DM', () => {
-            expect(getSendMoneyFlowOneTransactionThreadID([payAction], mockedReports[mockChatReportID])).toBeUndefined();
+            expect(getSendMoneyFlowOneTransactionReportAction([payAction], mockedReports[mockChatReportID])?.childReportID).toBeUndefined();
         });
 
         it('should return undefined for a valid `Pay` IOU action in DM chat that has also a create IOU action', () => {
-            expect(getSendMoneyFlowOneTransactionThreadID([payAction, createAction], mockedReports[mockDMChatReportID])).toBeUndefined();
+            expect(getSendMoneyFlowOneTransactionReportAction([payAction, createAction], mockedReports[mockDMChatReportID])?.childReportID).toBeUndefined();
         });
     });
 

--- a/tests/unit/ReportActionsUtilsTest.ts
+++ b/tests/unit/ReportActionsUtilsTest.ts
@@ -6,7 +6,7 @@ import {actionR14932 as mockIOUAction, originalMessageR14932 as mockOriginalMess
 import {chatReportR14932 as mockChatReport, iouReportR14932 as mockIOUReport} from '../../__mocks__/reportData/reports';
 import CONST from '../../src/CONST';
 import * as ReportActionsUtils from '../../src/libs/ReportActionsUtils';
-import {getOneTransactionThreadReportID, getOriginalMessage, getSendMoneyFlowOneTransactionReportAction, isIOUActionMatchingTransactionList} from '../../src/libs/ReportActionsUtils';
+import {getOneTransactionThreadReportID, getOriginalMessage, getSendMoneyFlowAction, isIOUActionMatchingTransactionList} from '../../src/libs/ReportActionsUtils';
 import ONYXKEYS from '../../src/ONYXKEYS';
 import type {Report, ReportAction} from '../../src/types/onyx';
 import {createRandomReport} from '../utils/collections/reports';
@@ -856,7 +856,7 @@ describe('ReportActionsUtils', () => {
         });
     });
 
-    describe('getSendMoneyFlowOneTransactionReportAction', () => {
+    describe('getSendMoneyFlowAction', () => {
         const mockChatReportID = `${ONYXKEYS.COLLECTION.REPORT}REPORT` as const;
         const mockDMChatReportID = `${ONYXKEYS.COLLECTION.REPORT}REPORT_DM` as const;
         const childReportID = `${ONYXKEYS.COLLECTION.REPORT}childReport123` as const;
@@ -891,27 +891,27 @@ describe('ReportActionsUtils', () => {
         };
 
         it('should return undefined for a single non-IOU action', () => {
-            expect(getSendMoneyFlowOneTransactionReportAction([nonIOUAction], mockedReports[mockDMChatReportID])?.childReportID).toBeUndefined();
+            expect(getSendMoneyFlowAction([nonIOUAction], mockedReports[mockDMChatReportID])?.childReportID).toBeUndefined();
         });
 
         it('should return undefined for multiple IOU actions regardless of type', () => {
-            expect(getSendMoneyFlowOneTransactionReportAction([payAction, payAction], mockedReports[mockDMChatReportID])?.childReportID).toBeUndefined();
+            expect(getSendMoneyFlowAction([payAction, payAction], mockedReports[mockDMChatReportID])?.childReportID).toBeUndefined();
         });
 
         it('should return undefined for a single IOU action that is not `Pay`', () => {
-            expect(getSendMoneyFlowOneTransactionReportAction([createAction], mockedReports[mockDMChatReportID])?.childReportID).toBeUndefined();
+            expect(getSendMoneyFlowAction([createAction], mockedReports[mockDMChatReportID])?.childReportID).toBeUndefined();
         });
 
         it('should return the appropriate childReportID for a valid single `Pay` IOU action in DM chat', () => {
-            expect(getSendMoneyFlowOneTransactionReportAction([payAction], mockedReports[mockDMChatReportID])?.childReportID).toEqual(childReportID);
+            expect(getSendMoneyFlowAction([payAction], mockedReports[mockDMChatReportID])?.childReportID).toEqual(childReportID);
         });
 
         it('should return undefined for a valid single `Pay` IOU action in a chat that is not DM', () => {
-            expect(getSendMoneyFlowOneTransactionReportAction([payAction], mockedReports[mockChatReportID])?.childReportID).toBeUndefined();
+            expect(getSendMoneyFlowAction([payAction], mockedReports[mockChatReportID])?.childReportID).toBeUndefined();
         });
 
         it('should return undefined for a valid `Pay` IOU action in DM chat that has also a create IOU action', () => {
-            expect(getSendMoneyFlowOneTransactionReportAction([payAction, createAction], mockedReports[mockDMChatReportID])?.childReportID).toBeUndefined();
+            expect(getSendMoneyFlowAction([payAction, createAction], mockedReports[mockDMChatReportID])?.childReportID).toBeUndefined();
         });
     });
 


### PR DESCRIPTION
### Explanation of Change

Currently wrong content is displayed for expenses, this PR aims to fix this issue by fetching the data the correct way. Please check the video at the bottom of description to see what **should** be displayed.

### Fixed Issues
$ https://github.com/Expensify/App/issues/66069
$ https://github.com/Expensify/App/issues/66420
PROPOSAL: N/A

### Tests

- Create a single expense (manual, distance, scanned) with someone else
- Open the expense in a single report view:

<img width="722" height="553" alt="Image" src="https://github.com/user-attachments/assets/408f271f-aaf2-4576-a56d-5464bdc9f764" />

- Go to console and use this command:

```ts
Onyx.set('nvp_sidePanel', { open: true })
```

- Verify that the correct content for `scan`/`distance`/`manual` is displayed 

Extra:
- Verify that correct content is displayed for `Workspace`, `Concierge`, `#announce`, `#admins` and `Expense Report` chats 

### Offline tests

N/A

### QA Steps

Same as tests

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos

<details>
<summary>MacOS: Chrome / Safari</summary>


https://github.com/user-attachments/assets/0caf4bcb-c667-4915-ae32-31c46af17013



</details>

