### PR TITLE
Remove withOnyx HOCs batch 7

### DIFF
--- a/src/pages/EnablePayments/AddBankAccount/substeps/ConfirmationStep.tsx
+++ b/src/pages/EnablePayments/AddBankAccount/substeps/ConfirmationStep.tsx
@@ -1,7 +1,5 @@
 import React from 'react';
 import {View} from 'react-native';
-import type {OnyxEntry} from 'react-native-onyx';
-import {withOnyx} from 'react-native-onyx';
 import Button from '@components/Button';
 import DotIndicatorMessage from '@components/DotIndicatorMessage';
 import MenuItemWithTopDescription from '@components/MenuItemWithTopDescription';
@@ -9,35 +7,28 @@ import ScrollView from '@components/ScrollView';
 import Text from '@components/Text';
 import useLocalize from '@hooks/useLocalize';
 import useNetwork from '@hooks/useNetwork';
+import useOnyx from '@hooks/useOnyx';
 import type {SubStepProps} from '@hooks/useSubStep/types';
 import useThemeStyles from '@hooks/useThemeStyles';
-import * as ErrorUtils from '@libs/ErrorUtils';
+import {getLatestErrorMessage} from '@libs/ErrorUtils';
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
-import type {PersonalBankAccountForm} from '@src/types/form';
 import INPUT_IDS from '@src/types/form/PersonalBankAccountForm';
-import type {PersonalBankAccount} from '@src/types/onyx';
 
-type ConfirmationOnyxProps = {
-    /** The draft values of the bank account being setup */
-    personalBankAccountDraft: OnyxEntry<PersonalBankAccountForm>;
-
-    /** The user's bank account */
-    personalBankAccount: OnyxEntry<PersonalBankAccount>;
-};
-
-type ConfirmationStepProps = ConfirmationOnyxProps & SubStepProps;
+type ConfirmationStepProps = SubStepProps;
 
 const BANK_INFO_STEP_KEYS = INPUT_IDS.BANK_INFO_STEP;
 const BANK_INFO_STEP_INDEXES = CONST.WALLET.SUBSTEP_INDEXES.BANK_ACCOUNT;
 
-function ConfirmationStep({personalBankAccount, personalBankAccountDraft, onNext, onMove}: ConfirmationStepProps) {
+function ConfirmationStep({onNext, onMove}: ConfirmationStepProps) {
     const {translate} = useLocalize();
     const styles = useThemeStyles();
     const {isOffline} = useNetwork();
+    const [personalBankAccountDraft] = useOnyx(ONYXKEYS.FORMS.PERSONAL_BANK_ACCOUNT_FORM_DRAFT, {canBeMissing: true});
+    const [personalBankAccount] = useOnyx(ONYXKEYS.PERSONAL_BANK_ACCOUNT, {canBeMissing: true});
 
     const isLoading = personalBankAccount?.isLoading ?? false;
-    const error = ErrorUtils.getLatestErrorMessage(personalBankAccount ?? {});
+    const error = getLatestErrorMessage(personalBankAccount ?? {});
 
     const handleModifyAccountNumbers = () => {
         onMove(BANK_INFO_STEP_INDEXES.ACCOUNT_NUMBERS);
@@ -80,15 +71,4 @@ function ConfirmationStep({personalBankAccount, personalBankAccountDraft, onNext
 
 ConfirmationStep.displayName = 'ConfirmationStep';
 
-export default withOnyx<ConfirmationStepProps, ConfirmationOnyxProps>({
-    personalBankAccountDraft: {
-        key: ONYXKEYS.FORMS.PERSONAL_BANK_ACCOUNT_FORM_DRAFT,
-    },
-    // @ts-expect-error: ONYXKEYS.PERSONAL_BANK_ACCOUNT is conflicting with ONYXKEYS.FORMS.PERSONAL_BANK_ACCOUNT_FORM
-    personalBankAccount: {
-        key: ONYXKEYS.PERSONAL_BANK_ACCOUNT,
-    },
-    userWallet: {
-        key: ONYXKEYS.USER_WALLET,
-    },
-})(ConfirmationStep);
+export default ConfirmationStep;

--- a/src/pages/EnablePayments/EnablePaymentsPage.tsx
+++ b/src/pages/EnablePayments/EnablePaymentsPage.tsx
@@ -6,7 +6,7 @@ import useLocalize from '@hooks/useLocalize';
 import useNetwork from '@hooks/useNetwork';
 import useOnyx from '@hooks/useOnyx';
 import Navigation from '@libs/Navigation/Navigation';
-import * as Wallet from '@userActions/Wallet';
+import {openEnablePaymentsPage} from '@userActions/Wallet';
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
 import ROUTES from '@src/ROUTES';
@@ -36,7 +36,7 @@ function EnablePaymentsPage() {
             return;
         }
 
-        Wallet.openEnablePaymentsPage();
+        openEnablePaymentsPage();
     }, [isOffline, isPendingOnfidoResult, hasFailedOnfido]);
 
     if (isEmptyObject(userWallet)) {

--- a/src/pages/EnablePayments/EnablePaymentsPage.tsx
+++ b/src/pages/EnablePayments/EnablePaymentsPage.tsx
@@ -21,7 +21,12 @@ import TermsStep from './TermsStep';
 function EnablePaymentsPage() {
     const {translate} = useLocalize();
     const {isOffline} = useNetwork();
-    const [userWallet] = useOnyx(ONYXKEYS.USER_WALLET, {canBeMissing: true, initWithStoredValues: false});
+    const [userWallet] = useOnyx(ONYXKEYS.USER_WALLET, {
+        canBeMissing: true,
+        // We want to refresh the wallet each time the user attempts to activate the wallet so we won't use the
+        // stored values here.
+        initWithStoredValues: false,
+    });
 
     const {isPendingOnfidoResult, hasFailedOnfido} = userWallet ?? {};
 

--- a/src/pages/EnablePayments/EnablePaymentsPage.tsx
+++ b/src/pages/EnablePayments/EnablePaymentsPage.tsx
@@ -1,17 +1,15 @@
 import React, {useEffect} from 'react';
-import {withOnyx} from 'react-native-onyx';
-import type {OnyxEntry} from 'react-native-onyx';
 import FullScreenLoadingIndicator from '@components/FullscreenLoadingIndicator';
 import HeaderWithBackButton from '@components/HeaderWithBackButton';
 import ScreenWrapper from '@components/ScreenWrapper';
 import useLocalize from '@hooks/useLocalize';
 import useNetwork from '@hooks/useNetwork';
+import useOnyx from '@hooks/useOnyx';
 import Navigation from '@libs/Navigation/Navigation';
 import * as Wallet from '@userActions/Wallet';
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
 import ROUTES from '@src/ROUTES';
-import type {UserWallet} from '@src/types/onyx';
 import {isEmptyObject} from '@src/types/utils/EmptyObject';
 import ActivateStep from './ActivateStep';
 import AdditionalDetailsStep from './AdditionalDetailsStep';
@@ -20,16 +18,10 @@ import FailedKYC from './FailedKYC';
 import OnfidoStep from './OnfidoStep';
 import TermsStep from './TermsStep';
 
-type EnablePaymentsPageOnyxProps = {
-    /** The user's wallet */
-    userWallet: OnyxEntry<UserWallet>;
-};
-
-type EnablePaymentsPageProps = EnablePaymentsPageOnyxProps;
-
-function EnablePaymentsPage({userWallet}: EnablePaymentsPageProps) {
+function EnablePaymentsPage() {
     const {translate} = useLocalize();
     const {isOffline} = useNetwork();
+    const [userWallet] = useOnyx(ONYXKEYS.USER_WALLET, {canBeMissing: true, initWithStoredValues: false});
 
     const {isPendingOnfidoResult, hasFailedOnfido} = userWallet ?? {};
 
@@ -92,12 +84,4 @@ function EnablePaymentsPage({userWallet}: EnablePaymentsPageProps) {
 
 EnablePaymentsPage.displayName = 'EnablePaymentsPage';
 
-export default withOnyx<EnablePaymentsPageProps, EnablePaymentsPageOnyxProps>({
-    userWallet: {
-        key: ONYXKEYS.USER_WALLET,
-
-        // We want to refresh the wallet each time the user attempts to activate the wallet so we won't use the
-        // stored values here.
-        initWithStoredValues: false,
-    },
-})(EnablePaymentsPage);
+export default EnablePaymentsPage;

--- a/src/pages/EnablePayments/OnfidoPrivacy.tsx
+++ b/src/pages/EnablePayments/OnfidoPrivacy.tsx
@@ -27,6 +27,7 @@ const DEFAULT_WALLET_ONFIDO_DATA = {
 };
 
 type OnfidoPrivacyProps = {
+    /** Stores various information used to build the UI and call any APIs */
     walletOnfidoData: OnyxEntry<WalletOnfido>;
 };
 

--- a/src/pages/EnablePayments/OnfidoPrivacy.tsx
+++ b/src/pages/EnablePayments/OnfidoPrivacy.tsx
@@ -2,7 +2,6 @@ import React, {useRef} from 'react';
 import {View} from 'react-native';
 // eslint-disable-next-line no-restricted-imports
 import type {ScrollView} from 'react-native';
-import {withOnyx} from 'react-native-onyx';
 import type {OnyxEntry} from 'react-native-onyx';
 import FixedFooter from '@components/FixedFooter';
 import FormAlertWithSubmitButton from '@components/FormAlertWithSubmitButton';
@@ -12,10 +11,9 @@ import Text from '@components/Text';
 import TextLink from '@components/TextLink';
 import useLocalize from '@hooks/useLocalize';
 import useThemeStyles from '@hooks/useThemeStyles';
-import * as ErrorUtils from '@libs/ErrorUtils';
-import * as BankAccounts from '@userActions/BankAccounts';
+import {getLatestErrorMessage} from '@libs/ErrorUtils';
+import {openOnfidoFlow} from '@userActions/BankAccounts';
 import CONST from '@src/CONST';
-import ONYXKEYS from '@src/ONYXKEYS';
 import type {WalletOnfido} from '@src/types/onyx';
 import {isEmptyObject} from '@src/types/utils/EmptyObject';
 
@@ -28,12 +26,9 @@ const DEFAULT_WALLET_ONFIDO_DATA = {
     hasAcceptedPrivacyPolicy: false,
 };
 
-type OnfidoPrivacyOnyxProps = {
-    /** Stores various information used to build the UI and call any APIs */
+type OnfidoPrivacyProps = {
     walletOnfidoData: OnyxEntry<WalletOnfido>;
 };
-
-type OnfidoPrivacyProps = OnfidoPrivacyOnyxProps;
 
 function OnfidoPrivacy({walletOnfidoData = DEFAULT_WALLET_ONFIDO_DATA}: OnfidoPrivacyProps) {
     const {translate} = useLocalize();
@@ -44,11 +39,7 @@ function OnfidoPrivacy({walletOnfidoData = DEFAULT_WALLET_ONFIDO_DATA}: OnfidoPr
     }
     const {isLoading = false, hasAcceptedPrivacyPolicy} = walletOnfidoData;
 
-    const openOnfidoFlow = () => {
-        BankAccounts.openOnfidoFlow();
-    };
-
-    const onfidoError = ErrorUtils.getLatestErrorMessage(walletOnfidoData) ?? '';
+    const onfidoError = getLatestErrorMessage(walletOnfidoData) ?? '';
     const onfidoFixableErrors = walletOnfidoData?.fixableErrors ?? [];
     if (Array.isArray(onfidoError)) {
         onfidoError[0] += !isEmptyObject(onfidoFixableErrors) ? `\n${onfidoFixableErrors.join('\n')}` : '';
@@ -92,11 +83,4 @@ function OnfidoPrivacy({walletOnfidoData = DEFAULT_WALLET_ONFIDO_DATA}: OnfidoPr
 
 OnfidoPrivacy.displayName = 'OnfidoPrivacy';
 
-export default withOnyx<OnfidoPrivacyProps, OnfidoPrivacyOnyxProps>({
-    walletOnfidoData: {
-        key: ONYXKEYS.WALLET_ONFIDO,
-
-        // Let's get a new onfido token each time the user hits this flow (as it should only be once)
-        initWithStoredValues: false,
-    },
-})(OnfidoPrivacy);
+export default OnfidoPrivacy;

--- a/src/pages/EnablePayments/OnfidoStep.tsx
+++ b/src/pages/EnablePayments/OnfidoStep.tsx
@@ -15,7 +15,7 @@ import OnfidoPrivacy from './OnfidoPrivacy';
 
 function OnfidoStep() {
     const {translate} = useLocalize();
-    const [walletOnfidoData] = useOnyx(ONYXKEYS.WALLET_ONFIDO, {initWithStoredValues: false});
+    const [walletOnfidoData] = useOnyx(ONYXKEYS.WALLET_ONFIDO, {initWithStoredValues: false, canBeMissing: true});
 
     const shouldShowOnfido = walletOnfidoData?.hasAcceptedPrivacyPolicy && !walletOnfidoData?.isLoading && !walletOnfidoData?.errors && walletOnfidoData?.sdkToken;
 

--- a/src/pages/EnablePayments/OnfidoStep.tsx
+++ b/src/pages/EnablePayments/OnfidoStep.tsx
@@ -1,43 +1,30 @@
 import React, {useCallback} from 'react';
-import {withOnyx} from 'react-native-onyx';
-import type {OnyxEntry} from 'react-native-onyx';
 import FullPageOfflineBlockingView from '@components/BlockingViews/FullPageOfflineBlockingView';
 import HeaderWithBackButton from '@components/HeaderWithBackButton';
 import Onfido from '@components/Onfido';
 import type {OnfidoData} from '@components/Onfido/types';
 import useLocalize from '@hooks/useLocalize';
+import useOnyx from '@hooks/useOnyx';
 import Growl from '@libs/Growl';
 import Navigation from '@libs/Navigation/Navigation';
-import * as BankAccounts from '@userActions/BankAccounts';
-import * as Wallet from '@userActions/Wallet';
+import {verifyIdentity as verifyIdentityAction} from '@userActions/BankAccounts';
+import {updateCurrentStep} from '@userActions/Wallet';
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
-import type {WalletOnfido} from '@src/types/onyx';
 import OnfidoPrivacy from './OnfidoPrivacy';
 
-const DEFAULT_WALLET_ONFIDO_DATA = {
-    loading: false,
-    hasAcceptedPrivacyPolicy: false,
-};
-
-type OnfidoStepOnyxProps = {
-    /** Stores various information used to build the UI and call any APIs */
-    walletOnfidoData: OnyxEntry<WalletOnfido>;
-};
-
-type OnfidoStepProps = OnfidoStepOnyxProps;
-
-function OnfidoStep({walletOnfidoData = DEFAULT_WALLET_ONFIDO_DATA}: OnfidoStepProps) {
+function OnfidoStep() {
     const {translate} = useLocalize();
+    const [walletOnfidoData] = useOnyx(ONYXKEYS.WALLET_ONFIDO, {initWithStoredValues: false});
 
-    const shouldShowOnfido = walletOnfidoData?.hasAcceptedPrivacyPolicy && !walletOnfidoData.isLoading && !walletOnfidoData.errors && walletOnfidoData.sdkToken;
+    const shouldShowOnfido = walletOnfidoData?.hasAcceptedPrivacyPolicy && !walletOnfidoData?.isLoading && !walletOnfidoData?.errors && walletOnfidoData?.sdkToken;
 
     const goBack = useCallback(() => {
         Navigation.goBack();
     }, []);
 
     const goToPreviousStep = useCallback(() => {
-        Wallet.updateCurrentStep(CONST.WALLET.STEP.ADDITIONAL_DETAILS);
+        updateCurrentStep(CONST.WALLET.STEP.ADDITIONAL_DETAILS);
     }, []);
 
     const reportError = useCallback(() => {
@@ -46,7 +33,7 @@ function OnfidoStep({walletOnfidoData = DEFAULT_WALLET_ONFIDO_DATA}: OnfidoStepP
 
     const verifyIdentity = useCallback(
         (data: OnfidoData) => {
-            BankAccounts.verifyIdentity({
+            verifyIdentityAction({
                 onfidoData: JSON.stringify({
                     ...data,
                     applicantID: walletOnfidoData?.applicantID,
@@ -71,7 +58,7 @@ function OnfidoStep({walletOnfidoData = DEFAULT_WALLET_ONFIDO_DATA}: OnfidoStepP
                         onSuccess={verifyIdentity}
                     />
                 ) : (
-                    <OnfidoPrivacy />
+                    <OnfidoPrivacy walletOnfidoData={walletOnfidoData} />
                 )}
             </FullPageOfflineBlockingView>
         </>
@@ -80,11 +67,4 @@ function OnfidoStep({walletOnfidoData = DEFAULT_WALLET_ONFIDO_DATA}: OnfidoStepP
 
 OnfidoStep.displayName = 'OnfidoStep';
 
-export default withOnyx<OnfidoStepProps, OnfidoStepOnyxProps>({
-    walletOnfidoData: {
-        key: ONYXKEYS.WALLET_ONFIDO,
-
-        // Let's get a new onfido token each time the user hits this flow (as it should only be once)
-        initWithStoredValues: false,
-    },
-})(OnfidoStep);
+export default OnfidoStep;

--- a/src/pages/EnablePayments/OnfidoStep.tsx
+++ b/src/pages/EnablePayments/OnfidoStep.tsx
@@ -15,7 +15,11 @@ import OnfidoPrivacy from './OnfidoPrivacy';
 
 function OnfidoStep() {
     const {translate} = useLocalize();
-    const [walletOnfidoData] = useOnyx(ONYXKEYS.WALLET_ONFIDO, {initWithStoredValues: false, canBeMissing: true});
+    const [walletOnfidoData] = useOnyx(ONYXKEYS.WALLET_ONFIDO, {
+        canBeMissing: true,
+        // Let's get a new onfido token each time the user hits this flow (as it should only be once)
+        initWithStoredValues: false,
+    });
 
     const shouldShowOnfido = walletOnfidoData?.hasAcceptedPrivacyPolicy && !walletOnfidoData?.isLoading && !walletOnfidoData?.errors && walletOnfidoData?.sdkToken;
 


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
<!-- Explain what your change does and how it addresses the linked issue -->
Refactor the following files to use useOnyx instead of withOnyx:

- [src/pages/EnablePayments/EnablePaymentsPage.tsx](https://github.com/Expensify/App/blob/main/src/pages/EnablePayments/EnablePaymentsPage.tsx)
- [src/pages/EnablePayments/OnfidoPrivacy.tsx](https://github.com/Expensify/App/blob/main/src/pages/EnablePayments/OnfidoPrivacy.tsx)
- [src/pages/EnablePayments/OnfidoStep.tsx](https://github.com/Expensify/App/blob/main/src/pages/EnablePayments/OnfidoStep.tsx)
- [src/pages/EnablePayments/AddBankAccount/substeps/ConfirmationStep.tsx](https://github.com/Expensify/App/blob/main/src/pages/EnablePayments/AddBankAccount/substeps/ConfirmationStep.tsx)

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/65968
PROPOSAL: https://github.com/Expensify/App/issues/65968#issuecomment-3064135910


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->
#### Test 1:
- For EnablePaymentsPage, OnfidoPrivacy and OnfidoStep
1. Open ND.
2. Navigate to the `enable-payments` page.  
   - You can access it via chat using https://dev.new.expensify.com:8082/enable-payments (for staging, replace the URL with `https://staging.new.expensify.com/enable-payments`).
3. Verify that the `Additional details` page is displayed correctly.
4. Open the console.
5. Run the following code to navigate to the OnfidoStep page:
   ```js
   Onyx.merge('userWallet', { currentStep: 'OnfidoStep' })
   ```
6. Verify that the OnfidoStep page is displayed privacy correctly.

### Test 2:
- For ConfirmationStep
1. Open ND.
2. Navigate to Account > Wallet > Enable Wallet.
3. Complete the Plaid flow.
4. After completing the Plaid flow, the app should return to the "Choose your bank account" page.
5. Select any bank account and tap "Next."
6. Verify that the "Confirm your bank account" step is displayed data correctly with the bank account information.

- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->
This test is similar to the above, but some steps require a network connection
### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->
Same as test above

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I verified there are no new alerts related to the `canBeMissing` param for `useOnyx`
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>


https://github.com/user-attachments/assets/9f53878a-1fd3-4971-bd28-3c2a24857a43


https://github.com/user-attachments/assets/84390ab9-c27f-4072-bcc8-03ca2b13c10e



</details>

<details>
<summary>Android: mWeb Chrome</summary>

<img width="1080" height="2400" alt="Screenshot_1752554708" src="https://github.com/user-attachments/assets/3350f01d-8ab6-4760-8ed7-d178c5505222" />


</details>

<details>
<summary>iOS: Native</summary>


https://github.com/user-attachments/assets/627af755-2932-49ab-9e8d-dbc671c54c3a

https://github.com/user-attachments/assets/4a803e0c-2121-4d83-afa1-42e3dd11dfba



</details>

<details>
<summary>iOS: mWeb Safari</summary>


https://github.com/user-attachments/assets/963d1b6d-85bd-4ab9-921a-8bfa43183f97


https://github.com/user-attachments/assets/22325b85-8e6d-476d-b6ee-d41532549c0a



</details>

<details>
<summary>MacOS: Chrome / Safari</summary>


https://github.com/user-attachments/assets/29bf30ac-78c3-402d-8f46-9cb873f60849


https://github.com/user-attachments/assets/c5cc5abe-2f43-404f-8358-1933086db5a9



</details>

<details>
<summary>MacOS: Desktop</summary>

<img width="1203" height="878" alt="Screenshot 2025-07-15 at 11 24 55" src="https://github.com/user-attachments/assets/aff2b50e-0d21-4f9e-8207-589de8506c32" />

https://github.com/user-attachments/assets/3065a53d-21fa-4534-b42f-f8a390265c54



</details>
