### PR TITLE
Remove remaining withOnyx HOCs from the project | Batch 6

### DIFF
--- a/src/pages/UnlinkLoginPage.tsx
+++ b/src/pages/UnlinkLoginPage.tsx
@@ -5,20 +5,21 @@ import usePrevious from '@hooks/usePrevious';
 import Navigation from '@libs/Navigation/Navigation';
 import type {PlatformStackScreenProps} from '@libs/Navigation/PlatformStackNavigation/types';
 import type {PublicScreensParamList} from '@navigation/types';
-import * as Session from '@userActions/Session';
+import {unlinkLogin} from '@userActions/Session';
+import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
 import type SCREENS from '@src/SCREENS';
 
 type UnlinkLoginPageProps = PlatformStackScreenProps<PublicScreensParamList, typeof SCREENS.UNLINK_LOGIN>;
 
 function UnlinkLoginPage({route}: UnlinkLoginPageProps) {
-    const accountID = route.params.accountID ?? -1;
+    const accountID = route.params.accountID ?? CONST.DEFAULT_NUMBER_ID;
     const validateCode = route.params.validateCode ?? '';
     const [account] = useOnyx(ONYXKEYS.ACCOUNT, {canBeMissing: true});
     const prevIsLoading = usePrevious(!!account?.isLoading);
 
     useEffect(() => {
-        Session.unlinkLogin(Number(accountID), validateCode);
+        unlinkLogin(Number(accountID), validateCode);
         // We only want this to run on mount
         // eslint-disable-next-line react-compiler/react-compiler, react-hooks/exhaustive-deps
     }, []);

--- a/src/pages/UnlinkLoginPage.tsx
+++ b/src/pages/UnlinkLoginPage.tsx
@@ -1,7 +1,6 @@
 import React, {useEffect} from 'react';
-import {withOnyx} from 'react-native-onyx';
-import type {OnyxEntry} from 'react-native-onyx';
 import FullScreenLoadingIndicator from '@components/FullscreenLoadingIndicator';
+import useOnyx from '@hooks/useOnyx';
 import usePrevious from '@hooks/usePrevious';
 import Navigation from '@libs/Navigation/Navigation';
 import type {PlatformStackScreenProps} from '@libs/Navigation/PlatformStackNavigation/types';
@@ -9,18 +8,13 @@ import type {PublicScreensParamList} from '@navigation/types';
 import * as Session from '@userActions/Session';
 import ONYXKEYS from '@src/ONYXKEYS';
 import type SCREENS from '@src/SCREENS';
-import type {Account} from '@src/types/onyx';
 
-type UnlinkLoginPageOnyxProps = {
-    /** The details about the account that the user is signing in with */
-    account: OnyxEntry<Account>;
-};
+type UnlinkLoginPageProps = PlatformStackScreenProps<PublicScreensParamList, typeof SCREENS.UNLINK_LOGIN>;
 
-type UnlinkLoginPageProps = UnlinkLoginPageOnyxProps & PlatformStackScreenProps<PublicScreensParamList, typeof SCREENS.UNLINK_LOGIN>;
-
-function UnlinkLoginPage({route, account}: UnlinkLoginPageProps) {
+function UnlinkLoginPage({route}: UnlinkLoginPageProps) {
     const accountID = route.params.accountID ?? -1;
     const validateCode = route.params.validateCode ?? '';
+    const [account] = useOnyx(ONYXKEYS.ACCOUNT, {canBeMissing: true});
     const prevIsLoading = usePrevious(!!account?.isLoading);
 
     useEffect(() => {
@@ -43,6 +37,4 @@ function UnlinkLoginPage({route, account}: UnlinkLoginPageProps) {
 
 UnlinkLoginPage.displayName = 'UnlinkLoginPage';
 
-export default withOnyx<UnlinkLoginPageProps, UnlinkLoginPageOnyxProps>({
-    account: {key: ONYXKEYS.ACCOUNT},
-})(UnlinkLoginPage);
+export default UnlinkLoginPage;

--- a/src/pages/signin/ChangeExpensifyLoginLink.tsx
+++ b/src/pages/signin/ChangeExpensifyLoginLink.tsx
@@ -1,27 +1,21 @@
 import React from 'react';
 import {View} from 'react-native';
-import type {OnyxEntry} from 'react-native-onyx';
-import {withOnyx} from 'react-native-onyx';
 import PressableWithFeedback from '@components/Pressable/PressableWithFeedback';
 import Text from '@components/Text';
 import useLocalize from '@hooks/useLocalize';
+import useOnyx from '@hooks/useOnyx';
 import useThemeStyles from '@hooks/useThemeStyles';
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
-import type {Credentials} from '@src/types/onyx';
 
-type ChangeExpensifyLoginLinkOnyxProps = {
-    /** The credentials of the person logging in */
-    credentials: OnyxEntry<Credentials>;
-};
-
-type ChangeExpensifyLoginLinkProps = ChangeExpensifyLoginLinkOnyxProps & {
+type ChangeExpensifyLoginLinkProps = {
     onPress: () => void;
 };
 
-function ChangeExpensifyLoginLink({credentials, onPress}: ChangeExpensifyLoginLinkProps) {
+function ChangeExpensifyLoginLink({onPress}: ChangeExpensifyLoginLinkProps) {
     const styles = useThemeStyles();
     const {translate, formatPhoneNumber} = useLocalize();
+    const [credentials] = useOnyx(ONYXKEYS.CREDENTIALS, {canBeMissing: true});
 
     return (
         <View style={[styles.changeExpensifyLoginLinkContainer, styles.mt3]}>
@@ -40,8 +34,4 @@ function ChangeExpensifyLoginLink({credentials, onPress}: ChangeExpensifyLoginLi
 
 ChangeExpensifyLoginLink.displayName = 'ChangeExpensifyLoginLink';
 
-export default withOnyx<ChangeExpensifyLoginLinkProps, ChangeExpensifyLoginLinkOnyxProps>({
-    credentials: {
-        key: ONYXKEYS.CREDENTIALS,
-    },
-})(ChangeExpensifyLoginLink);
+export default ChangeExpensifyLoginLink;

--- a/src/pages/signin/ChooseSSOOrMagicCode.tsx
+++ b/src/pages/signin/ChooseSSOOrMagicCode.tsx
@@ -6,16 +6,16 @@ import Text from '@components/Text';
 import useKeyboardState from '@hooks/useKeyboardState';
 import useLocalize from '@hooks/useLocalize';
 import useNetwork from '@hooks/useNetwork';
+import useOnyx from '@hooks/useOnyx';
 import useResponsiveLayout from '@hooks/useResponsiveLayout';
 import useThemeStyles from '@hooks/useThemeStyles';
-import * as ErrorUtils from '@libs/ErrorUtils';
+import {getLatestErrorMessage} from '@libs/ErrorUtils';
 import Navigation from '@libs/Navigation/Navigation';
-import * as Session from '@userActions/Session';
+import {clearSignInData, resendValidateCode} from '@userActions/Session';
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
 import ROUTES from '@src/ROUTES';
 import {isEmptyObject} from '@src/types/utils/EmptyObject';
-import useOnyx from '@hooks/useOnyx';
 import ChangeExpensifyLoginLink from './ChangeExpensifyLoginLink';
 import Terms from './Terms';
 
@@ -70,12 +70,12 @@ function ChooseSSOOrMagicCode({setIsUsingMagicCode}: ChooseSSOOrMagicCodeProps) 
                     text={translate('samlSignIn.useMagicCode')}
                     isLoading={account?.isLoading && account?.loadingForm === (account?.requiresTwoFactorAuth ? CONST.FORMS.VALIDATE_TFA_CODE_FORM : CONST.FORMS.VALIDATE_CODE_FORM)}
                     onPress={() => {
-                        Session.resendValidateCode(credentials?.login);
+                        resendValidateCode(credentials?.login);
                         setIsUsingMagicCode(true);
                     }}
                 />
-                {!!account && !isEmptyObject(account.errors) && <FormHelpMessage message={ErrorUtils.getLatestErrorMessage(account)} />}
-                <ChangeExpensifyLoginLink onPress={() => Session.clearSignInData()} />
+                {!!account && !isEmptyObject(account.errors) && <FormHelpMessage message={getLatestErrorMessage(account)} />}
+                <ChangeExpensifyLoginLink onPress={() => clearSignInData()} />
             </View>
             <View style={[styles.mt5, styles.signInPageWelcomeTextContainer]}>
                 <Terms />

--- a/src/pages/signin/ChooseSSOOrMagicCode.tsx
+++ b/src/pages/signin/ChooseSSOOrMagicCode.tsx
@@ -1,7 +1,5 @@
 import React, {useEffect} from 'react';
 import {Keyboard, View} from 'react-native';
-import {withOnyx} from 'react-native-onyx';
-import type {OnyxEntry} from 'react-native-onyx';
 import Button from '@components/Button';
 import FormHelpMessage from '@components/FormHelpMessage';
 import Text from '@components/Text';
@@ -16,30 +14,24 @@ import * as Session from '@userActions/Session';
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
 import ROUTES from '@src/ROUTES';
-import type {Account, Credentials} from '@src/types/onyx';
 import {isEmptyObject} from '@src/types/utils/EmptyObject';
+import useOnyx from '@hooks/useOnyx';
 import ChangeExpensifyLoginLink from './ChangeExpensifyLoginLink';
 import Terms from './Terms';
 
-type ChooseSSOOrMagicCodeOnyxProps = {
-    /** The credentials of the logged in person */
-    credentials: OnyxEntry<Credentials>;
-
-    /** The details about the account that the user is signing in with */
-    account: OnyxEntry<Account>;
-};
-
-type ChooseSSOOrMagicCodeProps = ChooseSSOOrMagicCodeOnyxProps & {
+type ChooseSSOOrMagicCodeProps = {
     /** Function that returns whether the user is using SAML or magic codes to log in */
     setIsUsingMagicCode: (value: boolean) => void;
 };
 
-function ChooseSSOOrMagicCode({credentials, account, setIsUsingMagicCode}: ChooseSSOOrMagicCodeProps) {
+function ChooseSSOOrMagicCode({setIsUsingMagicCode}: ChooseSSOOrMagicCodeProps) {
     const styles = useThemeStyles();
     const {isKeyboardShown} = useKeyboardState();
     const {translate} = useLocalize();
     const {isOffline} = useNetwork();
     const {shouldUseNarrowLayout} = useResponsiveLayout();
+    const [credentials] = useOnyx(ONYXKEYS.CREDENTIALS, {canBeMissing: true});
+    const [account] = useOnyx(ONYXKEYS.ACCOUNT, {canBeMissing: true});
 
     // This view doesn't have a field for user input, so dismiss the device keyboard if shown
     useEffect(() => {
@@ -94,7 +86,4 @@ function ChooseSSOOrMagicCode({credentials, account, setIsUsingMagicCode}: Choos
 
 ChooseSSOOrMagicCode.displayName = 'ChooseSSOOrMagicCode';
 
-export default withOnyx<ChooseSSOOrMagicCodeProps, ChooseSSOOrMagicCodeOnyxProps>({
-    credentials: {key: ONYXKEYS.CREDENTIALS},
-    account: {key: ONYXKEYS.ACCOUNT},
-})(ChooseSSOOrMagicCode);
+export default ChooseSSOOrMagicCode;

--- a/src/pages/signin/ThirdPartySignInPage.tsx
+++ b/src/pages/signin/ThirdPartySignInPage.tsx
@@ -1,7 +1,5 @@
 import React from 'react';
 import {ActivityIndicator, View} from 'react-native';
-import {withOnyx} from 'react-native-onyx';
-import type {OnyxEntry} from 'react-native-onyx';
 import {SafeAreaView} from 'react-native-safe-area-context';
 import type {ValueOf} from 'type-fest';
 import AppleSignIn from '@components/SignInButtons/AppleSignIn';
@@ -9,20 +7,15 @@ import GoogleSignIn from '@components/SignInButtons/GoogleSignIn';
 import Text from '@components/Text';
 import TextLink from '@components/TextLink';
 import useLocalize from '@hooks/useLocalize';
+import useOnyx from '@hooks/useOnyx';
 import useThemeStyles from '@hooks/useThemeStyles';
 import Navigation from '@libs/Navigation/Navigation';
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
 import ROUTES from '@src/ROUTES';
-import type {Account} from '@src/types/onyx';
 import SignInPageLayout from './SignInPageLayout';
 
-type ThirdPartySignInPageOnyxProps = {
-    /** State for the account */
-    account: OnyxEntry<Account>;
-};
-
-type ThirdPartySignInPageProps = ThirdPartySignInPageOnyxProps & {
+type ThirdPartySignInPageProps = {
     /** Which sign in provider we are using. */
     signInProvider: ValueOf<typeof CONST.SIGN_IN_METHOD>;
 };
@@ -31,12 +24,13 @@ type ThirdPartySignInPageProps = ThirdPartySignInPageOnyxProps & {
  * sign-in cannot work fully within Electron, so we escape to web and redirect
  * to desktop once we have an Expensify auth token.
  */
-function ThirdPartySignInPage({account, signInProvider}: ThirdPartySignInPageProps) {
+function ThirdPartySignInPage({signInProvider}: ThirdPartySignInPageProps) {
     const styles = useThemeStyles();
     const {translate} = useLocalize();
     const goBack = () => {
         Navigation.navigate(ROUTES.HOME);
     };
+    const [account] = useOnyx(ONYXKEYS.ACCOUNT, {canBeMissing: true});
 
     return (
         <SafeAreaView style={[styles.signInPage]}>
@@ -83,8 +77,4 @@ function ThirdPartySignInPage({account, signInProvider}: ThirdPartySignInPagePro
 
 ThirdPartySignInPage.displayName = 'ThirdPartySignInPage';
 
-export default withOnyx<ThirdPartySignInPageProps, ThirdPartySignInPageOnyxProps>({
-    account: {
-        key: ONYXKEYS.ACCOUNT,
-    },
-})(ThirdPartySignInPage);
+export default ThirdPartySignInPage;


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
<!-- Explain what your change does and how it addresses the linked issue -->

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/65967
PROPOSAL: https://github.com/Expensify/App/issues/65967#issuecomment-3067722536


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->
- For UnLinkLoginForm, UnLinkLoginPage
Precondition: Add a secondary login and don't validate this login
1. Sign out and sign with the secondary login email
2. Verify that the unlink login form is displayed
3. Click on UnLink button
4. Open the link received from the email
5. Verify that unlink login page is displayed with loading indicator and then the login is unlinked successfully


- For ThirdPartySignInPage
1. Logout and open the page with deeplink sign-in-with-google
2. Sign in with google
3. Verify that when the account is logging, a loading indicator is displayed

- For ChangeExpensifyLoginLink
1. Sign in with SAML
2. Verify that choose sso or magic code page is displayed correctly

- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->

- For UnLinkLoginForm, UnLinkLoginPage
Precondition: Add a secondary login and don't validate this login
1. Sign out and sign with the secondary login email
2. Verify that the unlink login form is displayed
3. Click on UnLink button
4. Open the link received from the email
5. Verify that unlink login page is displayed with loading indicator and then the login is unlinked successfully


- For ThirdPartySignInPage
1. Logout and open the page with deeplink sign-in-with-google
2. Sign in with google
3. Verify that when the account is logging, a loading indicator is displayed

- For ChangeExpensifyLoginLink
1. Sign in with SAML
2. Verify that choose sso or magic code page is displayed correctly


- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I verified there are no new alerts related to the `canBeMissing` param for `useOnyx`
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/52a80eaf-3500-4f32-ae31-e80473366e62

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->


https://github.com/user-attachments/assets/310445fe-a1b1-460c-b2bb-38de6390795d


https://github.com/user-attachments/assets/4a42b975-2ed4-41f7-870e-67054fb43229


https://github.com/user-attachments/assets/3d81b05f-abbc-48d4-ad4e-c01b71d3833e



</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->


https://github.com/user-attachments/assets/dbdbeaf6-0d8f-4e15-8bd8-d6a578c89f89


</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->


https://github.com/user-attachments/assets/0d8a1639-dd57-48e5-9886-f0ed584466af

https://github.com/user-attachments/assets/33ba443f-266c-45da-bc3c-e2e3680ecd8e

https://github.com/user-attachments/assets/3f3ec754-9460-4ea4-8e3e-0faaf7c76bd1

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->


https://github.com/user-attachments/assets/68804b71-6e36-48c4-8839-c1e0b034e354

https://github.com/user-attachments/assets/beaa7a82-5599-47a1-8990-16c09e314a7c

https://github.com/user-attachments/assets/4e623abd-2e18-41be-978a-96cce1772790


</details>

<details>
<summary>MacOS: Desktop</summary>

<!-- add screenshots or videos here -->


https://github.com/user-attachments/assets/af08fbda-f5f3-4a53-9659-02d147d02465



https://github.com/user-attachments/assets/0cd34657-82b6-4d4e-8ea0-eaacbb933816

https://github.com/user-attachments/assets/be05703b-cb8f-4679-9f08-361f68116a77


</details>
