### PR TITLE
[No QA] --paths input for generateTranslations

### DIFF
--- a/scripts/generateTranslations.ts
+++ b/scripts/generateTranslations.ts
@@ -700,7 +700,7 @@ async function main(): Promise<void> {
                     }
 
                     if (invalidPaths.length > 0) {
-                        throw new Error(`⚠️  Warning: --paths contains the following invalid paths: ${invalidPaths.join(', ')}`);
+                        throw new Error(`found the following invalid paths: ${JSON.stringify(invalidPaths)}`);
                     }
 
                     return validatedPaths;

--- a/scripts/generateTranslations.ts
+++ b/scripts/generateTranslations.ts
@@ -687,10 +687,6 @@ async function main(): Promise<void> {
                     const validatedPaths: TranslationPaths[] = [];
                     const invalidPaths: string[] = [];
 
-                    // We disable eslint here and do a dynamic require because tests mock the en.ts file using fs, and normal imports can't be mocked by jest
-                    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
-                    // const en = require(enSourceFile).default;
-
                     for (const rawPath of rawPaths) {
                         if (get(en, rawPath)) {
                             validatedPaths.push(rawPath as TranslationPaths);

--- a/scripts/utils/CLI.ts
+++ b/scripts/utils/CLI.ts
@@ -218,25 +218,30 @@ class CLI<TConfig extends CLIConfig> {
                 if (providedNamedArgs.has(name) && spec.supersedes) {
                     for (const supersededArg of spec.supersedes) {
                         supersededArgs.add(supersededArg);
+                        if (providedNamedArgs.has(supersededArg)) {
+                            console.warn(`⚠️  Warning: --${supersededArg} is superseded by --${name} and will be ignored.`);
+                        }
                     }
                 }
             }
 
             // Validate that all required args are present, assign defaults where values are not parsed
             for (const [name, spec] of Object.entries(config.namedArgs ?? {})) {
-                if (!(name in parsedNamedArgs)) {
+                if (name in parsedNamedArgs) {
                     if (supersededArgs.has(name)) {
-                        // This arg was superseded, so don't require it and don't assign a default
-                        continue;
-                    } else if (spec.default !== undefined) {
-                        parsedNamedArgs[name as keyof typeof parsedNamedArgs] = spec.default as ValueOf<typeof parsedNamedArgs>;
-                    } else if (spec.required === false) {
-                        // Explicitly marked as optional, leave undefined
-                        continue;
-                    } else {
-                        // Arguments without defaults are required by default (unless explicitly marked as optional)
-                        throw new Error(`Missing required named argument --${name}`);
+                        parsedNamedArgs[name as keyof typeof parsedNamedArgs] = undefined as ValueOf<typeof parsedNamedArgs>;
                     }
+                } else if (supersededArgs.has(name)) {
+                    // This arg was superseded, so don't require it and don't assign a default
+                    continue;
+                } else if (spec.default !== undefined) {
+                    parsedNamedArgs[name as keyof typeof parsedNamedArgs] = spec.default as ValueOf<typeof parsedNamedArgs>;
+                } else if (spec.required === false) {
+                    // Explicitly marked as optional, leave undefined
+                    continue;
+                } else {
+                    // Arguments without defaults are required by default (unless explicitly marked as optional)
+                    throw new Error(`Missing required named argument --${name}`);
                 }
             }
 

--- a/scripts/utils/CLI.ts
+++ b/scripts/utils/CLI.ts
@@ -212,7 +212,7 @@ class CLI<TConfig extends CLIConfig> {
                 }
             }
 
-            // Handle supercession logic
+            // Handle supersession logic
             const supersededArgs = new Set<string>();
             for (const [name, spec] of Object.entries(config.namedArgs ?? {})) {
                 if (providedNamedArgs.has(name) && spec.supersedes) {

--- a/scripts/utils/CLI.ts
+++ b/scripts/utils/CLI.ts
@@ -21,10 +21,13 @@ type BooleanArg = CLIArg;
  * Any other argument is provided raw in process.argv as a string.
  * It can remain a string, or can be transformed into another type by a custom `parse` function.
  * It can be optional (by providing a default) or required (no default value).
+ * It can also supersede other named arguments when provided.
  */
 type StringArg<T = unknown> = CLIArg & {
     default?: T;
     parse?: (val: string) => T;
+    supersedes?: string[];
+    required?: boolean;
 };
 
 /**
@@ -162,6 +165,8 @@ class CLI<TConfig extends CLIConfig> {
 
             const parsedNamedArgs: Partial<Writable<typeof this.namedArgs>> = {};
             const parsedPositionalArgs: Partial<Writable<typeof this.positionalArgs>> = {};
+            const providedNamedArgs = new Set<string>();
+
             let positionalIndex = 0;
             for (let i = 0; i < rawArgs.length; i++) {
                 const rawArg = rawArgs.at(i);
@@ -177,6 +182,8 @@ class CLI<TConfig extends CLIConfig> {
                         this.flags[rawArgName as keyof typeof this.flags] = true;
                     } else if (config.namedArgs && rawArgName in config.namedArgs) {
                         // Arg is a named arg
+                        providedNamedArgs.add(rawArgName);
+
                         // Grab the value from the split token, otherwise go for the next token
                         let argValueBeforeParse = '';
                         if (rawArgValue) {
@@ -205,16 +212,34 @@ class CLI<TConfig extends CLIConfig> {
                 }
             }
 
+            // Handle supercession logic
+            const supersededArgs = new Set<string>();
+            for (const [name, spec] of Object.entries(config.namedArgs ?? {})) {
+                if (providedNamedArgs.has(name) && spec.supersedes) {
+                    for (const supersededArg of spec.supersedes) {
+                        supersededArgs.add(supersededArg);
+                    }
+                }
+            }
+
             // Validate that all required args are present, assign defaults where values are not parsed
             for (const [name, spec] of Object.entries(config.namedArgs ?? {})) {
                 if (!(name in parsedNamedArgs)) {
-                    if (spec.default !== undefined) {
+                    if (supersededArgs.has(name)) {
+                        // This arg was superseded, so don't require it and don't assign a default
+                        continue;
+                    } else if (spec.default !== undefined) {
                         parsedNamedArgs[name as keyof typeof parsedNamedArgs] = spec.default as ValueOf<typeof parsedNamedArgs>;
+                    } else if (spec.required === false) {
+                        // Explicitly marked as optional, leave undefined
+                        continue;
                     } else {
+                        // Arguments without defaults are required by default (unless explicitly marked as optional)
                         throw new Error(`Missing required named argument --${name}`);
                     }
                 }
             }
+
             for (const spec of config.positionalArgs ?? []) {
                 if (!(spec.name in parsedPositionalArgs)) {
                     if (spec.default !== undefined) {
@@ -263,7 +288,8 @@ class CLI<TConfig extends CLIConfig> {
             console.log('Named Arguments:');
             for (const [name, spec] of Object.entries(namedArgs)) {
                 const defaultLabel = spec.default !== undefined ? ` (default: ${String(spec.default)})` : '';
-                console.log(`  --${name.padEnd(20)} ${spec.description}${defaultLabel}`);
+                const supersededLabel = spec.supersedes && spec.supersedes.length > 0 ? ` (supersedes: ${spec.supersedes.join(', ')})` : '';
+                console.log(`  --${name.padEnd(20)} ${spec.description}${defaultLabel}${supersededLabel}`);
             }
             console.log('');
         }

--- a/tests/unit/CLITests.ts
+++ b/tests/unit/CLITests.ts
@@ -215,7 +215,7 @@ describe('CLI', () => {
         expect(mockExit).toHaveBeenCalledWith(0);
     });
 
-    it('handles supercession when superseding arg is provided', () => {
+    it('handles supersession when superseding arg is provided', () => {
         process.argv.push('--paths', 'common.save,errors.generic');
         const cli = new CLI({
             namedArgs: {
@@ -256,7 +256,7 @@ describe('CLI', () => {
         expect(cli.namedArgs.compareRef).toBe('main');
     });
 
-    it('shows supercession information in help message', () => {
+    it('shows supersession information in help message', () => {
         process.argv.push('--help');
         expect(
             () =>

--- a/tests/unit/generateTranslationsTest.ts
+++ b/tests/unit/generateTranslationsTest.ts
@@ -9,6 +9,17 @@ import dedent from '@libs/StringUtils/dedent';
 import generateTranslations, {GENERATED_FILE_PREFIX} from '@scripts/generateTranslations';
 import Translator from '@scripts/utils/Translator/Translator';
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-assignment
+let mockEn: any = jest.requireActual('@src/languages/en');
+jest.mock('@src/languages/en', () => ({
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    __esModule: true,
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    get default() {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+        return mockEn;
+    },
+}));
 jest.mock('openai');
 
 let tempDir: string;
@@ -563,21 +574,24 @@ describe('generateTranslations', () => {
     });
 
     it('translates only specified paths when --paths is provided', async () => {
+        const strings = {
+            greeting: 'Hello',
+            farewell: 'Goodbye',
+            common: {
+                save: 'Save',
+                cancel: 'Cancel',
+            },
+            errors: {
+                generic: 'An error occurred',
+                network: 'Network error',
+            },
+        };
+        mockEn = strings;
+
         fs.writeFileSync(
             EN_PATH,
             dedent(`
-                const strings = {
-                    greeting: 'Hello',
-                    farewell: 'Goodbye',
-                    common: {
-                        save: 'Save',
-                        cancel: 'Cancel',
-                    },
-                    errors: {
-                        generic: 'An error occurred',
-                        network: 'Network error',
-                    },
-                };
+                const strings = ${JSON.stringify(strings)};
                 export default strings;
             `),
             'utf8',


### PR DESCRIPTION
### Explanation of Change
This PR implements a `--paths` input for `generateTranslations`, whereby we can specify specific paths in `en.ts` to retranslate.

### Fixed Issues
$ https://github.com/Expensify/App/issues/65754

### Tests
Added automated tests.

- [x] Verify that no errors appear in the JS console

### Offline tests
None.

### QA Steps
None.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
- [X] I linked the correct issue in the `### Fixed Issues` section above
- [X] I wrote clear testing steps that cover the changes made in this PR
    - [X] I added steps for local testing in the `Tests` section
    - [X] I added steps for the expected offline behavior in the `Offline steps` section
    - [X] I added steps for Staging and/or Production testing in the `QA steps` section
    - [X] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [X] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [X] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [X] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [X] I ran the tests on **all platforms** & verified they passed on:
    - [X] Android: Native
    - [X] Android: mWeb Chrome
    - [X] iOS: Native
    - [X] iOS: mWeb Safari
    - [X] MacOS: Chrome / Safari
    - [X] MacOS: Desktop
- [X] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [X] I verified there are no new alerts related to the `canBeMissing` param for `useOnyx`
- [X] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [X] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [X] I verified that comments were added to code that is not self explanatory
    - [X] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [X] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [X] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [X] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [X] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [X] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [X] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [X] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [X] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [X] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [X] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [X] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [X] I verified that if a function's arguments changed that all usages have also been updated correctly
- [X] If any new file was added I verified that:
    - [X] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [X] If a new CSS style is added I verified that:
    - [X] A similar style doesn't already exist
    - [X] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [X] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [X] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [X] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [X] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [X] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [X] I verified that all the inputs inside a form are aligned with each other.
    - [X] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [X] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [X] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [X] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Desktop</summary>

<!-- add screenshots or videos here -->

</details>
