### PR TITLE
Fix - Expense - When deleting distance rate, error appears in two expenses with different rates

### DIFF
--- a/src/libs/actions/Policy/DistanceRate.ts
+++ b/src/libs/actions/Policy/DistanceRate.ts
@@ -566,7 +566,12 @@ function deletePolicyDistanceRates(policyID: string, customUnit: CustomUnit, rat
         },
     ];
 
-    const transactions = Object.values(allTransactions ?? {}).filter((transaction) => transaction?.comment?.customUnit?.customUnitID === customUnit.customUnitID);
+    const transactions = Object.values(allTransactions ?? {}).filter(
+        (transaction) =>
+            transaction?.comment?.customUnit?.customUnitID === customUnit.customUnitID &&
+            transaction?.comment?.customUnit?.customUnitRateID &&
+            rateIDsToDelete.includes(transaction?.comment?.customUnit?.customUnitRateID),
+    );
     const optimisticTransactionsViolations: OnyxUpdate[] = [];
 
     transactions.forEach((transaction) => {

--- a/tests/unit/DistanceRateTest.ts
+++ b/tests/unit/DistanceRateTest.ts
@@ -41,9 +41,9 @@ describe('DistanceRate', () => {
                 ...{
                     areDistanceRatesEnabled: true,
                     customUnits: {
-                        [Symbol(customUnitID)]: {
+                        [customUnitID]: {
                             attributes: {
-                                unit: 'mi',
+                                unit: CONST.CUSTOM_UNITS.DISTANCE_UNIT_MILES,
                             },
                             customUnitID,
                             defaultCategory: 'Car',
@@ -56,7 +56,6 @@ describe('DistanceRate', () => {
                                     enabled: true,
                                     name: 'Default Rate',
                                     rate: 70,
-                                    attributes: [],
                                     subRates: [],
                                 },
                                 [customUnitRateID2]: {
@@ -65,7 +64,6 @@ describe('DistanceRate', () => {
                                     enabled: true,
                                     name: 'Default Rate',
                                     rate: 71,
-                                    attributes: [],
                                     subRates: [],
                                 },
                             },

--- a/tests/unit/DistanceRateTest.ts
+++ b/tests/unit/DistanceRateTest.ts
@@ -1,0 +1,99 @@
+import Onyx from 'react-native-onyx';
+import {deletePolicyDistanceRates} from '@libs/actions/Policy/DistanceRate';
+import CONST from '@src/CONST';
+import ONYXKEYS from '@src/ONYXKEYS';
+import type {Policy, Transaction, TransactionViolations} from '@src/types/onyx';
+import createRandomPolicy from '../utils/collections/policies';
+import createRandomTransaction from '../utils/collections/transaction';
+import waitForBatchedUpdates from '../utils/waitForBatchedUpdates';
+
+describe('DistanceRate', () => {
+    beforeAll(() => {
+        Onyx.init({keys: ONYXKEYS});
+        return waitForBatchedUpdates();
+    });
+
+    describe('deletePolicyDistanceRates', () => {
+        it('should set customUnitOutOfPolicy violation only for transactions that have the deleted custom unit rate', async () => {
+            const customUnitID = '5A55C2B68DDCB';
+            const customUnitRateID1 = '7255CA72C7E7B';
+            const customUnitRateID2 = '7255CA72C7E72';
+            const transaction1: Transaction = {
+                ...createRandomTransaction(1),
+                comment: {
+                    customUnit: {
+                        customUnitID,
+                        customUnitRateID: customUnitRateID1,
+                    },
+                },
+            };
+            const transaction2: Transaction = {
+                ...createRandomTransaction(2),
+                comment: {
+                    customUnit: {
+                        customUnitID,
+                        customUnitRateID: customUnitRateID2,
+                    },
+                },
+            };
+            const policy: Policy = {
+                ...createRandomPolicy(3),
+                ...{
+                    areDistanceRatesEnabled: true,
+                    customUnits: {
+                        [Symbol(customUnitID)]: {
+                            attributes: {
+                                unit: 'mi',
+                            },
+                            customUnitID,
+                            defaultCategory: 'Car',
+                            enabled: true,
+                            name: 'Distance',
+                            rates: {
+                                [customUnitRateID1]: {
+                                    currency: 'ETB',
+                                    customUnitRateID: customUnitRateID1,
+                                    enabled: true,
+                                    name: 'Default Rate',
+                                    rate: 70,
+                                    attributes: [],
+                                    subRates: [],
+                                },
+                                [customUnitRateID2]: {
+                                    currency: 'ETB',
+                                    customUnitRateID: customUnitRateID2,
+                                    enabled: true,
+                                    name: 'Default Rate',
+                                    rate: 71,
+                                    attributes: [],
+                                    subRates: [],
+                                },
+                            },
+                        },
+                    },
+                },
+            };
+            await Onyx.set(`${ONYXKEYS.COLLECTION.TRANSACTION}${transaction1.transactionID}`, transaction1);
+            await Onyx.set(`${ONYXKEYS.COLLECTION.TRANSACTION}${transaction2.transactionID}`, transaction2);
+            await Onyx.set(`${ONYXKEYS.COLLECTION.POLICY}${policy.id}`, policy);
+
+            if (policy.customUnits) {
+                deletePolicyDistanceRates(policy.id, policy.customUnits[customUnitID], [customUnitRateID1]);
+            }
+            await waitForBatchedUpdates();
+            const transactionViolations = await new Promise<Record<string, TransactionViolations | undefined>>((resolve) => {
+                Onyx.connect({
+                    key: ONYXKEYS.COLLECTION.TRANSACTION_VIOLATIONS,
+                    callback: resolve,
+                    waitForCollectionCallback: true,
+                });
+            });
+
+            expect(transactionViolations).toEqual({
+                [`${ONYXKEYS.COLLECTION.TRANSACTION_VIOLATIONS}${transaction1.transactionID}`]: [
+                    {name: CONST.VIOLATIONS.CUSTOM_UNIT_OUT_OF_POLICY, showInReview: true, type: CONST.VIOLATION_TYPES.VIOLATION},
+                ],
+            });
+        });
+    });
+});


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/65370
PROPOSAL: https://github.com/Expensify/App/issues/65370#issuecomment-3029002592


### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->
Prerequisite: Account has at least one workspace created.
Prerequisite 2: Distance rates enabled and at least two rates created.

1. Open the Expensify app.
2. Open the workspace chat.
3. Create two different distance expenses setting different distance rates.
4. Navigate to "Workspaces" and open the workspace where the expenses were created.
5. Tap on "Distance Rates"
6. Select the rate of one of the expenses and delete it.
7. Navigate to workspace chat again.
8. Note when deleting distance rate used for an expense, the error of `Rate not valid` should only appear for the expense with the deleted rate.

- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->
Same as above
### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->
Same as above
- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/bd8026fe-c086-404a-a7d0-7c2bb02a130d


</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/59a2ed51-6074-4af5-80c4-e5795c9734d9


</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/a9629443-2953-463b-b367-8938f5c8b083


</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/1c932150-6f74-41b5-a0d3-0e86f33cdb8e



</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/c6f9bbb5-1827-4f6a-b545-b02279d52ec1


</details>

<details>
<summary>MacOS: Desktop</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/47c7747e-0130-4419-bffb-0813008ba605


</details>



