### PR TITLE
[CP Staging]: Revert "Chat header's infinite loading after merge account"

### DIFF
--- a/src/libs/ReportUtils.ts
+++ b/src/libs/ReportUtils.ts
@@ -5281,7 +5281,7 @@ function getReportNameInternal({
     // Not a room or PolicyExpenseChat, generate title from first 5 other participants
     formattedName = buildReportNameFromParticipantNames({report, personalDetails});
 
-    return isArchivedNonExpense ? generateArchivedReportName(formattedName) : formattedName || (report?.reportName ?? '');
+    return isArchivedNonExpense ? generateArchivedReportName(formattedName) : formattedName;
 }
 
 /**

--- a/tests/unit/ReportUtilsTest.ts
+++ b/tests/unit/ReportUtilsTest.ts
@@ -741,50 +741,6 @@ describe('ReportUtils', () => {
                 expect(getReportName(expenseChatReport)).toEqual("Ragnar Lothbrok's expenses");
             });
         });
-
-        describe('Fallback scenarios', () => {
-            test('should fallback to report.reportName when primary name generation returns empty string', () => {
-                const reportWithFallbackName: Report = {
-                    reportID: '3',
-                    reportName: 'Custom Report Name',
-                    ownerAccountID: undefined,
-                    participants: {},
-                    policyID: undefined,
-                    chatType: undefined,
-                };
-
-                const result = getReportName(reportWithFallbackName);
-                expect(result).toBe('Custom Report Name');
-            });
-
-            test('should return empty string when both primary name generation and reportName are empty', () => {
-                const reportWithoutName: Report = {
-                    reportID: '4',
-                    reportName: '',
-                    ownerAccountID: undefined,
-                    participants: {},
-                    policyID: undefined,
-                    chatType: undefined,
-                };
-
-                const result = getReportName(reportWithoutName);
-                expect(result).toBe('');
-            });
-
-            test('should return empty string when reportName is undefined', () => {
-                const reportWithUndefinedName: Report = {
-                    reportID: '5',
-                    reportName: undefined,
-                    ownerAccountID: undefined,
-                    participants: {},
-                    policyID: undefined,
-                    chatType: undefined,
-                };
-
-                const result = getReportName(reportWithUndefinedName);
-                expect(result).toBe('');
-            });
-        });
     });
 
     describe('Automatically approved report message via automatic (not by a human) action is', () => {


### PR DESCRIPTION
Straight revert Expensify/App#65748

$ https://github.com/Expensify/App/issues/66248

QA Testing steps:

1. Go to staging.expensify.com
2. Log in with a new Gmail account.
3. Click Skip on work email step.
4. Select Something else and complete the onboarding.
5. Go to Reports > Chats.

Verify Concierge message will show "In Concierge".