### PR TITLE
Jakubkalinski0/show report total and report status in the new report preview component

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -52,6 +52,7 @@
         "autofilled",
         "automations",
         "autoplay",
+        "AUTOREIMBURSED",
         "autoreleasepool",
         "AUTOREPORTING",
         "autoresizesSubviews",

--- a/src/CONST/index.ts
+++ b/src/CONST/index.ts
@@ -1347,6 +1347,7 @@ const CONST = {
             SUBMITTED: 1,
             APPROVED: 2,
             BILLING: 3,
+            AUTOREIMBURSED: 6,
         },
         STATUS_NUM: {
             OPEN: 0,

--- a/src/components/ReportActionItem/MoneyRequestReportPreview/MoneyRequestReportPreviewContent.tsx
+++ b/src/components/ReportActionItem/MoneyRequestReportPreview/MoneyRequestReportPreviewContent.tsx
@@ -419,7 +419,11 @@ function MoneyRequestReportPreviewContent({
             ? {maxWidth: reportPreviewStyles.transactionPreviewCarouselStyle.width}
             : {};
 
-    const approvedOrSettledIcon = (iouSettled || isApproved) && (
+    const isIconNeeded = useMemo(() => {
+        return iouSettled || isApproved;
+    }, [iouSettled, isApproved]);
+
+    const approvedOrSettledIcon = isIconNeeded && (
         <ImageSVG
             src={isApproved ? Expensicons.ThumbsUp : Expensicons.Checkmark}
             fill={isApproved ? theme.icon : theme.iconSuccessFill}
@@ -709,7 +713,7 @@ function MoneyRequestReportPreviewContent({
                                     </View>
                                     {shouldShowEmptyPlaceholder ? <MoneyReportHeaderStatusBarSkeleton/> : (
                                         <View style={[styles.flexRow, styles.justifyContentStart, styles.alignItemsCenter, styles.mtn2, styles.mb1]}>
-                                            <View style={[styles.flexRow, styles.alignItemsCenter, styles.gap1]}>
+                                            <View style={[styles.flexRow, styles.alignItemsCenter, isIconNeeded && styles.gap1]}>
                                                 <Text
                                                     style={[styles.textLabelSupporting, styles.lh16]}
                                                     numberOfLines={1}

--- a/src/components/ReportActionItem/MoneyRequestReportPreview/MoneyRequestReportPreviewContent.tsx
+++ b/src/components/ReportActionItem/MoneyRequestReportPreview/MoneyRequestReportPreviewContent.tsx
@@ -639,11 +639,10 @@ function MoneyRequestReportPreviewContent({
                                                 {shouldShowEmptyPlaceholder ? (
                                                     <MoneyReportHeaderStatusBarSkeleton />
                                                 ) : (
-                                                    <View style={[styles.flexRow, styles.justifyContentStart, styles.alignItemsCenter, isIconNeeded && styles.gap1]}>
-                                                        <Text style={[styles.alignItemsCenter, styles.lh16]}>{approvedOrSettledIcon}</Text>
+                                                    <View style={[styles.flexRow, styles.justifyContentStart, styles.alignItemsCenter]}>
+                                                        {isIconNeeded && <View style={[styles.alignItemsCenter, styles.lh16, styles.ml0]}>{approvedOrSettledIcon}</View>}
                                                         <Text
                                                             style={[styles.textLabelSupporting, styles.lh16]}
-                                                            numberOfLines={1}
                                                         >
                                                             {`${reportStatus} ${CONST.DOT_SEPARATOR} ${expenseCount}`}
                                                         </Text>
@@ -745,7 +744,7 @@ function MoneyRequestReportPreviewContent({
                                                         style={[styles.textLabelSupporting]}
                                                         numberOfLines={1}
                                                     >
-                                                        Total
+                                                        {translate('common.total')}
                                                     </Text>
                                                     <Text style={[styles.headerText]}>{convertToDisplayString(totalDisplaySpend, iouReport?.currency)}</Text>
                                                 </View>

--- a/src/components/ReportActionItem/MoneyRequestReportPreview/MoneyRequestReportPreviewContent.tsx
+++ b/src/components/ReportActionItem/MoneyRequestReportPreview/MoneyRequestReportPreviewContent.tsx
@@ -397,6 +397,7 @@ function MoneyRequestReportPreviewContent({
             ? {maxWidth: reportPreviewStyles.transactionPreviewCarouselStyle.width}
             : {};
 
+    // We also show icons in case of Approved or Paid report for easier identification at glance
     const isIconNeeded = useMemo(() => {
         return iouSettled || isApproved;
     }, [iouSettled, isApproved]);

--- a/src/components/ReportActionItem/MoneyRequestReportPreview/MoneyRequestReportPreviewContent.tsx
+++ b/src/components/ReportActionItem/MoneyRequestReportPreview/MoneyRequestReportPreviewContent.tsx
@@ -640,7 +640,7 @@ function MoneyRequestReportPreviewContent({
                                                     <MoneyReportHeaderStatusBarSkeleton />
                                                 ) : (
                                                     <View style={[styles.flexRow, styles.justifyContentStart, styles.alignItemsCenter]}>
-                                                        {isIconNeeded && <View style={[styles.alignItemsCenter, styles.lh16, styles.ml0]}>{approvedOrSettledIcon}</View>}
+                                                        {isIconNeeded && <View style={[styles.alignItemsCenter, styles.lh16, styles.ml1]}>{approvedOrSettledIcon}</View>}
                                                         <Text style={[styles.textLabelSupporting, styles.lh16]}>{`${reportStatus} ${CONST.DOT_SEPARATOR} ${expenseCount}`}</Text>
                                                     </View>
                                                 )}

--- a/src/components/ReportActionItem/MoneyRequestReportPreview/MoneyRequestReportPreviewContent.tsx
+++ b/src/components/ReportActionItem/MoneyRequestReportPreview/MoneyRequestReportPreviewContent.tsx
@@ -669,14 +669,12 @@ function MoneyRequestReportPreviewContent({
                                                         </Text>
                                                     </Animated.View>
                                                 </View>
-                                                {shouldShowEmptyPlaceholder ? <MoneyReportHeaderStatusBarSkeleton/> : (
+                                                {shouldShowEmptyPlaceholder ? (
+                                                    <MoneyReportHeaderStatusBarSkeleton />
+                                                ) : (
                                                     <View style={[styles.flexRow, styles.justifyContentStart, styles.alignItemsCenter]}>
                                                         <View style={[styles.flexRow, styles.alignItemsCenter, isIconNeeded && styles.gap1]}>
-                                                            <Text
-                                                                style={[styles.flex1, styles.alignItemsCenter, styles.lh16]}
-                                                            >
-                                                                {approvedOrSettledIcon}
-                                                            </Text>
+                                                            <Text style={[styles.flex1, styles.alignItemsCenter, styles.lh16]}>{approvedOrSettledIcon}</Text>
                                                             <Text
                                                                 style={[styles.textLabelSupporting, styles.lh16]}
                                                                 numberOfLines={1}

--- a/src/components/ReportActionItem/MoneyRequestReportPreview/MoneyRequestReportPreviewContent.tsx
+++ b/src/components/ReportActionItem/MoneyRequestReportPreview/MoneyRequestReportPreviewContent.tsx
@@ -1,8 +1,7 @@
 import React, {useCallback, useContext, useDeferredValue, useEffect, useMemo, useRef, useState} from 'react';
 import {ActivityIndicator, FlatList, View} from 'react-native';
-import type {LayoutChangeEvent, ListRenderItemInfo, ViewToken} from 'react-native';
+import type {ListRenderItemInfo, ViewToken} from 'react-native';
 import Animated, {useAnimatedStyle, useSharedValue, withDelay, withSpring, withTiming} from 'react-native-reanimated';
-import type {LayoutRectangle} from 'react-native/Libraries/Types/CoreEventTypes';
 import Button from '@components/Button';
 import {getButtonRole} from '@components/Button/utils';
 import ButtonWithDropdownMenu from '@components/ButtonWithDropdownMenu';
@@ -77,17 +76,6 @@ import type {PaymentMethodType} from '@src/types/onyx/OriginalMessage';
 import EmptyMoneyRequestReportPreview from './EmptyMoneyRequestReportPreview';
 import type {MoneyRequestReportPreviewContentProps} from './types';
 
-type WebLayoutNativeEvent = {
-    layout: LayoutRectangle;
-    target: Element;
-};
-
-const checkIfReportNameOverflows = <T extends LayoutChangeEvent>({nativeEvent}: T) =>
-    'target' in nativeEvent ? (nativeEvent as WebLayoutNativeEvent).target.scrollHeight > variables.h70 : false;
-
-// Do not remove this empty view, it is a workaround for the icon padding at the end of the preview text
-const FixIconPadding = <View style={{height: variables.iconSizeNormal}} />;
-
 function MoneyRequestReportPreviewContent({
     iouReportID,
     chatReportID,
@@ -130,8 +118,6 @@ function MoneyRequestReportPreviewContent({
     const {translate} = useLocalize();
     const {isOffline} = useNetwork();
     const {shouldUseNarrowLayout} = useResponsiveLayout();
-
-    const [doesReportNameOverflow, setDoesReportNameOverflow] = useState(false);
 
     const {areAllRequestsBeingSmartScanned, hasNonReimbursableTransactions} = useMemo(
         () => ({
@@ -389,13 +375,6 @@ function MoneyRequestReportPreviewContent({
         carouselRef.current?.scrollToIndex({index, animated: true, viewOffset: 2 * styles.gap2.gap});
     };
 
-    const onTextLayoutChange = (e: LayoutChangeEvent) => {
-        const doesOverflow = checkIfReportNameOverflows(e);
-        if (doesOverflow !== doesReportNameOverflow) {
-            setDoesReportNameOverflow(doesOverflow);
-        }
-    };
-
     const renderFlatlistItem = (itemInfo: ListRenderItemInfo<Transaction>) => {
         if (itemInfo.index > 9) {
             return (
@@ -650,17 +629,10 @@ function MoneyRequestReportPreviewContent({
                                                 <View style={[styles.flexRow, styles.mw100, styles.flexShrink1]}>
                                                     <Animated.View style={[styles.flexRow, styles.alignItemsCenter, previewMessageStyle, styles.flexShrink1]}>
                                                         <Text
-                                                            onLayout={onTextLayoutChange}
-                                                            style={[styles.lh20]}
-                                                            numberOfLines={3}
+                                                            style={[styles.headerText]}
+                                                            testID="MoneyRequestReportPreview-reportName"
                                                         >
-                                                            {FixIconPadding}
-                                                            <Text
-                                                                style={[styles.headerText]}
-                                                                testID="MoneyRequestReportPreview-reportName"
-                                                            >
-                                                                {getMoneyReportPreviewName(action, iouReport, isInvoice)}
-                                                            </Text>
+                                                            {getMoneyReportPreviewName(action, iouReport, isInvoice)}
                                                         </Text>
                                                     </Animated.View>
                                                 </View>

--- a/src/components/ReportActionItem/MoneyRequestReportPreview/MoneyRequestReportPreviewContent.tsx
+++ b/src/components/ReportActionItem/MoneyRequestReportPreview/MoneyRequestReportPreviewContent.tsx
@@ -624,7 +624,7 @@ function MoneyRequestReportPreviewContent({
                             <View style={[reportPreviewStyles.wrapperStyle]}>
                                 <View style={[reportPreviewStyles.contentContainerStyle, styles.gap4]}>
                                     <View style={[styles.expenseAndReportPreviewTextContainer, styles.overflowHidden]}>
-                                        <View style={[styles.flexRow, styles.justifyContentBetween, styles.gap1]}>
+                                        <View style={[styles.flexRow, styles.justifyContentBetween, styles.flexShrink1, styles.gap1]}>
                                             <View style={[styles.flexColumn, styles.gap1, styles.flexShrink1]}>
                                                 <View style={[styles.flexRow, styles.mw100, styles.flexShrink1]}>
                                                     <Animated.View style={[styles.flexRow, styles.alignItemsCenter, previewMessageStyle, styles.flexShrink1]}>

--- a/src/components/ReportActionItem/MoneyRequestReportPreview/MoneyRequestReportPreviewContent.tsx
+++ b/src/components/ReportActionItem/MoneyRequestReportPreview/MoneyRequestReportPreviewContent.tsx
@@ -289,7 +289,7 @@ function MoneyRequestReportPreviewContent({
         [translate, numberOfRequests],
     );
 
-    const reportStatus = useMemo(() => getReportStatusTranslation(iouReport), [iouReport]);
+    const reportStatus = useMemo(() => getReportStatusTranslation(iouReport?.stateNum, iouReport?.statusNum), [iouReport?.stateNum, iouReport?.statusNum]);
 
     const totalAmountStyle = shouldUseNarrowLayout ? [styles.flexColumnReverse, styles.alignItemsStretch] : [styles.flexRow, styles.alignItemsBaseline];
 

--- a/src/components/ReportActionItem/MoneyRequestReportPreview/MoneyRequestReportPreviewContent.tsx
+++ b/src/components/ReportActionItem/MoneyRequestReportPreview/MoneyRequestReportPreviewContent.tsx
@@ -639,16 +639,14 @@ function MoneyRequestReportPreviewContent({
                                                 {shouldShowEmptyPlaceholder ? (
                                                     <MoneyReportHeaderStatusBarSkeleton />
                                                 ) : (
-                                                    <View style={[styles.flexRow, styles.justifyContentStart, styles.alignItemsCenter]}>
-                                                        <View style={[styles.flexRow, styles.alignItemsCenter, isIconNeeded && styles.gap1]}>
-                                                            <Text style={[styles.flex1, styles.alignItemsCenter, styles.lh16]}>{approvedOrSettledIcon}</Text>
-                                                            <Text
-                                                                style={[styles.textLabelSupporting, styles.lh16]}
-                                                                numberOfLines={1}
-                                                            >
-                                                                {`${reportStatus} ${CONST.DOT_SEPARATOR} ${expenseCount}`}
-                                                            </Text>
-                                                        </View>
+                                                    <View style={[styles.flexRow, styles.justifyContentStart, styles.alignItemsCenter, isIconNeeded && styles.gap1]}>
+                                                        <Text style={[styles.alignItemsCenter, styles.lh16]}>{approvedOrSettledIcon}</Text>
+                                                        <Text
+                                                            style={[styles.textLabelSupporting, styles.lh16]}
+                                                            numberOfLines={1}
+                                                        >
+                                                            {`${reportStatus} ${CONST.DOT_SEPARATOR} ${expenseCount}`}
+                                                        </Text>
                                                     </View>
                                                 )}
                                             </View>

--- a/src/components/ReportActionItem/MoneyRequestReportPreview/MoneyRequestReportPreviewContent.tsx
+++ b/src/components/ReportActionItem/MoneyRequestReportPreview/MoneyRequestReportPreviewContent.tsx
@@ -33,7 +33,6 @@ import {openUnreportedExpense} from '@libs/actions/Report';
 import ControlSelection from '@libs/ControlSelection';
 import {convertToDisplayString} from '@libs/CurrencyUtils';
 import {canUseTouchScreen} from '@libs/DeviceCapabilities';
-import {getTotalAmountForIOUReportPreviewButton} from '@libs/MoneyRequestReportUtils';
 import Navigation from '@libs/Navigation/Navigation';
 import Performance from '@libs/Performance';
 import {getConnectedIntegration} from '@libs/PolicyUtils';
@@ -503,13 +502,13 @@ function MoneyRequestReportPreviewContent({
         [CONST.REPORT.REPORT_PREVIEW_ACTIONS.SUBMIT]: (
             <Button
                 success={isWaitingForSubmissionFromCurrentUser}
-                text={translate('iou.submitAmount', {amount: getTotalAmountForIOUReportPreviewButton(iouReport, policy, reportPreviewAction)})}
+                text={translate('common.submit')}
                 onPress={() => submitReport(iouReport)}
             />
         ),
         [CONST.REPORT.REPORT_PREVIEW_ACTIONS.APPROVE]: (
             <Button
-                text={translate('iou.approve', {formattedAmount: getTotalAmountForIOUReportPreviewButton(iouReport, policy, reportPreviewAction)})}
+                text={translate('iou.approve')}
                 success
                 onPress={() => confirmApproval()}
             />
@@ -521,8 +520,6 @@ function MoneyRequestReportPreviewContent({
                 isApprovedAnimationRunning={isApprovedAnimationRunning}
                 canIOUBePaid={canIOUBePaidAndApproved || isPaidAnimationRunning}
                 onAnimationFinish={stopAnimation}
-                formattedAmount={getTotalAmountForIOUReportPreviewButton(iouReport, policy, reportPreviewAction)}
-                currency={iouReport?.currency}
                 chatReportID={chatReportID}
                 policyID={policy?.id}
                 iouReport={iouReport}
@@ -563,9 +560,7 @@ function MoneyRequestReportPreviewContent({
                 icon={Expensicons.DotIndicator}
                 iconFill={theme.danger}
                 iconHoverFill={theme.danger}
-                text={translate('common.review', {
-                    amount: getTotalAmountForIOUReportPreviewButton(iouReport, policy, reportPreviewAction),
-                })}
+                text={translate('common.review')}
                 onPress={() => openReportFromPreview()}
             />
         ),

--- a/src/components/ReportActionItem/MoneyRequestReportPreview/MoneyRequestReportPreviewContent.tsx
+++ b/src/components/ReportActionItem/MoneyRequestReportPreview/MoneyRequestReportPreviewContent.tsx
@@ -625,7 +625,7 @@ function MoneyRequestReportPreviewContent({
                                 <View style={[reportPreviewStyles.contentContainerStyle, styles.gap4]}>
                                     <View style={[styles.expenseAndReportPreviewTextContainer, styles.overflowHidden]}>
                                         <View style={[styles.flexRow, styles.justifyContentBetween, styles.gap1]}>
-                                            <View style={[styles.flexColumn, styles.gap1]}>
+                                            <View style={[styles.flexColumn, styles.gap1, styles.flexShrink1]}>
                                                 <View style={[styles.flexRow, styles.mw100, styles.flexShrink1]}>
                                                     <Animated.View style={[styles.flexRow, styles.alignItemsCenter, previewMessageStyle, styles.flexShrink1]}>
                                                         <Text

--- a/src/components/ReportActionItem/MoneyRequestReportPreview/MoneyRequestReportPreviewContent.tsx
+++ b/src/components/ReportActionItem/MoneyRequestReportPreview/MoneyRequestReportPreviewContent.tsx
@@ -429,7 +429,6 @@ function MoneyRequestReportPreviewContent({
             fill={isApproved ? theme.icon : theme.iconSuccessFill}
             width={variables.iconSizeExtraSmall}
             height={variables.iconSizeExtraSmall}
-            style={{transform: 'translateY(1px)'}}
             contentFit="cover"
         />
     );
@@ -649,25 +648,44 @@ function MoneyRequestReportPreviewContent({
                             ]}
                         >
                             <View style={[reportPreviewStyles.wrapperStyle]}>
-                                <View style={[reportPreviewStyles.contentContainerStyle]}>
-                                    <View style={[styles.expenseAndReportPreviewTextContainer, styles.overflowHidden, styles.mbn1]}>
-                                        <View style={[styles.flexRow, styles.justifyContentBetween, styles.gap3]}>
-                                            <View style={[styles.flexRow, styles.mw100, styles.flexShrink1]}>
-                                                <Animated.View style={[styles.flexRow, styles.alignItemsCenter, previewMessageStyle, styles.flexShrink1]}>
-                                                    <Text
-                                                        onLayout={onTextLayoutChange}
-                                                        style={[styles.lh20]}
-                                                        numberOfLines={3}
-                                                    >
-                                                        {FixIconPadding}
+                                <View style={[reportPreviewStyles.contentContainerStyle, styles.gap4]}>
+                                    <View style={[styles.expenseAndReportPreviewTextContainer, styles.overflowHidden]}>
+                                        <View style={[styles.flexRow, styles.justifyContentBetween, styles.gap1]}>
+                                            <View style={[styles.flexColumn, styles.gap1]}>
+                                                <View style={[styles.flexRow, styles.mw100, styles.flexShrink1]}>
+                                                    <Animated.View style={[styles.flexRow, styles.alignItemsCenter, previewMessageStyle, styles.flexShrink1]}>
                                                         <Text
-                                                            style={[styles.headerText]}
-                                                            testID="MoneyRequestReportPreview-reportName"
+                                                            onLayout={onTextLayoutChange}
+                                                            style={[styles.lh20]}
+                                                            numberOfLines={3}
                                                         >
-                                                            {getMoneyReportPreviewName(action, iouReport, isInvoice)}
+                                                            {FixIconPadding}
+                                                            <Text
+                                                                style={[styles.headerText]}
+                                                                testID="MoneyRequestReportPreview-reportName"
+                                                            >
+                                                                {getMoneyReportPreviewName(action, iouReport, isInvoice)}
+                                                            </Text>
                                                         </Text>
-                                                    </Text>
-                                                </Animated.View>
+                                                    </Animated.View>
+                                                </View>
+                                                {shouldShowEmptyPlaceholder ? <MoneyReportHeaderStatusBarSkeleton/> : (
+                                                    <View style={[styles.flexRow, styles.justifyContentStart, styles.alignItemsCenter]}>
+                                                        <View style={[styles.flexRow, styles.alignItemsCenter, isIconNeeded && styles.gap1]}>
+                                                            <Text
+                                                                style={[styles.flex1, styles.alignItemsCenter, styles.lh16]}
+                                                            >
+                                                                {approvedOrSettledIcon}
+                                                            </Text>
+                                                            <Text
+                                                                style={[styles.textLabelSupporting, styles.lh16]}
+                                                                numberOfLines={1}
+                                                            >
+                                                                {`${reportStatus} ${CONST.DOT_SEPARATOR} ${expenseCount}`}
+                                                            </Text>
+                                                        </View>
+                                                    </View>
+                                                )}
                                             </View>
                                             {!shouldUseNarrowLayout && transactions.length > 2 && reportPreviewStyles.expenseCountVisible && (
                                                 <View style={[styles.flexRow, styles.alignItemsCenter]}>
@@ -711,24 +729,6 @@ function MoneyRequestReportPreviewContent({
                                             )}
                                         </View>
                                     </View>
-                                    {shouldShowEmptyPlaceholder ? <MoneyReportHeaderStatusBarSkeleton/> : (
-                                        <View style={[styles.flexRow, styles.justifyContentStart, styles.alignItemsCenter, styles.mtn2, styles.mb1]}>
-                                            <View style={[styles.flexRow, styles.alignItemsCenter, isIconNeeded && styles.gap1]}>
-                                                <Text
-                                                    style={[styles.textLabelSupporting, styles.lh16]}
-                                                    numberOfLines={1}
-                                                >
-                                                    {approvedOrSettledIcon}
-                                                </Text>
-                                                <Text
-                                                    style={[styles.textLabelSupporting, styles.lh16]}
-                                                    numberOfLines={1}
-                                                >
-                                                    {`${reportStatus} ${CONST.DOT_SEPARATOR} ${expenseCount}`}
-                                                </Text>
-                                            </View>
-                                        </View>
-                                    )}
                                     {!currentWidth || shouldShowLoading || shouldShowLoadingDeferred ? (
                                         <View
                                             style={[
@@ -748,7 +748,7 @@ function MoneyRequestReportPreviewContent({
                                             />
                                         </View>
                                     ) : (
-                                        <View style={[styles.flex1, styles.flexColumn, styles.overflowVisible, styles.mtn1]}>
+                                        <View style={[styles.flex1, styles.flexColumn, styles.overflowVisible]}>
                                             <FlatList
                                                 snapToAlignment="start"
                                                 decelerationRate="fast"

--- a/src/components/ReportActionItem/MoneyRequestReportPreview/MoneyRequestReportPreviewContent.tsx
+++ b/src/components/ReportActionItem/MoneyRequestReportPreview/MoneyRequestReportPreviewContent.tsx
@@ -640,7 +640,7 @@ function MoneyRequestReportPreviewContent({
                                                     <MoneyReportHeaderStatusBarSkeleton />
                                                 ) : (
                                                     <View style={[styles.flexRow, styles.justifyContentStart, styles.alignItemsCenter]}>
-                                                        {isIconNeeded && <View style={[styles.alignItemsCenter, styles.lh16, styles.ml1]}>{approvedOrSettledIcon}</View>}
+                                                        {isIconNeeded && <View style={[styles.alignItemsCenter, styles.lh16, styles.mr1]}>{approvedOrSettledIcon}</View>}
                                                         <Text style={[styles.textLabelSupporting, styles.lh16]}>{`${reportStatus} ${CONST.DOT_SEPARATOR} ${expenseCount}`}</Text>
                                                     </View>
                                                 )}

--- a/src/components/ReportActionItem/MoneyRequestReportPreview/MoneyRequestReportPreviewContent.tsx
+++ b/src/components/ReportActionItem/MoneyRequestReportPreview/MoneyRequestReportPreviewContent.tsx
@@ -641,11 +641,7 @@ function MoneyRequestReportPreviewContent({
                                                 ) : (
                                                     <View style={[styles.flexRow, styles.justifyContentStart, styles.alignItemsCenter]}>
                                                         {isIconNeeded && <View style={[styles.alignItemsCenter, styles.lh16, styles.ml0]}>{approvedOrSettledIcon}</View>}
-                                                        <Text
-                                                            style={[styles.textLabelSupporting, styles.lh16]}
-                                                        >
-                                                            {`${reportStatus} ${CONST.DOT_SEPARATOR} ${expenseCount}`}
-                                                        </Text>
+                                                        <Text style={[styles.textLabelSupporting, styles.lh16]}>{`${reportStatus} ${CONST.DOT_SEPARATOR} ${expenseCount}`}</Text>
                                                     </View>
                                                 )}
                                             </View>

--- a/src/components/ReportActionItem/MoneyRequestReportPreview/MoneyRequestReportPreviewContent.tsx
+++ b/src/components/ReportActionItem/MoneyRequestReportPreview/MoneyRequestReportPreviewContent.tsx
@@ -714,7 +714,7 @@ function MoneyRequestReportPreviewContent({
                                     {/* Subheader with status and count */}
                                     <View style={[styles.flexRow, styles.justifyContentBetween, styles.alignItemsCenter, styles.mtn2, styles.mb1]}>
                                         <Text
-                                            style={[styles.textLabelSupporting, styles.lh16, styles.mt0]}
+                                            style={[styles.textLabelSupporting, styles.lh16]}
                                             numberOfLines={1}
                                             testID="MoneyRequestReportPreview-statusAndCount"
                                         >

--- a/src/components/ReportActionItem/MoneyRequestReportPreview/MoneyRequestReportPreviewContent.tsx
+++ b/src/components/ReportActionItem/MoneyRequestReportPreview/MoneyRequestReportPreviewContent.tsx
@@ -19,7 +19,6 @@ import type {ActionHandledType} from '@components/ProcessMoneyReportHoldMenu';
 import ExportWithDropdownMenu from '@components/ReportActionItem/ExportWithDropdownMenu';
 import AnimatedSettlementButton from '@components/SettlementButton/AnimatedSettlementButton';
 import {showContextMenuForReport} from '@components/ShowContextMenuContext';
-import SearchRowSkeleton from '@components/Skeletons/SearchRowSkeleton';
 import Text from '@components/Text';
 import useLocalize from '@hooks/useLocalize';
 import useNetwork from '@hooks/useNetwork';

--- a/src/components/ReportActionItem/MoneyRequestReportPreview/MoneyRequestReportPreviewContent.tsx
+++ b/src/components/ReportActionItem/MoneyRequestReportPreview/MoneyRequestReportPreviewContent.tsx
@@ -46,6 +46,7 @@ import {
     getMoneyRequestSpendBreakdown,
     getNonHeldAndFullAmount,
     getPolicyName,
+    getReportStatus,
     getTransactionsWithReceipts,
     hasHeldExpenses as hasHeldExpensesReportUtils,
     hasNonReimbursableTransactions as hasNonReimbursableTransactionsReportUtils,
@@ -59,7 +60,6 @@ import {
     isSettled,
     isTripRoom as isTripRoomReportUtils,
     isWaitingForSubmissionFromCurrentUser as isWaitingForSubmissionFromCurrentUserReportUtils,
-    getReportStatus,
 } from '@libs/ReportUtils';
 import shouldAdjustScroll from '@libs/shouldAdjustScroll';
 import {shouldRestrictUserBillableActions} from '@libs/SubscriptionUtils';
@@ -295,9 +295,13 @@ function MoneyRequestReportPreviewContent({
      * There is an edge case when there is only one distance expense with a pending route and amount = 0.
        In this case, we don't want to show the merchant or description because it says: "Pending route...", which is already displayed in the amount field.
      */
-    const expenseCount = useMemo(() => translate('iou.expenseCount', {
-        count: numberOfRequests,
-    }), [translate, numberOfRequests]);
+    const expenseCount = useMemo(
+        () =>
+            translate('iou.expenseCount', {
+                count: numberOfRequests,
+            }),
+        [translate, numberOfRequests],
+    );
 
     const reportStatus = useMemo(() => getReportStatus(iouReport), [iouReport]);
 

--- a/src/components/ReportActionItem/MoneyRequestReportPreview/MoneyRequestReportPreviewContent.tsx
+++ b/src/components/ReportActionItem/MoneyRequestReportPreview/MoneyRequestReportPreviewContent.tsx
@@ -46,7 +46,7 @@ import {
     getMoneyRequestSpendBreakdown,
     getNonHeldAndFullAmount,
     getPolicyName,
-    getReportStatus,
+    getReportStatusTranslation,
     getTransactionsWithReceipts,
     hasHeldExpenses as hasHeldExpensesReportUtils,
     hasNonReimbursableTransactions as hasNonReimbursableTransactionsReportUtils,
@@ -303,7 +303,9 @@ function MoneyRequestReportPreviewContent({
         [translate, numberOfRequests],
     );
 
-    const reportStatus = useMemo(() => getReportStatus(iouReport), [iouReport]);
+    const reportStatus = useMemo(() => getReportStatusTranslation(iouReport), [iouReport]);
+
+    const totalAmountStyle = shouldUseNarrowLayout ? [styles.flexColumnReverse, styles.alignItemsStretch] : [styles.flexRow, styles.alignItemsBaseline];
 
     useEffect(() => {
         if (!isPaidAnimationRunning || isApprovedAnimationRunning) {
@@ -710,18 +712,15 @@ function MoneyRequestReportPreviewContent({
                                             )}
                                         </View>
                                     </View>
-
-                                    {/* Subheader with status and count */}
                                     <View style={[styles.flexRow, styles.justifyContentBetween, styles.alignItemsCenter, styles.mtn2, styles.mb1]}>
                                         <Text
                                             style={[styles.textLabelSupporting, styles.lh16]}
                                             numberOfLines={1}
                                             testID="MoneyRequestReportPreview-statusAndCount"
                                         >
-                                            {`${reportStatus} • ${expenseCount}`}
+                                            {`${reportStatus} ${CONST.DOT_SEPARATOR} ${expenseCount}`}
                                         </Text>
                                     </View>
-
                                     {!currentWidth || shouldShowLoading || shouldShowLoadingDeferred ? (
                                         <View
                                             style={[
@@ -765,11 +764,10 @@ function MoneyRequestReportPreviewContent({
                                             {shouldShowEmptyPlaceholder && <EmptyMoneyRequestReportPreview emptyReportPreviewAction={reportPreviewActions[reportPreviewAction]} />}
                                         </View>
                                     )}
-                                    <View style={[styles.expenseAndReportPreviewTextContainer, styles.overflowHidden]}>
+                                    <View style={[styles.expenseAndReportPreviewTextContainer]}>
                                         <View
                                             style={[
-                                                shouldUseNarrowLayout ? styles.flexColumnReverse : styles.flexRow,
-                                                shouldUseNarrowLayout ? styles.alignItemsStretch : styles.alignItemsBaseline,
+                                                totalAmountStyle,
                                                 styles.justifyContentBetween,
                                                 styles.gap3,
                                                 StyleUtils.getMinimumHeight(variables.h28),
@@ -789,7 +787,6 @@ function MoneyRequestReportPreviewContent({
                                                     </Text>
                                                     <Text
                                                         style={[styles.headerText]}
-                                                        testID="MoneyRequestReportPreview-currencyAndAmount"
                                                     >
                                                         {convertToDisplayString(totalDisplaySpend, iouReport?.currency)}
                                                     </Text>

--- a/src/components/ReportActionItem/MoneyRequestReportPreview/MoneyRequestReportPreviewContent.tsx
+++ b/src/components/ReportActionItem/MoneyRequestReportPreview/MoneyRequestReportPreviewContent.tsx
@@ -646,7 +646,7 @@ function MoneyRequestReportPreviewContent({
                             <View style={[reportPreviewStyles.wrapperStyle]}>
                                 <View style={[reportPreviewStyles.contentContainerStyle]}>
                                     <View style={[styles.expenseAndReportPreviewTextContainer, styles.overflowHidden, styles.mbn1]}>
-                                        <View style={[styles.flexRow, styles.justifyContentBetween, styles.gap3, StyleUtils.getMinimumHeight(variables.h28)]}>
+                                        <View style={[styles.flexRow, styles.justifyContentBetween, styles.gap3]}>
                                             <View style={[styles.flexRow, styles.mw100, styles.flexShrink1]}>
                                                 <Animated.View style={[styles.flexRow, styles.alignItemsCenter, previewMessageStyle, styles.flexShrink1]}>
                                                     <Text
@@ -769,7 +769,7 @@ function MoneyRequestReportPreviewContent({
                                             style={[
                                                 totalAmountStyle,
                                                 styles.justifyContentBetween,
-                                                styles.gap3,
+                                                styles.gap4,
                                                 StyleUtils.getMinimumHeight(variables.h28),
                                             ]}
                                         >

--- a/src/components/ReportActionItem/MoneyRequestReportPreview/MoneyRequestReportPreviewContent.tsx
+++ b/src/components/ReportActionItem/MoneyRequestReportPreview/MoneyRequestReportPreviewContent.tsx
@@ -302,19 +302,17 @@ function MoneyRequestReportPreviewContent({
         };
     }, [translate, numberOfRequests]);
 
-    const isReportDeleted = action?.pendingAction === CONST.RED_BRICK_ROAD_PENDING_ACTION.DELETE;
-
     // Nedded for the status in the subheader of the report preview
-    // ============================================
-    // State    |   Status  |   What to display?  |
-    // 0	    |   0	    |   Draft             |
-    // 1	    |   1	    |   Outstanding       |
-    // 2	    |   2	    |   Done              |
-    // 2	    |   3	    |   Approved          |
-    // 2	    |   4	    |   Paid              |
-    // 3	    |   4	    |   Paid              |
-    // 6	    |   4	    |   Paid              |
-    // ============================================
+    // ========================================
+    // State  |  Status  |  What to display?  |
+    // 0	  |  0	     |  Draft             |   
+    // 1	  |  1	     |  Outstanding       |
+    // 2	  |  2	     |  Done              |
+    // 2	  |  3	     |  Approved          |
+    // 2	  |  4	     |  Paid              |
+    // 3	  |  4	     |  Paid              |
+    // 6	  |  4	     |  Paid              |
+    // ========================================
     const {getReportStatus} = useMemo(() => {
         if (iouReport?.stateNum === CONST.REPORT.STATE_NUM.OPEN && iouReport?.statusNum === CONST.REPORT.STATUS_NUM.OPEN) {
             return {
@@ -527,6 +525,8 @@ function MoneyRequestReportPreviewContent({
         [chatReportID, iouReport?.parentReportID, iouReport?.reportID, policy, translate],
     );
 
+    const isReportDeleted = action?.pendingAction === CONST.RED_BRICK_ROAD_PENDING_ACTION.DELETE;
+
     const reportPreviewActions = {
         [CONST.REPORT.REPORT_PREVIEW_ACTIONS.SUBMIT]: (
             <Button
@@ -704,7 +704,6 @@ function MoneyRequestReportPreviewContent({
                                             </View>
                                             {!shouldUseNarrowLayout && transactions.length > 2 && reportPreviewStyles.expenseCountVisible && (
                                                 <View style={[styles.flexRow, styles.alignItemsCenter]}>
-                                                    {/* <Text style={[styles.textLabelSupporting, styles.textLabelSupporting, styles.lh20, styles.mr1]}>{expenseCountText}</Text> */}
                                                     <PressableWithFeedback
                                                         accessibilityRole="button"
                                                         accessible

--- a/src/components/ReportActionItem/MoneyRequestReportPreview/MoneyRequestReportPreviewContent.tsx
+++ b/src/components/ReportActionItem/MoneyRequestReportPreview/MoneyRequestReportPreviewContent.tsx
@@ -708,7 +708,9 @@ function MoneyRequestReportPreviewContent({
                                             )}
                                         </View>
                                     </View>
-                                    {shouldShowEmptyPlaceholder? <MoneyReportHeaderStatusBarSkeleton/> : (
+                                    {shouldShowEmptyPlaceholder ? (
+                                        <MoneyReportHeaderStatusBarSkeleton />
+                                    ) : (
                                         <View style={[styles.flexRow, styles.justifyContentBetween, styles.alignItemsCenter, styles.mtn2, styles.mb1]}>
                                             <Text
                                                 style={[styles.textLabelSupporting, styles.lh16]}

--- a/src/components/ReportActionItem/MoneyRequestReportPreview/MoneyRequestReportPreviewContent.tsx
+++ b/src/components/ReportActionItem/MoneyRequestReportPreview/MoneyRequestReportPreviewContent.tsx
@@ -76,6 +76,8 @@ import type {Transaction} from '@src/types/onyx';
 import type {PaymentMethodType} from '@src/types/onyx/OriginalMessage';
 import EmptyMoneyRequestReportPreview from './EmptyMoneyRequestReportPreview';
 import type {MoneyRequestReportPreviewContentProps} from './types';
+import SearchRowSkeleton from '@components/Skeletons/SearchRowSkeleton';
+import MoneyReportHeaderStatusBarSkeleton from '@components/MoneyReportHeaderStatusBarSkeleton';
 
 type WebLayoutNativeEvent = {
     layout: LayoutRectangle;
@@ -712,14 +714,19 @@ function MoneyRequestReportPreviewContent({
                                             )}
                                         </View>
                                     </View>
-                                    <View style={[styles.flexRow, styles.justifyContentBetween, styles.alignItemsCenter, styles.mtn2, styles.mb1]}>
-                                        <Text
-                                            style={[styles.textLabelSupporting, styles.lh16]}
-                                            numberOfLines={1}
-                                        >
-                                            {`${reportStatus} ${CONST.DOT_SEPARATOR} ${expenseCount}`}
-                                        </Text>
-                                    </View>
+                                    {shouldShowEmptyPlaceholder && (
+                                        MoneyReportHeaderStatusBarSkeleton()
+                                    )}
+                                    {!shouldShowEmptyPlaceholder && (
+                                        <View style={[styles.flexRow, styles.justifyContentBetween, styles.alignItemsCenter, styles.mtn2, styles.mb1]}>
+                                            <Text
+                                                style={[styles.textLabelSupporting, styles.lh16]}
+                                                numberOfLines={1}
+                                            >
+                                                {`${reportStatus} ${CONST.DOT_SEPARATOR} ${expenseCount}`}
+                                            </Text>
+                                        </View>
+                                    )}
                                     {!currentWidth || shouldShowLoading || shouldShowLoadingDeferred ? (
                                         <View
                                             style={[

--- a/src/components/ReportActionItem/MoneyRequestReportPreview/MoneyRequestReportPreviewContent.tsx
+++ b/src/components/ReportActionItem/MoneyRequestReportPreview/MoneyRequestReportPreviewContent.tsx
@@ -10,6 +10,7 @@ import {DelegateNoAccessContext} from '@components/DelegateNoAccessModalProvider
 import Icon from '@components/Icon';
 import * as Expensicons from '@components/Icon/Expensicons';
 import ImageSVG from '@components/ImageSVG';
+import MoneyReportHeaderStatusBarSkeleton from '@components/MoneyReportHeaderStatusBarSkeleton';
 import OfflineWithFeedback from '@components/OfflineWithFeedback';
 import {PressableWithFeedback} from '@components/Pressable';
 import PressableWithoutFeedback from '@components/Pressable/PressableWithoutFeedback';
@@ -18,6 +19,7 @@ import type {ActionHandledType} from '@components/ProcessMoneyReportHoldMenu';
 import ExportWithDropdownMenu from '@components/ReportActionItem/ExportWithDropdownMenu';
 import AnimatedSettlementButton from '@components/SettlementButton/AnimatedSettlementButton';
 import {showContextMenuForReport} from '@components/ShowContextMenuContext';
+import SearchRowSkeleton from '@components/Skeletons/SearchRowSkeleton';
 import Text from '@components/Text';
 import useLocalize from '@hooks/useLocalize';
 import useNetwork from '@hooks/useNetwork';
@@ -76,8 +78,6 @@ import type {Transaction} from '@src/types/onyx';
 import type {PaymentMethodType} from '@src/types/onyx/OriginalMessage';
 import EmptyMoneyRequestReportPreview from './EmptyMoneyRequestReportPreview';
 import type {MoneyRequestReportPreviewContentProps} from './types';
-import SearchRowSkeleton from '@components/Skeletons/SearchRowSkeleton';
-import MoneyReportHeaderStatusBarSkeleton from '@components/MoneyReportHeaderStatusBarSkeleton';
 
 type WebLayoutNativeEvent = {
     layout: LayoutRectangle;
@@ -708,10 +708,7 @@ function MoneyRequestReportPreviewContent({
                                             )}
                                         </View>
                                     </View>
-                                    {shouldShowEmptyPlaceholder && (
-                                        MoneyReportHeaderStatusBarSkeleton()
-                                    )}
-                                    {!shouldShowEmptyPlaceholder && (
+                                    {shouldShowEmptyPlaceholder? <MoneyReportHeaderStatusBarSkeleton/> : (
                                         <View style={[styles.flexRow, styles.justifyContentBetween, styles.alignItemsCenter, styles.mtn2, styles.mb1]}>
                                             <Text
                                                 style={[styles.textLabelSupporting, styles.lh16]}
@@ -767,9 +764,7 @@ function MoneyRequestReportPreviewContent({
                                     <View style={[styles.expenseAndReportPreviewTextContainer]}>
                                         <View style={[totalAmountStyle, styles.justifyContentBetween, styles.gap4, StyleUtils.getMinimumHeight(variables.h28)]}>
                                             {/* height is needed to avoid flickering on animation */}
-                                            {!shouldShowEmptyPlaceholder && (
-                                                <View style={[buttonMaxWidth, styles.flex1, {height: variables.h40}]}>{reportPreviewActions[reportPreviewAction]}</View>
-                                            )}
+                                            <View style={[buttonMaxWidth, styles.flex1, {height: variables.h40}]}>{reportPreviewActions[reportPreviewAction]}</View>
                                             {transactions.length > 1 && (
                                                 <View style={[styles.flexRow, shouldUseNarrowLayout ? styles.justifyContentBetween : styles.gap2, styles.alignItemsBaseline]}>
                                                     <Text

--- a/src/components/ReportActionItem/MoneyRequestReportPreview/MoneyRequestReportPreviewContent.tsx
+++ b/src/components/ReportActionItem/MoneyRequestReportPreview/MoneyRequestReportPreviewContent.tsx
@@ -663,13 +663,7 @@ function MoneyRequestReportPreviewContent({
                                                         >
                                                             {getMoneyReportPreviewName(action, iouReport, isInvoice)}
                                                         </Text>
-                                                        {!doesReportNameOverflow && <>&nbsp;{approvedOrSettledIcon}</>}
                                                     </Text>
-                                                    {doesReportNameOverflow && (
-                                                        <View style={[styles.mtn0Half, (transactions.length < 3 || shouldUseNarrowLayout) && styles.alignSelfStart]}>
-                                                            {approvedOrSettledIcon}
-                                                        </View>
-                                                    )}
                                                 </Animated.View>
                                             </View>
                                             {!shouldUseNarrowLayout && transactions.length > 2 && reportPreviewStyles.expenseCountVisible && (
@@ -723,7 +717,7 @@ function MoneyRequestReportPreviewContent({
                                                 style={[styles.textLabelSupporting, styles.lh16]}
                                                 numberOfLines={1}
                                             >
-                                                {`${reportStatus} ${CONST.DOT_SEPARATOR} ${expenseCount}`}
+                                                {approvedOrSettledIcon} {`${reportStatus} ${CONST.DOT_SEPARATOR} ${expenseCount}`}
                                             </Text>
                                         </View>
                                     )}

--- a/src/components/ReportActionItem/MoneyRequestReportPreview/MoneyRequestReportPreviewContent.tsx
+++ b/src/components/ReportActionItem/MoneyRequestReportPreview/MoneyRequestReportPreviewContent.tsx
@@ -764,14 +764,7 @@ function MoneyRequestReportPreviewContent({
                                         </View>
                                     )}
                                     <View style={[styles.expenseAndReportPreviewTextContainer]}>
-                                        <View
-                                            style={[
-                                                totalAmountStyle,
-                                                styles.justifyContentBetween,
-                                                styles.gap4,
-                                                StyleUtils.getMinimumHeight(variables.h28),
-                                            ]}
-                                        >
+                                        <View style={[totalAmountStyle, styles.justifyContentBetween, styles.gap4, StyleUtils.getMinimumHeight(variables.h28)]}>
                                             {/* height is needed to avoid flickering on animation */}
                                             {!shouldShowEmptyPlaceholder && (
                                                 <View style={[buttonMaxWidth, styles.flex1, {height: variables.h40}]}>{reportPreviewActions[reportPreviewAction]}</View>
@@ -784,11 +777,7 @@ function MoneyRequestReportPreviewContent({
                                                     >
                                                         Total
                                                     </Text>
-                                                    <Text
-                                                        style={[styles.headerText]}
-                                                    >
-                                                        {convertToDisplayString(totalDisplaySpend, iouReport?.currency)}
-                                                    </Text>
+                                                    <Text style={[styles.headerText]}>{convertToDisplayString(totalDisplaySpend, iouReport?.currency)}</Text>
                                                 </View>
                                             )}
                                         </View>

--- a/src/components/ReportActionItem/MoneyRequestReportPreview/MoneyRequestReportPreviewContent.tsx
+++ b/src/components/ReportActionItem/MoneyRequestReportPreview/MoneyRequestReportPreviewContent.tsx
@@ -59,6 +59,7 @@ import {
     isSettled,
     isTripRoom as isTripRoomReportUtils,
     isWaitingForSubmissionFromCurrentUser as isWaitingForSubmissionFromCurrentUserReportUtils,
+    getReportStatus,
 } from '@libs/ReportUtils';
 import shouldAdjustScroll from '@libs/shouldAdjustScroll';
 import {shouldRestrictUserBillableActions} from '@libs/SubscriptionUtils';
@@ -294,50 +295,11 @@ function MoneyRequestReportPreviewContent({
      * There is an edge case when there is only one distance expense with a pending route and amount = 0.
        In this case, we don't want to show the merchant or description because it says: "Pending route...", which is already displayed in the amount field.
      */
-    const {expenseCountText} = useMemo(() => {
-        return {
-            expenseCountText: translate('iou.expenseCount', {
-                count: numberOfRequests,
-            }),
-        };
-    }, [translate, numberOfRequests]);
+    const expenseCount = useMemo(() => translate('iou.expenseCount', {
+        count: numberOfRequests,
+    }), [translate, numberOfRequests]);
 
-    // Nedded for the status in the subheader of the report preview
-    // ========================================
-    // State  |  Status  |  What to display?  |
-    // 0	  |  0	     |  Draft             |
-    // 1	  |  1	     |  Outstanding       |
-    // 2	  |  2	     |  Done              |
-    // 2	  |  3	     |  Approved          |
-    // 2	  |  4	     |  Paid              |
-    // 3	  |  4	     |  Paid              |
-    // 6	  |  4	     |  Paid              |
-    // ========================================
-    const {getReportStatus} = useMemo(() => {
-        if (iouReport?.stateNum === CONST.REPORT.STATE_NUM.OPEN && iouReport?.statusNum === CONST.REPORT.STATUS_NUM.OPEN) {
-            return {
-                getReportStatus: translate('common.draft'),
-            };
-        }
-        if (iouReport?.stateNum === CONST.REPORT.STATE_NUM.SUBMITTED && iouReport?.statusNum === CONST.REPORT.STATUS_NUM.SUBMITTED) {
-            return {
-                getReportStatus: translate('common.outstanding'),
-            };
-        }
-        if (iouReport?.stateNum === CONST.REPORT.STATE_NUM.APPROVED && iouReport?.statusNum === CONST.REPORT.STATUS_NUM.CLOSED) {
-            return {
-                getReportStatus: translate('common.done'),
-            };
-        }
-        if (iouReport?.stateNum === CONST.REPORT.STATE_NUM.APPROVED && iouReport?.statusNum === CONST.REPORT.STATUS_NUM.APPROVED) {
-            return {
-                getReportStatus: translate('iou.approved'),
-            };
-        }
-        return {
-            getReportStatus: translate('iou.settledExpensify'),
-        };
-    }, [translate, iouReport]);
+    const reportStatus = useMemo(() => getReportStatus(iouReport), [iouReport]);
 
     useEffect(() => {
         if (!isPaidAnimationRunning || isApprovedAnimationRunning) {
@@ -752,7 +714,7 @@ function MoneyRequestReportPreviewContent({
                                             numberOfLines={1}
                                             testID="MoneyRequestReportPreview-statusAndCount"
                                         >
-                                            {`${getReportStatus} • ${expenseCountText}`}
+                                            {`${reportStatus} • ${expenseCount}`}
                                         </Text>
                                     </View>
 

--- a/src/components/ReportActionItem/MoneyRequestReportPreview/MoneyRequestReportPreviewContent.tsx
+++ b/src/components/ReportActionItem/MoneyRequestReportPreview/MoneyRequestReportPreviewContent.tsx
@@ -423,9 +423,9 @@ function MoneyRequestReportPreviewContent({
         <ImageSVG
             src={isApproved ? Expensicons.ThumbsUp : Expensicons.Checkmark}
             fill={isApproved ? theme.icon : theme.iconSuccessFill}
-            width={variables.iconSizeNormal}
-            height={variables.iconSizeNormal}
-            style={{transform: 'translateY(4px)'}}
+            width={variables.iconSizeExtraSmall}
+            height={variables.iconSizeExtraSmall}
+            style={{transform: 'translateY(1px)'}}
             contentFit="cover"
         />
     );
@@ -707,16 +707,22 @@ function MoneyRequestReportPreviewContent({
                                             )}
                                         </View>
                                     </View>
-                                    {shouldShowEmptyPlaceholder ? (
-                                        <MoneyReportHeaderStatusBarSkeleton />
-                                    ) : (
-                                        <View style={[styles.flexRow, styles.justifyContentBetween, styles.alignItemsCenter, styles.mtn2, styles.mb1]}>
-                                            <Text
-                                                style={[styles.textLabelSupporting, styles.lh16]}
-                                                numberOfLines={1}
-                                            >
-                                                {approvedOrSettledIcon} {`${reportStatus} ${CONST.DOT_SEPARATOR} ${expenseCount}`}
-                                            </Text>
+                                    {shouldShowEmptyPlaceholder ? <MoneyReportHeaderStatusBarSkeleton/> : (
+                                        <View style={[styles.flexRow, styles.justifyContentStart, styles.alignItemsCenter, styles.mtn2, styles.mb1]}>
+                                            <View style={[styles.flexRow, styles.alignItemsCenter, styles.gap1]}>
+                                                <Text
+                                                    style={[styles.textLabelSupporting, styles.lh16]}
+                                                    numberOfLines={1}
+                                                >
+                                                    {approvedOrSettledIcon}
+                                                </Text>
+                                                <Text
+                                                    style={[styles.textLabelSupporting, styles.lh16]}
+                                                    numberOfLines={1}
+                                                >
+                                                    {`${reportStatus} ${CONST.DOT_SEPARATOR} ${expenseCount}`}
+                                                </Text>
+                                            </View>
                                         </View>
                                     )}
                                     {!currentWidth || shouldShowLoading || shouldShowLoadingDeferred ? (

--- a/src/components/ReportActionItem/MoneyRequestReportPreview/MoneyRequestReportPreviewContent.tsx
+++ b/src/components/ReportActionItem/MoneyRequestReportPreview/MoneyRequestReportPreviewContent.tsx
@@ -30,6 +30,7 @@ import useTheme from '@hooks/useTheme';
 import useThemeStyles from '@hooks/useThemeStyles';
 import {openUnreportedExpense} from '@libs/actions/Report';
 import ControlSelection from '@libs/ControlSelection';
+import {convertToDisplayString} from '@libs/CurrencyUtils';
 import {canUseTouchScreen} from '@libs/DeviceCapabilities';
 import {getTotalAmountForIOUReportPreviewButton} from '@libs/MoneyRequestReportUtils';
 import Navigation from '@libs/Navigation/Navigation';
@@ -72,7 +73,6 @@ import ONYXKEYS from '@src/ONYXKEYS';
 import ROUTES from '@src/ROUTES';
 import type {Transaction} from '@src/types/onyx';
 import type {PaymentMethodType} from '@src/types/onyx/OriginalMessage';
-import { convertToDisplayString } from '@libs/CurrencyUtils';
 import EmptyMoneyRequestReportPreview from './EmptyMoneyRequestReportPreview';
 import type {MoneyRequestReportPreviewContentProps} from './types';
 
@@ -305,7 +305,7 @@ function MoneyRequestReportPreviewContent({
     // Nedded for the status in the subheader of the report preview
     // ========================================
     // State  |  Status  |  What to display?  |
-    // 0	  |  0	     |  Draft             |   
+    // 0	  |  0	     |  Draft             |
     // 1	  |  1	     |  Outstanding       |
     // 2	  |  2	     |  Done              |
     // 2	  |  3	     |  Approved          |
@@ -750,7 +750,7 @@ function MoneyRequestReportPreviewContent({
                                         <Text
                                             style={[styles.textLabelSupporting, styles.lh16, styles.mt0]}
                                             numberOfLines={1}
-                                            testID = "MoneyRequestReportPreview-statusAndCount"
+                                            testID="MoneyRequestReportPreview-statusAndCount"
                                         >
                                             {`${getReportStatus} • ${expenseCountText}`}
                                         </Text>
@@ -800,12 +800,21 @@ function MoneyRequestReportPreviewContent({
                                         </View>
                                     )}
                                     <View style={[styles.expenseAndReportPreviewTextContainer, styles.overflowHidden]}>
-                                        <View style={[shouldUseNarrowLayout ? styles.flexColumnReverse : styles.flexRow, shouldUseNarrowLayout ? styles.alignItemsStretch : styles.alignItemsBaseline, styles.justifyContentBetween, styles.gap3, StyleUtils.getMinimumHeight(variables.h28)]}>
+                                        <View
+                                            style={[
+                                                shouldUseNarrowLayout ? styles.flexColumnReverse : styles.flexRow,
+                                                shouldUseNarrowLayout ? styles.alignItemsStretch : styles.alignItemsBaseline,
+                                                styles.justifyContentBetween,
+                                                styles.gap3,
+                                                StyleUtils.getMinimumHeight(variables.h28),
+                                            ]}
+                                        >
                                             {/* height is needed to avoid flickering on animation */}
-                                            {!shouldShowEmptyPlaceholder && <View style={[buttonMaxWidth, styles.flex1, {height: variables.h40}]}>{reportPreviewActions[reportPreviewAction]}</View>}
-                                            {transactions.length > 1 &&(
+                                            {!shouldShowEmptyPlaceholder && (
+                                                <View style={[buttonMaxWidth, styles.flex1, {height: variables.h40}]}>{reportPreviewActions[reportPreviewAction]}</View>
+                                            )}
+                                            {transactions.length > 1 && (
                                                 <View style={[styles.flexRow, shouldUseNarrowLayout ? styles.justifyContentBetween : styles.gap2, styles.alignItemsBaseline]}>
-
                                                     <Text
                                                         style={[styles.textLabelSupporting]}
                                                         numberOfLines={1}

--- a/src/components/ReportActionItem/MoneyRequestReportPreview/MoneyRequestReportPreviewContent.tsx
+++ b/src/components/ReportActionItem/MoneyRequestReportPreview/MoneyRequestReportPreviewContent.tsx
@@ -716,7 +716,6 @@ function MoneyRequestReportPreviewContent({
                                         <Text
                                             style={[styles.textLabelSupporting, styles.lh16]}
                                             numberOfLines={1}
-                                            testID="MoneyRequestReportPreview-statusAndCount"
                                         >
                                             {`${reportStatus} ${CONST.DOT_SEPARATOR} ${expenseCount}`}
                                         </Text>

--- a/src/components/ReportActionItem/MoneyRequestReportPreview/MoneyRequestReportPreviewContent.tsx
+++ b/src/components/ReportActionItem/MoneyRequestReportPreview/MoneyRequestReportPreviewContent.tsx
@@ -305,16 +305,16 @@ function MoneyRequestReportPreviewContent({
     const isReportDeleted = action?.pendingAction === CONST.RED_BRICK_ROAD_PENDING_ACTION.DELETE;
 
     // Nedded for the status in the subheader of the report preview
-    // ======================================
-    // State  |  Status | What to display?  |
-    // 0	  |  0	    | Draft             |   
-    // 1	  |  1	    | Outstanding       |
-    // 2	  |  2	    | Done              |
-    // 2	  |  3	    | Approved          |
-    // 2	  |  4	    | Paid              |
-    // 3	  |  4	    | Paid              |
-    // 6	  |  4	    | Paid              |
-    // ======================================
+    // ============================================
+    // State    |   Status  |   What to display?  |
+    // 0	    |   0	    |   Draft             |
+    // 1	    |   1	    |   Outstanding       |
+    // 2	    |   2	    |   Done              |
+    // 2	    |   3	    |   Approved          |
+    // 2	    |   4	    |   Paid              |
+    // 3	    |   4	    |   Paid              |
+    // 6	    |   4	    |   Paid              |
+    // ============================================
     const {getReportStatus} = useMemo(() => {
         if (iouReport?.stateNum === CONST.REPORT.STATE_NUM.OPEN && iouReport?.statusNum === CONST.REPORT.STATUS_NUM.OPEN) {
             return {

--- a/src/languages/de.ts
+++ b/src/languages/de.ts
@@ -545,6 +545,7 @@ const translations = {
         tax: 'Steuer',
         shared: 'Geteilt',
         drafts: 'Entwürfe',
+        draft: 'Entwurf',
         finished: 'Fertiggestellt',
         upgrade: 'Upgrade',
         downgradeWorkspace: 'Arbeitsbereich herabstufen',

--- a/src/languages/en.ts
+++ b/src/languages/en.ts
@@ -536,6 +536,7 @@ const translations = {
         tax: 'Tax',
         shared: 'Shared',
         drafts: 'Drafts',
+        draft: 'Draft',
         finished: 'Finished',
         upgrade: 'Upgrade',
         downgradeWorkspace: 'Downgrade workspace',

--- a/src/languages/es.ts
+++ b/src/languages/es.ts
@@ -529,6 +529,7 @@ const translations = {
         tax: 'Impuesto',
         shared: 'Compartidos',
         drafts: 'Borradores',
+        draft: 'Borrador',
         finished: 'Finalizados',
         upgrade: 'Mejora',
         downgradeWorkspace: 'Desmejora tu espacio de trabajo',

--- a/src/languages/fr.ts
+++ b/src/languages/fr.ts
@@ -545,6 +545,7 @@ const translations = {
         tax: 'Taxe',
         shared: 'Partagé',
         drafts: 'Brouillons',
+        draft: 'Brouillon',
         finished: 'Terminé',
         upgrade: 'Mise à niveau',
         downgradeWorkspace: "Rétrograder l'espace de travail",

--- a/src/languages/it.ts
+++ b/src/languages/it.ts
@@ -545,6 +545,7 @@ const translations = {
         tax: 'Tassa',
         shared: 'Condiviso',
         drafts: 'Bozze',
+        draft: 'Bozza',
         finished: 'Finito',
         upgrade: 'Aggiorna',
         downgradeWorkspace: 'Declassa spazio di lavoro',

--- a/src/languages/ja.ts
+++ b/src/languages/ja.ts
@@ -545,6 +545,7 @@ const translations = {
         tax: '税金',
         shared: '共有',
         drafts: '下書き',
+        draft: 'ドラフト',
         finished: '完了',
         upgrade: 'アップグレード',
         downgradeWorkspace: 'ワークスペースをダウングレードする',

--- a/src/languages/nl.ts
+++ b/src/languages/nl.ts
@@ -545,6 +545,7 @@ const translations = {
         tax: 'Belasting',
         shared: 'Gedeeld',
         drafts: 'Concepten',
+        draft: 'Ontwerp',
         finished: 'Voltooid',
         upgrade: 'Upgrade',
         downgradeWorkspace: 'Werkruimte downgraden',

--- a/src/languages/pl.ts
+++ b/src/languages/pl.ts
@@ -545,6 +545,7 @@ const translations = {
         tax: 'Podatek',
         shared: 'Udostępnione',
         drafts: 'Szkice',
+        draft: 'Szkic',
         finished: 'Zakończono',
         upgrade: 'Ulepszanie',
         downgradeWorkspace: 'Obniż poziom przestrzeni roboczej',

--- a/src/languages/pt-BR.ts
+++ b/src/languages/pt-BR.ts
@@ -545,6 +545,7 @@ const translations = {
         tax: 'Imposto',
         shared: 'Compartilhado',
         drafts: 'Rascunhos',
+        draft: 'Rascunho',
         finished: 'Concluído',
         upgrade: 'Atualizar',
         downgradeWorkspace: 'Reduzir espaço de trabalho',

--- a/src/languages/zh-hans.ts
+++ b/src/languages/zh-hans.ts
@@ -545,6 +545,7 @@ const translations = {
         tax: '税务',
         shared: '共享',
         drafts: '草稿',
+        draft: '草稿',
         finished: '完成',
         upgrade: '升级',
         downgradeWorkspace: '降级工作区',

--- a/src/libs/ReportUtils.ts
+++ b/src/libs/ReportUtils.ts
@@ -11141,7 +11141,7 @@ function getMoneyReportPreviewName(action: ReportAction, iouReport: OnyxEntry<Re
  * ========================================
  */
 function getReportStatusTranslation(stateNum?: number, statusNum?: number): string {
-    if (!stateNum || !statusNum) {
+    if (stateNum === undefined || statusNum === undefined) {
         return '';
     }
 

--- a/src/libs/ReportUtils.ts
+++ b/src/libs/ReportUtils.ts
@@ -11144,7 +11144,7 @@ function getReportStatusTranslation(report?: Report) {
     if (!report) {
         return '';
     }
-    
+
     if (report.stateNum === CONST.REPORT.STATE_NUM.OPEN && report.statusNum === CONST.REPORT.STATUS_NUM.OPEN) {
         return translateLocal('common.draft');
     }
@@ -11164,7 +11164,7 @@ function getReportStatusTranslation(report?: Report) {
     ) {
         return translateLocal('iou.settledExpensify');
     }
-    
+
     return '';
 }
 

--- a/src/libs/ReportUtils.ts
+++ b/src/libs/ReportUtils.ts
@@ -11137,30 +11137,34 @@ function getMoneyReportPreviewName(action: ReportAction, iouReport: OnyxEntry<Re
  * 2	  |  3	     |  Approved          |
  * 2	  |  4	     |  Paid              |
  * 3	  |  4	     |  Paid              |
- * 6      |  4	     |  Paid              | <- this case is problematic as stateNum = 6 does not exist on NewDot at the moment of writing
+ * 6      |  4	     |  Paid              |
  * ========================================
  */
 function getReportStatusTranslation(report?: Report) {
     if (!report) {
         return '';
     }
-
-    if (report.statusNum === CONST.REPORT.STATUS_NUM.OPEN) {
+    
+    if (report.stateNum === CONST.REPORT.STATE_NUM.OPEN && report.statusNum === CONST.REPORT.STATUS_NUM.OPEN) {
         return translateLocal('common.draft');
     }
-    if (report.statusNum === CONST.REPORT.STATUS_NUM.SUBMITTED) {
+    if (report.stateNum === CONST.REPORT.STATE_NUM.SUBMITTED && report.statusNum === CONST.REPORT.STATUS_NUM.SUBMITTED) {
         return translateLocal('common.outstanding');
     }
-    if (report.statusNum === CONST.REPORT.STATUS_NUM.CLOSED) {
+    if (report.stateNum === CONST.REPORT.STATE_NUM.APPROVED && report.statusNum === CONST.REPORT.STATUS_NUM.CLOSED) {
         return translateLocal('common.done');
     }
-    if (report.statusNum === CONST.REPORT.STATUS_NUM.APPROVED) {
+    if (report.stateNum === CONST.REPORT.STATE_NUM.APPROVED && report.statusNum === CONST.REPORT.STATUS_NUM.APPROVED) {
         return translateLocal('iou.approved');
     }
-    if (report.statusNum === CONST.REPORT.STATUS_NUM.REIMBURSED) {
+    if (
+        (report.stateNum === CONST.REPORT.STATE_NUM.APPROVED && report.statusNum === CONST.REPORT.STATUS_NUM.REIMBURSED) ||
+        (report.stateNum === CONST.REPORT.STATE_NUM.BILLING && report.statusNum === CONST.REPORT.STATUS_NUM.REIMBURSED) ||
+        (report.stateNum === CONST.REPORT.STATE_NUM.AUTOREIMBURSED && report.statusNum === CONST.REPORT.STATUS_NUM.REIMBURSED)
+    ) {
         return translateLocal('iou.settledExpensify');
     }
-
+    
     return '';
 }
 

--- a/src/libs/ReportUtils.ts
+++ b/src/libs/ReportUtils.ts
@@ -11137,30 +11137,31 @@ function getMoneyReportPreviewName(action: ReportAction, iouReport: OnyxEntry<Re
  * 2	  |  3	     |  Approved          |
  * 2	  |  4	     |  Paid              |
  * 3	  |  4	     |  Paid              |
+ * 6      |  4	     |  Paid              | <- this case is problematic as stateNum = 6 does not exist on NewDot at the moment of writing
  * ========================================
  */
 function getReportStatusTranslation(report?: Report) {
     if (!report) {
         return '';
     }
-    if (report?.stateNum === CONST.REPORT.STATE_NUM.OPEN && report?.statusNum === CONST.REPORT.STATUS_NUM.OPEN) {
+
+    if (report.statusNum === CONST.REPORT.STATUS_NUM.OPEN) {
         return translateLocal('common.draft');
     }
-    if (report?.stateNum === CONST.REPORT.STATE_NUM.SUBMITTED && report?.statusNum === CONST.REPORT.STATUS_NUM.SUBMITTED) {
+    if (report.statusNum === CONST.REPORT.STATUS_NUM.SUBMITTED) {
         return translateLocal('common.outstanding');
     }
-    if (report?.stateNum === CONST.REPORT.STATE_NUM.APPROVED && report?.statusNum === CONST.REPORT.STATUS_NUM.CLOSED) {
+    if (report.statusNum === CONST.REPORT.STATUS_NUM.CLOSED) {
         return translateLocal('common.done');
     }
-    if (report?.stateNum === CONST.REPORT.STATE_NUM.APPROVED && report?.statusNum === CONST.REPORT.STATUS_NUM.APPROVED) {
+    if (report.statusNum === CONST.REPORT.STATUS_NUM.APPROVED) {
         return translateLocal('iou.approved');
     }
-    if (
-        (report?.stateNum === CONST.REPORT.STATE_NUM.APPROVED && report?.statusNum === CONST.REPORT.STATUS_NUM.REIMBURSED) ||
-        (report?.stateNum === CONST.REPORT.STATE_NUM.BILLING && report?.statusNum === CONST.REPORT.STATUS_NUM.REIMBURSED)
-    ) {
+    if (report.statusNum === CONST.REPORT.STATUS_NUM.REIMBURSED) {
         return translateLocal('iou.settledExpensify');
     }
+
+    return '';
 }
 
 export {

--- a/src/libs/ReportUtils.ts
+++ b/src/libs/ReportUtils.ts
@@ -11140,27 +11140,27 @@ function getMoneyReportPreviewName(action: ReportAction, iouReport: OnyxEntry<Re
  * 6      |  4	     |  Paid              |
  * ========================================
  */
-function getReportStatusTranslation(report?: Report) {
-    if (!report) {
+function getReportStatusTranslation(stateNum?: number, statusNum?: number): string {
+    if (!stateNum || !statusNum) {
         return '';
     }
 
-    if (report.stateNum === CONST.REPORT.STATE_NUM.OPEN && report.statusNum === CONST.REPORT.STATUS_NUM.OPEN) {
+    if (stateNum === CONST.REPORT.STATE_NUM.OPEN && statusNum === CONST.REPORT.STATUS_NUM.OPEN) {
         return translateLocal('common.draft');
     }
-    if (report.stateNum === CONST.REPORT.STATE_NUM.SUBMITTED && report.statusNum === CONST.REPORT.STATUS_NUM.SUBMITTED) {
+    if (stateNum === CONST.REPORT.STATE_NUM.SUBMITTED && statusNum === CONST.REPORT.STATUS_NUM.SUBMITTED) {
         return translateLocal('common.outstanding');
     }
-    if (report.stateNum === CONST.REPORT.STATE_NUM.APPROVED && report.statusNum === CONST.REPORT.STATUS_NUM.CLOSED) {
+    if (stateNum === CONST.REPORT.STATE_NUM.APPROVED && statusNum === CONST.REPORT.STATUS_NUM.CLOSED) {
         return translateLocal('common.done');
     }
-    if (report.stateNum === CONST.REPORT.STATE_NUM.APPROVED && report.statusNum === CONST.REPORT.STATUS_NUM.APPROVED) {
+    if (stateNum === CONST.REPORT.STATE_NUM.APPROVED && statusNum === CONST.REPORT.STATUS_NUM.APPROVED) {
         return translateLocal('iou.approved');
     }
     if (
-        (report.stateNum === CONST.REPORT.STATE_NUM.APPROVED && report.statusNum === CONST.REPORT.STATUS_NUM.REIMBURSED) ||
-        (report.stateNum === CONST.REPORT.STATE_NUM.BILLING && report.statusNum === CONST.REPORT.STATUS_NUM.REIMBURSED) ||
-        (report.stateNum === CONST.REPORT.STATE_NUM.AUTOREIMBURSED && report.statusNum === CONST.REPORT.STATUS_NUM.REIMBURSED)
+        (stateNum === CONST.REPORT.STATE_NUM.APPROVED && statusNum === CONST.REPORT.STATUS_NUM.REIMBURSED) ||
+        (stateNum === CONST.REPORT.STATE_NUM.BILLING && statusNum === CONST.REPORT.STATUS_NUM.REIMBURSED) ||
+        (stateNum === CONST.REPORT.STATE_NUM.AUTOREIMBURSED && statusNum === CONST.REPORT.STATUS_NUM.REIMBURSED)
     ) {
         return translateLocal('iou.settledExpensify');
     }

--- a/src/libs/ReportUtils.ts
+++ b/src/libs/ReportUtils.ts
@@ -11125,6 +11125,42 @@ function getMoneyReportPreviewName(action: ReportAction, iouReport: OnyxEntry<Re
     return getReportName(iouReport) || action.childReportName;
 }
 
+/**
+ * Returns the current status of the report based on its state and status numbers.
+ * The status is determined by the stateNum and statusNum of the report.
+ * The mapping is as follows:
+ * ========================================
+ * State  |  Status  |  What to display?  |
+ * 0	  |  0	     |  Draft             |
+ * 1	  |  1	     |  Outstanding       |
+ * 2	  |  2	     |  Done              |
+ * 2	  |  3	     |  Approved          |
+ * 2	  |  4	     |  Paid              |
+ * 3	  |  4	     |  Paid              |
+ * ========================================
+ */
+function getReportStatus(report?: Report) {
+    if (report?.stateNum === CONST.REPORT.STATE_NUM.OPEN && report?.statusNum === CONST.REPORT.STATUS_NUM.OPEN) {
+        return translateLocal('common.draft');
+    }
+    if (report?.stateNum === CONST.REPORT.STATE_NUM.SUBMITTED && report?.statusNum === CONST.REPORT.STATUS_NUM.SUBMITTED) {
+        return translateLocal('common.outstanding');
+    }
+    if (report?.stateNum === CONST.REPORT.STATE_NUM.APPROVED && report?.statusNum === CONST.REPORT.STATUS_NUM.CLOSED) {
+        return translateLocal('common.done');
+    }
+    if (report?.stateNum === CONST.REPORT.STATE_NUM.APPROVED && report?.statusNum === CONST.REPORT.STATUS_NUM.APPROVED) {
+        return translateLocal('iou.approved');
+    }
+    if (
+        (report?.stateNum === CONST.REPORT.STATE_NUM.APPROVED && report?.statusNum === CONST.REPORT.STATUS_NUM.REIMBURSED) || 
+        (report?.stateNum === CONST.REPORT.STATE_NUM.BILLING && report?.statusNum === CONST.REPORT.STATUS_NUM.REIMBURSED)
+    ) {
+        return translateLocal('iou.settledExpensify');
+    }
+    return ('');
+};
+
 export {
     addDomainToShortMention,
     completeShortMention,
@@ -11504,6 +11540,7 @@ export {
     getNextApproverAccountID,
     isWorkspaceTaskReport,
     isWorkspaceThread,
+    getReportStatus,
 };
 
 export type {

--- a/src/libs/ReportUtils.ts
+++ b/src/libs/ReportUtils.ts
@@ -11153,13 +11153,13 @@ function getReportStatus(report?: Report) {
         return translateLocal('iou.approved');
     }
     if (
-        (report?.stateNum === CONST.REPORT.STATE_NUM.APPROVED && report?.statusNum === CONST.REPORT.STATUS_NUM.REIMBURSED) || 
+        (report?.stateNum === CONST.REPORT.STATE_NUM.APPROVED && report?.statusNum === CONST.REPORT.STATUS_NUM.REIMBURSED) ||
         (report?.stateNum === CONST.REPORT.STATE_NUM.BILLING && report?.statusNum === CONST.REPORT.STATUS_NUM.REIMBURSED)
     ) {
         return translateLocal('iou.settledExpensify');
     }
-    return ('');
-};
+    return '';
+}
 
 export {
     addDomainToShortMention,

--- a/src/libs/ReportUtils.ts
+++ b/src/libs/ReportUtils.ts
@@ -11126,7 +11126,7 @@ function getMoneyReportPreviewName(action: ReportAction, iouReport: OnyxEntry<Re
 }
 
 /**
- * Returns the current status of the report based on its state and status numbers.
+ * Returns the translated, human-readable status of the report based on its state and status values.
  * The status is determined by the stateNum and statusNum of the report.
  * The mapping is as follows:
  * ========================================
@@ -11139,7 +11139,10 @@ function getMoneyReportPreviewName(action: ReportAction, iouReport: OnyxEntry<Re
  * 3	  |  4	     |  Paid              |
  * ========================================
  */
-function getReportStatus(report?: Report) {
+function getReportStatusTranslation(report?: Report) {
+    if (!report) {
+        return '';
+    }
     if (report?.stateNum === CONST.REPORT.STATE_NUM.OPEN && report?.statusNum === CONST.REPORT.STATUS_NUM.OPEN) {
         return translateLocal('common.draft');
     }
@@ -11158,7 +11161,6 @@ function getReportStatus(report?: Report) {
     ) {
         return translateLocal('iou.settledExpensify');
     }
-    return '';
 }
 
 export {
@@ -11540,7 +11542,7 @@ export {
     getNextApproverAccountID,
     isWorkspaceTaskReport,
     isWorkspaceThread,
-    getReportStatus,
+    getReportStatusTranslation,
 };
 
 export type {

--- a/src/libs/ReportUtils.ts
+++ b/src/libs/ReportUtils.ts
@@ -11126,7 +11126,7 @@ function getMoneyReportPreviewName(action: ReportAction, iouReport: OnyxEntry<Re
 }
 
 /**
- * Returns the current status of the report based on its state and status numbers.
+ * Returns the translated, human-readable status of the report based on its state and status values.
  * The status is determined by the stateNum and statusNum of the report.
  * The mapping is as follows:
  * ========================================

--- a/tests/unit/ReportUtilsTest.ts
+++ b/tests/unit/ReportUtilsTest.ts
@@ -4726,7 +4726,7 @@ describe('ReportUtils', () => {
             const report: Report = {
                 ...createRandomReport(0),
                 stateNum: CONST.REPORT.STATE_NUM.OPEN,
-                statusNum: CONST.REPORT.STATUS_NUM.OPEN
+                statusNum: CONST.REPORT.STATUS_NUM.OPEN,
             };
             expect(getReportStatusTranslation(report)).toBe(translateLocal('common.draft'));
         });
@@ -4735,7 +4735,7 @@ describe('ReportUtils', () => {
             const report: Report = {
                 ...createRandomReport(1),
                 stateNum: CONST.REPORT.STATE_NUM.SUBMITTED,
-                statusNum: CONST.REPORT.STATUS_NUM.SUBMITTED
+                statusNum: CONST.REPORT.STATUS_NUM.SUBMITTED,
             };
             expect(getReportStatusTranslation(report)).toBe(translateLocal('common.outstanding'));
         });
@@ -4744,7 +4744,7 @@ describe('ReportUtils', () => {
             const report: Report = {
                 ...createRandomReport(2),
                 stateNum: CONST.REPORT.STATE_NUM.APPROVED,
-                statusNum: CONST.REPORT.STATUS_NUM.CLOSED
+                statusNum: CONST.REPORT.STATUS_NUM.CLOSED,
             };
             expect(getReportStatusTranslation(report)).toBe(translateLocal('common.done'));
         });
@@ -4753,7 +4753,7 @@ describe('ReportUtils', () => {
             const report: Report = {
                 ...createRandomReport(3),
                 stateNum: CONST.REPORT.STATE_NUM.APPROVED,
-                statusNum: CONST.REPORT.STATUS_NUM.APPROVED
+                statusNum: CONST.REPORT.STATUS_NUM.APPROVED,
             };
             expect(getReportStatusTranslation(report)).toBe(translateLocal('iou.approved'));
         });
@@ -4762,7 +4762,7 @@ describe('ReportUtils', () => {
             const report: Report = {
                 ...createRandomReport(4),
                 stateNum: CONST.REPORT.STATE_NUM.APPROVED,
-                statusNum: CONST.REPORT.STATUS_NUM.REIMBURSED
+                statusNum: CONST.REPORT.STATUS_NUM.REIMBURSED,
             };
             expect(getReportStatusTranslation(report)).toBe(translateLocal('iou.settledExpensify'));
         });
@@ -4771,7 +4771,7 @@ describe('ReportUtils', () => {
             const report: Report = {
                 ...createRandomReport(5),
                 stateNum: CONST.REPORT.STATE_NUM.BILLING,
-                statusNum: CONST.REPORT.STATUS_NUM.REIMBURSED
+                statusNum: CONST.REPORT.STATUS_NUM.REIMBURSED,
             };
             expect(getReportStatusTranslation(report)).toBe(translateLocal('iou.settledExpensify'));
         });
@@ -4780,7 +4780,7 @@ describe('ReportUtils', () => {
             const report: Report = {
                 ...createRandomReport(6),
                 stateNum: CONST.REPORT.STATE_NUM.AUTOREIMBURSED,
-                statusNum: CONST.REPORT.STATUS_NUM.REIMBURSED
+                statusNum: CONST.REPORT.STATUS_NUM.REIMBURSED,
             };
             expect(getReportStatusTranslation(report)).toBe(translateLocal('iou.settledExpensify'));
         });

--- a/tests/unit/ReportUtilsTest.ts
+++ b/tests/unit/ReportUtilsTest.ts
@@ -46,6 +46,7 @@ import {
     getReasonAndReportActionThatRequiresAttention,
     getReportIDFromLink,
     getReportName,
+    getReportStatusTranslation,
     getWorkspaceIcon,
     getWorkspaceNameUpdatedMessage,
     hasReceiptError,
@@ -4717,6 +4718,71 @@ describe('ReportUtils', () => {
             it('should return false for a non-archived chat report', () => {
                 expect(shouldShowFlagComment(actionFromConcierge, chatReport, false)).toBe(false);
             });
+        });
+    });
+
+    describe('getReportStatusTranslation', () => {
+        it('should return "Draft" for state 0, status 0', () => {
+            const report: Report = {
+                ...createRandomReport(0),
+                stateNum: CONST.REPORT.STATE_NUM.OPEN,
+                statusNum: CONST.REPORT.STATUS_NUM.OPEN
+            };
+            expect(getReportStatusTranslation(report)).toBe(translateLocal('common.draft'));
+        });
+
+        it('should return "Outstanding" for state 1, status 1', () => {
+            const report: Report = {
+                ...createRandomReport(1),
+                stateNum: CONST.REPORT.STATE_NUM.SUBMITTED,
+                statusNum: CONST.REPORT.STATUS_NUM.SUBMITTED
+            };
+            expect(getReportStatusTranslation(report)).toBe(translateLocal('common.outstanding'));
+        });
+
+        it('should return "Done" for state 2, status 2', () => {
+            const report: Report = {
+                ...createRandomReport(2),
+                stateNum: CONST.REPORT.STATE_NUM.APPROVED,
+                statusNum: CONST.REPORT.STATUS_NUM.CLOSED
+            };
+            expect(getReportStatusTranslation(report)).toBe(translateLocal('common.done'));
+        });
+
+        it('should return "Approved" for state 2, status 3', () => {
+            const report: Report = {
+                ...createRandomReport(3),
+                stateNum: CONST.REPORT.STATE_NUM.APPROVED,
+                statusNum: CONST.REPORT.STATUS_NUM.APPROVED
+            };
+            expect(getReportStatusTranslation(report)).toBe(translateLocal('iou.approved'));
+        });
+
+        it('should return "Paid" for state 2, status 4', () => {
+            const report: Report = {
+                ...createRandomReport(4),
+                stateNum: CONST.REPORT.STATE_NUM.APPROVED,
+                statusNum: CONST.REPORT.STATUS_NUM.REIMBURSED
+            };
+            expect(getReportStatusTranslation(report)).toBe(translateLocal('iou.settledExpensify'));
+        });
+
+        it('should return "Paid" for state 3, status 4', () => {
+            const report: Report = {
+                ...createRandomReport(5),
+                stateNum: CONST.REPORT.STATE_NUM.BILLING,
+                statusNum: CONST.REPORT.STATUS_NUM.REIMBURSED
+            };
+            expect(getReportStatusTranslation(report)).toBe(translateLocal('iou.settledExpensify'));
+        });
+
+        it('should return "Paid" for state 6, status 4', () => {
+            const report: Report = {
+                ...createRandomReport(6),
+                stateNum: CONST.REPORT.STATE_NUM.AUTOREIMBURSED,
+                statusNum: CONST.REPORT.STATUS_NUM.REIMBURSED
+            };
+            expect(getReportStatusTranslation(report)).toBe(translateLocal('iou.settledExpensify'));
         });
     });
 });

--- a/tests/unit/ReportUtilsTest.ts
+++ b/tests/unit/ReportUtilsTest.ts
@@ -4723,66 +4723,37 @@ describe('ReportUtils', () => {
 
     describe('getReportStatusTranslation', () => {
         it('should return "Draft" for state 0, status 0', () => {
-            const report: Report = {
-                ...createRandomReport(0),
-                stateNum: CONST.REPORT.STATE_NUM.OPEN,
-                statusNum: CONST.REPORT.STATUS_NUM.OPEN,
-            };
-            expect(getReportStatusTranslation(report)).toBe(translateLocal('common.draft'));
+            expect(getReportStatusTranslation(CONST.REPORT.STATE_NUM.OPEN, CONST.REPORT.STATUS_NUM.OPEN)).toBe(translateLocal('common.draft'));
         });
 
         it('should return "Outstanding" for state 1, status 1', () => {
-            const report: Report = {
-                ...createRandomReport(1),
-                stateNum: CONST.REPORT.STATE_NUM.SUBMITTED,
-                statusNum: CONST.REPORT.STATUS_NUM.SUBMITTED,
-            };
-            expect(getReportStatusTranslation(report)).toBe(translateLocal('common.outstanding'));
+            expect(getReportStatusTranslation(CONST.REPORT.STATE_NUM.SUBMITTED, CONST.REPORT.STATUS_NUM.SUBMITTED)).toBe(translateLocal('common.outstanding'));
         });
 
         it('should return "Done" for state 2, status 2', () => {
-            const report: Report = {
-                ...createRandomReport(2),
-                stateNum: CONST.REPORT.STATE_NUM.APPROVED,
-                statusNum: CONST.REPORT.STATUS_NUM.CLOSED,
-            };
-            expect(getReportStatusTranslation(report)).toBe(translateLocal('common.done'));
+            expect(getReportStatusTranslation(CONST.REPORT.STATE_NUM.APPROVED, CONST.REPORT.STATUS_NUM.CLOSED)).toBe(translateLocal('common.done'));
         });
 
         it('should return "Approved" for state 2, status 3', () => {
-            const report: Report = {
-                ...createRandomReport(3),
-                stateNum: CONST.REPORT.STATE_NUM.APPROVED,
-                statusNum: CONST.REPORT.STATUS_NUM.APPROVED,
-            };
-            expect(getReportStatusTranslation(report)).toBe(translateLocal('iou.approved'));
+            expect(getReportStatusTranslation(CONST.REPORT.STATE_NUM.APPROVED, CONST.REPORT.STATUS_NUM.APPROVED)).toBe(translateLocal('iou.approved'));
         });
 
         it('should return "Paid" for state 2, status 4', () => {
-            const report: Report = {
-                ...createRandomReport(4),
-                stateNum: CONST.REPORT.STATE_NUM.APPROVED,
-                statusNum: CONST.REPORT.STATUS_NUM.REIMBURSED,
-            };
-            expect(getReportStatusTranslation(report)).toBe(translateLocal('iou.settledExpensify'));
+            expect(getReportStatusTranslation(CONST.REPORT.STATE_NUM.APPROVED, CONST.REPORT.STATUS_NUM.REIMBURSED)).toBe(translateLocal('iou.settledExpensify'));
         });
 
         it('should return "Paid" for state 3, status 4', () => {
-            const report: Report = {
-                ...createRandomReport(5),
-                stateNum: CONST.REPORT.STATE_NUM.BILLING,
-                statusNum: CONST.REPORT.STATUS_NUM.REIMBURSED,
-            };
-            expect(getReportStatusTranslation(report)).toBe(translateLocal('iou.settledExpensify'));
+            expect(getReportStatusTranslation(CONST.REPORT.STATE_NUM.BILLING, CONST.REPORT.STATUS_NUM.REIMBURSED)).toBe(translateLocal('iou.settledExpensify'));
         });
 
         it('should return "Paid" for state 6, status 4', () => {
-            const report: Report = {
-                ...createRandomReport(6),
-                stateNum: CONST.REPORT.STATE_NUM.AUTOREIMBURSED,
-                statusNum: CONST.REPORT.STATUS_NUM.REIMBURSED,
-            };
-            expect(getReportStatusTranslation(report)).toBe(translateLocal('iou.settledExpensify'));
+            expect(getReportStatusTranslation(CONST.REPORT.STATE_NUM.AUTOREIMBURSED, CONST.REPORT.STATUS_NUM.REIMBURSED)).toBe(translateLocal('iou.settledExpensify'));
+        });
+
+        it('should return an empty string when stateNum or statusNum is undefined', () => {
+            expect(getReportStatusTranslation(undefined, undefined)).toBe('');
+            expect(getReportStatusTranslation(CONST.REPORT.STATE_NUM.OPEN, undefined)).toBe('');
+            expect(getReportStatusTranslation(undefined, CONST.REPORT.STATUS_NUM.OPEN)).toBe('');
         });
     });
 });


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
<!-- Explain what your change does and how it addresses the linked issue -->

This whole issue concerns only one component: **_MoneyRequestReportPreviewContent_**
It would be great if you can check if the design is ok - tag design team after

**1. Subheader Status • X expenses and removing the expenses counter from the top right corner** 
I have added a View below the money report preview title that is responsible for the subheader in the format: _Status • X expenses_. The 'Status' is determined by a newly created **_const {getReportStatus} = useMemo(() => {...})_** based on the current stateNum and statusNum of the Report according to the table provided in the issue discussion by @trjExpensify :

State | Status | What to display?
-- | -- | --
0  | 0  | Draft
1   | 1  | Outstanding
2  | 2  | Done
2  | 3  | Approved
2  | 4  | Paid
3  | 4  | Paid
6  | 4  | Paid

The expense counter displayed in the second part of this View after "•" was already implemented and located to the left of the arrow buttons so i only removed it from there and renamed it to better describe it's purpose. 
**2. Pagination dots removal on mobile**
I also completely removed the pagination dots on mobile.
**3. Adding the total for 2+ expenses**
Here i wrapped the **_'View'_** button in the bottom and the new View responsible for total in another View in order to easily modify how it looks on mobile and desktop. I have managed to place the total in the bottom right on Desktop and under the expenses on Mobile by using style manipulation based on whether the **_'shouldUseNarrowLayout'_** is true or false. The total itself is based on properly formatting already calculated **_totalDisplaySpend_** and the currency of the Report by **_convertToDisplayString_**.

There were 2 translations added for the singular form of the word **_'Draft'_**. It was added in _common_ section to english and spanish (using JaimeGPT).

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/63038
PROPOSAL: doesn't apply -> SWM engineer


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

1. Open a clear chat with somebody in your inbox
2. Create the first expense and verify that subheader is shown under the report name and that it looks like this **_Outstanding • 1 expense_**,
3. Still having only one expense verify that there should be no Total in the bottom right corner on Desktop and under the expenses on Mobile,
4. Add a second expense (it can be of any kind and currency as it shouldn't matter - the currency in total should be recalculated to the preffered currency chosen in account settings) and verify that total appears as **'Total _moneyvalue_'** in the bottom right corner on Desktop and under the expenses on Mobile - it should be equal to the sum of those 2 expenses
5. Still with two expenses verify that the subheader now looks like that **_Outstanding • 2 expenses_** and that there are no pagination dots on mobile
6. **_NEEDED ONLY FOR DESKTOP_** Add a third expense and verify if there is no expense counter near the pagination controls on desktop and if the subheader now is **_Outstanding • 3 expenses_** and the total value is now equal to the sum of all the expenses of this report


- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

SAME AS TESTS ^

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->
// TODO: These must be filled out, or the issue title must include "[No QA]."

SAME AS TESTS ^

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I verified there are no new alerts related to the `canBeMissing` param for `useOnyx`
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message: https://swmansion.slack.com/archives/C01GTK53T8Q/p1752689040708369?thread_ts=1752683433.064489&cid=C01GTK53T8Q
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->
<img width="300" alt="android1" src="https://github.com/user-attachments/assets/c91f2a87-2650-45d9-ba42-fa746d60bb24" />
<img width="300" alt="android2" src="https://github.com/user-attachments/assets/d5ca8208-2291-4645-b445-2c2d9a323135" />
<img width="300" alt="android3" src="https://github.com/user-attachments/assets/4c633947-7329-476a-87aa-141920633330" />


</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->
<img width="300" alt="androidWeb1" src="https://github.com/user-attachments/assets/84aa382b-a97e-4e5d-bc6f-1449a4880d8c" />
<img width="300" alt="androidWeb2" src="https://github.com/user-attachments/assets/4e35a464-bacc-44f7-ba87-30f0f2fcc044" />
<img width="300" alt="androidWeb3" src="https://github.com/user-attachments/assets/597bd20a-95b0-456f-908e-5807aae97ed1" />

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->
<img width="300"  alt="ios1" src="https://github.com/user-attachments/assets/b26f6c02-a7bb-4cb7-bb22-2eca52cbb830" />
<img width="300" alt="ios2" src="https://github.com/user-attachments/assets/f0aa9973-a254-4c62-812d-acbd7367c1c9" />
<img width="300" alt="ios3" src="https://github.com/user-attachments/assets/2bf5b300-8fd0-4ea1-98fc-aec2f5aa6566" />
</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->
<img width="300" alt="iosWeb1" src="https://github.com/user-attachments/assets/ec2b95e9-8870-449d-8e52-d1802a338181" />
<img width="300" alt="iosWeb2" src="https://github.com/user-attachments/assets/cc6fcf7b-7cd9-48ab-be04-7f474655c6f0" />
<img width="300" alt="iosWeb3" src="https://github.com/user-attachments/assets/c2b49388-3543-4837-a5fa-cffc79378284" />

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->
<img width="300" alt="web1" src="https://github.com/user-attachments/assets/a24a952a-66ff-40c1-9919-5e5c78c9b5e2" />
<img width="300" alt="web2" src="https://github.com/user-attachments/assets/7838d04e-c5fa-4b21-aab4-dedda78fb0fd" />
<img width="300" alt="web3" src="https://github.com/user-attachments/assets/e42eeece-1f43-445f-9e3c-407e4cadce13" />

</details>

<details>
<summary>MacOS: Desktop</summary>

<!-- add screenshots or videos here -->
<img width="300" alt="desktop1" src="https://github.com/user-attachments/assets/04c9e88c-ee17-48dd-9477-b96dfad91cf0" />
<img width="300" alt="desktop2" src="https://github.com/user-attachments/assets/463c3905-cf4d-4b09-827a-67427e6230fb" />
<img width="300" alt="desktop3" src="https://github.com/user-attachments/assets/cc6a606d-de82-4caf-a9b8-077f1884bc27" />

</details>