### PR TITLE
[No QA] Prevent noisy `CP` errors from `find` finding patches that have already been copied

### DIFF
--- a/scripts/applyPatches.sh
+++ b/scripts/applyPatches.sh
@@ -21,7 +21,7 @@ readonly NEW_DOT_FLAG="${STANDALONE_NEW_DOT:-false}"
 
 # Wrapper to run patch-package.
 function patchPackage() {
-  TEMP_PATCH_DIR=$(mktemp -d ./patches/tmp-patches-XXX)
+  TEMP_PATCH_DIR=$(mktemp --directory ./tmp-patches-XXX)
   trap 'rm -rf "$TEMP_PATCH_DIR"' RETURN
 
   find ./patches -type f -name '*.patch' -exec cp {} "$TEMP_PATCH_DIR" \;


### PR DESCRIPTION
### Explanation of Change
Our applyPatches script generates a bunch of noisy `cp` logs (see below), because it copies files into the directory that it is actively searching, then tries to copy them again when it finds them. This change prevents that behavior by moving the temporary patches directory outside of `.patches`.

<details>
<summary>log output</summary>

```
cp: ./patches/tmp-patches-pAG/react-native-webview+13.13.1.patch and ./patches/tmp-patches-pAG/react-native-webview+13.13.1.patch are identical (not copied).
cp: ./patches/tmp-patches-pAG/@react-navigation+stack+7.3.3+004+fix-failing-jest-by-disabling-esmodule.patch and ./patches/tmp-patches-pAG/@react-navigation+stack+7.3.3+004+fix-failing-jest-by-disabling-esmodule.patch are identical (not copied).
cp: ./patches/tmp-patches-pAG/react-native-render-html+6.3.1.patch and ./patches/tmp-patches-pAG/react-native-render-html+6.3.1.patch are identical (not copied).
cp: ./patches/tmp-patches-pAG/lottie-react-native+6.5.1+002+bridgeless.patch and ./patches/tmp-patches-pAG/lottie-react-native+6.5.1+002+bridgeless.patch are identical (not copied).
cp: ./patches/tmp-patches-pAG/@react-native-community+netinfo+11.2.1+001+initial.patch and ./patches/tmp-patches-pAG/@react-native-community+netinfo+11.2.1+001+initial.patch are identical (not copied).
cp: ./patches/tmp-patches-pAG/react-native+0.79.2+018+fix-text-selecting-on-change.patch and ./patches/tmp-patches-pAG/react-native+0.79.2+018+fix-text-selecting-on-change.patch are identical (not copied).
cp: ./patches/tmp-patches-pAG/@react-navigation+routers+7.4.0+001+fix-failing-jest-by-disabling-esmodule.patch and ./patches/tmp-patches-pAG/@react-navigation+routers+7.4.0+001+fix-failing-jest-by-disabling-esmodule.patch are identical (not copied).
cp: ./patches/tmp-patches-pAG/react-native-web+0.20.0+008+fix-nested-flatlist-scroll-on-web.patch and ./patches/tmp-patches-pAG/react-native-web+0.20.0+008+fix-nested-flatlist-scroll-on-web.patch are identical (not copied).
cp: ./patches/tmp-patches-pAG/link+2.1.1.patch and ./patches/tmp-patches-pAG/link+2.1.1.patch are identical (not copied).
cp: ./patches/tmp-patches-pAG/react-native-render-html+6.3.1+002+fix-console-warning.patch and ./patches/tmp-patches-pAG/react-native-render-html+6.3.1+002+fix-console-warning.patch are identical (not copied).
cp: ./patches/tmp-patches-pAG/react-native+0.79.2+015+redactAppParameters.patch and ./patches/tmp-patches-pAG/react-native+0.79.2+015+redactAppParameters.patch are identical (not copied).
cp: ./patches/tmp-patches-pAG/eslint-plugin-react-native-a11y+3.3.0.patch and ./patches/tmp-patches-pAG/eslint-plugin-react-native-a11y+3.3.0.patch are identical (not copied).
cp: ./patches/tmp-patches-pAG/react-native-sound+0.11.2.patch and ./patches/tmp-patches-pAG/react-native-sound+0.11.2.patch are identical (not copied).
cp: ./patches/tmp-patches-pAG/html-entities+2.5.2.patch and ./patches/tmp-patches-pAG/html-entities+2.5.2.patch are identical (not copied).
cp: ./patches/tmp-patches-pAG/react-native+0.79.2+009+copyStateOnClone.patch and ./patches/tmp-patches-pAG/react-native+0.79.2+009+copyStateOnClone.patch are identical (not copied).
cp: ./patches/tmp-patches-pAG/@react-ng+bounds-observer+0.2.1.patch and ./patches/tmp-patches-pAG/@react-ng+bounds-observer+0.2.1.patch are identical (not copied).
cp: ./patches/tmp-patches-pAG/react-native-web+0.20.0+004+fixPointerEventDown.patch and ./patches/tmp-patches-pAG/react-native-web+0.20.0+004+fixPointerEventDown.patch are identical (not copied).
cp: ./patches/tmp-patches-pAG/react-native-performance+5.1.4+001+fix-soft-crash-by-checking-for-active-react-instance.patch and ./patches/tmp-patches-pAG/react-native-performance+5.1.4+001+fix-soft-crash-by-checking-for-active-react-instance.patch are identical (not copied).
cp: ./patches/tmp-patches-pAG/react-native+0.79.2+001+initial.patch and ./patches/tmp-patches-pAG/react-native+0.79.2+001+initial.patch are identical (not copied).
cp: ./patches/tmp-patches-pAG/react-native-draggable-flatlist+4.0.3+002+fix-console-error-ref-measureLayout.patch and ./patches/tmp-patches-pAG/react-native-draggable-flatlist+4.0.3+002+fix-console-error-ref-measureLayout.patch are identical (not copied).
cp: ./patches/tmp-patches-pAG/@react-navigation+native-stack+7.3.14+001+added-interaction-manager-integration.patch and ./patches/tmp-patches-pAG/@react-navigation+native-stack+7.3.14+001+added-interaction-manager-integration.patch are identical (not copied).
cp: ./patches/tmp-patches-pAG/react-native-config+1.5.3.patch and ./patches/tmp-patches-pAG/react-native-config+1.5.3.patch are identical (not copied).
cp: ./patches/tmp-patches-pAG/react-native-reanimated+3.17.1+002+dontWhitelistTextProp.patch and ./patches/tmp-patches-pAG/react-native-reanimated+3.17.1+002+dontWhitelistTextProp.patch are identical (not copied).
cp: ./patches/tmp-patches-pAG/react-native-reanimated+3.17.1+003+hybrid-app.patch and ./patches/tmp-patches-pAG/react-native-reanimated+3.17.1+003+hybrid-app.patch are identical (not copied).
cp: ./patches/tmp-patches-pAG/@react-native-firebase+app+12.9.3+002+bridgeless.patch and ./patches/tmp-patches-pAG/@react-native-firebase+app+12.9.3+002+bridgeless.patch are identical (not copied).
cp: ./patches/tmp-patches-pAG/react-native+0.79.2+024+restore-old-line-height-algorithm.patch and ./patches/tmp-patches-pAG/react-native+0.79.2+024+restore-old-line-height-algorithm.patch are identical (not copied).
cp: ./patches/tmp-patches-pAG/react-native-web+0.20.0+001+initial.patch and ./patches/tmp-patches-pAG/react-native-web+0.20.0+001+initial.patch are identical (not copied).
cp: ./patches/tmp-patches-pAG/expo-modules-core+2.3.12+001+disableViewRecycling.patch and ./patches/tmp-patches-pAG/expo-modules-core+2.3.12+001+disableViewRecycling.patch are identical (not copied).
cp: ./patches/tmp-patches-pAG/react-native-plaid-link-sdk+11.11.0.patch and ./patches/tmp-patches-pAG/react-native-plaid-link-sdk+11.11.0.patch are identical (not copied).
cp: ./patches/tmp-patches-pAG/react-native+0.79.2+006+disableNonTranslucentStatusBar.patch and ./patches/tmp-patches-pAG/react-native+0.79.2+006+disableNonTranslucentStatusBar.patch are identical (not copied).
cp: ./patches/tmp-patches-pAG/react-native+0.79.2+005+resetAutoresizingOnView.patch and ./patches/tmp-patches-pAG/react-native+0.79.2+005+resetAutoresizingOnView.patch are identical (not copied).
cp: ./patches/tmp-patches-pAG/http-server+14.1.1.patch and ./patches/tmp-patches-pAG/http-server+14.1.1.patch are identical (not copied).
cp: ./patches/tmp-patches-pAG/react-native+0.79.2+004+iOSFontResolution.patch and ./patches/tmp-patches-pAG/react-native+0.79.2+004+iOSFontResolution.patch are identical (not copied).
cp: ./patches/tmp-patches-pAG/react-native+0.79.2+020+fix-dropping-mutations-in-transactions.patch and ./patches/tmp-patches-pAG/react-native+0.79.2+020+fix-dropping-mutations-in-transactions.patch are identical (not copied).
cp: ./patches/tmp-patches-pAG/react-native-device-info+10.3.1+001+initial.patch and ./patches/tmp-patches-pAG/react-native-device-info+10.3.1+001+initial.patch are identical (not copied).
cp: ./patches/tmp-patches-pAG/react-compiler-healthcheck+19.0.0-beta-8a03594-20241020+003+json.patch and ./patches/tmp-patches-pAG/react-compiler-healthcheck+19.0.0-beta-8a03594-20241020+003+json.patch are identical (not copied).
cp: ./patches/tmp-patches-pAG/react-compiler-healthcheck+19.0.0-beta-8a03594-20241020+002+enable-ref-identifiers.patch and ./patches/tmp-patches-pAG/react-compiler-healthcheck+19.0.0-beta-8a03594-20241020+002+enable-ref-identifiers.patch are identical (not copied).
cp: ./patches/tmp-patches-pAG/react-native-web+0.20.0+006+remove-focus-trap-from-modal.patch and ./patches/tmp-patches-pAG/react-native-web+0.20.0+006+remove-focus-trap-from-modal.patch are identical (not copied).
cp: ./patches/tmp-patches-pAG/react-native-image-picker+7.1.2+001+allowedMimeTypes.patch and ./patches/tmp-patches-pAG/react-native-image-picker+7.1.2+001+allowedMimeTypes.patch are identical (not copied).
cp: ./patches/tmp-patches-pAG/@perf-profiler+android+0.13.0+001+pid-changed.patch and ./patches/tmp-patches-pAG/@perf-profiler+android+0.13.0+001+pid-changed.patch are identical (not copied).
cp: ./patches/tmp-patches-pAG/@react-navigation+material-top-tabs+7.2.13+001+fix-failing-jest-by-disabling-esmodule.patch and ./patches/tmp-patches-pAG/@react-navigation+material-top-tabs+7.2.13+001+fix-failing-jest-by-disabling-esmodule.patch are identical (not copied).
cp: ./patches/tmp-patches-pAG/@react-native+virtualized-lists+0.79.2+001+osr-improvement.patch and ./patches/tmp-patches-pAG/@react-native+virtualized-lists+0.79.2+001+osr-improvement.patch are identical (not copied).
cp: ./patches/tmp-patches-pAG/react-native+0.79.2+012+alert-style.patch and ./patches/tmp-patches-pAG/react-native+0.79.2+012+alert-style.patch are identical (not copied).
cp: ./patches/tmp-patches-pAG/@react-native-firebase+perf+12.9.3+001+hybrid-app.patch and ./patches/tmp-patches-pAG/@react-native-firebase+perf+12.9.3+001+hybrid-app.patch are identical (not copied).
cp: ./patches/tmp-patches-pAG/react-native-pdf+6.7.3+001+update-podspec-to-support-new-arch.patch and ./patches/tmp-patches-pAG/react-native-pdf+6.7.3+001+update-podspec-to-support-new-arch.patch are identical (not copied).
cp: ./patches/tmp-patches-pAG/react-native-web+0.20.0+007+fix-scrollable-overflown-text.patch and ./patches/tmp-patches-pAG/react-native-web+0.20.0+007+fix-scrollable-overflown-text.patch are identical (not copied).
cp: ./patches/tmp-patches-pAG/react-native+0.79.2+002+fixMVCPAndroid.patch and ./patches/tmp-patches-pAG/react-native+0.79.2+002+fixMVCPAndroid.patch are identical (not copied).
cp: ./patches/tmp-patches-pAG/react-native+0.79.2+022+fix-surface-stopped-before-started.patch and ./patches/tmp-patches-pAG/react-native+0.79.2+022+fix-surface-stopped-before-started.patch are identical (not copied).
cp: ./patches/tmp-patches-pAG/react-native-reanimated+3.17.1+006+fix-crashing-build-variants.patch and ./patches/tmp-patches-pAG/react-native-reanimated+3.17.1+006+fix-crashing-build-variants.patch are identical (not copied).
cp: ./patches/tmp-patches-pAG/react-native+0.79.2+016+android-keyboard-avoiding-view.patch and ./patches/tmp-patches-pAG/react-native+0.79.2+016+android-keyboard-avoiding-view.patch are identical (not copied).
cp: ./patches/tmp-patches-pAG/react-native-google-places-autocomplete+2.5.6+001+react-19-support.patch and ./patches/tmp-patches-pAG/react-native-google-places-autocomplete+2.5.6+001+react-19-support.patch are identical (not copied).
cp: ./patches/tmp-patches-pAG/react-native-animatable+1.3.3+002+fixAnimationFlicker.patch and ./patches/tmp-patches-pAG/react-native-animatable+1.3.3+002+fixAnimationFlicker.patch are identical (not copied).
cp: ./patches/tmp-patches-pAG/react-native-modal+13.0.1+001+initial.patch and ./patches/tmp-patches-pAG/react-native-modal+13.0.1+001+initial.patch are identical (not copied).
cp: ./patches/tmp-patches-pAG/react-native+0.79.2+014+fixScrollViewState.patch and ./patches/tmp-patches-pAG/react-native+0.79.2+014+fixScrollViewState.patch are identical (not copied).
cp: ./patches/tmp-patches-pAG/react-native+0.79.2+025+fix-display-contents-not-updating-nodes.patch and ./patches/tmp-patches-pAG/react-native+0.79.2+025+fix-display-contents-not-updating-nodes.patch are identical (not copied).
cp: ./patches/tmp-patches-pAG/@perf-profiler+types+0.8.0+001+pid-changed.patch and ./patches/tmp-patches-pAG/@perf-profiler+types+0.8.0+001+pid-changed.patch are identical (not copied).
cp: ./patches/tmp-patches-pAG/react-native-web+0.20.0+002+fixLastSpacer.patch and ./patches/tmp-patches-pAG/react-native-web+0.20.0+002+fixLastSpacer.patch are identical (not copied).
cp: ./patches/tmp-patches-pAG/react-native-tab-view+4.1.0+001+fix-tab-animation.patch and ./patches/tmp-patches-pAG/react-native-tab-view+4.1.0+001+fix-tab-animation.patch are identical (not copied).
cp: ./patches/tmp-patches-pAG/react-native-modal+13.0.1+002+modal-navigation-bar-translucent.patch and ./patches/tmp-patches-pAG/react-native-modal+13.0.1+002+modal-navigation-bar-translucent.patch are identical (not copied).
cp: ./patches/tmp-patches-pAG/react-native-animatable+1.3.3+001+initial.patch and ./patches/tmp-patches-pAG/react-native-animatable+1.3.3+001+initial.patch are identical (not copied).
cp: ./patches/tmp-patches-pAG/react-native-reanimated+3.17.1+005+fix-cancelAnimation-on-web.patch and ./patches/tmp-patches-pAG/react-native-reanimated+3.17.1+005+fix-cancelAnimation-on-web.patch are identical (not copied).
cp: ./patches/tmp-patches-pAG/@react-navigation+native+7.1.10+002+fix-failing-jest-by-disabling-esmodule.patch and ./patches/tmp-patches-pAG/@react-navigation+native+7.1.10+002+fix-failing-jest-by-disabling-esmodule.patch are identical (not copied).
cp: ./patches/tmp-patches-pAG/recyclerlistview+4.2.3.patch and ./patches/tmp-patches-pAG/recyclerlistview+4.2.3.patch are identical (not copied).
cp: ./patches/tmp-patches-pAG/focus-trap+7.6.4.patch and ./patches/tmp-patches-pAG/focus-trap+7.6.4.patch are identical (not copied).
cp: ./patches/tmp-patches-pAG/expo-av+15.1.5+002+handle-unsupported-videos-ios.patch and ./patches/tmp-patches-pAG/expo-av+15.1.5+002+handle-unsupported-videos-ios.patch are identical (not copied).
cp: ./patches/tmp-patches-pAG/react-native+0.79.2+008+iOSCoreAnimationBorderRendering.patch and ./patches/tmp-patches-pAG/react-native+0.79.2+008+iOSCoreAnimationBorderRendering.patch are identical (not copied).
cp: ./patches/tmp-patches-pAG/@react-native-firebase+analytics+12.9.3+001+hybrid-app.patch and ./patches/tmp-patches-pAG/@react-native-firebase+analytics+12.9.3+001+hybrid-app.patch are identical (not copied).
cp: ./patches/tmp-patches-pAG/react-native+0.79.2+021+fix-crash-when-deleting-expense.patch and ./patches/tmp-patches-pAG/react-native+0.79.2+021+fix-crash-when-deleting-expense.patch are identical (not copied).
cp: ./patches/tmp-patches-pAG/expo-av+15.1.5+001+fix-blank-screen-android.patch and ./patches/tmp-patches-pAG/expo-av+15.1.5+001+fix-blank-screen-android.patch are identical (not copied).
cp: ./patches/tmp-patches-pAG/react-native+0.79.2+019+fix-scroll-view-jump.patch and ./patches/tmp-patches-pAG/react-native+0.79.2+019+fix-scroll-view-jump.patch are identical (not copied).
cp: ./patches/tmp-patches-pAG/@react-navigation+native+7.1.10+001+initial.patch and ./patches/tmp-patches-pAG/@react-navigation+native+7.1.10+001+initial.patch are identical (not copied).
cp: ./patches/tmp-patches-pAG/@react-navigation+core+7.10.0+001+fix-failing-jest-by-disabling-esmodule.patch and ./patches/tmp-patches-pAG/@react-navigation+core+7.10.0+001+fix-failing-jest-by-disabling-esmodule.patch are identical (not copied).
cp: ./patches/tmp-patches-pAG/react-native+0.79.2+007+TextInput.patch and ./patches/tmp-patches-pAG/react-native+0.79.2+007+TextInput.patch are identical (not copied).
cp: ./patches/tmp-patches-pAG/@react-navigation+stack+7.3.3+002+dontDetachScreen.patch and ./patches/tmp-patches-pAG/@react-navigation+stack+7.3.3+002+dontDetachScreen.patch are identical (not copied).
cp: ./patches/tmp-patches-pAG/@react-navigation+stack+7.3.3+001+edge-drag-gesture.patch and ./patches/tmp-patches-pAG/@react-navigation+stack+7.3.3+001+edge-drag-gesture.patch are identical (not copied).
cp: ./patches/tmp-patches-pAG/@react-navigation+core+7.10.0+001+platform-navigation-stack-types.patch and ./patches/tmp-patches-pAG/@react-navigation+core+7.10.0+001+platform-navigation-stack-types.patch are identical (not copied).
cp: ./patches/tmp-patches-pAG/react-native-tab-view+4.1.0+002+fix-glitching-on-initial-load.patch and ./patches/tmp-patches-pAG/react-native-tab-view+4.1.0+002+fix-glitching-on-initial-load.patch are identical (not copied).
cp: ./patches/tmp-patches-pAG/react-native+0.79.2+010+textinput-clear-command.patch and ./patches/tmp-patches-pAG/react-native+0.79.2+010+textinput-clear-command.patch are identical (not copied).
cp: ./patches/tmp-patches-pAG/@react-navigation+native-stack+7.3.14+002+fix-failing-jest-by-disabling-esmodule.patch and ./patches/tmp-patches-pAG/@react-navigation+native-stack+7.3.14+002+fix-failing-jest-by-disabling-esmodule.patch are identical (not copied).
cp: ./patches/tmp-patches-pAG/@react-navigation+elements+2.4.3+001+fix-failing-jest-by-disabling-esmodule.patch and ./patches/tmp-patches-pAG/@react-navigation+elements+2.4.3+001+fix-failing-jest-by-disabling-esmodule.patch are identical (not copied).
cp: ./patches/tmp-patches-pAG/react-native+0.79.2+011+Add-onPaste-to-TextInput.patch and ./patches/tmp-patches-pAG/react-native+0.79.2+011+Add-onPaste-to-TextInput.patch are identical (not copied).
cp: ./patches/tmp-patches-pAG/react-native+0.79.2+013+fixNavigationAnimations.patch and ./patches/tmp-patches-pAG/react-native+0.79.2+013+fixNavigationAnimations.patch are identical (not copied).
cp: ./patches/tmp-patches-pAG/react-native-modal+13.0.1+002+fix-modal-flicker-on-open.patch and ./patches/tmp-patches-pAG/react-native-modal+13.0.1+002+fix-modal-flicker-on-open.patch are identical (not copied).
cp: ./patches/tmp-patches-pAG/react-native-vision-camera+4.6.1.patch and ./patches/tmp-patches-pAG/react-native-vision-camera+4.6.1.patch are identical (not copied).
cp: ./patches/tmp-patches-pAG/@react-navigation+core+7.10.0+002+fix-crash-when-parsing-emoji.patch and ./patches/tmp-patches-pAG/@react-navigation+core+7.10.0+002+fix-crash-when-parsing-emoji.patch are identical (not copied).
cp: ./patches/tmp-patches-pAG/react-native-draggable-flatlist+4.0.3+001+listfooter-constraint.patch and ./patches/tmp-patches-pAG/react-native-draggable-flatlist+4.0.3+001+listfooter-constraint.patch are identical (not copied).
cp: ./patches/tmp-patches-pAG/react-native+0.79.2+003+disableTextInputRecycling.patch and ./patches/tmp-patches-pAG/react-native+0.79.2+003+disableTextInputRecycling.patch are identical (not copied).
cp: ./patches/tmp-patches-pAG/react-native+0.79.2+023+publish-gradle.patch and ./patches/tmp-patches-pAG/react-native+0.79.2+023+publish-gradle.patch are identical (not copied).
cp: ./patches/tmp-patches-pAG/react-native+0.79.2+017+fix-mask-persisting-recycling.patch and ./patches/tmp-patches-pAG/react-native+0.79.2+017+fix-mask-persisting-recycling.patch are identical (not copied).

```
</details>

### Fixed Issues
None
Discovered while troubleshooting https://github.com/Expensify/App/issues/66662

### Tests
1. Run `npm i`
2. verify that the `cp` errors do not appear

- [x] Verify that no errors appear in the JS console

### Offline tests
N/A

### QA Steps
N/A

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I verified there are no new alerts related to the `canBeMissing` param for `useOnyx`
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Desktop</summary>

<!-- add screenshots or videos here -->

</details>
