### PR TITLE
[No QA] Fix generateTranslations script

### DIFF
--- a/scripts/stubReactNative.js
+++ b/scripts/stubReactNative.js
@@ -1,0 +1,72 @@
+// Comprehensive React Native module interceptor for ts-node
+const Module = require('module');
+
+const originalRequire = Module.prototype.require;
+
+// List of modules to stub (we don't need these in scripts)
+const MODULES_TO_STUB = [
+    'react-native',
+    'react-native-config',
+    'react-native-key-command',
+    '@expensify/react-native-hybrid-app',
+    'react-native-sound',
+    'react-native-blob-util',
+    'react-native-fs',
+    'react-native-reanimated',
+    'react-native-performance',
+    'react-native-gesture-handler',
+    'react-native-safe-area-context',
+    'react-native-picker-select',
+    'react-native-onyx',
+    '@react-navigation/native',
+    'expo-av',
+];
+
+// Stub implementations
+const STUBS = {
+    'react-native': {
+        Platform: {OS: 'web', isPad: false, isTV: false, isTesting: false, Version: '0.0.0'},
+        NativeModules: {},
+        Dimensions: {get: () => ({width: 1024, height: 768})},
+        AppState: {currentState: 'active'},
+        Linking: {},
+        DeviceEventEmitter: {emit: () => {}, addListener: () => ({})},
+        PixelRatio: {get: () => 1, getFontScale: () => 1},
+    },
+    'react-native-config': {},
+    'react-native-key-command': {
+        constants: {
+            keyModifierControl: 'keyModifierControl',
+            keyModifierCommand: 'keyModifierCommand',
+            keyModifierShift: 'keyModifierShift',
+            keyModifierShiftControl: 'keyModifierShiftControl',
+            keyModifierShiftCommand: 'keyModifierShiftCommand',
+            keyInputEscape: 'keyInputEscape',
+            keyInputEnter: 'keyInputEnter',
+            keyInputUpArrow: 'keyInputUpArrow',
+            keyInputDownArrow: 'keyInputDownArrow',
+            keyInputLeftArrow: 'keyInputLeftArrow',
+            keyInputRightArrow: 'keyInputRightArrow',
+        },
+        addEventListener: () => ({}),
+        removeEventListener: () => {},
+    },
+    '@expensify/react-native-hybrid-app': {
+        isHybridApp: () => false,
+        getHybridAppSettings: () => Promise.resolve(null),
+    },
+};
+
+// Override require to intercept React Native modules
+Module.prototype.require = function (...args) {
+    const id = args[0];
+
+    // Check if this is a module we want to stub
+    if (MODULES_TO_STUB.includes(id) || id.startsWith('react-native')) {
+        const stub = STUBS[id] || {};
+        return {__esModule: true, default: stub, ...stub};
+    }
+
+    // For other modules, use original require
+    return originalRequire.apply(this, args);
+};

--- a/scripts/tsconfig.json
+++ b/scripts/tsconfig.json
@@ -1,7 +1,11 @@
 {
     "extends": "../tsconfig.json",
     "ts-node": {
+        "require": ["tsconfig-paths/register", "./stubReactNative.js"],
         "transpileOnly": true,
-        "require": ["tsconfig-paths/register"]
+        "compilerOptions": {
+            "module": "commonjs",
+            "target": "es2020"
+        }
     }
 }


### PR DESCRIPTION
### Explanation of Change
On main, `npx ts-node ./scripts/generateTranslations.ts --dry-run --locales=it --compare-ref=main` fails with opaque errors, saying stuff like `unexpected typeof` in random files that seem unrelated to the generateTranslations script.

The root cause of that problem is that `generateTranslations.ts` transitively imports react-native, react-native-config, and other dependencies written with Flow (a typed superset of JavaScript, similar to but different from TypeScript).

`ts-node`, the package we use to run Node.js scripts written in TypeScript, doesn't know what to do with Flow code. It treats it like regular JavaScript code, then barfs 🤮 when it encounters Flow syntax that's not valid JavaScript. There might be other issues beyond just Flow too; worklets, iOS/Android native code bindings, and other stuff that has no place in a ts-node environment.

To fix this problem in the past, I simply refactored `generateTranslations.ts` to not directly import `@src/CONST`, because that transitively imports `react-native-config`. That is a pretty brittle solution, because if someone adds an import in the wrong place while working on something totally unrelated, it could break the script.

I added this workflow that runs `generateTranslations.ts` in a dry-run in the hopes that it would catch changes that break the script before they are merged to main. Somehow it didn't catch something. I'm not exactly sure how, but my theory is that a PR which would break `generateTranslations.ts` was sitting there with checks passing ready to merge, then we turned on the check, then it was merged. Thus `generateTranslations.ts` was broken on main.

In this PR, I add a more robust solution - a custom module resolver for `ts-node` that stubs out react-native, react-native-config, and a few other dependencies to be no-ops. They can be imported as no-ops without breaking the script (you still can't _use_ them from within a `ts-node` script, but with all of these I can't see any reason you'd ever want to).

### Fixed Issues
$ n/a - https://expensify.slack.com/archives/C01GTK53T8Q/p1752791020137969?thread_ts=1752790710.197899&cid=C01GTK53T8Q

### Tests
Run `npx ts-node ./scripts/generateTranslations.ts --dry-run --locales=it --compare-ref=main`, verify that the script completes successfully.

- [x] Verify that no errors appear in the JS console

### Offline tests
None.

### QA Steps
None.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
- [X] I linked the correct issue in the `### Fixed Issues` section above
- [X] I wrote clear testing steps that cover the changes made in this PR
    - [X] I added steps for local testing in the `Tests` section
    - [X] I added steps for the expected offline behavior in the `Offline steps` section
    - [X] I added steps for Staging and/or Production testing in the `QA steps` section
    - [X] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [X] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [X] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [X] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [X] I ran the tests on **all platforms** & verified they passed on:
    - [X] Android: Native
    - [X] Android: mWeb Chrome
    - [X] iOS: Native
    - [X] iOS: mWeb Safari
    - [X] MacOS: Chrome / Safari
    - [X] MacOS: Desktop
- [X] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [X] I verified there are no new alerts related to the `canBeMissing` param for `useOnyx`
- [X] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [X] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [X] I verified that comments were added to code that is not self explanatory
    - [X] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [X] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [X] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [X] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [X] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [X] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [X] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [X] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [X] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [X] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [X] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [X] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [X] I verified that if a function's arguments changed that all usages have also been updated correctly
- [X] If any new file was added I verified that:
    - [X] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [X] If a new CSS style is added I verified that:
    - [X] A similar style doesn't already exist
    - [X] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [X] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [X] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [X] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [X] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [X] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [X] I verified that all the inputs inside a form are aligned with each other.
    - [X] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [X] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [X] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [X] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Desktop</summary>

<!-- add screenshots or videos here -->

</details>
