### PR TITLE
perf: convertToDisplayString optimization

### DIFF
--- a/src/CONST/LOCALES.ts
+++ b/src/CONST/LOCALES.ts
@@ -41,6 +41,8 @@ const LOCALES = {
     ...BETA_LOCALES,
 } as const;
 
+const COMMON_CURRENCIES = ['USD', 'EUR', 'GBP', 'CAD', 'AUD', 'JPY', 'CNY', 'CHF', 'INR', 'MXN'];
+
 /**
  * Locales that are valid translation targets. This does not include English, because it's used as the source of truth.
  */
@@ -86,6 +88,7 @@ export {
     EXTENDED_LOCALES,
     FULLY_SUPPORTED_LOCALES,
     LOCALES,
+    COMMON_CURRENCIES,
     LOCALE_TO_LANGUAGE_STRING,
     SORTED_LOCALES,
     TRANSLATION_TARGET_LOCALES,

--- a/src/libs/CurrencyUtils.ts
+++ b/src/libs/CurrencyUtils.ts
@@ -100,7 +100,7 @@ function convertToFrontendAmountAsString(amountAsInt: number | null | undefined,
  * Get a cached currency formatter for better performance
  */
 function getCachedCurrencyFormatter(locale: string, currency: string, decimals: number): Intl.NumberFormat | undefined {
-    const key = `${locale}-${currency}`;
+    const key = `${locale}-${currency}-${decimals}`;
 
     if (!currencyFormatterCache.has(key)) {
         // Limit cache size to prevent memory issues
@@ -190,7 +190,7 @@ function convertAmountToDisplayString(amount = 0, currency: string = CONST.CURRE
  * Get a cached number formatter (without currency) for better performance
  */
 function getCachedNumberFormatter(locale: string, decimals: number): Intl.NumberFormat | undefined {
-    const key = `${locale}-number-${decimals}`;
+    const key = `${locale}-decimal-${decimals}`;
 
     if (!currencyFormatterCache.has(key)) {
         // Limit cache size to prevent memory issues

--- a/src/libs/CurrencyUtils.ts
+++ b/src/libs/CurrencyUtils.ts
@@ -1,9 +1,9 @@
 import Onyx from 'react-native-onyx';
 import CONST from '@src/CONST';
+import {COMMON_CURRENCIES} from '@src/CONST/LOCALES';
 import IntlStore from '@src/languages/IntlStore';
 import type {OnyxValues} from '@src/ONYXKEYS';
 import ONYXKEYS from '@src/ONYXKEYS';
-import {COMMON_CURRENCIES} from '@src/CONST/LOCALES';
 import {format, formatToParts} from './NumberFormatUtils';
 
 let currencyList: OnyxValues[typeof ONYXKEYS.CURRENCY_LIST] = {};
@@ -107,15 +107,18 @@ function getCachedCurrencyFormatter(locale: string, currency: string, decimals: 
         if (currencyFormatterCache.size >= CACHE_SIZE_LIMIT) {
             // Remove oldest entries (first half of the cache)
             const entriesToDelete = Array.from(currencyFormatterCache.keys()).slice(0, CACHE_SIZE_LIMIT / 2);
-            entriesToDelete.forEach(k => currencyFormatterCache.delete(k));
+            entriesToDelete.forEach((k) => currencyFormatterCache.delete(k));
         }
 
-        currencyFormatterCache.set(key, new Intl.NumberFormat(locale, {
-            style: 'currency',
-            currency,
-            minimumFractionDigits: decimals,
-            maximumFractionDigits: Math.min(decimals, 2),
-        }));
+        currencyFormatterCache.set(
+            key,
+            new Intl.NumberFormat(locale, {
+                style: 'currency',
+                currency,
+                minimumFractionDigits: decimals,
+                maximumFractionDigits: Math.min(decimals, 2),
+            }),
+        );
     }
 
     return currencyFormatterCache.get(key);
@@ -141,7 +144,9 @@ function convertToDisplayString(amountInCents = 0, currency: string = CONST.CURR
     } catch (e) {
         // Fallback to manual formatting if Intl fails
         const symbol = getCurrencySymbol(currencyWithFallback) ?? currencyWithFallback;
-        const formatted = Math.abs(amount).toFixed(decimals).replace(/\B(?=(\d{3})+(?!\d))/g, ',');
+        const formatted = Math.abs(amount)
+            .toFixed(decimals)
+            .replace(/\B(?=(\d{3})+(?!\d))/g, ',');
         return `${amount < 0 ? '-' : ''}${symbol}${formatted}`;
     }
 }
@@ -165,7 +170,9 @@ function convertToShortDisplayString(amountInCents = 0, currency: string = CONST
     } catch (e) {
         // Fallback to manual formatting if Intl fails
         const symbol = getCurrencySymbol(currencyWithFallback) ?? currencyWithFallback;
-        const formatted = Math.abs(amount).toFixed(0).replace(/\B(?=(\d{3})+(?!\d))/g, ',');
+        const formatted = Math.abs(amount)
+            .toFixed(0)
+            .replace(/\B(?=(\d{3})+(?!\d))/g, ',');
         return `${amount < 0 ? '-' : ''}${symbol}${formatted}`;
     }
 }
@@ -197,14 +204,17 @@ function getCachedNumberFormatter(locale: string, decimals: number): Intl.Number
         if (currencyFormatterCache.size >= CACHE_SIZE_LIMIT) {
             // Remove oldest entries (first half of the cache)
             const entriesToDelete = Array.from(currencyFormatterCache.keys()).slice(0, CACHE_SIZE_LIMIT / 2);
-            entriesToDelete.forEach(k => currencyFormatterCache.delete(k));
+            entriesToDelete.forEach((k) => currencyFormatterCache.delete(k));
         }
 
-        currencyFormatterCache.set(key, new Intl.NumberFormat(locale, {
-            style: 'decimal',
-            minimumFractionDigits: decimals,
-            maximumFractionDigits: Math.min(decimals, 2),
-        }));
+        currencyFormatterCache.set(
+            key,
+            new Intl.NumberFormat(locale, {
+                style: 'decimal',
+                minimumFractionDigits: decimals,
+                maximumFractionDigits: Math.min(decimals, 2),
+            }),
+        );
     }
 
     return currencyFormatterCache.get(key);
@@ -224,7 +234,9 @@ function convertToDisplayStringWithoutCurrency(amountInCents: number, currency: 
         return formatter?.format(amount);
     } catch (e) {
         // Fallback to manual formatting if Intl fails
-        const formatted = Math.abs(amount).toFixed(decimals).replace(/\B(?=(\d{3})+(?!\d))/g, ',');
+        const formatted = Math.abs(amount)
+            .toFixed(decimals)
+            .replace(/\B(?=(\d{3})+(?!\d))/g, ',');
         return `${amount < 0 ? '-' : ''}${formatted}`;
     }
 }
@@ -248,7 +260,7 @@ function sanitizeCurrencyCode(currencyCode: string): string {
 function prewarmCurrencyCache() {
     const locale = IntlStore.getCurrentLocale() ?? CONST.LOCALES.DEFAULT;
 
-    COMMON_CURRENCIES.forEach(currency => {
+    COMMON_CURRENCIES.forEach((currency) => {
         const decimals = getCurrencyDecimals(currency);
         // Pre-create formatters for common currencies
         getCachedCurrencyFormatter(locale, currency, decimals);

--- a/src/setup/index.ts
+++ b/src/setup/index.ts
@@ -1,5 +1,6 @@
 import {I18nManager} from 'react-native';
 import Onyx from 'react-native-onyx';
+import {prewarmCurrencyCache} from '@libs/CurrencyUtils';
 import intlPolyfill from '@libs/IntlPolyfill';
 import {setDeviceID} from '@userActions/Device';
 import initLocale from '@userActions/Locale';
@@ -59,6 +60,8 @@ export default function () {
     initOnyxDerivedValues();
 
     setDeviceID();
+
+    prewarmCurrencyCache();
 
     // Force app layout to work left to right because our design does not currently support devices using this mode
     I18nManager.allowRTL(false);


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
This change replaces expensive repeated Intl.NumberFormat creation with a locale-aware cache that stores up to 100 formatter instances keyed by locale-currency-decimals, eliminating performance bottlenecks in currency formatting while preserving full internationalization support.

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$
**PROPOSAL:** Cache Currency Formatters for Better Performance

**Background**:
Currency formatting uses Intl.NumberFormat which is expensive to create. Current caching only stores 10 instances with poor hit rates. A single expense display triggers convertToDisplayString multiple times across UI components.

**Problem**:
When users view expense reports, repeated Intl.NumberFormat creation causes UI lag, which prevents smooth navigation of reports data.

**Solution**:
Cache up to 100 Intl.NumberFormat instances keyed by locale-currency-decimals. Pre-warm cache on startup with common currencies. Update formatting functions to reuse cached instances with manual formatting fallback. This eliminates creation overhead while preserving locale support.

```
Trace Comparison:
Before: convertToDisplayString total: 73.11ms
After: convertToDisplayString total: 1.29ms
```
☝️flow: click on FAB and create an expense. 

Before:

<img width="445" height="138" alt="Zrzut ekranu 2025-07-29 o 13 48 47" src="https://github.com/user-attachments/assets/2a13bcb0-32eb-48c8-9540-2e1fb9c53b55" />

After:

<img width="759" height="115" alt="Zrzut ekranu 2025-07-29 o 13 49 24" src="https://github.com/user-attachments/assets/416de97b-27e8-4531-8eff-111f3d39348f" />

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->
1. Click on FAB 
2. Create an expense (test different currencies). 
3. Navigate to the expense report view. 
4. Navigate to the `Reports` tab and click on any expense report. 

Expected behavior: The currency and amount in all these views should remain valid (as they were before this change).

- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->
Same as Tests. 

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
6. Upload an image via copy paste
7. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->
Same as Tests.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I verified there are no new alerts related to the `canBeMissing` param for `useOnyx`
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

https://github.com/user-attachments/assets/d4050ea3-46d3-4a7b-a075-2c8857420dd7

</details>

<details>
<summary>Android: mWeb Chrome</summary>

https://github.com/user-attachments/assets/0c36aed4-cd8c-4c70-a887-033ff466b2da

</details>

<details>
<summary>iOS: Native</summary>

https://github.com/user-attachments/assets/208fa891-eb39-4c9e-820a-c5b98e68b19b

</details>

<details>
<summary>iOS: mWeb Safari</summary>

https://github.com/user-attachments/assets/e0ed8183-20ce-4488-b2af-fc3e53c95900

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

https://github.com/user-attachments/assets/4227afdd-f91f-4cb5-b254-c08dc726cd64

</details>

<details>
<summary>MacOS: Desktop</summary>

https://github.com/user-attachments/assets/ead6ff22-492d-44fe-98d2-1bec18af33a9

</details>
