### PR TITLE
[NoQA] Test Coverage Refactoring and Fixes

### DIFF
--- a/.github/actions/javascript/authorChecklist/index.js
+++ b/.github/actions/javascript/authorChecklist/index.js
@@ -15574,6 +15574,21 @@ const CONST = {
     EVENTS: {
         ISSUE_COMMENT: 'issue_comment',
     },
+    RUN_EVENT: {
+        PULL_REQUEST: 'pull_request',
+        PULL_REQUEST_TARGET: 'pull_request_target',
+        PUSH: 'push',
+    },
+    RUN_STATUS: {
+        COMPLETED: 'completed',
+        IN_PROGRESS: 'in_progress',
+        QUEUED: 'queued',
+    },
+    RUN_STATUS_CONCLUSION: {
+        SUCCESS: 'success',
+    },
+    TEST_WORKFLOW_NAME: 'Jest Unit Tests',
+    TEST_WORKFLOW_PATH: '.github/workflows/test.yml',
     PROPOSAL_KEYWORD: 'Proposal',
     DATE_FORMAT_STRING: 'yyyy-MM-dd',
     PULL_REQUEST_REGEX: new RegExp(`${GITHUB_BASE_URL_REGEX.source}/.*/.*/pull/([0-9]+).*`),

--- a/.github/actions/javascript/awaitStagingDeploys/index.js
+++ b/.github/actions/javascript/awaitStagingDeploys/index.js
@@ -12365,6 +12365,21 @@ const CONST = {
     EVENTS: {
         ISSUE_COMMENT: 'issue_comment',
     },
+    RUN_EVENT: {
+        PULL_REQUEST: 'pull_request',
+        PULL_REQUEST_TARGET: 'pull_request_target',
+        PUSH: 'push',
+    },
+    RUN_STATUS: {
+        COMPLETED: 'completed',
+        IN_PROGRESS: 'in_progress',
+        QUEUED: 'queued',
+    },
+    RUN_STATUS_CONCLUSION: {
+        SUCCESS: 'success',
+    },
+    TEST_WORKFLOW_NAME: 'Jest Unit Tests',
+    TEST_WORKFLOW_PATH: '.github/workflows/test.yml',
     PROPOSAL_KEYWORD: 'Proposal',
     DATE_FORMAT_STRING: 'yyyy-MM-dd',
     PULL_REQUEST_REGEX: new RegExp(`${GITHUB_BASE_URL_REGEX.source}/.*/.*/pull/([0-9]+).*`),

--- a/.github/actions/javascript/checkDeployBlockers/index.js
+++ b/.github/actions/javascript/checkDeployBlockers/index.js
@@ -11631,6 +11631,21 @@ const CONST = {
     EVENTS: {
         ISSUE_COMMENT: 'issue_comment',
     },
+    RUN_EVENT: {
+        PULL_REQUEST: 'pull_request',
+        PULL_REQUEST_TARGET: 'pull_request_target',
+        PUSH: 'push',
+    },
+    RUN_STATUS: {
+        COMPLETED: 'completed',
+        IN_PROGRESS: 'in_progress',
+        QUEUED: 'queued',
+    },
+    RUN_STATUS_CONCLUSION: {
+        SUCCESS: 'success',
+    },
+    TEST_WORKFLOW_NAME: 'Jest Unit Tests',
+    TEST_WORKFLOW_PATH: '.github/workflows/test.yml',
     PROPOSAL_KEYWORD: 'Proposal',
     DATE_FORMAT_STRING: 'yyyy-MM-dd',
     PULL_REQUEST_REGEX: new RegExp(`${GITHUB_BASE_URL_REGEX.source}/.*/.*/pull/([0-9]+).*`),

--- a/.github/actions/javascript/createOrUpdateStagingDeploy/index.js
+++ b/.github/actions/javascript/createOrUpdateStagingDeploy/index.js
@@ -11713,6 +11713,21 @@ const CONST = {
     EVENTS: {
         ISSUE_COMMENT: 'issue_comment',
     },
+    RUN_EVENT: {
+        PULL_REQUEST: 'pull_request',
+        PULL_REQUEST_TARGET: 'pull_request_target',
+        PUSH: 'push',
+    },
+    RUN_STATUS: {
+        COMPLETED: 'completed',
+        IN_PROGRESS: 'in_progress',
+        QUEUED: 'queued',
+    },
+    RUN_STATUS_CONCLUSION: {
+        SUCCESS: 'success',
+    },
+    TEST_WORKFLOW_NAME: 'Jest Unit Tests',
+    TEST_WORKFLOW_PATH: '.github/workflows/test.yml',
     PROPOSAL_KEYWORD: 'Proposal',
     DATE_FORMAT_STRING: 'yyyy-MM-dd',
     PULL_REQUEST_REGEX: new RegExp(`${GITHUB_BASE_URL_REGEX.source}/.*/.*/pull/([0-9]+).*`),

--- a/.github/actions/javascript/getArtifactInfo/index.js
+++ b/.github/actions/javascript/getArtifactInfo/index.js
@@ -11592,6 +11592,21 @@ const CONST = {
     EVENTS: {
         ISSUE_COMMENT: 'issue_comment',
     },
+    RUN_EVENT: {
+        PULL_REQUEST: 'pull_request',
+        PULL_REQUEST_TARGET: 'pull_request_target',
+        PUSH: 'push',
+    },
+    RUN_STATUS: {
+        COMPLETED: 'completed',
+        IN_PROGRESS: 'in_progress',
+        QUEUED: 'queued',
+    },
+    RUN_STATUS_CONCLUSION: {
+        SUCCESS: 'success',
+    },
+    TEST_WORKFLOW_NAME: 'Jest Unit Tests',
+    TEST_WORKFLOW_PATH: '.github/workflows/test.yml',
     PROPOSAL_KEYWORD: 'Proposal',
     DATE_FORMAT_STRING: 'yyyy-MM-dd',
     PULL_REQUEST_REGEX: new RegExp(`${GITHUB_BASE_URL_REGEX.source}/.*/.*/pull/([0-9]+).*`),

--- a/.github/actions/javascript/getDeployPullRequestList/index.js
+++ b/.github/actions/javascript/getDeployPullRequestList/index.js
@@ -11751,6 +11751,21 @@ const CONST = {
     EVENTS: {
         ISSUE_COMMENT: 'issue_comment',
     },
+    RUN_EVENT: {
+        PULL_REQUEST: 'pull_request',
+        PULL_REQUEST_TARGET: 'pull_request_target',
+        PUSH: 'push',
+    },
+    RUN_STATUS: {
+        COMPLETED: 'completed',
+        IN_PROGRESS: 'in_progress',
+        QUEUED: 'queued',
+    },
+    RUN_STATUS_CONCLUSION: {
+        SUCCESS: 'success',
+    },
+    TEST_WORKFLOW_NAME: 'Jest Unit Tests',
+    TEST_WORKFLOW_PATH: '.github/workflows/test.yml',
     PROPOSAL_KEYWORD: 'Proposal',
     DATE_FORMAT_STRING: 'yyyy-MM-dd',
     PULL_REQUEST_REGEX: new RegExp(`${GITHUB_BASE_URL_REGEX.source}/.*/.*/pull/([0-9]+).*`),

--- a/.github/actions/javascript/getPreviousVersion/index.js
+++ b/.github/actions/javascript/getPreviousVersion/index.js
@@ -11589,6 +11589,21 @@ const CONST = {
     EVENTS: {
         ISSUE_COMMENT: 'issue_comment',
     },
+    RUN_EVENT: {
+        PULL_REQUEST: 'pull_request',
+        PULL_REQUEST_TARGET: 'pull_request_target',
+        PUSH: 'push',
+    },
+    RUN_STATUS: {
+        COMPLETED: 'completed',
+        IN_PROGRESS: 'in_progress',
+        QUEUED: 'queued',
+    },
+    RUN_STATUS_CONCLUSION: {
+        SUCCESS: 'success',
+    },
+    TEST_WORKFLOW_NAME: 'Jest Unit Tests',
+    TEST_WORKFLOW_PATH: '.github/workflows/test.yml',
     PROPOSAL_KEYWORD: 'Proposal',
     DATE_FORMAT_STRING: 'yyyy-MM-dd',
     PULL_REQUEST_REGEX: new RegExp(`${GITHUB_BASE_URL_REGEX.source}/.*/.*/pull/([0-9]+).*`),

--- a/.github/actions/javascript/getPullRequestDetails/index.js
+++ b/.github/actions/javascript/getPullRequestDetails/index.js
@@ -11712,6 +11712,21 @@ const CONST = {
     EVENTS: {
         ISSUE_COMMENT: 'issue_comment',
     },
+    RUN_EVENT: {
+        PULL_REQUEST: 'pull_request',
+        PULL_REQUEST_TARGET: 'pull_request_target',
+        PUSH: 'push',
+    },
+    RUN_STATUS: {
+        COMPLETED: 'completed',
+        IN_PROGRESS: 'in_progress',
+        QUEUED: 'queued',
+    },
+    RUN_STATUS_CONCLUSION: {
+        SUCCESS: 'success',
+    },
+    TEST_WORKFLOW_NAME: 'Jest Unit Tests',
+    TEST_WORKFLOW_PATH: '.github/workflows/test.yml',
     PROPOSAL_KEYWORD: 'Proposal',
     DATE_FORMAT_STRING: 'yyyy-MM-dd',
     PULL_REQUEST_REGEX: new RegExp(`${GITHUB_BASE_URL_REGEX.source}/.*/.*/pull/([0-9]+).*`),

--- a/.github/actions/javascript/isStagingDeployLocked/index.js
+++ b/.github/actions/javascript/isStagingDeployLocked/index.js
@@ -11592,6 +11592,21 @@ const CONST = {
     EVENTS: {
         ISSUE_COMMENT: 'issue_comment',
     },
+    RUN_EVENT: {
+        PULL_REQUEST: 'pull_request',
+        PULL_REQUEST_TARGET: 'pull_request_target',
+        PUSH: 'push',
+    },
+    RUN_STATUS: {
+        COMPLETED: 'completed',
+        IN_PROGRESS: 'in_progress',
+        QUEUED: 'queued',
+    },
+    RUN_STATUS_CONCLUSION: {
+        SUCCESS: 'success',
+    },
+    TEST_WORKFLOW_NAME: 'Jest Unit Tests',
+    TEST_WORKFLOW_PATH: '.github/workflows/test.yml',
     PROPOSAL_KEYWORD: 'Proposal',
     DATE_FORMAT_STRING: 'yyyy-MM-dd',
     PULL_REQUEST_REGEX: new RegExp(`${GITHUB_BASE_URL_REGEX.source}/.*/.*/pull/([0-9]+).*`),

--- a/.github/actions/javascript/markPullRequestsAsDeployed/index.js
+++ b/.github/actions/javascript/markPullRequestsAsDeployed/index.js
@@ -13006,6 +13006,21 @@ const CONST = {
     EVENTS: {
         ISSUE_COMMENT: 'issue_comment',
     },
+    RUN_EVENT: {
+        PULL_REQUEST: 'pull_request',
+        PULL_REQUEST_TARGET: 'pull_request_target',
+        PUSH: 'push',
+    },
+    RUN_STATUS: {
+        COMPLETED: 'completed',
+        IN_PROGRESS: 'in_progress',
+        QUEUED: 'queued',
+    },
+    RUN_STATUS_CONCLUSION: {
+        SUCCESS: 'success',
+    },
+    TEST_WORKFLOW_NAME: 'Jest Unit Tests',
+    TEST_WORKFLOW_PATH: '.github/workflows/test.yml',
     PROPOSAL_KEYWORD: 'Proposal',
     DATE_FORMAT_STRING: 'yyyy-MM-dd',
     PULL_REQUEST_REGEX: new RegExp(`${GITHUB_BASE_URL_REGEX.source}/.*/.*/pull/([0-9]+).*`),

--- a/.github/actions/javascript/postTestBuildComment/index.js
+++ b/.github/actions/javascript/postTestBuildComment/index.js
@@ -11722,6 +11722,21 @@ const CONST = {
     EVENTS: {
         ISSUE_COMMENT: 'issue_comment',
     },
+    RUN_EVENT: {
+        PULL_REQUEST: 'pull_request',
+        PULL_REQUEST_TARGET: 'pull_request_target',
+        PUSH: 'push',
+    },
+    RUN_STATUS: {
+        COMPLETED: 'completed',
+        IN_PROGRESS: 'in_progress',
+        QUEUED: 'queued',
+    },
+    RUN_STATUS_CONCLUSION: {
+        SUCCESS: 'success',
+    },
+    TEST_WORKFLOW_NAME: 'Jest Unit Tests',
+    TEST_WORKFLOW_PATH: '.github/workflows/test.yml',
     PROPOSAL_KEYWORD: 'Proposal',
     DATE_FORMAT_STRING: 'yyyy-MM-dd',
     PULL_REQUEST_REGEX: new RegExp(`${GITHUB_BASE_URL_REGEX.source}/.*/.*/pull/([0-9]+).*`),

--- a/.github/actions/javascript/postTestCoverageComment/index.js
+++ b/.github/actions/javascript/postTestCoverageComment/index.js
@@ -11884,7 +11884,7 @@ async function run() {
     try {
         const osBotifyToken = core.getInput('OS_BOTIFY_TOKEN', { required: true });
         GithubUtils_1.default.initOctokitWithToken(osBotifyToken);
-        const prNumber = parseInt(core.getInput('PR_NUMBER', { required: true }), 10);
+        const prNumber = Number(core.getInput('PR_NUMBER', { required: true }));
         const baseCoveragePath = core.getInput('BASE_COVERAGE_PATH', { required: false });
         const coverageUrl = core.getInput('COVERAGE_URL', { required: false });
         console.log(`Processing test coverage for PR #${prNumber}`);
@@ -11918,7 +11918,7 @@ async function run() {
             .addRaw(coverageSection.replace(COVERAGE_SECTION_HEADER, ''))
             .addSeparator()
             .addRaw('💡 This summary is also available at the end of the PR description.')
-            .write();
+            .write({ overwrite: true });
         // Set outputs
         core.setOutput('coverage-summary', JSON.stringify(coverageData.overall));
         core.setOutput('coverage-changed', changedFiles.length > 0);
@@ -11975,6 +11975,21 @@ const CONST = {
     EVENTS: {
         ISSUE_COMMENT: 'issue_comment',
     },
+    RUN_EVENT: {
+        PULL_REQUEST: 'pull_request',
+        PULL_REQUEST_TARGET: 'pull_request_target',
+        PUSH: 'push',
+    },
+    RUN_STATUS: {
+        COMPLETED: 'completed',
+        IN_PROGRESS: 'in_progress',
+        QUEUED: 'queued',
+    },
+    RUN_STATUS_CONCLUSION: {
+        SUCCESS: 'success',
+    },
+    TEST_WORKFLOW_NAME: 'Jest Unit Tests',
+    TEST_WORKFLOW_PATH: '.github/workflows/test.yml',
     PROPOSAL_KEYWORD: 'Proposal',
     DATE_FORMAT_STRING: 'yyyy-MM-dd',
     PULL_REQUEST_REGEX: new RegExp(`${GITHUB_BASE_URL_REGEX.source}/.*/.*/pull/([0-9]+).*`),

--- a/.github/actions/javascript/postTestCoverageComment/postTestCoverageComment.ts
+++ b/.github/actions/javascript/postTestCoverageComment/postTestCoverageComment.ts
@@ -425,7 +425,7 @@ async function run(): Promise<void> {
         const osBotifyToken = core.getInput('OS_BOTIFY_TOKEN', {required: true});
         GithubUtils.initOctokitWithToken(osBotifyToken);
 
-        const prNumber = parseInt(core.getInput('PR_NUMBER', {required: true}), 10);
+        const prNumber = Number(core.getInput('PR_NUMBER', {required: true}));
         const baseCoveragePath = core.getInput('BASE_COVERAGE_PATH', {required: false});
         const coverageUrl = core.getInput('COVERAGE_URL', {required: false});
 
@@ -469,7 +469,7 @@ async function run(): Promise<void> {
             .addRaw(coverageSection.replace(COVERAGE_SECTION_HEADER, ''))
             .addSeparator()
             .addRaw('💡 This summary is also available at the end of the PR description.')
-            .write();
+            .write({overwrite: true});
 
         // Set outputs
         core.setOutput('coverage-summary', JSON.stringify(coverageData.overall));

--- a/.github/actions/javascript/proposalPoliceComment/index.js
+++ b/.github/actions/javascript/proposalPoliceComment/index.js
@@ -11850,6 +11850,21 @@ const CONST = {
     EVENTS: {
         ISSUE_COMMENT: 'issue_comment',
     },
+    RUN_EVENT: {
+        PULL_REQUEST: 'pull_request',
+        PULL_REQUEST_TARGET: 'pull_request_target',
+        PUSH: 'push',
+    },
+    RUN_STATUS: {
+        COMPLETED: 'completed',
+        IN_PROGRESS: 'in_progress',
+        QUEUED: 'queued',
+    },
+    RUN_STATUS_CONCLUSION: {
+        SUCCESS: 'success',
+    },
+    TEST_WORKFLOW_NAME: 'Jest Unit Tests',
+    TEST_WORKFLOW_PATH: '.github/workflows/test.yml',
     PROPOSAL_KEYWORD: 'Proposal',
     DATE_FORMAT_STRING: 'yyyy-MM-dd',
     PULL_REQUEST_REGEX: new RegExp(`${GITHUB_BASE_URL_REGEX.source}/.*/.*/pull/([0-9]+).*`),

--- a/.github/actions/javascript/reopenIssueWithComment/index.js
+++ b/.github/actions/javascript/reopenIssueWithComment/index.js
@@ -11602,6 +11602,21 @@ const CONST = {
     EVENTS: {
         ISSUE_COMMENT: 'issue_comment',
     },
+    RUN_EVENT: {
+        PULL_REQUEST: 'pull_request',
+        PULL_REQUEST_TARGET: 'pull_request_target',
+        PUSH: 'push',
+    },
+    RUN_STATUS: {
+        COMPLETED: 'completed',
+        IN_PROGRESS: 'in_progress',
+        QUEUED: 'queued',
+    },
+    RUN_STATUS_CONCLUSION: {
+        SUCCESS: 'success',
+    },
+    TEST_WORKFLOW_NAME: 'Jest Unit Tests',
+    TEST_WORKFLOW_PATH: '.github/workflows/test.yml',
     PROPOSAL_KEYWORD: 'Proposal',
     DATE_FORMAT_STRING: 'yyyy-MM-dd',
     PULL_REQUEST_REGEX: new RegExp(`${GITHUB_BASE_URL_REGEX.source}/.*/.*/pull/([0-9]+).*`),

--- a/.github/actions/javascript/reviewerChecklist/index.js
+++ b/.github/actions/javascript/reviewerChecklist/index.js
@@ -11694,6 +11694,21 @@ const CONST = {
     EVENTS: {
         ISSUE_COMMENT: 'issue_comment',
     },
+    RUN_EVENT: {
+        PULL_REQUEST: 'pull_request',
+        PULL_REQUEST_TARGET: 'pull_request_target',
+        PUSH: 'push',
+    },
+    RUN_STATUS: {
+        COMPLETED: 'completed',
+        IN_PROGRESS: 'in_progress',
+        QUEUED: 'queued',
+    },
+    RUN_STATUS_CONCLUSION: {
+        SUCCESS: 'success',
+    },
+    TEST_WORKFLOW_NAME: 'Jest Unit Tests',
+    TEST_WORKFLOW_PATH: '.github/workflows/test.yml',
     PROPOSAL_KEYWORD: 'Proposal',
     DATE_FORMAT_STRING: 'yyyy-MM-dd',
     PULL_REQUEST_REGEX: new RegExp(`${GITHUB_BASE_URL_REGEX.source}/.*/.*/pull/([0-9]+).*`),

--- a/.github/actions/javascript/verifySignedCommits/index.js
+++ b/.github/actions/javascript/verifySignedCommits/index.js
@@ -11634,6 +11634,21 @@ const CONST = {
     EVENTS: {
         ISSUE_COMMENT: 'issue_comment',
     },
+    RUN_EVENT: {
+        PULL_REQUEST: 'pull_request',
+        PULL_REQUEST_TARGET: 'pull_request_target',
+        PUSH: 'push',
+    },
+    RUN_STATUS: {
+        COMPLETED: 'completed',
+        IN_PROGRESS: 'in_progress',
+        QUEUED: 'queued',
+    },
+    RUN_STATUS_CONCLUSION: {
+        SUCCESS: 'success',
+    },
+    TEST_WORKFLOW_NAME: 'Jest Unit Tests',
+    TEST_WORKFLOW_PATH: '.github/workflows/test.yml',
     PROPOSAL_KEYWORD: 'Proposal',
     DATE_FORMAT_STRING: 'yyyy-MM-dd',
     PULL_REQUEST_REGEX: new RegExp(`${GITHUB_BASE_URL_REGEX.source}/.*/.*/pull/([0-9]+).*`),

--- a/.github/actions/javascript/waitforJestTests/index.js
+++ b/.github/actions/javascript/waitforJestTests/index.js
@@ -11573,38 +11573,65 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 /* eslint-disable @typescript-eslint/naming-convention */
 const core = __importStar(__nccwpck_require__(2186));
 const github_1 = __nccwpck_require__(5438);
+const CONST_1 = __importDefault(__nccwpck_require__(9873));
 const GithubUtils_1 = __importDefault(__nccwpck_require__(9296));
 async function waitForJestTests() {
     const maxWaitTime = 30 * 60 * 1000; // 30 minutes
     const pollInterval = 10 * 1000; // 10 seconds
     const startTime = Date.now();
+    // Get PR number and SHA (backwards compatible with manual dispatch)
+    let prNumber;
+    let headSha;
+    if (github_1.context.payload.pull_request?.number) {
+        prNumber = github_1.context.payload.pull_request.number;
+        headSha = github_1.context.sha;
+        console.log(`Using PR context - PR #${prNumber}, SHA: ${headSha}`);
+    }
+    else {
+        prNumber = Number(github_1.context.payload.inputs?.pr_number ?? '0');
+        if (!prNumber) {
+            core.setFailed('PR number is required when pull_request context is not available.');
+            return;
+        }
+        // Get PR details to find the head SHA
+        console.log(`Using workflow inputs - Getting details for PR #${prNumber}`);
+        const prResponse = await GithubUtils_1.default.octokit.pulls.get({
+            owner: github_1.context.repo.owner,
+            repo: github_1.context.repo.repo,
+            pull_number: prNumber,
+        });
+        headSha = prResponse.data.head.sha;
+        console.log(`PR #${prNumber} head SHA: ${headSha}`);
+    }
     console.log(`Looking for test workflow runs for PR #${github_1.context.payload.pull_request?.number}`);
     console.log(`Head SHA: ${github_1.context.sha}`);
     while (Date.now() - startTime < maxWaitTime) {
         // Get all recent workflow runs for this repo
         const workflows = await GithubUtils_1.default.listWorkflowRunsForRepo({
             per_page: 50, // Increased to handle many concurrent workflows
-            status: 'completed', // Only look at completed runs
+            status: CONST_1.default.RUN_STATUS.COMPLETED, // Only look at completed runs
         });
-        console.log(`Found ${workflows.data.workflow_runs.length} recent workflow runs`);
+        console.log(`Found ${workflows.data.workflow_runs.length} recent workflow runs.`);
         // Look for test workflow runs that match our criteria
         const testRuns = workflows.data.workflow_runs.filter((run) => {
             // Check if it's the Jest Unit Tests workflow specifically
-            const isTestWorkflow = run.name === 'Jest Unit Tests' || run.path === '.github/workflows/test.yml';
-            // Check if it's for our PR
-            const matchesPR = run.head_sha === github_1.context.sha;
-            // Check if it's a pull request event
-            const isPREvent = run.event === 'pull_request' || run.event === 'pull_request_target';
-            return isTestWorkflow && matchesPR && isPREvent;
+            const isTestWorkflow = run.name === CONST_1.default.TEST_WORKFLOW_NAME || run.path === CONST_1.default.TEST_WORKFLOW_PATH;
+            // Check if it's for our PR's head SHA
+            const matchesSHA = run.head_sha === github_1.context.sha;
+            // For manual dispatch or when no PR context, be more flexible with event types
+            // For regular PR events, maintain existing strict logic
+            const isValidEvent = github_1.context.payload.pull_request
+                ? run.event === CONST_1.default.RUN_EVENT.PULL_REQUEST || run.event === CONST_1.default.RUN_EVENT.PULL_REQUEST_TARGET
+                : run.event === CONST_1.default.RUN_EVENT.PULL_REQUEST || run.event === CONST_1.default.RUN_EVENT.PULL_REQUEST_TARGET || run.event === CONST_1.default.RUN_EVENT.PUSH;
+            return isTestWorkflow && matchesSHA && isValidEvent;
         });
-        console.log(`Found ${testRuns.length} matching test runs`);
+        console.log(`Found ${testRuns.length} matching test runs.`);
         if (testRuns.length > 0) {
-            // Get the most recent matching run
             const testRun = testRuns.at(0);
             console.log(`Test workflow status: ${testRun?.status}, conclusion: ${testRun?.conclusion}`);
             console.log(`Test workflow name: ${testRun?.name}, path: ${testRun?.path}`);
-            if (testRun?.status === 'completed') {
-                if (testRun?.conclusion === 'success') {
+            if (testRun?.status === CONST_1.default.RUN_STATUS.COMPLETED) {
+                if (testRun?.conclusion === CONST_1.default.RUN_STATUS_CONCLUSION.SUCCESS) {
                     console.log('Test workflow completed successfully!');
                     return;
                 }
@@ -11618,23 +11645,27 @@ async function waitForJestTests() {
                 per_page: 50, // Same increased scope for in-progress runs
             });
             const inProgressTestRuns = inProgressWorkflows.data.workflow_runs.filter((run) => {
-                const isTestWorkflow = run.name === 'Jest Unit Tests' || run.path === '.github/workflows/test.yml';
-                const matchesPR = run.head_sha === github_1.context.sha;
-                const isPREvent = run.event === 'pull_request' || run.event === 'pull_request_target';
-                return isTestWorkflow && matchesPR && isPREvent && (run.status === 'in_progress' || run.status === 'queued');
+                const isTestWorkflow = run.name === CONST_1.default.TEST_WORKFLOW_NAME || run.path === CONST_1.default.TEST_WORKFLOW_PATH;
+                const matchesSHA = run.head_sha === github_1.context.sha;
+                const isValidEvent = github_1.context.payload.pull_request
+                    ? run.event === CONST_1.default.RUN_EVENT.PULL_REQUEST || run.event === CONST_1.default.RUN_EVENT.PULL_REQUEST_TARGET
+                    : run.event === CONST_1.default.RUN_EVENT.PULL_REQUEST || run.event === CONST_1.default.RUN_EVENT.PULL_REQUEST_TARGET || run.event === CONST_1.default.RUN_EVENT.PUSH;
+                const inProgress = run.status === CONST_1.default.RUN_STATUS.IN_PROGRESS || run.status === CONST_1.default.RUN_STATUS.QUEUED;
+                return isTestWorkflow && matchesSHA && isValidEvent && inProgress;
             });
             if (inProgressTestRuns.length > 0) {
-                console.log(`Found ${inProgressTestRuns.length} in-progress test runs, continuing to wait...`);
+                console.log(`Found ${inProgressTestRuns.length} in-progress test runs, awaiting completion...`);
             }
             else {
                 console.log('No matching test workflow runs found, checking if tests are required...');
                 // Check if there might be no test workflow triggered
                 // This could happen if the PR doesn't have testable changes
                 const allRecentRuns = workflows.data.workflow_runs.filter((run) => run.head_sha === github_1.context.sha);
-                console.log(`Found ${allRecentRuns.length} workflow runs for this SHA`);
+                console.log(`Found ${allRecentRuns.length} workflow runs for this SHA.`);
+                // Assume tests passed if no workflow runs exist
                 if (allRecentRuns.length === 0) {
-                    console.log('No workflow runs found for this SHA, tests might not be required');
-                    return; // Assume tests passed if no workflow runs exist
+                    console.log('No workflow runs found for this SHA, tests might not be required.');
+                    return;
                 }
             }
         }
@@ -11642,7 +11673,7 @@ async function waitForJestTests() {
             setTimeout(resolve, pollInterval);
         });
     }
-    core.setFailed('Test workflow did not complete within timeout');
+    core.setFailed('Test workflow did not complete within timeout.');
 }
 // Run the action
 waitForJestTests().catch((error) => {
@@ -11692,6 +11723,21 @@ const CONST = {
     EVENTS: {
         ISSUE_COMMENT: 'issue_comment',
     },
+    RUN_EVENT: {
+        PULL_REQUEST: 'pull_request',
+        PULL_REQUEST_TARGET: 'pull_request_target',
+        PUSH: 'push',
+    },
+    RUN_STATUS: {
+        COMPLETED: 'completed',
+        IN_PROGRESS: 'in_progress',
+        QUEUED: 'queued',
+    },
+    RUN_STATUS_CONCLUSION: {
+        SUCCESS: 'success',
+    },
+    TEST_WORKFLOW_NAME: 'Jest Unit Tests',
+    TEST_WORKFLOW_PATH: '.github/workflows/test.yml',
     PROPOSAL_KEYWORD: 'Proposal',
     DATE_FORMAT_STRING: 'yyyy-MM-dd',
     PULL_REQUEST_REGEX: new RegExp(`${GITHUB_BASE_URL_REGEX.source}/.*/.*/pull/([0-9]+).*`),

--- a/.github/actions/javascript/waitforJestTests/waitForJestTests.ts
+++ b/.github/actions/javascript/waitforJestTests/waitForJestTests.ts
@@ -1,12 +1,41 @@
 /* eslint-disable @typescript-eslint/naming-convention */
 import * as core from '@actions/core';
 import {context} from '@actions/github';
+import CONST from '@github/libs/CONST';
 import GithubUtils from '@github/libs/GithubUtils';
 
 async function waitForJestTests(): Promise<void> {
     const maxWaitTime = 30 * 60 * 1000; // 30 minutes
     const pollInterval = 10 * 1000; // 10 seconds
     const startTime = Date.now();
+
+    // Get PR number and SHA (backwards compatible with manual dispatch)
+    let prNumber: number;
+    let headSha: string;
+
+    if (context.payload.pull_request?.number) {
+        prNumber = context.payload.pull_request.number;
+        headSha = context.sha;
+        console.log(`Using PR context - PR #${prNumber}, SHA: ${headSha}`);
+    } else {
+        prNumber = Number((context.payload.inputs as Record<string, {pr_number: number}>)?.pr_number ?? '0');
+
+        if (!prNumber) {
+            core.setFailed('PR number is required when pull_request context is not available.');
+            return;
+        }
+
+        // Get PR details to find the head SHA
+        console.log(`Using workflow inputs - Getting details for PR #${prNumber}`);
+        const prResponse = await GithubUtils.octokit.pulls.get({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            pull_number: prNumber,
+        });
+
+        headSha = prResponse.data.head.sha;
+        console.log(`PR #${prNumber} head SHA: ${headSha}`);
+    }
 
     console.log(`Looking for test workflow runs for PR #${context.payload.pull_request?.number}`);
     console.log(`Head SHA: ${context.sha}`);
@@ -15,33 +44,35 @@ async function waitForJestTests(): Promise<void> {
         // Get all recent workflow runs for this repo
         const workflows = await GithubUtils.listWorkflowRunsForRepo({
             per_page: 50, // Increased to handle many concurrent workflows
-            status: 'completed', // Only look at completed runs
+            status: CONST.RUN_STATUS.COMPLETED, // Only look at completed runs
         });
 
-        console.log(`Found ${workflows.data.workflow_runs.length} recent workflow runs`);
+        console.log(`Found ${workflows.data.workflow_runs.length} recent workflow runs.`);
 
         // Look for test workflow runs that match our criteria
         const testRuns = workflows.data.workflow_runs.filter((run) => {
             // Check if it's the Jest Unit Tests workflow specifically
-            const isTestWorkflow = run.name === 'Jest Unit Tests' || run.path === '.github/workflows/test.yml';
-            // Check if it's for our PR
-            const matchesPR = run.head_sha === context.sha;
-            // Check if it's a pull request event
-            const isPREvent = run.event === 'pull_request' || run.event === 'pull_request_target';
+            const isTestWorkflow = run.name === CONST.TEST_WORKFLOW_NAME || run.path === CONST.TEST_WORKFLOW_PATH;
+            // Check if it's for our PR's head SHA
+            const matchesSHA = run.head_sha === context.sha;
+            // For manual dispatch or when no PR context, be more flexible with event types
+            // For regular PR events, maintain existing strict logic
+            const isValidEvent = context.payload.pull_request
+                ? run.event === CONST.RUN_EVENT.PULL_REQUEST || run.event === CONST.RUN_EVENT.PULL_REQUEST_TARGET
+                : run.event === CONST.RUN_EVENT.PULL_REQUEST || run.event === CONST.RUN_EVENT.PULL_REQUEST_TARGET || run.event === CONST.RUN_EVENT.PUSH;
 
-            return isTestWorkflow && matchesPR && isPREvent;
+            return isTestWorkflow && matchesSHA && isValidEvent;
         });
 
-        console.log(`Found ${testRuns.length} matching test runs`);
+        console.log(`Found ${testRuns.length} matching test runs.`);
 
         if (testRuns.length > 0) {
-            // Get the most recent matching run
             const testRun = testRuns.at(0);
             console.log(`Test workflow status: ${testRun?.status}, conclusion: ${testRun?.conclusion}`);
             console.log(`Test workflow name: ${testRun?.name}, path: ${testRun?.path}`);
 
-            if (testRun?.status === 'completed') {
-                if (testRun?.conclusion === 'success') {
+            if (testRun?.status === CONST.RUN_STATUS.COMPLETED) {
+                if (testRun?.conclusion === CONST.RUN_STATUS_CONCLUSION.SUCCESS) {
                     console.log('Test workflow completed successfully!');
                     return;
                 }
@@ -55,25 +86,29 @@ async function waitForJestTests(): Promise<void> {
             });
 
             const inProgressTestRuns = inProgressWorkflows.data.workflow_runs.filter((run) => {
-                const isTestWorkflow = run.name === 'Jest Unit Tests' || run.path === '.github/workflows/test.yml';
-                const matchesPR = run.head_sha === context.sha;
-                const isPREvent = run.event === 'pull_request' || run.event === 'pull_request_target';
+                const isTestWorkflow = run.name === CONST.TEST_WORKFLOW_NAME || run.path === CONST.TEST_WORKFLOW_PATH;
+                const matchesSHA = run.head_sha === context.sha;
+                const isValidEvent = context.payload.pull_request
+                    ? run.event === CONST.RUN_EVENT.PULL_REQUEST || run.event === CONST.RUN_EVENT.PULL_REQUEST_TARGET
+                    : run.event === CONST.RUN_EVENT.PULL_REQUEST || run.event === CONST.RUN_EVENT.PULL_REQUEST_TARGET || run.event === CONST.RUN_EVENT.PUSH;
+                const inProgress = run.status === CONST.RUN_STATUS.IN_PROGRESS || run.status === CONST.RUN_STATUS.QUEUED;
 
-                return isTestWorkflow && matchesPR && isPREvent && (run.status === 'in_progress' || run.status === 'queued');
+                return isTestWorkflow && matchesSHA && isValidEvent && inProgress;
             });
 
             if (inProgressTestRuns.length > 0) {
-                console.log(`Found ${inProgressTestRuns.length} in-progress test runs, continuing to wait...`);
+                console.log(`Found ${inProgressTestRuns.length} in-progress test runs, awaiting completion...`);
             } else {
                 console.log('No matching test workflow runs found, checking if tests are required...');
                 // Check if there might be no test workflow triggered
                 // This could happen if the PR doesn't have testable changes
                 const allRecentRuns = workflows.data.workflow_runs.filter((run) => run.head_sha === context.sha);
-                console.log(`Found ${allRecentRuns.length} workflow runs for this SHA`);
+                console.log(`Found ${allRecentRuns.length} workflow runs for this SHA.`);
 
+                // Assume tests passed if no workflow runs exist
                 if (allRecentRuns.length === 0) {
-                    console.log('No workflow runs found for this SHA, tests might not be required');
-                    return; // Assume tests passed if no workflow runs exist
+                    console.log('No workflow runs found for this SHA, tests might not be required.');
+                    return;
                 }
             }
         }
@@ -83,7 +118,7 @@ async function waitForJestTests(): Promise<void> {
         });
     }
 
-    core.setFailed('Test workflow did not complete within timeout');
+    core.setFailed('Test workflow did not complete within timeout.');
 }
 
 // Run the action

--- a/.github/libs/CONST.ts
+++ b/.github/libs/CONST.ts
@@ -31,6 +31,21 @@ const CONST = {
     EVENTS: {
         ISSUE_COMMENT: 'issue_comment',
     },
+    RUN_EVENT: {
+        PULL_REQUEST: 'pull_request',
+        PULL_REQUEST_TARGET: 'pull_request_target',
+        PUSH: 'push',
+    },
+    RUN_STATUS: {
+        COMPLETED: 'completed',
+        IN_PROGRESS: 'in_progress',
+        QUEUED: 'queued',
+    },
+    RUN_STATUS_CONCLUSION: {
+        SUCCESS: 'success',
+    },
+    TEST_WORKFLOW_NAME: 'Jest Unit Tests',
+    TEST_WORKFLOW_PATH: '.github/workflows/test.yml',
     PROPOSAL_KEYWORD: 'Proposal',
     DATE_FORMAT_STRING: 'yyyy-MM-dd',
     PULL_REQUEST_REGEX: new RegExp(`${GITHUB_BASE_URL_REGEX.source}/.*/.*/pull/([0-9]+).*`),

--- a/.github/scripts/generateBaselineCoverage.sh
+++ b/.github/scripts/generateBaselineCoverage.sh
@@ -20,11 +20,17 @@ for file in "${CHANGED_FILES_ARRAY[@]}"; do
     COVERAGE_ARGS+=("--collectCoverageFrom=$file")
 done
 
+# Get CPU core count with fallback
+echo "MAX_WORKERS environment variable: ${MAX_WORKERS}"
+WORKERS=${MAX_WORKERS:-4}
+echo "Using $WORKERS workers (w/ fallback to 4)"
+
 echo "Running baseline coverage for changed files only..."
 echo "Coverage patterns: ${COVERAGE_ARGS[*]}"
+echo "Timeout: 60s, Workers: $WORKERS, Memory: 8GB"
 
 # Run Jest with coverage focused on SAME changed files
-NODE_OPTIONS="--max-old-space-size=4096 --experimental-vm-modules" npx jest \
+NODE_OPTIONS="--experimental-vm-modules" npx jest \
     --coverage \
     --coverageDirectory=coverage \
     "${COVERAGE_ARGS[@]}" \
@@ -38,8 +44,8 @@ NODE_OPTIONS="--max-old-space-size=4096 --experimental-vm-modules" npx jest \
     --coverageReporters=lcov \
     --coverageReporters=html \
     --coverageReporters=text-summary \
-    --maxWorkers=2 \
-    --testTimeout=30000 \
+    --maxWorkers="$WORKERS" \
+    --testTimeout=60000 \
     --silent
 
 # Move main branch coverage to baseline directory

--- a/.github/scripts/runCoverage.sh
+++ b/.github/scripts/runCoverage.sh
@@ -11,11 +11,17 @@ for file in "${CHANGED_FILES_ARRAY[@]}"; do
   COVERAGE_ARGS+=("--collectCoverageFrom=$file")
 done
 
+# Get CPU core count with fallback
+echo "MAX_WORKERS environment variable: ${MAX_WORKERS}"
+WORKERS=${MAX_WORKERS:-4}
+echo "Using $WORKERS workers (w/ fallback to 4)"
+
 echo "Running coverage with focused patterns..."
 echo "Coverage patterns: ${COVERAGE_ARGS[*]}"
+echo "Timeout: 60s, Workers: $WORKERS, Memory: 8GB"
 
 # Run Jest with coverage focused on changed files only
-NODE_OPTIONS="--max-old-space-size=4096 --experimental-vm-modules" npx jest \
+NODE_OPTIONS="--experimental-vm-modules" npx jest \
   --coverage \
   --coverageDirectory=coverage \
   "${COVERAGE_ARGS[@]}" \
@@ -29,6 +35,6 @@ NODE_OPTIONS="--max-old-space-size=4096 --experimental-vm-modules" npx jest \
   --coverageReporters=lcov \
   --coverageReporters=html \
   --coverageReporters=text-summary \
-  --maxWorkers=2 \
-  --testTimeout=30000 \
+  --maxWorkers="$WORKERS" \
+  --testTimeout=60000 \
   --silent

--- a/.github/workflows/testCoverage.yml
+++ b/.github/workflows/testCoverage.yml
@@ -57,11 +57,15 @@ jobs:
       - name: Setup Node
         uses: ./.github/actions/composite/setupNode
 
+      - name: Get Number of CPU Cores
+        id: cpu-cores
+        uses: SimenB/github-actions-cpu-cores@31e91de0f8654375a21e8e83078be625380e2b18
+
       - name: Check Changed Coverage src/ Files
         id: check-src-changes
         run: ./.github/scripts/checkCoverageChanges.sh
 
-      - name: Wait for Jest Tests to Complete
+      - name: Await Jest Unit Tests Completion Before Coverage
         if: steps.check-src-changes.outputs.run_coverage == 'true'
         uses: ./.github/actions/javascript/waitforJestTests
         with:
@@ -71,11 +75,13 @@ jobs:
         if: steps.check-src-changes.outputs.run_coverage == 'true'
         run: ./.github/scripts/runCoverage.sh
         env:
-          CI: true
+          MAX_WORKERS: ${{ steps.cpu-cores.outputs.count }}
 
       - name: Generate Baseline Coverage From The Main Branch
         if: steps.check-src-changes.outputs.run_coverage == 'true'
         run: ./.github/scripts/generateBaselineCoverage.sh
+        env:
+          MAX_WORKERS: ${{ steps.cpu-cores.outputs.count }}
 
       - name: Configure AWS Credentials
         if: steps.check-src-changes.outputs.run_coverage == 'true'


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
<!-- Explain what your change does and how it addresses the linked issue -->

- passed `overwrite: true` to core.summary to not have multiple summaries posted on the workflow run (fixes [this](https://github.com/Expensify/App/actions/runs/16659278337))
- optimized jest coverage run steps by increasing `--max-workers` / timeout and removed hard memory limit set with `--max-old-space-size` allowing node to dynamically manage memory (didn't add sharding because it would complicate things a lot in terms of coverage collection) [if we will experience issues with jest coverage runs failing, we can work on implementing sharding in the future]
- refactored the `waitForJestTests.ts` action file and added backwards compatible fix for this issue, meaning whenever we decide to allow the workflow to run on `pull_request` open / sync event, the `waitForJestTests` will still work (works with both): ensuring we await for Jest Unit Tests to complete successfully before proceeding with the coverage (step has failsafe)

cc @blimpich 

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$
PROPOSAL:


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

**N/A**

- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

**N/A**

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->

**N/A**

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I verified there are no new alerts related to the `canBeMissing` param for `useOnyx`
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Desktop</summary>

<!-- add screenshots or videos here -->

</details>
