### PR TITLE
perf: Refactor sortReportsToDisplayInLHN by splitting into smaller parts

### DIFF
--- a/src/libs/SidebarUtils.ts
+++ b/src/libs/SidebarUtils.ts
@@ -344,17 +344,6 @@ function categorizeReportsForLHN(
     reportNameValuePairs?: OnyxCollection<ReportNameValuePairs>,
     reportAttributes?: ReportAttributesDerivedValue['reports'],
 ) {
-    // The LHN is split into five distinct groups, and each group is sorted a little differently. The groups will ALWAYS be in this order:
-    // 1. Pinned/GBR - Always sorted by reportDisplayName
-    // 2. Error reports - Always sorted by reportDisplayName
-    // 3. Drafts - Always sorted by reportDisplayName
-    // 4. Non-archived reports and settled IOUs
-    //      - Sorted by lastVisibleActionCreated in default (most recent) view mode
-    //      - Sorted by reportDisplayName in GSD (focus) view mode
-    // 5. Archived reports
-    //      - Sorted by lastVisibleActionCreated in default (most recent) view mode
-    //      - Sorted by reportDisplayName in GSD (focus) view mode
-
     const pinnedAndGBRReports: MiniReport[] = [];
     const errorReports: MiniReport[] = [];
     const draftReports: MiniReport[] = [];
@@ -363,10 +352,6 @@ function categorizeReportsForLHN(
 
     // There are a few properties that need to be calculated for the report which are used when sorting reports.
     for (const report of Object.values(reportsToDisplay)) {
-        if (!report?.reportID) {
-            continue;
-        }
-
         const reportID = report.reportID;
         const isPinned = report.isPinned ?? false;
         const hasErrors = report.hasErrorsOtherThanFailedReceipt;
@@ -475,6 +460,9 @@ function combineReportCategories(
     return [...pinnedAndGBRReports, ...errorReports, ...draftReports, ...nonArchivedReports, ...archivedReports].map((report) => report?.reportID).filter(Boolean) as string[];
 }
 
+/**
+ * @returns An array of reportIDs sorted in the proper order
+ */
 function sortReportsToDisplayInLHN(
     reportsToDisplay: ReportsToDisplayInLHN,
     priorityMode: OnyxEntry<PriorityMode>,
@@ -486,6 +474,16 @@ function sortReportsToDisplayInLHN(
 
     const isInFocusMode = priorityMode === CONST.PRIORITY_MODE.GSD;
     const isInDefaultMode = !isInFocusMode;
+    // The LHN is split into five distinct groups, and each group is sorted a little differently. The groups will ALWAYS be in this order:
+    // 1. Pinned/GBR - Always sorted by reportDisplayName
+    // 2. Error reports - Always sorted by reportDisplayName
+    // 3. Drafts - Always sorted by reportDisplayName
+    // 4. Non-archived reports and settled IOUs
+    //      - Sorted by lastVisibleActionCreated in default (most recent) view mode
+    //      - Sorted by reportDisplayName in GSD (focus) view mode
+    // 5. Archived reports
+    //      - Sorted by lastVisibleActionCreated in default (most recent) view mode
+    //      - Sorted by reportDisplayName in GSD (focus) view mode
 
     // Step 1: Categorize reports
     const categories = categorizeReportsForLHN(reportsToDisplay, reportNameValuePairs, reportAttributes);

--- a/src/libs/SidebarUtils.ts
+++ b/src/libs/SidebarUtils.ts
@@ -353,8 +353,8 @@ function categorizeReportsForLHN(
     // There are a few properties that need to be calculated for the report which are used when sorting reports.
     for (const report of Object.values(reportsToDisplay)) {
         const reportID = report.reportID;
-        const isPinned = report.isPinned ?? false;
-        const hasErrors = report.hasErrorsOtherThanFailedReceipt;
+        const isPinned = !!report.isPinned;
+        const hasErrors = !!report.hasErrorsOtherThanFailedReceipt;
         const hasDraft = reportID ? hasValidDraftComment(reportID) : false;
         const reportNameValuePairsKey = `${ONYXKEYS.COLLECTION.REPORT_NAME_VALUE_PAIRS}${reportID}`;
         const rNVPs = reportNameValuePairs?.[reportNameValuePairsKey];

--- a/src/libs/SidebarUtils.ts
+++ b/src/libs/SidebarUtils.ts
@@ -336,20 +336,14 @@ function updateReportsToDisplayInLHN(
 
     return displayedReportsCopy;
 }
-
 /**
- * @returns An array of reportIDs sorted in the proper order
+ * Categorizes reports into their respective LHN groups
  */
-function sortReportsToDisplayInLHN(
+function categorizeReportsForLHN(
     reportsToDisplay: ReportsToDisplayInLHN,
-    priorityMode: OnyxEntry<PriorityMode>,
-    localeCompare: LocaleContextProps['localeCompare'],
     reportNameValuePairs?: OnyxCollection<ReportNameValuePairs>,
     reportAttributes?: ReportAttributesDerivedValue['reports'],
-): string[] {
-    Performance.markStart(CONST.TIMING.GET_ORDERED_REPORT_IDS);
-    const isInFocusMode = priorityMode === CONST.PRIORITY_MODE.GSD;
-    const isInDefaultMode = !isInFocusMode;
+) {
     // The LHN is split into five distinct groups, and each group is sorted a little differently. The groups will ALWAYS be in this order:
     // 1. Pinned/GBR - Always sorted by reportDisplayName
     // 2. Error reports - Always sorted by reportDisplayName
@@ -368,36 +362,79 @@ function sortReportsToDisplayInLHN(
     const archivedReports: MiniReport[] = [];
 
     // There are a few properties that need to be calculated for the report which are used when sorting reports.
-    Object.values(reportsToDisplay).forEach((reportToDisplay) => {
-        const report = reportToDisplay;
+    for (const report of Object.values(reportsToDisplay)) {
+        if (!report?.reportID) {
+            continue;
+        }
+
+        const reportID = report.reportID;
+        const isPinned = report.isPinned ?? false;
+        const hasErrors = report.hasErrorsOtherThanFailedReceipt;
+        const hasDraft = reportID ? hasValidDraftComment(reportID) : false;
+        const reportNameValuePairsKey = `${ONYXKEYS.COLLECTION.REPORT_NAME_VALUE_PAIRS}${reportID}`;
+        const rNVPs = reportNameValuePairs?.[reportNameValuePairsKey];
+
         const miniReport: MiniReport = {
-            reportID: report?.reportID,
+            reportID,
             displayName: getReportName(report),
-            lastVisibleActionCreated: report?.lastVisibleActionCreated,
+            lastVisibleActionCreated: report.lastVisibleActionCreated,
         };
 
-        const isPinned = report?.isPinned ?? false;
-        const rNVPs = reportNameValuePairs?.[`${ONYXKEYS.COLLECTION.REPORT_NAME_VALUE_PAIRS}${report?.reportID}`];
-        if (isPinned || reportAttributes?.[report?.reportID]?.requiresAttention) {
+        if (isPinned || (reportID && reportAttributes?.[reportID]?.requiresAttention)) {
             pinnedAndGBRReports.push(miniReport);
-        } else if (report?.hasErrorsOtherThanFailedReceipt) {
+        } else if (hasErrors) {
             errorReports.push(miniReport);
-        } else if (hasValidDraftComment(report?.reportID)) {
+        } else if (hasDraft) {
             draftReports.push(miniReport);
         } else if (isArchivedNonExpenseReport(report, !!rNVPs?.private_isArchived)) {
             archivedReports.push(miniReport);
         } else {
             nonArchivedReports.push(miniReport);
         }
-    });
+    }
+
+    return {
+        pinnedAndGBRReports,
+        errorReports,
+        draftReports,
+        nonArchivedReports,
+        archivedReports,
+    };
+}
+
+/**
+ * Sorts categorized reports and returns new sorted arrays (pure function).
+ * This function does not mutate the input and returns new arrays for better testability.
+ */
+function sortCategorizedReports(
+    categories: {
+        pinnedAndGBRReports: MiniReport[];
+        errorReports: MiniReport[];
+        draftReports: MiniReport[];
+        nonArchivedReports: MiniReport[];
+        archivedReports: MiniReport[];
+    },
+    isInDefaultMode: boolean,
+    localeCompare: LocaleContextProps['localeCompare'],
+): {
+    pinnedAndGBRReports: MiniReport[];
+    errorReports: MiniReport[];
+    draftReports: MiniReport[];
+    nonArchivedReports: MiniReport[];
+    archivedReports: MiniReport[];
+} {
+    const {pinnedAndGBRReports, errorReports, draftReports, nonArchivedReports, archivedReports} = categories;
 
     // Sort each group of reports accordingly
-    pinnedAndGBRReports.sort((a, b) => (a?.displayName && b?.displayName ? localeCompare(a.displayName, b.displayName) : 0));
-    errorReports.sort((a, b) => (a?.displayName && b?.displayName ? localeCompare(a.displayName, b.displayName) : 0));
-    draftReports.sort((a, b) => (a?.displayName && b?.displayName ? localeCompare(a.displayName, b.displayName) : 0));
+    const sortedPinnedAndGBRReports = [...pinnedAndGBRReports].sort((a, b) => (a?.displayName && b?.displayName ? localeCompare(a.displayName, b.displayName) : 0));
+    const sortedErrorReports = [...errorReports].sort((a, b) => (a?.displayName && b?.displayName ? localeCompare(a.displayName, b.displayName) : 0));
+    const sortedDraftReports = [...draftReports].sort((a, b) => (a?.displayName && b?.displayName ? localeCompare(a.displayName, b.displayName) : 0));
+
+    let sortedNonArchivedReports: MiniReport[];
+    let sortedArchivedReports: MiniReport[];
 
     if (isInDefaultMode) {
-        nonArchivedReports.sort((a, b) => {
+        sortedNonArchivedReports = [...nonArchivedReports].sort((a, b) => {
             const compareDates = a?.lastVisibleActionCreated && b?.lastVisibleActionCreated ? compareStringDates(b.lastVisibleActionCreated, a.lastVisibleActionCreated) : 0;
             if (compareDates) {
                 return compareDates;
@@ -406,19 +443,67 @@ function sortReportsToDisplayInLHN(
             return compareDisplayNames;
         });
         // For archived reports ensure that most recent reports are at the top by reversing the order
-        archivedReports.sort((a, b) => (a?.lastVisibleActionCreated && b?.lastVisibleActionCreated ? compareStringDates(b.lastVisibleActionCreated, a.lastVisibleActionCreated) : 0));
+        sortedArchivedReports = [...archivedReports].sort((a, b) =>
+            a?.lastVisibleActionCreated && b?.lastVisibleActionCreated ? compareStringDates(b.lastVisibleActionCreated, a.lastVisibleActionCreated) : 0,
+        );
     } else {
-        nonArchivedReports.sort((a, b) => (a?.displayName && b?.displayName ? localeCompare(a.displayName, b.displayName) : 0));
-        archivedReports.sort((a, b) => (a?.displayName && b?.displayName ? localeCompare(a.displayName, b.displayName) : 0));
+        sortedNonArchivedReports = [...nonArchivedReports].sort((a, b) => (a?.displayName && b?.displayName ? localeCompare(a.displayName, b.displayName) : 0));
+        sortedArchivedReports = [...archivedReports].sort((a, b) => (a?.displayName && b?.displayName ? localeCompare(a.displayName, b.displayName) : 0));
     }
 
+    return {
+        pinnedAndGBRReports: sortedPinnedAndGBRReports,
+        errorReports: sortedErrorReports,
+        draftReports: sortedDraftReports,
+        nonArchivedReports: sortedNonArchivedReports,
+        archivedReports: sortedArchivedReports,
+    };
+}
+
+/**
+ * Combines sorted report categories and extracts report IDs
+ */
+function combineReportCategories(
+    pinnedAndGBRReports: MiniReport[],
+    errorReports: MiniReport[],
+    draftReports: MiniReport[],
+    nonArchivedReports: MiniReport[],
+    archivedReports: MiniReport[],
+): string[] {
     // Now that we have all the reports grouped and sorted, they must be flattened into an array and only return the reportID.
     // The order the arrays are concatenated in matters and will determine the order that the groups are displayed in the sidebar.
+    return [...pinnedAndGBRReports, ...errorReports, ...draftReports, ...nonArchivedReports, ...archivedReports].map((report) => report?.reportID).filter(Boolean) as string[];
+}
 
-    const LHNReports = [...pinnedAndGBRReports, ...errorReports, ...draftReports, ...nonArchivedReports, ...archivedReports].map((report) => report?.reportID).filter(Boolean) as string[];
+function sortReportsToDisplayInLHN(
+    reportsToDisplay: ReportsToDisplayInLHN,
+    priorityMode: OnyxEntry<PriorityMode>,
+    localeCompare: LocaleContextProps['localeCompare'],
+    reportNameValuePairs?: OnyxCollection<ReportNameValuePairs>,
+    reportAttributes?: ReportAttributesDerivedValue['reports'],
+): string[] {
+    Performance.markStart(CONST.TIMING.GET_ORDERED_REPORT_IDS);
+
+    const isInFocusMode = priorityMode === CONST.PRIORITY_MODE.GSD;
+    const isInDefaultMode = !isInFocusMode;
+
+    // Step 1: Categorize reports
+    const categories = categorizeReportsForLHN(reportsToDisplay, reportNameValuePairs, reportAttributes);
+
+    // Step 2: Sort each category
+    const sortedCategories = sortCategorizedReports(categories, isInDefaultMode, localeCompare);
+
+    // Step 3: Combine and extract IDs
+    const result = combineReportCategories(
+        sortedCategories.pinnedAndGBRReports,
+        sortedCategories.errorReports,
+        sortedCategories.draftReports,
+        sortedCategories.nonArchivedReports,
+        sortedCategories.archivedReports,
+    );
 
     Performance.markEnd(CONST.TIMING.GET_ORDERED_REPORT_IDS);
-    return LHNReports;
+    return result;
 }
 
 type ReasonAndReportActionThatHasRedBrickRoad = {
@@ -961,6 +1046,9 @@ function getRoomWelcomeMessage(report: OnyxEntry<Report>, isReportArchived = fal
 export default {
     getOptionData,
     sortReportsToDisplayInLHN,
+    categorizeReportsForLHN,
+    sortCategorizedReports,
+    combineReportCategories,
     getWelcomeMessage,
     getReasonAndReportActionThatHasRedBrickRoad,
     shouldShowRedBrickRoad,

--- a/tests/unit/SidebarUtilsTest.ts
+++ b/tests/unit/SidebarUtilsTest.ts
@@ -1478,14 +1478,16 @@ describe('SidebarUtils', () => {
     describe('sortReportsToDisplayInLHN', () => {
         describe('categorizeReportsForLHN', () => {
             it('should categorize reports into correct groups', () => {
-                // Mock hasValidDraftComment to return true for report '2'
+                // Given hasValidDraftComment is mocked to return true for report '2'
                 const {hasValidDraftComment} = require('@libs/DraftCommentUtils') as {hasValidDraftComment: jest.Mock};
                 hasValidDraftComment.mockImplementation((reportID: string) => reportID === '2');
 
                 const {reports, reportNameValuePairs, reportAttributes} = createSidebarTestData();
 
+                // When the reports are categorized
                 const result = SidebarUtils.categorizeReportsForLHN(reports, reportNameValuePairs, reportAttributes);
 
+                // Then the reports are categorized into the correct groups
                 expect(result.pinnedAndGBRReports).toHaveLength(1);
                 expect(result.pinnedAndGBRReports.at(0)?.reportID).toBe('0');
                 expect(result.errorReports).toHaveLength(1);
@@ -1499,6 +1501,7 @@ describe('SidebarUtils', () => {
             });
 
             it('should handle reports with requiresAttention flag', () => {
+                // Given the reports are created
                 const reports = createSidebarReportsCollection([
                     {
                         reportName: 'Attention Report',
@@ -1517,13 +1520,16 @@ describe('SidebarUtils', () => {
                     },
                 };
 
+                // When the reports are categorized
                 const result = SidebarUtils.categorizeReportsForLHN(reports, undefined, reportAttributes);
 
+                // Then the reports are categorized into the correct groups
                 expect(result.pinnedAndGBRReports).toHaveLength(1);
                 expect(result.pinnedAndGBRReports.at(0)?.reportID).toBe('0');
             });
 
             it('should skip reports without reportID', () => {
+                // Given the reports are created
                 const reports = createSidebarReportsCollection([
                     {
                         reportName: 'Valid Report',
@@ -1532,7 +1538,7 @@ describe('SidebarUtils', () => {
                     },
                 ]);
 
-                // Add a report with empty reportID manually
+                // Given a report with empty reportID
                 reports['1'] = {
                     ...createRandomReport(1),
                     reportID: '',
@@ -1541,8 +1547,10 @@ describe('SidebarUtils', () => {
                     hasErrorsOtherThanFailedReceipt: false,
                 };
 
+                // When the reports are categorized
                 const result = SidebarUtils.categorizeReportsForLHN(reports);
 
+                // Then the reports are categorized into the correct groups
                 expect(result.pinnedAndGBRReports).toHaveLength(0);
                 expect(result.errorReports).toHaveLength(0);
                 expect(result.draftReports).toHaveLength(0);
@@ -1552,8 +1560,10 @@ describe('SidebarUtils', () => {
             });
 
             it('should handle empty reports object', () => {
+                // Given the reports are empty
                 const result = SidebarUtils.categorizeReportsForLHN({});
 
+                // Then the reports are categorized into the correct groups
                 expect(result.pinnedAndGBRReports).toHaveLength(0);
                 expect(result.errorReports).toHaveLength(0);
                 expect(result.draftReports).toHaveLength(0);
@@ -1566,6 +1576,7 @@ describe('SidebarUtils', () => {
             const mockLocaleCompare = (a: string, b: string) => a.localeCompare(b);
 
             it('should sort reports correctly in default mode', () => {
+                // Given the reports are created
                 const categories = {
                     pinnedAndGBRReports: [
                         {reportID: '1', displayName: 'Zebra', lastVisibleActionCreated: '2024-01-01 10:00:00'},
@@ -1589,30 +1600,32 @@ describe('SidebarUtils', () => {
                     ],
                 };
 
+                // When the reports are sorted
                 const result = SidebarUtils.sortCategorizedReports(categories, true, mockLocaleCompare);
 
-                // Check that pinned reports are sorted by display name
+                // Then the pinned reports are sorted by display name
                 expect(result.pinnedAndGBRReports.at(0)?.displayName).toBe('Alpha');
                 expect(result.pinnedAndGBRReports.at(1)?.displayName).toBe('Zebra');
 
-                // Check that error reports are sorted by display name
+                // Then the error reports are sorted by display name
                 expect(result.errorReports.at(0)?.displayName).toBe('Beta');
                 expect(result.errorReports.at(1)?.displayName).toBe('Charlie');
 
-                // Check that draft reports are sorted by display name
+                // Then the draft reports are sorted by display name
                 expect(result.draftReports.at(0)?.displayName).toBe('Delta');
                 expect(result.draftReports.at(1)?.displayName).toBe('Echo');
 
-                // Check that non-archived reports are sorted by date (most recent first) in default mode
+                // Then the non-archived reports are sorted by date (most recent first) in default mode
                 expect(result.nonArchivedReports.at(0)?.lastVisibleActionCreated).toBe('2024-01-08 10:00:00');
                 expect(result.nonArchivedReports.at(1)?.lastVisibleActionCreated).toBe('2024-01-07 10:00:00');
 
-                // Check that archived reports are sorted by date (most recent first) in default mode
+                // Then the archived reports are sorted by date (most recent first) in default mode
                 expect(result.archivedReports.at(0)?.lastVisibleActionCreated).toBe('2024-01-10 10:00:00');
                 expect(result.archivedReports.at(1)?.lastVisibleActionCreated).toBe('2024-01-09 10:00:00');
             });
 
             it('should sort reports correctly in focus mode (GSD)', () => {
+                // Given the reports are created
                 const categories = {
                     pinnedAndGBRReports: [
                         {reportID: '1', displayName: 'Zebra', lastVisibleActionCreated: '2024-01-01 10:00:00'},
@@ -1636,26 +1649,32 @@ describe('SidebarUtils', () => {
                     ],
                 };
 
+                // When the reports are sorted
                 const result = SidebarUtils.sortCategorizedReports(categories, false, mockLocaleCompare);
 
-                // Check that all reports are sorted by display name in focus mode
+                // Then the pinned reports are sorted by display name in focus mode
                 expect(result.pinnedAndGBRReports.at(0)?.displayName).toBe('Alpha');
                 expect(result.pinnedAndGBRReports.at(1)?.displayName).toBe('Zebra');
 
+                // Then the error reports are sorted by display name
                 expect(result.errorReports.at(0)?.displayName).toBe('Beta');
                 expect(result.errorReports.at(1)?.displayName).toBe('Charlie');
 
+                // Then the draft reports are sorted by display name
                 expect(result.draftReports.at(0)?.displayName).toBe('Delta');
                 expect(result.draftReports.at(1)?.displayName).toBe('Echo');
 
+                // Then the non-archived reports are sorted by display name
                 expect(result.nonArchivedReports.at(0)?.displayName).toBe('Golf');
                 expect(result.nonArchivedReports.at(1)?.displayName).toBe('Hotel');
 
+                // Then the archived reports are sorted by display name
                 expect(result.archivedReports.at(0)?.displayName).toBe('India');
                 expect(result.archivedReports.at(1)?.displayName).toBe('Juliet');
             });
 
             it('should handle reports with missing display names', () => {
+                // Given the reports are created
                 const categories = {
                     pinnedAndGBRReports: [
                         {reportID: '1', displayName: '', lastVisibleActionCreated: '2024-01-01 10:00:00'},
@@ -1667,13 +1686,15 @@ describe('SidebarUtils', () => {
                     archivedReports: [],
                 };
 
+                // When the reports are sorted
                 const result = SidebarUtils.sortCategorizedReports(categories, true, mockLocaleCompare);
 
-                // Should not crash and should maintain order
+                // Then the pinned reports are sorted by display name
                 expect(result.pinnedAndGBRReports).toHaveLength(2);
             });
 
             it('should handle reports with missing dates', () => {
+                // Given the reports are created
                 const categories = {
                     pinnedAndGBRReports: [],
                     errorReports: [],
@@ -1685,9 +1706,10 @@ describe('SidebarUtils', () => {
                     archivedReports: [],
                 };
 
+                // When the reports are sorted
                 const result = SidebarUtils.sortCategorizedReports(categories, true, mockLocaleCompare);
 
-                // Should fall back to display name comparison
+                // Then the non-archived reports are sorted by display name
                 expect(result.nonArchivedReports.at(0)?.displayName).toBe('Alpha');
                 expect(result.nonArchivedReports.at(1)?.displayName).toBe('Beta');
             });
@@ -1695,6 +1717,7 @@ describe('SidebarUtils', () => {
 
         describe('combineReportCategories', () => {
             it('should combine categories in correct order', () => {
+                // Given the reports are created
                 const pinnedAndGBRReports = [
                     {reportID: '1', displayName: 'Pinned 1'},
                     {reportID: '2', displayName: 'Pinned 2'},
@@ -1716,13 +1739,15 @@ describe('SidebarUtils', () => {
                     {reportID: '10', displayName: 'Archived 2'},
                 ];
 
+                // When the reports are combined
                 const result = SidebarUtils.combineReportCategories(pinnedAndGBRReports, errorReports, draftReports, nonArchivedReports, archivedReports);
 
-                // Should maintain the order: pinned -> error -> draft -> non-archived -> archived
+                // Then the reports are combined in the correct order
                 expect(result).toEqual(['1', '2', '3', '4', '5', '6', '7', '8', '9', '10']);
             });
 
             it('should filter out reports with undefined reportID', () => {
+                // Given the reports are created
                 const pinnedAndGBRReports = [
                     {reportID: '1', displayName: 'Pinned 1'},
                     {reportID: undefined, displayName: 'Invalid'},
@@ -1732,20 +1757,25 @@ describe('SidebarUtils', () => {
                 const nonArchivedReports: Array<{reportID?: string; displayName: string; lastVisibleActionCreated?: string}> = [];
                 const archivedReports: Array<{reportID?: string; displayName: string; lastVisibleActionCreated?: string}> = [];
 
+                // When the reports are combined
                 const result = SidebarUtils.combineReportCategories(pinnedAndGBRReports, errorReports, draftReports, nonArchivedReports, archivedReports);
 
+                // Then the reports are combined in the correct order
                 expect(result).toEqual(['1', '2']);
             });
 
             it('should handle empty categories', () => {
+                // Given the reports are empty
                 const result = SidebarUtils.combineReportCategories([], [], [], [], []);
 
+                // Then the reports are combined in the correct order
                 expect(result).toEqual([]);
             });
         });
 
         describe('sortReportsToDisplayInLHN', () => {
             it('should sort reports correctly', () => {
+                // Given the reports are created
                 const reports = createSidebarReportsCollection([
                     {
                         reportName: 'Pinned Report',
@@ -1767,9 +1797,10 @@ describe('SidebarUtils', () => {
                 const mockLocaleCompare = (a: string, b: string) => a.localeCompare(b);
                 const priorityMode = CONST.PRIORITY_MODE.DEFAULT;
 
+                // When the reports are sorted
                 const result = SidebarUtils.sortReportsToDisplayInLHN(reports, priorityMode, mockLocaleCompare);
 
-                // Should return report IDs in the correct order (0-based indexing)
+                // Then the reports are sorted in the correct order
                 expect(result).toContain('0'); // Pinned first
                 expect(result).toContain('1'); // Error second
                 expect(result).toContain('2'); // Normal third
@@ -1777,6 +1808,7 @@ describe('SidebarUtils', () => {
             });
 
             it('should handle different priority modes correctly', () => {
+                // Given the reports are created
                 const reports = createSidebarReportsCollection([
                     {
                         reportName: 'Alpha',
@@ -1794,12 +1826,13 @@ describe('SidebarUtils', () => {
 
                 const mockLocaleCompare = (a: string, b: string) => a.localeCompare(b);
 
-                // Test default mode (sort by date)
+                // When the reports are sorted in default mode
                 const defaultResult = SidebarUtils.sortReportsToDisplayInLHN(reports, CONST.PRIORITY_MODE.DEFAULT, mockLocaleCompare);
 
-                // Test GSD mode (sort by name)
+                // When the reports are sorted in GSD mode
                 const gsdResult = SidebarUtils.sortReportsToDisplayInLHN(reports, CONST.PRIORITY_MODE.GSD, mockLocaleCompare);
 
+                // Then the reports are sorted in the correct order
                 expect(defaultResult).toEqual(['1', '0']); // Most recent first (index 1 has later date)
                 expect(gsdResult).toEqual(['0', '1']); // Alphabetical (Alpha comes before Beta)
             });

--- a/tests/unit/SidebarUtilsTest.ts
+++ b/tests/unit/SidebarUtilsTest.ts
@@ -1528,7 +1528,7 @@ describe('SidebarUtils', () => {
                 expect(result.pinnedAndGBRReports.at(0)?.reportID).toBe('0');
             });
 
-            it('should skip reports without reportID', () => {
+            it('should process reports with empty reportID', () => {
                 // Given the reports are created
                 const reports = createSidebarReportsCollection([
                     {
@@ -1554,8 +1554,9 @@ describe('SidebarUtils', () => {
                 expect(result.pinnedAndGBRReports).toHaveLength(0);
                 expect(result.errorReports).toHaveLength(0);
                 expect(result.draftReports).toHaveLength(0);
-                expect(result.nonArchivedReports).toHaveLength(1);
+                expect(result.nonArchivedReports).toHaveLength(2);
                 expect(result.nonArchivedReports.at(0)?.reportID).toBe('0');
+                expect(result.nonArchivedReports.at(1)?.reportID).toBe('');
                 expect(result.archivedReports).toHaveLength(0);
             });
 
@@ -1801,10 +1802,7 @@ describe('SidebarUtils', () => {
                 const result = SidebarUtils.sortReportsToDisplayInLHN(reports, priorityMode, mockLocaleCompare);
 
                 // Then the reports are sorted in the correct order
-                expect(result).toContain('0'); // Pinned first
-                expect(result).toContain('1'); // Error second
-                expect(result).toContain('2'); // Normal third
-                expect(result.length).toBe(3);
+                expect(result).toEqual(['0', '1', '2']); // Pinned first, Error second, Normal third
             });
 
             it('should handle different priority modes correctly', () => {

--- a/tests/utils/collections/sidebarReports.ts
+++ b/tests/utils/collections/sidebarReports.ts
@@ -1,0 +1,131 @@
+import type {ValueOf} from 'react-native-gesture-handler/lib/typescript/typeUtils';
+import type {OnyxCollection} from 'react-native-onyx';
+import type {ReportsToDisplayInLHN} from '@hooks/useSidebarOrderedReports';
+import CONST from '@src/CONST';
+import ONYXKEYS from '@src/ONYXKEYS';
+import type {Report, ReportAttributesDerivedValue, ReportNameValuePairs} from '@src/types/onyx';
+import createCollection from './createCollection';
+import {createRandomReport} from './reports';
+
+/**
+ * Creates a mock report for sidebar testing with specific properties
+ */
+function createSidebarReport(
+    index: number,
+    options: {
+        reportName?: string;
+        type?: ValueOf<typeof CONST.REPORT.TYPE>;
+        isPinned?: boolean;
+        hasErrorsOtherThanFailedReceipt?: boolean;
+        lastVisibleActionCreated?: string;
+        isOwnPolicyExpenseChat?: boolean;
+        chatType?: ValueOf<typeof CONST.REPORT.CHAT_TYPE>;
+        ownerAccountID?: number;
+        policyID?: string;
+        currency?: string;
+    } = {},
+): Report & {hasErrorsOtherThanFailedReceipt?: boolean} {
+    const reportID = index.toString();
+    const baseReport = createRandomReport(index);
+
+    return {
+        ...baseReport,
+        reportID,
+        reportName: options.reportName ?? baseReport.reportName,
+        type: options.type ?? CONST.REPORT.TYPE.CHAT,
+        isPinned: options.isPinned ?? false,
+        hasErrorsOtherThanFailedReceipt: options.hasErrorsOtherThanFailedReceipt ?? false,
+        lastVisibleActionCreated: options.lastVisibleActionCreated ?? '2024-01-01 10:00:00',
+        isOwnPolicyExpenseChat: options.isOwnPolicyExpenseChat ?? false,
+        chatType: options.chatType ?? CONST.REPORT.CHAT_TYPE.POLICY_ROOM,
+        ownerAccountID: options.ownerAccountID ?? index,
+        policyID: options.policyID ?? reportID,
+        currency: options.currency ?? 'USD',
+    };
+}
+
+/**
+ * Creates a collection of mock reports for sidebar testing using the createCollection pattern
+ */
+function createSidebarReportsCollection(
+    reportConfigs: Array<{
+        reportName?: string;
+        type?: ValueOf<typeof CONST.REPORT.TYPE>;
+        isPinned?: boolean;
+        hasErrorsOtherThanFailedReceipt?: boolean;
+        lastVisibleActionCreated?: string;
+        isOwnPolicyExpenseChat?: boolean;
+        chatType?: ValueOf<typeof CONST.REPORT.CHAT_TYPE>;
+        ownerAccountID?: number;
+        policyID?: string;
+        currency?: string;
+    }>,
+): ReportsToDisplayInLHN {
+    return createCollection<Report & {hasErrorsOtherThanFailedReceipt?: boolean}>(
+        (item) => item.reportID,
+        (index) => createSidebarReport(index, reportConfigs.at(index) ?? {}),
+        reportConfigs.length,
+    );
+}
+
+/**
+ * Creates a comprehensive test set with all report types
+ */
+function createSidebarTestData(): {
+    reports: ReportsToDisplayInLHN;
+    reportNameValuePairs: OnyxCollection<ReportNameValuePairs>;
+    reportAttributes: ReportAttributesDerivedValue['reports'];
+} {
+    const reports = createSidebarReportsCollection([
+        {
+            reportName: 'Pinned Report',
+            isPinned: true,
+            hasErrorsOtherThanFailedReceipt: false,
+        },
+        {
+            reportName: 'Error Report',
+            isPinned: false,
+            hasErrorsOtherThanFailedReceipt: true,
+        },
+        {
+            reportName: 'Draft Report',
+            isPinned: false,
+            hasErrorsOtherThanFailedReceipt: false,
+        },
+        {
+            reportName: 'Normal Report',
+            isPinned: false,
+            hasErrorsOtherThanFailedReceipt: false,
+        },
+        {
+            reportName: 'Archived Report',
+            isPinned: false,
+            hasErrorsOtherThanFailedReceipt: false,
+        },
+    ]);
+
+    const reportNameValuePairs = {
+        [`${ONYXKEYS.COLLECTION.REPORT_NAME_VALUE_PAIRS}4`]: {
+            private_isArchived: '2024-01-01 10:00:00',
+        },
+    };
+
+    const reportAttributes = {
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        '0': {
+            requiresAttention: false,
+            reportName: 'Test Report',
+            isEmpty: false,
+            brickRoadStatus: undefined,
+            reportErrors: {} as Record<string, string | null>,
+        },
+    };
+
+    return {
+        reports,
+        reportNameValuePairs,
+        reportAttributes,
+    };
+}
+
+export {createSidebarReport, createSidebarReportsCollection, createSidebarTestData};


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
<!-- Explain what your change does and how it addresses the linked issue -->
This PR refactors the `sortReportsToDisplayInLHN` function by splitting it into smaller, more focused parts, replacing `forEach` loops with `for...of` for better performance, and adding unit tests to cover its behavior.

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/67894
PROPOSAL:


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

1. Open the app and navigate to the Inbox.
2. Verify each type appears in the correct section of the Inbox, with the appropriate icon or label
        * Pinned/GBR chats at the top
        * Chats with errors next
        * Draft chats (unsent messages)
        * Regular chats
        * Archived chats at the bottom 
3. Go to Settings → Preferences → Priority Mode
4. Set to Most Recent chats should be sorted by most recent activity
5. Switch to #focus mode → chats should be sorted alphabetically for "regular chats" and "archived chats"

- [ ] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
6. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->
// TODO: These must be filled out, or the issue title must include "[No QA]."

Same as tests

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I verified there are no new alerts related to the `canBeMissing` param for `useOnyx`
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->
[android_native_2.webm](https://github.com/user-attachments/assets/7cb214b2-cd29-4422-bf09-af80cf1025e4)

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->
[android_mweb_2.webm](https://github.com/user-attachments/assets/a30ecf15-033a-4ffa-8e01-0722b88c528b)


</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->


https://github.com/user-attachments/assets/49751d60-5a46-476c-ae3d-226eee0df769


</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/b7c94761-5678-407e-9efc-fc1586960d06


</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->


https://github.com/user-attachments/assets/be38b76d-e922-4be2-90e2-da9952aa4522


</details>

<details>
<summary>MacOS: Desktop</summary>

<!-- add screenshots or videos here -->


https://github.com/user-attachments/assets/063d4771-ecc0-4543-b716-6b2cc72e1aeb


</details>
