### PR TITLE
fix: add getAssignedCardSortKey to prioritize physical Expensify cards

### DIFF
--- a/src/libs/CardUtils.ts
+++ b/src/libs/CardUtils.ts
@@ -40,6 +40,13 @@ function getMonthFromExpirationDateString(expirationDateString: string) {
  * @param card
  * @returns boolean
  */
+function getAssignedCardSortKey(card: Card): number {
+    if (!isExpensifyCard(card)) {
+        return 2;
+    }
+    return card?.nameValuePairs?.isVirtual ? 1 : 0;
+}
+
 function isExpensifyCard(card?: Card) {
     if (!card) {
         return false;
@@ -663,6 +670,7 @@ function getFundIdFromSettingsKey(key: string) {
 }
 
 export {
+    getAssignedCardSortKey,
     isExpensifyCard,
     getDomainCards,
     formatCardExpiration,

--- a/src/libs/CardUtils.ts
+++ b/src/libs/CardUtils.ts
@@ -38,7 +38,7 @@ function getMonthFromExpirationDateString(expirationDateString: string) {
 
 /**
  * @param card
- * @returns boolean
+ * @returns number
  */
 function getAssignedCardSortKey(card: Card): number {
     if (!isExpensifyCard(card)) {
@@ -47,6 +47,10 @@ function getAssignedCardSortKey(card: Card): number {
     return card?.nameValuePairs?.isVirtual ? 1 : 0;
 }
 
+/**
+ * @param card
+ * @returns boolean
+ */
 function isExpensifyCard(card?: Card) {
     if (!card) {
         return false;

--- a/src/libs/CardUtils.ts
+++ b/src/libs/CardUtils.ts
@@ -37,8 +37,13 @@ function getMonthFromExpirationDateString(expirationDateString: string) {
 }
 
 /**
- * Ensure to sort physical Expensify cards first, no matter what their cardIDs are. This way ensures the Expensify Combo Card detail is rendered correctly, because we will always use the cardID of the physical card from the combo card duo.
- * @param card
+ * Sorting logic for assigned cards.
+ * 
+ * Ensure to sort physical Expensify cards first, no matter what their cardIDs are.
+ * This way ensures the Expensify Combo Card detail is rendered correctly,
+ * because we will always use the cardID of the physical card from the combo card duo.
+ *
+ * @param card - card to get the sort key for
  * @returns number
  */
 function getAssignedCardSortKey(card: Card): number {

--- a/src/libs/CardUtils.ts
+++ b/src/libs/CardUtils.ts
@@ -38,7 +38,7 @@ function getMonthFromExpirationDateString(expirationDateString: string) {
 
 /**
  * Sorting logic for assigned cards.
- * 
+ *
  * Ensure to sort physical Expensify cards first, no matter what their cardIDs are.
  * This way ensures the Expensify Combo Card detail is rendered correctly,
  * because we will always use the cardID of the physical card from the combo card duo.

--- a/src/libs/CardUtils.ts
+++ b/src/libs/CardUtils.ts
@@ -37,6 +37,7 @@ function getMonthFromExpirationDateString(expirationDateString: string) {
 }
 
 /**
+ * Ensure to sort physical Expensify cards first, no matter what their cardIDs are. This way ensures the Expensify Combo Card detail is rendered correctly, because we will always use the cardID of the physical card from the combo card duo.
  * @param card
  * @returns number
  */

--- a/src/pages/settings/Wallet/PaymentMethodList.tsx
+++ b/src/pages/settings/Wallet/PaymentMethodList.tsx
@@ -21,7 +21,7 @@ import useStyleUtils from '@hooks/useStyleUtils';
 import useThemeIllustrations from '@hooks/useThemeIllustrations';
 import useThemeStyles from '@hooks/useThemeStyles';
 import {clearAddPaymentMethodError, clearDeletePaymentMethodError} from '@libs/actions/PaymentMethods';
-import {getCardFeedIcon, getPlaidInstitutionIconUrl, isExpensifyCard, lastFourNumbersFromCardName, maskCardNumber} from '@libs/CardUtils';
+import {getAssignedCardSortKey, getCardFeedIcon, getPlaidInstitutionIconUrl, isExpensifyCard, lastFourNumbersFromCardName, maskCardNumber} from '@libs/CardUtils';
 import Log from '@libs/Log';
 import Navigation from '@libs/Navigation/Navigation';
 import {formatPaymentMethods} from '@libs/PaymentUtils';
@@ -219,7 +219,8 @@ function PaymentMethodList({
             const assignedCards = Object.values(isLoadingCardList ? {} : (cardList ?? {}))
                 // Filter by active cards associated with a domain
                 .filter((card) => !!card.domainName && CONST.EXPENSIFY_CARD.ACTIVE_STATES.includes(card.state ?? 0));
-            const assignedCardsSorted = lodashSortBy(assignedCards, (card) => !isExpensifyCard(card));
+
+            const assignedCardsSorted = lodashSortBy(assignedCards, getAssignedCardSortKey);
 
             const assignedCardsGrouped: PaymentMethodItem[] = [];
             assignedCardsSorted.forEach((card) => {

--- a/tests/unit/CardUtilsTest.ts
+++ b/tests/unit/CardUtilsTest.ts
@@ -1149,10 +1149,10 @@ describe('CardUtils', () => {
             } as unknown as CardList;
 
             const sorted = lodashSortBy(Object.values(cardList), getAssignedCardSortKey);
-            expect(sorted.map((r: any) => r.cardID)).toEqual([10, 11]);
+            expect(sorted.map((r: Card) => r.cardID)).toEqual([10, 11]);
         });
 
-        it('places physical Expensify card before its virtual sibling', async () => {
+        it('places physical Expensify card before its virtual sibling', () => {
             const cardList = {
                 10: {cardID: 10, bank: CONST.EXPENSIFY_CARD.BANK, nameValuePairs: {isVirtual: true}}, // Expensify virtual
                 11: {cardID: 11, bank: CONST.EXPENSIFY_CARD.BANK}, // Expensify physical
@@ -1160,7 +1160,7 @@ describe('CardUtils', () => {
             } as unknown as CardList;
 
             const sorted = lodashSortBy(Object.values(cardList), getAssignedCardSortKey);
-            expect(sorted.map((r: any) => r.cardID)).toEqual([11, 10, 99]);
+            expect(sorted.map((r: Card) => r.cardID)).toEqual([11, 10, 99]);
         });
     });
 });

--- a/tests/unit/CardUtilsTest.ts
+++ b/tests/unit/CardUtilsTest.ts
@@ -1,9 +1,9 @@
+import lodashSortBy from 'lodash/sortBy';
 import type {OnyxCollection} from 'react-native-onyx';
 import type IllustrationsType from '@styles/theme/illustrations/types';
 import type * as Illustrations from '@src/components/Icon/Illustrations';
 import CONST from '@src/CONST';
 import IntlStore from '@src/languages/IntlStore';
-import lodashSortBy from 'lodash/sortBy';
 import {
     checkIfFeedConnectionIsBroken,
     filterInactiveCards,
@@ -35,8 +35,6 @@ import type {Card, CardFeeds, CardList, CompanyCardFeed, ExpensifyCardSettings, 
 import type {CompanyCardFeedWithNumber} from '@src/types/onyx/CardFeeds';
 import {localeCompare} from '../utils/TestHelper';
 import waitForBatchedUpdates from '../utils/waitForBatchedUpdates';
-import Onyx from 'react-native-onyx';
-import ONYXKEYS from '@src/ONYXKEYS';
 
 const shortDate = '0924';
 const shortDateSlashed = '09/24';


### PR DESCRIPTION
### Explanation of Change
This PR fixes an issue where the **Assigned Cards → Expensify Card** row in Wallet would navigate to a page showing only the virtual card when a workspace has both physical and virtual Expensify cards, with the physical card being a replacement.

The root cause was in the card sorting logic within `PaymentMethodList`. The original comparator only considered whether a card was an Expensify card, ignoring the physical/virtual distinction. Since virtual cards typically have lower `cardID` values than replacement physical cards, the virtual card would be sorted first and used for navigation, causing the physical card to be filtered out on the destination screen.

The fix introduces a new utility function `getAssignedCardSortKey` that prioritizes physical Expensify cards over virtual ones, ensuring that when both exist, the physical card's `cardID` is used for navigation, which properly displays both cards on the details screen.

Added unit tests to validate sorting logic for assigned cards.

### Fixed Issues
$ https://github.com/Expensify/App/issues/68033
PROPOSAL: https://github.com/Expensify/App/issues/68033#issuecomment-3160900558

### Tests

<details>
  <summary>If you don't have access to Expensify cards:</summary>
  You can manually set the cardList in Onyx using console:

```
Onyx.set("cardList", {
	200: {
		accountID: 20410919,
		availableSpend: 100,
		bank: "Expensify Card",
		cardID: 200,
		cardName: "455594XXXXXX1234",
		domainName: "expensify-policydAAA.exfy",
		fraud: "none",
		fundID: "123456",
		isVirtual: true,
		lastFourPAN: "1234",
		lastScrape: "",
		lastScrapeResult: 200,
		nameValuePairs: {
			cardTitle: "My virtual card",
			expirationDate: "2029-03-31",
			feedCountry: "US",
			hasCustomUnapprovedExpenseLimit: true,
			isVirtual: true,
			limitType: "fixed",
			unapprovedExpenseLimit: 5000,
		},
		scrapeMinDate: "",
		state: 3,
		token: "ABC-XYZ-V",
	},
	1000: {
		accountID: 20410919,
		availableSpend: 100,
		bank: "Expensify Card",
		cardID: 1000,
		cardName: "455594XXXXXX1234",
		domainName: "expensify-policydAAA.exfy",
		fraud: "none",
		fundID: "123456",
		isVirtual: false,
		lastFourPAN: "1234",
		lastScrape: "",
		lastScrapeResult: 200,
		nameValuePairs: {
			cardTitle: "My physical card",
			expirationDate: "2029-03-31",
			feedCountry: "US",
			hasCustomUnapprovedExpenseLimit: true,
			isVirtual: false,
			limitType: "fixed",
			unapprovedExpenseLimit: 5000,
		},
		scrapeMinDate: "",
		state: 3,
		token: "ABC-XYZ-V",
	}
});
```
</details>
</br>

**Prerequisites:**
- You must have a combo Expensify Card (i.e. an Expensify Card that was assigned to you in OD)
- Physical card should be a replacement card (higher cardID than virtual card)
- Both cards should be in active state

**Test Steps:**
1. Navigate to Settings → Wallet → Assigned Cards
2. Verify that clicking on the Expensify Card row navigates to a page showing both cards

- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

- [x] Verify that the card sorting behavior remains consistent when offline
- [x] Verify that navigation to card details works properly in offline mode

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->
**Prerequisites:**
- You must have a combo Expensify Card (i.e. an Expensify Card that was assigned to you in OD)
- Physical card should be a replacement card (higher cardID than virtual card)
- Both cards should be in active state



**Test Steps:**
1. Navigate to Settings → Wallet → Assigned Cards
2. Verify that clicking on the Expensify Card row navigates to a page showing both cards

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I verified there are no new alerts related to the `canBeMissing` param for `useOnyx`
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

https://github.com/user-attachments/assets/3fe557fd-ad3b-43a9-9786-9562b7a73e51



</details>

<details>
<summary>Android: mWeb Chrome</summary>

Couldn't set the Oynx data.

</details>

<details>
<summary>iOS: Native</summary>

https://github.com/user-attachments/assets/f56df2a5-2cda-40a9-ac1b-0b9188b784eb


</details>

<details>
<summary>iOS: mWeb Safari</summary>

Couldn't set the Oynx data
</details>

<details>
<summary>MacOS: Chrome / Safari</summary>


https://github.com/user-attachments/assets/67391c97-bd18-49d5-86c3-eccc38e095ba



</details>

<details>
<summary>MacOS: Desktop</summary>

https://github.com/user-attachments/assets/b7682775-f294-4db7-9bc6-8b008e3df6a3



</details>
