### PR TITLE
[CP staging] fix: Android - Chat - App crashes when opening emoji picker.

### DIFF
--- a/src/components/Search/SearchAutocompleteInput.tsx
+++ b/src/components/Search/SearchAutocompleteInput.tsx
@@ -239,7 +239,6 @@ function SearchAutocompleteInput(
                         multiline={false}
                         parser={parser}
                         selection={selection}
-                        shouldDelayFocus
                     />
                 </View>
                 {!!value && (

--- a/src/components/TextInput/BaseTextInput/implementation/index.native.tsx
+++ b/src/components/TextInput/BaseTextInput/implementation/index.native.tsx
@@ -1,4 +1,3 @@
-import {useFocusEffect} from '@react-navigation/native';
 import {Str} from 'expensify-common';
 import type {ForwardedRef} from 'react';
 import React, {forwardRef, useCallback, useEffect, useRef, useState} from 'react';
@@ -79,7 +78,6 @@ function BaseTextInput(
         placeholderTextColor,
         onClearInput,
         iconContainerStyle,
-        shouldDelayFocus = false,
         shouldUseDefaultLineHeightForPrefix = true,
         ...props
     }: BaseTextInputProps,
@@ -95,7 +93,6 @@ function BaseTextInput(
     const markdownStyle = useMarkdownStyle(false, excludedMarkdownStyles);
     const StyleUtils = useStyleUtils();
     const {translate} = useLocalize();
-    const focusTimeoutRef = useRef<NodeJS.Timeout | null>(null);
 
     const {hasError = false} = inputProps;
     // Disabling this line for safeness as nullish coalescing works only if the value is undefined or null
@@ -286,24 +283,6 @@ function BaseTextInput(
     // Height fix is needed only for Text single line inputs
     const shouldApplyHeight = !shouldUseFullInputHeight && !isMultiline && !isMarkdownEnabled;
 
-    /** We added a delay to focus on text input to allow navigation/modal animations to get completed, see issue https://github.com/Expensify/App/issues/65855 for more details */
-    useFocusEffect(
-        useCallback(() => {
-            if (!shouldDelayFocus || !inputProps.autoFocus) {
-                return;
-            }
-
-            focusTimeoutRef.current = setTimeout(() => {
-                if (!input.current) {
-                    return;
-                }
-                input.current.focus();
-            }, CONST.ANIMATED_TRANSITION);
-
-            return () => focusTimeoutRef.current && clearTimeout(focusTimeoutRef.current);
-        }, [shouldDelayFocus, inputProps.autoFocus]),
-    );
-
     return (
         <>
             <View style={[containerStyles]}>
@@ -441,7 +420,6 @@ function BaseTextInput(
                                 readOnly={isReadOnly}
                                 defaultValue={defaultValue}
                                 markdownStyle={markdownStyle}
-                                autoFocus={shouldDelayFocus ? false : inputProps.autoFocus}
                             />
                             {!!suffixCharacter && (
                                 <View style={[styles.textInputSuffixWrapper, suffixContainerStyle]}>

--- a/src/components/TextInput/BaseTextInput/types.ts
+++ b/src/components/TextInput/BaseTextInput/types.ts
@@ -187,9 +187,6 @@ type CustomBaseTextInputProps = {
     /** Whether the input should be enforced to take full height of container. Default is `false` */
     shouldUseFullInputHeight?: boolean;
 
-    /** Whether focus event should be delayed */
-    shouldDelayFocus?: boolean;
-
     /** Whether the input prefix should use the default `Text` line height fallback. Disable this if you intentionally want the prefix to have `lineHeight: undefined` */
     shouldUseDefaultLineHeightForPrefix?: boolean;
 };


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
- The issue occurs because `EmojiPicker` component isn't wrapped in `NavigationRoot`, which caused "Couldn't find a navigation object. Is your component inside NavigationContainer?"
https://github.com/Expensify/App/blob/a7ed0bcd3adb07b84ddd083a43785637f9c6e962/src/Expensify.tsx#L273-L310
- The solution is to move the input focus logic inside `SearchRouter`. `SearchRouter` is rendered inside `AuthScreens` and `AuthScreens` is wrapped inside `NavigationRoot` so we won't get the error there.
https://github.com/Expensify/App/blob/a7ed0bcd3adb07b84ddd083a43785637f9c6e962/src/libs/Navigation/AppNavigator/AuthScreens.tsx#L770

### Fixed Issues
$ https://github.com/Expensify/App/issues/65855
$ https://github.com/Expensify/App/issues/68186
PROPOSAL: https://github.com/Expensify/App/issues/65855#issuecomment-3060780374

### Tests
Test 1
1. Open any chat.
2. Tap on the emoji icon on compose box.
3. Verify emoji picker is opened and is working

Test 2
1. Tap on the search icon on the top right corner.
2. Verify that input is focused and keyboard is automatically opened.
3. Return to "Inbox" and tap on the search icon again.
4. Verify that input is focused and keyboard is automatically opened.


- [x] Verify that no errors appear in the JS console

### Offline tests
Test 1
1. Open any chat.
2. Tap on the emoji icon on compose box.
3. Verify emoji picker is opened and is working

Test 2
1. Tap on the search icon on the top right corner.
2. Verify that input is focused and keyboard is automatically opened.
3. Return to "Inbox" and tap on the search icon again.
4. Verify that input is focused and keyboard is automatically opened.


### QA Steps
Test 1
1. Open any chat.
2. Tap on the emoji icon on compose box.
3. Verify emoji picker is opened and is working

Test 2
1. Tap on the search icon on the top right corner.
2. Verify that input is focused and keyboard is automatically opened.
3. Return to "Inbox" and tap on the search icon again.
4. Verify that input is focused and keyboard is automatically opened.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.


### Screenshots/Videos
<details>
<summary>Android: Native</summary>

https://github.com/user-attachments/assets/1785c8c0-2f28-4926-9baf-9f350994f2da

</details>

<details>
<summary>Android: mWeb Chrome</summary>

https://github.com/user-attachments/assets/6f172c49-db41-4fd3-af27-e78b99060469

</details>

<details>
<summary>iOS: Native</summary>

https://github.com/user-attachments/assets/398f4416-36c0-4451-8a36-76d9124c6f4a

</details>

<details>
<summary>iOS: mWeb Safari</summary>

https://github.com/user-attachments/assets/1f6b8715-6f2a-4ec3-847e-1ad8176833b2

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

https://github.com/user-attachments/assets/69c3f97c-1ae9-44bf-8a3c-ca65e9dacaf9

</details>

<details>
<summary>MacOS: Desktop</summary>

https://github.com/user-attachments/assets/a41c2fa0-af1f-44dd-9677-d567c7815bb7

</details>
