### PR TITLE
ESLint: allow legitimate JSX prop spreading; keep clarity on native tags

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -239,6 +239,9 @@ module.exports = {
         'react/prop-types': 'off',
         'react/jsx-key': 'error',
         'react/jsx-no-constructed-context-values': 'error',
+        // Allow spreading on custom components (common for wrappers/HOCs),
+        // but still enforce on HTML/native tags for clarity.
+        'react/jsx-props-no-spreading': ['error', {html: 'enforce', custom: 'ignore'}],
         'react-native-a11y/has-valid-accessibility-descriptors': [
             'error',
             {
@@ -326,6 +329,8 @@ module.exports = {
                 },
             },
         ],
+
+        // no eslint-comments enforcement to avoid widespread changes in existing code
     },
 
     overrides: [


### PR DESCRIPTION
## Summary
- Disable blanket restriction on spreading for custom components but keep it enforced for HTML/native tags.
- Keep readability by still flagging `{...obj}` on native tags where implicit props are harder to read.

## Why
- We have hundreds of disable comments for `react/jsx-props-no-spreading` where spreading is a legitimate pattern (HOCs, forwardRef, wrappers, third‑party interop).
- Tim’s original concern is readability: it’s hard to know what props are passed to a child. That concern applies most strongly to native/HTML tags where implicit attributes can be surprising.
- For custom components, spreading a well‑typed props bag is common and safe in TS; it also matches ecosystem patterns.

## How it works
- Use the upstream rule configuration rather than a custom rule:
  - Set `react/jsx-props-no-spreading` to enforce only for `html`/native tags and ignore for `custom` components:
    ```js
    'react/jsx-props-no-spreading': ['error', {html: 'enforce', custom: 'ignore'}]
    ```
- No code churn required. Existing disable comments can gradually be removed where they targeted custom components.

## Examples
- Still flagged (native/HTML):
  ```tsx
  // flagged for readability
  <div {...someObj} />
  ```
- Allowed (custom wrapper/HOC/forwardRef):
  ```tsx
  // allowed by config, still type-checked by TS
  <MyWrapper {...props} />
  ```

## Tradeoffs
- We intentionally err on readability for native tags while unblocking common React patterns for custom components.
- If we later want additional guardrails (e.g., disallow object-literal spreads anywhere), we can add a small `no-restricted-syntax` for `JSXSpreadAttribute[argument.type="ObjectExpression"]`.

## Test plan
- Ran `npm run lint` locally: configuration passes and existing code is unaffected except that native tag spreads would still be flagged.

## Links
- Slack discussion referenced in the PR request about `react/jsx-props-no-spreading` usage and alternatives.