### PR TITLE
Modify script to exclude key splitter tests

### DIFF
--- a/Auth/make.sh
+++ b/Auth/make.sh
@@ -1,0 +1,153 @@
+#!/bin/bash
+set -e
+
+export CC="clang-18"
+export CXX="clang++-18"
+
+# Read options from the commandline.
+PRODUCTION=""
+CLEAN=""
+TEST=""
+NO_KEYSPLITTER=""
+
+# Use the number of dev build threads the user set in their bash profile, otherwise default to 8.
+JOBS="${DEV_BUILD_THREADS:-8}"
+
+KEEP_GOING=""
+for i in "$@"
+do
+case $i in
+    -t|--test)
+    TEST="true"
+    shift # past argument=value
+    ;;
+    --no-bedrock)
+    NO_BEDROCK="true"
+    shift # past argument=value
+    ;;
+    --no-keysplitter)
+    NO_KEYSPLITTER="true"
+    shift # past argument=value
+    ;;
+    -c|--clean)
+    CLEAN="true"
+    shift # past argument=value
+    ;;
+    -j=*|--jobs=*)
+    JOBS=("${i#*=}")
+    shift # past argument=value
+    ;;
+    -k|--keep-going)
+    KEEP_GOING="--keep-going"
+    ;;
+    *)
+            # unknown option
+    ;;
+esac
+done
+
+if [[ -e `which ccache` ]]; then
+    # We set this export manually since not everyone has this path prepended locally in their dev env.
+    export PATH=/usr/lib/ccache:$PATH
+    /usr/sbin/update-ccache-symlinks
+
+    # If TRAVIS_BRANCH is set, we're compiling on GH Actions, which means we'll want to change CC and CXX to have ccache prepended to it.
+    if [[ -n "${TRAVIS_BRANCH}" ]]; then
+        export CC="ccache ${CC}"
+        export CXX="ccache ${CXX}"
+    fi
+
+    export CCACHE_COMPILERCHECK="mtime"
+
+    # We have include_file_ctime and include_file_mtime since travis never modifies the header file during execution
+    # and travis shouldn't care about ctime and mtime between new branches.
+    export CCACHE_SLOPPINESS="pch_defines,time_macros,include_file_ctime,include_file_mtime"
+
+    # If CCACHE_MAXSIZE is not set use, 5GB as default
+    if [[ -z "${CCACHE_MAXSIZE}" ]]; then
+        # Set the max cache size to 5GB
+        export CCACHE_MAXSIZE="5G"
+    fi
+
+    # ccache recommends a compression level of 5 or less for faster compilations.
+    # Compression speeds up the tar and untar of the cache between gh action runs.
+    export CCACHE_COMPRESS="true"
+    if [[ -z "${CCACHE_COMPRESSLEVEL}" ]]; then
+        export CCACHE_COMPRESSLEVEL="1"
+    fi
+
+
+    # Use the root build directory that encapsulates Bedrock, Auth, Fuzzybot, ExpensifyBackupManager
+    # For local use /vagrant, otherwise this should be set for travis in the env variables.
+    if [[ -z "${CCACHE_BASEDIR}" ]]; then
+        export CCACHE_BASEDIR="/vagrant"
+    fi
+
+    # print out the cache config
+    ccache -p
+
+    # Reset cache statistics.
+    ccache -z
+fi
+
+# Function to run make with automatic stale dependency cleanup on failure
+function run_make_with_cleanup() {
+    local TARGET="$1"
+    local JOBS="$2"
+    local KEEP_GOING="$3"
+
+    # Try the build and capture output
+    # Using '|| true' prevents set -e from exiting, then we check PIPESTATUS
+    make "$TARGET" -j "$JOBS" $KEEP_GOING 2>&1 | tee /tmp/make_output.log || true
+    local MAKE_EXIT_CODE=${PIPESTATUS[0]}
+
+    if [[ $MAKE_EXIT_CODE -eq 0 ]]; then
+        # Build succeeded, clean up and return
+        rm -f /tmp/make_output.log
+    else
+        # Build failed - check if it's a stale dependency error
+        if grep -q "make: \*\*\* No rule to make target.*needed by" /tmp/make_output.log; then
+            echo "Stale dependency error detected. Cleaning and retrying..."
+            ./clean_stale_deps.sh
+            make "$TARGET" -j "$JOBS" $KEEP_GOING
+        else
+            # Not a stale dependency error, propagate the failure
+            rm -f /tmp/make_output.log
+            return $MAKE_EXIT_CODE
+        fi
+        rm -f /tmp/make_output.log
+    fi
+}
+
+if [ -n "$CLEAN" ]; then
+    if [[ -z "$NO_BEDROCK" ]] ; then
+        cd ../Bedrock
+        make clean
+        cd -
+    fi
+    make clean
+else
+    if [[ -z "$NO_BEDROCK" ]] ; then
+        cd ../Bedrock
+        run_make_with_cleanup "bedrock" "$JOBS" ""
+        cd -
+    fi
+
+    run_make_with_cleanup "auth" "$JOBS" "$KEEP_GOING"
+
+    # If test is set, make the tests.
+    if [ -n "$TEST" ]; then
+        run_make_with_cleanup "test" "$JOBS" "$KEEP_GOING"
+        
+        # Only build keysplittertest if --no-keysplitter flag is not set
+        if [[ -z "$NO_KEYSPLITTER" ]]; then
+            run_make_with_cleanup "keysplittertest" "$JOBS" ""
+        fi
+    fi
+
+fi
+
+# Print cache statistics.
+if [[ -e `which ccache` ]]; then
+    ccache -s
+fi


### PR DESCRIPTION
### Explanation of Change
This PR introduces a new `--no-keysplitter` option to the `Auth/make.sh` script. When used with the `--test` flag, this option allows developers to build the regular tests while skipping the `keysplittertest` target, providing more flexibility and potentially faster test compilation times.

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$
PROPOSAL:


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
1. Run `./Auth/make.sh --test` and verify that both `test` and `keysplittertest` targets are built.
2. Run `./Auth/make.sh --test --no-keysplitter` and verify that only the `test` target is built, and `keysplittertest` is skipped.
- [ ] Verify that no errors appear in the JS console

### Offline tests
N/A

### QA Steps
Same as tests.
- [ ] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [ ] I linked the correct issue in the `### Fixed Issues` section above
- [ ] I wrote clear testing steps that cover the changes made in this PR
    - [ ] I added steps for local testing in the `Tests` section
    - [ ] I added steps for the expected offline behavior in the `Offline steps` section
    - [ ] I added steps for Staging and/or Production testing in the `QA steps` section
    - [ ] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [ ] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [ ] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [ ] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [ ] I ran the tests on **all platforms** & verified they passed on:
    - [ ] Android: Native
    - [ ] Android: mWeb Chrome
    - [ ] iOS: Native
    - [ ] iOS: mWeb Safari
    - [ ] MacOS: Chrome / Safari
    - [ ] MacOS: Desktop
- [ ] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [ ] I verified there are no new alerts related to the `canBeMissing` param for `useOnyx`
- [ ] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [ ] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [ ] I verified that comments were added to code that is not self explanatory
    - [ ] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [ ] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [ ] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [ ] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [ ] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [ ] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [ ] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [ ] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [ ] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [ ] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [ ] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [ ] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [ ] I verified that if a function's arguments changed that all usages have also been updated correctly
- [ ] If any new file was added I verified that:
    - [ ] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [ ] If a new CSS style is added I verified that:
    - [ ] A similar style doesn't already exist
    - [ ] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [ ] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [ ] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [ ] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [ ] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [ ] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [ ] I verified that all the inputs inside a form are aligned with each other.
    - [ ] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [ ] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [ ] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [ ] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Desktop</summary>

<!-- add screenshots or videos here -->

</details>

---
<a href="https://cursor.com/background-agent?bcId=bc-247e1cb6-f12b-4a17-9795-fdcd763f3f77">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-247e1cb6-f12b-4a17-9795-fdcd763f3f77">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

