### PR TITLE
Display custom tag name on Tags page for single-level tags

### DIFF
--- a/src/languages/de.ts
+++ b/src/languages/de.ts
@@ -4755,6 +4755,7 @@ const translations = {
             editTags: 'Tags bearbeiten',
             findTag: 'Tag finden',
             subtitle: 'Tags bieten detailliertere Möglichkeiten, Kosten zu klassifizieren.',
+            subtitleWithCustomName: ({tagName}: {tagName: string}) => `Diese ${tagName} Tags bieten detailliertere Möglichkeiten, Kosten zu klassifizieren.`,
             dependentMultiLevelTagsSubtitle: {
                 phrase1: 'Sie verwenden',
                 phrase2: 'abhängige Tags',
@@ -4780,6 +4781,7 @@ const translations = {
             invalidTagNameError: 'Der Tag-Name darf nicht 0 sein. Bitte wählen Sie einen anderen Wert.',
             genericFailureMessage: 'Beim Aktualisieren des Tags ist ein Fehler aufgetreten, bitte versuchen Sie es erneut.',
             importedFromAccountingSoftware: 'Die unten stehenden Tags werden aus Ihrem',
+            importedFromAccountingSoftwareWithCustomName: ({tagName}: {tagName: string}) => `Diese ${tagName} Tags werden aus Ihrem`,
             glCode: 'GL-Code',
             updateGLCodeFailureMessage: 'Beim Aktualisieren des GL-Codes ist ein Fehler aufgetreten, bitte versuchen Sie es erneut.',
             tagRules: 'Tag-Regeln',

--- a/src/languages/en.ts
+++ b/src/languages/en.ts
@@ -4738,6 +4738,7 @@ const translations = {
             editTags: 'Edit tags',
             findTag: 'Find tag',
             subtitle: 'Tags add more detailed ways to classify costs.',
+            subtitleWithCustomName: ({tagName}: {tagName: string}) => `These ${tagName} tags add more detailed ways to classify costs.`,
             dependentMultiLevelTagsSubtitle: {
                 phrase1: ' You are using ',
                 phrase2: 'dependent tags',
@@ -4763,6 +4764,7 @@ const translations = {
             invalidTagNameError: 'Tag name cannot be 0. Please choose a different value.',
             genericFailureMessage: 'An error occurred while updating the tag, please try again',
             importedFromAccountingSoftware: 'The tags below are imported from your',
+            importedFromAccountingSoftwareWithCustomName: ({tagName}: {tagName: string}) => `These ${tagName} tags are imported from your`,
             glCode: 'GL code',
             updateGLCodeFailureMessage: 'An error occurred while updating the GL code, please try again',
             tagRules: 'Tag rules',

--- a/src/languages/es.ts
+++ b/src/languages/es.ts
@@ -4748,6 +4748,7 @@ const translations = {
             editTags: 'Editar etiquetas',
             findTag: 'Encontrar etiquetas',
             subtitle: 'Las etiquetas añaden formas más detalladas de clasificar los costos.',
+            subtitleWithCustomName: ({tagName}: {tagName: string}) => `Estas etiquetas ${tagName} añaden formas más detalladas de clasificar los costos.`,
             dependentMultiLevelTagsSubtitle: {
                 phrase1: ' Estás usando ',
                 phrase2: 'etiquetas dependientes',
@@ -4772,6 +4773,7 @@ const translations = {
             invalidTagNameError: 'El nombre de la etiqueta no puede ser 0. Por favor, elige un valor diferente.',
             genericFailureMessage: 'Se ha producido un error al actualizar la etiqueta. Por favor, inténtelo nuevamente.',
             importedFromAccountingSoftware: 'Etiquetas importadas desde',
+            importedFromAccountingSoftwareWithCustomName: ({tagName}: {tagName: string}) => `Estas etiquetas ${tagName} están importadas desde`,
             glCode: 'Código de Libro Mayor',
             updateGLCodeFailureMessage: 'Se produjo un error al actualizar el código de Libro Mayor. Por favor, inténtelo nuevamente.',
             tagRules: 'Reglas de etiquetas',

--- a/src/languages/fr.ts
+++ b/src/languages/fr.ts
@@ -4771,6 +4771,7 @@ const translations = {
             editTags: 'Modifier les balises',
             findTag: 'Trouver une balise',
             subtitle: 'Les étiquettes ajoutent des moyens plus détaillés pour classer les coûts.',
+            subtitleWithCustomName: ({tagName}: {tagName: string}) => `Ces étiquettes ${tagName} ajoutent des moyens plus détaillés pour classer les coûts.`,
             dependentMultiLevelTagsSubtitle: {
                 phrase1: 'Vous utilisez',
                 phrase2: 'balises dépendantes',
@@ -4796,6 +4797,7 @@ const translations = {
             invalidTagNameError: 'Le nom de la balise ne peut pas être 0. Veuillez choisir une autre valeur.',
             genericFailureMessage: "Une erreur s'est produite lors de la mise à jour du tag, veuillez réessayer.",
             importedFromAccountingSoftware: 'Les balises ci-dessous sont importées de votre',
+            importedFromAccountingSoftwareWithCustomName: ({tagName}: {tagName: string}) => `Ces étiquettes ${tagName} sont importées de votre`,
             glCode: 'Code GL',
             updateGLCodeFailureMessage: "Une erreur s'est produite lors de la mise à jour du code GL, veuillez réessayer.",
             tagRules: 'Règles de balise',

--- a/src/languages/it.ts
+++ b/src/languages/it.ts
@@ -4770,6 +4770,7 @@ const translations = {
             editTags: 'Modifica tag',
             findTag: 'Trova tag',
             subtitle: 'I tag aggiungono modi più dettagliati per classificare i costi.',
+            subtitleWithCustomName: ({tagName}: {tagName: string}) => `Questi tag ${tagName} aggiungono modi più dettagliati per classificare i costi.`,
             dependentMultiLevelTagsSubtitle: {
                 phrase1: 'Stai usando',
                 phrase2: 'tag dipendenti',
@@ -4795,6 +4796,7 @@ const translations = {
             invalidTagNameError: 'Il nome del tag non può essere 0. Si prega di scegliere un valore diverso.',
             genericFailureMessage: "Si è verificato un errore durante l'aggiornamento del tag, riprova.",
             importedFromAccountingSoftware: 'I tag qui sotto sono importati dal tuo',
+            importedFromAccountingSoftwareWithCustomName: ({tagName}: {tagName: string}) => `Questi tag ${tagName} sono importati dal tuo`,
             glCode: 'Codice GL',
             updateGLCodeFailureMessage: "Si è verificato un errore durante l'aggiornamento del codice GL, riprova.",
             tagRules: 'Regole dei tag',

--- a/src/languages/ja.ts
+++ b/src/languages/ja.ts
@@ -4749,6 +4749,7 @@ const translations = {
             editTags: 'タグを編集',
             findTag: 'タグを見つける',
             subtitle: 'タグは、コストをより詳細に分類する方法を追加します。',
+            subtitleWithCustomName: ({tagName}: {tagName: string}) => `これらの${tagName}タグは、コストをより詳細に分類する方法を追加します。`,
             dependentMultiLevelTagsSubtitle: {
                 phrase1: '使用中です',
                 phrase2: '依存タグ',
@@ -4774,6 +4775,7 @@ const translations = {
             invalidTagNameError: 'タグ名は0にできません。別の値を選んでください。',
             genericFailureMessage: 'タグの更新中にエラーが発生しました。もう一度お試しください。',
             importedFromAccountingSoftware: '以下のタグはあなたのからインポートされます',
+            importedFromAccountingSoftwareWithCustomName: ({tagName}: {tagName: string}) => `これらの${tagName}タグはあなたのからインポートされます`,
             glCode: 'GLコード',
             updateGLCodeFailureMessage: 'GLコードの更新中にエラーが発生しました。もう一度お試しください。',
             tagRules: 'Tag rules',

--- a/src/languages/nl.ts
+++ b/src/languages/nl.ts
@@ -4772,6 +4772,7 @@ const translations = {
             editTags: 'Bewerk tags',
             findTag: 'Tag vinden',
             subtitle: 'Tags voegen meer gedetailleerde manieren toe om kosten te classificeren.',
+            subtitleWithCustomName: ({tagName}: {tagName: string}) => `Deze ${tagName} tags voegen meer gedetailleerde manieren toe om kosten te classificeren.`,
             dependentMultiLevelTagsSubtitle: {
                 phrase1: 'U gebruikt',
                 phrase2: 'afhankelijke tags',
@@ -4797,6 +4798,7 @@ const translations = {
             invalidTagNameError: 'Tagnaam kan niet 0 zijn. Kies een andere waarde.',
             genericFailureMessage: 'Er is een fout opgetreden bij het bijwerken van de tag, probeer het alstublieft opnieuw.',
             importedFromAccountingSoftware: 'De onderstaande labels zijn geïmporteerd uit uw',
+            importedFromAccountingSoftwareWithCustomName: ({tagName}: {tagName: string}) => `Deze ${tagName} labels zijn geïmporteerd uit uw`,
             glCode: 'GL-code',
             updateGLCodeFailureMessage: 'Er is een fout opgetreden bij het bijwerken van de GL-code, probeer het alstublieft opnieuw.',
             tagRules: 'Tagregels',

--- a/src/languages/pl.ts
+++ b/src/languages/pl.ts
@@ -4761,6 +4761,7 @@ const translations = {
             editTags: 'Edytuj tagi',
             findTag: 'Znajdź tag',
             subtitle: 'Tagi dodają bardziej szczegółowe sposoby klasyfikacji kosztów.',
+            subtitleWithCustomName: ({tagName}: {tagName: string}) => `Te tagi ${tagName} dodają bardziej szczegółowe sposoby klasyfikacji kosztów.`,
             dependentMultiLevelTagsSubtitle: {
                 phrase1: 'Używasz',
                 phrase2: 'tagi zależne',
@@ -4786,6 +4787,7 @@ const translations = {
             invalidTagNameError: 'Nazwa tagu nie może być 0. Proszę wybrać inną wartość.',
             genericFailureMessage: 'Wystąpił błąd podczas aktualizacji tagu, spróbuj ponownie.',
             importedFromAccountingSoftware: 'Tagi poniżej są importowane z twojego',
+            importedFromAccountingSoftwareWithCustomName: ({tagName}: {tagName: string}) => `Te tagi ${tagName} są importowane z twojego`,
             glCode: 'Kod GL',
             updateGLCodeFailureMessage: 'Wystąpił błąd podczas aktualizacji kodu GL, spróbuj ponownie.',
             tagRules: 'Zasady tagów',

--- a/src/languages/pt-BR.ts
+++ b/src/languages/pt-BR.ts
@@ -4767,6 +4767,7 @@ const translations = {
             editTags: 'Editar tags',
             findTag: 'Find tag',
             subtitle: 'Tags adicionam maneiras mais detalhadas de classificar custos.',
+            subtitleWithCustomName: ({tagName}: {tagName: string}) => `Essas tags ${tagName} adicionam maneiras mais detalhadas de classificar custos.`,
             dependentMultiLevelTagsSubtitle: {
                 phrase1: 'Você está usando',
                 phrase2: 'tags dependentes',
@@ -4792,6 +4793,7 @@ const translations = {
             invalidTagNameError: 'O nome da tag não pode ser 0. Por favor, escolha um valor diferente.',
             genericFailureMessage: 'Ocorreu um erro ao atualizar a tag, por favor, tente novamente.',
             importedFromAccountingSoftware: 'As tags abaixo são importadas do seu',
+            importedFromAccountingSoftwareWithCustomName: ({tagName}: {tagName: string}) => `Essas tags ${tagName} são importadas do seu`,
             glCode: 'Código GL',
             updateGLCodeFailureMessage: 'Ocorreu um erro ao atualizar o código GL, por favor, tente novamente.',
             tagRules: 'Regras de tag',

--- a/src/languages/zh-hans.ts
+++ b/src/languages/zh-hans.ts
@@ -4685,6 +4685,7 @@ const translations = {
             editTags: '编辑标签',
             findTag: '查找标签',
             subtitle: '标签提供了更详细的方法来分类费用。',
+            subtitleWithCustomName: ({tagName}: {tagName: string}) => `这些${tagName}标签提供了更详细的方法来分类费用。`,
             dependentMultiLevelTagsSubtitle: {
                 phrase1: '您正在使用',
                 phrase2: '依赖标签',
@@ -4710,6 +4711,7 @@ const translations = {
             invalidTagNameError: '标签名称不能为0。请选择其他值。',
             genericFailureMessage: '更新标签时发生错误，请重试。',
             importedFromAccountingSoftware: '以下标签是从您的...导入的',
+            importedFromAccountingSoftwareWithCustomName: ({tagName}: {tagName: string}) => `这些${tagName}标签是从您的...导入的`,
             glCode: 'GL代码',
             updateGLCodeFailureMessage: '更新总账代码时发生错误，请重试。',
             tagRules: '标签规则',

--- a/src/pages/workspace/tags/WorkspaceTagsPage.tsx
+++ b/src/pages/workspace/tags/WorkspaceTagsPage.tsx
@@ -601,12 +601,20 @@ function WorkspaceTagsPage({route}: WorkspaceTagsPageProps) {
 
     const selectionModeHeader = isMobileSelectionModeEnabled && shouldUseNarrowLayout;
 
+    const customTagName = !isMultiLevelTags ? policyTagLists.at(0)?.name : undefined;
+    const hasCustomTagName = customTagName && customTagName.trim() !== '';
+
     const headerContent = (
         <>
             <View style={[styles.ph5, styles.pb5, styles.pt3, shouldUseNarrowLayout ? styles.workspaceSectionMobile : undefined]}>
                 {!hasSyncError && isConnectionVerified ? (
                     <Text>
-                        <Text style={[styles.textNormal, styles.colorMuted]}>{`${translate('workspace.tags.importedFromAccountingSoftware')} `}</Text>
+                        <Text style={[styles.textNormal, styles.colorMuted]}>
+                            {hasCustomTagName 
+                                ? `${translate('workspace.tags.importedFromAccountingSoftwareWithCustomName', {tagName: customTagName})} `
+                                : `${translate('workspace.tags.importedFromAccountingSoftware')} `
+                            }
+                        </Text>
                         <TextLink
                             style={[styles.textNormal, styles.link]}
                             href={`${environmentURL}/${ROUTES.POLICY_ACCOUNTING.getRoute(policyID)}`}
@@ -617,7 +625,10 @@ function WorkspaceTagsPage({route}: WorkspaceTagsPageProps) {
                     </Text>
                 ) : (
                     <Text style={[styles.textNormal, styles.colorMuted]}>
-                        {translate('workspace.tags.subtitle')}
+                        {hasCustomTagName 
+                            ? translate('workspace.tags.subtitleWithCustomName', {tagName: customTagName})
+                            : translate('workspace.tags.subtitle')
+                        }
                         {hasDependentTags && (
                             <>
                                 <Text style={[styles.textNormal, styles.colorMuted]}>{translate('workspace.tags.dependentMultiLevelTagsSubtitle.phrase1')}</Text>


### PR DESCRIPTION
## Summary
- Displays custom tag name prominently on the Tags page for single-level tags
- Shows "These [CustomTagName] tags..." instead of generic "Tags..." text
- Works for both QBO-imported and admin-manually-set custom tags
- Maintains backward compatibility with existing behavior

## Implementation Details
- **Single-level tags**: Extracts custom name from `policyTagLists.at(0)?.name`
- **Accounting integrations**: Uses new translation key for "These [CustomTagName] tags are imported from your [AccountingSoftware]"
- **Manual tags**: Uses new translation key for "These [CustomTagName] tags add more detailed ways to classify costs"
- **Multi-level tags**: No changes (preserves existing behavior)
- **Fallback**: Uses original text when no custom tag name exists

## Test Plan
- [ ] Test single-level tags with custom names show "These [Name] tags..."
- [ ] Test QBO integration shows "These [Name] tags are imported from QuickBooks Online"
- [ ] Test single-level tags without custom names show original text
- [ ] Test multi-level tags are unchanged
- [ ] Test all language locales display correctly

Fixes #68607

🤖 Generated with [Claude Code](https://claude.ai/code)