### PR TITLE
fix: The global process.env.EXPO_OS is not defined. This should be inlined by babel-preset-expo during transformation

### DIFF
--- a/config/webpack/webpack.common.ts
+++ b/config/webpack/webpack.common.ts
@@ -153,6 +153,8 @@ const getCommonConfiguration = ({file = '.env', platform = 'web'}: Environment):
             ...(platform === 'web' ? [new CustomVersionFilePlugin()] : []),
             new DefinePlugin({
                 ...(platform === 'desktop' ? {} : {process: {env: {}}}),
+                // Define EXPO_OS for web platform to fix expo-modules-core warning
+                'process.env.EXPO_OS': JSON.stringify('web'),
                 // eslint-disable-next-line @typescript-eslint/naming-convention
                 __REACT_WEB_CONFIG__: JSON.stringify(dotenv.config({path: file}).parsed),
 

--- a/config/webpack/webpack.common.ts
+++ b/config/webpack/webpack.common.ts
@@ -154,6 +154,7 @@ const getCommonConfiguration = ({file = '.env', platform = 'web'}: Environment):
             new DefinePlugin({
                 ...(platform === 'desktop' ? {} : {process: {env: {}}}),
                 // Define EXPO_OS for web platform to fix expo-modules-core warning
+                // eslint-disable-next-line @typescript-eslint/naming-convention
                 'process.env.EXPO_OS': JSON.stringify('web'),
                 // eslint-disable-next-line @typescript-eslint/naming-convention
                 __REACT_WEB_CONFIG__: JSON.stringify(dotenv.config({path: file}).parsed),

--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ import Config from './src/CONFIG';
 import additionalAppSetup from './src/setup';
 
 // Define EXPO_OS before any imports to prevent console errors from Expo DOM components
-if (!process.env.EXPO_OS) {
+if (!process.env.EXPO_OS && __DEV__) {
     const {Platform} = require('react-native');
     // Create a new process.env object with EXPO_OS defined
     const originalEnv = process.env;

--- a/index.js
+++ b/index.js
@@ -6,5 +6,16 @@ import App from './src/App';
 import Config from './src/CONFIG';
 import additionalAppSetup from './src/setup';
 
+// Define EXPO_OS before any imports to prevent console errors from Expo DOM components
+if (!process.env.EXPO_OS) {
+    const {Platform} = require('react-native');
+    // Create a new process.env object with EXPO_OS defined
+    const originalEnv = process.env;
+    process.env = {
+        ...originalEnv,
+        EXPO_OS: Platform.OS,
+    };
+}
+
 AppRegistry.registerComponent(Config.APP_NAME, () => App);
 additionalAppSetup();

--- a/metro.config.js
+++ b/metro.config.js
@@ -33,6 +33,7 @@ const config = {
                 inlineRequires: true,
             },
         }),
+        platforms: ['ios', 'android', 'native', 'web'],
     },
 };
 

--- a/metro.config.js
+++ b/metro.config.js
@@ -33,7 +33,6 @@ const config = {
                 inlineRequires: true,
             },
         }),
-        platforms: ['ios', 'android', 'native', 'web'],
     },
 };
 


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
This PR provides array of platforms added in transformer object in metro config to fix the issue with console warning related to not defined EXPO_OS. The platforms array in the transformer section tells Metro which platforms are supported. 

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/68855

**PROPOSAL: Get rid of missing EXPO_OS definition warning**
**Background:**
When starting up our Expo-based application, Metro transforms and bundles the code before launching the app across multiple platforms. This bundling process uses Babel presets to inline environment variables so that code relying on them behaves consistently across environments.

**Problem:**
When process.env.EXPO_OS is not defined during app startup, it triggers a persistent console warning, which prevents developers from having a clear, trustworthy signal of real issues in the logs.

**Solution:**
We updated the Metro bundler configuration to explicitly define supported platforms within the transformer object in metro.config.js:

```
transformer: {
  ...
  platforms: ['ios', 'android', 'native', 'web'],
}
```

This ensures that babel-preset-expo correctly inlines process.env.EXPO_OS during transformation, eliminating the warning at startup. With this change:
* Developers no longer see spurious warnings in the console.
* Startup logs become easier to interpret, helping identify real issues more quickly.
* The fix requires only a small configuration change and introduces no risk to production behavior, since it only clarifies platform targets for Metro during development and bundling.


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->
* Run the mobile app locally and check console. On startup there should be no errors/warnings related to EXPO_OS definition. 

- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->
Same as Tests. 

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->
Same as Tests.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I verified there are no new alerts related to the `canBeMissing` param for `useOnyx`
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

https://github.com/user-attachments/assets/3bec8609-c178-4e9a-9d15-678785ef6fcc

</details>

<details>
<summary>Android: mWeb Chrome</summary>

https://github.com/user-attachments/assets/432d4403-d3d4-405b-8455-939fa8cb8a04

</details>

<details>
<summary>iOS: Native</summary>

https://github.com/user-attachments/assets/4a8f7ce1-de7c-4949-b95d-1563363846cf

</details>

<details>
<summary>iOS: mWeb Safari</summary>

https://github.com/user-attachments/assets/4732a936-280e-4923-bec0-858c303491d5

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

https://github.com/user-attachments/assets/c507baf7-4343-4dbc-9177-f41c125ad1fd

</details>

<details>
<summary>MacOS: Desktop</summary>

https://github.com/user-attachments/assets/4ef94084-34f7-4100-ae8e-7caec0b77204

</details>
