### PR TITLE
Jakubkalinski0/fix console errors related to forward ref batch4

### DIFF
--- a/src/components/AmountForm.tsx
+++ b/src/components/AmountForm.tsx
@@ -50,25 +50,23 @@ type AmountFormProps = {
 /**
  * Wrapper around NumberWithSymbolForm with currency handling.
  */
-function AmountForm(
-    {
-        value,
-        currency = CONST.CURRENCY.USD,
-        amountMaxLength,
-        errorText,
-        onInputChange,
-        onCurrencyButtonPress,
-        displayAsTextInput = false,
-        isCurrencyPressable = true,
-        label,
-        decimals: decimalsProp,
-        hideCurrencySymbol = false,
-        autoFocus,
-        autoGrowExtraSpace,
-        autoGrowMarginSide,
-        forwardedRef,
-    }: AmountFormProps,
-) {
+function AmountForm({
+    value,
+    currency = CONST.CURRENCY.USD,
+    amountMaxLength,
+    errorText,
+    onInputChange,
+    onCurrencyButtonPress,
+    displayAsTextInput = false,
+    isCurrencyPressable = true,
+    label,
+    decimals: decimalsProp,
+    hideCurrencySymbol = false,
+    autoFocus,
+    autoGrowExtraSpace,
+    autoGrowMarginSide,
+    forwardedRef,
+}: AmountFormProps) {
     const styles = useThemeStyles();
     const decimals = decimalsProp ?? getCurrencyDecimals(currency);
 

--- a/src/components/AmountForm.tsx
+++ b/src/components/AmountForm.tsx
@@ -44,7 +44,7 @@ type AmountFormProps = {
     hideCurrencySymbol?: boolean;
 
     /** Reference to the outer element */
-    forwardedRef: ForwardedRef<BaseTextInputRef>;
+    forwardedRef?: ForwardedRef<BaseTextInputRef>;
 } & Pick<BaseTextInputProps, 'autoFocus' | 'autoGrowExtraSpace' | 'autoGrowMarginSide'>;
 
 /**

--- a/src/components/AmountForm.tsx
+++ b/src/components/AmountForm.tsx
@@ -1,5 +1,5 @@
 import type {ForwardedRef} from 'react';
-import React, {forwardRef} from 'react';
+import React from 'react';
 import useThemeStyles from '@hooks/useThemeStyles';
 import {getCurrencyDecimals, getLocalizedCurrencySymbol} from '@libs/CurrencyUtils';
 import CONST from '@src/CONST';
@@ -42,6 +42,9 @@ type AmountFormProps = {
 
     /** Whether to hide the currency symbol */
     hideCurrencySymbol?: boolean;
+
+    /** Reference to the outer element */
+    forwardedRef: ForwardedRef<BaseTextInputRef>;
 } & Pick<BaseTextInputProps, 'autoFocus' | 'autoGrowExtraSpace' | 'autoGrowMarginSide'>;
 
 /**
@@ -63,8 +66,8 @@ function AmountForm(
         autoFocus,
         autoGrowExtraSpace,
         autoGrowMarginSide,
+        forwardedRef,
     }: AmountFormProps,
-    forwardedRef: ForwardedRef<BaseTextInputRef>,
 ) {
     const styles = useThemeStyles();
     const decimals = decimalsProp ?? getCurrencyDecimals(currency);
@@ -77,11 +80,11 @@ function AmountForm(
             displayAsTextInput={displayAsTextInput}
             onInputChange={onInputChange}
             onSymbolButtonPress={onCurrencyButtonPress}
-            ref={(ref: BaseTextInputRef) => {
+            forwardedRef={(ref: BaseTextInputRef | null) => {
                 if (typeof forwardedRef === 'function') {
                     forwardedRef(ref);
                 } else if (forwardedRef && 'current' in forwardedRef) {
-                    // eslint-disable-next-line no-param-reassign
+                    // eslint-disable-next-line no-param-reassign, react-compiler/react-compiler
                     forwardedRef.current = ref;
                 }
             }}
@@ -103,5 +106,5 @@ function AmountForm(
 
 AmountForm.displayName = 'AmountForm';
 
-export default forwardRef(AmountForm);
+export default AmountForm;
 export type {AmountFormProps};

--- a/src/components/AmountPicker/AmountSelectorModal.tsx
+++ b/src/components/AmountPicker/AmountSelectorModal.tsx
@@ -70,7 +70,7 @@ function AmountSelectorModal({value, description = '', onValueSelected, isVisibl
                             {...rest}
                             value={currentValue}
                             onInputChange={setValue}
-                            ref={(ref) => inputCallbackRef(ref)}
+                            forwardedRef={(ref) => inputCallbackRef(ref)}
                         />
                         <Button
                             success

--- a/src/components/AmountTextInput.tsx
+++ b/src/components/AmountTextInput.tsx
@@ -43,24 +43,22 @@ type AmountTextInputProps = {
     hideFocusedState?: boolean;
 } & Pick<BaseTextInputProps, 'autoFocus' | 'autoGrowExtraSpace' | 'submitBehavior' | 'ref'>;
 
-function AmountTextInput(
-    {
-        formattedAmount,
-        onChangeAmount,
-        placeholder,
-        selection,
-        onSelectionChange,
-        style,
-        touchableInputWrapperStyle,
-        onKeyPress,
-        containerStyle,
-        disableKeyboard = true,
-        hideFocusedState = true,
-        shouldApplyPaddingToContainer = false,
-        ref,
-        ...rest
-    }: AmountTextInputProps,
-) {
+function AmountTextInput({
+    formattedAmount,
+    onChangeAmount,
+    placeholder,
+    selection,
+    onSelectionChange,
+    style,
+    touchableInputWrapperStyle,
+    onKeyPress,
+    containerStyle,
+    disableKeyboard = true,
+    hideFocusedState = true,
+    shouldApplyPaddingToContainer = false,
+    ref,
+    ...rest
+}: AmountTextInputProps) {
     return (
         <TextInput
             autoGrow

--- a/src/components/AmountTextInput.tsx
+++ b/src/components/AmountTextInput.tsx
@@ -1,10 +1,9 @@
 import React from 'react';
-import type {ForwardedRef} from 'react';
 import type {NativeSyntheticEvent, StyleProp, TextInputKeyPressEventData, TextInputSelectionChangeEventData, TextStyle, ViewStyle} from 'react-native';
 import CONST from '@src/CONST';
 import type {TextSelection} from './Composer/types';
 import TextInput from './TextInput';
-import type {BaseTextInputProps, BaseTextInputRef} from './TextInput/BaseTextInput/types';
+import type {BaseTextInputProps} from './TextInput/BaseTextInput/types';
 
 type AmountTextInputProps = {
     /** Formatted amount in local currency  */
@@ -42,7 +41,7 @@ type AmountTextInputProps = {
 
     /** Hide the focus styles on TextInput */
     hideFocusedState?: boolean;
-} & Pick<BaseTextInputProps, 'autoFocus' | 'autoGrowExtraSpace' | 'submitBehavior'>;
+} & Pick<BaseTextInputProps, 'autoFocus' | 'autoGrowExtraSpace' | 'submitBehavior' | 'ref'>;
 
 function AmountTextInput(
     {
@@ -58,9 +57,9 @@ function AmountTextInput(
         disableKeyboard = true,
         hideFocusedState = true,
         shouldApplyPaddingToContainer = false,
+        ref,
         ...rest
     }: AmountTextInputProps,
-    ref: ForwardedRef<BaseTextInputRef>,
 ) {
     return (
         <TextInput
@@ -99,4 +98,4 @@ function AmountTextInput(
 
 AmountTextInput.displayName = 'AmountTextInput';
 
-export default React.forwardRef(AmountTextInput);
+export default AmountTextInput;

--- a/src/components/Composer/implementation/index.native.tsx
+++ b/src/components/Composer/implementation/index.native.tsx
@@ -69,7 +69,7 @@ function Composer(
      * Set the TextInput Ref
      * @param {Element} el
      */
-    const setTextInputRef = useCallback((el: AnimatedMarkdownTextInputRef) => {
+    const setTextInputRef = useCallback((el: AnimatedMarkdownTextInputRef | null) => {
         // eslint-disable-next-line react-compiler/react-compiler
         textInput.current = el;
         if (typeof ref !== 'function' || textInput.current === null) {

--- a/src/components/Form/FormProvider.tsx
+++ b/src/components/Form/FormProvider.tsx
@@ -100,28 +100,26 @@ type FormProviderProps<TFormID extends OnyxFormKey = OnyxFormKey> = FormProps<TF
     shouldPreventDefaultFocusOnPressSubmit?: boolean;
 
     /** Reference to the outer element */
-    forwardedRef?: ForwardedRef<FormRef>,
+    forwardedRef?: ForwardedRef<FormRef>;
 };
 
-function FormProvider(
-    {
-        formID,
-        validate,
-        shouldValidateOnBlur = true,
-        shouldValidateOnChange = true,
-        children,
-        enabledWhenOffline = false,
-        onSubmit,
-        shouldTrimValues = true,
-        allowHTML = false,
-        isLoading = false,
-        shouldRenderFooterAboveSubmit = false,
-        shouldUseStrictHtmlTagValidation = false,
-        shouldPreventDefaultFocusOnPressSubmit = false,
-        forwardedRef,
-        ...rest
-    }: FormProviderProps,
-) {
+function FormProvider({
+    formID,
+    validate,
+    shouldValidateOnBlur = true,
+    shouldValidateOnChange = true,
+    children,
+    enabledWhenOffline = false,
+    onSubmit,
+    shouldTrimValues = true,
+    allowHTML = false,
+    isLoading = false,
+    shouldRenderFooterAboveSubmit = false,
+    shouldUseStrictHtmlTagValidation = false,
+    shouldPreventDefaultFocusOnPressSubmit = false,
+    forwardedRef,
+    ...rest
+}: FormProviderProps) {
     const [network] = useOnyx(ONYXKEYS.NETWORK, {canBeMissing: true});
     const [formState] = useOnyx<OnyxFormKey, Form>(`${formID}`, {canBeMissing: true});
     const [draftValues, draftValuesMetadata] = useOnyx<OnyxFormDraftKey, Form>(`${formID}Draft`, {canBeMissing: true});

--- a/src/components/Form/FormProvider.tsx
+++ b/src/components/Form/FormProvider.tsx
@@ -1,6 +1,6 @@
 import {useFocusEffect} from '@react-navigation/native';
 import {deepEqual} from 'fast-equals';
-import type {ForwardedRef, MutableRefObject, ReactNode} from 'react';
+import type {ForwardedRef, RefObject, ReactNode} from 'react';
 import React, {createRef, useCallback, useEffect, useImperativeHandle, useMemo, useRef, useState} from 'react';
 import {InteractionManager} from 'react-native';
 import type {NativeSyntheticEvent, StyleProp, TextInputSubmitEditingEventData, ViewStyle} from 'react-native';
@@ -315,7 +315,7 @@ function FormProvider({
 
     const registerInput = useCallback<RegisterInput>(
         (inputID, shouldSubmitForm, inputProps) => {
-            const newRef: MutableRefObject<InputComponentBaseProps> = inputRefs.current[inputID] ?? inputProps.ref ?? createRef();
+            const newRef: RefObject<InputComponentBaseProps> = inputRefs.current[inputID] ?? inputProps.ref ?? createRef();
             if (inputRefs.current[inputID] !== newRef) {
                 inputRefs.current[inputID] = newRef;
             }

--- a/src/components/Form/FormProvider.tsx
+++ b/src/components/Form/FormProvider.tsx
@@ -1,6 +1,6 @@
 import {useFocusEffect} from '@react-navigation/native';
 import {deepEqual} from 'fast-equals';
-import type {ForwardedRef, RefObject, ReactNode} from 'react';
+import type {ForwardedRef, ReactNode, RefObject} from 'react';
 import React, {createRef, useCallback, useEffect, useImperativeHandle, useMemo, useRef, useState} from 'react';
 import {InteractionManager} from 'react-native';
 import type {NativeSyntheticEvent, StyleProp, TextInputSubmitEditingEventData, ViewStyle} from 'react-native';

--- a/src/components/Form/FormProvider.tsx
+++ b/src/components/Form/FormProvider.tsx
@@ -1,7 +1,7 @@
 import {useFocusEffect} from '@react-navigation/native';
 import {deepEqual} from 'fast-equals';
-import type {ForwardedRef, MutableRefObject, ReactNode, RefAttributes} from 'react';
-import React, {createRef, forwardRef, useCallback, useEffect, useImperativeHandle, useMemo, useRef, useState} from 'react';
+import type {ForwardedRef, MutableRefObject, ReactNode} from 'react';
+import React, {createRef, useCallback, useEffect, useImperativeHandle, useMemo, useRef, useState} from 'react';
 import {InteractionManager} from 'react-native';
 import type {NativeSyntheticEvent, StyleProp, TextInputSubmitEditingEventData, ViewStyle} from 'react-native';
 import {useInputBlurContext} from '@components/InputBlurContext';
@@ -98,6 +98,9 @@ type FormProviderProps<TFormID extends OnyxFormKey = OnyxFormKey> = FormProps<TF
 
     /** Prevents the submit button from triggering blur on mouse down. */
     shouldPreventDefaultFocusOnPressSubmit?: boolean;
+
+    /** Reference to the outer element */
+    forwardedRef?: ForwardedRef<FormRef>,
 };
 
 function FormProvider(
@@ -115,9 +118,9 @@ function FormProvider(
         shouldRenderFooterAboveSubmit = false,
         shouldUseStrictHtmlTagValidation = false,
         shouldPreventDefaultFocusOnPressSubmit = false,
+        forwardedRef,
         ...rest
     }: FormProviderProps,
-    forwardedRef: ForwardedRef<FormRef>,
 ) {
     const [network] = useOnyx(ONYXKEYS.NETWORK, {canBeMissing: true});
     const [formState] = useOnyx<OnyxFormKey, Form>(`${formID}`, {canBeMissing: true});
@@ -468,6 +471,6 @@ function FormProvider(
 
 FormProvider.displayName = 'Form';
 
-export default forwardRef(FormProvider) as <TFormID extends OnyxFormKey>(props: FormProviderProps<TFormID> & RefAttributes<FormRef>) => ReactNode;
+export default FormProvider as <TFormID extends OnyxFormKey>(props: FormProviderProps<TFormID>) => ReactNode;
 
 export type {FormProviderProps};

--- a/src/components/MoneyRequestAmountInput.tsx
+++ b/src/components/MoneyRequestAmountInput.tsx
@@ -118,36 +118,34 @@ const defaultOnFormatAmount = (amount: number, currency?: string) => convertToFr
 /**
  * Specialized money amount input with currency and money amount formatting.
  */
-function MoneyRequestAmountInput(
-    {
-        amount = 0,
-        currency = CONST.CURRENCY.USD,
-        isCurrencyPressable = true,
-        onCurrencyButtonPress,
-        onAmountChange,
-        prefixCharacter = '',
-        hideCurrencySymbol = false,
-        moneyRequestAmountInputRef,
-        disableKeyboard = true,
-        onFormatAmount = defaultOnFormatAmount,
-        formatAmountOnBlur,
-        maxLength,
-        hideFocusedState = true,
-        shouldKeepUserInput = false,
-        shouldShowBigNumberPad = false,
-        inputStyle,
-        autoGrow = true,
-        autoGrowExtraSpace,
-        contentWidth,
-        testID,
-        submitBehavior,
-        shouldApplyPaddingToContainer = false,
-        shouldUseDefaultLineHeightForPrefix = true,
-        shouldWrapInputInContainer = true,
-        forwardedRef,
-        ...props
-    }: MoneyRequestAmountInputProps,
-) {
+function MoneyRequestAmountInput({
+    amount = 0,
+    currency = CONST.CURRENCY.USD,
+    isCurrencyPressable = true,
+    onCurrencyButtonPress,
+    onAmountChange,
+    prefixCharacter = '',
+    hideCurrencySymbol = false,
+    moneyRequestAmountInputRef,
+    disableKeyboard = true,
+    onFormatAmount = defaultOnFormatAmount,
+    formatAmountOnBlur,
+    maxLength,
+    hideFocusedState = true,
+    shouldKeepUserInput = false,
+    shouldShowBigNumberPad = false,
+    inputStyle,
+    autoGrow = true,
+    autoGrowExtraSpace,
+    contentWidth,
+    testID,
+    submitBehavior,
+    shouldApplyPaddingToContainer = false,
+    shouldUseDefaultLineHeightForPrefix = true,
+    shouldWrapInputInContainer = true,
+    forwardedRef,
+    ...props
+}: MoneyRequestAmountInputProps) {
     const textInput = useRef<BaseTextInputRef | null>(null);
     const numberFormRef = useRef<NumberWithSymbolFormRef | null>(null);
     const decimals = getCurrencyDecimals(currency);

--- a/src/components/MoneyRequestAmountInput.tsx
+++ b/src/components/MoneyRequestAmountInput.tsx
@@ -103,6 +103,9 @@ type MoneyRequestAmountInputProps = {
      * E.g., Split amount input
      */
     shouldWrapInputInContainer?: boolean;
+
+    /** Reference to the outer element */
+    forwardedRef?: ForwardedRef<BaseTextInputRef>;
 } & Pick<TextInputWithSymbolProps, 'autoGrowExtraSpace' | 'submitBehavior' | 'shouldUseDefaultLineHeightForPrefix'>;
 
 type Selection = {
@@ -141,9 +144,9 @@ function MoneyRequestAmountInput(
         shouldApplyPaddingToContainer = false,
         shouldUseDefaultLineHeightForPrefix = true,
         shouldWrapInputInContainer = true,
+        forwardedRef,
         ...props
     }: MoneyRequestAmountInputProps,
-    forwardedRef: ForwardedRef<BaseTextInputRef>,
 ) {
     const textInput = useRef<BaseTextInputRef | null>(null);
     const numberFormRef = useRef<NumberWithSymbolFormRef | null>(null);
@@ -186,7 +189,7 @@ function MoneyRequestAmountInput(
                 if (typeof forwardedRef === 'function') {
                     forwardedRef(ref);
                 } else if (forwardedRef?.current) {
-                    // eslint-disable-next-line no-param-reassign
+                    // eslint-disable-next-line no-param-reassign, react-compiler/react-compiler
                     forwardedRef.current = ref;
                 }
                 // eslint-disable-next-line react-compiler/react-compiler
@@ -230,5 +233,5 @@ function MoneyRequestAmountInput(
 
 MoneyRequestAmountInput.displayName = 'MoneyRequestAmountInput';
 
-export default React.forwardRef(MoneyRequestAmountInput);
+export default MoneyRequestAmountInput;
 export type {MoneyRequestAmountInputProps, MoneyRequestAmountInputRef};

--- a/src/components/MoneyRequestAmountInput.tsx
+++ b/src/components/MoneyRequestAmountInput.tsx
@@ -182,7 +182,7 @@ function MoneyRequestAmountInput(
             onSymbolButtonPress={onCurrencyButtonPress}
             onInputChange={onAmountChange}
             onBlur={formatAmount}
-            ref={(ref) => {
+            forwardedRef={(ref) => {
                 if (typeof forwardedRef === 'function') {
                     forwardedRef(ref);
                 } else if (forwardedRef?.current) {

--- a/src/components/NumberWithSymbolForm.tsx
+++ b/src/components/NumberWithSymbolForm.tsx
@@ -82,37 +82,35 @@ const NUM_PAD_VIEW_ID = 'numPadView';
  * Can render either a standard TextInput or a number input with BigNumberPad and symbol interaction.
  * Already handles number decimals and input validation.
  */
-function NumberWithSymbolForm(
-    {
-        value: number,
-        symbol = '',
-        symbolPosition = CONST.TEXT_INPUT_SYMBOL_POSITION.PREFIX,
-        hideSymbol = false,
-        decimals = 0,
-        maxLength,
-        errorText,
-        onInputChange,
-        onSymbolButtonPress,
-        isSymbolPressable = true,
-        shouldShowBigNumberPad = canUseTouchScreen,
-        displayAsTextInput = false,
-        footer,
-        numberFormRef,
-        label,
-        style,
-        containerStyle,
-        symbolTextStyle,
-        autoGrow = true,
-        disableKeyboard = true,
-        prefixCharacter = '',
-        hideFocusedState = true,
-        shouldApplyPaddingToContainer = false,
-        shouldUseDefaultLineHeightForPrefix = true,
-        shouldWrapInputInContainer = true,
-        forwardedRef,
-        ...props
-    }: NumberWithSymbolFormProps,
-) {
+function NumberWithSymbolForm({
+    value: number,
+    symbol = '',
+    symbolPosition = CONST.TEXT_INPUT_SYMBOL_POSITION.PREFIX,
+    hideSymbol = false,
+    decimals = 0,
+    maxLength,
+    errorText,
+    onInputChange,
+    onSymbolButtonPress,
+    isSymbolPressable = true,
+    shouldShowBigNumberPad = canUseTouchScreen,
+    displayAsTextInput = false,
+    footer,
+    numberFormRef,
+    label,
+    style,
+    containerStyle,
+    symbolTextStyle,
+    autoGrow = true,
+    disableKeyboard = true,
+    prefixCharacter = '',
+    hideFocusedState = true,
+    shouldApplyPaddingToContainer = false,
+    shouldUseDefaultLineHeightForPrefix = true,
+    shouldWrapInputInContainer = true,
+    forwardedRef,
+    ...props
+}: NumberWithSymbolFormProps) {
     const styles = useThemeStyles();
     const {toLocaleDigit, numberFormat} = useLocalize();
 

--- a/src/components/NumberWithSymbolForm.tsx
+++ b/src/components/NumberWithSymbolForm.tsx
@@ -53,7 +53,7 @@ type NumberWithSymbolFormProps = {
     shouldWrapInputInContainer?: boolean;
 
     /** Reference to the outer element */
-    forwardedRef: ForwardedRef<BaseTextInputRef>;
+    forwardedRef?: ForwardedRef<BaseTextInputRef>;
 } & Omit<TextInputWithSymbolProps, 'formattedAmount' | 'onAmountChange' | 'placeholder' | 'onSelectionChange' | 'onKeyPress' | 'onMouseDown' | 'onMouseUp'>;
 
 type NumberWithSymbolFormRef = {

--- a/src/components/NumberWithSymbolForm.tsx
+++ b/src/components/NumberWithSymbolForm.tsx
@@ -350,7 +350,7 @@ function NumberWithSymbolForm(
             onChangeAmount={setNewNumber}
             onSymbolButtonPress={onSymbolButtonPress}
             placeholder={numberFormat(0)}
-            ref={(ref: BaseTextInputRef) => {
+            ref={(ref: BaseTextInputRef | null) => {
                 if (typeof forwardedRef === 'function') {
                     forwardedRef(ref);
                 } else if (forwardedRef && 'current' in forwardedRef) {

--- a/src/components/NumberWithSymbolForm.tsx
+++ b/src/components/NumberWithSymbolForm.tsx
@@ -1,6 +1,6 @@
 import {useIsFocused} from '@react-navigation/native';
 import type {ForwardedRef} from 'react';
-import React, {forwardRef, useCallback, useEffect, useImperativeHandle, useRef, useState} from 'react';
+import React, {useCallback, useEffect, useImperativeHandle, useRef, useState} from 'react';
 import type {NativeSyntheticEvent} from 'react-native';
 import {View} from 'react-native';
 import useLocalize from '@hooks/useLocalize';
@@ -51,6 +51,9 @@ type NumberWithSymbolFormProps = {
 
     /** Whether to wrap the input in a container */
     shouldWrapInputInContainer?: boolean;
+
+    /** Reference to the outer element */
+    forwardedRef: ForwardedRef<BaseTextInputRef>;
 } & Omit<TextInputWithSymbolProps, 'formattedAmount' | 'onAmountChange' | 'placeholder' | 'onSelectionChange' | 'onKeyPress' | 'onMouseDown' | 'onMouseUp'>;
 
 type NumberWithSymbolFormRef = {
@@ -106,9 +109,9 @@ function NumberWithSymbolForm(
         shouldApplyPaddingToContainer = false,
         shouldUseDefaultLineHeightForPrefix = true,
         shouldWrapInputInContainer = true,
+        forwardedRef,
         ...props
     }: NumberWithSymbolFormProps,
-    forwardedRef: ForwardedRef<BaseTextInputRef>,
 ) {
     const styles = useThemeStyles();
     const {toLocaleDigit, numberFormat} = useLocalize();
@@ -321,7 +324,7 @@ function NumberWithSymbolForm(
                     if (typeof forwardedRef === 'function') {
                         forwardedRef(ref);
                     } else if (forwardedRef && 'current' in forwardedRef) {
-                        // eslint-disable-next-line no-param-reassign
+                        // eslint-disable-next-line react-compiler/react-compiler, no-param-reassign
                         forwardedRef.current = ref;
                     }
                 }}
@@ -444,5 +447,5 @@ function NumberWithSymbolForm(
 
 NumberWithSymbolForm.displayName = 'NumberWithSymbolForm';
 
-export default forwardRef(NumberWithSymbolForm);
+export default NumberWithSymbolForm;
 export type {NumberWithSymbolFormProps, NumberWithSymbolFormRef};

--- a/src/components/NumberWithSymbolForm.tsx
+++ b/src/components/NumberWithSymbolForm.tsx
@@ -320,7 +320,7 @@ function NumberWithSymbolForm(
                 accessibilityLabel={label}
                 value={formattedNumber}
                 onChangeText={setFormattedNumber}
-                ref={(ref: BaseTextInputRef) => {
+                ref={(ref: BaseTextInputRef | null) => {
                     if (typeof forwardedRef === 'function') {
                         forwardedRef(ref);
                     } else if (forwardedRef && 'current' in forwardedRef) {

--- a/src/components/PercentageForm.tsx
+++ b/src/components/PercentageForm.tsx
@@ -56,7 +56,7 @@ function PercentageForm({value: amount, errorText, onInputChange, label, ...rest
             value={formattedAmount}
             onChangeText={setNewAmount}
             placeholder={numberFormat(0)}
-            ref={(ref: BaseTextInputRef) => {
+            ref={(ref: BaseTextInputRef | null) => {
                 if (typeof forwardedRef === 'function') {
                     forwardedRef(ref);
                 } else if (forwardedRef && 'current' in forwardedRef) {

--- a/src/components/RNMarkdownTextInput.tsx
+++ b/src/components/RNMarkdownTextInput.tsx
@@ -18,7 +18,7 @@ type AnimatedMarkdownTextInputRef = typeof AnimatedMarkdownTextInput & MarkdownT
 // Make the parser prop optional for this component because we are always defaulting to `parseExpensiMark`
 type RNMarkdownTextInputWithRefProps = Omit<MarkdownTextInputProps, 'parser'> & {
     parser?: MarkdownTextInputProps['parser'];
-    ref?: ForwardedRef<AnimatedMarkdownTextInputRef>
+    ref?: ForwardedRef<AnimatedMarkdownTextInputRef>;
 };
 
 function RNMarkdownTextInputWithRef({maxLength, parser, ref, ...props}: RNMarkdownTextInputWithRefProps) {

--- a/src/components/RNMarkdownTextInput.tsx
+++ b/src/components/RNMarkdownTextInput.tsx
@@ -1,7 +1,7 @@
 import type {MarkdownTextInputProps} from '@expensify/react-native-live-markdown';
 import {MarkdownTextInput} from '@expensify/react-native-live-markdown';
 import type {ForwardedRef} from 'react';
-import React, {forwardRef, useCallback, useEffect, useRef} from 'react';
+import React, {useCallback, useEffect, useRef} from 'react';
 import Animated, {useSharedValue} from 'react-native-reanimated';
 import useShortMentionsList from '@hooks/useShortMentionsList';
 import useTheme from '@hooks/useTheme';
@@ -18,9 +18,10 @@ type AnimatedMarkdownTextInputRef = typeof AnimatedMarkdownTextInput & MarkdownT
 // Make the parser prop optional for this component because we are always defaulting to `parseExpensiMark`
 type RNMarkdownTextInputWithRefProps = Omit<MarkdownTextInputProps, 'parser'> & {
     parser?: MarkdownTextInputProps['parser'];
+    ref?: ForwardedRef<AnimatedMarkdownTextInputRef>
 };
 
-function RNMarkdownTextInputWithRef({maxLength, parser, ...props}: RNMarkdownTextInputWithRefProps, ref: ForwardedRef<AnimatedMarkdownTextInputRef>) {
+function RNMarkdownTextInputWithRef({maxLength, parser, ref, ...props}: RNMarkdownTextInputWithRefProps) {
     const theme = useTheme();
 
     const {availableLoginsList, currentUserMentions} = useShortMentionsList();
@@ -87,5 +88,5 @@ function RNMarkdownTextInputWithRef({maxLength, parser, ...props}: RNMarkdownTex
 
 RNMarkdownTextInputWithRef.displayName = 'RNTextInputWithRef';
 
-export default forwardRef(RNMarkdownTextInputWithRef);
+export default RNMarkdownTextInputWithRef;
 export type {AnimatedMarkdownTextInputRef};

--- a/src/components/RNMaskedTextInput.tsx
+++ b/src/components/RNMaskedTextInput.tsx
@@ -11,7 +11,11 @@ const AnimatedTextInput = Animated.createAnimatedComponent(MaskedTextInput);
 
 type AnimatedTextInputRef = typeof AnimatedTextInput & TextInput & HTMLInputElement;
 
-function RNMaskedTextInputWithRef(props: MaskedTextInputProps, ref: ForwardedRef<AnimatedTextInputRef>) {
+type RNMaskedTextInputWithRefProps = MaskedTextInputProps & {
+    ref?: ForwardedRef<AnimatedTextInputRef>;
+};
+
+function RNMaskedTextInputWithRef({ref, ...props}: RNMaskedTextInputWithRefProps) {
     const theme = useTheme();
 
     return (
@@ -35,4 +39,4 @@ function RNMaskedTextInputWithRef(props: MaskedTextInputProps, ref: ForwardedRef
 
 RNMaskedTextInputWithRef.displayName = 'RNMaskedTextInputWithRef';
 
-export default React.forwardRef(RNMaskedTextInputWithRef);
+export default RNMaskedTextInputWithRef;

--- a/src/components/RNTextInput.tsx
+++ b/src/components/RNTextInput.tsx
@@ -10,7 +10,11 @@ const AnimatedTextInput = Animated.createAnimatedComponent(TextInput);
 
 type AnimatedTextInputRef = typeof AnimatedTextInput & TextInput & HTMLInputElement;
 
-function RNTextInputWithRef(props: TextInputProps, ref: ForwardedRef<AnimatedTextInputRef>) {
+type RNTextInputWithRefProps = TextInputProps & {
+    ref?: ForwardedRef<AnimatedTextInputRef>;
+};
+
+function RNTextInputWithRef({ref, ...props}: RNTextInputWithRefProps) {
     const theme = useTheme();
 
     return (
@@ -32,5 +36,5 @@ function RNTextInputWithRef(props: TextInputProps, ref: ForwardedRef<AnimatedTex
 
 RNTextInputWithRef.displayName = 'RNTextInputWithRef';
 
-export default React.forwardRef(RNTextInputWithRef);
+export default RNTextInputWithRef;
 export type {AnimatedTextInputRef};

--- a/src/components/SubStepForms/AddressStep.tsx
+++ b/src/components/SubStepForms/AddressStep.tsx
@@ -134,7 +134,7 @@ function AddressStep<TFormID extends keyof OnyxFormValuesMapping>({
             validate={customValidate ?? validate}
             onSubmit={onSubmit}
             style={[styles.mh5, styles.flexGrow1]}
-            ref={formRef}
+            forwardedRef={formRef}
             enabledWhenOffline
         >
             <View>

--- a/src/components/TextInput/BaseTextInput/implementation/index.native.tsx
+++ b/src/components/TextInput/BaseTextInput/implementation/index.native.tsx
@@ -28,60 +28,58 @@ import isInputAutoFilled from '@libs/isInputAutoFilled';
 import variables from '@styles/variables';
 import CONST from '@src/CONST';
 
-function BaseTextInput(
-    {
-        label = '',
-        /**
-         * To be able to function as either controlled or uncontrolled component we should not
-         * assign a default prop value for `value` or `defaultValue` props
-         */
-        value = undefined,
-        defaultValue = undefined,
-        placeholder = '',
-        errorText = '',
-        iconLeft = null,
-        icon = null,
-        textInputContainerStyles,
-        shouldApplyPaddingToContainer = true,
-        touchableInputWrapperStyle,
-        containerStyles,
-        inputStyle,
-        shouldUseFullInputHeight = false,
-        forceActiveLabel = false,
-        disableKeyboard = false,
-        autoGrow = false,
-        autoGrowExtraSpace = 0,
-        autoGrowMarginSide,
-        autoGrowHeight = false,
-        maxAutoGrowHeight,
-        hideFocusedState = false,
-        maxLength = undefined,
-        hint = '',
-        onInputChange = () => {},
-        multiline = false,
-        autoCorrect = true,
-        prefixCharacter = '',
-        suffixCharacter = '',
-        inputID,
-        type = 'default',
-        excludedMarkdownStyles = [],
-        shouldShowClearButton = false,
-        shouldHideClearButton = true,
-        prefixContainerStyle = [],
-        prefixStyle = [],
-        suffixContainerStyle = [],
-        suffixStyle = [],
-        contentWidth,
-        loadingSpinnerStyle,
-        uncontrolled,
-        placeholderTextColor,
-        onClearInput,
-        iconContainerStyle,
-        shouldUseDefaultLineHeightForPrefix = true,
-        ref,
-        ...props
-    }: BaseTextInputProps,
-) {
+function BaseTextInput({
+    label = '',
+    /**
+     * To be able to function as either controlled or uncontrolled component we should not
+     * assign a default prop value for `value` or `defaultValue` props
+     */
+    value = undefined,
+    defaultValue = undefined,
+    placeholder = '',
+    errorText = '',
+    iconLeft = null,
+    icon = null,
+    textInputContainerStyles,
+    shouldApplyPaddingToContainer = true,
+    touchableInputWrapperStyle,
+    containerStyles,
+    inputStyle,
+    shouldUseFullInputHeight = false,
+    forceActiveLabel = false,
+    disableKeyboard = false,
+    autoGrow = false,
+    autoGrowExtraSpace = 0,
+    autoGrowMarginSide,
+    autoGrowHeight = false,
+    maxAutoGrowHeight,
+    hideFocusedState = false,
+    maxLength = undefined,
+    hint = '',
+    onInputChange = () => {},
+    multiline = false,
+    autoCorrect = true,
+    prefixCharacter = '',
+    suffixCharacter = '',
+    inputID,
+    type = 'default',
+    excludedMarkdownStyles = [],
+    shouldShowClearButton = false,
+    shouldHideClearButton = true,
+    prefixContainerStyle = [],
+    prefixStyle = [],
+    suffixContainerStyle = [],
+    suffixStyle = [],
+    contentWidth,
+    loadingSpinnerStyle,
+    uncontrolled,
+    placeholderTextColor,
+    onClearInput,
+    iconContainerStyle,
+    shouldUseDefaultLineHeightForPrefix = true,
+    ref,
+    ...props
+}: BaseTextInputProps) {
     const InputComponent = InputComponentMap.get(type) ?? RNTextInput;
     const isMarkdownEnabled = type === 'markdown';
     const isAutoGrowHeightMarkdown = isMarkdownEnabled && autoGrowHeight;
@@ -375,7 +373,7 @@ function BaseTextInput(
                                         ref.current = baseTextInputRef;
                                     }
 
-                                    const elementRef = element as AnimatedTextInputRef | AnimatedMarkdownTextInputRef | null
+                                    const elementRef = element as AnimatedTextInputRef | AnimatedMarkdownTextInputRef | null;
                                     input.current = elementRef;
                                 }}
                                 // eslint-disable-next-line

--- a/src/components/TextInput/BaseTextInput/implementation/index.native.tsx
+++ b/src/components/TextInput/BaseTextInput/implementation/index.native.tsx
@@ -1,6 +1,5 @@
 import {Str} from 'expensify-common';
-import type {ForwardedRef} from 'react';
-import React, {forwardRef, useCallback, useEffect, useRef, useState} from 'react';
+import React, {useCallback, useEffect, useRef, useState} from 'react';
 import type {GestureResponderEvent, LayoutChangeEvent, NativeSyntheticEvent, StyleProp, TextInput, TextInputFocusEventData, ViewStyle} from 'react-native';
 import {ActivityIndicator, StyleSheet, View} from 'react-native';
 import {Easing, useSharedValue, withTiming} from 'react-native-reanimated';
@@ -79,9 +78,9 @@ function BaseTextInput(
         onClearInput,
         iconContainerStyle,
         shouldUseDefaultLineHeightForPrefix = true,
+        ref,
         ...props
     }: BaseTextInputProps,
-    ref: ForwardedRef<BaseTextInputRef>,
 ) {
     const InputComponent = InputComponentMap.get(type) ?? RNTextInput;
     const isMarkdownEnabled = type === 'markdown';
@@ -367,7 +366,7 @@ function BaseTextInput(
                                 </View>
                             )}
                             <InputComponent
-                                ref={(element: AnimatedTextInputRef | AnimatedMarkdownTextInputRef | null): void => {
+                                ref={(element: HTMLFormElement | AnimatedTextInputRef | AnimatedMarkdownTextInputRef | null): void => {
                                     const baseTextInputRef = element as BaseTextInputRef | null;
                                     if (typeof ref === 'function') {
                                         ref(baseTextInputRef);
@@ -376,7 +375,8 @@ function BaseTextInput(
                                         ref.current = baseTextInputRef;
                                     }
 
-                                    input.current = element;
+                                    const elementRef = element as AnimatedTextInputRef | AnimatedMarkdownTextInputRef | null
+                                    input.current = elementRef;
                                 }}
                                 // eslint-disable-next-line
                                 {...inputProps}
@@ -513,4 +513,4 @@ function BaseTextInput(
 
 BaseTextInput.displayName = 'BaseTextInput';
 
-export default forwardRef(BaseTextInput);
+export default BaseTextInput;

--- a/src/components/TextInput/BaseTextInput/implementation/index.tsx
+++ b/src/components/TextInput/BaseTextInput/implementation/index.tsx
@@ -1,6 +1,6 @@
 import {Str} from 'expensify-common';
-import type {ForwardedRef, RefObject} from 'react';
-import React, {forwardRef, useCallback, useEffect, useRef, useState} from 'react';
+import type {RefObject} from 'react';
+import React, {useCallback, useEffect, useRef, useState} from 'react';
 import type {GestureResponderEvent, LayoutChangeEvent, NativeSyntheticEvent, StyleProp, TextInput, TextInputFocusEventData, ViewStyle} from 'react-native';
 import {ActivityIndicator, StyleSheet, View} from 'react-native';
 import {Easing, useSharedValue, withTiming} from 'react-native-reanimated';
@@ -81,9 +81,9 @@ function BaseTextInput(
         onClearInput,
         iconContainerStyle,
         shouldUseDefaultLineHeightForPrefix = true,
+        ref,
         ...inputProps
     }: BaseTextInputProps,
-    ref: ForwardedRef<BaseTextInputRef>,
 ) {
     const InputComponent = InputComponentMap.get(type) ?? RNTextInput;
     const isMarkdownEnabled = type === 'markdown';
@@ -376,7 +376,7 @@ function BaseTextInput(
                                 </View>
                             )}
                             <InputComponent
-                                ref={(element: AnimatedTextInputRef | AnimatedMarkdownTextInputRef | null): void => {
+                                ref={(element: HTMLFormElement | AnimatedTextInputRef | AnimatedMarkdownTextInputRef | null): void => {
                                     const baseTextInputRef = element as BaseTextInputRef | null;
                                     if (typeof ref === 'function') {
                                         ref(baseTextInputRef);
@@ -534,4 +534,4 @@ function BaseTextInput(
 
 BaseTextInput.displayName = 'BaseTextInput';
 
-export default forwardRef(BaseTextInput);
+export default BaseTextInput;

--- a/src/components/TextInput/BaseTextInput/implementation/index.tsx
+++ b/src/components/TextInput/BaseTextInput/implementation/index.tsx
@@ -32,59 +32,57 @@ import isInputAutoFilled from '@libs/isInputAutoFilled';
 import variables from '@styles/variables';
 import CONST from '@src/CONST';
 
-function BaseTextInput(
-    {
-        label = '',
-        /**
-         * To be able to function as either controlled or uncontrolled component we should not
-         * assign a default prop value for `value` or `defaultValue` props
-         */
-        value = undefined,
-        defaultValue = undefined,
-        placeholder = '',
-        errorText = '',
-        icon = null,
-        iconLeft = null,
-        textInputContainerStyles,
-        shouldApplyPaddingToContainer = true,
-        touchableInputWrapperStyle,
-        containerStyles,
-        inputStyle,
-        forceActiveLabel = false,
-        disableKeyboard = false,
-        autoGrow = false,
-        autoGrowHeight = false,
-        maxAutoGrowHeight,
-        hideFocusedState = false,
-        maxLength = undefined,
-        hint = '',
-        onInputChange = () => {},
-        multiline = false,
-        shouldInterceptSwipe = false,
-        autoCorrect = true,
-        prefixCharacter = '',
-        suffixCharacter = '',
-        inputID,
-        type = 'default',
-        excludedMarkdownStyles = [],
-        shouldShowClearButton = false,
-        shouldHideClearButton = true,
-        shouldUseDisabledStyles = true,
-        prefixContainerStyle = [],
-        prefixStyle = [],
-        suffixContainerStyle = [],
-        suffixStyle = [],
-        contentWidth,
-        loadingSpinnerStyle,
-        uncontrolled = false,
-        placeholderTextColor,
-        onClearInput,
-        iconContainerStyle,
-        shouldUseDefaultLineHeightForPrefix = true,
-        ref,
-        ...inputProps
-    }: BaseTextInputProps,
-) {
+function BaseTextInput({
+    label = '',
+    /**
+     * To be able to function as either controlled or uncontrolled component we should not
+     * assign a default prop value for `value` or `defaultValue` props
+     */
+    value = undefined,
+    defaultValue = undefined,
+    placeholder = '',
+    errorText = '',
+    icon = null,
+    iconLeft = null,
+    textInputContainerStyles,
+    shouldApplyPaddingToContainer = true,
+    touchableInputWrapperStyle,
+    containerStyles,
+    inputStyle,
+    forceActiveLabel = false,
+    disableKeyboard = false,
+    autoGrow = false,
+    autoGrowHeight = false,
+    maxAutoGrowHeight,
+    hideFocusedState = false,
+    maxLength = undefined,
+    hint = '',
+    onInputChange = () => {},
+    multiline = false,
+    shouldInterceptSwipe = false,
+    autoCorrect = true,
+    prefixCharacter = '',
+    suffixCharacter = '',
+    inputID,
+    type = 'default',
+    excludedMarkdownStyles = [],
+    shouldShowClearButton = false,
+    shouldHideClearButton = true,
+    shouldUseDisabledStyles = true,
+    prefixContainerStyle = [],
+    prefixStyle = [],
+    suffixContainerStyle = [],
+    suffixStyle = [],
+    contentWidth,
+    loadingSpinnerStyle,
+    uncontrolled = false,
+    placeholderTextColor,
+    onClearInput,
+    iconContainerStyle,
+    shouldUseDefaultLineHeightForPrefix = true,
+    ref,
+    ...inputProps
+}: BaseTextInputProps) {
     const InputComponent = InputComponentMap.get(type) ?? RNTextInput;
     const isMarkdownEnabled = type === 'markdown';
     const isAutoGrowHeightMarkdown = isMarkdownEnabled && autoGrowHeight;

--- a/src/components/TextInput/BaseTextInput/implementations.ts
+++ b/src/components/TextInput/BaseTextInput/implementations.ts
@@ -6,9 +6,9 @@ import type {BaseTextInputProps, InputType} from './types';
 type InputComponentType = React.ComponentType<BaseTextInputProps>;
 
 const InputComponentMap = new Map<InputType, InputComponentType>([
-    ['default', RNTextInput],
+    ['default', RNTextInput as InputComponentType],
     ['mask', RNMaskedTextInput as InputComponentType],
-    ['markdown', RNMarkdownTextInput],
+    ['markdown', RNMarkdownTextInput as InputComponentType],
 ]);
 
 export default InputComponentMap;

--- a/src/components/TextInput/BaseTextInput/index.e2e.tsx
+++ b/src/components/TextInput/BaseTextInput/index.e2e.tsx
@@ -1,10 +1,9 @@
-import type {ForwardedRef} from 'react';
-import React, {forwardRef, useEffect} from 'react';
+import React, {useEffect} from 'react';
 import {DeviceEventEmitter} from 'react-native';
 import BaseTextInput from './implementation';
-import type {BaseTextInputProps, BaseTextInputRef} from './types';
+import type {BaseTextInputProps} from './types';
 
-function BaseTextInputE2E(props: BaseTextInputProps, ref: ForwardedRef<BaseTextInputRef>) {
+function BaseTextInputE2E({ref, ...props}: BaseTextInputProps) {
     useEffect(() => {
         const testId = props.testID;
         if (!testId) {
@@ -24,4 +23,4 @@ function BaseTextInputE2E(props: BaseTextInputProps, ref: ForwardedRef<BaseTextI
     );
 }
 
-export default forwardRef(BaseTextInputE2E);
+export default BaseTextInputE2E;

--- a/src/components/TextInput/BaseTextInput/types.ts
+++ b/src/components/TextInput/BaseTextInput/types.ts
@@ -1,9 +1,9 @@
 import type {MarkdownRange, MarkdownStyle} from '@expensify/react-native-live-markdown';
+import type {ForwardedRef} from 'react';
 import type {GestureResponderEvent, StyleProp, TextInputProps, TextStyle, ViewStyle} from 'react-native';
 import type {MaskedTextInputOwnProps} from 'react-native-advanced-input-mask/lib/typescript/src/types';
 import type {AnimatedTextInputRef} from '@components/RNTextInput';
 import type IconAsset from '@src/types/utils/IconAsset';
-import type { ForwardedRef } from 'react';
 
 type InputType = 'markdown' | 'mask' | 'default';
 type CustomBaseTextInputProps = {
@@ -192,7 +192,7 @@ type CustomBaseTextInputProps = {
     shouldUseDefaultLineHeightForPrefix?: boolean;
 
     /** Reference to the outer element */
-    ref?: ForwardedRef<BaseTextInputRef>,
+    ref?: ForwardedRef<BaseTextInputRef>;
 };
 
 type BaseTextInputRef = HTMLFormElement | AnimatedTextInputRef;

--- a/src/components/TextInput/BaseTextInput/types.ts
+++ b/src/components/TextInput/BaseTextInput/types.ts
@@ -192,7 +192,7 @@ type CustomBaseTextInputProps = {
     shouldUseDefaultLineHeightForPrefix?: boolean;
 
     /** Reference to the outer element */
-    ref: ForwardedRef<BaseTextInputRef>,
+    ref?: ForwardedRef<BaseTextInputRef>,
 };
 
 type BaseTextInputRef = HTMLFormElement | AnimatedTextInputRef;

--- a/src/components/TextInput/BaseTextInput/types.ts
+++ b/src/components/TextInput/BaseTextInput/types.ts
@@ -3,6 +3,7 @@ import type {GestureResponderEvent, StyleProp, TextInputProps, TextStyle, ViewSt
 import type {MaskedTextInputOwnProps} from 'react-native-advanced-input-mask/lib/typescript/src/types';
 import type {AnimatedTextInputRef} from '@components/RNTextInput';
 import type IconAsset from '@src/types/utils/IconAsset';
+import type { ForwardedRef } from 'react';
 
 type InputType = 'markdown' | 'mask' | 'default';
 type CustomBaseTextInputProps = {
@@ -189,6 +190,9 @@ type CustomBaseTextInputProps = {
 
     /** Whether the input prefix should use the default `Text` line height fallback. Disable this if you intentionally want the prefix to have `lineHeight: undefined` */
     shouldUseDefaultLineHeightForPrefix?: boolean;
+
+    /** Reference to the outer element */
+    ref: ForwardedRef<BaseTextInputRef>,
 };
 
 type BaseTextInputRef = HTMLFormElement | AnimatedTextInputRef;

--- a/src/components/TextInput/index.native.tsx
+++ b/src/components/TextInput/index.native.tsx
@@ -1,11 +1,10 @@
-import type {ForwardedRef} from 'react';
-import React, {forwardRef, useEffect} from 'react';
+import React, {useEffect} from 'react';
 import {AppState, Keyboard} from 'react-native';
 import useThemeStyles from '@hooks/useThemeStyles';
 import BaseTextInput from './BaseTextInput';
-import type {BaseTextInputProps, BaseTextInputRef} from './BaseTextInput/types';
+import type {BaseTextInputProps} from './BaseTextInput/types';
 
-function TextInput(props: BaseTextInputProps, ref: ForwardedRef<BaseTextInputRef>) {
+function TextInput({ref, ...props}: BaseTextInputProps) {
     const styles = useThemeStyles();
 
     useEffect(() => {
@@ -42,4 +41,4 @@ function TextInput(props: BaseTextInputProps, ref: ForwardedRef<BaseTextInputRef
 
 TextInput.displayName = 'TextInput';
 
-export default forwardRef(TextInput);
+export default TextInput;

--- a/src/components/TextInput/index.tsx
+++ b/src/components/TextInput/index.tsx
@@ -1,7 +1,7 @@
 import React, {useEffect, useRef} from 'react';
 import type {StyleProp, ViewStyle} from 'react-native';
 import useThemeStyles from '@hooks/useThemeStyles';
-import * as Browser from '@libs/Browser';
+import {isMobileChrome} from '@libs/Browser';
 import DomUtils from '@libs/DomUtils';
 import Visibility from '@libs/Visibility';
 import BaseTextInput from './BaseTextInput';
@@ -26,7 +26,7 @@ function TextInput({ref, ...props}: BaseTextInputProps) {
         }
 
         removeVisibilityListener = Visibility.onVisibilityChange(() => {
-            if (!Browser.isMobileChrome() || !Visibility.isVisible() || !textInputRef.current || DomUtils.getActiveElement() !== textInputRef.current) {
+            if (!isMobileChrome() || !Visibility.isVisible() || !textInputRef.current || DomUtils.getActiveElement() !== textInputRef.current) {
                 return;
             }
             textInputRef.current.blur();

--- a/src/components/TextInput/index.tsx
+++ b/src/components/TextInput/index.tsx
@@ -1,4 +1,3 @@
-import type {ForwardedRef} from 'react';
 import React, {useEffect, useRef} from 'react';
 import type {StyleProp, ViewStyle} from 'react-native';
 import useThemeStyles from '@hooks/useThemeStyles';
@@ -6,12 +5,12 @@ import * as Browser from '@libs/Browser';
 import DomUtils from '@libs/DomUtils';
 import Visibility from '@libs/Visibility';
 import BaseTextInput from './BaseTextInput';
-import type {BaseTextInputProps, BaseTextInputRef} from './BaseTextInput/types';
+import type {BaseTextInputProps} from './BaseTextInput/types';
 import * as styleConst from './styleConst';
 
 type RemoveVisibilityListener = () => void;
 
-function TextInput(props: BaseTextInputProps, ref: ForwardedRef<BaseTextInputRef>) {
+function TextInput({ref, ...props}: BaseTextInputProps) {
     const styles = useThemeStyles();
     const textInputRef = useRef<HTMLFormElement | null>(null);
     const removeVisibilityListenerRef = useRef<RemoveVisibilityListener>(null);
@@ -80,4 +79,4 @@ function TextInput(props: BaseTextInputProps, ref: ForwardedRef<BaseTextInputRef
 
 TextInput.displayName = 'TextInput';
 
-export default React.forwardRef(TextInput);
+export default TextInput;

--- a/src/components/TextInputWithSymbol/BaseTextInputWithSymbol.tsx
+++ b/src/components/TextInputWithSymbol/BaseTextInputWithSymbol.tsx
@@ -8,25 +8,23 @@ import {addLeadingZero, replaceAllDigits} from '@libs/MoneyRequestUtils';
 import CONST from '@src/CONST';
 import type BaseTextInputWithSymbolProps from './types';
 
-function BaseTextInputWithSymbol(
-    {
-        symbol,
-        symbolPosition = CONST.TEXT_INPUT_SYMBOL_POSITION.PREFIX,
-        onSymbolButtonPress = () => {},
-        onChangeAmount = () => {},
-        formattedAmount,
-        placeholder,
-        selection,
-        onSelectionChange = () => {},
-        onKeyPress = () => {},
-        isSymbolPressable = true,
-        hideSymbol = false,
-        style,
-        symbolTextStyle,
-        ref,
-        ...rest
-    }: BaseTextInputWithSymbolProps,
-) {
+function BaseTextInputWithSymbol({
+    symbol,
+    symbolPosition = CONST.TEXT_INPUT_SYMBOL_POSITION.PREFIX,
+    onSymbolButtonPress = () => {},
+    onChangeAmount = () => {},
+    formattedAmount,
+    placeholder,
+    selection,
+    onSelectionChange = () => {},
+    onKeyPress = () => {},
+    isSymbolPressable = true,
+    hideSymbol = false,
+    style,
+    symbolTextStyle,
+    ref,
+    ...rest
+}: BaseTextInputWithSymbolProps) {
     const {fromLocaleDigit} = useLocalize();
     const styles = useThemeStyles();
 

--- a/src/components/TextInputWithSymbol/BaseTextInputWithSymbol.tsx
+++ b/src/components/TextInputWithSymbol/BaseTextInputWithSymbol.tsx
@@ -5,7 +5,6 @@ import SymbolButton from '@components/SymbolButton';
 import useLocalize from '@hooks/useLocalize';
 import useThemeStyles from '@hooks/useThemeStyles';
 import {addLeadingZero, replaceAllDigits} from '@libs/MoneyRequestUtils';
-import type {BaseTextInputRef} from '@src/components/TextInput/BaseTextInput/types';
 import CONST from '@src/CONST';
 import type BaseTextInputWithSymbolProps from './types';
 
@@ -24,9 +23,9 @@ function BaseTextInputWithSymbol(
         hideSymbol = false,
         style,
         symbolTextStyle,
+        ref,
         ...rest
     }: BaseTextInputWithSymbolProps,
-    ref: React.ForwardedRef<BaseTextInputRef>,
 ) {
     const {fromLocaleDigit} = useLocalize();
     const styles = useThemeStyles();
@@ -79,4 +78,4 @@ function BaseTextInputWithSymbol(
 
 BaseTextInputWithSymbol.displayName = 'BaseTextInputWithSymbol';
 
-export default React.forwardRef(BaseTextInputWithSymbol);
+export default BaseTextInputWithSymbol;

--- a/src/components/TextInputWithSymbol/index.android.tsx
+++ b/src/components/TextInputWithSymbol/index.android.tsx
@@ -1,10 +1,9 @@
 import React, {useEffect, useState} from 'react';
 import type {NativeSyntheticEvent, TextInputSelectionChangeEventData} from 'react-native';
-import type {BaseTextInputRef} from '@src/components/TextInput/BaseTextInput/types';
 import BaseTextInputWithSymbol from './BaseTextInputWithSymbol';
 import type {TextInputWithSymbolProps} from './types';
 
-function TextInputWithSymbol({onSelectionChange = () => {}, ...props}: TextInputWithSymbolProps, ref: React.ForwardedRef<BaseTextInputRef>) {
+function TextInputWithSymbol({onSelectionChange = () => {}, ref, ...props}: TextInputWithSymbolProps) {
     const [skipNextSelectionChange, setSkipNextSelectionChange] = useState(false);
 
     useEffect(() => {
@@ -29,4 +28,4 @@ function TextInputWithSymbol({onSelectionChange = () => {}, ...props}: TextInput
 
 TextInputWithSymbol.displayName = 'TextInputWithSymbol';
 
-export default React.forwardRef(TextInputWithSymbol);
+export default TextInputWithSymbol;

--- a/src/components/TextInputWithSymbol/index.tsx
+++ b/src/components/TextInputWithSymbol/index.tsx
@@ -1,10 +1,9 @@
 import React from 'react';
 import type {NativeSyntheticEvent, TextInputSelectionChangeEventData} from 'react-native';
-import type {BaseTextInputRef} from '@src/components/TextInput/BaseTextInput/types';
 import BaseTextInputWithSymbol from './BaseTextInputWithSymbol';
 import type {TextInputWithSymbolProps} from './types';
 
-function TextInputWithSymbol({onSelectionChange = () => {}, ...props}: TextInputWithSymbolProps, ref: React.ForwardedRef<BaseTextInputRef>) {
+function TextInputWithSymbol({onSelectionChange = () => {}, ref, ...props}: TextInputWithSymbolProps) {
     return (
         <BaseTextInputWithSymbol
             // eslint-disable-next-line react/jsx-props-no-spreading
@@ -19,4 +18,4 @@ function TextInputWithSymbol({onSelectionChange = () => {}, ...props}: TextInput
 
 TextInputWithSymbol.displayName = 'TextInputWithSymbol';
 
-export default React.forwardRef(TextInputWithSymbol);
+export default TextInputWithSymbol;

--- a/src/components/TextInputWithSymbol/index.web.tsx
+++ b/src/components/TextInputWithSymbol/index.web.tsx
@@ -3,7 +3,7 @@ import type {NativeSyntheticEvent, TextInputSelectionChangeEventData} from 'reac
 import BaseTextInputWithSymbol from './BaseTextInputWithSymbol';
 import type {TextInputWithSymbolProps} from './types';
 
-function TextInputWithSymbol({onSelectionChange = () => {}, ...props}: TextInputWithSymbolProps, ref: React.ForwardedRef<HTMLFormElement>) {
+function TextInputWithSymbol({onSelectionChange = () => {}, ref, ...props}: TextInputWithSymbolProps) {
     const textInputRef = useRef<HTMLFormElement | null>(null);
 
     return (
@@ -39,4 +39,4 @@ function TextInputWithSymbol({onSelectionChange = () => {}, ...props}: TextInput
 
 TextInputWithSymbol.displayName = 'TextInputWithSymbol';
 
-export default React.forwardRef(TextInputWithSymbol);
+export default TextInputWithSymbol;

--- a/src/components/TextInputWithSymbol/types.ts
+++ b/src/components/TextInputWithSymbol/types.ts
@@ -88,7 +88,7 @@ type BaseTextInputWithSymbolProps = {
 
     /** The test ID of TextInput. Used to locate the view in end-to-end tests. */
     testID?: string;
-} & Pick<BaseTextInputProps, 'autoFocus' | 'autoGrow' | 'autoGrowExtraSpace' | 'autoGrowMarginSide' | 'contentWidth' | 'onPress' | 'submitBehavior' | 'shouldUseDefaultLineHeightForPrefix'>;
+} & Pick<BaseTextInputProps, 'autoFocus' | 'autoGrow' | 'autoGrowExtraSpace' | 'autoGrowMarginSide' | 'contentWidth' | 'onPress' | 'submitBehavior' | 'shouldUseDefaultLineHeightForPrefix' | 'ref'>;
 
 type TextInputWithSymbolProps = Omit<BaseTextInputWithSymbolProps, 'onSelectionChange'> & {
     onSelectionChange?: (start: number, end: number) => void;

--- a/src/components/TextInputWithSymbol/types.ts
+++ b/src/components/TextInputWithSymbol/types.ts
@@ -88,7 +88,10 @@ type BaseTextInputWithSymbolProps = {
 
     /** The test ID of TextInput. Used to locate the view in end-to-end tests. */
     testID?: string;
-} & Pick<BaseTextInputProps, 'autoFocus' | 'autoGrow' | 'autoGrowExtraSpace' | 'autoGrowMarginSide' | 'contentWidth' | 'onPress' | 'submitBehavior' | 'shouldUseDefaultLineHeightForPrefix' | 'ref'>;
+} & Pick<
+    BaseTextInputProps,
+    'autoFocus' | 'autoGrow' | 'autoGrowExtraSpace' | 'autoGrowMarginSide' | 'contentWidth' | 'onPress' | 'submitBehavior' | 'shouldUseDefaultLineHeightForPrefix' | 'ref'
+>;
 
 type TextInputWithSymbolProps = Omit<BaseTextInputWithSymbolProps, 'onSelectionChange'> & {
     onSelectionChange?: (start: number, end: number) => void;

--- a/src/components/TextPicker/types.ts
+++ b/src/components/TextPicker/types.ts
@@ -28,7 +28,7 @@ type TextSelectorModalProps = {
     /** Whether the field is required */
     required?: boolean;
 } & Pick<MenuItemBaseProps, 'subtitle' | 'description'> &
-    TextProps;
+    Omit<TextProps, 'ref'>;
 
 type TextPickerProps = {
     /** Item to display */

--- a/src/pages/PrivateNotes/PrivateNotesEditPage.tsx
+++ b/src/pages/PrivateNotes/PrivateNotesEditPage.tsx
@@ -167,7 +167,7 @@ function PrivateNotesEditPage({route, report, accountID}: PrivateNotesEditPagePr
                             debouncedSavePrivateNote(text);
                             setPrivateNote(text);
                         }}
-                        ref={(el: AnimatedTextInputRef) => {
+                        ref={(el: AnimatedTextInputRef | null) => {
                             if (!el) {
                                 return;
                             }

--- a/src/pages/PrivateNotes/PrivateNotesEditPage.tsx
+++ b/src/pages/PrivateNotes/PrivateNotesEditPage.tsx
@@ -43,7 +43,7 @@ function PrivateNotesEditPage({route, report, accountID}: PrivateNotesEditPagePr
     const backTo = route.params.backTo;
     const styles = useThemeStyles();
     const {translate} = useLocalize();
-    const [personalDetailsList] = useOnyx(ONYXKEYS.PERSONAL_DETAILS_LIST);
+    const [personalDetailsList] = useOnyx(ONYXKEYS.PERSONAL_DETAILS_LIST, {canBeMissing: false});
 
     // We need to edit the note in markdown format, but display it in HTML format
     const [privateNote, setPrivateNote] = useState(

--- a/src/pages/iou/MoneyRequestAmountForm.tsx
+++ b/src/pages/iou/MoneyRequestAmountForm.tsx
@@ -58,25 +58,23 @@ const isTaxAmountInvalid = (currentAmount: string, taxAmount: number, isTaxAmoun
 /**
  * Wrapper around MoneyRequestAmountInput with money request flow-specific logics.
  */
-function MoneyRequestAmountForm(
-    {
-        amount = 0,
-        taxAmount = 0,
-        currency = CONST.CURRENCY.USD,
-        isCurrencyPressable = true,
-        isEditing = false,
-        skipConfirmation = false,
-        iouType = CONST.IOU.TYPE.SUBMIT,
-        policyID = '',
-        onCurrencyButtonPress,
-        onSubmitButtonPress,
-        selectedTab = CONST.TAB_REQUEST.MANUAL,
-        shouldKeepUserInput = false,
-        chatReportID,
-        hideCurrencySymbol = false,
-        forwardedRef,
-    }: MoneyRequestAmountFormProps,
-) {
+function MoneyRequestAmountForm({
+    amount = 0,
+    taxAmount = 0,
+    currency = CONST.CURRENCY.USD,
+    isCurrencyPressable = true,
+    isEditing = false,
+    skipConfirmation = false,
+    iouType = CONST.IOU.TYPE.SUBMIT,
+    policyID = '',
+    onCurrencyButtonPress,
+    onSubmitButtonPress,
+    selectedTab = CONST.TAB_REQUEST.MANUAL,
+    shouldKeepUserInput = false,
+    chatReportID,
+    hideCurrencySymbol = false,
+    forwardedRef,
+}: MoneyRequestAmountFormProps) {
     const styles = useThemeStyles();
     const {isExtraSmallScreenHeight} = useResponsiveLayout();
     const {translate} = useLocalize();

--- a/src/pages/iou/MoneyRequestAmountForm.tsx
+++ b/src/pages/iou/MoneyRequestAmountForm.tsx
@@ -1,4 +1,3 @@
-import type {ForwardedRef} from 'react';
 import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import {View} from 'react-native';
 import type {ValueOf} from 'type-fest';
@@ -75,8 +74,8 @@ function MoneyRequestAmountForm(
         shouldKeepUserInput = false,
         chatReportID,
         hideCurrencySymbol = false,
+        forwardedRef,
     }: MoneyRequestAmountFormProps,
-    forwardedRef: ForwardedRef<BaseTextInputRef>,
 ) {
     const styles = useThemeStyles();
     const {isExtraSmallScreenHeight} = useResponsiveLayout();
@@ -220,11 +219,11 @@ function MoneyRequestAmountForm(
                     setFormError('');
                 }}
                 shouldShowBigNumberPad={canUseTouchScreen}
-                ref={(ref) => {
+                forwardedRef={(ref) => {
                     if (typeof forwardedRef === 'function') {
                         forwardedRef(ref);
                     } else if (forwardedRef && 'current' in forwardedRef) {
-                        // eslint-disable-next-line no-param-reassign
+                        // eslint-disable-next-line no-param-reassign, react-compiler/react-compiler
                         forwardedRef.current = ref;
                     }
                     textInput.current = ref;
@@ -244,5 +243,5 @@ function MoneyRequestAmountForm(
 
 MoneyRequestAmountForm.displayName = 'MoneyRequestAmountForm';
 
-export default React.forwardRef(MoneyRequestAmountForm);
+export default MoneyRequestAmountForm;
 export type {CurrentMoney, MoneyRequestAmountFormProps};

--- a/src/pages/iou/request/step/IOURequestStepAmount.tsx
+++ b/src/pages/iou/request/step/IOURequestStepAmount.tsx
@@ -332,7 +332,7 @@ function IOURequestStepAmount({
                 skipConfirmation={shouldSkipConfirmation ?? false}
                 iouType={iouType}
                 policyID={policy?.id}
-                ref={(e) => {
+                forwardedRef={(e) => {
                     textInput.current = e;
                 }}
                 shouldKeepUserInput={transaction?.shouldShowOriginalAmount}

--- a/src/pages/iou/request/step/IOURequestStepTaxAmountPage.tsx
+++ b/src/pages/iou/request/step/IOURequestStepTaxAmountPage.tsx
@@ -152,7 +152,7 @@ function IOURequestStepTaxAmountPage({
                 currency={currency}
                 amount={Math.abs(transactionDetails?.taxAmount ?? 0)}
                 taxAmount={getTaxAmount(currentTransaction, policy, currency, !!(backTo || isEditing))}
-                ref={(e) => {
+                forwardedRef={(e) => {
                     textInput.current = e;
                 }}
                 onCurrencyButtonPress={navigateToCurrencySelectionPage}

--- a/src/pages/settings/Profile/CustomStatus/StatusPage.tsx
+++ b/src/pages/settings/Profile/CustomStatus/StatusPage.tsx
@@ -193,7 +193,7 @@ function StatusPage() {
             <FormProvider
                 formID={ONYXKEYS.FORMS.SETTINGS_STATUS_SET_FORM}
                 style={[styles.flexGrow1, styles.flex1]}
-                ref={formRef}
+                forwardedRef={formRef}
                 submitButtonText={translate('statusPage.save')}
                 submitButtonStyles={[styles.mh5, styles.flexGrow1]}
                 onSubmit={updateStatus}

--- a/src/pages/settings/Security/MergeAccounts/AccountDetailsPage.tsx
+++ b/src/pages/settings/Security/MergeAccounts/AccountDetailsPage.tsx
@@ -178,7 +178,7 @@ function AccountDetailsPage() {
                     validate={validate}
                     submitButtonText={translate('common.next')}
                     isSubmitButtonVisible={false}
-                    ref={formRef}
+                    forwardedRef={formRef}
                 >
                     <View style={[styles.flexGrow1, styles.mt3]}>
                         <View>

--- a/src/pages/settings/Wallet/InternationalDepositAccount/substeps/AccountType.tsx
+++ b/src/pages/settings/Wallet/InternationalDepositAccount/substeps/AccountType.tsx
@@ -56,7 +56,7 @@ function AccountType({isEditing, onNext, fieldsMap}: CustomSubStepProps) {
             style={[styles.flexGrow1, styles.mt3]}
             submitButtonStyles={[styles.ph5, styles.mb0]}
             enabledWhenOffline
-            ref={formRef}
+            forwardedRef={formRef}
             isSubmitButtonVisible={!isEditing}
         >
             <View style={styles.ph5}>

--- a/src/pages/workspace/reports/CreateReportFieldsPage.tsx
+++ b/src/pages/workspace/reports/CreateReportFieldsPage.tsx
@@ -122,7 +122,7 @@ function WorkspaceCreateReportFieldsPage({
                     onBackButtonPress={Navigation.goBack}
                 />
                 <FormProvider
-                    ref={formRef}
+                    forwardedRef={formRef}
                     style={[styles.mh5, styles.flex1]}
                     formID={ONYXKEYS.FORMS.WORKSPACE_REPORT_FIELDS_FORM}
                     onSubmit={submitForm}


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
<!-- Explain what your change does and how it addresses the linked issue -->

The whole issue comes from `forwardRef` being deprecated in the near future of react thus we will no longer be able to access the passed `ref` by `element.ref` as `forwardRef` is needed for passing `ref` as a separate attribute. Now in order to pass there reference it has to be passed as one of the `props` so we can access it directly or like that -> `element.props.ref`.

In order to adjust the codebase to new react recommendations in every file that was using `forwardRef` the ref had to be moved to the `props` instead of being a separate attribute and `forwardRef` had to be completely removed. 

Some files had to be changed due to the changes made in other components. In response to the number of files that needed adjusting the changes are made in batches with this one being `the fourth one`. 

In this batch I mostly took care of `Create Manual Expense` flow. At first it was part of one PR which was supposed to cover whole `create expense` flow but it grew too big. This batch touches plenty of components responsible for handling input from user.

**`Manual money request` ->**

<img width="300" alt="image" src="https://github.com/user-attachments/assets/6876117d-662b-4b78-806b-228fc6eecdb4" />

1. src/pages/iou/MoneyRequestAmountForm.tsx

<img width="300" alt="image" src="https://github.com/user-attachments/assets/6fe8b78a-e723-46cb-93c1-affee05760b5" />

2. src/components/MoneyRequestAmountInput.tsx

<img width="300" alt="image" src="https://github.com/user-attachments/assets/482bb197-0175-4e82-ad16-d244c41a72cf" />

3. src/components/NumberWithSymbolForm.tsx

<img width="300" alt="image" src="https://github.com/user-attachments/assets/33f8c751-ee6f-4b3f-b092-7904ccb9b3fd" />

4. src/components/TextInputWithSymbol/BaseTextInputWithSymbol.tsx
5. src/components/TextInputWithSymbol/index.android.tsx
6. src/components/TextInputWithSymbol/index.tsx
7. src/components/TextInputWithSymbol/index.web.tsx
8. src/components/TextInputWithSymbol/types.ts

<img width="300" alt="image" src="https://github.com/user-attachments/assets/9ff5c27e-cc7c-47f2-913a-0fb5b99fa6de" />

9. src/components/AmountTextInput.tsx

<img width="300" alt="image" src="https://github.com/user-attachments/assets/142bb897-8065-45e7-be1d-aba702e23fa2" />

10. src/components/TextInput/BaseTextInput/implementation/index.native.tsx
11. src/components/TextInput/BaseTextInput/implementation/index.tsx
12. src/components/TextInput/BaseTextInput/index.e2e.tsx
13. src/components/TextInput/BaseTextInput/types.ts
14. src/components/TextInput/index.native.tsx
15. src/components/TextInput/index.tsx

<img width="300" alt="image" src="https://github.com/user-attachments/assets/0d88b623-211b-4665-b731-d008cc9bde5e" />

16. src/components/RNTextInput.tsx
17. src/components/RNMarkdownTextInput.tsx
18. src/components/RNMaskedTextInput.tsx

**Those required change in order for certain inputs using them to work without `forwardRef` ->**

19. src/components/AmountForm.tsx
20. src/components/Form/FormProvider.tsx

**These here had to be changed in response to the changes made in other files. They required only `cosmetic changes` which cannot produce any issues and thus they require no testing ->**

21. src/components/AmountPicker/AmountSelectorModal.tsx
22. src/components/Composer/implementation/index.native.tsx
23. src/components/PercentageForm.tsx
24. src/components/SubStepForms/AddressStep.tsx
25. src/components/TextPicker/types.ts
26. src/components/TextInput/BaseTextInput/implementations.ts
27. src/pages/PrivateNotes/PrivateNotesEditPage.tsx
28. src/pages/iou/request/step/IOURequestStepAmount.tsx
29. src/pages/iou/request/step/IOURequestStepTaxAmountPage.tsx
30. src/pages/settings/Profile/CustomStatus/StatusPage.tsx
31. src/pages/settings/Security/MergeAccounts/AccountDetailsPage.tsx
32. src/pages/settings/Wallet/InternationalDepositAccount/substeps/AccountType.tsx
33. src/pages/workspace/reports/CreateReportFieldsPage.tsx

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/67033
PROPOSAL:


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

1. When you have your app on, open DevTools console
2. Throughout this whole flow look out in console for any new errors while inputing the amount or while writing in 1:1 chat
3. Click on the floating "+" button in the navigation bar on the left or in the 1:1 chat.
4. Press "Create Expense"
5. When the sidePanel on the right opens choose "Manual"
6. Change the currency
7. Input the amount
8. Verify that the input works
9. Press "Next" button
10. Press "Create X amount expense" button
11. Go to 1:1 chat
12. Input any message
13. Verify that input works
14. Send message

- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

SAME AS TESTS ^

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->
// TODO: These must be filled out, or the issue title must include "[No QA]."

SAME AS TESTS ^

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I verified there are no new alerts related to the `canBeMissing` param for `useOnyx`
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

https://github.com/user-attachments/assets/424db642-c9e1-4b11-b1e7-34bd1dfd03cb

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Desktop</summary>

<!-- add screenshots or videos here -->

</details>
