### PR TITLE
Revert "[No QA] Bump `react-native-screens` to 4.12.0 to fix memory leak"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -122,7 +122,7 @@
         "react-native-release-profiler": "^0.2.1",
         "react-native-render-html": "6.3.1",
         "react-native-safe-area-context": "5.4.0",
-        "react-native-screens": "4.12.0",
+        "react-native-screens": "4.11.1",
         "react-native-share": "11.0.2",
         "react-native-sound": "^0.11.2",
         "react-native-svg": "15.9.0",
@@ -21803,6 +21803,13 @@
         "undici-types": "~6.21.0"
       }
     },
+    "node_modules/electron/node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/emittery": {
       "version": "0.13.1",
       "dev": true,
@@ -35061,9 +35068,9 @@
       }
     },
     "node_modules/react-native-screens": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/react-native-screens/-/react-native-screens-4.12.0.tgz",
-      "integrity": "sha512-T2KL6RcDSYDRZswh9glRe600Hvaeq240U21eaqv0uxCNmJz05UeFc4YGQgbFPI8XsakPKx3HjNonItxElFy+QA==",
+      "version": "4.11.1",
+      "resolved": "https://registry.npmjs.org/react-native-screens/-/react-native-screens-4.11.1.tgz",
+      "integrity": "sha512-F0zOzRVa3ptZfLpD0J8ROdo+y1fEPw+VBFq1MTY/iyDu08al7qFUO5hLMd+EYMda5VXGaTFCa8q7bOppUszhJw==",
       "license": "MIT",
       "dependencies": {
         "react-freeze": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -192,7 +192,7 @@
     "react-native-release-profiler": "^0.2.1",
     "react-native-render-html": "6.3.1",
     "react-native-safe-area-context": "5.4.0",
-    "react-native-screens": "4.12.0",
+    "react-native-screens": "4.11.1",
     "react-native-share": "11.0.2",
     "react-native-sound": "^0.11.2",
     "react-native-svg": "15.9.0",


### PR DESCRIPTION
Reverts Expensify/App#68858 because it created workflow blockers: https://expensify.slack.com/archives/C01GTK53T8Q/p1755792682893759