### PR TITLE
[CP Staging] Revert "Fix - Strike through is not applied for quote markdown text"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@expensify/nitro-utils": "file:./modules/ExpensifyNitroUtils",
         "@expensify/react-native-background-task": "file:./modules/background-task",
         "@expensify/react-native-hybrid-app": "file:./modules/hybrid-app",
-        "@expensify/react-native-live-markdown": "0.1.301",
+        "@expensify/react-native-live-markdown": "0.1.299",
         "@expensify/react-native-wallet": "^0.1.5",
         "@expo/metro-runtime": "^5.0.4",
         "@firebase/app": "^0.13.2",
@@ -3822,9 +3822,9 @@
       "link": true
     },
     "node_modules/@expensify/react-native-live-markdown": {
-      "version": "0.1.301",
-      "resolved": "https://registry.npmjs.org/@expensify/react-native-live-markdown/-/react-native-live-markdown-0.1.301.tgz",
-      "integrity": "sha512-nMZrHgxzivseXaEstMbC5vIuvPONEbDKuHf0FNvyOgPuWAXNtJQOVGem+Tnv+ugbEQgnh3A/oKnGg0LeSlB7qQ==",
+      "version": "0.1.299",
+      "resolved": "https://registry.npmjs.org/@expensify/react-native-live-markdown/-/react-native-live-markdown-0.1.299.tgz",
+      "integrity": "sha512-kqbNG726Xtk3V2TFll1rxJSRdAQUZ2Ret3bEYopEm49fcy5FLCQZ76MVm5yg6dbpnYnqRukQ+aIut1lEXzoMiw==",
       "license": "MIT",
       "workspaces": [
         "./example",
@@ -3834,7 +3834,7 @@
         "node": ">= 18.0.0"
       },
       "peerDependencies": {
-        "expensify-common": ">=2.0.148",
+        "expensify-common": ">=2.0.115",
         "react": "*",
         "react-native": "*",
         "react-native-reanimated": ">=3.17.0"

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "@expensify/nitro-utils": "file:./modules/ExpensifyNitroUtils",
     "@expensify/react-native-background-task": "file:./modules/background-task",
     "@expensify/react-native-hybrid-app": "file:./modules/hybrid-app",
-    "@expensify/react-native-live-markdown": "0.1.301",
+    "@expensify/react-native-live-markdown": "0.1.299",
     "@expensify/react-native-wallet": "^0.1.5",
     "@expo/metro-runtime": "^5.0.4",
     "@firebase/app": "^0.13.2",


### PR DESCRIPTION
Reverts Expensify/App#68850

Fixes https://github.com/Expensify/App/issues/69048

I am seeing bunch of issues - no placeholder for the text input https://github.com/Expensify/App/pull/68850#issuecomment-3215371764

confirming the missing composer placeholder was present on the bump PR 
<img width="608" height="152" alt="image" src="https://github.com/user-attachments/assets/4ac25a5c-c642-404b-bf68-3311920fb53d" />
