### PR TITLE
fix: Tags setting - Members must tag all expenses toggle is misaligned in some languages.

### DIFF
--- a/src/components/ImportSpreadsheetColumns.tsx
+++ b/src/components/ImportSpreadsheetColumns.tsx
@@ -80,8 +80,7 @@ function ImportSpreadsheetColumns({
                     </Text>
                     {shouldShowColumnHeader && (
                         <View style={[styles.mt7, styles.flexRow, styles.justifyContentBetween, styles.alignItemsCenter]}>
-                            <Text>{translate('spreadsheet.fileContainsHeader')}</Text>
-
+                            <Text style={styles.flex1}>{translate('spreadsheet.fileContainsHeader')}</Text>
                             <Switch
                                 accessibilityLabel={translate('spreadsheet.fileContainsHeader')}
                                 isOn={containsHeader}

--- a/src/components/ImportSpreadsheetColumns.tsx
+++ b/src/components/ImportSpreadsheetColumns.tsx
@@ -80,7 +80,7 @@ function ImportSpreadsheetColumns({
                     </Text>
                     {shouldShowColumnHeader && (
                         <View style={[styles.mt7, styles.flexRow, styles.justifyContentBetween, styles.alignItemsCenter]}>
-                            <Text style={styles.flex1}>{translate('spreadsheet.fileContainsHeader')}</Text>
+                            <Text style={[styles.flex1, styles.mr2]}>{translate('spreadsheet.fileContainsHeader')}</Text>
                             <Switch
                                 accessibilityLabel={translate('spreadsheet.fileContainsHeader')}
                                 isOn={containsHeader}

--- a/src/pages/workspace/rules/RulesProhibitedDefaultPage.tsx
+++ b/src/pages/workspace/rules/RulesProhibitedDefaultPage.tsx
@@ -55,7 +55,7 @@ function RulesProhibitedDefaultPage({
                             key={translate(`workspace.rules.individualExpenseRules.${prohibitedExpense}`)}
                         >
                             <View style={[styles.flexRow, styles.alignItemsCenter, styles.justifyContentBetween, styles.mt3, styles.mh5, styles.mb5]}>
-                                <Text>{translate(`workspace.rules.individualExpenseRules.${prohibitedExpense}`)}</Text>
+                                <Text style={styles.flex1}>{translate(`workspace.rules.individualExpenseRules.${prohibitedExpense}`)}</Text>
                                 <Switch
                                     isOn={policy?.prohibitedExpenses?.[prohibitedExpense] ?? false}
                                     accessibilityLabel={translate(`workspace.rules.individualExpenseRules.${prohibitedExpense}`)}

--- a/src/pages/workspace/rules/RulesProhibitedDefaultPage.tsx
+++ b/src/pages/workspace/rules/RulesProhibitedDefaultPage.tsx
@@ -55,7 +55,7 @@ function RulesProhibitedDefaultPage({
                             key={translate(`workspace.rules.individualExpenseRules.${prohibitedExpense}`)}
                         >
                             <View style={[styles.flexRow, styles.alignItemsCenter, styles.justifyContentBetween, styles.mt3, styles.mh5, styles.mb5]}>
-                                <Text style={styles.flex1}>{translate(`workspace.rules.individualExpenseRules.${prohibitedExpense}`)}</Text>
+                                <Text style={[styles.flex1, styles.mr2]}>{translate(`workspace.rules.individualExpenseRules.${prohibitedExpense}`)}</Text>
                                 <Switch
                                     isOn={policy?.prohibitedExpenses?.[prohibitedExpense] ?? false}
                                     accessibilityLabel={translate(`workspace.rules.individualExpenseRules.${prohibitedExpense}`)}

--- a/src/pages/workspace/tags/ImportMultiLevelTagsSettingsPage.tsx
+++ b/src/pages/workspace/tags/ImportMultiLevelTagsSettingsPage.tsx
@@ -92,7 +92,7 @@ function ImportMultiLevelTagsSettingsPage({route}: ImportMultiLevelTagsSettingsP
                     <Text style={[styles.textSupporting, styles.textNormal, styles.ph5]}>{translate('workspace.tags.configureMultiLevelTags')}</Text>
 
                     <View style={[styles.flexRow, styles.mh5, styles.mv4, styles.alignItemsCenter, styles.justifyContentBetween]}>
-                        <Text style={[styles.textNormal]}>{translate('workspace.tags.importMultiLevelTags.firstRowTitle')}</Text>
+                        <Text style={[styles.textNormal, styles.flex1]}>{translate('workspace.tags.importMultiLevelTags.firstRowTitle')}</Text>
                         <Switch
                             isOn={spreadsheet?.containsHeader ?? true}
                             accessibilityLabel={translate('workspace.tags.importMultiLevelTags.firstRowTitle')}
@@ -103,7 +103,7 @@ function ImportMultiLevelTagsSettingsPage({route}: ImportMultiLevelTagsSettingsP
                     </View>
 
                     <View style={[styles.flexRow, styles.mh5, styles.mv4, styles.alignItemsCenter, styles.justifyContentBetween]}>
-                        <Text style={[styles.textNormal]}>{translate('workspace.tags.importMultiLevelTags.independentTags')}</Text>
+                        <Text style={[styles.textNormal, styles.flex1]}>{translate('workspace.tags.importMultiLevelTags.independentTags')}</Text>
                         <Switch
                             isOn={spreadsheet?.isImportingIndependentMultiLevelTags ?? true}
                             accessibilityLabel={translate('workspace.tags.importMultiLevelTags.independentTags')}
@@ -114,7 +114,7 @@ function ImportMultiLevelTagsSettingsPage({route}: ImportMultiLevelTagsSettingsP
                     </View>
 
                     <View style={[styles.flexRow, styles.mh5, styles.mv4, styles.alignItemsCenter, styles.justifyContentBetween]}>
-                        <Text style={[styles.textNormal]}>{translate('workspace.tags.importMultiLevelTags.glAdjacentColumn')}</Text>
+                        <Text style={[styles.textNormal, styles.flex1]}>{translate('workspace.tags.importMultiLevelTags.glAdjacentColumn')}</Text>
                         <Switch
                             isOn={spreadsheet?.isGLAdjacent ?? false}
                             accessibilityLabel={translate('workspace.tags.importMultiLevelTags.glAdjacentColumn')}

--- a/src/pages/workspace/tags/ImportMultiLevelTagsSettingsPage.tsx
+++ b/src/pages/workspace/tags/ImportMultiLevelTagsSettingsPage.tsx
@@ -103,7 +103,7 @@ function ImportMultiLevelTagsSettingsPage({route}: ImportMultiLevelTagsSettingsP
                     </View>
 
                     <View style={[styles.flexRow, styles.mh5, styles.mv4, styles.alignItemsCenter, styles.justifyContentBetween]}>
-                        <Text style={[styles.textNormal, styles.flex1]}>{translate('workspace.tags.importMultiLevelTags.independentTags')}</Text>
+                        <Text style={[styles.textNormal, styles.flex1, styles.mr2]}>{translate('workspace.tags.importMultiLevelTags.independentTags')}</Text>
                         <Switch
                             isOn={spreadsheet?.isImportingIndependentMultiLevelTags ?? true}
                             accessibilityLabel={translate('workspace.tags.importMultiLevelTags.independentTags')}
@@ -114,7 +114,7 @@ function ImportMultiLevelTagsSettingsPage({route}: ImportMultiLevelTagsSettingsP
                     </View>
 
                     <View style={[styles.flexRow, styles.mh5, styles.mv4, styles.alignItemsCenter, styles.justifyContentBetween]}>
-                        <Text style={[styles.textNormal, styles.flex1]}>{translate('workspace.tags.importMultiLevelTags.glAdjacentColumn')}</Text>
+                        <Text style={[styles.textNormal, styles.flex1, styles.mr2]}>{translate('workspace.tags.importMultiLevelTags.glAdjacentColumn')}</Text>
                         <Switch
                             isOn={spreadsheet?.isGLAdjacent ?? false}
                             accessibilityLabel={translate('workspace.tags.importMultiLevelTags.glAdjacentColumn')}

--- a/src/pages/workspace/tags/WorkspaceTagsSettingsPage.tsx
+++ b/src/pages/workspace/tags/WorkspaceTagsSettingsPage.tsx
@@ -97,7 +97,7 @@ function WorkspaceTagsSettingsPage({route}: WorkspaceTagsSettingsPageProps) {
                 errorRowStyles={styles.mh5}
             >
                 <View style={[styles.flexRow, styles.mh5, styles.mv4, styles.alignItemsCenter, styles.justifyContentBetween]}>
-                    <Text style={[styles.textNormal]}>{translate('workspace.tags.requiresTag')}</Text>
+                    <Text style={[styles.textNormal, styles.flex1]}>{translate('workspace.tags.requiresTag')}</Text>
                     <Switch
                         isOn={policy?.requiresTag ?? false}
                         accessibilityLabel={translate('workspace.tags.requiresTag')}
@@ -108,7 +108,7 @@ function WorkspaceTagsSettingsPage({route}: WorkspaceTagsSettingsPageProps) {
             </OfflineWithFeedback>
             <OfflineWithFeedback pendingAction={billableExpensesPending(policy)}>
                 <View style={[styles.flexRow, styles.mh5, styles.mv4, styles.alignItemsCenter, styles.justifyContentBetween]}>
-                    <Text style={[styles.textNormal]}>{translate('workspace.tags.trackBillable')}</Text>
+                    <Text style={[styles.textNormal, styles.flex1]}>{translate('workspace.tags.trackBillable')}</Text>
                     <Switch
                         isOn={!(policy?.disabledFields?.defaultBillable ?? false)}
                         accessibilityLabel={translate('workspace.tags.trackBillable')}

--- a/src/pages/workspace/tags/WorkspaceTagsSettingsPage.tsx
+++ b/src/pages/workspace/tags/WorkspaceTagsSettingsPage.tsx
@@ -97,7 +97,7 @@ function WorkspaceTagsSettingsPage({route}: WorkspaceTagsSettingsPageProps) {
                 errorRowStyles={styles.mh5}
             >
                 <View style={[styles.flexRow, styles.mh5, styles.mv4, styles.alignItemsCenter, styles.justifyContentBetween]}>
-                    <Text style={[styles.textNormal, styles.flex1]}>{translate('workspace.tags.requiresTag')}</Text>
+                    <Text style={[styles.textNormal, styles.flex1, styles.mr2]}>{translate('workspace.tags.requiresTag')}</Text>
                     <Switch
                         isOn={policy?.requiresTag ?? false}
                         accessibilityLabel={translate('workspace.tags.requiresTag')}
@@ -108,7 +108,7 @@ function WorkspaceTagsSettingsPage({route}: WorkspaceTagsSettingsPageProps) {
             </OfflineWithFeedback>
             <OfflineWithFeedback pendingAction={billableExpensesPending(policy)}>
                 <View style={[styles.flexRow, styles.mh5, styles.mv4, styles.alignItemsCenter, styles.justifyContentBetween]}>
-                    <Text style={[styles.textNormal, styles.flex1]}>{translate('workspace.tags.trackBillable')}</Text>
+                    <Text style={[styles.textNormal, styles.flex1, styles.mr2]}>{translate('workspace.tags.trackBillable')}</Text>
                     <Switch
                         isOn={!(policy?.disabledFields?.defaultBillable ?? false)}
                         accessibilityLabel={translate('workspace.tags.trackBillable')}


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
<!-- Explain what your change does and how it addresses the linked issue -->

### Fixed Issues
$ https://github.com/Expensify/App/issues/68395
PROPOSAL: https://github.com/Expensify/App/issues/68395#issuecomment-3180366224

### Tests
Precondition: Tags is enabled in the workspace 

1. Go to Account > Preferences > Language > Select "日本語" (Japanese)
2. Go to Tags in workspace setting
3. Tap More - Settings
4. Verify toggle for "Members must tag all expenses" (first toggle row) is aligned correctly and there is some gap between text and toggle button
5. Open dropdown menu > Select "Import spreadsheet" (second option) > Select "Single level of tags" (first option)
6. Click on green button > Select a valid tags file 
7. Verify first toggle row is aligned correctly and there is some gap between text and toggle button

- [x] Verify that no errors appear in the JS console

### Offline tests
Precondition: Tags is enabled in the workspace 

1. Go to Account > Preferences > Language > Select "日本語" (Japanese)
2. Go to Tags in workspace setting
3. Tap More - Settings
4. Verify toggle for "Members must tag all expenses" (first toggle row) is aligned correctly and there is some gap between text and toggle button
5. Open dropdown menu > Select "Import spreadsheet" (second option) > Select "Single level of tags" (first option)
6. Click on green button > Select a valid tags file 
7. Verify first toggle row is aligned correctly and there is some gap between text and toggle button

### QA Steps
Precondition: Tags is enabled in the workspace 

1. Go to Account > Preferences > Language > Select "日本語" (Japanese)
2. Go to Tags in workspace setting
3. Tap More - Settings
4. Verify toggle for "Members must tag all expenses" (first toggle row) is aligned correctly and there is some gap between text and toggle button
5. Open dropdown menu > Select "Import spreadsheet" (second option) > Select "Single level of tags" (first option)
6. Click on green button > Select a valid tags file 
7. Verify first toggle row is aligned correctly and there is some gap between text and toggle button

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.


### Screenshots/Videos
<details>
<summary>Android: Native</summary>

https://github.com/user-attachments/assets/629e2601-c44d-4a70-842b-6ccaa382f65a

</details>

<details>
<summary>Android: mWeb Chrome</summary>

https://github.com/user-attachments/assets/3b309f71-7497-4516-92f9-a47d6930282c

</details>

<details>
<summary>iOS: Native</summary>

https://github.com/user-attachments/assets/e427cf0a-8913-4f76-bca3-0227ece8bc3a

</details>

<details>
<summary>iOS: mWeb Safari</summary>

https://github.com/user-attachments/assets/2ca644f4-e691-40fb-b728-2bef100b294f

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

https://github.com/user-attachments/assets/ebca88d6-87d2-4ab4-b84f-5302cae5cf72

</details>

<details>
<summary>MacOS: Desktop</summary>

https://github.com/user-attachments/assets/ddddae41-3af8-4c77-b0b0-875ab8aeb2b3

</details>
