### PR TITLE
fix: Workspace - Unable to leave workspace after changing an expense to it.

### DIFF
--- a/src/libs/PolicyUtils.ts
+++ b/src/libs/PolicyUtils.ts
@@ -124,7 +124,13 @@ const isPolicyAdmin = (policy: OnyxInputOrEntry<Policy> | SearchPolicy, currentU
  * Checks if we have any errors stored within the policy?.employeeList. Determines whether we should show a red brick road error or not.
  */
 function shouldShowEmployeeListError(policy: OnyxEntry<Policy>): boolean {
-    return isPolicyAdmin(policy) && Object.values(policy?.employeeList ?? {}).some((employee) => Object.keys(employee?.errors ?? {}).length > 0);
+    const currentUserLogin = getCurrentUserEmail();
+
+    if (isPolicyAdmin(policy, currentUserLogin ?? undefined)) {
+        return Object.values(policy?.employeeList ?? {}).some((employee) => Object.keys(employee?.errors ?? {}).length > 0);
+    }
+
+    return !!currentUserLogin && Object.keys(policy?.employeeList?.[currentUserLogin]?.errors ?? {}).length > 0;
 }
 
 /**

--- a/tests/unit/PolicyUtilsTest.ts
+++ b/tests/unit/PolicyUtilsTest.ts
@@ -14,6 +14,7 @@ import {
     getUnitRateValue,
     isCurrentUserMemberOfAnyPolicy,
     isPolicyMemberWithoutPendingDelete,
+    shouldShowEmployeeListError,
     shouldShowPolicy,
     sortWorkspacesBySelected,
 } from '@libs/PolicyUtils';
@@ -963,6 +964,271 @@ describe('PolicyUtils', () => {
             };
             const result = isPolicyMemberWithoutPendingDelete('fakeEmail', policy as unknown as Policy);
             expect(result).toBe(false);
+        });
+    });
+
+    describe('shouldShowEmployeeListError', () => {
+        beforeEach(() => {
+            jest.clearAllMocks();
+        });
+
+        it('should return true for policy admin when any employee has errors', () => {
+            const getCurrentUserEmailSpy = jest.spyOn(require('@libs/actions/Report'), 'getCurrentUserEmail').mockReturnValue('admin@test.com');
+
+            const policy = {
+                ...createRandomPolicy(1),
+                id: 'test-policy-id',
+                role: CONST.POLICY.ROLE.ADMIN,
+                employeeList: {
+                    'admin@test.com': {
+                        email: 'admin@test.com',
+                        role: 'admin',
+                        errors: {},
+                    },
+                    'employee@test.com': {
+                        email: 'employee@test.com',
+                        role: 'user',
+                        errors: {
+                            someError: 'Employee has an error',
+                        },
+                    },
+                },
+            } as Policy;
+
+            const result = shouldShowEmployeeListError(policy);
+            expect(result).toBe(true);
+            expect(getCurrentUserEmailSpy).toHaveBeenCalled();
+
+            getCurrentUserEmailSpy.mockRestore();
+        });
+
+        it('should return false for policy admin when no employees have errors', () => {
+            const getCurrentUserEmailSpy = jest.spyOn(require('@libs/actions/Report'), 'getCurrentUserEmail').mockReturnValue('admin@test.com');
+
+            const policy = {
+                ...createRandomPolicy(1),
+                id: 'test-policy-id',
+                role: CONST.POLICY.ROLE.ADMIN,
+                employeeList: {
+                    'admin@test.com': {
+                        email: 'admin@test.com',
+                        role: 'admin',
+                        errors: {},
+                    },
+                    'employee@test.com': {
+                        email: 'employee@test.com',
+                        role: 'user',
+                        errors: {},
+                    },
+                },
+            } as Policy;
+
+            const result = shouldShowEmployeeListError(policy);
+            expect(result).toBe(false);
+            expect(getCurrentUserEmailSpy).toHaveBeenCalled();
+
+            getCurrentUserEmailSpy.mockRestore();
+        });
+
+        it('should return true for non-admin user when current user has employee errors', () => {
+            const getCurrentUserEmailSpy = jest.spyOn(require('@libs/actions/Report'), 'getCurrentUserEmail').mockReturnValue('employee@test.com');
+
+            const policy = {
+                ...createRandomPolicy(1),
+                id: 'test-policy-id',
+                role: CONST.POLICY.ROLE.USER,
+                employeeList: {
+                    'admin@test.com': {
+                        email: 'admin@test.com',
+                        role: 'admin',
+                        errors: {},
+                    },
+                    'employee@test.com': {
+                        email: 'employee@test.com',
+                        role: 'user',
+                        errors: {
+                            personalError: 'User has a personal error',
+                        },
+                    },
+                    'other@test.com': {
+                        email: 'other@test.com',
+                        role: 'user',
+                        errors: {
+                            otherError: 'Other user has an error',
+                        },
+                    },
+                },
+            } as Policy;
+
+            const result = shouldShowEmployeeListError(policy);
+            expect(result).toBe(true);
+            expect(getCurrentUserEmailSpy).toHaveBeenCalled();
+
+            getCurrentUserEmailSpy.mockRestore();
+        });
+
+        it('should return false for non-admin user when current user has no employee errors', () => {
+            const getCurrentUserEmailSpy = jest.spyOn(require('@libs/actions/Report'), 'getCurrentUserEmail').mockReturnValue('employee@test.com');
+
+            const policy = {
+                ...createRandomPolicy(1),
+                id: 'test-policy-id',
+                role: CONST.POLICY.ROLE.USER,
+                employeeList: {
+                    'admin@test.com': {
+                        email: 'admin@test.com',
+                        role: 'admin',
+                        errors: {},
+                    },
+                    'employee@test.com': {
+                        email: 'employee@test.com',
+                        role: 'user',
+                        errors: {},
+                    },
+                    'other@test.com': {
+                        email: 'other@test.com',
+                        role: 'user',
+                        errors: {
+                            otherError: 'Other user has an error',
+                        },
+                    },
+                },
+            } as Policy;
+
+            const result = shouldShowEmployeeListError(policy);
+            expect(result).toBe(false);
+            expect(getCurrentUserEmailSpy).toHaveBeenCalled();
+
+            getCurrentUserEmailSpy.mockRestore();
+        });
+
+        it('should return false for non-admin user when current user is not in employee list', () => {
+            const getCurrentUserEmailSpy = jest.spyOn(require('@libs/actions/Report'), 'getCurrentUserEmail').mockReturnValue('nonexistent@test.com');
+
+            const policy = {
+                ...createRandomPolicy(1),
+                id: 'test-policy-id',
+                role: CONST.POLICY.ROLE.USER,
+                employeeList: {
+                    'admin@test.com': {
+                        email: 'admin@test.com',
+                        role: 'admin',
+                        errors: {},
+                    },
+                    'employee@test.com': {
+                        email: 'employee@test.com',
+                        role: 'user',
+                        errors: {
+                            someError: 'Employee has an error',
+                        },
+                    },
+                },
+            } as Policy;
+
+            const result = shouldShowEmployeeListError(policy);
+            expect(result).toBe(false);
+            expect(getCurrentUserEmailSpy).toHaveBeenCalled();
+
+            getCurrentUserEmailSpy.mockRestore();
+        });
+
+        it('should return false when getCurrentUserEmail returns null', () => {
+            const getCurrentUserEmailSpy = jest.spyOn(require('@libs/actions/Report'), 'getCurrentUserEmail').mockReturnValue(null);
+
+            const policy = {
+                ...createRandomPolicy(1),
+                id: 'test-policy-id',
+                role: CONST.POLICY.ROLE.USER,
+                employeeList: {
+                    'employee@test.com': {
+                        email: 'employee@test.com',
+                        role: 'user',
+                        errors: {
+                            someError: 'Employee has an error',
+                        },
+                    },
+                },
+            } as Policy;
+
+            const result = shouldShowEmployeeListError(policy);
+            expect(result).toBe(false);
+            expect(getCurrentUserEmailSpy).toHaveBeenCalled();
+
+            getCurrentUserEmailSpy.mockRestore();
+        });
+
+        it('should return false when getCurrentUserEmail returns undefined', () => {
+            const getCurrentUserEmailSpy = jest.spyOn(require('@libs/actions/Report'), 'getCurrentUserEmail').mockReturnValue(undefined);
+
+            const policy = {
+                ...createRandomPolicy(1),
+                id: 'test-policy-id',
+                role: CONST.POLICY.ROLE.USER,
+                employeeList: {
+                    'employee@test.com': {
+                        email: 'employee@test.com',
+                        role: 'user',
+                        errors: {
+                            someError: 'Employee has an error',
+                        },
+                    },
+                },
+            } as Policy;
+
+            const result = shouldShowEmployeeListError(policy);
+            expect(result).toBe(false);
+            expect(getCurrentUserEmailSpy).toHaveBeenCalled();
+
+            getCurrentUserEmailSpy.mockRestore();
+        });
+
+        it('should return false when policy is null', () => {
+            const getCurrentUserEmailSpy = jest.spyOn(require('@libs/actions/Report'), 'getCurrentUserEmail').mockReturnValue('employee@test.com');
+
+            const result = shouldShowEmployeeListError(null as unknown as Policy);
+            expect(result).toBe(false);
+            expect(getCurrentUserEmailSpy).toHaveBeenCalled();
+
+            getCurrentUserEmailSpy.mockRestore();
+        });
+
+        it('should return false when policy has no employeeList', () => {
+            const getCurrentUserEmailSpy = jest.spyOn(require('@libs/actions/Report'), 'getCurrentUserEmail').mockReturnValue('employee@test.com');
+
+            const policy = {
+                ...createRandomPolicy(1),
+                id: 'test-policy-id',
+                role: CONST.POLICY.ROLE.USER,
+            } as Policy;
+
+            const result = shouldShowEmployeeListError(policy);
+            expect(result).toBe(false);
+            expect(getCurrentUserEmailSpy).toHaveBeenCalled();
+
+            getCurrentUserEmailSpy.mockRestore();
+        });
+
+        it('should handle edge case where employee exists but has no errors field', () => {
+            const getCurrentUserEmailSpy = jest.spyOn(require('@libs/actions/Report'), 'getCurrentUserEmail').mockReturnValue('employee@test.com');
+
+            const policy = {
+                ...createRandomPolicy(1),
+                id: 'test-policy-id',
+                role: CONST.POLICY.ROLE.USER,
+                employeeList: {
+                    'employee@test.com': {
+                        email: 'employee@test.com',
+                        role: 'user',
+                        // No errors field - this is handled gracefully in the implementation
+                    },
+                },
+            } as Policy;
+
+            const result = shouldShowEmployeeListError(policy);
+            expect(result).toBe(false);
+            expect(getCurrentUserEmailSpy).toHaveBeenCalled();
+
+            getCurrentUserEmailSpy.mockRestore();
         });
     });
 });


### PR DESCRIPTION


<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
<!-- Explain what your change does and how it addresses the linked issue -->

### Fixed Issues
$ https://github.com/Expensify/App/issues/62442
PROPOSAL: https://github.com/Expensify/App/issues/62442#issuecomment-3201945480


### Tests
Prerequisite: Have two accounts opened on two different devices or environments.
Prerequisite 2: User A has at least one workspace created.
Prerequisite 3: User B has at least one workspace created.

1. Open the expensify app.
2. Log in as User A.
3. Switch to User B account.
4. Navigate to "Workspaces"
5. Open any workspace and select "Members"
6. Invite User A to the workspace.
7. Switch to User A account again.
8. Submit a manual expense to an owned workspace.
9. Open the just created workspace and tap on "More"
10. Tap on "Change Workspace" and select the workspace where the user was invited.
11. Navigate to "Workspaces" and open workspaces list.
12. Tap on the three dots icon of the workspace where the user was invited.
13. Tap on "Leave"

- [x] Verify that no errors appear in the JS console

### Offline tests
Prerequisite: Have two accounts opened on two different devices or environments.
Prerequisite 2: User A has at least one workspace created.
Prerequisite 3: User B has at least one workspace created.

1. Open the expensify app.
2. Log in as User A.
3. Switch to User B account.
4. Navigate to "Workspaces"
5. Open any workspace and select "Members"
6. Invite User A to the workspace.
7. Switch to User A account again.
8. Submit a manual expense to an owned workspace.
9. Open the just created workspace and tap on "More"
10. Tap on "Change Workspace" and select the workspace where the user was invited.
11. Navigate to "Workspaces" and open workspaces list.
12. Tap on the three dots icon of the workspace where the user was invited.
13. Tap on "Leave"

### QA Steps
Prerequisite: Have two accounts opened on two different devices or environments.
Prerequisite 2: User A has at least one workspace created.
Prerequisite 3: User B has at least one workspace created.

1. Open the expensify app.
2. Log in as User A.
3. Switch to User B account.
4. Navigate to "Workspaces"
5. Open any workspace and select "Members"
6. Invite User A to the workspace.
7. Switch to User A account again.
8. Submit a manual expense to an owned workspace.
9. Open the just created workspace and tap on "More"
10. Tap on "Change Workspace" and select the workspace where the user was invited.
11. Navigate to "Workspaces" and open workspaces list.
12. Tap on the three dots icon of the workspace where the user was invited.
13. Tap on "Leave"

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [ ] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.


### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Desktop</summary>

<!-- add screenshots or videos here -->

</details>
