### PR TITLE
iOS - Reports - Reports load infinitely when opening for first time after creating account

### DIFF
--- a/src/components/Search/index.tsx
+++ b/src/components/Search/index.tsx
@@ -21,6 +21,7 @@ import {openSearch, updateSearchResultsWithTransactionThreadReportID} from '@lib
 import Timing from '@libs/actions/Timing';
 import {canUseTouchScreen} from '@libs/DeviceCapabilities';
 import Log from '@libs/Log';
+import isRoutePreloaded from '@libs/Navigation/helpers/isRoutePreloaded';
 import isSearchTopmostFullScreenRoute from '@libs/Navigation/helpers/isSearchTopmostFullScreenRoute';
 import type {PlatformStackNavigationProp} from '@libs/Navigation/PlatformStackNavigation/types';
 import Performance from '@libs/Performance';
@@ -338,8 +339,9 @@ function Search({queryJSON, searchResults, onSearchListScroll, contentContainerS
     useEffect(() => {
         const focusedRoute = findFocusedRoute(navigationRef.getRootState());
         const isMigratedModalDisplayed = focusedRoute?.name === NAVIGATORS.MIGRATED_USER_MODAL_NAVIGATOR || focusedRoute?.name === SCREENS.MIGRATED_USER_WELCOME_MODAL.ROOT;
+        const isSearchPreloaded = isRoutePreloaded(NAVIGATORS.SEARCH_FULLSCREEN_NAVIGATOR);
 
-        if ((!isFocused && !isMigratedModalDisplayed) || isOffline) {
+        if ((!isSearchPreloaded && !isFocused && !isMigratedModalDisplayed) || isOffline) {
             return;
         }
 

--- a/src/libs/Navigation/AppNavigator/createRootStackNavigator/RootStackRouter.ts
+++ b/src/libs/Navigation/AppNavigator/createRootStackNavigator/RootStackRouter.ts
@@ -19,6 +19,7 @@ import syncBrowserHistory from './syncBrowserHistory';
 import type {
     DismissModalActionType,
     OpenWorkspaceSplitActionType,
+    PreloadActionType,
     PushActionType,
     ReplaceActionType,
     RootStackNavigatorAction,
@@ -44,6 +45,10 @@ function isDismissModalAction(action: RootStackNavigatorAction): action is Dismi
 
 function isToggleSidePanelWithHistoryAction(action: RootStackNavigatorAction): action is ToggleSidePanelWithHistoryActionType {
     return action.type === CONST.NAVIGATION.ACTION_TYPE.TOGGLE_SIDE_PANEL_WITH_HISTORY;
+}
+
+function isPreloadAction(action: RootStackNavigatorAction): action is PreloadActionType {
+    return action.type === CONST.NAVIGATION.ACTION_TYPE.PRELOAD;
 }
 
 function shouldPreventReset(state: StackNavigationState<ParamListBase>, action: CommonActions.Action | StackActionType) {
@@ -80,6 +85,10 @@ function RootStackRouter(options: RootStackNavigatorRouterOptions) {
     return {
         ...stackRouter,
         getStateForAction(state: StackNavigationState<ParamListBase>, action: RootStackNavigatorAction, configOptions: RouterConfigOptions) {
+            if (isPreloadAction(action) && action.payload.name === state.routes.at(-1)?.name) {
+                return state;
+            }
+
             if (isToggleSidePanelWithHistoryAction(action)) {
                 return handleToggleSidePanelWithHistoryAction(state, action);
             }

--- a/src/libs/Navigation/AppNavigator/createRootStackNavigator/types.ts
+++ b/src/libs/Navigation/AppNavigator/createRootStackNavigator/types.ts
@@ -18,6 +18,16 @@ type RootStackNavigatorActionType =
               policyID: string;
               screenName: WorkspaceScreenName;
           };
+      }
+    | {
+          type: typeof CONST.NAVIGATION.ACTION_TYPE.PRELOAD;
+          payload: {
+              name: string;
+              params: {
+                  screen: string;
+                  params: Record<string, unknown>;
+              };
+          };
       };
 
 type OpenWorkspaceSplitActionType = RootStackNavigatorActionType & {
@@ -27,6 +37,8 @@ type OpenWorkspaceSplitActionType = RootStackNavigatorActionType & {
 type ToggleSidePanelWithHistoryActionType = RootStackNavigatorActionType & {
     type: typeof CONST.NAVIGATION.ACTION_TYPE.TOGGLE_SIDE_PANEL_WITH_HISTORY;
 };
+
+type PreloadActionType = RootStackNavigatorAction & {type: typeof CONST.NAVIGATION.ACTION_TYPE.PRELOAD};
 
 type PushActionType = StackActionType & {type: typeof CONST.NAVIGATION.ACTION_TYPE.PUSH};
 
@@ -45,6 +57,7 @@ export type {
     PushActionType,
     ReplaceActionType,
     DismissModalActionType,
+    PreloadActionType,
     RootStackNavigatorAction,
     RootStackNavigatorRouterOptions,
     ToggleSidePanelWithHistoryActionType,

--- a/src/libs/Navigation/helpers/getAccountTabScreenToOpen.ts
+++ b/src/libs/Navigation/helpers/getAccountTabScreenToOpen.ts
@@ -1,0 +1,29 @@
+import {findFocusedRoute} from '@react-navigation/native';
+import type {NavigatorScreenParams} from '@react-navigation/native';
+import type {ValueOf} from 'type-fest';
+import getIsNarrowLayout from '@libs/getIsNarrowLayout';
+import type {NavigationPartialRoute, SettingsSplitNavigatorParamList} from '@libs/Navigation/types';
+import type CONST from '@src/CONST';
+import SCREENS from '@src/SCREENS';
+import {getSettingsTabStateFromSessionStorage} from './lastVisitedTabPathUtils';
+
+/**
+ * Returns the Settings screen that should be opened on the Account tab.
+ */
+export default function getAccountTabScreenToOpen(subscriptionPlan: ValueOf<typeof CONST.POLICY.TYPE> | null): NavigatorScreenParams<SettingsSplitNavigatorParamList> {
+    if (getIsNarrowLayout()) {
+        return {screen: SCREENS.SETTINGS.ROOT};
+    }
+
+    const settingsTabState = getSettingsTabStateFromSessionStorage();
+    if (!settingsTabState) {
+        return {screen: SCREENS.SETTINGS.PROFILE.ROOT, params: {}};
+    }
+
+    const focusedRoute = findFocusedRoute(settingsTabState) as NavigationPartialRoute<keyof SettingsSplitNavigatorParamList> | undefined;
+    if ((!subscriptionPlan && focusedRoute?.name === SCREENS.SETTINGS.SUBSCRIPTION.ROOT) || !focusedRoute) {
+        return {screen: SCREENS.SETTINGS.PROFILE.ROOT, params: {}};
+    }
+
+    return {screen: focusedRoute.name};
+}

--- a/src/libs/Navigation/helpers/getAccountTabScreenToOpen.ts
+++ b/src/libs/Navigation/helpers/getAccountTabScreenToOpen.ts
@@ -1,8 +1,8 @@
-import {findFocusedRoute} from '@react-navigation/native';
 import type {NavigatorScreenParams} from '@react-navigation/native';
+import {findFocusedRoute} from '@react-navigation/native';
 import type {ValueOf} from 'type-fest';
 import getIsNarrowLayout from '@libs/getIsNarrowLayout';
-import type {NavigationPartialRoute, SettingsSplitNavigatorParamList} from '@libs/Navigation/types';
+import type {SettingsSplitNavigatorParamList} from '@libs/Navigation/types';
 import type CONST from '@src/CONST';
 import SCREENS from '@src/SCREENS';
 import {getSettingsTabStateFromSessionStorage} from './lastVisitedTabPathUtils';
@@ -20,10 +20,10 @@ export default function getAccountTabScreenToOpen(subscriptionPlan: ValueOf<type
         return {screen: SCREENS.SETTINGS.PROFILE.ROOT, params: {}};
     }
 
-    const focusedRoute = findFocusedRoute(settingsTabState) as NavigationPartialRoute<keyof SettingsSplitNavigatorParamList> | undefined;
-    if ((!subscriptionPlan && focusedRoute?.name === SCREENS.SETTINGS.SUBSCRIPTION.ROOT) || !focusedRoute) {
+    const screen = findFocusedRoute(settingsTabState)?.name as keyof SettingsSplitNavigatorParamList | undefined;
+    if ((!subscriptionPlan && screen === SCREENS.SETTINGS.SUBSCRIPTION.ROOT) || !screen) {
         return {screen: SCREENS.SETTINGS.PROFILE.ROOT, params: {}};
     }
 
-    return {screen: focusedRoute.name};
+    return {screen};
 }

--- a/src/libs/Navigation/helpers/getReportsTabScreenToOpen.ts
+++ b/src/libs/Navigation/helpers/getReportsTabScreenToOpen.ts
@@ -1,0 +1,27 @@
+import type {NavigatorScreenParams} from '@react-navigation/native';
+import {getPreservedNavigatorState} from '@libs/Navigation/AppNavigator/createSplitNavigator/usePreserveNavigatorState';
+import type {AuthScreensParamList, NavigationPartialRoute, SearchFullscreenNavigatorParamList, State} from '@libs/Navigation/types';
+import {buildCannedSearchQuery} from '@libs/SearchQueryUtils';
+import type {SearchTypeMenuSection} from '@libs/SearchUIUtils';
+import NAVIGATORS from '@src/NAVIGATORS';
+import SCREENS from '@src/SCREENS';
+import type {SaveSearch} from '@src/types/onyx';
+
+export default function getReportsTabScreenToOpen(
+    rootState: State<AuthScreensParamList>,
+    typeMenuSections: SearchTypeMenuSection[],
+    savedSearches: SaveSearch | undefined,
+): NavigatorScreenParams<SearchFullscreenNavigatorParamList> {
+    const lastSearchNavigator = rootState.routes.findLast((route) => route.name === NAVIGATORS.SEARCH_FULLSCREEN_NAVIGATOR);
+    const lastSearchNavigatorState = lastSearchNavigator && lastSearchNavigator.key ? getPreservedNavigatorState(lastSearchNavigator?.key) : undefined;
+    const lastSearchRoute = lastSearchNavigatorState?.routes.at(-1) as NavigationPartialRoute<keyof SearchFullscreenNavigatorParamList> | undefined;
+
+    if (lastSearchRoute?.name === SCREENS.SEARCH.ROOT && lastSearchRoute?.params) {
+        const params = lastSearchRoute.params as SearchFullscreenNavigatorParamList[typeof SCREENS.SEARCH.ROOT];
+        return {screen: SCREENS.SEARCH.ROOT, params};
+    }
+
+    const nonExploreTypeQuery = typeMenuSections.at(0)?.menuItems.at(0)?.searchQuery;
+    const savedSearchQuery = Object.values(savedSearches ?? {}).at(0)?.query;
+    return {screen: SCREENS.SEARCH.ROOT, params: {q: nonExploreTypeQuery ?? savedSearchQuery ?? buildCannedSearchQuery()}};
+}

--- a/src/libs/Navigation/helpers/isRoutePreloaded.ts
+++ b/src/libs/Navigation/helpers/isRoutePreloaded.ts
@@ -1,0 +1,8 @@
+import type {NavigationState} from '@react-navigation/native';
+import navigationRef from '@libs/Navigation/navigationRef';
+import type {AuthScreensParamList, NavigationPartialRoute} from '@libs/Navigation/types';
+
+export default function isRoutePreloaded(routeName: keyof AuthScreensParamList) {
+    const rootState = navigationRef.getRootState() as NavigationState<AuthScreensParamList> & {preloadedRoutes: Array<NavigationPartialRoute<keyof AuthScreensParamList>>};
+    return rootState?.preloadedRoutes?.some((preloadedRoute) => preloadedRoute.name === routeName);
+}


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
<!-- Explain what your change does and how it addresses the linked issue -->

This PR fixes https://github.com/Expensify/App/issues/69812. It modifies the hook in `Search/index.ts` responsible for calling `handleSearch`. Now it's called for preloaded search route as well. 

The reason why this issue appeared is early return in the mentioned hook. It checks if the search route is focused. When this route is preloaded it isn't so there was no data to display. 

This PR also adds some improvements for the preloading feature:
- add early return if we try to preload the current route
- fixes the default query for the preloaded search route
- fixes navigation when the target screen isn't preloaded

The app behaviour after being fixed:

https://github.com/user-attachments/assets/8bdfb529-bf83-488f-a35c-a60896b59350




### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/69812
PROPOSAL:


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

- [ ] Verify that no errors appear in the JS console

1. Launch Expensify app.
2. Log in with a new Gmail account.
3. Tap Skip on work email step.
4. Select Something else.
5. Complete the onboarding.
6. Go to Reports.
7. Verify if the screen in the reports tab has been loaded correctly.

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->

- [ ] Verify that no errors appear in the JS console

1. Launch Expensify app.
2. Log in with a new Gmail account.
3. Tap Skip on work email step.
4. Select Something else.
5. Complete the onboarding.
6. Go to Reports.
7. Verify if the screen in the reports tab has been loaded correctly.

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I verified there are no new alerts related to the `canBeMissing` param for `useOnyx`
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Desktop</summary>

<!-- add screenshots or videos here -->

</details>
