### PR TITLE
Fix highlight for Workspace list row

### DIFF
--- a/src/pages/workspace/WorkspacesListRow.tsx
+++ b/src/pages/workspace/WorkspacesListRow.tsx
@@ -141,7 +141,7 @@ function WorkspacesListRow({
         borderRadius: variables.componentBorderRadius,
         shouldHighlight: !!shouldAnimateInHighlight,
         highlightColor: theme.messageHighlightBG,
-        backgroundColor: theme.highlightBG,
+        backgroundColor: theme.transparent,
     });
 
     useEffect(() => {
@@ -213,80 +213,82 @@ function WorkspacesListRow({
     );
 
     return (
-        <Animated.View style={[styles.flexRow, styles.highlightBG, style, isWide && styles.gap5, styles.br3, styles.p5, animatedHighlightStyle, rowStyles]}>
-            <View style={[isWide ? styles.flexRow : styles.flexColumn, styles.flex1, isWide && styles.gap5]}>
-                <View style={[styles.flexRow, styles.justifyContentBetween, styles.flex2, isNarrow && styles.mb3, styles.alignItemsCenter]}>
-                    <View style={[styles.flexRow, styles.gap3, styles.flex1, styles.alignItemsCenter]}>
-                        <Avatar
-                            imageStyles={[styles.alignSelfCenter]}
-                            size={CONST.AVATAR_SIZE.DEFAULT}
-                            source={workspaceIcon}
-                            fallbackIcon={fallbackWorkspaceIcon}
-                            avatarID={policyID}
-                            name={title}
-                            type={CONST.ICON_TYPE_WORKSPACE}
-                        />
-                        <TextWithTooltip
-                            text={title}
-                            shouldShowTooltip
-                            style={[styles.flex1, styles.flexGrow1, styles.textStrong, isDeleted ? styles.offlineFeedback.deleted : {}]}
-                        />
-                    </View>
-                    {isNarrow && ThreeDotMenuOrPendingIcon}
-                </View>
-                <View style={[styles.flexRow, isWide && styles.flex1, isWide && styles.workspaceOwnerSectionMinWidth, styles.gap2, styles.alignItemsCenter]}>
-                    {!!ownerDetails && (
-                        <>
+        <View style={[styles.flexRow, styles.highlightBG, rowStyles, style, styles.br3]}>
+            <Animated.View style={[styles.flex1, styles.flexRow, styles.bgTransparent, isWide && styles.gap5, styles.p5, animatedHighlightStyle]}>
+                <View style={[isWide ? styles.flexRow : styles.flexColumn, styles.flex1, isWide && styles.gap5]}>
+                    <View style={[styles.flexRow, styles.justifyContentBetween, styles.flex2, isNarrow && styles.mb3, styles.alignItemsCenter]}>
+                        <View style={[styles.flexRow, styles.gap3, styles.flex1, styles.alignItemsCenter]}>
                             <Avatar
-                                source={ownerDetails.avatar}
-                                avatarID={ownerDetails.accountID}
-                                type={CONST.ICON_TYPE_AVATAR}
-                                size={CONST.AVATAR_SIZE.SMALL}
-                                containerStyles={styles.workspaceOwnerAvatarWrapper}
+                                imageStyles={[styles.alignSelfCenter]}
+                                size={CONST.AVATAR_SIZE.DEFAULT}
+                                source={workspaceIcon}
+                                fallbackIcon={fallbackWorkspaceIcon}
+                                avatarID={policyID}
+                                name={title}
+                                type={CONST.ICON_TYPE_WORKSPACE}
                             />
-                            <View style={styles.flex1}>
-                                <WorkspacesListRowDisplayName
-                                    isDeleted={isDeleted}
-                                    ownerName={getDisplayNameOrDefault(ownerDetails)}
+                            <TextWithTooltip
+                                text={title}
+                                shouldShowTooltip
+                                style={[styles.flex1, styles.flexGrow1, styles.textStrong, isDeleted ? styles.offlineFeedback.deleted : {}]}
+                            />
+                        </View>
+                        {isNarrow && ThreeDotMenuOrPendingIcon}
+                    </View>
+                    <View style={[styles.flexRow, isWide && styles.flex1, isWide && styles.workspaceOwnerSectionMinWidth, styles.gap2, styles.alignItemsCenter]}>
+                        {!!ownerDetails && (
+                            <>
+                                <Avatar
+                                    source={ownerDetails.avatar}
+                                    avatarID={ownerDetails.accountID}
+                                    type={CONST.ICON_TYPE_AVATAR}
+                                    size={CONST.AVATAR_SIZE.SMALL}
+                                    containerStyles={styles.workspaceOwnerAvatarWrapper}
                                 />
+                                <View style={styles.flex1}>
+                                    <WorkspacesListRowDisplayName
+                                        isDeleted={isDeleted}
+                                        ownerName={getDisplayNameOrDefault(ownerDetails)}
+                                    />
+                                    <Text
+                                        numberOfLines={1}
+                                        style={[styles.textMicro, styles.textSupporting, isDeleted ? styles.offlineFeedback.deleted : {}]}
+                                    >
+                                        {Str.removeSMSDomain(ownerDetails?.login ?? '')}
+                                    </Text>
+                                </View>
+                            </>
+                        )}
+                    </View>
+                    <View style={[styles.flexRow, isWide && styles.flex1, styles.gap2, styles.alignItemsCenter]}>
+                        <Icon
+                            src={workspaceTypeIcon(workspaceType)}
+                            width={variables.workspaceTypeIconWidth}
+                            height={variables.workspaceTypeIconWidth}
+                            additionalStyles={styles.workspaceTypeWrapper}
+                        />
+                        <View>
+                            {!!workspaceType && (
                                 <Text
                                     numberOfLines={1}
-                                    style={[styles.textMicro, styles.textSupporting, isDeleted ? styles.offlineFeedback.deleted : {}]}
+                                    style={[styles.labelStrong, isDeleted ? styles.offlineFeedback.deleted : {}]}
                                 >
-                                    {Str.removeSMSDomain(ownerDetails?.login ?? '')}
+                                    {getUserFriendlyWorkspaceType(workspaceType)}
                                 </Text>
-                            </View>
-                        </>
-                    )}
-                </View>
-                <View style={[styles.flexRow, isWide && styles.flex1, styles.gap2, styles.alignItemsCenter]}>
-                    <Icon
-                        src={workspaceTypeIcon(workspaceType)}
-                        width={variables.workspaceTypeIconWidth}
-                        height={variables.workspaceTypeIconWidth}
-                        additionalStyles={styles.workspaceTypeWrapper}
-                    />
-                    <View>
-                        {!!workspaceType && (
+                            )}
                             <Text
                                 numberOfLines={1}
-                                style={[styles.labelStrong, isDeleted ? styles.offlineFeedback.deleted : {}]}
+                                style={[styles.textMicro, styles.textSupporting, isDeleted ? styles.offlineFeedback.deleted : {}]}
                             >
-                                {getUserFriendlyWorkspaceType(workspaceType)}
+                                {translate('workspace.common.plan')}
                             </Text>
-                        )}
-                        <Text
-                            numberOfLines={1}
-                            style={[styles.textMicro, styles.textSupporting, isDeleted ? styles.offlineFeedback.deleted : {}]}
-                        >
-                            {translate('workspace.common.plan')}
-                        </Text>
+                        </View>
                     </View>
                 </View>
-            </View>
 
-            {!isNarrow && ThreeDotMenuOrPendingIcon}
-        </Animated.View>
+                {!isNarrow && ThreeDotMenuOrPendingIcon}
+            </Animated.View>
+        </View>
     );
 }
 


### PR DESCRIPTION
### Explanation of Change
There are some conflicts between animated highlight and hover events. Separating them to different views fix the problem (like we do for any other item rows)

### Fixed Issues

$ https://github.com/Expensify/App/pull/69146
$ https://github.com/Expensify/App/issues/70017
PROPOSAL:


### Tests

1. Go to staging.new.expensify.com
2. Go to Account > Preferences
3. Click Theme
4. Select another them (If light, then dark. If dark, then light)
5. Go to Workspaces tab
6. Hover over the workspace row
7. Verify that row is hovered correctly without changing themes

- [x] Verify that no errors appear in the JS console

### Offline tests
No changes

### QA Steps

1. Go to staging.new.expensify.com
2. Go to Account > Preferences
3. Click Theme
4. Select another them (If light, then dark. If dark, then light)
5. Go to Workspaces tab
6. Hover over the workspace row
7. Verify that row is hovered correctly

- [x] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x]  I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I verified there are no new alerts related to the `canBeMissing` param for `useOnyx`
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>


https://github.com/user-attachments/assets/fbfafa41-c3d6-4b55-a973-0bf0be78517a


</details>

<details>
<summary>iOS: Native</summary>


https://github.com/user-attachments/assets/b23a7ce1-9e80-4c55-9ec9-f6c1f7a0ae84


</details>

<details>
<summary>iOS: mWeb Safari</summary>


https://github.com/user-attachments/assets/49d7eb5b-2bc2-4ed4-9d41-ef5c82e448dc


</details>

<details>
<summary>MacOS: Chrome / Safari</summary>


https://github.com/user-attachments/assets/fbff0247-2ad4-44f3-86b3-e9ffb6b8744d


</details>

<details>
<summary>MacOS: Desktop</summary>


https://github.com/user-attachments/assets/97ab3364-fb64-4fc6-bbb6-6a7bf66e18a6


</details>
