### PR TITLE
[No QA] Clearing logs in unit tests

### DIFF
--- a/jest/setup.ts
+++ b/jest/setup.ts
@@ -1,5 +1,4 @@
 /* eslint-disable max-classes-per-file */
-import * as core from '@actions/core';
 import '@shopify/flash-list/jestSetup';
 import type * as RNAppLogs from 'react-native-app-logs';
 import 'react-native-gesture-handler/jestSetup';
@@ -44,11 +43,25 @@ jest.mock('react-native/Libraries/LogBox/LogBox', () => ({
 const isVerbose = process.env.JEST_VERBOSE === 'true';
 
 if (!isVerbose) {
-    jest.spyOn(core, 'startGroup').mockImplementation(() => {});
-    jest.spyOn(core, 'endGroup').mockImplementation(() => {});
-    jest.spyOn(core, 'group').mockImplementation(<T>(_title: string, fn: () => T) => fn());
-    jest.spyOn(core, 'info').mockImplementation(() => {});
-    jest.spyOn(core, 'setOutput').mockImplementation(() => {});
+    jest.mock('@actions/core', () => {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+        const originalCore = jest.requireActual('@actions/core'); // this is giving lint error
+
+        const createMockFn = () => {
+            const mockFn = jest.fn(() => {});
+            return mockFn;
+        };
+
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+        return {
+            ...originalCore,
+            startGroup: createMockFn(),
+            endGroup: createMockFn(),
+            group: jest.fn((_title: unknown, fn: unknown) => fn),
+            info: createMockFn(),
+            setOutput: createMockFn(),
+        };
+    });
 
     // Make them global to override module-level console calls
     global.console = {

--- a/jest/setup.ts
+++ b/jest/setup.ts
@@ -44,7 +44,6 @@ jest.spyOn(console, 'log').mockImplementation(() => {});
 jest.spyOn(console, 'info').mockImplementation(() => {});
 jest.spyOn(console, 'debug').mockImplementation(() => {});
 jest.spyOn(console, 'warn').mockImplementation(() => {});
-jest.spyOn(console, 'error').mockImplementation(() => {});
 
 // This mock is required for mocking file systems when running tests
 jest.mock('react-native-fs', () => ({

--- a/jest/setup.ts
+++ b/jest/setup.ts
@@ -1,4 +1,5 @@
 /* eslint-disable max-classes-per-file */
+import * as core from '@actions/core';
 import '@shopify/flash-list/jestSetup';
 import type * as RNAppLogs from 'react-native-app-logs';
 import 'react-native-gesture-handler/jestSetup';
@@ -40,10 +41,19 @@ jest.mock('react-native/Libraries/LogBox/LogBox', () => ({
     },
 }));
 
-jest.spyOn(console, 'log').mockImplementation(() => {});
-jest.spyOn(console, 'info').mockImplementation(() => {});
-jest.spyOn(console, 'debug').mockImplementation(() => {});
-jest.spyOn(console, 'warn').mockImplementation(() => {});
+const isVerbose = process.argv.includes('verbose') || process.env.JEST_VERBOSE === 'true';
+
+if (!isVerbose) {
+    jest.spyOn(console, 'log').mockImplementation(() => {});
+    jest.spyOn(console, 'info').mockImplementation(() => {});
+    jest.spyOn(console, 'debug').mockImplementation(() => {});
+    jest.spyOn(console, 'warn').mockImplementation(() => {});
+    jest.spyOn(core, 'startGroup').mockImplementation(() => {});
+    jest.spyOn(core, 'endGroup').mockImplementation(() => {});
+    jest.spyOn(core, 'group').mockImplementation(<T>(_title: string, fn: () => T) => fn());
+    jest.spyOn(core, 'info').mockImplementation(() => {});
+    jest.spyOn(core, 'setOutput').mockImplementation(() => {});
+}
 
 // This mock is required for mocking file systems when running tests
 jest.mock('react-native-fs', () => ({

--- a/jest/setup.ts
+++ b/jest/setup.ts
@@ -41,18 +41,23 @@ jest.mock('react-native/Libraries/LogBox/LogBox', () => ({
     },
 }));
 
-const isVerbose = process.argv.includes('verbose') || process.env.JEST_VERBOSE === 'true';
+const isVerbose = process.env.JEST_VERBOSE === 'true';
 
 if (!isVerbose) {
-    jest.spyOn(console, 'log').mockImplementation(() => {});
-    jest.spyOn(console, 'info').mockImplementation(() => {});
-    jest.spyOn(console, 'debug').mockImplementation(() => {});
-    jest.spyOn(console, 'warn').mockImplementation(() => {});
     jest.spyOn(core, 'startGroup').mockImplementation(() => {});
     jest.spyOn(core, 'endGroup').mockImplementation(() => {});
     jest.spyOn(core, 'group').mockImplementation(<T>(_title: string, fn: () => T) => fn());
     jest.spyOn(core, 'info').mockImplementation(() => {});
     jest.spyOn(core, 'setOutput').mockImplementation(() => {});
+
+    // Make them global to override module-level console calls
+    global.console = {
+        ...console,
+        log: jest.fn(),
+        info: jest.fn(),
+        debug: jest.fn(),
+        warn: jest.fn(),
+    } as Console;
 }
 
 // This mock is required for mocking file systems when running tests

--- a/jest/setup.ts
+++ b/jest/setup.ts
@@ -40,16 +40,11 @@ jest.mock('react-native/Libraries/LogBox/LogBox', () => ({
     },
 }));
 
-// Turn off the console logs for timing events. They are not relevant for unit tests and create a lot of noise
-jest.spyOn(console, 'debug').mockImplementation((...params: string[]) => {
-    if (params.at(0)?.startsWith('Timing:')) {
-        return;
-    }
-
-    // Send the message to console.log but don't re-used console.debug or else this mock method is called in an infinite loop. Instead, just prefix the output with the word "DEBUG"
-    // eslint-disable-next-line no-console
-    console.log('DEBUG', ...params);
-});
+jest.spyOn(console, 'log').mockImplementation(() => {});
+jest.spyOn(console, 'info').mockImplementation(() => {});
+jest.spyOn(console, 'debug').mockImplementation(() => {});
+jest.spyOn(console, 'warn').mockImplementation(() => {});
+jest.spyOn(console, 'error').mockImplementation(() => {});
 
 // This mock is required for mocking file systems when running tests
 jest.mock('react-native-fs', () => ({

--- a/jest/setup.ts
+++ b/jest/setup.ts
@@ -1,4 +1,5 @@
 /* eslint-disable max-classes-per-file */
+import * as core from '@actions/core';
 import '@shopify/flash-list/jestSetup';
 import type * as RNAppLogs from 'react-native-app-logs';
 import 'react-native-gesture-handler/jestSetup';
@@ -43,25 +44,11 @@ jest.mock('react-native/Libraries/LogBox/LogBox', () => ({
 const isVerbose = process.env.JEST_VERBOSE === 'true';
 
 if (!isVerbose) {
-    jest.mock('@actions/core', () => {
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-        const originalCore = jest.requireActual('@actions/core'); // this is giving lint error
-
-        const createMockFn = () => {
-            const mockFn = jest.fn(() => {});
-            return mockFn;
-        };
-
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-        return {
-            ...originalCore,
-            startGroup: createMockFn(),
-            endGroup: createMockFn(),
-            group: jest.fn((_title: unknown, fn: unknown) => fn),
-            info: createMockFn(),
-            setOutput: createMockFn(),
-        };
-    });
+    jest.spyOn(core, 'startGroup').mockImplementation(() => {});
+    jest.spyOn(core, 'endGroup').mockImplementation(() => {});
+    jest.spyOn(core, 'group').mockImplementation(<T>(_title: string, fn: () => T) => fn());
+    jest.spyOn(core, 'info').mockImplementation(() => {});
+    jest.spyOn(core, 'setOutput').mockImplementation(() => {});
 
     // Make them global to override module-level console calls
     global.console = {

--- a/jest/setupAfterEnv.ts
+++ b/jest/setupAfterEnv.ts
@@ -1,21 +1,3 @@
 import '@testing-library/react-native';
-import * as Log from '../scripts/utils/Logger';
-
-const isVerbose = process.argv.includes('--verbose') || process.env.JEST_VERBOSE === 'true';
-
-beforeEach(() => {
-    if (isVerbose) {
-        return;
-    }
-
-    jest.spyOn(console, 'log').mockImplementation(() => {});
-    jest.spyOn(console, 'info').mockImplementation(() => {});
-    jest.spyOn(console, 'debug').mockImplementation(() => {});
-    jest.spyOn(console, 'warn').mockImplementation(() => {});
-    jest.spyOn(Log, 'log').mockImplementation(() => {});
-    jest.spyOn(Log, 'info').mockImplementation(() => {});
-    jest.spyOn(Log, 'success').mockImplementation(() => {});
-    jest.spyOn(Log, 'warn').mockImplementation(() => {});
-});
 
 jest.useRealTimers();

--- a/jest/setupAfterEnv.ts
+++ b/jest/setupAfterEnv.ts
@@ -1,6 +1,13 @@
 import '@testing-library/react-native';
 
+const isVerbose = process.argv.includes('--verbose') || process.env.JEST_VERBOSE === 'true';
+
+
 beforeEach(() => {
+    if (isVerbose) {
+        return;
+    }
+
     jest.spyOn(console, 'log').mockImplementation(() => {});
     jest.spyOn(console, 'info').mockImplementation(() => {});
     jest.spyOn(console, 'debug').mockImplementation(() => {});

--- a/jest/setupAfterEnv.ts
+++ b/jest/setupAfterEnv.ts
@@ -2,7 +2,6 @@ import '@testing-library/react-native';
 
 const isVerbose = process.argv.includes('--verbose') || process.env.JEST_VERBOSE === 'true';
 
-
 beforeEach(() => {
     if (isVerbose) {
         return;

--- a/jest/setupAfterEnv.ts
+++ b/jest/setupAfterEnv.ts
@@ -5,7 +5,6 @@ beforeEach(() => {
     jest.spyOn(console, 'info').mockImplementation(() => {});
     jest.spyOn(console, 'debug').mockImplementation(() => {});
     jest.spyOn(console, 'warn').mockImplementation(() => {});
-    jest.spyOn(console, 'error').mockImplementation(() => {});
 });
 
 jest.useRealTimers();

--- a/jest/setupAfterEnv.ts
+++ b/jest/setupAfterEnv.ts
@@ -1,4 +1,5 @@
 import '@testing-library/react-native';
+import * as Log from '../scripts/utils/Logger';
 
 const isVerbose = process.argv.includes('--verbose') || process.env.JEST_VERBOSE === 'true';
 
@@ -11,6 +12,10 @@ beforeEach(() => {
     jest.spyOn(console, 'info').mockImplementation(() => {});
     jest.spyOn(console, 'debug').mockImplementation(() => {});
     jest.spyOn(console, 'warn').mockImplementation(() => {});
+    jest.spyOn(Log, 'log').mockImplementation(() => {});
+    jest.spyOn(Log, 'info').mockImplementation(() => {});
+    jest.spyOn(Log, 'success').mockImplementation(() => {});
+    jest.spyOn(Log, 'warn').mockImplementation(() => {});
 });
 
 jest.useRealTimers();

--- a/jest/setupAfterEnv.ts
+++ b/jest/setupAfterEnv.ts
@@ -1,3 +1,11 @@
 import '@testing-library/react-native';
 
+beforeEach(() => {
+    jest.spyOn(console, 'log').mockImplementation(() => {});
+    jest.spyOn(console, 'info').mockImplementation(() => {});
+    jest.spyOn(console, 'debug').mockImplementation(() => {});
+    jest.spyOn(console, 'warn').mockImplementation(() => {});
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+});
+
 jest.useRealTimers();

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "android-build": "bundle exec fastlane android build_local",
     "android-hybrid-build": "bundle exec fastlane android build_local_hybrid",
     "test": "TZ=utc NODE_OPTIONS=--experimental-vm-modules jest",
+    "test:verbose": "TZ=utc NODE_OPTIONS=--experimental-vm-modules JEST_VERBOSE=true jest",
     "test:debug": "TZ=utc NODE_OPTIONS='--inspect-brk --experimental-vm-modules' jest --runInBand",
     "perf-test": "NODE_OPTIONS=--experimental-vm-modules npx reassure",
     "typecheck": "NODE_OPTIONS=--max_old_space_size=8192 tsc",

--- a/tests/unit/CIGitLogicTest.ts
+++ b/tests/unit/CIGitLogicTest.ts
@@ -473,13 +473,6 @@ async function assertPRsMergedBetween(from: string, to: string, expected: number
 let startingDir: string;
 describe('CIGitLogic', () => {
     beforeAll(() => {
-        if (!isVerbose) {
-            jest.spyOn(Log, 'log').mockImplementation(() => {});
-            jest.spyOn(Log, 'info').mockImplementation(() => {});
-            jest.spyOn(Log, 'success').mockImplementation(() => {});
-            jest.spyOn(Log, 'warn').mockImplementation(() => {});
-        }
-
         Log.info('Starting setup');
         startingDir = process.cwd();
         initGitServer();

--- a/tests/unit/CIGitLogicTest.ts
+++ b/tests/unit/CIGitLogicTest.ts
@@ -24,7 +24,7 @@ const GIT_REMOTE = path.resolve(os.homedir(), 'dummyGitRemotes/DumDumRepo');
 // Used to mock the Octokit GithubAPI
 const mockGetInput = jest.fn<string | undefined, [string]>();
 
-const isVerbose = process.argv.includes('--verbose') || process.env.JEST_VERBOSE === 'true';
+const isVerbose = process.env.JEST_VERBOSE === 'true';
 
 type ExecSyncError = {stderr: Buffer};
 

--- a/tests/unit/CIGitLogicTest.ts
+++ b/tests/unit/CIGitLogicTest.ts
@@ -471,6 +471,11 @@ async function assertPRsMergedBetween(from: string, to: string, expected: number
 let startingDir: string;
 describe('CIGitLogic', () => {
     beforeAll(() => {
+        jest.spyOn(Log, 'log').mockImplementation(() => {});
+        jest.spyOn(Log, 'info').mockImplementation(() => {});
+        jest.spyOn(Log, 'success').mockImplementation(() => {});
+        jest.spyOn(Log, 'warn').mockImplementation(() => {});
+
         Log.info('Starting setup');
         startingDir = process.cwd();
         initGitServer();

--- a/tests/unit/CIGitLogicTest.ts
+++ b/tests/unit/CIGitLogicTest.ts
@@ -24,12 +24,14 @@ const GIT_REMOTE = path.resolve(os.homedir(), 'dummyGitRemotes/DumDumRepo');
 // Used to mock the Octokit GithubAPI
 const mockGetInput = jest.fn<string | undefined, [string]>();
 
+const isVerbose = process.argv.includes('--verbose') || process.env.JEST_VERBOSE === 'true';
+
 type ExecSyncError = {stderr: Buffer};
 
 function exec(command: string) {
     try {
         Log.info(command);
-        execSync(command, {stdio: 'inherit'});
+        execSync(command, {stdio: isVerbose ? 'inherit' : 'pipe'});
     } catch (error) {
         if ((error as ExecSyncError).stderr) {
             Log.error((error as ExecSyncError).stderr.toString());
@@ -471,10 +473,12 @@ async function assertPRsMergedBetween(from: string, to: string, expected: number
 let startingDir: string;
 describe('CIGitLogic', () => {
     beforeAll(() => {
-        jest.spyOn(Log, 'log').mockImplementation(() => {});
-        jest.spyOn(Log, 'info').mockImplementation(() => {});
-        jest.spyOn(Log, 'success').mockImplementation(() => {});
-        jest.spyOn(Log, 'warn').mockImplementation(() => {});
+        if (!isVerbose) {
+            jest.spyOn(Log, 'log').mockImplementation(() => {});
+            jest.spyOn(Log, 'info').mockImplementation(() => {});
+            jest.spyOn(Log, 'success').mockImplementation(() => {});
+            jest.spyOn(Log, 'warn').mockImplementation(() => {});
+        }
 
         Log.info('Starting setup');
         startingDir = process.cwd();


### PR DESCRIPTION
### Explanation of Change
Clearing logs in unit tests

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/70676
PROPOSAL: Clearing console logs from unit tests

**Background:** 
Unit tests often include many logs that can provide insight on what's happening in that test. In JavaScript, console logs are generally divided into four levels:
`debug`
`info` (this is generally the default used by console.log)
`warn`
`error`

If you are running a full test suite, you're likely to be most interested in error logs, because they will be the ones that show you which tests are failing and why. If you're running or debugging an individual test, you're more likely to be interested in all logs.

**Problem**
When running our jest tests, the large volume of logs across all tests makes it difficult to quickly see which tests failed and why. This prevents us from quickly resolving issues when tests fail on a PR, which in turn can delay the merge and deploy of the PR.

**Solution**
Silence `debug`, `info`, and `warn` logs by default in our jest tests. This will greatly reduce the volume of logs and make it easier to quickly identify which tests failed and why. Enable developers to see all log levels by passing the `--verbose` flag to jest; that way we can still dive into more detail in an individual test for debugging purposes.

<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->
// TODO: These must be filled out, or the issue title must include "[No QA]."

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I verified there are no new alerts related to the `canBeMissing` param for `useOnyx`
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Desktop</summary>

<!-- add screenshots or videos here -->

</details>