### PR TITLE
[CP Staging] Revert #69355 'Reports - Details of last created expense, are not seen on preview on "Submit" while offline'

### DIFF
--- a/src/libs/SearchUIUtils.ts
+++ b/src/libs/SearchUIUtils.ts
@@ -1461,10 +1461,6 @@ function getReportSections(
             } else if (reportIDToTransactions[reportKey]) {
                 reportIDToTransactions[reportKey].transactions = [transaction];
                 reportIDToTransactions[reportKey].from = data.personalDetailsList[data?.[reportKey as ReportKey]?.accountID ?? CONST.DEFAULT_NUMBER_ID];
-            } else {
-                reportIDToTransactions[reportKey] = {} as TransactionReportGroupListItemType;
-                reportIDToTransactions[reportKey].transactions = [transaction];
-                reportIDToTransactions[reportKey].from = data.personalDetailsList[data?.[reportKey as ReportKey]?.accountID ?? CONST.DEFAULT_NUMBER_ID];
             }
         }
     }

--- a/tests/unit/Search/SearchUIUtilsTest.ts
+++ b/tests/unit/Search/SearchUIUtilsTest.ts
@@ -1784,63 +1784,6 @@ describe('SearchUIUtils', () => {
                 SearchUIUtils.getSections(CONST.SEARCH.DATA_TYPES.EXPENSE, searchResultsGroupByWithdrawalID.data, 2074551, formatPhoneNumber, CONST.SEARCH.GROUP_BY.WITHDRAWAL_ID),
             ).toStrictEqual(transactionWithdrawalIDGroupListItems);
         });
-
-        it('should handle transaction keys before report keys correctly when groupBy is report', () => {
-            const originalData = searchResults.data;
-
-            const searchResultsWithTransactionKeysFirst: OnyxTypes.SearchResults = {
-                data: {
-                    // First add non-transaction and non-report keys
-                    personalDetailsList: originalData.personalDetailsList,
-                    [`policy_${policyID}`]: originalData[`policy_${policyID}`],
-                    [`reportActions_${reportID}`]: originalData[`reportActions_${reportID}`],
-
-                    // Then add transaction keys first (this is the key part of the test)
-                    [`transactions_${transactionID}`]: originalData[`transactions_${transactionID}`],
-                    [`transactions_${transactionID2}`]: originalData[`transactions_${transactionID2}`],
-                    [`transactions_${transactionID3}`]: originalData[`transactions_${transactionID3}`],
-                    [`transactions_${transactionID4}`]: originalData[`transactions_${transactionID4}`],
-
-                    // Finally add report keys after transaction keys
-                    [`report_${reportID}`]: originalData[`report_${reportID}`],
-                    [`report_${reportID2}`]: originalData[`report_${reportID2}`],
-                    [`report_${reportID3}`]: originalData[`report_${reportID3}`],
-                    [`report_${reportID4}`]: originalData[`report_${reportID4}`],
-                    [`report_${reportID5}`]: originalData[`report_${reportID5}`],
-                },
-                search: searchResults.search,
-            };
-
-            const resultWithTransactionKeysFirst = SearchUIUtils.getSections(
-                CONST.SEARCH.DATA_TYPES.EXPENSE,
-                searchResultsWithTransactionKeysFirst.data,
-                2074551,
-                formatPhoneNumber,
-                CONST.SEARCH.GROUP_BY.REPORTS,
-            );
-
-            const resultWithNormalOrder = SearchUIUtils.getSections(CONST.SEARCH.DATA_TYPES.EXPENSE, searchResults.data, 2074551, formatPhoneNumber, CONST.SEARCH.GROUP_BY.REPORTS);
-
-            expect(resultWithTransactionKeysFirst.length).toBe(resultWithNormalOrder.length);
-
-            const reportsWithTransactionKeysFirst = resultWithTransactionKeysFirst as TransactionReportGroupListItemType[];
-            const reportsWithNormalOrder = resultWithNormalOrder as TransactionReportGroupListItemType[];
-
-            reportsWithTransactionKeysFirst.forEach((reportWithTransactionKeysFirst, index) => {
-                const reportWithNormalOrder = reportsWithNormalOrder.at(index);
-                expect(reportWithTransactionKeysFirst.transactions.length).toBe(reportWithNormalOrder?.transactions.length);
-                expect(reportWithTransactionKeysFirst.reportID).toBe(reportWithNormalOrder?.reportID);
-
-                if (reportWithTransactionKeysFirst.reportID === reportID) {
-                    expect(reportWithTransactionKeysFirst.transactions.length).toBeGreaterThan(0);
-                    expect(reportWithTransactionKeysFirst.transactions.at(0)?.transactionID).toBe(transactionID);
-                }
-                if (reportWithTransactionKeysFirst.reportID === reportID2) {
-                    expect(reportWithTransactionKeysFirst.transactions.length).toBeGreaterThan(0);
-                    expect(reportWithTransactionKeysFirst.transactions.at(0)?.transactionID).toBe(transactionID2);
-                }
-            });
-        });
     });
 
     describe('Test getSortedSections', () => {


### PR DESCRIPTION
### Explanation of Change
Straight revert of #69355, which caused a blocker while removing expenses from a report while offline

### Fixed Issues
$ https://github.com/Expensify/App/issues/69998
$ https://github.com/Expensify/App/issues/70057


### Tests
Same as QA
- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

### QA Steps
1. Create a workspace
2. Create a report with an expense on it
3. Go to Reports > Reports
4. Expand the report summary so you can see the "view" link next to your expense
5. Go offline
6. Click View > Report > Remove from report
7. Make sure that the UI changes to a report preview that says "This report has no expenses"

---

1. Create a report with at least 2 expenses
2. Go to the Reports page
3. Go offline
4. Click on the report to open it
5. Delete the report
6. Make sure it gets removed from the UI entirely


- [x] Verify that no errors appear in the JS console

### PR Author Checklist


- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I verified there are no new alerts related to the `canBeMissing` param for `useOnyx`
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos

<details>
<summary>MacOS: Chrome / Safari</summary>


For #69998

<table>
<tr>
<th>Before
<th>After
<tr>
<td><video src="https://github.com/user-attachments/assets/f393bb9e-a9b3-443b-8a86-70655b4d270d" />
<td><video src="https://github.com/user-attachments/assets/332b6092-ee18-4138-b47a-7a7ba9b12fd7" />
</table>

For #70057

<table>
<tr>
<th>Before
<th>After
<tr>
<td><video src="https://github.com/user-attachments/assets/e0a97b01-cdca-4dbe-92ea-b1d96c82a078" />
<td><video src="https://github.com/user-attachments/assets/7472674c-257b-49ff-a672-ab4c579a0d32" />
</table>

</details>











