### PR TITLE
Create unlisted-docs-info.md

### DIFF
--- a/docs/articles/Unlisted/unlisted-docs-info.md
+++ b/docs/articles/Unlisted/unlisted-docs-info.md
@@ -1,0 +1,2 @@
+Docs in this folder are not listed or searchable on the help site, but can be accessed via direct URL. They are included in AgentZero's reference. 
+If you want to also exclude your doc from AgentZero's reference, try the folder docs/Hidden


### PR DESCRIPTION
Added a new folder called Unlisted that omits docs from helpsite search while still including them for AgentZero's reference 