### PR TITLE
Fix: Uber invite navigation and press

### DIFF
--- a/src/CONST/index.ts
+++ b/src/CONST/index.ts
@@ -2975,7 +2975,7 @@ const CONST = {
             ARE_WORKFLOWS_ENABLED: 'areWorkflowsEnabled',
             ARE_REPORT_FIELDS_ENABLED: 'areReportFieldsEnabled',
             ARE_CONNECTIONS_ENABLED: 'areConnectionsEnabled',
-            ARE_RECEIPT_PARTNERS_ENABLED: 'areReceiptPartnersEnabled',
+            ARE_RECEIPT_PARTNERS_ENABLED: 'receiptPartners',
             ARE_COMPANY_CARDS_ENABLED: 'areCompanyCardsEnabled',
             ARE_EXPENSIFY_CARDS_ENABLED: 'areExpensifyCardsEnabled',
             ARE_INVOICES_ENABLED: 'areInvoicesEnabled',

--- a/src/libs/API/parameters/InviteWorkspaceEmployeesToUberParams.ts
+++ b/src/libs/API/parameters/InviteWorkspaceEmployeesToUberParams.ts
@@ -1,6 +1,6 @@
 type InviteWorkspaceEmployeesToUberParams = {
     policyID: string;
-    emails: string[];
+    emailList: string[];
 };
 
 export default InviteWorkspaceEmployeesToUberParams;

--- a/src/libs/API/parameters/InviteWorkspaceEmployeesToUberParams.ts
+++ b/src/libs/API/parameters/InviteWorkspaceEmployeesToUberParams.ts
@@ -1,6 +1,7 @@
 type InviteWorkspaceEmployeesToUberParams = {
     policyID: string;
-    emailList: string[];
+    /** The list of emails to invite to Uber for Business in CSV format */
+    emailList: string;
 };
 
 export default InviteWorkspaceEmployeesToUberParams;

--- a/src/libs/PolicyUtils.ts
+++ b/src/libs/PolicyUtils.ts
@@ -673,6 +673,9 @@ function isPolicyFeatureEnabled(policy: OnyxEntry<Policy>, featureName: PolicyFe
     if (featureName === CONST.POLICY.MORE_FEATURES.ARE_CONNECTIONS_ENABLED) {
         return policy?.[featureName] ? !!policy?.[featureName] : !isEmptyObject(policy?.connections);
     }
+    if (featureName === CONST.POLICY.MORE_FEATURES.ARE_RECEIPT_PARTNERS_ENABLED) {
+        return policy?.receiptPartners?.enabled ?? false;
+    }
 
     return !!policy?.[featureName];
 }

--- a/src/libs/actions/Policy/Policy.ts
+++ b/src/libs/actions/Policy/Policy.ts
@@ -2925,7 +2925,7 @@ function inviteWorkspaceEmployeesToUber(policyID: string, emails: string[]) {
 
     const params: InviteWorkspaceEmployeesToUberParams = {
         policyID,
-        emailList: emails,
+        emailList: emails.join(','),
     };
 
     // Build optimistic employees mapping: mark invited emails as invited

--- a/src/libs/actions/Policy/Policy.ts
+++ b/src/libs/actions/Policy/Policy.ts
@@ -2930,7 +2930,7 @@ function inviteWorkspaceEmployeesToUber(policyID: string, emails: string[]) {
 
     // Build optimistic employees mapping: mark invited emails as invited
     const invitedEmployees = emails.reduce<Record<string, {status: string}>>((acc, email) => {
-        acc[email] = {status: 'invited'};
+        acc[email] = {status: CONST.POLICY.RECEIPT_PARTNERS.UBER_EMPLOYEE_STATUS.INVITED};
         return acc;
     }, {});
 

--- a/src/libs/actions/Policy/Policy.ts
+++ b/src/libs/actions/Policy/Policy.ts
@@ -3709,9 +3709,9 @@ function enablePolicyReceiptPartners(policyID: string, enabled: boolean, shouldN
                 value: {
                     receiptPartners: {
                         enabled,
-                    },
-                    pendingFields: {
-                        areReceiptPartnersEnabled: CONST.RED_BRICK_ROAD_PENDING_ACTION.UPDATE,
+                        pendingFields: {
+                            enabled: CONST.RED_BRICK_ROAD_PENDING_ACTION.UPDATE,
+                        },
                     },
                 },
             },
@@ -3721,8 +3721,10 @@ function enablePolicyReceiptPartners(policyID: string, enabled: boolean, shouldN
                 onyxMethod: Onyx.METHOD.MERGE,
                 key: `${ONYXKEYS.COLLECTION.POLICY}${policyID}`,
                 value: {
-                    pendingFields: {
-                        areReceiptPartnersEnabled: null,
+                    receiptPartners: {
+                        pendingFields: {
+                            enabled: null,
+                        },
                     },
                 },
             },
@@ -3734,9 +3736,9 @@ function enablePolicyReceiptPartners(policyID: string, enabled: boolean, shouldN
                 value: {
                     receiptPartners: {
                         enabled: !enabled,
-                    },
-                    pendingFields: {
-                        areReceiptPartnersEnabled: null,
+                        pendingFields: {
+                            enabled: null,
+                        },
                     },
                 },
             },

--- a/src/libs/actions/Policy/Policy.ts
+++ b/src/libs/actions/Policy/Policy.ts
@@ -2925,7 +2925,7 @@ function inviteWorkspaceEmployeesToUber(policyID: string, emails: string[]) {
 
     const params: InviteWorkspaceEmployeesToUberParams = {
         policyID,
-        emails,
+        emailList: emails,
     };
 
     // Build optimistic employees mapping: mark invited emails as invited

--- a/src/libs/actions/Policy/Policy.ts
+++ b/src/libs/actions/Policy/Policy.ts
@@ -3707,7 +3707,9 @@ function enablePolicyReceiptPartners(policyID: string, enabled: boolean, shouldN
                 onyxMethod: Onyx.METHOD.MERGE,
                 key: `${ONYXKEYS.COLLECTION.POLICY}${policyID}`,
                 value: {
-                    areReceiptPartnersEnabled: enabled,
+                    receiptPartners: {
+                        enabled,
+                    },
                     pendingFields: {
                         areReceiptPartnersEnabled: CONST.RED_BRICK_ROAD_PENDING_ACTION.UPDATE,
                     },
@@ -3730,7 +3732,9 @@ function enablePolicyReceiptPartners(policyID: string, enabled: boolean, shouldN
                 onyxMethod: Onyx.METHOD.MERGE,
                 key: `${ONYXKEYS.COLLECTION.POLICY}${policyID}`,
                 value: {
-                    areReceiptPartnersEnabled: !enabled,
+                    receiptPartners: {
+                        enabled: !enabled,
+                    },
                     pendingFields: {
                         areReceiptPartnersEnabled: null,
                     },

--- a/src/pages/workspace/WorkspaceInitialPage.tsx
+++ b/src/pages/workspace/WorkspaceInitialPage.tsx
@@ -150,7 +150,7 @@ function WorkspaceInitialPage({policyDraft, policy: policyProp, route}: Workspac
             [CONST.POLICY.MORE_FEATURES.ARE_RULES_ENABLED]: policy?.areRulesEnabled,
             [CONST.POLICY.MORE_FEATURES.ARE_INVOICES_ENABLED]: policy?.areInvoicesEnabled,
             [CONST.POLICY.MORE_FEATURES.ARE_PER_DIEM_RATES_ENABLED]: policy?.arePerDiemRatesEnabled,
-            [CONST.POLICY.MORE_FEATURES.ARE_RECEIPT_PARTNERS_ENABLED]: isUberForBusinessEnabled && (policy?.areReceiptPartnersEnabled ?? false),
+            [CONST.POLICY.MORE_FEATURES.ARE_RECEIPT_PARTNERS_ENABLED]: isUberForBusinessEnabled && (policy?.receiptPartners?.enabled ?? false),
         }),
         [policy, isUberForBusinessEnabled],
     ) as PolicyFeatureStates;

--- a/src/pages/workspace/WorkspaceMoreFeaturesPage.tsx
+++ b/src/pages/workspace/WorkspaceMoreFeaturesPage.tsx
@@ -332,7 +332,7 @@ function WorkspaceMoreFeaturesPage({policy, route}: WorkspaceMoreFeaturesPagePro
             icon: Illustrations.ReceiptPartners,
             titleTranslationKey: 'workspace.moreFeatures.receiptPartners.title',
             subtitleTranslationKey: 'workspace.moreFeatures.receiptPartners.subtitle',
-            isActive: policy?.receiptPartners?.uber?.enabled ?? false,
+            isActive: policy?.receiptPartners?.enabled ?? false,
             pendingAction: policy?.pendingFields?.areReceiptPartnersEnabled,
             disabledAction: () => {
                 if (!isUberConnected) {

--- a/src/pages/workspace/WorkspaceMoreFeaturesPage.tsx
+++ b/src/pages/workspace/WorkspaceMoreFeaturesPage.tsx
@@ -332,7 +332,7 @@ function WorkspaceMoreFeaturesPage({policy, route}: WorkspaceMoreFeaturesPagePro
             icon: Illustrations.ReceiptPartners,
             titleTranslationKey: 'workspace.moreFeatures.receiptPartners.title',
             subtitleTranslationKey: 'workspace.moreFeatures.receiptPartners.subtitle',
-            isActive: policy?.areReceiptPartnersEnabled ?? false,
+            isActive: policy?.receiptPartners?.uber?.enabled ?? false,
             pendingAction: policy?.pendingFields?.areReceiptPartnersEnabled,
             disabledAction: () => {
                 if (!isUberConnected) {

--- a/src/pages/workspace/WorkspaceMoreFeaturesPage.tsx
+++ b/src/pages/workspace/WorkspaceMoreFeaturesPage.tsx
@@ -333,7 +333,7 @@ function WorkspaceMoreFeaturesPage({policy, route}: WorkspaceMoreFeaturesPagePro
             titleTranslationKey: 'workspace.moreFeatures.receiptPartners.title',
             subtitleTranslationKey: 'workspace.moreFeatures.receiptPartners.subtitle',
             isActive: policy?.receiptPartners?.enabled ?? false,
-            pendingAction: policy?.pendingFields?.areReceiptPartnersEnabled,
+            pendingAction: policy?.receiptPartners?.pendingFields?.enabled,
             disabledAction: () => {
                 if (!isUberConnected) {
                     return;

--- a/src/pages/workspace/receiptPartners/EditInviteReceiptPartnerPolicyPage.tsx
+++ b/src/pages/workspace/receiptPartners/EditInviteReceiptPartnerPolicyPage.tsx
@@ -6,6 +6,7 @@ import Button from '@components/Button';
 import HeaderWithBackButton from '@components/HeaderWithBackButton';
 import * as Expensicons from '@components/Icon/Expensicons';
 import * as Illustrations from '@components/Icon/Illustrations';
+import OfflineWithFeedback from '@components/OfflineWithFeedback';
 import ScreenWrapper from '@components/ScreenWrapper';
 import SelectionList from '@components/SelectionList';
 import type {ListItem} from '@components/SelectionList/types';
@@ -180,10 +181,12 @@ function EditInviteReceiptPartnerPolicyPage({route}: EditInviteReceiptPartnerPol
                 isDisabled: true,
             });
 
-            list.push({...option, rightElement} as MemberForList & ListItem);
+            const rightElementWithOfflineFeedback = <OfflineWithFeedback pendingAction={policy?.receiptPartners?.uber?.pendingFields?.employees}>{rightElement}</OfflineWithFeedback>;
+
+            list.push({...option, rightElement: rightElementWithOfflineFeedback} as MemberForList & ListItem);
         });
         return sortAlphabetically(list, 'text', localeCompare);
-    }, [deriveStatus, localeCompare, policy?.employeeList, translate, isOffline, styles.ml3, inviteOrResend]);
+    }, [deriveStatus, localeCompare, policy?.employeeList, translate, isOffline, styles.ml3, inviteOrResend, policy?.receiptPartners?.uber?.pendingFields?.employees]);
 
     const applyTabStatusFilter = useCallback(
         (tab: ReceiptPartnersTab, data: MemberForList[]) => {

--- a/src/pages/workspace/receiptPartners/EditInviteReceiptPartnerPolicyPage.tsx
+++ b/src/pages/workspace/receiptPartners/EditInviteReceiptPartnerPolicyPage.tsx
@@ -16,6 +16,7 @@ import useLocalize from '@hooks/useLocalize';
 import useNetwork from '@hooks/useNetwork';
 import usePolicy from '@hooks/usePolicy';
 import useThemeStyles from '@hooks/useThemeStyles';
+import {inviteWorkspaceEmployeesToUber} from '@libs/actions/Policy/Policy';
 import {formatPhoneNumber} from '@libs/LocalePhoneNumber';
 import Navigation from '@libs/Navigation/Navigation';
 import OnyxTabNavigator, {TabScreenWithFocusTrapWrapper, TopTab} from '@libs/Navigation/OnyxTabNavigator';
@@ -54,6 +55,16 @@ function EditInviteReceiptPartnerPolicyPage({route}: EditInviteReceiptPartnerPol
 
     const policyID = route.params.policyID;
     const policy = usePolicy(policyID);
+
+    const inviteOrResend = useCallback(
+        (email: string) => {
+            if (!policyID) {
+                return;
+            }
+            inviteWorkspaceEmployeesToUber(policyID, [email]);
+        },
+        [policyID],
+    );
 
     // Maintain independent search state per tab to avoid carryover across tabs
     const [allSearchTerm, allDebouncedSearchTerm, setAllSearchTerm] = useDebouncedState('');
@@ -123,7 +134,8 @@ function EditInviteReceiptPartnerPolicyPage({route}: EditInviteReceiptPartnerPol
                     <Button
                         small
                         text={translate('workspace.receiptPartners.uber.status.resend')}
-                        onPress={() => {}}
+                        onPress={() => inviteOrResend(email)}
+                        isDisabled={isOffline}
                         style={[styles.ml3]}
                     />
                 );
@@ -134,8 +146,9 @@ function EditInviteReceiptPartnerPolicyPage({route}: EditInviteReceiptPartnerPol
                     <Button
                         small
                         text={translate('workspace.receiptPartners.uber.status.invite')}
-                        onPress={() => {}}
+                        onPress={() => inviteOrResend(email)}
                         success
+                        isDisabled={isOffline}
                         style={[styles.ml3]}
                     />
                 );
@@ -172,7 +185,7 @@ function EditInviteReceiptPartnerPolicyPage({route}: EditInviteReceiptPartnerPol
             list.push({...option, rightElement} as MemberForList & ListItem);
         });
         return sortAlphabetically(list, 'text', localeCompare);
-    }, [deriveStatus, localeCompare, policy?.employeeList, translate, isOffline, styles.ml3]);
+    }, [deriveStatus, localeCompare, policy?.employeeList, translate, isOffline, styles.ml3, inviteOrResend]);
 
     const applyTabStatusFilter = useCallback(
         (tab: ReceiptPartnersTab, data: MemberForList[]) => {

--- a/src/pages/workspace/receiptPartners/EditInviteReceiptPartnerPolicyPage.tsx
+++ b/src/pages/workspace/receiptPartners/EditInviteReceiptPartnerPolicyPage.tsx
@@ -135,7 +135,6 @@ function EditInviteReceiptPartnerPolicyPage({route}: EditInviteReceiptPartnerPol
                         small
                         text={translate('workspace.receiptPartners.uber.status.resend')}
                         onPress={() => inviteOrResend(email)}
-                        isDisabled={isOffline}
                         style={[styles.ml3]}
                     />
                 );
@@ -148,7 +147,6 @@ function EditInviteReceiptPartnerPolicyPage({route}: EditInviteReceiptPartnerPol
                         text={translate('workspace.receiptPartners.uber.status.invite')}
                         onPress={() => inviteOrResend(email)}
                         success
-                        isDisabled={isOffline}
                         style={[styles.ml3]}
                     />
                 );

--- a/src/pages/workspace/receiptPartners/InviteReceiptPartnerPolicyPage.tsx
+++ b/src/pages/workspace/receiptPartners/InviteReceiptPartnerPolicyPage.tsx
@@ -43,15 +43,22 @@ function InviteReceiptPartnerPolicyPage({route}: InviteReceiptPartnerPolicyPageP
     const policy = usePolicy(policyID);
     const shouldShowTextInput = policy?.employeeList && Object.keys(policy.employeeList).length >= CONST.STANDARD_LIST_ITEM_LIMIT;
     const textInputLabel = shouldShowTextInput ? translate('common.search') : undefined;
-
     const workspaceMembers = useMemo(() => {
         let membersList: MemberForList[] = [];
         if (!policy?.employeeList) {
             return membersList;
         }
 
+        // Get the list of employees already in Uber receipt partners
+        const uberEmployeeEmails = policy?.receiptPartners?.uber?.employees ? Object.keys(policy.receiptPartners.uber.employees) : [];
+
         Object.entries(policy.employeeList).forEach(([email, policyEmployee]) => {
             if (isDeletedPolicyEmployee(policyEmployee, isOffline)) {
+                return;
+            }
+
+            // Skip employees who are already in Uber receipt partners
+            if (uberEmployeeEmails.includes(email)) {
                 return;
             }
 
@@ -82,7 +89,7 @@ function InviteReceiptPartnerPolicyPage({route}: InviteReceiptPartnerPolicyPageP
         membersList = sortAlphabetically(membersList, 'text', localeCompare);
 
         return membersList;
-    }, [isOffline, policy?.employeeList, localeCompare]);
+    }, [isOffline, policy?.employeeList, policy?.receiptPartners?.uber?.employees, localeCompare]);
 
     const sections = useMemo(() => {
         if (workspaceMembers.length === 0) {

--- a/src/pages/workspace/receiptPartners/InviteReceiptPartnerPolicyPage.tsx
+++ b/src/pages/workspace/receiptPartners/InviteReceiptPartnerPolicyPage.tsx
@@ -49,16 +49,21 @@ function InviteReceiptPartnerPolicyPage({route}: InviteReceiptPartnerPolicyPageP
             return membersList;
         }
 
-        // Get the list of employees already in Uber receipt partners
-        const uberEmployeeEmails = policy?.receiptPartners?.uber?.employees ? Object.keys(policy.receiptPartners.uber.employees) : [];
+        // Get the list of employees from the U4B organization
+        const uberEmployees = policy?.receiptPartners?.uber?.employees ?? {};
 
         Object.entries(policy.employeeList).forEach(([email, policyEmployee]) => {
             if (isDeletedPolicyEmployee(policyEmployee, isOffline)) {
                 return;
             }
 
-            // Skip employees who are already in Uber receipt partners
-            if (uberEmployeeEmails.includes(email)) {
+            // Skip employees who are in the "Linked" section
+            const employeeStatus = uberEmployees[email]?.status;
+            if (
+                employeeStatus === CONST.POLICY.RECEIPT_PARTNERS.UBER_EMPLOYEE_STATUS.LINKED ||
+                employeeStatus === CONST.POLICY.RECEIPT_PARTNERS.UBER_EMPLOYEE_STATUS.LINKED_PENDING_APPROVAL ||
+                employeeStatus === CONST.POLICY.RECEIPT_PARTNERS.UBER_EMPLOYEE_STATUS.SUSPENDED
+            ) {
                 return;
             }
 

--- a/src/pages/workspace/receiptPartners/WorkspaceReceiptPartnersPage.tsx
+++ b/src/pages/workspace/receiptPartners/WorkspaceReceiptPartnersPage.tsx
@@ -153,8 +153,9 @@ function WorkspaceReceiptPartnersPage({route}: WorkspaceReceiptPartnersPageProps
             return;
         }
         removePolicyReceiptPartnersConnection(policyID, selectedPartner, integrations?.[selectedPartner]);
+        fetchReceiptPartners();
         onCloseModal();
-    }, [policyID, selectedPartner, integrations, onCloseModal]);
+    }, [policyID, selectedPartner, integrations, onCloseModal, fetchReceiptPartners]);
 
     const connectionsMenuItems: MenuItemData[] = useMemo(() => {
         if (policyID) {

--- a/src/pages/workspace/receiptPartners/WorkspaceReceiptPartnersPage.tsx
+++ b/src/pages/workspace/receiptPartners/WorkspaceReceiptPartnersPage.tsx
@@ -61,8 +61,7 @@ function WorkspaceReceiptPartnersPage({route}: WorkspaceReceiptPartnersPageProps
         ({name}: {name: string}) => {
             switch (name) {
                 case CONST.POLICY.RECEIPT_PARTNERS.NAME.UBER: {
-                    const formData = String(integrations?.uber?.connectFormData ?? '');
-                    openExternalLink(`${CONST.UBER_CONNECT_URL}?${formData}`);
+                    openExternalLink(`${CONST.UBER_CONNECT_URL}?${integrations?.uber?.connectFormData}`);
                     break;
                 }
                 default: {

--- a/src/pages/workspace/receiptPartners/WorkspaceReceiptPartnersPromotionBanner.tsx
+++ b/src/pages/workspace/receiptPartners/WorkspaceReceiptPartnersPromotionBanner.tsx
@@ -30,7 +30,7 @@ function WorkspaceReceiptPartnersPromotionBanner({policy, readOnly}: WorkspaceRe
     const {isBetaEnabled} = usePermissions();
     const policyID = policy?.id;
     const {setAsDismissed, isDismissed} = useDismissedUberBanners({policyID});
-    const shouldDismissBanner = !!policy?.areReceiptPartnersEnabled || !isBetaEnabled(CONST.BETAS.UBER_FOR_BUSINESS) || isDismissed || readOnly;
+    const shouldDismissBanner = !!policy?.receiptPartners?.enabled || !isBetaEnabled(CONST.BETAS.UBER_FOR_BUSINESS) || isDismissed || readOnly;
 
     const handleConnectUber = useCallback(() => {
         if (!policyID) {

--- a/src/types/onyx/Policy.ts
+++ b/src/types/onyx/Policy.ts
@@ -168,10 +168,12 @@ type UberReceiptPartner = {
 };
 
 /** Policy Receipt partners */
-type ReceiptPartners = {
-    /** Whether receipt partners are enabled */
-    enabled?: boolean;
-} & Record<string, OnyxCommon.OnyxValueWithOfflineFeedback<UberReceiptPartner>>;
+type ReceiptPartners = OnyxCommon.OnyxValueWithOfflineFeedback<
+    {
+        /** Whether receipt partners are enabled */
+        enabled?: boolean;
+    } & Record<string, OnyxCommon.OnyxValueWithOfflineFeedback<UberReceiptPartner>>
+>;
 
 /** Policy disabled fields */
 type DisabledFields = {
@@ -1900,9 +1902,6 @@ type Policy = OnyxCommon.OnyxValueWithOfflineFeedback<
 
         /** Whether the Report Fields feature is enabled */
         areReportFieldsEnabled?: boolean;
-
-        /** Whether the Receipt Partners feature is enabled */
-        areReceiptPartnersEnabled?: boolean;
 
         /** Whether the Connections feature is enabled */
         areConnectionsEnabled?: boolean;

--- a/src/types/onyx/Policy.ts
+++ b/src/types/onyx/Policy.ts
@@ -168,7 +168,10 @@ type UberReceiptPartner = {
 };
 
 /** Policy Receipt partners */
-type ReceiptPartners = Record<string, OnyxCommon.OnyxValueWithOfflineFeedback<UberReceiptPartner>>;
+type ReceiptPartners = {
+    /** Whether receipt partners are enabled */
+    enabled?: boolean;
+} & Record<string, OnyxCommon.OnyxValueWithOfflineFeedback<UberReceiptPartner>>;
 
 /** Policy disabled fields */
 type DisabledFields = {


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->


### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/70470
$ https://github.com/Expensify/App/issues/70472
PROPOSAL: N/A


### Tests

Test 1: 
1. Go to workspace
2. Enable receipt partners
3. Click on connect to uber
4. proceed with connection
5. Go back to the app 
6. Observe invite screen appeared

Test 2: 
1. Go to workspace
2. Enable receipt partners
3. Click on connect to uber
4. Create a new organization in uber
5. go back to expensify app
5. Click on the "Manage invites"
6. Click invite 
7. User should be invited


- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

1. Go to workspace
2. Enable receipt partners
3. Click on connect to uber
4. Create a new organization in uber
5. go back to expensify app
6. go to manage invites
6. go to offline
7. Check that update pending indicator exists

### QA Steps
Same as tests

- [X] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [X] I linked the correct issue in the `### Fixed Issues` section above
- [X] I wrote clear testing steps that cover the changes made in this PR
    - [X] I added steps for local testing in the `Tests` section
    - [X] I added steps for the expected offline behavior in the `Offline steps` section
    - [X] I added steps for Staging and/or Production testing in the `QA steps` section
    - [X] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [X] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [X] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [X] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [X] I ran the tests on **all platforms** & verified they passed on:
    - [X] Android / native
    - [X] Android / Chrome
    - [X] iOS / native
    - [x] iOS / Safari
    - [X] MacOS / Chrome / Safari
    - [X] MacOS / Desktop
- [X] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [X] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [X] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [X] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [X] I verified that comments were added to code that is not self explanatory
    - [X] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [X] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [X] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [X] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [X] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [X] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [X] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [X] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [X] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [X] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [X] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [X] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [X] I verified that if a function's arguments changed that all usages have also been updated correctly
- [X] If a new component is created I verified that:
    - [X] A similar component doesn't exist in the codebase
    - [X] All props are defined accurately and each prop has a `/** comment above it */`
    - [X] The file is named correctly
    - [X] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [X] The only data being stored in the state is data necessary for rendering and nothing else
    - [X] If we are not using the full Onyx data that we loaded, I've added the proper selector in order to ensure the component only re-renders when the data it is using changes
    - [X] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [X] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [X] All JSX used for rendering exists in the render method
    - [X] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [X] If any new file was added I verified that:
    - [X] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [X] If a new CSS style is added I verified that:
    - [X] A similar style doesn't already exist
    - [X] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG)`)
- [X] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [X] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [X] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [X] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [X] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [X] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos

<details>



https://github.com/user-attachments/assets/d8343319-330c-4e7a-a31c-da02e05ea8d2


</details>
