### PR TITLE
Revert "Remove the `react-native-modal` library"

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -98,6 +98,10 @@ const restrictedImportPaths = [
         message: "Please use 'deepEqual' from 'fast-equals' instead.",
     },
     {
+        name: 'react-native-animatable',
+        message: "Please use 'react-native-reanimated' instead.",
+    },
+    {
         name: 'react-native-onyx',
         importNames: ['useOnyx'],
         message: "Please use '@hooks/useOnyx' instead.",

--- a/config/webpack/webpack.common.ts
+++ b/config/webpack/webpack.common.ts
@@ -27,6 +27,7 @@ type PreloadWebpackPluginClass = Class<WebpackPluginInstance, [Options]>;
 const PreloadWebpackPlugin = require('@vue/preload-webpack-plugin') as PreloadWebpackPluginClass;
 
 const includeModules = [
+    'react-native-animatable',
     'react-native-reanimated',
     'react-native-picker-select',
     'react-native-web',
@@ -36,6 +37,7 @@ const includeModules = [
     '@react-navigation/native',
     '@react-navigation/native-stack',
     '@react-navigation/stack',
+    'react-native-modal',
     'react-native-gesture-handler',
     'react-native-google-places-autocomplete',
     'react-native-qrcode-svg',

--- a/package-lock.json
+++ b/package-lock.json
@@ -111,6 +111,7 @@
         "react-native-keyboard-controller": "1.18.5",
         "react-native-launch-arguments": "^4.0.2",
         "react-native-localize": "^2.2.6",
+        "react-native-modal": "^13.0.0",
         "react-native-nitro-modules": "0.26.2",
         "react-native-nitro-sqlite": "9.1.10",
         "react-native-onyx": "2.0.138",
@@ -32305,6 +32306,13 @@
         "react-native": "*"
       }
     },
+    "node_modules/react-native-animatable": {
+      "version": "1.3.3",
+      "license": "MIT",
+      "dependencies": {
+        "prop-types": "^15.7.2"
+      }
+    },
     "node_modules/react-native-app-logs": {
       "version": "0.3.1",
       "license": "MIT",
@@ -32552,6 +32560,18 @@
         "react-native-windows": {
           "optional": true
         }
+      }
+    },
+    "node_modules/react-native-modal": {
+      "version": "13.0.1",
+      "license": "MIT",
+      "dependencies": {
+        "prop-types": "^15.6.2",
+        "react-native-animatable": "1.3.3"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": ">=0.65.0"
       }
     },
     "node_modules/react-native-nitro-modules": {

--- a/package.json
+++ b/package.json
@@ -181,6 +181,7 @@
     "react-native-keyboard-controller": "1.18.5",
     "react-native-launch-arguments": "^4.0.2",
     "react-native-localize": "^2.2.6",
+    "react-native-modal": "^13.0.0",
     "react-native-nitro-modules": "0.26.2",
     "react-native-nitro-sqlite": "9.1.10",
     "react-native-onyx": "2.0.138",

--- a/patches/react-native-animatable+1.3.3+001+initial.patch
+++ b/patches/react-native-animatable+1.3.3+001+initial.patch
@@ -1,0 +1,23 @@
+diff --git a/node_modules/react-native-animatable/createAnimatableComponent.js b/node_modules/react-native-animatable/createAnimatableComponent.js
+index 2847e12..331d44f 100644
+--- a/node_modules/react-native-animatable/createAnimatableComponent.js
++++ b/node_modules/react-native-animatable/createAnimatableComponent.js
+@@ -465,7 +465,9 @@ export default function createAnimatableComponent(WrappedComponent) {
+         const needsZeroClamping =
+           ZERO_CLAMPED_STYLE_PROPERTIES.indexOf(property) !== -1;
+         if (needsInterpolation) {
+-          transitionValue.setValue(0);
++          transitionValue = new Animated.Value(0);
++          transitionValues[property] = transitionValue;
++
+           transitionStyle[property] = transitionValue.interpolate({
+             inputRange: [0, 1],
+             outputRange: [fromValue, toValue],
+@@ -546,7 +548,6 @@ export default function createAnimatableComponent(WrappedComponent) {
+           transitions.to[property] = toValue;
+         }
+       });
+-
+       if (Object.keys(transitions.from).length) {
+         this.transition(transitions.from, transitions.to, duration, easing);
+       }

--- a/patches/react-native-animatable+1.3.3+002+fixAnimationFlicker.patch
+++ b/patches/react-native-animatable+1.3.3+002+fixAnimationFlicker.patch
@@ -1,0 +1,49 @@
+diff --git a/node_modules/react-native-animatable/createAnimatableComponent.js b/node_modules/react-native-animatable/createAnimatableComponent.js
+index 331d44f..fd92b8e 100644
+--- a/node_modules/react-native-animatable/createAnimatableComponent.js
++++ b/node_modules/react-native-animatable/createAnimatableComponent.js
+@@ -362,14 +362,17 @@ export default function createAnimatableComponent(WrappedComponent) {
+ 
+     setAnimation(animation, callback) {
+       const compiledAnimation = getCompiledAnimation(animation);
++      const animationValue = new Animated.Value(0);
++
+       this.setState(
+-        state => ({
++        {
+           animationStyle: makeInterpolatedStyle(
+             compiledAnimation,
+-            state.animationValue,
++            animationValue,
+           ),
+           compiledAnimation,
+-        }),
++          animationValue,
++        },
+         callback,
+       );
+     }
+@@ -401,7 +404,6 @@ export default function createAnimatableComponent(WrappedComponent) {
+       let currentIteration = iteration || 0;
+       const fromValue = getAnimationOrigin(currentIteration, direction);
+       const toValue = getAnimationTarget(currentIteration, direction);
+-      animationValue.setValue(fromValue);
+ 
+       if (typeof easing === 'string') {
+         easing = EASING_FUNCTIONS[easing];
+@@ -422,7 +424,6 @@ export default function createAnimatableComponent(WrappedComponent) {
+         useNativeDriver,
+         delay: iterationDelay || 0,
+       };
+-
+       Animated.timing(animationValue, config).start(endState => {
+         currentIteration += 1;
+         if (
+@@ -467,7 +468,6 @@ export default function createAnimatableComponent(WrappedComponent) {
+         if (needsInterpolation) {
+           transitionValue = new Animated.Value(0);
+           transitionValues[property] = transitionValue;
+-
+           transitionStyle[property] = transitionValue.interpolate({
+             inputRange: [0, 1],
+             outputRange: [fromValue, toValue],

--- a/patches/react-native-modal/details.md
+++ b/patches/react-native-modal/details.md
@@ -1,0 +1,22 @@
+# `react-native-modal` patches
+
+### [react-native-modal+13.0.1+001+initial.patch](react-native-modal+13.0.1+001+initial.patch)
+- Reason: Add ESC key to close the modal
+- Upstream PR/issue: N/A
+- E/App issue: [#11930](https://github.com/Expensify/App/issues/11930)
+- PR Introducing Patch: [#12864](https://github.com/Expensify/App/pull/12864)
+- PR Updating Patch: [#18221](https://github.com/Expensify/App/pull/18221), [#48160](https://github.com/Expensify/App/pull/48160)
+
+### [react-native-modal+13.0.1+002+fix-modal-flicker-on-open.patch](react-native-modal+13.0.1+002+fix-modal-flicker-on-open.patch)
+- Reason: Fix modal flickers on iOS
+- Upstream PR/issue: N/A
+- E/App issue: [#48911](https://github.com/Expensify/App/issues/48911)
+- PR Introducing Patch: [#51475](https://github.com/Expensify/App/pull/51475)
+- PR Updating Patch: N/A
+
+### [react-native-modal+13.0.1+002+modal-navigation-bar-translucent.patch](react-native-modal+13.0.1+002+modal-navigation-bar-translucent.patch)
+- Reason: Fix navigationBarTranslucent property
+- Upstream PR/issue: N/A
+- E/App issue: [#52116](https://github.com/Expensify/App/issues/52116)
+- PR Introducing Patch: [#52392](https://github.com/Expensify/App/pull/52392)
+- PR Updating Patch: [#55861](https://github.com/Expensify/App/pull/55861)

--- a/patches/react-native-modal/react-native-modal+13.0.1+001+initial.patch
+++ b/patches/react-native-modal/react-native-modal+13.0.1+001+initial.patch
@@ -1,0 +1,82 @@
+diff --git a/node_modules/react-native-modal/dist/modal.d.ts b/node_modules/react-native-modal/dist/modal.d.ts
+index b63bcfc..bd6419e 100644
+--- a/node_modules/react-native-modal/dist/modal.d.ts
++++ b/node_modules/react-native-modal/dist/modal.d.ts
+@@ -161,6 +161,7 @@ export declare class ReactNativeModal extends React.Component<ModalProps, State>
+     getDeviceHeight: () => number;
+     getDeviceWidth: () => number;
+     onBackButtonPress: () => boolean;
++    handleEscape: (e: KeyboardEvent) => void;
+     shouldPropagateSwipe: (evt: GestureResponderEvent, gestureState: PanResponderGestureState) => boolean;
+     buildPanResponder: () => void;
+     getAccDistancePerDirection: (gestureState: PanResponderGestureState) => number;
+diff --git a/node_modules/react-native-modal/dist/modal.js b/node_modules/react-native-modal/dist/modal.js
+index 80f4e75..5c9d275 100644
+--- a/node_modules/react-native-modal/dist/modal.js
++++ b/node_modules/react-native-modal/dist/modal.js
+@@ -75,6 +75,13 @@ export class ReactNativeModal extends React.Component {
+             }
+             return false;
+         };
++        this.handleEscape = (e) => {
++            if (e.key === 'Escape') {
++                if (this.onBackButtonPress() === true) {
++                    e.stopImmediatePropagation();
++                }
++            }
++        };
+         this.shouldPropagateSwipe = (evt, gestureState) => {
+             return typeof this.props.propagateSwipe === 'function'
+                 ? this.props.propagateSwipe(evt, gestureState)
+@@ -383,7 +390,9 @@ export class ReactNativeModal extends React.Component {
+                             this.setState({
+                                 isVisible: false,
+                             }, () => {
+-                                this.props.onModalHide();
++                                if (Platform.OS !== 'ios') {
++                                    this.props.onModalHide();
++                                }
+                             });
+                         });
+                     }
+@@ -453,10 +462,18 @@ export class ReactNativeModal extends React.Component {
+         if (this.state.isVisible) {
+             this.open();
+         }
++        if (Platform.OS === 'web') {
++            document?.body?.addEventListener?.('keyup', this.handleEscape, true);
++            return;
++        }
+         BackHandler.addEventListener('hardwareBackPress', this.onBackButtonPress);
+     }
+     componentWillUnmount() {
+-        BackHandler.removeEventListener('hardwareBackPress', this.onBackButtonPress);
++        if (Platform.OS === 'web') {
++            document?.body?.removeEventListener?.('keyup', this.handleEscape, true);
++        } else {
++            BackHandler.removeEventListener('hardwareBackPress', this.onBackButtonPress);
++        }
+         if (this.didUpdateDimensionsEmitter) {
+             this.didUpdateDimensionsEmitter.remove();
+         }
+@@ -490,7 +507,7 @@ export class ReactNativeModal extends React.Component {
+     }
+     render() {
+         /* eslint-disable @typescript-eslint/no-unused-vars */
+-        const { animationIn, animationInTiming, animationOut, animationOutTiming, avoidKeyboard, coverScreen, hasBackdrop, backdropColor, backdropOpacity, backdropTransitionInTiming, backdropTransitionOutTiming, customBackdrop, children, isVisible, onModalShow, onBackButtonPress, useNativeDriver, propagateSwipe, style, ...otherProps } = this.props;
++        const { animationIn, animationInTiming, animationOut, animationOutTiming, avoidKeyboard, coverScreen, hasBackdrop, backdropColor, backdropOpacity, backdropTransitionInTiming, backdropTransitionOutTiming, customBackdrop, children, isVisible, onModalShow, onBackButtonPress, useNativeDriver, propagateSwipe, style, onDismiss, ...otherProps } = this.props;
+         const { testID, ...containerProps } = otherProps;
+         const computedStyle = [
+             { margin: this.getDeviceWidth() * 0.05, transform: [{ translateY: 0 }] },
+@@ -523,9 +540,9 @@ export class ReactNativeModal extends React.Component {
+                 this.makeBackdrop(),
+                 containerView));
+         }
+-        return (React.createElement(Modal, Object.assign({ transparent: true, animationType: 'none', visible: this.state.isVisible, onRequestClose: onBackButtonPress }, otherProps),
++        return (React.createElement(Modal, Object.assign({ transparent: true, animationType: 'none', visible: this.state.isVisible, onRequestClose: onBackButtonPress, onDismiss: () => {onDismiss();if (Platform.OS === 'ios'){this.props.onModalHide();}} }, otherProps),
+             this.makeBackdrop(),
+-            avoidKeyboard ? (React.createElement(KeyboardAvoidingView, { behavior: Platform.OS === 'ios' ? 'padding' : undefined, pointerEvents: "box-none", style: computedStyle.concat([{ margin: 0 }]) }, containerView)) : (containerView)));
++            avoidKeyboard ? (React.createElement(KeyboardAvoidingView, { behavior: 'padding', pointerEvents: "box-none", style: computedStyle.concat([{ margin: 0 }]) }, containerView)) : (containerView)));
+     }
+ }
+ ReactNativeModal.propTypes = {

--- a/patches/react-native-modal/react-native-modal+13.0.1+002+fix-modal-flicker-on-open.patch
+++ b/patches/react-native-modal/react-native-modal+13.0.1+002+fix-modal-flicker-on-open.patch
@@ -1,0 +1,21 @@
+diff --git a/node_modules/react-native-modal/dist/modal.js b/node_modules/react-native-modal/dist/modal.js
+index 46277ea..2e70c0c 100644
+--- a/node_modules/react-native-modal/dist/modal.js
++++ b/node_modules/react-native-modal/dist/modal.js
+@@ -4,6 +4,7 @@ import * as PropTypes from 'prop-types';
+ import * as animatable from 'react-native-animatable';
+ import { initializeAnimations, buildAnimations, reversePercentage, } from './utils';
+ import styles from './modal.style';
++
+ // Override default react-native-animatable animations
+ initializeAnimations();
+ const defaultProps = {
+@@ -535,7 +536,7 @@ export class ReactNativeModal extends React.Component {
+         const _children = this.props.hideModalContentWhileAnimating &&
+             this.props.useNativeDriver &&
+             !this.state.showContent ? (React.createElement(animatable.View, null)) : (children);
+-        const containerView = (React.createElement(animatable.View, Object.assign({}, panHandlers, { ref: ref => (this.contentRef = ref), style: [panPosition, computedStyle], pointerEvents: "box-none", useNativeDriver: useNativeDriver }, containerProps), _children));
++        const containerView = (React.createElement(animatable.View, Object.assign({}, panHandlers, { ref: ref => (this.contentRef = ref), style: [panPosition, computedStyle], pointerEvents: "box-none", useNativeDriver: useNativeDriver, animation: animationIn }, containerProps), _children));
+         // If coverScreen is set to false by the user
+         // we render the modal inside the parent view directly
+         if (!coverScreen && this.state.isVisible) {

--- a/patches/react-native-modal/react-native-modal+13.0.1+002+modal-navigation-bar-translucent.patch
+++ b/patches/react-native-modal/react-native-modal+13.0.1+002+modal-navigation-bar-translucent.patch
@@ -1,0 +1,58 @@
+diff --git a/node_modules/react-native-modal/dist/modal.d.ts b/node_modules/react-native-modal/dist/modal.d.ts
+index bd6419e..029762c 100644
+--- a/node_modules/react-native-modal/dist/modal.d.ts
++++ b/node_modules/react-native-modal/dist/modal.d.ts
+@@ -46,6 +46,7 @@ declare const defaultProps: {
+     scrollOffsetMax: number;
+     scrollHorizontal: boolean;
+     statusBarTranslucent: boolean;
++    navigationBarTranslucent: boolean;
+     supportedOrientations: ("landscape" | "portrait" | "portrait-upside-down" | "landscape-left" | "landscape-right")[];
+ };
+ export declare type ModalProps = ViewProps & {
+@@ -137,6 +138,7 @@ export declare class ReactNativeModal extends React.Component<ModalProps, State>
+         scrollOffsetMax: number;
+         scrollHorizontal: boolean;
+         statusBarTranslucent: boolean;
++        navigationBarTranslucent: boolean;
+         supportedOrientations: ("landscape" | "portrait" | "portrait-upside-down" | "landscape-left" | "landscape-right")[];
+     };
+     state: State;
+diff --git a/node_modules/react-native-modal/dist/modal.js b/node_modules/react-native-modal/dist/modal.js
+index 2e70c0c..7a39705 100644
+--- a/node_modules/react-native-modal/dist/modal.js
++++ b/node_modules/react-native-modal/dist/modal.js
+@@ -39,6 +39,7 @@ const defaultProps = {
+     scrollOffsetMax: 0,
+     scrollHorizontal: false,
+     statusBarTranslucent: false,
++    navigationBarTranslucent: false,
+     supportedOrientations: ['portrait', 'landscape'],
+ };
+ const extractAnimationFromProps = (props) => ({
+@@ -69,6 +70,7 @@ export class ReactNativeModal extends React.Component {
+         this.interactionHandle = null;
+         this.getDeviceHeight = () => this.props.deviceHeight || this.state.deviceHeight;
+         this.getDeviceWidth = () => this.props.deviceWidth || this.state.deviceWidth;
++        this.backHandlerEventSubscription = null;
+         this.onBackButtonPress = () => {
+             if (this.props.onBackButtonPress && this.props.isVisible) {
+                 this.props.onBackButtonPress();
+@@ -467,13 +469,15 @@ export class ReactNativeModal extends React.Component {
+             document?.body?.addEventListener?.('keyup', this.handleEscape, true);
+             return;
+         }
+-        BackHandler.addEventListener('hardwareBackPress', this.onBackButtonPress);
++        this.backHandlerEventSubscription = BackHandler.addEventListener('hardwareBackPress', this.onBackButtonPress);
+     }
+     componentWillUnmount() {
+         if (Platform.OS === 'web') {
+             document?.body?.removeEventListener?.('keyup', this.handleEscape, true);
+         } else {
+-            BackHandler.removeEventListener('hardwareBackPress', this.onBackButtonPress);
++            if (this.backHandlerEventSubscription) {
++                this.backHandlerEventSubscription.remove();
++            }
+         }
+         if (this.didUpdateDimensionsEmitter) {
+             this.didUpdateDimensionsEmitter.remove();

--- a/src/components/AttachmentComposerModal.tsx
+++ b/src/components/AttachmentComposerModal.tsx
@@ -225,6 +225,7 @@ function AttachmentComposerModal({onConfirm, onModalShow = () => {}, onModalHide
                     setCurrentAttachment(null);
                     setPage(0);
                 }}
+                propagateSwipe
                 initialFocus={() => {
                     if (!submitRef.current) {
                         return false;

--- a/src/components/AttachmentModal.tsx
+++ b/src/components/AttachmentModal.tsx
@@ -450,6 +450,7 @@ function AttachmentModal({
                         });
                     }
                 }}
+                propagateSwipe
                 initialFocus={() => {
                     if (!submitRef.current) {
                         return false;

--- a/src/components/Modal/BaseModal.tsx
+++ b/src/components/Modal/BaseModal.tsx
@@ -3,7 +3,11 @@ import type {LayoutChangeEvent} from 'react-native';
 // Animated required for side panel navigation
 // eslint-disable-next-line no-restricted-imports
 import {Animated, View} from 'react-native';
+import type {ModalProps as ReactNativeModalProps} from 'react-native-modal';
+import ReactNativeModal from 'react-native-modal';
+import type {ValueOf} from 'type-fest';
 import ColorSchemeWrapper from '@components/ColorSchemeWrapper';
+import FocusTrapForModal from '@components/FocusTrap/FocusTrapForModal';
 import NavigationBar from '@components/NavigationBar';
 import ScreenWrapperOfflineIndicatorContext from '@components/ScreenWrapper/ScreenWrapperOfflineIndicatorContext';
 import useKeyboardState from '@hooks/useKeyboardState';
@@ -22,9 +26,93 @@ import Overlay from '@libs/Navigation/AppNavigator/Navigators/Overlay';
 import Navigation from '@libs/Navigation/Navigation';
 import {areAllModalsHidden, closeTop, onModalDidClose, setCloseModal, setModalVisibility, willAlertModalBecomeVisible} from '@userActions/Modal';
 import CONST from '@src/CONST';
+import ModalContent from './ModalContent';
 import ModalContext from './ModalContext';
 import ReanimatedModal from './ReanimatedModal';
+import type ReanimatedModalProps from './ReanimatedModal/types';
 import type BaseModalProps from './types';
+import type {FocusTrapOptions} from './types';
+
+const REANIMATED_MODAL_TYPES: Array<ValueOf<typeof CONST.MODAL.MODAL_TYPE>> = [
+    CONST.MODAL.MODAL_TYPE.BOTTOM_DOCKED,
+    CONST.MODAL.MODAL_TYPE.FULLSCREEN,
+    CONST.MODAL.MODAL_TYPE.POPOVER,
+    CONST.MODAL.MODAL_TYPE.RIGHT_DOCKED,
+    CONST.MODAL.MODAL_TYPE.CENTERED,
+    CONST.MODAL.MODAL_TYPE.CENTERED_SMALL,
+    CONST.MODAL.MODAL_TYPE.CENTERED_UNSWIPEABLE,
+    CONST.MODAL.MODAL_TYPE.CENTERED_SWIPEABLE_TO_RIGHT,
+    CONST.MODAL.MODAL_TYPE.CONFIRM,
+];
+
+type ModalComponentProps = (ReactNativeModalProps | ReanimatedModalProps) & {
+    type?: ValueOf<typeof CONST.MODAL.MODAL_TYPE>;
+    shouldUseReanimatedModal?: boolean;
+    shouldPreventScrollOnFocus?: boolean;
+    initialFocus?: FocusTrapOptions['initialFocus'];
+    isVisible: boolean;
+    isKeyboardActive: boolean;
+    saveFocusState: () => void;
+};
+
+function ModalComponent({
+    type,
+    shouldUseReanimatedModal,
+    isVisible,
+    shouldPreventScrollOnFocus,
+    initialFocus,
+    children,
+    saveFocusState,
+    onDismiss = () => {},
+    isKeyboardActive,
+    ...props
+}: ModalComponentProps) {
+    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+    if ((type && REANIMATED_MODAL_TYPES.includes(type)) || shouldUseReanimatedModal) {
+        return (
+            <ReanimatedModal
+                // eslint-disable-next-line react/jsx-props-no-spreading
+                {...(props as ReanimatedModalProps)}
+                type={type}
+                isVisible={isVisible}
+                shouldPreventScrollOnFocus={shouldPreventScrollOnFocus}
+                initialFocus={initialFocus}
+                onDismiss={onDismiss}
+            >
+                <ModalContent
+                    onModalWillShow={saveFocusState}
+                    onDismiss={onDismiss}
+                >
+                    {children}
+                </ModalContent>
+                {!isKeyboardActive && <NavigationBar />}
+            </ReanimatedModal>
+        );
+    }
+
+    return (
+        <ReactNativeModal
+            // eslint-disable-next-line react/jsx-props-no-spreading
+            {...(props as ReactNativeModalProps)}
+            isVisible={isVisible}
+            onDismiss={onDismiss}
+        >
+            <ModalContent
+                onModalWillShow={saveFocusState}
+                onDismiss={onDismiss}
+            >
+                <FocusTrapForModal
+                    active={isVisible}
+                    initialFocus={initialFocus}
+                    shouldPreventScroll={shouldPreventScrollOnFocus}
+                >
+                    {children}
+                </FocusTrapForModal>
+            </ModalContent>
+            {!isKeyboardActive && <NavigationBar />}
+        </ReactNativeModal>
+    );
+}
 
 function BaseModal(
     {
@@ -39,9 +127,12 @@ function BaseModal(
         onModalShow = () => {},
         onModalWillShow,
         onModalWillHide,
+        propagateSwipe,
         fullscreen = true,
         animationIn,
         animationOut,
+        useNativeDriver,
+        useNativeDriverForBackdrop,
         hideModalContentWhileAnimating = false,
         animationInTiming,
         animationOutTiming,
@@ -61,10 +152,12 @@ function BaseModal(
         swipeThreshold = 150,
         swipeDirection,
         shouldPreventScrollOnFocus = false,
+        disableAnimationIn = false,
         enableEdgeToEdgeBottomSafeAreaPadding,
         shouldApplySidePanelOffset = type === CONST.MODAL.MODAL_TYPE.RIGHT_DOCKED,
         hasBackdrop,
         backdropOpacity,
+        shouldUseReanimatedModal = false,
         shouldDisableBottomSafeAreaPadding = false,
         shouldIgnoreBackHandlerDuringTransition = false,
         forwardedFSClass = CONST.FULLSTORY.CLASS.UNMASK,
@@ -83,7 +176,11 @@ function BaseModal(
     const {isSmallScreenWidth, shouldUseNarrowLayout, isInNarrowPaneModal} = useResponsiveLayout();
 
     const {sidePanelOffset} = useSidePanel();
-    const sidePanelAnimatedStyle = shouldApplySidePanelOffset && !isSmallScreenWidth ? {transform: [{translateX: Animated.multiply(sidePanelOffset.current, -1)}]} : undefined;
+    const sidePanelStyle = !shouldUseReanimatedModal && shouldApplySidePanelOffset && !isSmallScreenWidth ? {paddingRight: sidePanelOffset.current} : undefined;
+    const sidePanelAnimatedStyle =
+        (shouldUseReanimatedModal || type === CONST.MODAL.MODAL_TYPE.POPOVER || type === CONST.MODAL.MODAL_TYPE.RIGHT_DOCKED) && shouldApplySidePanelOffset && !isSmallScreenWidth
+            ? {transform: [{translateX: Animated.multiply(sidePanelOffset.current, -1)}]}
+            : undefined;
     const keyboardStateContextValue = useKeyboardState();
 
     const [modalOverlapsWithTopSafeArea, setModalOverlapsWithTopSafeArea] = useState(false);
@@ -286,6 +383,25 @@ function BaseModal(
         [isVisible, type],
     );
 
+    const animationInProps = useMemo(() => {
+        // disableAnimationIn applies only to legacy modals. This should be removed once we fully migrate to `reanimated-modal`.
+        // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+        if (disableAnimationIn && ((type && !REANIMATED_MODAL_TYPES.includes(type)) || !shouldUseReanimatedModal)) {
+            // We need to apply these animation props to completely disable the "animation in". Simply setting it to 0 and undefined will not work.
+            // Based on: https://github.com/react-native-modal/react-native-modal/issues/191
+            return {
+                animationIn: {from: {opacity: 1}, to: {opacity: 1}},
+                animationInTiming: 0,
+            };
+        }
+
+        return {
+            animationIn: animationIn ?? modalStyleAnimationIn,
+            animationInDelay,
+            animationInTiming,
+        };
+    }, [animationIn, animationInDelay, animationInTiming, disableAnimationIn, modalStyleAnimationIn, shouldUseReanimatedModal, type]);
+
     // In Modals we need to reset the ScreenWrapperOfflineIndicatorContext to allow nested ScreenWrapper components to render offline indicators,
     // except if we are in a narrow pane navigator. In this case, we use the narrow pane's original values.
     const {isInNarrowPane} = useContext(NarrowPaneContext);
@@ -308,13 +424,15 @@ function BaseModal(
                     collapsable={false}
                     style={[styles.pAbsolute, {zIndex: 1}]}
                 >
-                    <ReanimatedModal
+                    <ModalComponent
                         // Prevent the parent element to capture a click. This is useful when the modal component is put inside a pressable.
                         onClick={(e) => e.stopPropagation()}
                         onBackdropPress={handleBackdropPress}
                         // Note: Escape key on web/desktop will trigger onBackButtonPress callback
+                        // eslint-disable-next-line react/jsx-props-no-multi-spaces
                         onBackButtonPress={closeTop}
                         onModalShow={handleShowModal}
+                        propagateSwipe={propagateSwipe}
                         onModalHide={hideModal}
                         onModalWillShow={() => {
                             saveFocusState();
@@ -333,14 +451,15 @@ function BaseModal(
                         backdropTransitionOutTiming={0}
                         hasBackdrop={hasBackdrop ?? fullscreen}
                         coverScreen={fullscreen}
-                        style={modalStyle}
+                        style={[modalStyle, sidePanelStyle]}
                         deviceHeight={windowHeight}
                         deviceWidth={windowWidth}
-                        animationIn={animationIn ?? modalStyleAnimationIn}
-                        animationInTiming={animationInTiming}
-                        animationInDelay={animationInDelay}
+                        // eslint-disable-next-line react/jsx-props-no-spreading
+                        {...animationInProps}
                         animationOut={animationOut ?? modalStyleAnimationOut}
                         animationOutTiming={animationOutTiming}
+                        useNativeDriver={useNativeDriver}
+                        useNativeDriverForBackdrop={useNativeDriverForBackdrop}
                         hideModalContentWhileAnimating={hideModalContentWhileAnimating}
                         statusBarTranslucent={statusBarTranslucent}
                         navigationBarTranslucent={navigationBarTranslucent}
@@ -348,6 +467,9 @@ function BaseModal(
                         avoidKeyboard={avoidKeyboard}
                         customBackdrop={shouldUseCustomBackdrop ? <Overlay onPress={handleBackdropPress} /> : undefined}
                         type={type}
+                        shouldUseReanimatedModal={shouldUseReanimatedModal}
+                        isKeyboardActive={keyboardStateContextValue?.isKeyboardActive}
+                        saveFocusState={saveFocusState}
                         shouldIgnoreBackHandlerDuringTransition={shouldIgnoreBackHandlerDuringTransition}
                     >
                         <Animated.View
@@ -358,8 +480,7 @@ function BaseModal(
                         >
                             <ColorSchemeWrapper>{children}</ColorSchemeWrapper>
                         </Animated.View>
-                        {!keyboardStateContextValue?.isKeyboardActive && <NavigationBar />}
-                    </ReanimatedModal>
+                    </ModalComponent>
                 </View>
             </ScreenWrapperOfflineIndicatorContext.Provider>
         </ModalContext.Provider>

--- a/src/components/Modal/ModalContent.tsx
+++ b/src/components/Modal/ModalContent.tsx
@@ -1,0 +1,29 @@
+import type {ReactNode} from 'react';
+import React from 'react';
+
+type ModalContentProps = {
+    /** Modal contents */
+    children: ReactNode;
+
+    /**
+     * Callback method fired after modal content is unmounted.
+     * isVisible is not enough to cover all modal close cases,
+     * such as closing the attachment modal through the browser's back button.
+     * */
+    onDismiss: () => void;
+
+    /** Callback method fired after modal content is mounted. */
+    onModalWillShow: () => void;
+};
+
+function ModalContent({children, onDismiss = () => {}, onModalWillShow = () => {}}: ModalContentProps) {
+    React.useEffect(() => {
+        onModalWillShow();
+        return onDismiss;
+        // eslint-disable-next-line react-compiler/react-compiler, react-hooks/exhaustive-deps
+    }, []);
+    return children;
+}
+ModalContent.displayName = 'ModalContent';
+
+export default ModalContent;

--- a/src/components/Modal/ReanimatedModal/index.tsx
+++ b/src/components/Modal/ReanimatedModal/index.tsx
@@ -14,6 +14,7 @@ import CONST from '@src/CONST';
 import Backdrop from './Backdrop';
 import Container from './Container';
 import type ReanimatedModalProps from './types';
+import type {AnimationInType, AnimationOutType} from './types';
 
 function ReanimatedModal({
     testID,
@@ -161,8 +162,8 @@ function ReanimatedModal({
             animationInDelay={animationInDelay}
             onOpenCallBack={onOpenCallBack}
             onCloseCallBack={onCloseCallBack}
-            animationIn={animationIn}
-            animationOut={animationOut}
+            animationIn={animationIn as AnimationInType}
+            animationOut={animationOut as AnimationOutType}
             style={style}
             type={type}
             onSwipeComplete={onSwipeComplete}

--- a/src/components/Modal/ReanimatedModal/types.ts
+++ b/src/components/Modal/ReanimatedModal/types.ts
@@ -1,5 +1,6 @@
 import type {ReactNode} from 'react';
 import type {NativeSyntheticEvent, StyleProp, ViewProps, ViewStyle} from 'react-native';
+import type {ModalProps as ReactNativeModalProps} from 'react-native-modal';
 import type {SharedValue} from 'react-native-reanimated';
 import type {ValueOf} from 'type-fest';
 import type {FocusTrapOptions} from '@components/Modal/types';
@@ -26,8 +27,10 @@ type GestureHandlerProps = {
     swipeDirection?: SwipeDirection | SwipeDirection[];
 };
 
-type AnimationIn = 'fadeIn' | 'slideInUp' | 'slideInRight';
-type AnimationOut = 'fadeOut' | 'slideOutDown' | 'slideOutRight';
+type AnimationInType = 'fadeIn' | 'slideInUp' | 'slideInRight';
+type AnimationOutType = 'fadeOut' | 'slideOutDown' | 'slideOutRight';
+
+type AnimationOut = ValueOf<Pick<ReactNativeModalProps, 'animationOut'>>;
 
 type ReanimatedModalProps = ViewProps &
     GestureProps &
@@ -57,14 +60,18 @@ type ReanimatedModalProps = ViewProps &
         /** The presentation style of the modal */
         presentationStyle?: 'fullScreen' | 'pageSheet' | 'formSheet' | 'overFullScreen';
 
+        /** Default ModalProps Provided */
+        /** Whether to use the native driver for the backdrop animation */
+        useNativeDriverForBackdrop?: boolean;
+
         /** Enum for animation type when modal appears */
-        animationIn?: AnimationIn;
+        animationIn?: ValueOf<Pick<ReactNativeModalProps, 'animationIn'>> | AnimationInType;
 
         /** Duration of the animation when modal appears */
         animationInTiming?: number;
 
         /** Enum for animation type when modal disappears */
-        animationOut?: AnimationOut;
+        animationOut?: AnimationOut | AnimationOutType;
 
         /** Duration of the animation when modal disappears */
         animationOutTiming?: number;
@@ -178,11 +185,11 @@ type ContainerProps = {
     panPosition?: {translateX: SharedValue<number>; translateY: SharedValue<number>};
 
     /** Animation played when modal shows */
-    animationIn: AnimationIn;
+    animationIn: AnimationInType;
 
     /** Animation played when modal disappears */
-    animationOut: AnimationOut;
+    animationOut: AnimationOutType;
 };
 
 export default ReanimatedModalProps;
-export type {BackdropProps, ContainerProps, GestureHandlerProps, AnimationIn, AnimationOut, SwipeDirection};
+export type {BackdropProps, ContainerProps, GestureHandlerProps, AnimationOut, AnimationInType, AnimationOutType, SwipeDirection};

--- a/src/components/Modal/ReanimatedModal/utils.ts
+++ b/src/components/Modal/ReanimatedModal/utils.ts
@@ -2,11 +2,11 @@ import type {ViewStyle} from 'react-native';
 import {Easing} from 'react-native-reanimated';
 import type {ValidKeyframeProps} from 'react-native-reanimated/lib/typescript/commonTypes';
 import variables from '@styles/variables';
-import type {AnimationIn, AnimationOut} from './types';
+import type {AnimationInType, AnimationOutType} from './types';
 
 const easing = Easing.bezier(0.76, 0.0, 0.24, 1.0).factory();
 
-function getModalInAnimation(animationType: AnimationIn): ValidKeyframeProps {
+function getModalInAnimation(animationType: AnimationInType): ValidKeyframeProps {
     switch (animationType) {
         case 'slideInRight':
             return {
@@ -40,7 +40,7 @@ function getModalInAnimation(animationType: AnimationIn): ValidKeyframeProps {
 /**
  * @returns A function that takes a number between 0 and 1 and returns a ViewStyle object.
  */
-function getModalInAnimationStyle(animationType: AnimationIn): (progress: number) => ViewStyle {
+function getModalInAnimationStyle(animationType: AnimationInType): (progress: number) => ViewStyle {
     switch (animationType) {
         case 'slideInRight':
             return (progress) => ({transform: [{translateX: `${100 * (1 - progress)}%`}]});
@@ -53,7 +53,7 @@ function getModalInAnimationStyle(animationType: AnimationIn): (progress: number
     }
 }
 
-function getModalOutAnimation(animationType: AnimationOut): ValidKeyframeProps {
+function getModalOutAnimation(animationType: AnimationOutType): ValidKeyframeProps {
     switch (animationType) {
         case 'slideOutRight':
             return {

--- a/src/components/Modal/index.android.tsx
+++ b/src/components/Modal/index.android.tsx
@@ -2,13 +2,17 @@ import React from 'react';
 import BaseModal from './BaseModal';
 import type BaseModalProps from './types';
 
-function Modal({children, ...rest}: BaseModalProps) {
+// Only want to use useNativeDriver on Android. It has strange flashes issue on IOS
+// https://github.com/react-native-modal/react-native-modal#the-modal-flashes-in-a-weird-way-when-animating
+function Modal({useNativeDriver = true, ...rest}: BaseModalProps) {
     return (
         <BaseModal
+            useNativeDriver={useNativeDriver}
+            useNativeDriverForBackdrop={false}
             // eslint-disable-next-line react/jsx-props-no-spreading
             {...rest}
         >
-            {children}
+            {rest.children}
         </BaseModal>
     );
 }

--- a/src/components/Modal/index.ios.tsx
+++ b/src/components/Modal/index.ios.tsx
@@ -11,6 +11,7 @@ function Modal({children, ...rest}: BaseModalProps) {
 
     return (
         <BaseModal
+            useNativeDriver
             // eslint-disable-next-line react/jsx-props-no-spreading
             {...rest}
             animationInTiming={animationInTiming}

--- a/src/components/Modal/index.tsx
+++ b/src/components/Modal/index.tsx
@@ -78,6 +78,8 @@ function Modal({fullscreen = true, onModalHide = () => {}, type, onModalShow = (
             onModalWillHide={onModalWillHide}
             avoidKeyboard={false}
             fullscreen={fullscreen}
+            useNativeDriver={false}
+            useNativeDriverForBackdrop={false}
             type={type}
         >
             {children}

--- a/src/components/Modal/types.ts
+++ b/src/components/Modal/types.ts
@@ -1,10 +1,10 @@
 import type {FocusTrapProps} from 'focus-trap-react';
-import type {ViewStyle} from 'react-native';
+import type {GestureResponderEvent, PanResponderGestureState, ViewStyle} from 'react-native';
+import type {Direction, ModalProps as ReactNativeModalProps} from 'react-native-modal';
 import type {ValueOf} from 'type-fest';
 import type {ForwardedFSClassProps} from '@libs/Fullstory/types';
 import type CONST from '@src/CONST';
 import type ReanimatedModalProps from './ReanimatedModal/types';
-import type {SwipeDirection} from './ReanimatedModal/types';
 
 type FocusTrapOptions = Exclude<FocusTrapProps['focusTrapOptions'], undefined>;
 
@@ -19,10 +19,14 @@ type WindowState = {
     shouldGoBack: boolean;
 };
 
-type BaseModalProps = Partial<ReanimatedModalProps> &
+type BaseModalProps = Partial<ReactNativeModalProps> &
+    Partial<ReanimatedModalProps> &
     ForwardedFSClassProps & {
         /** Decides whether the modal should cover fullscreen. FullScreen modal has backdrop */
         fullscreen?: boolean;
+
+        /** Should we close modal on outside click */
+        shouldCloseOnOutsideClick?: boolean;
 
         /** Should we announce the Modal visibility changes? */
         shouldSetModalVisibility?: boolean;
@@ -48,7 +52,6 @@ type BaseModalProps = Partial<ReanimatedModalProps> &
         /** The anchor position of a popover modal. Has no effect on other modal types. */
         popoverAnchorPosition?: PopoverAnchorPosition;
 
-        /** Styles for the outer most view wrapper */
         outerStyle?: ViewStyle;
 
         /** Whether the modal should go under the system statusbar */
@@ -63,13 +66,21 @@ type BaseModalProps = Partial<ReanimatedModalProps> &
         /** Modal container styles  */
         innerContainerStyle?: ViewStyle;
 
+        /**
+         * Whether the modal should hide its content while animating. On iOS, set to true
+         * if `useNativeDriver` is also true, to avoid flashes in the UI.
+         *
+         * See: https://github.com/react-native-modal/react-native-modal/pull/116
+         * */
+        hideModalContentWhileAnimating?: boolean;
+
         /** Whether handle navigation back when modal show. */
         shouldHandleNavigationBack?: boolean;
 
         /** Should we use a custom backdrop for the modal? (This prevents focus issues on desktop) */
         shouldUseCustomBackdrop?: boolean;
 
-        /** Unique id for the modal */
+        /** unique id for the modal */
         modalId?: number;
 
         /**
@@ -84,17 +95,23 @@ type BaseModalProps = Partial<ReanimatedModalProps> &
         /** Should we apply padding style in modal itself. If this value is false, we will handle it in ScreenWrapper */
         shouldUseModalPaddingStyle?: boolean;
 
+        /** Whether swipe gestures should propagate to parent components */
+        propagateSwipe?: boolean | ((event?: GestureResponderEvent, gestureState?: PanResponderGestureState) => boolean);
+
         /** After swipe more than threshold modal will close */
         swipeThreshold?: number;
 
         /** In which direction modal will swipe */
-        swipeDirection?: SwipeDirection;
+        swipeDirection?: Direction;
 
         /** Used to set the element that should receive the initial focus */
         initialFocus?: FocusTrapOptions['initialFocus'];
 
         /** Whether to prevent the focus trap from scrolling the element into view. */
         shouldPreventScrollOnFocus?: boolean;
+
+        /** Whether to disable the animation in */
+        disableAnimationIn?: boolean;
 
         /**
          * Temporary flag to disable safe area bottom spacing in modals and to allow edge-to-edge content.
@@ -113,6 +130,11 @@ type BaseModalProps = Partial<ReanimatedModalProps> &
          * Disables the bottom safe area padding in the modal. Used in for scrollable FeatureTrainingModal.
          */
         shouldDisableBottomSafeAreaPadding?: boolean;
+
+        /**
+         * Whether the modal should use ReanimatedModal implementation.
+         */
+        shouldUseReanimatedModal?: boolean;
     };
 
 export default BaseModalProps;

--- a/src/components/Popover/index.tsx
+++ b/src/components/Popover/index.tsx
@@ -84,6 +84,7 @@ function Popover(props: PopoverProps) {
                 popoverAnchorPosition={anchorPosition}
                 animationInTiming={disableAnimation ? DISABLED_ANIMATION_DURATION : animationInTiming}
                 animationOutTiming={disableAnimation ? DISABLED_ANIMATION_DURATION : animationOutTiming}
+                shouldCloseOnOutsideClick
                 onLayout={onLayout}
                 animationIn={animationIn}
                 animationOut={animationOut}

--- a/src/components/PopoverMenu.tsx
+++ b/src/components/PopoverMenu.tsx
@@ -4,6 +4,7 @@ import type {ReactNode, RefObject} from 'react';
 import React, {useCallback, useLayoutEffect, useMemo, useState} from 'react';
 import {StyleSheet, View} from 'react-native';
 import type {GestureResponderEvent, LayoutChangeEvent, StyleProp, TextStyle, ViewStyle} from 'react-native';
+import type {ModalProps} from 'react-native-modal';
 import type {SvgProps} from 'react-native-svg';
 import useArrowKeyFocusManager from '@hooks/useArrowKeyFocusManager';
 import useKeyboardShortcut from '@hooks/useKeyboardShortcut';
@@ -76,9 +77,9 @@ type PopoverMenuItem = MenuItemProps & {
     shouldCloseModalOnSelect?: boolean;
 };
 
-type ModalAnimationProps = Pick<ReanimatedModalProps, 'animationInDelay' | 'animationIn' | 'animationInTiming' | 'animationOut' | 'animationOutTiming'>;
+type PopoverModalProps = Pick<ModalProps, 'animationIn' | 'animationOut' | 'animationInTiming' | 'animationOutTiming'> & Pick<ReanimatedModalProps, 'animationInDelay'>;
 
-type PopoverMenuProps = Partial<ModalAnimationProps> & {
+type PopoverMenuProps = Partial<PopoverModalProps> & {
     /** Callback method fired when the user requests to close the modal */
     onClose: () => void;
 
@@ -440,6 +441,7 @@ function BasePopoverMenu({
             withoutOverlay={withoutOverlay}
             shouldSetModalVisibility={shouldSetModalVisibility}
             shouldEnableNewFocusManagement={shouldEnableNewFocusManagement}
+            useNativeDriver
             restoreFocusType={restoreFocusType}
             innerContainerStyle={{...styles.pv0, ...innerContainerStyle}}
             shouldUseModalPaddingStyle={shouldUseModalPaddingStyle}

--- a/src/components/PopoverWithMeasuredContent/PopoverWithMeasuredContentBase.tsx
+++ b/src/components/PopoverWithMeasuredContent/PopoverWithMeasuredContentBase.tsx
@@ -36,6 +36,7 @@ function PopoverWithMeasuredContentBase({
     children,
     withoutOverlay = false,
     fullscreen = true,
+    shouldCloseOnOutsideClick = false,
     shouldSetModalVisibility = true,
     statusBarTranslucent = true,
     navigationBarTranslucent = true,
@@ -192,6 +193,7 @@ function PopoverWithMeasuredContentBase({
             isVisible={isVisible}
             withoutOverlay={withoutOverlay}
             fullscreen={fullscreen}
+            shouldCloseOnOutsideClick={shouldCloseOnOutsideClick}
             shouldSetModalVisibility={shouldSetModalVisibility}
             statusBarTranslucent={statusBarTranslucent}
             navigationBarTranslucent={navigationBarTranslucent}

--- a/src/components/PopoverWithoutOverlay/types.ts
+++ b/src/components/PopoverWithoutOverlay/types.ts
@@ -17,7 +17,7 @@ type PopoverWithoutOverlayProps = ChildrenProps &
         /** The anchor ref of the popover */
         anchorRef: RefObject<View | HTMLDivElement | Text | null>;
 
-        /** Time in milliseconds for the modal entering animation */
+        /** A react-native-animatable animation timing for the modal display animation */
         animationInTiming?: number;
 
         /** Whether disable the animations */

--- a/src/components/Search/SearchRouter/SearchRouterModal.tsx
+++ b/src/components/Search/SearchRouter/SearchRouterModal.tsx
@@ -28,6 +28,7 @@ function SearchRouterModal() {
             innerContainerStyle={{paddingTop: viewportOffsetTop}}
             popoverAnchorPosition={{right: 6, top: 6}}
             fullscreen
+            propagateSwipe
             swipeDirection={shouldUseNarrowLayout ? CONST.SWIPE_DIRECTION.RIGHT : undefined}
             onClose={closeSearchRouter}
             onModalHide={() => setShouldHideInputCaret(isMobileWebIOS)}

--- a/src/components/SidePanel/HelpComponents/HelpContent.tsx
+++ b/src/components/SidePanel/HelpComponents/HelpContent.tsx
@@ -1,8 +1,10 @@
 import {findFocusedRoute} from '@react-navigation/native';
 import React, {useEffect, useMemo, useRef, useState} from 'react';
+import {ScrollView} from 'react-native-gesture-handler';
 import FullScreenLoadingIndicator from '@components/FullscreenLoadingIndicator';
+// Importing from the react-native-gesture-handler package instead of the `components/ScrollView` to fix scroll issue:
+// https://github.com/react-native-modal/react-native-modal/issues/236
 import HeaderGap from '@components/HeaderGap';
-import ScrollView from '@components/ScrollView';
 import getHelpContent from '@components/SidePanel/getHelpContent';
 import useEnvironment from '@hooks/useEnvironment';
 import useLocalize from '@hooks/useLocalize';
@@ -110,6 +112,7 @@ function HelpContent({closeSidePanel}: HelpContentProps) {
             ) : (
                 <ScrollView
                     style={[styles.ph5, styles.pb5]}
+                    userSelect="auto"
                     scrollIndicatorInsets={{right: Number.MIN_VALUE}}
                 >
                     {getHelpContent(styles, route, isProduction, expandedIndex, setExpandedIndex)}

--- a/src/components/SidePanel/HelpModal/index.ios.tsx
+++ b/src/components/SidePanel/HelpModal/index.ios.tsx
@@ -11,6 +11,7 @@ function Help({shouldHideSidePanel, closeSidePanel}: HelpProps) {
             isVisible={!shouldHideSidePanel}
             type={CONST.MODAL.MODAL_TYPE.RIGHT_DOCKED}
             shouldHandleNavigationBack
+            propagateSwipe
             swipeDirection={CONST.SWIPE_DIRECTION.RIGHT}
         >
             <HelpContent closeSidePanel={closeSidePanel} />

--- a/src/components/TestDrive/TestDriveDemo.tsx
+++ b/src/components/TestDrive/TestDriveDemo.tsx
@@ -64,6 +64,7 @@ function TestDriveDemo() {
                     type={CONST.MODAL.MODAL_TYPE.FULLSCREEN}
                     style={styles.backgroundWhite}
                     innerContainerStyle={{...styles.flex1, marginTop: paddingTop, marginBottom: paddingBottom}}
+                    useNativeDriver={false} // We need to disable native driver in order to prevent https://github.com/Expensify/App/issues/61032
                 >
                     <TestDriveBanner onPress={closeModal} />
                     <FullPageOfflineBlockingView>

--- a/src/hooks/useResponsiveLayout/index.native.ts
+++ b/src/hooks/useResponsiveLayout/index.native.ts
@@ -13,14 +13,14 @@ import type ResponsiveLayoutResult from './types';
  *
  * There are two kinds of modals in this app:
  *     1. Modal stack navigators from react-navigation
- *     2. Modal components that use react-native-reanimated
+ *     2. Modal components that use react-native-modal
  *
  * This hook is designed to handle both. `shouldUseNarrowLayout` will return `true` if any of the following are true:
  *     1. The device screen width is narrow
- *     2. The consuming component is the child of a "right docked" react-native-reanimated component
- *     3. The consuming component is a screen in a modal stack navigator and not a child of a "non-right-docked" react-native-reanimated component.
+ *     2. The consuming component is the child of a "right docked" react-native-modal component
+ *     3. The consuming component is a screen in a modal stack navigator and not a child of a "non-right-docked" react-native-modal component.
  *
- * For more details on the various modal types we've defined for this app and implemented using react-native-reanimated, see `ModalType`.
+ * For more details on the various modal types we've defined for this app and implemented using react-native-modal, see `ModalType`.
  */
 export default function useResponsiveLayout(): ResponsiveLayoutResult {
     const {windowWidth, windowHeight} = useWindowDimensions();
@@ -36,7 +36,7 @@ export default function useResponsiveLayout(): ResponsiveLayoutResult {
     // we need to always take screen width into consideration, no matter the platform.
     const onboardingIsMediumOrLargerScreenWidth = windowWidth > variables.mobileResponsiveWidthBreakpoint;
 
-    // Note: activeModalType refers to our react-native-reanimated component wrapper, not react-navigation's modal stack navigators.
+    // Note: activeModalType refers to our react-native-modal component wrapper, not react-navigation's modal stack navigators.
     // This means it will only be defined if the component calling this hook is a child of a modal component. See BaseModal for the provider.
     const {activeModalType} = useContext(ModalContext);
 

--- a/src/hooks/useResponsiveLayout/index.ts
+++ b/src/hooks/useResponsiveLayout/index.ts
@@ -14,14 +14,14 @@ import type ResponsiveLayoutResult from './types';
  *
  * There are two kinds of modals in this app:
  *     1. Modal stack navigators from react-navigation
- *     2. Modal components that use react-native-reanimated
+ *     2. Modal components that use react-native-modal
  *
  * This hook is designed to handle both. `shouldUseNarrowLayout` will return `true` if any of the following are true:
  *     1. The device screen width is narrow
- *     2. The consuming component is the child of a "right docked" react-native-reanimated component
- *     3. The consuming component is a screen in a modal stack navigator and not a child of a "non-right-docked" react-native-reanimated component.
+ *     2. The consuming component is the child of a "right docked" react-native-modal component
+ *     3. The consuming component is a screen in a modal stack navigator and not a child of a "non-right-docked" react-native-modal component.
  *
- * For more details on the various modal types we've defined for this app and implemented using react-native-reanimated, see `ModalType`.
+ * For more details on the various modal types we've defined for this app and implemented using react-native-modal, see `ModalType`.
  */
 export default function useResponsiveLayout(): ResponsiveLayoutResult {
     const {windowWidth, windowHeight} = useWindowDimensions();
@@ -39,7 +39,7 @@ export default function useResponsiveLayout(): ResponsiveLayoutResult {
     const lowerScreenDimension = Math.min(windowWidth, windowHeight);
     const isSmallScreen = lowerScreenDimension <= variables.mobileResponsiveWidthBreakpoint;
 
-    // Note: activeModalType refers to our react-native-reanimated component wrapper, not react-navigation's modal stack navigators.
+    // Note: activeModalType refers to our react-native-modal component wrapper, not react-navigation's modal stack navigators.
     // This means it will only be defined if the component calling this hook is a child of a modal component. See BaseModal for the provider.
     const {activeModalType} = useContext(ModalContext);
 

--- a/src/pages/media/AttachmentModalScreen/AttachmentModalContainer/index.tsx
+++ b/src/pages/media/AttachmentModalScreen/AttachmentModalContainer/index.tsx
@@ -1,4 +1,5 @@
 import React, {useCallback, useContext, useEffect, useState} from 'react';
+import {InteractionManager} from 'react-native';
 import Modal from '@components/Modal';
 import Navigation from '@libs/Navigation/Navigation';
 import AttachmentModalBaseContent from '@pages/media/AttachmentModalScreen/AttachmentModalBaseContent';
@@ -11,6 +12,7 @@ import type AttachmentModalContainerProps from './types';
 function AttachmentModalContainer<Screen extends AttachmentModalScreenType>({contentProps, modalType, onShow, onClose, shouldHandleNavigationBack}: AttachmentModalContainerProps<Screen>) {
     const [isVisible, setIsVisible] = useState(true);
     const attachmentsContext = useContext(AttachmentModalContext);
+    const [shouldDisableAnimationAfterInitialMount, setShouldDisableAnimationAfterInitialMount] = useState(false);
 
     /**
      * Closes the modal.
@@ -34,14 +36,25 @@ function AttachmentModalContainer<Screen extends AttachmentModalScreenType>({con
         [attachmentsContext, onClose],
     );
 
+    // After the modal has initially been mounted and animated in,
+    // we don't want to show another animation when the modal type changes or
+    // when the browser switches to narrow layout.
+    useEffect(() => {
+        InteractionManager.runAfterInteractions(() => {
+            setShouldDisableAnimationAfterInitialMount(true);
+        });
+    }, []);
+
     useEffect(() => {
         onShow?.();
     }, [onShow]);
 
     return (
         <Modal
+            disableAnimationIn={shouldDisableAnimationAfterInitialMount}
             isVisible={isVisible}
             type={modalType ?? CONST.MODAL.MODAL_TYPE.CENTERED_UNSWIPEABLE}
+            propagateSwipe
             initialFocus={() => {
                 if (!contentProps.submitRef?.current) {
                     return false;

--- a/src/styles/utils/generators/ModalStyleUtils.ts
+++ b/src/styles/utils/generators/ModalStyleUtils.ts
@@ -1,5 +1,5 @@
 import type {ViewStyle} from 'react-native';
-import type ReanimatedModalProps from '@components/Modal/ReanimatedModal/types';
+import type {ModalProps} from 'react-native-modal';
 import {isMobileSafari} from '@libs/Browser';
 import type {ThemeStyles} from '@styles/index';
 import variables from '@styles/variables';
@@ -26,9 +26,9 @@ type WindowDimensions = {
 type GetModalStyles = {
     modalStyle: ViewStyle;
     modalContainerStyle: ViewStyle;
-    swipeDirection: ReanimatedModalProps['swipeDirection'];
-    animationIn: ReanimatedModalProps['animationIn'];
-    animationOut: ReanimatedModalProps['animationOut'];
+    swipeDirection: ModalProps['swipeDirection'];
+    animationIn: ModalProps['animationIn'];
+    animationOut: ModalProps['animationOut'];
     hideBackdrop: boolean;
     shouldAddTopSafeAreaMargin: boolean;
     shouldAddBottomSafeAreaMargin: boolean;


### PR DESCRIPTION
Reverts Expensify/App#70289

# Fixed Issues
$ https://github.com/Expensify/App/issues/70684




Following the test steps in the linked issue, this seems to have fixed it.


https://github.com/user-attachments/assets/1dec4fbc-5c08-4b6e-93a8-761242b0f167



### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I verified there are no new alerts related to the `canBeMissing` param for `useOnyx`
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
