### PR TITLE
[No QA] Move data binding to it's own philosophy doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -588,17 +588,7 @@ If you seek some additional information you can always refer to the [extended ve
 This application is built with the following principles.
 1. [Data Flow](contributingGuides/philosophies/DATA-FLOW.md)
 1. [Offline First](contributingGuides/philosophies/OFFLINE.md)
-1. **UI Binds to data on disk**
-    - Onyx is a Pub/Sub library to connect the application to the data stored on disk.
-    - UI components subscribe to Onyx (using `withOnyx()`) and any change to the Onyx data is published to the component by calling `setState()` with the changed data.
-    - Libraries subscribe to Onyx (with `Onyx.connect()`) and any change to the Onyx data is published to the callback with the changed data.
-    - The UI should never call any Onyx methods except for `Onyx.connect()`. That is the job of Actions (see next section).
-    - The UI always triggers an Action when something needs to happen (eg. a person inputs data, the UI triggers an Action with this data).
-    - The UI should be as flexible as possible when it comes to:
-        - Incomplete or missing data. Always assume data is incomplete or not there. For example, when a comment is pushed to the client from a pusher event, it's possible that Onyx does not have data for that report yet. That's OK. A partial report object is added to Onyx for the report key `report_1234 = {reportID: 1234, isUnread: true}`. Then there is code that monitors Onyx for reports with incomplete data, and calls `openReport(1234)` to get the full data for that report. The UI should be able to gracefully handle the report object not being complete. In this example, the sidebar wouldn't display any report that does not have a report name.
-        - The order that actions are done in. All actions should be done in parallel instead of sequence.
-            - Parallel actions are asynchronous methods that don't return promises. Any number of these actions can be called at one time and it doesn't matter what order they happen in or when they complete.
-            - In-Sequence actions are asynchronous methods that return promises. This is necessary when one asynchronous method depends on the results from a previous asynchronous method. Example: Making an XHR to `command=CreateChatReport` which returns a reportID which is used to call `command=Get&rvl=reportStuff`.
+1. [Data Binding](contributingGuides/philosophies/DATA_BINDING.md)
 1. **Actions manage Onyx Data**
     - When data needs to be written to or read from the server, this is done through Actions only.
     - Action methods should only have return values (data or a promise) if they are called by other actions. This is done to encourage that action methods can be called in parallel with no dependency on other methods (see discussion above).

--- a/contributingGuides/philosophies/DATA-BINDING.md
+++ b/contributingGuides/philosophies/DATA-BINDING.md
@@ -4,7 +4,7 @@ The UI binds to the data stored on the local device's database (Onyx).
 - Onyx is a Pub/Sub library to connect the application to the data stored on disk.
 
 ## Rules
-### - The UI MUST use `useOnyx` to subscribe to changes in Onyx data
+### - The UI MUST use `useOnyx` to get data and subscribe to changes of that data in Onyx
 ### - The UI MUST NOT call any Onyx methods directly
 ### - The UI MUST trigger an an action when something needs to happen
 For example, a person inputs data, the UI calls an action and passes the user's input.

--- a/contributingGuides/philosophies/DATA-BINDING.md
+++ b/contributingGuides/philosophies/DATA-BINDING.md
@@ -19,7 +19,7 @@ Do not wait for one action to finish before calling another action. If you find 
 Returning a promise is the first sign that the rule above this is being broken. Let the UI react to changes to Onyx data that is modified in the action instead.
 
 ### - Library files that are not connected or associated to any UI SHOULD use `Onyx.connectWithoutView()` to subscribe to changes in Onyx data
-Library files are the files located in `/src/lib` but excluding the actions in `/src/lib/actions`.
+Library files are located in `/src/lib` but excluding the actions in `/src/lib/actions` which have their own rule below.
 
 Exclusions:
 - If a library method is used by an action method (like a utility), then follow the rule below for action methods

--- a/contributingGuides/philosophies/DATA-BINDING.md
+++ b/contributingGuides/philosophies/DATA-BINDING.md
@@ -22,7 +22,7 @@ Returning a promise is the first sign that the rule above this is being broken. 
 Library files are located in `/src/lib` but excluding the actions in `/src/lib/actions` which have their own rule below.
 
 Exclusions:
-- If a library method is used by an action method (like a utility), then follow the rule below for action methods
+- If a library method is used by an action method (like a utility), then follow the rule below for action methods.
 
 ### - Action methods (`/src/lib/actions`) SHOULD be pure functions and not access global data
 Pure functions are ones that have all necessary data passed as parameters and do not create side-effects.

--- a/contributingGuides/philosophies/DATA-BINDING.md
+++ b/contributingGuides/philosophies/DATA-BINDING.md
@@ -1,0 +1,18 @@
+# Data Binding Philosophy
+The UI binds to the data stored on the local device's database (Onyx).
+
+- Onyx is a Pub/Sub library to connect the application to the data stored on disk.
+
+## Rules
+### - The UI MUST NOT call any Onyx methods directly
+### - The UI MUST trigger an an action when something needs to happen
+For example, a person inputs data, the UI calls an action and passes the user's input.
+
+### - The UI SHOULD anticipate missing or incomplete data
+Use fallbacks and default values to handle data that can be missing.
+
+### - The UI MUST call all action methods in parallel and not in sequence
+Do not wait for one action to finish before calling another action. If you find yourself running into this problem, you should rethink how the component is built. Ask for help in our open source room and there will be plenty of people willing to help you think through a better approach. They can be tricky sometimes!
+
+### - Action methods SHOULD not return a promise
+Returning a promise is the first sign that the rule above this is being broken. Let the UI react to changes to Onyx data that is modified in the action instead.

--- a/contributingGuides/philosophies/DATA-BINDING.md
+++ b/contributingGuides/philosophies/DATA-BINDING.md
@@ -4,6 +4,7 @@ The UI binds to the data stored on the local device's database (Onyx).
 - Onyx is a Pub/Sub library to connect the application to the data stored on disk.
 
 ## Rules
+### - The UI MUST use `useOnyx` to subscribe to changes in Onyx data
 ### - The UI MUST NOT call any Onyx methods directly
 ### - The UI MUST trigger an an action when something needs to happen
 For example, a person inputs data, the UI calls an action and passes the user's input.
@@ -16,3 +17,12 @@ Do not wait for one action to finish before calling another action. If you find 
 
 ### - Action methods SHOULD not return a promise
 Returning a promise is the first sign that the rule above this is being broken. Let the UI react to changes to Onyx data that is modified in the action instead.
+
+### - Library files that are not connected or associated to any UI SHOULD use `Onyx.connectWithoutView()` to subscribe to changes in Onyx data
+Library files are the files located in `/src/lib` but excluding the actions in `/src/lib/actions`.
+
+Exclusions:
+- If a library method is used by an action method (like a utility), then follow the rule below for action methods
+
+### - Action methods (`/src/lib/actions`) SHOULD be pure functions and not access global data
+Pure functions are ones that have all necessary data passed as parameters and do not create side-effects.

--- a/contributingGuides/philosophies/INDEX.md
+++ b/contributingGuides/philosophies/INDEX.md
@@ -7,6 +7,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 ## Contents
 * [Cross-Platform Philosophy](/contributingGuides/philosophies/CROSS-PLATFORM.md)
 * [Data Flow Philosophy](/contributingGuides/philosophies/DATA-FLOW.md)
+* [Data Binding Philosophy](/contributingGuides/philosophies/DATA-BINDING.md)
 * [Directory Structure and File Naming Philosophy](/contributingGuides/philosophies/DIRECTORIES.md)
 * [Offline Philosophy](/contributingGuides/philosophies/OFFLINE.md)
 * [Routing Philosophy](/contributingGuides/philosophies/ROUTING.md)


### PR DESCRIPTION
### Explanation of Change
I rewrote a fair amount of this because the examples in the original text were really outdated.

### Fixed Issues
None

### Tests
None

### Offline tests
None

### QA Steps
None

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I verified there are no new alerts related to the `canBeMissing` param for `useOnyx`
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Desktop</summary>

<!-- add screenshots or videos here -->

</details>
