### PR TITLE
[CP Staging] Revert "Fix: User is dropped in the Inbox after enabling camera permission and replacing receipt"

### DIFF
--- a/src/libs/Navigation/NavigationRoot.tsx
+++ b/src/libs/Navigation/NavigationRoot.tsx
@@ -129,12 +129,6 @@ function NavigationRoot({authenticated, lastVisitedPath, initialUrl, onReady}: N
 
         const isTransitioning = path?.includes(ROUTES.TRANSITION_BETWEEN_APPS);
 
-        // If we have a transition URL, don't restore last visited path - let React Navigation handle it
-        // This prevents reusing deep links after logout regardless of authentication status
-        if (isTransitioning) {
-            return undefined;
-        }
-
         // If the user haven't completed the flow, we want to always redirect them to the onboarding flow.
         // We also make sure that the user is authenticated, isn't part of a group workspace, isn't in the transition flow & wasn't invited to NewDot.
         if (!CONFIG.IS_HYBRID_APP && !hasNonPersonalPolicy && !isOnboardingCompleted && !wasInvitedToNewDot && authenticated && !isTransitioning) {
@@ -150,20 +144,20 @@ function NavigationRoot({authenticated, lastVisitedPath, initialUrl, onReady}: N
             );
         }
 
-        if (shouldOpenLastVisitedPath(lastVisitedPath) && authenticated) {
-            // Only skip restoration if there's a specific deep link that's not the root
-            // This allows restoration when app is killed and reopened without a deep link
-            const isRootPath = !path || path === '' || path === '/';
-            const isSpecificDeepLink = path && !isRootPath;
-
-            if (!isSpecificDeepLink) {
-                Log.info('Restoring last visited path on app startup', false, {lastVisitedPath, initialUrl, path});
-                return getAdaptedStateFromPath(lastVisitedPath, linkingConfig.config);
-            }
+        // If there is no lastVisitedPath, we can do early return. We won't modify the default behavior.
+        // The same applies to HybridApp, as we always define the route to which we want to transition.
+        if (!shouldOpenLastVisitedPath(lastVisitedPath) || CONFIG.IS_HYBRID_APP) {
+            return undefined;
         }
 
-        // Default behavior - let React Navigation handle the initial state
-        return undefined;
+        // If the user opens the root of app "/" it will be parsed to empty string "".
+        // If the path is defined and different that empty string we don't want to modify the default behavior.
+        if (path) {
+            return;
+        }
+
+        // Otherwise we want to redirect the user to the last visited path.
+        return getAdaptedStateFromPath(lastVisitedPath, linkingConfig.config);
 
         // The initialState value is relevant only on the first render.
         // eslint-disable-next-line react-compiler/react-compiler, react-hooks/exhaustive-deps

--- a/src/libs/actions/App.ts
+++ b/src/libs/actions/App.ts
@@ -1,5 +1,4 @@
 // Issue - https://github.com/Expensify/App/issues/26719
-import {getPathFromState} from '@react-navigation/native';
 import {Str} from 'expensify-common';
 import type {AppStateStatus} from 'react-native';
 import {AppState} from 'react-native';
@@ -12,8 +11,7 @@ import * as Browser from '@libs/Browser';
 import DateUtils from '@libs/DateUtils';
 import Log from '@libs/Log';
 import getCurrentUrl from '@libs/Navigation/currentUrl';
-import {linkingConfig} from '@libs/Navigation/linkingConfig';
-import Navigation, {navigationRef} from '@libs/Navigation/Navigation';
+import Navigation from '@libs/Navigation/Navigation';
 import Performance from '@libs/Performance';
 import {isPublicRoom, isValidReport} from '@libs/ReportUtils';
 import {isLoggingInAsNewUser as isLoggingInAsNewUserSessionUtils} from '@libs/SessionUtils';
@@ -209,36 +207,10 @@ function setAppLoading(isLoading: boolean) {
     Onyx.set(ONYXKEYS.IS_LOADING_APP, isLoading);
 }
 
-/**
- * Saves the current navigation path to lastVisitedPath before app goes to background
- */
-function saveCurrentPathBeforeBackground() {
-    try {
-        if (!navigationRef.isReady()) {
-            return;
-        }
-
-        const currentState = navigationRef.getRootState();
-        if (!currentState) {
-            return;
-        }
-
-        const currentPath = getPathFromState(currentState, linkingConfig.config);
-
-        if (currentPath) {
-            Log.info('Saving current path before background', false, {currentPath});
-            updateLastVisitedPath(currentPath);
-        }
-    } catch (error) {
-        Log.warn('Failed to save current path before background', {error});
-    }
-}
-
 let appState: AppStateStatus;
 AppState.addEventListener('change', (nextAppState) => {
     if (nextAppState.match(/inactive|background/) && appState === 'active') {
         Log.info('Flushing logs as app is going inactive', true, {}, true);
-        saveCurrentPathBeforeBackground();
     }
     appState = nextAppState;
 });

--- a/src/libs/shouldOpenLastVisitedPath/index.native.ts
+++ b/src/libs/shouldOpenLastVisitedPath/index.native.ts
@@ -1,5 +1,6 @@
+import {getReportIDFromLink} from '@libs/ReportUtils';
 import type {Route} from '@src/ROUTES';
 
 export default function shouldOpenLastVisitedPath(lastVisitedPath: Route) {
-    return !!lastVisitedPath;
+    return !!lastVisitedPath && !!getReportIDFromLink(lastVisitedPath);
 }

--- a/src/pages/iou/request/step/IOURequestStepScan/index.native.tsx
+++ b/src/pages/iou/request/step/IOURequestStepScan/index.native.tsx
@@ -45,7 +45,6 @@ import HapticFeedback from '@libs/HapticFeedback';
 import {navigateToParticipantPage} from '@libs/IOUUtils';
 import Log from '@libs/Log';
 import Navigation from '@libs/Navigation/Navigation';
-import navigationRef from '@libs/Navigation/navigationRef';
 import {getManagerMcTestParticipant, getParticipantsOption, getReportOption} from '@libs/OptionsListUtils';
 import {isPaidGroupPolicy} from '@libs/PolicyUtils';
 import {findSelfDMReportID, generateReportID, getPolicyExpenseChat, isArchivedReport, isPolicyExpenseChat} from '@libs/ReportUtils';
@@ -70,7 +69,6 @@ import type {GpsPoint} from '@userActions/IOU';
 import {buildOptimisticTransactionAndCreateDraft, removeDraftTransactions, removeTransactionReceipt} from '@userActions/TransactionEdit';
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
-import type {Route} from '@src/ROUTES';
 import ROUTES from '@src/ROUTES';
 import type {Policy} from '@src/types/onyx';
 import type {Participant} from '@src/types/onyx/IOU';
@@ -525,23 +523,10 @@ function IOURequestStepScan({
 
     const updateScanAndNavigate = useCallback(
         (file: FileObject, source: string) => {
-            // Fix for the issue where the navigation state is lost after returning from device settings https://github.com/Expensify/App/issues/65992
-            const navigationState = navigationRef.current?.getState();
-            const reportsSplitNavigator = navigationState?.routes?.find((route) => route.name === 'ReportsSplitNavigator');
-            const hasLostNavigationsState = reportsSplitNavigator && !reportsSplitNavigator.state;
-            if (hasLostNavigationsState) {
-                if (backTo) {
-                    Navigation.navigate(backTo as Route);
-                } else {
-                    Navigation.navigate(ROUTES.HOME);
-                }
-            } else {
-                navigateBack();
-            }
-
+            navigateBack();
             replaceReceipt({transactionID: initialTransactionID, file: file as File, source});
         },
-        [initialTransactionID, backTo],
+        [initialTransactionID],
     );
 
     /**


### PR DESCRIPTION
Reverts Expensify/App#67245

Straight revert

### Tests/ QA

Pre-condition: As admin , add a member in workspace 

1. Launch app as member 
2. Open employee workspace chat 
3. Create a manual expense 
4. Open the expense 
5. Tap plus icon and add a receipt
6. After adding receipt in employee workspace, user must be directed to expense details page.
