### PR TITLE
[CP Staging] Reverts PR#70250 Open transaction thread on top

### DIFF
--- a/src/components/ActionSheetAwareScrollView/index.ios.tsx
+++ b/src/components/ActionSheetAwareScrollView/index.ios.tsx
@@ -6,7 +6,7 @@ import {Actions, ActionSheetAwareScrollViewContext, ActionSheetAwareScrollViewPr
 import type {ActionSheetAwareScrollViewProps, RenderActionSheetAwareScrollViewComponent} from './types';
 import useActionSheetKeyboardSpacing from './useActionSheetKeyboardSpacing';
 
-const ActionSheetAwareScrollView = forwardRef<ScrollView, ActionSheetAwareScrollViewProps>(({style, children, isInvertedScrollView, ...props}, ref) => {
+const ActionSheetAwareScrollView = forwardRef<ScrollView, ActionSheetAwareScrollViewProps>(({style, children, ...props}, ref) => {
     const scrollViewAnimatedRef = useAnimatedRef<Reanimated.ScrollView>();
 
     const onRef = useCallback(
@@ -24,16 +24,9 @@ const ActionSheetAwareScrollView = forwardRef<ScrollView, ActionSheetAwareScroll
     );
 
     const spacing = useActionSheetKeyboardSpacing(scrollViewAnimatedRef);
-    const animatedStyle = useAnimatedStyle(() =>
-        isInvertedScrollView
-            ? {
-                  paddingTop: spacing.get(),
-              }
-            : {
-                  // On non-inverted scroll views we use bottom to ensure that content is displayed above the context menu / keyboard
-                  bottom: spacing.get(),
-              },
-    );
+    const animatedStyle = useAnimatedStyle(() => ({
+        paddingTop: spacing.get(),
+    }));
 
     return (
         <Reanimated.ScrollView

--- a/src/components/ActionSheetAwareScrollView/types.ts
+++ b/src/components/ActionSheetAwareScrollView/types.ts
@@ -1,10 +1,6 @@
 import type {PropsWithChildren} from 'react';
 import type {ScrollViewProps} from 'react-native';
 
-type ActionSheetAwareScrollViewAnimationProps = {
-    /** Whether the child ScrollView is inverted */
-    isInvertedScrollView?: boolean;
-};
-type ActionSheetAwareScrollViewProps = PropsWithChildren<ScrollViewProps> & ActionSheetAwareScrollViewAnimationProps;
+type ActionSheetAwareScrollViewProps = PropsWithChildren<ScrollViewProps>;
 type RenderActionSheetAwareScrollViewComponent = ((props: ActionSheetAwareScrollViewProps) => React.ReactElement<ScrollViewProps>) | undefined;
 export type {ActionSheetAwareScrollViewProps, RenderActionSheetAwareScrollViewComponent};

--- a/src/hooks/useReportScrollManager/index.native.ts
+++ b/src/hooks/useReportScrollManager/index.native.ts
@@ -54,12 +54,12 @@ function useReportScrollManager(): ReportScrollManagerData {
     }, [flatListRef]);
 
     const scrollToOffset = useCallback(
-        (offset: number, animated = false) => {
+        (offset: number) => {
             if (!flatListRef?.current) {
                 return;
             }
 
-            flatListRef.current.scrollToOffset({offset, animated});
+            flatListRef.current.scrollToOffset({offset, animated: false});
         },
         [flatListRef],
     );

--- a/src/hooks/useReportScrollManager/index.ts
+++ b/src/hooks/useReportScrollManager/index.ts
@@ -34,24 +34,21 @@ function useReportScrollManager(): ReportScrollManagerData {
     /**
      * Scroll to the end of the FlatList.
      */
-    const scrollToEnd = useCallback(
-        (animated = false) => {
-            if (!flatListRef?.current) {
-                return;
-            }
+    const scrollToEnd = useCallback(() => {
+        if (!flatListRef?.current) {
+            return;
+        }
 
-            flatListRef.current.scrollToEnd({animated});
-        },
-        [flatListRef],
-    );
+        flatListRef.current.scrollToEnd({animated: false});
+    }, [flatListRef]);
 
     const scrollToOffset = useCallback(
-        (offset: number, animated = true) => {
+        (offset: number) => {
             if (!flatListRef?.current) {
                 return;
             }
 
-            flatListRef.current.scrollToOffset({animated, offset});
+            flatListRef.current.scrollToOffset({animated: true, offset});
         },
         [flatListRef],
     );

--- a/src/hooks/useReportScrollManager/types.ts
+++ b/src/hooks/useReportScrollManager/types.ts
@@ -4,8 +4,8 @@ type ReportScrollManagerData = {
     ref: FlatListRefType;
     scrollToIndex: (index: number, isEditing?: boolean) => void;
     scrollToBottom: () => void;
-    scrollToEnd: (animated?: boolean) => void;
-    scrollToOffset: (offset: number, animated?: boolean) => void;
+    scrollToEnd: () => void;
+    scrollToOffset: (offset: number) => void;
 };
 
 export default ReportScrollManagerData;

--- a/src/pages/home/report/ReportActionsList.tsx
+++ b/src/pages/home/report/ReportActionsList.tsx
@@ -361,6 +361,8 @@ function ReportActionsList({
     const topOffset = useMemo(() => safariViewportOffsetTop || (isMobileChrome() ? initialHeight - windowHeight : 0), [safariViewportOffsetTop, initialHeight, windowHeight]);
     const prevTopOffset = useRef(0);
 
+    const {isInNarrowPaneModal} = useResponsiveLayout();
+
     const {isFloatingMessageCounterVisible, setIsFloatingMessageCounterVisible, trackVerticalScrolling, onViewableItemsChanged} = useReportUnreadMessageScrollTracking({
         reportID: report.reportID,
         currentVerticalScrollingOffsetRef: scrollingVerticalOffset,
@@ -849,10 +851,15 @@ function ReportActionsList({
             // When using FlatList for money requests, we need to manually add top padding (pt4) and remove bottom padding (pb0)
             // to maintain consistent spacing and visual appearance at the top of the list.
             baseStyles.push(styles.pb0, styles.pt4);
+
+            // For money requests, we want the content to be vertically aligned to the bottom of the screen, but only on wide screens.
+            if (!isInNarrowPaneModal) {
+                baseStyles.push(styles.justifyContentEnd);
+            }
         }
 
         return baseStyles;
-    }, [shouldFocusToTopOnMount, styles.chatContentScrollView, styles.pb0, styles.pt4]);
+    }, [isInNarrowPaneModal, shouldFocusToTopOnMount, styles.chatContentScrollView, styles.justifyContentEnd, styles.pb0, styles.pt4]);
 
     /**
      * Wraps the provided renderScrollComponent to pass isInvertedScrollView prop.

--- a/src/pages/home/report/ReportActionsList.tsx
+++ b/src/pages/home/report/ReportActionsList.tsx
@@ -3,19 +3,15 @@ import {useIsFocused, useRoute} from '@react-navigation/native';
 import {isUserValidatedSelector} from '@selectors/Account';
 import {accountIDSelector} from '@selectors/Session';
 import React, {memo, useCallback, useContext, useEffect, useLayoutEffect, useMemo, useRef, useState} from 'react';
-import type {LayoutChangeEvent, NativeScrollEvent, NativeSyntheticEvent, ScrollViewProps, StyleProp, ViewStyle} from 'react-native';
+import type {LayoutChangeEvent, NativeScrollEvent, NativeSyntheticEvent} from 'react-native';
 import {DeviceEventEmitter, InteractionManager, View} from 'react-native';
 import type {OnyxEntry} from 'react-native-onyx';
 import {renderScrollComponent as renderActionSheetAwareScrollView} from '@components/ActionSheetAwareScrollView';
-import type {RenderActionSheetAwareScrollViewComponent} from '@components/ActionSheetAwareScrollView/types';
-import FlatList from '@components/FlatList';
 import InvertedFlatList from '@components/InvertedFlatList';
 import {AUTOSCROLL_TO_TOP_THRESHOLD} from '@components/InvertedFlatList/BaseInvertedFlatList';
-import KeyboardAvoidingView from '@components/KeyboardAvoidingView';
 import {PersonalDetailsContext, usePersonalDetails} from '@components/OnyxListItemProvider';
 import ReportActionsSkeletonView from '@components/ReportActionsSkeletonView';
 import useCurrentUserPersonalDetails from '@hooks/useCurrentUserPersonalDetails';
-import useInitialWindowDimensions from '@hooks/useInitialWindowDimensions';
 import useLocalize from '@hooks/useLocalize';
 import useNetworkWithOfflineStatus from '@hooks/useNetworkWithOfflineStatus';
 import useOnyx from '@hooks/useOnyx';
@@ -24,9 +20,8 @@ import useReportIsArchived from '@hooks/useReportIsArchived';
 import useReportScrollManager from '@hooks/useReportScrollManager';
 import useResponsiveLayout from '@hooks/useResponsiveLayout';
 import useThemeStyles from '@hooks/useThemeStyles';
-import useViewportOffsetTop from '@hooks/useViewportOffsetTop';
 import useWindowDimensions from '@hooks/useWindowDimensions';
-import {isMobileChrome, isSafari} from '@libs/Browser';
+import {isSafari} from '@libs/Browser';
 import DateUtils from '@libs/DateUtils';
 import FS from '@libs/Fullstory';
 import durationHighlightItem from '@libs/Navigation/helpers/getDurationHighlightItem';
@@ -55,8 +50,9 @@ import {
     getReportLastVisibleActionCreated,
     isArchivedNonExpenseReport,
     isCanceledTaskReport,
+    isExpenseReport,
     isInvoiceReport,
-    isMoneyRequestReport,
+    isIOUReport,
     isTaskReport,
     isUnread,
 } from '@libs/ReportUtils';
@@ -136,10 +132,6 @@ let prevReportID: string | null = null;
  * random enough to avoid collisions
  */
 function keyExtractor(item: OnyxTypes.ReportAction): string {
-    if (item.actionName === CONST.REPORT.ACTIONS.TYPE.CREATED) {
-        return CONST.REPORT.ACTIONS.TYPE.CREATED;
-    }
-
     return item.reportActionID;
 }
 
@@ -191,6 +183,7 @@ function ReportActionsList({
     const [tryNewDot] = useOnyx(ONYXKEYS.NVP_TRY_NEW_DOT, {canBeMissing: false});
     const isTryNewDotNVPDismissed = !!tryNewDot?.classicRedirect?.dismissed;
     const [isScrollToBottomEnabled, setIsScrollToBottomEnabled] = useState(false);
+    const [shouldScrollToEndAfterLayout, setShouldScrollToEndAfterLayout] = useState(false);
     const [actionIdToHighlight, setActionIdToHighlight] = useState('');
 
     useEffect(() => {
@@ -206,19 +199,6 @@ function ReportActionsList({
     const hasHeaderRendered = useRef(false);
     const linkedReportActionID = route?.params?.reportActionID;
 
-    const isTransactionThreadReport = useMemo(() => isTransactionThread(parentReportAction), [parentReportAction]);
-    const isMoneyRequestOrInvoiceReport = useMemo(() => isMoneyRequestReport(report) || isInvoiceReport(report), [report]);
-    const shouldFocusToTopOnMount = useMemo(() => isTransactionThreadReport || isMoneyRequestOrInvoiceReport, [isMoneyRequestOrInvoiceReport, isTransactionThreadReport]);
-
-    // FlatList displays items from top to bottom, so we need the oldest actions first.
-    // Since sortedReportActions and sortedVisibleReportActions are ordered from newest to oldest,
-    // we use toReversed() to reverse the order when using FlatList, ensuring the oldest action appears at the top.
-    // InvertedFlatList automatically shows the newest action at the bottom, so no reversal is needed there.
-    const reportActions = useMemo(() => (shouldFocusToTopOnMount ? sortedReportActions.toReversed() : sortedReportActions), [shouldFocusToTopOnMount, sortedReportActions]);
-    const visibleReportActions = useMemo(
-        () => (shouldFocusToTopOnMount ? sortedVisibleReportActions.toReversed() : sortedVisibleReportActions),
-        [shouldFocusToTopOnMount, sortedVisibleReportActions],
-    );
     const lastAction = sortedVisibleReportActions.at(0);
     const sortedVisibleReportActionsObjects: OnyxTypes.ReportActions = useMemo(
         () =>
@@ -353,54 +333,17 @@ function ReportActionsList({
     // Display the new message indicator when comment linking and not close to the newest message.
     const reportActionID = route?.params?.reportActionID;
 
-    const safariViewportOffsetTop = useViewportOffsetTop();
-    const {initialHeight} = useInitialWindowDimensions();
-    const flatListVerticalOffset = useRef(0);
-    const prevFlatListVerticalOffset = useRef(0);
-    // initialHeight - windowHeight gives us the height of the keyboard when it's open on mobile Chrome.
-    const topOffset = useMemo(() => safariViewportOffsetTop || (isMobileChrome() ? initialHeight - windowHeight : 0), [safariViewportOffsetTop, initialHeight, windowHeight]);
-    const prevTopOffset = useRef(0);
-
-    const {isInNarrowPaneModal} = useResponsiveLayout();
-
     const {isFloatingMessageCounterVisible, setIsFloatingMessageCounterVisible, trackVerticalScrolling, onViewableItemsChanged} = useReportUnreadMessageScrollTracking({
         reportID: report.reportID,
         currentVerticalScrollingOffsetRef: scrollingVerticalOffset,
         readActionSkippedRef: readActionSkipped,
         unreadMarkerReportActionIndex,
-        isInverted: !shouldFocusToTopOnMount,
+        isInverted: true,
         onTrackScrolling: (event: NativeSyntheticEvent<NativeScrollEvent>) => {
-            // On mobile Safari, when the keyboard is open, the content is pushed up then we apply a marginTop to push the page down.
-            // This push caused onScroll to be triggered but we don't want to consider this as user scrolling.
-            // Otherwise, the scrollToOffset would be triggered with the wrong offset.
-            if (safariViewportOffsetTop > 0) {
-                return;
-            }
-            if (shouldFocusToTopOnMount) {
-                // For money requests, calculate distance from bottom like MoneyRequestReportActionsList
-                const {layoutMeasurement, contentSize, contentOffset} = event.nativeEvent;
-                scrollingVerticalOffset.current = contentSize.height - layoutMeasurement.height - contentOffset.y;
-
-                // We want to keep track of the actual offset of the FlatList so that when the keyboard is opened/closed we can adjust the offset accordingly
-                flatListVerticalOffset.current = contentOffset.y;
-            } else {
-                // For regular reports (InvertedFlatList), use raw contentOffset.y
-                scrollingVerticalOffset.current = event.nativeEvent.contentOffset.y;
-            }
+            scrollingVerticalOffset.current = event.nativeEvent.contentOffset.y;
             onScroll?.(event);
         },
     });
-
-    const scrollToBottom = useCallback(() => {
-        if (shouldFocusToTopOnMount) {
-            // In money requests, we want to scroll to the end of the list
-            reportScrollManager.scrollToEnd(true);
-            return;
-        }
-
-        // On remaining reports, we want to scroll to the bottom of the inverted FlatList which is the top of the list (offset: 0)
-        reportScrollManager.scrollToBottom();
-    }, [shouldFocusToTopOnMount, reportScrollManager]);
 
     useEffect(() => {
         if (
@@ -410,20 +353,11 @@ function ReportActionsList({
             hasNewestReportAction
         ) {
             setIsFloatingMessageCounterVisible(false);
-            scrollToBottom();
+            reportScrollManager.scrollToBottom();
         }
         previousLastIndex.current = lastActionIndex;
         reportActionSize.current = sortedVisibleReportActions.length;
-    }, [
-        lastActionIndex,
-        sortedVisibleReportActions,
-        reportScrollManager,
-        hasNewestReportAction,
-        linkedReportActionID,
-        setIsFloatingMessageCounterVisible,
-        parentReportAction,
-        scrollToBottom,
-    ]);
+    }, [lastActionIndex, sortedVisibleReportActions, reportScrollManager, hasNewestReportAction, linkedReportActionID, setIsFloatingMessageCounterVisible]);
 
     useEffect(() => {
         userActiveSince.current = DateUtils.getDBTime();
@@ -457,10 +391,18 @@ function ReportActionsList({
             return;
         }
 
+        const shouldScrollToEnd =
+            (isExpenseReport(report) || isTransactionThread(parentReportAction)) && isSearchTopmostFullScreenRoute() && hasNewestReportAction && !unreadMarkerReportActionID;
+
+        if (shouldScrollToEnd) {
+            setShouldScrollToEndAfterLayout(true);
+        }
+
         InteractionManager.runAfterInteractions(() => {
             setIsFloatingMessageCounterVisible(false);
-            if (!shouldFocusToTopOnMount) {
-                scrollToBottom();
+
+            if (!shouldScrollToEnd) {
+                reportScrollManager.scrollToBottom();
             }
         });
         // eslint-disable-next-line react-compiler/react-compiler, react-hooks/exhaustive-deps
@@ -475,10 +417,10 @@ function ReportActionsList({
         const prevSorted = lastAction?.reportActionID ? prevSortedVisibleReportActionsObjects[lastAction?.reportActionID] : null;
         if (lastAction?.actionName === CONST.REPORT.ACTIONS.TYPE.ACTIONABLE_TRACK_EXPENSE_WHISPER && !prevSorted) {
             InteractionManager.runAfterInteractions(() => {
-                scrollToBottom();
+                reportScrollManager.scrollToBottom();
             });
         }
-    }, [lastAction, parentReportAction, prevSortedVisibleReportActionsObjects, reportScrollManager, scrollToBottom]);
+    }, [lastAction, prevSortedVisibleReportActionsObjects, reportScrollManager]);
 
     const scrollToBottomForCurrentUserAction = useCallback(
         (isFromCurrentUser: boolean, action?: OnyxTypes.ReportAction) => {
@@ -505,20 +447,20 @@ function ReportActionsList({
                         }, 100);
                     } else {
                         setIsFloatingMessageCounterVisible(false);
-                        scrollToBottom();
+                        reportScrollManager.scrollToBottom();
                     }
                     if (action?.reportActionID) {
                         setActionIdToHighlight(action.reportActionID);
                     }
                 } else {
                     setIsFloatingMessageCounterVisible(false);
-                    scrollToBottom();
+                    reportScrollManager.scrollToBottom();
                 }
 
                 setIsScrollToBottomEnabled(true);
             });
         },
-        [sortedVisibleReportActions, report.reportID, reportScrollManager, setIsFloatingMessageCounterVisible, scrollToBottom],
+        [report.reportID, reportScrollManager, setIsFloatingMessageCounterVisible, sortedVisibleReportActions],
     );
 
     // Clear the highlighted report action after scrolling and highlighting
@@ -573,10 +515,10 @@ function ReportActionsList({
             return;
         }
         InteractionManager.runAfterInteractions(() => {
-            scrollToBottom();
+            reportScrollManager.scrollToBottom();
         });
         // eslint-disable-next-line react-compiler/react-compiler, react-hooks/exhaustive-deps
-    }, [lastAction, scrollToBottom]);
+    }, [lastAction]);
 
     const scrollToBottomAndMarkReportAsRead = useCallback(() => {
         setIsFloatingMessageCounterVisible(false);
@@ -592,13 +534,13 @@ function ReportActionsList({
                 Navigation.navigate(ROUTES.REPORT_WITH_ID.getRoute(report.reportID));
             }
             openReport(report.reportID);
-            scrollToBottom();
+            reportScrollManager.scrollToBottom();
             return;
         }
-        scrollToBottom();
+        reportScrollManager.scrollToBottom();
         readActionSkipped.current = false;
         readNewestAction(report.reportID);
-    }, [setIsFloatingMessageCounterVisible, hasNewestReportAction, scrollToBottom, report.reportID]);
+    }, [setIsFloatingMessageCounterVisible, hasNewestReportAction, reportScrollManager, report.reportID]);
 
     /**
      * Calculates the ideal number of report actions to render in the first render, based on the screen height and on
@@ -632,7 +574,7 @@ function ReportActionsList({
             return false;
         }
 
-        if (isTransactionThreadReport) {
+        if (isTransactionThread(parentReportAction)) {
             return !isDeletedParentAction(parentReportAction) && !isReversedTransaction(parentReportAction);
         }
 
@@ -640,8 +582,8 @@ function ReportActionsList({
             return !isCanceledTaskReport(report, parentReportAction);
         }
 
-        return isMoneyRequestOrInvoiceReport;
-    }, [isMoneyRequestOrInvoiceReport, isTransactionThreadReport, parentReportAction, report, sortedVisibleReportActions]);
+        return isExpenseReport(report) || isIOUReport(report) || isInvoiceReport(report);
+    }, [parentReportAction, report, sortedVisibleReportActions]);
 
     useEffect(() => {
         if (report.reportID !== prevReportID) {
@@ -685,7 +627,6 @@ function ReportActionsList({
 
     const renderItem = useCallback(
         ({item: reportAction, index}: ListRenderItemInfo<OnyxTypes.ReportAction>) => {
-            const actionIndex = shouldFocusToTopOnMount ? sortedVisibleReportActions.length - index - 1 : index;
             const originalReportID = getOriginalReportID(report.reportID, reportAction);
             const reportDraftMessages = draftMessage?.[`${ONYXKEYS.COLLECTION.REPORT_ACTIONS_DRAFTS}${originalReportID}`];
             const matchingDraftMessage = reportDraftMessages?.[reportAction.reportActionID];
@@ -701,7 +642,7 @@ function ReportActionsList({
                     allReports={allReports}
                     policies={policies}
                     reportAction={reportAction}
-                    reportActions={reportActions}
+                    reportActions={sortedReportActions}
                     parentReportAction={parentReportAction}
                     parentReportActionForTransactionThread={parentReportActionForTransactionThread}
                     index={index}
@@ -709,8 +650,8 @@ function ReportActionsList({
                     transactionThreadReport={transactionThreadReport}
                     linkedReportActionID={linkedReportActionID}
                     displayAsGroup={
-                        !isConsecutiveChronosAutomaticTimerAction(sortedVisibleReportActions, actionIndex, chatIncludesChronosWithID(reportAction?.reportID)) &&
-                        isConsecutiveActionMadeByPreviousActor(sortedVisibleReportActions, actionIndex)
+                        !isConsecutiveChronosAutomaticTimerAction(sortedVisibleReportActions, index, chatIncludesChronosWithID(reportAction?.reportID)) &&
+                        isConsecutiveActionMadeByPreviousActor(sortedVisibleReportActions, index)
                     }
                     mostRecentIOUReportActionID={mostRecentIOUReportActionID}
                     shouldHideThreadDividerLine={shouldHideThreadDividerLine}
@@ -734,30 +675,29 @@ function ReportActionsList({
             );
         },
         [
-            shouldFocusToTopOnMount,
-            sortedVisibleReportActions,
-            report,
             draftMessage,
             emojiReactions,
-            transactions,
             allReports,
             policies,
-            reportActions,
+            sortedReportActions,
             parentReportAction,
             parentReportActionForTransactionThread,
+            report,
             transactionThreadReport,
             linkedReportActionID,
+            sortedVisibleReportActions,
             mostRecentIOUReportActionID,
             shouldHideThreadDividerLine,
             unreadMarkerReportActionID,
             firstVisibleReportActionID,
             shouldUseThreadDividerLine,
+            transactions,
             userWalletTierName,
             isUserValidated,
             personalDetailsList,
-            isReportArchived,
             userBillingFundID,
             isTryNewDotNVPDismissed,
+            isReportArchived,
         ],
     );
 
@@ -774,27 +714,16 @@ function ReportActionsList({
     const onLayoutInner = useCallback(
         (event: LayoutChangeEvent) => {
             onLayout(event);
-            // We only want to apply the offset adjustment when the topOffset changes, on money requests, which only happens on mobile browsers because of the virtual keyboards.
-            if (shouldFocusToTopOnMount && topOffset !== prevTopOffset.current) {
-                // When the keyboard is shown, the topOffset is > 0 and we need to increase the offset to keep the same view.
-                if (topOffset > 0) {
-                    // Store the previous offset before the keyboard was shown.
-                    prevFlatListVerticalOffset.current = flatListVerticalOffset.current;
-                    reportScrollManager.scrollToOffset(flatListVerticalOffset.current + topOffset, false);
-                } else {
-                    // When the keyboard is hidden, the topOffset is 0 and we need to restore the previous offset before the keyboard was shown.
-                    reportScrollManager.scrollToOffset(prevFlatListVerticalOffset.current, false);
-                }
-
-                // Update the previous topOffset value for future comparisons.
-                prevTopOffset.current = topOffset;
-            }
             if (isScrollToBottomEnabled) {
-                scrollToBottom();
+                reportScrollManager.scrollToBottom();
                 setIsScrollToBottomEnabled(false);
             }
+            if (shouldScrollToEndAfterLayout) {
+                reportScrollManager.scrollToEnd();
+                setShouldScrollToEndAfterLayout(false);
+            }
         },
-        [onLayout, shouldFocusToTopOnMount, topOffset, isScrollToBottomEnabled, reportScrollManager, scrollToBottom],
+        [isScrollToBottomEnabled, onLayout, reportScrollManager, shouldScrollToEndAfterLayout],
     );
 
     const retryLoadNewerChatsError = useCallback(() => {
@@ -840,43 +769,6 @@ function ReportActionsList({
         loadOlderChats(false);
     }, [loadOlderChats]);
 
-    // FlatList is used for transaction threads to keep the list scrolled at the top and display actions in chronological order.
-    // InvertedFlatList is used for regular reports, always scrolling to the bottom initially and showing the newest messages at the bottom.
-    const ListComponent = shouldFocusToTopOnMount ? FlatList : InvertedFlatList;
-    const contentContainerStyle = useMemo(() => {
-        const baseStyles: StyleProp<ViewStyle> = [styles.chatContentScrollView];
-
-        if (shouldFocusToTopOnMount) {
-            // InvertedFlatList applies a scale: -1 transform, so top padding becomes bottom padding and vice versa.
-            // When using FlatList for money requests, we need to manually add top padding (pt4) and remove bottom padding (pb0)
-            // to maintain consistent spacing and visual appearance at the top of the list.
-            baseStyles.push(styles.pb0, styles.pt4);
-
-            // For money requests, we want the content to be vertically aligned to the bottom of the screen, but only on wide screens.
-            if (!isInNarrowPaneModal) {
-                baseStyles.push(styles.justifyContentEnd);
-            }
-        }
-
-        return baseStyles;
-    }, [isInNarrowPaneModal, shouldFocusToTopOnMount, styles.chatContentScrollView, styles.justifyContentEnd, styles.pb0, styles.pt4]);
-
-    /**
-     * Wraps the provided renderScrollComponent to pass isInvertedScrollView prop.
-     *
-     * This is required for correct handling of inverted scroll views in transaction threads, when context menu is shown.
-     */
-    const getRenderScrollComponentWithAnimationProps = useCallback(
-        (render: NonNullable<RenderActionSheetAwareScrollViewComponent>) => (props: ScrollViewProps) =>
-            render({
-                ...props,
-                isInvertedScrollView: !shouldFocusToTopOnMount,
-            }),
-        [shouldFocusToTopOnMount],
-    );
-
-    const ListWrapper = shouldFocusToTopOnMount ? KeyboardAvoidingView : View;
-
     return (
         <>
             <FloatingMessageCounter
@@ -884,25 +776,19 @@ function ReportActionsList({
                 isActive={isFloatingMessageCounterVisible}
                 onClick={scrollToBottomAndMarkReportAsRead}
             />
-            <ListWrapper
-                // If styles.pb4 is changed, please also update the keyboardVerticalOffset prop below
+            <View
                 style={[styles.flex1, !shouldShowReportRecipientLocalTime && !hideComposer ? styles.pb4 : {}]}
-                // eslint-disable-next-line react/forbid-component-props
                 fsClass={reportActionsListFSClass}
-                behavior="height"
-                // We need to take into account the initial height difference between the list and the keyboard
-                // which corresponds to the footer min height plus the bottom padding (16)
-                keyboardVerticalOffset={-CONST.CHAT_FOOTER_MIN_HEIGHT - 16}
             >
-                <ListComponent
+                <InvertedFlatList
                     accessibilityLabel={translate('sidebarScreen.listOfChatMessages')}
                     ref={reportScrollManager.ref}
                     testID="report-actions-list"
                     style={styles.overscrollBehaviorContain}
-                    data={visibleReportActions}
+                    data={sortedVisibleReportActions}
                     renderItem={renderItem}
-                    renderScrollComponent={renderActionSheetAwareScrollView ? getRenderScrollComponentWithAnimationProps(renderActionSheetAwareScrollView) : undefined}
-                    contentContainerStyle={contentContainerStyle}
+                    renderScrollComponent={renderActionSheetAwareScrollView}
+                    contentContainerStyle={styles.chatContentScrollView}
                     keyExtractor={keyExtractor}
                     initialNumToRender={initialNumToRender}
                     onEndReached={onEndReached}
@@ -924,7 +810,7 @@ function ReportActionsList({
                         trackVerticalScrolling(undefined);
                     }}
                 />
-            </ListWrapper>
+            </View>
         </>
     );
 }


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
<!-- Explain what your change does and how it addresses the linked issue -->

This PR reverts:
https://github.com/Expensify/App/pull/70250
https://github.com/Expensify/App/pull/70976 - since this one is a follow up fix of the first PR.

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/70997
PROPOSAL: N/A


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

- [x] Verify that no errors appear in the JS console

1. Launch Expensify app.
2. Open FAB > Create expense > Manual.
3. Submit an expense to any user.
4. Go to Reports > Menu > Expenses.
5. Open the expense from Step 3.
6. See the thread is opened in the bottom.
7. Tap on the composer.
8. Scroll to the top, see it works as expected.

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

Same, as in the **Tests** section

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->
// TODO: These must be filled out, or the issue title must include "[No QA]."

- [x] Verify that no errors appear in the JS console

Same, as in the **Tests** section

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I verified there are no new alerts related to the `canBeMissing` param for `useOnyx`
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->


https://github.com/user-attachments/assets/bf55d0fd-e0ac-4706-8fad-28ffe62586b3



</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->


https://github.com/user-attachments/assets/ae106ac8-3af7-4d2e-87df-505d88e79a49



</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->


https://github.com/user-attachments/assets/ccdaf2c7-4235-4586-8613-4fd43ac96a13




</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->


https://github.com/user-attachments/assets/85d3f95d-6477-41d8-87d0-d48b2cd0d46c



</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->


https://github.com/user-attachments/assets/b7af8815-9472-4d00-b343-8fefe87c3c5d



</details>

<details>
<summary>MacOS: Desktop</summary>

<!-- add screenshots or videos here -->


https://github.com/user-attachments/assets/d13840e9-376d-487d-8b81-d92dc2b751e2





</details>
