### PR TITLE
Fix: scroll to bottom when error appears after content size change

### DIFF
--- a/src/components/BookTravelButton.tsx
+++ b/src/components/BookTravelButton.tsx
@@ -1,7 +1,7 @@
 import {emailSelector} from '@selectors/Session';
 import {Str} from 'expensify-common';
 import type {ReactElement} from 'react';
-import React, {useCallback, useEffect, useState} from 'react';
+import React, {useCallback, useState} from 'react';
 import useCurrentUserPersonalDetails from '@hooks/useCurrentUserPersonalDetails';
 import useEnvironment from '@hooks/useEnvironment';
 import useLocalize from '@hooks/useLocalize';
@@ -74,12 +74,13 @@ function BookTravelButton({text, shouldRenderErrorMessageBelowButton = false, se
     const hidePreventionModal = () => setPreventionModalVisibility(false);
     const hideVerificationModal = () => setVerificationModalVisibility(false);
 
-    useEffect(() => {
-        if (!errorMessage) {
-            return;
-        }
-        setShouldScrollToBottom?.(true);
-    }, [errorMessage, setShouldScrollToBottom]);
+    const showError = useCallback(
+        (msg: string | ReactElement) => {
+            setErrorMessage(msg);
+            setShouldScrollToBottom?.(true);
+        },
+        [setShouldScrollToBottom],
+    );
 
     const bookATrip = useCallback(() => {
         setErrorMessage('');
@@ -91,7 +92,7 @@ function BookTravelButton({text, shouldRenderErrorMessageBelowButton = false, se
 
         // The primary login of the user is where Spotnana sends the emails with booking confirmations, itinerary etc. It can't be a phone number.
         if (!primaryContactMethod || Str.isSMSLogin(primaryContactMethod)) {
-            setErrorMessage(<RenderHTML html={translate('travel.phoneError', {phoneErrorMethodsRoute})} />);
+            showError(<RenderHTML html={translate('travel.phoneError', {phoneErrorMethodsRoute})} />);
             return;
         }
 
@@ -107,7 +108,7 @@ function BookTravelButton({text, shouldRenderErrorMessageBelowButton = false, se
         }
 
         if (!isPaidGroupPolicy(policy)) {
-            setErrorMessage(translate('travel.termsAndConditions.defaultWorkspaceError'));
+            showError(translate('travel.termsAndConditions.defaultWorkspaceError'));
             return;
         }
 
@@ -147,6 +148,7 @@ function BookTravelButton({text, shouldRenderErrorMessageBelowButton = false, se
         translate,
         isUserValidated,
         phoneErrorMethodsRoute,
+        showError,
     ]);
 
     return (

--- a/src/pages/Travel/ManageTrips.tsx
+++ b/src/pages/Travel/ManageTrips.tsx
@@ -1,7 +1,7 @@
-import React, {useEffect, useRef, useState} from 'react';
+import React, {useCallback, useRef, useState} from 'react';
 // eslint-disable-next-line no-restricted-imports
 import type {ScrollView as RNScrollView} from 'react-native';
-import {InteractionManager, Linking, View} from 'react-native';
+import {Linking, View} from 'react-native';
 import BookTravelButton from '@components/BookTravelButton';
 import Button from '@components/Button';
 import type {FeatureListItem} from '@components/FeatureList';
@@ -38,17 +38,11 @@ function ManageTrips() {
 
     const scrollViewRef = useRef<RNScrollView>(null);
 
-    const scrollToBottom = () => {
-        InteractionManager.runAfterInteractions(() => {
-            scrollViewRef.current?.scrollToEnd({animated: true});
-        });
-    };
-
-    useEffect(() => {
+    const handleOnContentSizeChange = useCallback(() => {
         if (!shouldScrollToBottom) {
             return;
         }
-        scrollToBottom();
+        scrollViewRef.current?.scrollToEnd({animated: true});
         setShouldScrollToBottom(false);
     }, [shouldScrollToBottom]);
 
@@ -56,6 +50,7 @@ function ManageTrips() {
         <ScrollView
             contentContainerStyle={styles.pt3}
             ref={scrollViewRef}
+            onContentSizeChange={handleOnContentSizeChange}
         >
             <View style={[styles.flex1, shouldUseNarrowLayout ? styles.workspaceSectionMobile : styles.workspaceSection]}>
                 <FeatureList


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
This PR ensures the page auto-scrolls to the bottom whenever a new error message is rendered and causes the content size to grow.

In BookTravelButton.tsx, I centralized error setting in a showError() helper which also toggles a shouldScrollToBottom flag (passed from the parent).

In ManageTrips.tsx, I listen to onContentSizeChange on the page ScrollView and, when shouldScrollToBottom is true, I programmatically call scrollToEnd({animated: true}) and reset the flag.
This addresses the case where validation / eligibility errors appear below the fold (e.g., when booking travel) and were previously off-screen.

###Fixed Issues

$ https://github.com/Expensify/App/issues/70601

PROPOSAL: https://github.com/Expensify/App/issues/70601#issuecomment-3315477109 

###Tests
**Precondition**

- Sign in to an Expensifail account in OldDot.
- Ensure you have at least one group workspace (create 1–2 if needed).
- Set Individual workspace as the default.

**Steps**

1. Open dev.new.expensify.com:8082 (local dev).
2. Go to Workspaces → (any group workspace) → Book travel.
3. Click Book travel.
4. Verify: As soon as an error message renders (e.g., “default workspace” error), the page auto-scrolls so the error is fully visible.
5. Repeat on mWeb  platforms (listed below) and confirm the same scrolling behavior.

**Extra scenario (BookTravelButton errors)**

- In the same page, trigger an error from BookTravelButton (e.g., phone-as-primary-login or non-paid-policy).
- Verify the page scrolls instantly to bring the error fully into view.


### Offline tests  N/A

### QA Steps
Same as Tests above.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [ ] Android: Native
    - [ ] Android: mWeb Chrome
    - [ ] iOS: Native
    - [ ] iOS: mWeb Safari
    - [x] Windows: Chrome/Edge
    - [ ] MacOS: Chrome / Safari
    - [ ] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I verified there are no new alerts related to the `canBeMissing` param for `useOnyx`
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details> <summary>Windows: Chrome ✅</summary>

[✔️] Verified that the page auto-scrolls when the error message appears.

https://github.com/user-attachments/assets/ddb2bd8b-8191-4f73-8e55-4504e2da2b57

</details> <details> <summary>Windows: Edge ✅</summary>

[✔️] Verified that the page auto-scrolls when the error message appears.

[Scroll-error-edge.webm](https://github.com/user-attachments/assets/9e89c44e-2136-44a9-bc7e-6412679f7403)

</details> <details> <summary>Android: Native ❌</summary>

Not tested (no device/emulator access)

</details> <details> <summary>Android: mWeb Chrome ❌</summary>

Not tested (no device/emulator access)

</details> <details> <summary>iOS: Native ❌</summary>

Not tested (no device/emulator access)

</details> <details> <summary>iOS: mWeb Safari ❌</summary>

Not tested (no device/emulator access)

</details> <details> <summary>MacOS: Desktop ❌</summary>

Not tested (no desktop app access)

</details>

