### PR TITLE
[No QA] Correctly handle context in incremental translations

### DIFF
--- a/scripts/generateTranslations.ts
+++ b/scripts/generateTranslations.ts
@@ -718,7 +718,8 @@ class TranslationGenerator {
             }
         }
 
-        if ((isOnAddedLine || isOnRemovedLine || hasContextChange) && this.shouldTranslateNode(node)) {
+        const hasChanges = isOnAddedLine || isOnRemovedLine || hasContextChange;
+        if (hasChanges && this.shouldTranslateNode(node)) {
             // This node is on a changed line and should be translated
             // Traverse up the tree to build the dot notation path
             const translationsNode = this.findTranslationsNode(node.getSourceFile() ?? this.sourceFile);

--- a/scripts/generateTranslations.ts
+++ b/scripts/generateTranslations.ts
@@ -403,11 +403,32 @@ class TranslationGenerator {
     }
 
     /**
+     * Extract context annotation value from a string (comment or text).
+     * Returns the context value if found, undefined otherwise.
+     */
+    private extractContextFromString(text: string): string | undefined {
+        const match = text.match(TranslationGenerator.CONTEXT_REGEX);
+        return match?.[1].trim();
+    }
+
+    /**
+     * Check if a specific line in the source file contains a context annotation.
+     */
+    private lineContainsContextAnnotation(lineNumber: number, sourceFile: ts.SourceFile): boolean {
+        const lines = sourceFile.getFullText().split('\n');
+        const line = lines.at(lineNumber - 1); // Convert to 0-based index
+        if (!line) {
+            return false;
+        }
+        return this.extractContextFromString(line) !== undefined;
+    }
+
+    /**
      * Extract any leading context annotation for a given node.
      */
     private getContextForNode(node: ts.Node): string | undefined {
-        // First, check for an inline context comment.
-        const inlineContext = node.getFullText().match(TranslationGenerator.CONTEXT_REGEX)?.[1].trim();
+        // First, check for an inline context comment
+        const inlineContext = this.extractContextFromString(node.getFullText());
         if (inlineContext) {
             return inlineContext;
         }
@@ -423,9 +444,9 @@ class TranslationGenerator {
         const commentRanges = ts.getLeadingCommentRanges(this.sourceFile.getFullText(), nearestPropertyAssignmentAncestor.getFullStart()) ?? [];
         for (const range of commentRanges.reverse()) {
             const commentText = this.sourceFile.getFullText().slice(range.pos, range.end);
-            const match = commentText.match(TranslationGenerator.CONTEXT_REGEX);
-            if (match) {
-                return match[1].trim();
+            const context = this.extractContextFromString(commentText);
+            if (context) {
+                return context;
             }
         }
 
@@ -604,7 +625,8 @@ class TranslationGenerator {
             }
 
             // Traverse current en.ts for added and modified paths
-            this.extractPathsFromChangedLines(translationsNode, new Set([...changedLines.addedLines, ...changedLines.modifiedLines]), new Set());
+            // Also pass removedLines to detect context annotation removals
+            this.extractPathsFromChangedLines(translationsNode, new Set([...changedLines.addedLines, ...changedLines.modifiedLines]), changedLines.removedLines);
 
             // For removed paths, we need to traverse the old version of en.ts
             if (changedLines.removedLines.size > 0 || changedLines.modifiedLines.size > 0) {
@@ -670,22 +692,49 @@ class TranslationGenerator {
         const isOnAddedLine = nodeLines.some((lineNumber) => addedLines.has(lineNumber));
         const isOnRemovedLine = nodeLines.some((lineNumber) => removedLines.has(lineNumber));
 
-        if ((isOnAddedLine || isOnRemovedLine) && this.shouldTranslateNode(node)) {
+        // Also check if this node has context annotation changes in its leading comments
+        let hasContextChange = false;
+        if (this.shouldTranslateNode(node)) {
+            // Find the nearest property assignment ancestor (same logic as getContextForNode)
+            const nearestPropertyAssignmentAncestor = TSCompilerUtils.findAncestor(node, (n): n is ts.PropertyAssignment => ts.isPropertyAssignment(n));
+            if (nearestPropertyAssignmentAncestor) {
+                // Get leading comment ranges for this property assignment
+                const commentRanges = ts.getLeadingCommentRanges(sourceFile.getFullText(), nearestPropertyAssignmentAncestor.getFullStart()) ?? [];
+                for (const range of commentRanges) {
+                    const commentStart = sourceFile.getLineAndCharacterOfPosition(range.pos);
+                    const commentEnd = sourceFile.getLineAndCharacterOfPosition(range.end);
+
+                    // Check if any line of this comment is in the changed lines
+                    const commentLines = Array.from({length: commentEnd.line - commentStart.line + 1}, (_, i) => commentStart.line + i + 1);
+                    for (const commentLineNumber of commentLines) {
+                        if ((addedLines.has(commentLineNumber) || removedLines.has(commentLineNumber)) && this.lineContainsContextAnnotation(commentLineNumber, sourceFile)) {
+                            hasContextChange = true;
+                            break;
+                        }
+                    }
+                    if (hasContextChange) {
+                        break;
+                    }
+                }
+            }
+        }
+
+        if ((isOnAddedLine || isOnRemovedLine || hasContextChange) && this.shouldTranslateNode(node)) {
             // This node is on a changed line and should be translated
             // Traverse up the tree to build the dot notation path
             const translationsNode = this.findTranslationsNode(node.getSourceFile() ?? this.sourceFile);
             const dotPath = TSCompilerUtils.buildDotNotationPath(node, translationsNode ?? undefined);
             if (dotPath) {
-                if (isOldVersion && isOnRemovedLine) {
+                if (isOldVersion && (isOnRemovedLine || hasContextChange)) {
                     // When traversing old version, removed lines indicate paths to remove
                     this.pathsToRemove.add(dotPath as TranslationPaths);
-                } else if (!isOldVersion && isOnAddedLine) {
+                } else if (!isOldVersion && (isOnAddedLine || hasContextChange)) {
                     // When traversing current version, added lines indicate paths to modify/add
                     this.pathsToModify.add(dotPath as TranslationPaths);
                 }
 
                 if (this.verbose) {
-                    console.log(`🔄 Found changed path: ${dotPath} (added: ${isOnAddedLine}, removed: ${isOnRemovedLine})`);
+                    console.log(`🔄 Found changed path: ${dotPath} (added: ${isOnAddedLine}, removed: ${isOnRemovedLine}, contextChange: ${hasContextChange})`);
                 }
             }
         }

--- a/scripts/generateTranslations.ts
+++ b/scripts/generateTranslations.ts
@@ -625,7 +625,6 @@ class TranslationGenerator {
             }
 
             // Traverse current en.ts for added and modified paths
-            // Also pass removedLines to detect context annotation removals
             this.extractPathsFromChangedLines(translationsNode, new Set([...changedLines.addedLines, ...changedLines.modifiedLines]), changedLines.removedLines);
 
             // For removed paths, we need to traverse the old version of en.ts

--- a/scripts/generateTranslations.ts
+++ b/scripts/generateTranslations.ts
@@ -406,7 +406,7 @@ class TranslationGenerator {
      * Extract context annotation value from a string (comment or text).
      * Returns the context value if found, undefined otherwise.
      */
-    private extractContextFromString(text: string): string | undefined {
+    private extractContextAnnotationFromString(text: string): string | undefined {
         const match = text.match(TranslationGenerator.CONTEXT_REGEX);
         return match?.[1].trim();
     }
@@ -420,7 +420,7 @@ class TranslationGenerator {
         if (!line) {
             return false;
         }
-        return this.extractContextFromString(line) !== undefined;
+        return this.extractContextAnnotationFromString(line) !== undefined;
     }
 
     /**
@@ -428,7 +428,7 @@ class TranslationGenerator {
      */
     private getContextForNode(node: ts.Node): string | undefined {
         // First, check for an inline context comment
-        const inlineContext = this.extractContextFromString(node.getFullText());
+        const inlineContext = this.extractContextAnnotationFromString(node.getFullText());
         if (inlineContext) {
             return inlineContext;
         }
@@ -444,7 +444,7 @@ class TranslationGenerator {
         const commentRanges = ts.getLeadingCommentRanges(this.sourceFile.getFullText(), nearestPropertyAssignmentAncestor.getFullStart()) ?? [];
         for (const range of commentRanges.reverse()) {
             const commentText = this.sourceFile.getFullText().slice(range.pos, range.end);
-            const context = this.extractContextFromString(commentText);
+            const context = this.extractContextAnnotationFromString(commentText);
             if (context) {
                 return context;
             }

--- a/src/languages/de.ts
+++ b/src/languages/de.ts
@@ -407,7 +407,7 @@ const translations = {
         download: 'Herunterladen',
         downloading: 'Herunterladen',
         uploading: 'Hochladen',
-        pin: 'Pin',
+        pin: 'Anheften',
         unPin: 'Lösen',
         back: 'Zurück',
         saveAndContinue: 'Speichern & fortfahren',

--- a/src/languages/en.ts
+++ b/src/languages/en.ts
@@ -399,6 +399,7 @@ const translations = {
         download: 'Download',
         downloading: 'Downloading',
         uploading: 'Uploading',
+        // @context as a verb, not a noun
         pin: 'Pin',
         unPin: 'Unpin',
         back: 'Back',

--- a/src/languages/it.ts
+++ b/src/languages/it.ts
@@ -407,7 +407,7 @@ const translations = {
         download: 'Scarica',
         downloading: 'Scaricamento',
         uploading: 'Caricamento in corso',
-        pin: '[it][ctx: as a verb, not a noun] Pin',
+        pin: 'Fissa',
         unPin: 'Rimuovi dal pin',
         back: 'Indietro',
         saveAndContinue: 'Salva e continua',

--- a/src/languages/it.ts
+++ b/src/languages/it.ts
@@ -407,7 +407,7 @@ const translations = {
         download: 'Scarica',
         downloading: 'Scaricamento',
         uploading: 'Caricamento in corso',
-        pin: 'Pin',
+        pin: '[it][ctx: as a verb, not a noun] Pin',
         unPin: 'Rimuovi dal pin',
         back: 'Indietro',
         saveAndContinue: 'Salva e continua',

--- a/src/languages/ja.ts
+++ b/src/languages/ja.ts
@@ -407,7 +407,7 @@ const translations = {
         download: 'ダウンロード',
         downloading: 'ダウンロード中',
         uploading: 'アップロード中',
-        pin: 'ピン',
+        pin: 'ピン留めする',
         unPin: 'ピン留めを解除',
         back: '戻る',
         saveAndContinue: '保存して続行',

--- a/src/languages/nl.ts
+++ b/src/languages/nl.ts
@@ -407,7 +407,7 @@ const translations = {
         download: 'Downloaden',
         downloading: 'Downloaden',
         uploading: 'Uploaden',
-        pin: 'Pincode',
+        pin: 'Vastpinnen',
         unPin: 'Losmaken van vastzetten',
         back: 'Terug',
         saveAndContinue: 'Opslaan & doorgaan',

--- a/src/languages/pt-BR.ts
+++ b/src/languages/pt-BR.ts
@@ -407,7 +407,7 @@ const translations = {
         download: 'Baixar',
         downloading: 'Baixando',
         uploading: 'Carregando',
-        pin: 'Pin',
+        pin: 'Fixar',
         unPin: 'Desafixar',
         back: 'Voltar',
         saveAndContinue: 'Salvar e continuar',


### PR DESCRIPTION
### Explanation of Change
I discovered a [bug](https://github.com/Expensify/App/issues/71512) in incremental translations. This PR fixes it.

### Fixed Issues
Fixes https://github.com/Expensify/App/issues/71512

### Tests
1. Add a context annotation to a translation in `en.ts`.
2. Commit the change
3. Run `npx ts-node ./scripts/generateTranslations.ts --compare-ref HEAD~1`
4. Verify that the key you added a context annotation for changed.

- [x] Verify that no errors appear in the JS console

### Offline tests
None.

### QA Steps
None.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I verified there are no new alerts related to the `canBeMissing` param for `useOnyx`
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Desktop</summary>

<!-- add screenshots or videos here -->

</details>
