### PR TITLE
Fix `<` (backspace) button in time picker

### DIFF
--- a/src/components/TimePicker/TimePicker.tsx
+++ b/src/components/TimePicker/TimePicker.tsx
@@ -132,17 +132,18 @@ function TimePicker(
     const value = DateUtils.extractTime12Hour(defaultValue, showFullFormat);
     const canUseTouchScreen = canUseTouchScreenDeviceCapabilities();
 
-    const [isError, setError] = useState(false);
-    const [errorMessage, setErrorMessage] = useState('');
-    const [selectionHour, setSelectionHour] = useState({start: 0, end: 0});
-    const [selectionMinute, setSelectionMinute] = useState(showFullFormat ? {start: 0, end: 0} : {start: 2, end: 2}); // we focus it by default so need  to have selection on the end
-    const [selectionSecond, setSelectionSecond] = useState({start: 0, end: 0});
-    const [selectionMillisecond, setSelectionMillisecond] = useState(showFullFormat ? {start: 6, end: 6} : {start: 0, end: 0});
     const [hours, setHours] = useState(() => DateUtils.get12HourTimeObjectFromDate(value, showFullFormat).hour);
     const [minutes, setMinutes] = useState(() => DateUtils.get12HourTimeObjectFromDate(value, showFullFormat).minute);
     const [seconds, setSeconds] = useState(() => DateUtils.get12HourTimeObjectFromDate(value, showFullFormat).seconds);
     const [milliseconds, setMilliseconds] = useState(() => DateUtils.get12HourTimeObjectFromDate(value, showFullFormat).milliseconds);
     const [amPmValue, setAmPmValue] = useState(() => DateUtils.get12HourTimeObjectFromDate(value, showFullFormat).period);
+
+    const [isError, setError] = useState(false);
+    const [errorMessage, setErrorMessage] = useState('');
+    const [selectionHour, setSelectionHour] = useState({start: 0, end: 0});
+    const [selectionMinute, setSelectionMinute] = useState(showFullFormat ? {start: 0, end: 0} : {start: minutes.length, end: minutes.length}); // we focus it by default so need to have selection on the end
+    const [selectionSecond, setSelectionSecond] = useState({start: 0, end: 0});
+    const [selectionMillisecond, setSelectionMillisecond] = useState(showFullFormat ? {start: milliseconds.length, end: milliseconds.length} : {start: 0, end: 0});
 
     const lastPressedKey = useRef('');
     const hourInputRef = useRef<TextInput | null>(null);
@@ -922,3 +923,5 @@ function TimePicker(
 TimePicker.displayName = 'TimePicker';
 
 export default React.forwardRef(TimePicker);
+
+export type {TimePickerProps, TimePickerRef, TimePickerRefName};

--- a/tests/ui/components/TimePickerTest.tsx
+++ b/tests/ui/components/TimePickerTest.tsx
@@ -1,0 +1,135 @@
+import {NavigationContainer} from '@react-navigation/native';
+import {fireEvent, render, screen} from '@testing-library/react-native';
+import React, {act, createRef} from 'react';
+import type {TextInput, TextInputProps} from 'react-native';
+import TimePicker from '@src/components/TimePicker/TimePicker';
+import type {TimePickerProps, TimePickerRef} from '@src/components/TimePicker/TimePicker';
+
+// Tests currently run against index.ios.ts source, where functions that call
+// native code (such as `isFocused` or `setNativeProps`) are not implemented.
+// We need to implement them manually since tests are not run on actual devices.
+jest.mock('react-native/Libraries/Components/TextInput/TextInput', () => {
+    const originalReact: typeof React = jest.requireActual('react');
+
+    const TextInputMock = originalReact.forwardRef<TextInput, TextInputProps>((props, ref) => {
+        const [isFocused, setIsFocused] = originalReact.useState(false);
+
+        originalReact.useImperativeHandle(
+            ref,
+            () =>
+                ({
+                    focus: () => {
+                        setIsFocused(true);
+                    },
+                    blur: () => {
+                        setIsFocused(false);
+                    },
+                    isFocused: () => isFocused,
+                    setNativeProps: () => {},
+                    props,
+                }) as unknown as TextInput,
+            [isFocused, props],
+        );
+
+        return null;
+    });
+
+    return {
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        __esModule: true,
+        default: TextInputMock,
+    };
+});
+
+describe('TimePicker Component', () => {
+    const renderTimePicker = (props: Partial<TimePickerProps> = {}, ref?: React.Ref<TimePickerRef>) =>
+        render(
+            <NavigationContainer>
+                <TimePicker
+                    ref={ref}
+                    onSubmit={() => {}}
+                    // eslint-disable-next-line react/jsx-props-no-spreading
+                    {...props}
+                />
+            </NavigationContainer>,
+        );
+
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    describe('replaces digits with 0 when the backspace button is pressed', () => {
+        function pressBackspaceAndExpect(
+            ref: React.RefObject<TimePickerRef | null>,
+            expected: {
+                hours: string;
+                minutes: string;
+                seconds?: string;
+                milliseconds?: string;
+            },
+        ) {
+            const backspaceBtn = screen.getByTestId('button_<');
+            fireEvent.press(backspaceBtn);
+
+            expect(ref.current?.hourRef?.props.value).toBe(expected.hours);
+            expect(ref.current?.minuteRef?.props.value).toBe(expected.minutes);
+            expect(ref.current?.secondRef?.props.value).toBe(expected.seconds);
+            expect(ref.current?.millisecondRef?.props.value).toBe(expected.milliseconds);
+        }
+
+        it('when showFullFormat=true', () => {
+            const ref = createRef<TimePickerRef>();
+            renderTimePicker({defaultValue: '2025-01-01 12:34:56.789 AM', showFullFormat: true}, ref);
+
+            act(() => {
+                ref.current?.millisecondRef?.focus();
+            });
+
+            const backspaceBtn = screen.getByTestId('button_<');
+
+            // Milliseconds
+            pressBackspaceAndExpect(ref, {hours: '12', minutes: '34', seconds: '56', milliseconds: '780'});
+            pressBackspaceAndExpect(ref, {hours: '12', minutes: '34', seconds: '56', milliseconds: '700'});
+            pressBackspaceAndExpect(ref, {hours: '12', minutes: '34', seconds: '56', milliseconds: '000'});
+
+            fireEvent.press(backspaceBtn); // Skip separator
+
+            // Seconds
+            pressBackspaceAndExpect(ref, {hours: '12', minutes: '34', seconds: '50', milliseconds: '000'});
+            pressBackspaceAndExpect(ref, {hours: '12', minutes: '34', seconds: '00', milliseconds: '000'});
+
+            fireEvent.press(backspaceBtn); // Skip separator
+
+            // Minutes
+            pressBackspaceAndExpect(ref, {hours: '12', minutes: '30', seconds: '00', milliseconds: '000'});
+            pressBackspaceAndExpect(ref, {hours: '12', minutes: '00', seconds: '00', milliseconds: '000'});
+
+            fireEvent.press(backspaceBtn); // Skip separator
+
+            // Hours
+            pressBackspaceAndExpect(ref, {hours: '10', minutes: '00', seconds: '00', milliseconds: '000'});
+            pressBackspaceAndExpect(ref, {hours: '00', minutes: '00', seconds: '00', milliseconds: '000'});
+        });
+
+        it('when showFullFormat=false', () => {
+            const ref = createRef<TimePickerRef>();
+            renderTimePicker({defaultValue: '2025-01-01 12:34 AM', showFullFormat: false}, ref);
+
+            act(() => {
+                ref.current?.minuteRef?.focus();
+            });
+
+            const backspaceBtn = screen.getByTestId('button_<');
+
+            // Minutes
+            pressBackspaceAndExpect(ref, {hours: '12', minutes: '30'});
+            pressBackspaceAndExpect(ref, {hours: '12', minutes: '00'});
+
+            fireEvent.press(backspaceBtn); // Skip separator
+
+            // Hours
+            pressBackspaceAndExpect(ref, {hours: '10', minutes: '00'});
+            pressBackspaceAndExpect(ref, {hours: '00', minutes: '00'});
+        });
+    });
+});


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
<!-- Explain what your change does and how it addresses the linked issue -->

Fixes the `<` button in the TimePicker component, which is unresponsive in Standalone app and causes a crash in HybridApp. This only occurs with "full format" input (also includes seconds and milliseconds).

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/71345
PROPOSAL: https://github.com/Expensify/App/issues/71345#issuecomment-3339747232


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

Same as QA Steps

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

N/A

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->

1. Go to Account > Troubleshoot and turn on Debug mode
1. Create a new workspace if not already
1. Navigate to the Inbox and press the View button to open DebugReportPage
1. Scroll down and open one of the DateTime fields
1. Try to change the time by tapping the "<" button on the opened keyboard
1. Verify that the last digit is being replaced with 0

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I verified there are no new alerts related to the `canBeMissing` param for `useOnyx`
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

https://github.com/user-attachments/assets/6e9cfc83-ffd6-4d96-9de7-7ca4570623e1

</details>

<details>
<summary>Android: mWeb Chrome</summary>

https://github.com/user-attachments/assets/57e0f1d2-4aee-4d18-b788-7f99b9b0d7da

</details>

<details>
<summary>iOS: Native</summary>

https://github.com/user-attachments/assets/357a1cd8-732c-4031-82df-b9c5d5ab27e0

</details>

<details>
<summary>iOS: mWeb Safari</summary>

https://github.com/user-attachments/assets/2c0a9540-d214-4c18-b92c-d66be7e0ab0d

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

https://github.com/user-attachments/assets/a0c83d39-86fc-4ac3-8158-9e231a4208b6

</details>

<details>
<summary>MacOS: Desktop</summary>

https://github.com/user-attachments/assets/f14bedb6-6974-45c6-a3f3-e2d922c99769

</details>
