### PR TITLE
Fix search results footer showing stale data after deleting expenses

### DIFF
--- a/src/components/Search/SearchPageFooter.tsx
+++ b/src/components/Search/SearchPageFooter.tsx
@@ -10,9 +10,9 @@ import useThemeStyles from '@hooks/useThemeStyles';
 import {convertToDisplayString} from '@libs/CurrencyUtils';
 
 type SearchPageFooterProps = {
-    count: number;
-    total: number;
-    currency: string | undefined;
+    count?: number;
+    total?: number;
+    currency?: string;
 };
 
 function SearchPageFooter({count, total, currency}: SearchPageFooterProps) {

--- a/src/components/Search/SearchPageFooter.tsx
+++ b/src/components/Search/SearchPageFooter.tsx
@@ -10,8 +10,8 @@ import useThemeStyles from '@hooks/useThemeStyles';
 import {convertToDisplayString} from '@libs/CurrencyUtils';
 
 type SearchPageFooterProps = {
-    count: number | undefined;
-    total: number | undefined;
+    count: number;
+    total: number;
     currency: string | undefined;
 };
 
@@ -53,3 +53,4 @@ function SearchPageFooter({count, total, currency}: SearchPageFooterProps) {
 SearchPageFooter.displayName = 'SearchPageFooter';
 
 export default SearchPageFooter;
+export type {SearchPageFooterProps};

--- a/src/components/Search/index.tsx
+++ b/src/components/Search/index.tsx
@@ -843,7 +843,7 @@ function Search({queryJSON, searchResults, onSearchListScroll, contentContainerS
 
     const visibleData = data.filter((item) => item.pendingAction !== CONST.RED_BRICK_ROAD_PENDING_ACTION.DELETE || isOffline);
     const visibleDataLength = visibleData.length;
-    const shouldShowFooter = type === CONST.SEARCH.DATA_TYPES.EXPENSE && visibleDataLength > 0;
+    const shouldShowFooter = (type === CONST.SEARCH.DATA_TYPES.EXPENSE || type === CONST.SEARCH.DATA_TYPES.INVOICE || type === CONST.SEARCH.DATA_TYPES.TRIP) && visibleDataLength > 0;
 
     const footerData = useMemo(() => {
         if (!shouldShowFooter) {

--- a/src/components/Search/index.tsx
+++ b/src/components/Search/index.tsx
@@ -963,7 +963,7 @@ function Search({queryJSON, searchResults, onSearchListScroll, contentContainerS
                     shouldAnimate={type === CONST.SEARCH.DATA_TYPES.EXPENSE}
                     newTransactions={newTransactions}
                 />
-                {shouldShowFooter && footerData && (
+                {!!footerData && (
                     <SearchPageFooter
                         count={footerData.count}
                         total={footerData.total}

--- a/src/components/Search/index.tsx
+++ b/src/components/Search/index.tsx
@@ -6,7 +6,7 @@ import type {OnyxCollection, OnyxEntry} from 'react-native-onyx';
 import Animated, {FadeIn, FadeOut, useAnimatedStyle, useSharedValue, withTiming} from 'react-native-reanimated';
 import FullPageErrorView from '@components/BlockingViews/FullPageErrorView';
 import FullPageOfflineBlockingView from '@components/BlockingViews/FullPageOfflineBlockingView';
-import ScreenWrapper from '@components/ScreenWrapper';
+import OfflineIndicator from '@components/OfflineIndicator';
 import SearchTableHeader, {getExpenseHeaders} from '@components/SelectionListWithSections/SearchTableHeader';
 import type {ReportActionListItemType, SearchListItem, SelectionListHandle, TransactionGroupListItemType, TransactionListItemType} from '@components/SelectionListWithSections/types';
 import SearchRowSkeleton from '@components/Skeletons/SearchRowSkeleton';
@@ -869,6 +869,12 @@ function Search({queryJSON, searchResults, onSearchListScroll, contentContainerS
         return calculatedFooterData;
     }, [areAllMatchingItemsSelected, searchMetadata, selectedTransactions, groupBy]);
 
+    const offlineIndicatorStyles = useMemo(() => {
+        const baseStyles = shouldUseNarrowLayout ? [styles.mtAuto, styles.pb3] : [styles.pAbsolute, styles.h10, styles.b0];
+
+        return [...baseStyles, styles.pl5];
+    }, [shouldUseNarrowLayout, styles]);
+
     if (shouldShowLoadingState) {
         return (
             <Animated.View
@@ -982,22 +988,14 @@ function Search({queryJSON, searchResults, onSearchListScroll, contentContainerS
                     newTransactions={newTransactions}
                 />
                 <View style={[styles.mtAuto]}>
-                    <ScreenWrapper
-                        testID="SearchPageFooterWrapper"
-                        shouldShowOfflineIndicator
-                        shouldShowOfflineIndicatorInWideScreen
-                        offlineIndicatorStyle={shouldUseNarrowLayout ? [styles.mtAuto] : [styles.pAbsolute, styles.h10, styles.b0]}
-                        shouldEnableKeyboardAvoidingView={false}
-                        shouldEnableMaxHeight={false}
-                    >
-                        {!!footerData && (
-                            <SearchPageFooter
-                                count={footerData.count}
-                                total={footerData.total}
-                                currency={footerData.currency}
-                            />
-                        )}
-                    </ScreenWrapper>
+                    {!!footerData && (
+                        <SearchPageFooter
+                            count={footerData.count}
+                            total={footerData.total}
+                            currency={footerData.currency}
+                        />
+                    )}
+                    <OfflineIndicator containerStyles={offlineIndicatorStyles} />
                 </View>
             </Animated.View>
         </SearchScopeProvider>

--- a/src/components/Search/index.tsx
+++ b/src/components/Search/index.tsx
@@ -6,6 +6,7 @@ import type {OnyxCollection, OnyxEntry} from 'react-native-onyx';
 import Animated, {FadeIn, FadeOut, useAnimatedStyle, useSharedValue, withTiming} from 'react-native-reanimated';
 import FullPageErrorView from '@components/BlockingViews/FullPageErrorView';
 import FullPageOfflineBlockingView from '@components/BlockingViews/FullPageOfflineBlockingView';
+import ScreenWrapper from '@components/ScreenWrapper';
 import SearchTableHeader, {getExpenseHeaders} from '@components/SelectionListWithSections/SearchTableHeader';
 import type {ReportActionListItemType, SearchListItem, SelectionListHandle, TransactionGroupListItemType, TransactionListItemType} from '@components/SelectionListWithSections/types';
 import SearchRowSkeleton from '@components/Skeletons/SearchRowSkeleton';
@@ -963,13 +964,24 @@ function Search({queryJSON, searchResults, onSearchListScroll, contentContainerS
                     shouldAnimate={type === CONST.SEARCH.DATA_TYPES.EXPENSE}
                     newTransactions={newTransactions}
                 />
-                {!!footerData && (
-                    <SearchPageFooter
-                        count={footerData.count}
-                        total={footerData.total}
-                        currency={footerData.currency}
-                    />
-                )}
+                <View style={[styles.mtAuto]}>
+                    <ScreenWrapper
+                        testID="SearchPageFooterWrapper"
+                        shouldShowOfflineIndicator
+                        shouldShowOfflineIndicatorInWideScreen
+                        offlineIndicatorStyle={shouldUseNarrowLayout ? [styles.mtAuto] : [styles.pAbsolute, styles.h10, styles.b0]}
+                        shouldEnableKeyboardAvoidingView={false}
+                        shouldEnableMaxHeight={false}
+                    >
+                        {!!footerData && (
+                            <SearchPageFooter
+                                count={footerData.count}
+                                total={footerData.total}
+                                currency={footerData.currency}
+                            />
+                        )}
+                    </ScreenWrapper>
+                </View>
             </Animated.View>
         </SearchScopeProvider>
     );

--- a/src/components/Search/index.tsx
+++ b/src/components/Search/index.tsx
@@ -75,7 +75,7 @@ import {isEmptyObject} from '@src/types/utils/EmptyObject';
 import arraysEqual from '@src/utils/arraysEqual';
 import {useSearchContext} from './SearchContext';
 import SearchList from './SearchList';
-import SearchPageFooter, { SearchPageFooterProps } from './SearchPageFooter';
+import SearchPageFooter, {SearchPageFooterProps} from './SearchPageFooter';
 import {SearchScopeProvider} from './SearchScopeProvider';
 import type {SearchColumnType, SearchParams, SearchQueryJSON, SelectedTransactionInfo, SelectedTransactions, SortOrder} from './types';
 

--- a/src/components/Search/index.tsx
+++ b/src/components/Search/index.tsx
@@ -862,9 +862,9 @@ function Search({queryJSON, searchResults, onSearchListScroll, contentContainerS
         // Substitute the deleted data from the calculated footer data so that the footer shows optimistic data
         if (deletedData.length > 0 && calculatedFooterData.count) {
             const deletedTransactionsData = calculateSearchPageFooterData({}, deletedData, groupBy, searchMetadata?.currency);
-            calculatedFooterData.count -= (deletedTransactionsData?.count ?? 0);
+            calculatedFooterData.count -= deletedTransactionsData?.count ?? 0;
             if (calculatedFooterData.total) {
-                calculatedFooterData.total -= (deletedTransactionsData?.total ?? 0);
+                calculatedFooterData.total -= deletedTransactionsData?.total ?? 0;
             }
         }
         return calculatedFooterData;

--- a/src/components/Search/index.tsx
+++ b/src/components/Search/index.tsx
@@ -75,7 +75,8 @@ import {isEmptyObject} from '@src/types/utils/EmptyObject';
 import arraysEqual from '@src/utils/arraysEqual';
 import {useSearchContext} from './SearchContext';
 import SearchList from './SearchList';
-import SearchPageFooter, {SearchPageFooterProps} from './SearchPageFooter';
+import type {SearchPageFooterProps} from './SearchPageFooter';
+import SearchPageFooter from './SearchPageFooter';
 import {SearchScopeProvider} from './SearchScopeProvider';
 import type {SearchColumnType, SearchParams, SearchQueryJSON, SelectedTransactionInfo, SelectedTransactions, SortOrder} from './types';
 
@@ -854,16 +855,16 @@ function Search({queryJSON, searchResults, onSearchListScroll, contentContainerS
             calculatedFooterData = {count: searchMetadata?.count, total: searchMetadata?.total, currency: searchMetadata?.currency};
         }
 
-        if (!calculatedFooterData || !calculatedFooterData.count) {
+        if (!calculatedFooterData?.count) {
             return null;
         }
 
         // Substitute the deleted data from the calculated footer data so that the footer shows optimistic data
         if (deletedData.length > 0 && calculatedFooterData.count) {
             const deletedTransactionsData = calculateSearchPageFooterData({}, deletedData, groupBy, searchMetadata?.currency);
-            calculatedFooterData.count = calculatedFooterData.count - (deletedTransactionsData?.count ?? 0);
+            calculatedFooterData.count -= (deletedTransactionsData?.count ?? 0);
             if (calculatedFooterData.total) {
-                calculatedFooterData.total = calculatedFooterData.total - (deletedTransactionsData?.total ?? 0);
+                calculatedFooterData.total -= (deletedTransactionsData?.total ?? 0);
             }
         }
         return calculatedFooterData;

--- a/src/libs/SearchUIUtils.ts
+++ b/src/libs/SearchUIUtils.ts
@@ -2403,7 +2403,8 @@ function calculateSearchPageFooterData(
     }
 
     // Use convertedCurrency from first transaction or fallback to metadata currency
-    const footerCurrency = transactions.at(0)?.convertedCurrency || currency;
+    const firstTransactionCurrency = transactions.at(0)?.convertedCurrency;
+    const footerCurrency = firstTransactionCurrency && firstTransactionCurrency !== '' ? firstTransactionCurrency : currency;
     const count = transactions.length;
     const total = transactions.reduce((sum, transaction) => sum + Math.abs(transaction.convertedAmount ?? 0), 0);
 

--- a/src/libs/SearchUIUtils.ts
+++ b/src/libs/SearchUIUtils.ts
@@ -2369,17 +2369,17 @@ function getColumnsToShow(
 /**
  * Calculates footer data for expense search results
  * If transactions are selected, shows count and total for selected transactions only
- * Otherwise, shows count and total for all visible transactions
+ * Otherwise, calculates count and total for given search data
  *
  * @param selectedTransactions - The currently selected transactions
- * @param visibleData - The filtered search data (excluding pending deletes)
+ * @param searchData - The search data to calculate the footer data for
  * @param groupBy - The groupBy parameter from the search query
  * @param currency - The currency from search results metadata (common currency for all transactions)
  * @returns Footer data with count, total, and currency or null if not applicable
  */
 function calculateSearchPageFooterData(
     selectedTransactions: SelectedTransactions,
-    visibleData: SearchListItem[],
+    searchData: SearchListItem[] | null,
     groupBy: SearchGroupBy | undefined,
     currency: string | undefined,
 ): SearchPageFooterProps | null {
@@ -2392,11 +2392,11 @@ function calculateSearchPageFooterData(
         transactions = Object.values(selectedTransactions) as unknown as TransactionListItemType[];
     } else {
         // Otherwise, use all visible transactions
-        if (!visibleData || visibleData.length === 0) {
+        if (!searchData || searchData.length === 0) {
             return null;
         }
 
-        transactions = groupBy ? (visibleData as TransactionGroupListItemType[]).flatMap((item) => item.transactions) : (visibleData as TransactionListItemType[]);
+        transactions = groupBy ? (searchData as TransactionGroupListItemType[]).flatMap((item) => item.transactions) : (searchData as TransactionListItemType[]);
         if (transactions.length === 0) {
             return null;
         }

--- a/src/libs/SearchUIUtils.ts
+++ b/src/libs/SearchUIUtils.ts
@@ -2403,7 +2403,7 @@ function calculateSearchPageFooterData(
     }
 
     // Use convertedCurrency from first transaction or fallback to metadata currency
-    const footerCurrency = transactions[0]?.convertedCurrency ?? currency;
+    const footerCurrency = transactions.at(0)?.convertedCurrency ?? currency;
     const count = transactions.length;
     const total = transactions.reduce((sum, transaction) => sum + Math.abs(transaction.convertedAmount ?? 0), 0);
 

--- a/src/libs/SearchUIUtils.ts
+++ b/src/libs/SearchUIUtils.ts
@@ -2403,7 +2403,7 @@ function calculateSearchPageFooterData(
     }
 
     // Use convertedCurrency from first transaction or fallback to metadata currency
-    const footerCurrency = transactions.at(0)?.convertedCurrency ?? currency;
+    const footerCurrency = transactions.at(0)?.convertedCurrency || currency;
     const count = transactions.length;
     const total = transactions.reduce((sum, transaction) => sum + Math.abs(transaction.convertedAmount ?? 0), 0);
 

--- a/src/libs/SearchUIUtils.ts
+++ b/src/libs/SearchUIUtils.ts
@@ -2406,7 +2406,7 @@ function calculateSearchPageFooterData(
     const firstTransactionCurrency = transactions.at(0)?.convertedCurrency;
     const footerCurrency = firstTransactionCurrency && firstTransactionCurrency !== '' ? firstTransactionCurrency : currency;
     const count = transactions.length;
-    const total = transactions.reduce((sum, transaction) => sum + Math.abs(transaction.convertedAmount ?? 0), 0);
+    const total = transactions.reduce((sum, transaction) => sum - (transaction.convertedAmount ?? 0), 0);
 
     return {count, total, currency: footerCurrency};
 }

--- a/src/pages/Search/SearchPage.tsx
+++ b/src/pages/Search/SearchPage.tsx
@@ -648,10 +648,6 @@ function SearchPage({route}: SearchPageProps) {
         searchResults = lastNonEmptySearchResults.current;
     }
 
-    const shouldShowOfflineIndicator = !!searchResults?.data;
-
-    const offlineIndicatorStyle = [styles.mtAuto];
-
     // Handles video player cleanup:
     // 1. On mount: Resets player if navigating from report screen
     // 2. On unmount: Stops video when leaving this screen
@@ -782,8 +778,7 @@ function SearchPage({route}: SearchPageProps) {
                     <View style={styles.searchSplitContainer}>
                         <ScreenWrapper
                             testID={Search.displayName}
-                            shouldShowOfflineIndicatorInWideScreen={!!shouldShowOfflineIndicator}
-                            offlineIndicatorStyle={offlineIndicatorStyle}
+                            shouldShowOfflineIndicatorInWideScreen={false}
                         >
                             <DragAndDropProvider>
                                 {PDFValidationComponent}

--- a/src/pages/Search/SearchPage.tsx
+++ b/src/pages/Search/SearchPage.tsx
@@ -15,7 +15,6 @@ import ScreenWrapper from '@components/ScreenWrapper';
 import {ScrollOffsetContext} from '@components/ScrollOffsetContextProvider';
 import Search from '@components/Search';
 import {useSearchContext} from '@components/Search/SearchContext';
-import SearchPageFooter from '@components/Search/SearchPageFooter';
 import SearchFiltersBar from '@components/Search/SearchPageHeader/SearchFiltersBar';
 import type {SearchHeaderOptionValue} from '@components/Search/SearchPageHeader/SearchPageHeader';
 import SearchPageHeader from '@components/Search/SearchPageHeader/SearchPageHeader';
@@ -649,17 +648,9 @@ function SearchPage({route}: SearchPageProps) {
         searchResults = lastNonEmptySearchResults.current;
     }
 
-    const metadata = searchResults?.search;
     const shouldShowOfflineIndicator = !!searchResults?.data;
-    const shouldShowFooter = !!metadata?.count || selectedTransactionsKeys.length > 0;
 
-    const offlineIndicatorStyle = useMemo(() => {
-        if (shouldShowFooter) {
-            return [styles.mtAuto, styles.pAbsolute, styles.h10, styles.b0];
-        }
-
-        return [styles.mtAuto];
-    }, [shouldShowFooter, styles]);
+    const offlineIndicatorStyle = [styles.mtAuto];
 
     // Handles video player cleanup:
     // 1. On mount: Resets player if navigating from report screen
@@ -698,16 +689,6 @@ function SearchPage({route}: SearchPageProps) {
         }
     }, []);
 
-    const footerData = useMemo(() => {
-        const shouldUseClientTotal = !metadata?.count || (selectedTransactionsKeys.length > 0 && !areAllMatchingItemsSelected);
-        const selectedTransactionItems = Object.values(selectedTransactions);
-        const currency = metadata?.currency ?? selectedTransactionItems.at(0)?.convertedCurrency;
-        const count = shouldUseClientTotal ? selectedTransactionsKeys.length : metadata?.count;
-        const total = shouldUseClientTotal ? selectedTransactionItems.reduce((acc, transaction) => acc - (transaction.convertedAmount ?? 0), 0) : metadata?.total;
-
-        return {count, total, currency};
-    }, [areAllMatchingItemsSelected, metadata?.count, metadata?.currency, metadata?.total, selectedTransactions, selectedTransactionsKeys.length]);
-
     if (shouldUseNarrowLayout) {
         return (
             <>
@@ -715,11 +696,9 @@ function SearchPage({route}: SearchPageProps) {
                     {PDFValidationComponent}
                     <SearchPageNarrow
                         queryJSON={queryJSON}
-                        metadata={metadata}
                         headerButtonsOptions={headerButtonsOptions}
                         searchResults={searchResults}
                         isMobileSelectionModeEnabled={isMobileSelectionModeEnabled}
-                        footerData={footerData}
                         currentSelectedPolicyID={selectedPolicyIDs?.at(0)}
                         currentSelectedReportID={selectedTransactionReportIDs?.at(0) ?? selectedReportIDs?.at(0)}
                         confirmPayment={onBulkPaySelected}
@@ -840,13 +819,6 @@ function SearchPage({route}: SearchPageProps) {
                                         setIsSorting(true);
                                     }}
                                 />
-                                {shouldShowFooter && (
-                                    <SearchPageFooter
-                                        count={footerData.count}
-                                        total={footerData.total}
-                                        currency={footerData.currency}
-                                    />
-                                )}
                                 <DragAndDropConsumer onDrop={initScanRequest}>
                                     <DropZoneUI
                                         icon={Expensicons.SmartScan}

--- a/src/pages/Search/SearchPageNarrow.tsx
+++ b/src/pages/Search/SearchPageNarrow.tsx
@@ -144,8 +144,7 @@ function SearchPageNarrow({
             <ScreenWrapper
                 testID={SearchPageNarrow.displayName}
                 style={styles.pv0}
-                offlineIndicatorStyle={styles.mtAuto}
-                shouldShowOfflineIndicator={!!searchResults}
+                shouldShowOfflineIndicator={false}
             >
                 <FullPageNotFoundView
                     shouldShow={!queryJSON}
@@ -163,10 +162,9 @@ function SearchPageNarrow({
         <ScreenWrapper
             testID={SearchPageNarrow.displayName}
             shouldEnableMaxHeight
-            offlineIndicatorStyle={styles.mtAuto}
             bottomContent={<NavigationTabBar selectedTab={NAVIGATION_TABS.SEARCH} />}
             headerGapStyles={styles.searchHeaderGap}
-            shouldShowOfflineIndicator={!!searchResults}
+            shouldShowOfflineIndicator={false}
         >
             <View style={[styles.flex1, styles.overflowHidden]}>
                 {!isMobileSelectionModeEnabled ? (

--- a/src/pages/Search/SearchPageNarrow.tsx
+++ b/src/pages/Search/SearchPageNarrow.tsx
@@ -37,7 +37,6 @@ import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
 import ROUTES from '@src/ROUTES';
 import type {SearchResults} from '@src/types/onyx';
-import type {SearchResultsInfo} from '@src/types/onyx/SearchResults';
 
 const TOO_CLOSE_TO_TOP_DISTANCE = 10;
 const TOO_CLOSE_TO_BOTTOM_DISTANCE = 10;

--- a/src/pages/Search/SearchPageNarrow.tsx
+++ b/src/pages/Search/SearchPageNarrow.tsx
@@ -68,7 +68,7 @@ function SearchPageNarrow({
     const {windowHeight} = useWindowDimensions();
     const styles = useThemeStyles();
     const StyleUtils = useStyleUtils();
-    const {clearSelectedTransactions, selectedTransactions} = useSearchContext();
+    const {clearSelectedTransactions} = useSearchContext();
     const [searchRouterListVisible, setSearchRouterListVisible] = useState(false);
     const {isOffline} = useNetwork();
     const currentSearchResultsKey = queryJSON?.hash ?? CONST.DEFAULT_NUMBER_ID;

--- a/src/pages/Search/SearchPageNarrow.tsx
+++ b/src/pages/Search/SearchPageNarrow.tsx
@@ -13,7 +13,6 @@ import ScreenWrapper from '@components/ScreenWrapper';
 import {ScrollOffsetContext} from '@components/ScrollOffsetContextProvider';
 import Search from '@components/Search';
 import {useSearchContext} from '@components/Search/SearchContext';
-import SearchPageFooter from '@components/Search/SearchPageFooter';
 import SearchFiltersBar from '@components/Search/SearchPageHeader/SearchFiltersBar';
 import SearchPageHeader from '@components/Search/SearchPageHeader/SearchPageHeader';
 import type {SearchHeaderOptionValue} from '@components/Search/SearchPageHeader/SearchPageHeader';
@@ -46,15 +45,9 @@ const ANIMATION_DURATION_IN_MS = 300;
 
 type SearchPageNarrowProps = {
     queryJSON?: SearchQueryJSON;
-    metadata?: SearchResultsInfo;
     headerButtonsOptions: Array<DropdownOption<SearchHeaderOptionValue>>;
     searchResults?: SearchResults;
     isMobileSelectionModeEnabled: boolean;
-    footerData: {
-        count: number | undefined;
-        total: number | undefined;
-        currency: string | undefined;
-    };
     currentSelectedPolicyID?: string | undefined;
     currentSelectedReportID?: string | undefined;
     confirmPayment?: (paymentType: PaymentMethodType | undefined) => void;
@@ -66,8 +59,6 @@ function SearchPageNarrow({
     headerButtonsOptions,
     searchResults,
     isMobileSelectionModeEnabled,
-    metadata,
-    footerData,
     currentSelectedPolicyID,
     currentSelectedReportID,
     latestBankItems,
@@ -166,7 +157,6 @@ function SearchPageNarrow({
         );
     }
 
-    const shouldShowFooter = !!metadata?.count || Object.keys(selectedTransactions).length > 0;
     const isDataLoaded = isSearchDataLoaded(searchResults, queryJSON);
     const shouldShowLoadingState = !isOffline && (!isDataLoaded || !!currentSearchResults?.search?.isLoading);
 
@@ -254,13 +244,6 @@ function SearchPageNarrow({
                             isMobileSelectionModeEnabled={isMobileSelectionModeEnabled}
                         />
                     </View>
-                )}
-                {shouldShowFooter && (
-                    <SearchPageFooter
-                        count={footerData.count}
-                        total={footerData.total}
-                        currency={footerData.currency}
-                    />
                 )}
             </View>
         </ScreenWrapper>

--- a/tests/unit/Search/SearchUIUtilsTest.ts
+++ b/tests/unit/Search/SearchUIUtilsTest.ts
@@ -2879,7 +2879,7 @@ describe('SearchUIUtils', () => {
             const visibleData = [
                 {...transactionsListItems.at(0), convertedAmount: 10000, convertedCurrency: 'USD'},
                 {...transactionsListItems.at(0), convertedAmount: 15000, convertedCurrency: 'USD'},
-            ];
+            ] as TransactionListItemType[];
 
             const ungroupedResult = SearchUIUtils.calculateSearchPageFooterData({}, visibleData, undefined, 'USD');
             expect(ungroupedResult).toEqual({
@@ -2916,7 +2916,7 @@ describe('SearchUIUtils', () => {
             const visibleData = [
                 {...transactionsListItems.at(0), convertedAmount: -10000},
                 {...transactionsListItems.at(0), convertedAmount: -5000},
-            ];
+            ] as TransactionListItemType[];
 
             const visibleResult = SearchUIUtils.calculateSearchPageFooterData({}, visibleData, undefined, 'USD');
             expect(visibleResult).toEqual({

--- a/tests/unit/Search/SearchUIUtilsTest.ts
+++ b/tests/unit/Search/SearchUIUtilsTest.ts
@@ -2862,8 +2862,8 @@ describe('SearchUIUtils', () => {
 
         it('should calculate footer data for selected transactions and use first transaction currency', () => {
             const selectedTransactions = {
-                txn1: mockTransaction(5000, 'EUR'),
-                txn2: mockTransaction(3000, 'EUR'),
+                txn1: mockTransaction(-5000, 'EUR'),
+                txn2: mockTransaction(-3000, 'EUR'),
             };
 
             const result = SearchUIUtils.calculateSearchPageFooterData(selectedTransactions, [], undefined, 'USD');
@@ -2878,8 +2878,8 @@ describe('SearchUIUtils', () => {
         it('should calculate footer data for search data (ungrouped and grouped)', () => {
             // Ungrouped transactions
             const searchData = [
-                {...transactionsListItems.at(0), convertedAmount: 10000, convertedCurrency: 'USD'},
-                {...transactionsListItems.at(0), convertedAmount: 15000, convertedCurrency: 'USD'},
+                {...transactionsListItems.at(0), convertedAmount: -10000, convertedCurrency: 'USD'},
+                {...transactionsListItems.at(0), convertedAmount: -15000, convertedCurrency: 'USD'},
             ] as TransactionListItemType[];
 
             const ungroupedResult = SearchUIUtils.calculateSearchPageFooterData({}, searchData, undefined, 'USD');
@@ -2893,13 +2893,13 @@ describe('SearchUIUtils', () => {
             const groupedData: TransactionGroupListItemType[] = [
                 {
                     transactions: [
-                        {...transactionsListItems.at(0), convertedAmount: 10000},
-                        {...transactionsListItems.at(0), convertedAmount: 5000},
+                        {...transactionsListItems.at(0), convertedAmount: -10000},
+                        {...transactionsListItems.at(0), convertedAmount: -5000},
                     ],
                     keyForList: 'group1',
                 } as TransactionGroupListItemType,
                 {
-                    transactions: [{...transactionsListItems.at(0), convertedAmount: 8000}],
+                    transactions: [{...transactionsListItems.at(0), convertedAmount: -8000}],
                     keyForList: 'group2',
                 } as TransactionGroupListItemType,
             ];
@@ -2922,12 +2922,12 @@ describe('SearchUIUtils', () => {
             const result = SearchUIUtils.calculateSearchPageFooterData({}, searchData, undefined, 'USD');
             expect(result).toEqual({
                 count: 2,
-                total: 15000, // abs(-10000) + abs(-5000)
+                total: 15000,
                 currency: 'USD',
             });
 
             // Test that selected transactions are prioritized over search data
-            const selectedTransactions = {txn1: mockTransaction(5000)};
+            const selectedTransactions = {txn1: mockTransaction(-5000)};
             const priorityResult = SearchUIUtils.calculateSearchPageFooterData(selectedTransactions, searchData, undefined, 'USD');
             expect(priorityResult).toEqual({
                 count: 1,

--- a/tests/unit/Search/SearchUIUtilsTest.ts
+++ b/tests/unit/Search/SearchUIUtilsTest.ts
@@ -2870,7 +2870,7 @@ describe('SearchUIUtils', () => {
             expect(result).toEqual({
                 count: 2,
                 total: 8000,
-                currency: 'EUR', // Uses first transaction currency, not metadata currency
+                currency: 'EUR',
             });
         });
 

--- a/tests/unit/Search/SearchUIUtilsTest.ts
+++ b/tests/unit/Search/SearchUIUtilsTest.ts
@@ -2877,8 +2877,8 @@ describe('SearchUIUtils', () => {
         it('should calculate footer data for visible transactions (ungrouped and grouped)', () => {
             // Ungrouped transactions
             const visibleData = [
-                {...transactionsListItems[0], convertedAmount: 10000, convertedCurrency: 'USD'},
-                {...transactionsListItems[0], convertedAmount: 15000, convertedCurrency: 'USD'},
+                {...transactionsListItems.at(0), convertedAmount: 10000, convertedCurrency: 'USD'},
+                {...transactionsListItems.at(0), convertedAmount: 15000, convertedCurrency: 'USD'},
             ];
 
             const ungroupedResult = SearchUIUtils.calculateSearchPageFooterData({}, visibleData, undefined, 'USD');
@@ -2892,13 +2892,13 @@ describe('SearchUIUtils', () => {
             const groupedData: TransactionGroupListItemType[] = [
                 {
                     transactions: [
-                        {...transactionsListItems[0], convertedAmount: 10000},
-                        {...transactionsListItems[0], convertedAmount: 5000},
+                        {...transactionsListItems.at(0), convertedAmount: 10000},
+                        {...transactionsListItems.at(0), convertedAmount: 5000},
                     ],
                     keyForList: 'group1',
                 } as TransactionGroupListItemType,
                 {
-                    transactions: [{...transactionsListItems[0], convertedAmount: 8000}],
+                    transactions: [{...transactionsListItems.at(0), convertedAmount: 8000}],
                     keyForList: 'group2',
                 } as TransactionGroupListItemType,
             ];
@@ -2914,8 +2914,8 @@ describe('SearchUIUtils', () => {
         it('should use Math.abs for negative amounts and prioritize selected transactions', () => {
             // Test negative amounts with visible data
             const visibleData = [
-                {...transactionsListItems[0], convertedAmount: -10000},
-                {...transactionsListItems[0], convertedAmount: -5000},
+                {...transactionsListItems.at(0), convertedAmount: -10000},
+                {...transactionsListItems.at(0), convertedAmount: -5000},
             ];
 
             const visibleResult = SearchUIUtils.calculateSearchPageFooterData({}, visibleData, undefined, 'USD');

--- a/tests/unit/Search/SearchUIUtilsTest.ts
+++ b/tests/unit/Search/SearchUIUtilsTest.ts
@@ -2853,6 +2853,7 @@ describe('SearchUIUtils', () => {
             amount,
             convertedAmount: amount,
             convertedCurrency: currency,
+            currency,
         });
 
         it('should return null when no data provided', () => {
@@ -2874,14 +2875,14 @@ describe('SearchUIUtils', () => {
             });
         });
 
-        it('should calculate footer data for visible transactions (ungrouped and grouped)', () => {
+        it('should calculate footer data for search data (ungrouped and grouped)', () => {
             // Ungrouped transactions
-            const visibleData = [
+            const searchData = [
                 {...transactionsListItems.at(0), convertedAmount: 10000, convertedCurrency: 'USD'},
                 {...transactionsListItems.at(0), convertedAmount: 15000, convertedCurrency: 'USD'},
             ] as TransactionListItemType[];
 
-            const ungroupedResult = SearchUIUtils.calculateSearchPageFooterData({}, visibleData, undefined, 'USD');
+            const ungroupedResult = SearchUIUtils.calculateSearchPageFooterData({}, searchData, undefined, 'USD');
             expect(ungroupedResult).toEqual({
                 count: 2,
                 total: 25000,
@@ -2912,22 +2913,22 @@ describe('SearchUIUtils', () => {
         });
 
         it('should use Math.abs for negative amounts and prioritize selected transactions', () => {
-            // Test negative amounts with visible data
-            const visibleData = [
+            // Test negative amounts with search data
+            const searchData = [
                 {...transactionsListItems.at(0), convertedAmount: -10000},
                 {...transactionsListItems.at(0), convertedAmount: -5000},
             ] as TransactionListItemType[];
 
-            const visibleResult = SearchUIUtils.calculateSearchPageFooterData({}, visibleData, undefined, 'USD');
-            expect(visibleResult).toEqual({
+            const result = SearchUIUtils.calculateSearchPageFooterData({}, searchData, undefined, 'USD');
+            expect(result).toEqual({
                 count: 2,
                 total: 15000, // abs(-10000) + abs(-5000)
                 currency: 'USD',
             });
 
-            // Test that selected transactions are prioritized over visible data
+            // Test that selected transactions are prioritized over search data
             const selectedTransactions = {txn1: mockTransaction(5000)};
-            const priorityResult = SearchUIUtils.calculateSearchPageFooterData(selectedTransactions, visibleData, undefined, 'USD');
+            const priorityResult = SearchUIUtils.calculateSearchPageFooterData(selectedTransactions, searchData, undefined, 'USD');
             expect(priorityResult).toEqual({
                 count: 1,
                 total: 5000, // Only selected transaction


### PR DESCRIPTION
### Explanation of Change
The search results footer was showing stale data after deleting an expense. When users deleted the last expense from the "Submit" section, the footer would incorrectly display "1 expense" with the deleted expense amount instead of disappearing or showing accurate values for remaining expenses.

The root cause was that the footer displayed raw server metadata without accounting for optimistically deleted transactions (marked with `pendingAction: DELETE`). While the expense list correctly filtered these out, the footer continued showing the original server count and total.

The fix optimistically adjusts server-side metadata by subtracting pending deleted transactions. The footer now:

- Uses server-side metadata (count and total) as the source of truth
- Calculates totals for transactions with `pendingAction: DELETE` 
- Subtracts deleted transaction count and total from server metadata for optimistic display
- Shows count and total for selected transactions when any are selected (existing behavior)
- Uses the `calculateSearchPageFooterData()` utility function to compute totals for both selected and deleted transactions
- Handles multi-currency transactions using the `convertedAmount` and `convertedCurrency` fields from the backend

This approach maintains server-side data integrity while providing immediate visual feedback when deleting expenses.

### Fixed Issues

$ https://github.com/Expensify/App/issues/69798
PROPOSAL: https://github.com/Expensify/App/issues/69798#issuecomment-3254611532


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests

1. Open any workspace chat
2. Create a manual expense
3. Navigate to Reports > Submit 
4. Delete all the expenses with netork throttling enabled
5. Verify the footer disappears (no "Expenses: <count> Total spend: <amount>" shown)
6. Create 2-3 new expenses with different currencies
7. Navigate to Reports > Submit
8. Verify footer shows correct count and total in correct currency
9. Delete one expense
10. Verify footer updates immediately with new count/total (excluding the deleted expense)
11. Select one or more expenses using checkboxes
12. Verify footer shows count/total for only selected expenses
13. Deselect all expenses
14. Verify footer reverts to showing count for all expenses
15. Delete all remaining expenses
16. Verify empty state is shown without footer

- [x] Verify that no errors appear in the JS console

### Offline tests
1. Add 2-3 expenses in same report/chat and navigate to Reports > Submit
2. Enable airplane/offline mode 
3. Verify offline indicator is visible correctly
4. Select an expense for a report and click Move expense -> Remove from report
5. Verify moved expense is removed from the expenses list and footer is updated with correct count and total.

### QA Steps

Same as Tests

- [x] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I verified there are no new alerts related to the `canBeMissing` param for `useOnyx`
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

https://github.com/user-attachments/assets/e1b464ec-612d-4d8c-9338-e0eec08bbb7f



</details>

<details>
<summary>MacOS: Desktop</summary>

<!-- add screenshots or videos here -->

</details>
