### PR TITLE
[CP Staging] Revert "Fix: Prevent "From" link display when user lacks access to parent report"

### DIFF
--- a/src/components/ParentNavigationSubtitle.tsx
+++ b/src/components/ParentNavigationSubtitle.tsx
@@ -13,7 +13,7 @@ import {isFullScreenName} from '@libs/Navigation/helpers/isNavigatorName';
 import Navigation from '@libs/Navigation/Navigation';
 import type {SearchFullscreenNavigatorParamList} from '@libs/Navigation/types';
 import {getReportAction, shouldReportActionBeVisible} from '@libs/ReportActionsUtils';
-import {canCurrentUserOpenReport, canUserPerformWriteAction as canUserPerformWriteActionReportUtils} from '@libs/ReportUtils';
+import {canUserPerformWriteAction as canUserPerformWriteActionReportUtils} from '@libs/ReportUtils';
 import CONST from '@src/CONST';
 import type {ParentNavigationSummaryParams} from '@src/languages/params';
 import NAVIGATORS from '@src/NAVIGATORS';
@@ -67,8 +67,8 @@ function ParentNavigationSubtitle({
     const isReportInRHP = currentRoute.name === SCREENS.SEARCH.REPORT_RHP;
     const currentFullScreenRoute = useRootNavigationState((state) => state?.routes?.findLast((route) => isFullScreenName(route.name)));
 
-    // We should not display the parent navigation subtitle if the user does not have access to the parent chat (the reportName is empty or user lacks access)
-    if (!reportName || !canCurrentUserOpenReport(report, isReportArchived)) {
+    // We should not display the parent navigation subtitle if the user does not have access to the parent chat (the reportName is empty in this case)
+    if (!reportName) {
         return;
     }
 


### PR DESCRIPTION
Reverts Expensify/App#71443

$ https://github.com/Expensify/App/issues/71727