### PR TITLE
fix: migrate scheduledCall to use parameter instead of split keys

### DIFF
--- a/src/languages/de.ts
+++ b/src/languages/de.ts
@@ -7209,7 +7209,7 @@ const translations = {
         book: {
             title: 'Anruf planen',
             description: 'Finden Sie eine Zeit, die für Sie passt.',
-            slots: 'Verfügbare Zeiten für',
+            slots: ({date}: {date: string}) => `<muted-text>Verfügbare Zeiten für <strong>${date}</strong></muted-text>`,
         },
         confirmation: {
             title: 'Anruf bestätigen',

--- a/src/languages/en.ts
+++ b/src/languages/en.ts
@@ -7161,7 +7161,7 @@ const translations = {
         book: {
             title: 'Schedule call',
             description: 'Find a time that works for you.',
-            slots: 'Available times for ',
+            slots: ({date}: {date: string}) => `<muted-text>Available times for <strong>${date}</strong></muted-text>`,
         },
         confirmation: {
             title: 'Confirm call',

--- a/src/languages/es.ts
+++ b/src/languages/es.ts
@@ -7652,7 +7652,7 @@ const translations = {
         book: {
             title: 'Programar llamada',
             description: 'Encuentra un horario que funcione para ti.',
-            slots: 'Horarios disponibles para el ',
+            slots: ({date}: {date: string}) => `<muted-text>Horarios disponibles para el <strong>${date}</strong></muted-text>`,
         },
         confirmation: {
             title: 'Confirmar llamada',

--- a/src/languages/fr.ts
+++ b/src/languages/fr.ts
@@ -7216,7 +7216,7 @@ const translations = {
         book: {
             title: 'Planifier un appel',
             description: 'Trouvez un moment qui vous convient.',
-            slots: 'Heures disponibles pour',
+            slots: ({date}: {date: string}) => `<muted-text>Heures disponibles pour <strong>${date}</strong></muted-text>`,
         },
         confirmation: {
             title: "Confirmer l'appel",

--- a/src/languages/it.ts
+++ b/src/languages/it.ts
@@ -7217,7 +7217,7 @@ const translations = {
         book: {
             title: 'Pianifica chiamata',
             description: 'Trova un orario che funzioni per te.',
-            slots: 'Orari disponibili per',
+            slots: ({date}: {date: string}) => `<muted-text>Orari disponibili per <strong>${date}</strong></muted-text>`,
         },
         confirmation: {
             title: 'Conferma chiamata',

--- a/src/languages/ja.ts
+++ b/src/languages/ja.ts
@@ -7147,7 +7147,7 @@ const translations = {
         book: {
             title: '通話をスケジュールする',
             description: 'あなたに都合の良い時間を見つけてください。',
-            slots: '利用可能な時間',
+            slots: ({date}: {date: string}) => `<muted-text>利用可能な時間 <strong>${date}</strong></muted-text>`,
         },
         confirmation: {
             title: '通話を確認',

--- a/src/languages/nl.ts
+++ b/src/languages/nl.ts
@@ -7199,7 +7199,7 @@ const translations = {
         book: {
             title: 'Gesprek plannen',
             description: 'Vind een tijd die voor jou werkt.',
-            slots: 'Beschikbare tijden voor',
+            slots: ({date}: {date: string}) => `<muted-text>Beschikbare tijden voor <strong>${date}</strong></muted-text>`,
         },
         confirmation: {
             title: 'Oproep bevestigen',

--- a/src/languages/pl.ts
+++ b/src/languages/pl.ts
@@ -7187,7 +7187,7 @@ const translations = {
         book: {
             title: 'Zaplanuj rozmowę',
             description: 'Znajdź czas, który Ci odpowiada.',
-            slots: 'Dostępne godziny dla',
+            slots: ({date}: {date: string}) => `<muted-text>Dostępne godziny dla <strong>${date}</strong></muted-text>`,
         },
         confirmation: {
             title: 'Potwierdź połączenie',

--- a/src/languages/pt-BR.ts
+++ b/src/languages/pt-BR.ts
@@ -7200,7 +7200,7 @@ const translations = {
         book: {
             title: 'Agendar chamada',
             description: 'Encontre um horário que funcione para você.',
-            slots: 'Horários disponíveis para',
+            slots: ({date}: {date: string}) => `<muted-text>Horários disponíveis para <strong>${date}</strong></muted-text>`,
         },
         confirmation: {
             title: 'Confirmar chamada',

--- a/src/languages/zh-hans.ts
+++ b/src/languages/zh-hans.ts
@@ -7049,7 +7049,7 @@ const translations = {
         book: {
             title: '安排通话',
             description: '找到一个适合你的时间。',
-            slots: '可用时间为',
+            slots: ({date}: {date: string}) => `<muted-text>可用时间为 <strong>${date}</strong></muted-text>`,
         },
         confirmation: {
             title: '确认通话',

--- a/src/pages/ScheduleCall/ScheduleCallPage.tsx
+++ b/src/pages/ScheduleCall/ScheduleCallPage.tsx
@@ -10,6 +10,7 @@ import FullScreenLoadingIndicator from '@components/FullscreenLoadingIndicator';
 import HeaderWithBackButton from '@components/HeaderWithBackButton';
 import MenuItemWithTopDescription from '@components/MenuItemWithTopDescription';
 import {useSession} from '@components/OnyxListItemProvider';
+import RenderHTML from '@components/RenderHTML';
 import ScreenWrapper from '@components/ScreenWrapper';
 import ScrollView from '@components/ScrollView';
 import Text from '@components/Text';
@@ -198,11 +199,12 @@ function ScheduleCallPage() {
                         )}
                         {!!scheduleCallDraft?.date && (
                             <View style={[styles.ph5, styles.mb5]}>
-                                <Text style={[styles.mb5, styles.colorMuted]}>
-                                    {translate('scheduledCall.book.slots')}
-                                    <Text style={[styles.textStrong, styles.colorMuted]}>
-                                        {DateUtils.formatInTimeZoneWithFallback(scheduleCallDraft.date, userTimezone, CONST.DATE.MONTH_DAY_YEAR_FORMAT)}
-                                    </Text>
+                                <Text style={[styles.mb5]}>
+                                    <RenderHTML
+                                        html={translate('scheduledCall.book.slots', {
+                                            date: DateUtils.formatInTimeZoneWithFallback(scheduleCallDraft.date, userTimezone, CONST.DATE.MONTH_DAY_YEAR_FORMAT),
+                                        })}
+                                    />
                                 </Text>
                                 <View style={[styles.flexRow, styles.flexWrap, styles.justifyContentStart, styles.gap2]}>
                                     {timeSlotsForSelectedData.map((timeSlot: TimeSlot) => (


### PR DESCRIPTION
### Explanation of Change
Fix/Migrate `scheduledCall.book.slots` to use parameter instead of split keys string
### Fixed Issues
$ https://github.com/Expensify/App/issues/72056
PROPOSAL: https://github.com/Expensify/App/issues/72056#issuecomment-3379325585

### Tests
Prerequisite: Don't use a `+` prefix in the email address

1. Open Expensify App
2. Go to workspace `#admins` room if any / or create new one
3. Click the `Schedule call` button
4. Once redirected to the schedule call page
5. Verify that the `Available times for` display the correct text along with the **date** using the bold format

- [X] Verify that no errors appear in the JS console

### Offline tests
Same as Tests
### QA Steps
Same as Tests

- [X] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [X] I linked the correct issue in the `### Fixed Issues` section above
- [X] I wrote clear testing steps that cover the changes made in this PR
    - [X] I added steps for local testing in the `Tests` section
    - [X] I added steps for the expected offline behavior in the `Offline steps` section
    - [X] I added steps for Staging and/or Production testing in the `QA steps` section
    - [X] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [X] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [X] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [X] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [X] I ran the tests on **all platforms** & verified they passed on:
    - [X] Android: Native
    - [X] Android: mWeb Chrome
    - [X] iOS: Native
    - [X] iOS: mWeb Safari
    - [X] MacOS: Chrome / Safari
    - [X] MacOS: Desktop
- [X] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [X] I verified there are no new alerts related to the `canBeMissing` param for `useOnyx`
- [X] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [X] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [X] I verified that comments were added to code that is not self explanatory
    - [X] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [X] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [X] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [X] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [X] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [X] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [X] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [X] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [X] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [X] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [X] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [X] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [X] I verified that if a function's arguments changed that all usages have also been updated correctly
- [X] If any new file was added I verified that:
    - [X] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [X] If a new CSS style is added I verified that:
    - [X] A similar style doesn't already exist
    - [X] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [X] If new assets were added or existing ones were modified, I verified that:
    - [X] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [X] The assets load correctly across all supported platforms.
- [X] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [X] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [X] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [X] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [X] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [X] I verified that all the inputs inside a form are aligned with each other.
    - [X] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [X] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [X] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [X] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

https://github.com/user-attachments/assets/3dbe4d7a-f806-4d6e-8302-015522b87b38


<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

https://github.com/user-attachments/assets/662ca9c1-8b79-45dc-80d1-7340aa053e5f


<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

https://github.com/user-attachments/assets/31733ba5-c601-4329-adec-a2c803867af1


<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>


https://github.com/user-attachments/assets/3a7f055f-c647-486b-bd1c-79fec0f618be

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>



https://github.com/user-attachments/assets/dbe05135-55f8-4794-ba26-36aa87c69773



<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Desktop</summary>

https://github.com/user-attachments/assets/28738554-ec4a-451c-8012-8048706ccce1
<!-- add screenshots or videos here -->

</details>
