### PR TITLE
[No QA] Suppress lint on all existing usages of translateLocal

### DIFF
--- a/src/components/LocaleContextProvider.tsx
+++ b/src/components/LocaleContextProvider.tsx
@@ -7,7 +7,6 @@ import DateUtils from '@libs/DateUtils';
 import {buildEmojisTrie} from '@libs/EmojiTrie';
 import {fromLocaleDigit as fromLocaleDigitLocaleDigitUtils, toLocaleDigit as toLocaleDigitLocaleDigitUtils, toLocaleOrdinal as toLocaleOrdinalLocaleDigitUtils} from '@libs/LocaleDigitUtils';
 import {formatPhoneNumberWithCountryCode} from '@libs/LocalePhoneNumber';
-// eslint-disable-next-line @typescript-eslint/no-deprecated
 import {getDevicePreferredLocale, translate as translateLocalize} from '@libs/Localize';
 import localeEventCallback from '@libs/Localize/localeEventCallback';
 import {format} from '@libs/NumberFormatUtils';
@@ -137,7 +136,6 @@ function LocaleContextProvider({children}: LocaleContextProviderProps) {
     const translate = useMemo<LocaleContextProps['translate']>(
         () =>
             (path, ...parameters) =>
-                // eslint-disable-next-line @typescript-eslint/no-deprecated
                 translateLocalize(currentLocale, path, ...parameters),
         [currentLocale],
     );
@@ -182,7 +180,6 @@ function LocaleContextProvider({children}: LocaleContextProviderProps) {
             const date = new Date(datetime);
             const formattedDate = formatDate(date, CONST.DATE.MONTH_DAY_YEAR_ABBR_FORMAT);
             const formattedHour = formatDate(date, CONST.DATE.LOCAL_TIME_FORMAT);
-            // eslint-disable-next-line @typescript-eslint/no-deprecated
             const at = translateLocalize(currentLocale, 'common.conjunctionAt');
             return `${formattedDate} ${at} ${formattedHour}`;
         },

--- a/src/components/LocaleContextProvider.tsx
+++ b/src/components/LocaleContextProvider.tsx
@@ -7,6 +7,7 @@ import DateUtils from '@libs/DateUtils';
 import {buildEmojisTrie} from '@libs/EmojiTrie';
 import {fromLocaleDigit as fromLocaleDigitLocaleDigitUtils, toLocaleDigit as toLocaleDigitLocaleDigitUtils, toLocaleOrdinal as toLocaleOrdinalLocaleDigitUtils} from '@libs/LocaleDigitUtils';
 import {formatPhoneNumberWithCountryCode} from '@libs/LocalePhoneNumber';
+// eslint-disable-next-line @typescript-eslint/no-deprecated
 import {getDevicePreferredLocale, translate as translateLocalize} from '@libs/Localize';
 import localeEventCallback from '@libs/Localize/localeEventCallback';
 import {format} from '@libs/NumberFormatUtils';
@@ -136,6 +137,7 @@ function LocaleContextProvider({children}: LocaleContextProviderProps) {
     const translate = useMemo<LocaleContextProps['translate']>(
         () =>
             (path, ...parameters) =>
+                // eslint-disable-next-line @typescript-eslint/no-deprecated
                 translateLocalize(currentLocale, path, ...parameters),
         [currentLocale],
     );
@@ -180,6 +182,7 @@ function LocaleContextProvider({children}: LocaleContextProviderProps) {
             const date = new Date(datetime);
             const formattedDate = formatDate(date, CONST.DATE.MONTH_DAY_YEAR_ABBR_FORMAT);
             const formattedHour = formatDate(date, CONST.DATE.LOCAL_TIME_FORMAT);
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             const at = translateLocalize(currentLocale, 'common.conjunctionAt');
             return `${formattedDate} ${at} ${formattedHour}`;
         },

--- a/src/libs/CardUtils.ts
+++ b/src/libs/CardUtils.ts
@@ -14,6 +14,7 @@ import type {FilteredCardList} from '@src/types/onyx/Card';
 import type {CardFeedData, CompanyCardFeedWithNumber, CompanyCardNicknames, CompanyFeeds, DirectCardFeedData} from '@src/types/onyx/CardFeeds';
 import {isEmptyObject} from '@src/types/utils/EmptyObject';
 import type IconAsset from '@src/types/utils/IconAsset';
+// eslint-disable-next-line @typescript-eslint/no-deprecated
 import {translateLocal} from './Localize';
 import {filterObject} from './ObjectUtils';
 import {getDisplayNameOrDefault} from './PersonalDetailsUtils';
@@ -64,6 +65,7 @@ function getCardDescription(card?: Card) {
     }
     const isPlaid = !!getPlaidInstitutionId(card.bank);
     const bankName = isPlaid ? card?.cardName : getBankName(card.bank as CompanyCardFeed);
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     const cardDescriptor = card.state === CONST.EXPENSIFY_CARD.STATE.NOT_ACTIVATED ? translateLocal('cardTransactions.notActivated') : card.lastFourPAN;
     const humanReadableBankName = card.bank === CONST.EXPENSIFY_CARD.BANK ? CONST.EXPENSIFY_CARD.BANK : bankName;
     return cardDescriptor && !isPlaid ? `${humanReadableBankName} - ${cardDescriptor}` : `${humanReadableBankName}`;
@@ -416,6 +418,7 @@ function getCustomOrFormattedFeedName(feed?: CompanyCardFeed, companyCardNicknam
     }
 
     const feedName = getBankName(feed);
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     const formattedFeedName = shouldAddCardsSuffix ? translateLocal('workspace.companyCards.feedName', {feedName}) : feedName;
 
     // Custom feed name can be empty. Fallback to default feed name

--- a/src/libs/CategoryOptionListUtils.ts
+++ b/src/libs/CategoryOptionListUtils.ts
@@ -7,6 +7,7 @@ import type {PolicyCategories} from '@src/types/onyx';
 import type * as OnyxCommon from '@src/types/onyx/OnyxCommon';
 import {isEmptyObject} from '@src/types/utils/EmptyObject';
 import times from '@src/utils/times';
+// eslint-disable-next-line @typescript-eslint/no-deprecated
 import {translateLocal} from './Localize';
 import type {OptionTree, SectionBase} from './OptionsListUtils';
 import tokenizedSearch from './tokenizedSearch';
@@ -190,6 +191,7 @@ function getCategoryListSections({
         const data = getCategoryOptionTree(cutRecentlyUsedCategories, true);
         categorySections.push({
             // "Recent" section
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             title: translateLocal('common.recent'),
             shouldShow: true,
             data,
@@ -200,6 +202,7 @@ function getCategoryListSections({
     const data = getCategoryOptionTree(filteredCategories, false, selectedOptionsWithDisabledState);
     categorySections.push({
         // "All" section when items amount more than the threshold
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         title: translateLocal('common.all'),
         shouldShow: true,
         data,

--- a/src/libs/ConnectionUtils.ts
+++ b/src/libs/ConnectionUtils.ts
@@ -1,16 +1,21 @@
 import CONST from '@src/CONST';
 import type {QBDNonReimbursableExportAccountType, QBONonReimbursableExportAccountType} from '@src/types/onyx/Policy';
+// eslint-disable-next-line @typescript-eslint/no-deprecated
 import {translateLocal} from './Localize';
 
 function getQBONonReimbursableExportAccountType(exportDestination: QBONonReimbursableExportAccountType | undefined): string {
     switch (exportDestination) {
         case CONST.QUICKBOOKS_NON_REIMBURSABLE_EXPORT_ACCOUNT_TYPE.DEBIT_CARD:
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             return translateLocal('workspace.qbo.bankAccount');
         case CONST.QUICKBOOKS_NON_REIMBURSABLE_EXPORT_ACCOUNT_TYPE.CREDIT_CARD:
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             return translateLocal('workspace.qbo.creditCardAccount');
         case CONST.QUICKBOOKS_NON_REIMBURSABLE_EXPORT_ACCOUNT_TYPE.VENDOR_BILL:
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             return translateLocal('workspace.qbo.accountsPayable');
         default:
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             return translateLocal('workspace.qbo.account');
     }
 }
@@ -18,12 +23,16 @@ function getQBONonReimbursableExportAccountType(exportDestination: QBONonReimbur
 function getQBDNonReimbursableExportAccountType(exportDestination: QBDNonReimbursableExportAccountType | undefined): string {
     switch (exportDestination) {
         case CONST.QUICKBOOKS_DESKTOP_NON_REIMBURSABLE_EXPORT_ACCOUNT_TYPE.CHECK:
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             return translateLocal('workspace.qbd.bankAccount');
         case CONST.QUICKBOOKS_DESKTOP_NON_REIMBURSABLE_EXPORT_ACCOUNT_TYPE.CREDIT_CARD:
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             return translateLocal('workspace.qbd.creditCardAccount');
         case CONST.QUICKBOOKS_DESKTOP_NON_REIMBURSABLE_EXPORT_ACCOUNT_TYPE.VENDOR_BILL:
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             return translateLocal('workspace.qbd.accountsPayable');
         default:
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             return translateLocal('workspace.qbd.account');
     }
 }

--- a/src/libs/DateUtils.ts
+++ b/src/libs/DateUtils.ts
@@ -39,6 +39,7 @@ import {timezoneBackwardToNewMap, timezoneNewToBackwardMap} from '@src/TIMEZONES
 import type Locale from '@src/types/onyx/Locale';
 import type {SelectedTimezone, Timezone} from '@src/types/onyx/PersonalDetails';
 import {setCurrentDate} from './actions/CurrentDate';
+// eslint-disable-next-line @typescript-eslint/no-deprecated
 import {translate, translateLocal} from './Localize';
 import Log from './Log';
 import memoize from './memoize';
@@ -468,9 +469,11 @@ function getDateFromStatusType(type: CustomStatusTypes): string {
 function getLocalizedTimePeriodDescription(data: string): string {
     switch (data) {
         case getEndOfToday():
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             return translateLocal('statusPage.timePeriods.afterToday');
         case CONST.CUSTOM_STATUS_TYPES.NEVER:
         case '':
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             return translateLocal('statusPage.timePeriods.never');
         default:
             return formatDateTimeTo12Hour(data);
@@ -491,20 +494,24 @@ function getStatusUntilDate(inputDate: string): string {
 
     // If the date is adjusted to the following day
     if (isSameSecond(input, endOfToday)) {
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         return translateLocal('statusPage.untilTomorrow');
     }
 
     // If it's a time on the same date
     if (isSameDay(input, now)) {
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         return translateLocal('statusPage.untilTime', {time: format(input, CONST.DATE.LOCAL_TIME_FORMAT)});
     }
 
     // If it's further in the future than tomorrow but within the same year
     if (isAfter(input, now) && isSameYear(input, now)) {
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         return translateLocal('statusPage.untilTime', {time: format(input, `${CONST.DATE.SHORT_DATE_FORMAT} ${CONST.DATE.LOCAL_TIME_FORMAT}`)});
     }
 
     // If it's in another year
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     return translateLocal('statusPage.untilTime', {time: format(input, `${CONST.DATE.FNS_FORMAT_STRING} ${CONST.DATE.LOCAL_TIME_FORMAT}`)});
 }
 
@@ -633,6 +640,7 @@ const getDayValidationErrorKey = (inputDate: Date): string => {
     }
 
     if (isAfter(startOfDay(new Date()), startOfDay(inputDate))) {
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         return translateLocal('common.error.invalidDateShouldBeFuture');
     }
     return '';
@@ -656,6 +664,7 @@ const isFutureDay = (inputDate: Date): boolean => {
 const getTimeValidationErrorKey = (inputTime: Date): string => {
     const timeNowPlusOneMinute = addMinutes(new Date(), 1);
     if (isBefore(inputTime, timeNowPlusOneMinute)) {
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         return translateLocal('common.error.invalidTimeShouldBeFuture');
     }
     return '';
@@ -732,9 +741,11 @@ function getFormattedDateRange(date1: Date, date2: Date): string {
     }
     if (isSameYear(date1, date2)) {
         // Dates are in the same year, differ by months
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         return `${format(date1, 'MMM d')} ${translateLocal('common.to').toLowerCase()} ${format(date2, 'MMM d')}`;
     }
     // Dates differ by years, months, days
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     return `${format(date1, 'MMM d, yyyy')} ${translateLocal('common.to').toLowerCase()} ${format(date2, 'MMM d, yyyy')}`;
 }
 
@@ -757,9 +768,11 @@ function getFormattedReservationRangeDate(date1: Date, date2: Date): string {
     }
     if (isSameYear(date1, date2) && isThisYear(date1)) {
         // Dates are in the current year, differ by months
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         return `${format(date1, 'EEEE, MMM d')} ${translateLocal('common.conjunctionTo')} ${format(date2, 'EEEE, MMM d')}`;
     }
     // Dates differ by years, months, days or only by months but the year is not current
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     return `${format(date1, 'EEEE, MMM d, yyyy')} ${translateLocal('common.conjunctionTo')} ${format(date2, 'EEEE, MMM d, yyyy')}`;
 }
 
@@ -771,8 +784,10 @@ function getFormattedReservationRangeDate(date1: Date, date2: Date): string {
  */
 function getFormattedTransportDate(date: Date): string {
     if (isThisYear(date)) {
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         return `${translateLocal('travel.departs')} ${format(date, 'EEEE, MMM d')} ${translateLocal('common.conjunctionAt')} ${format(date, 'hh:mm a')}`;
     }
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     return `${translateLocal('travel.departs')} ${format(date, 'EEEE, MMM d, yyyy')} ${translateLocal('common.conjunctionAt')} ${format(date, 'hh:mm a')}`;
 }
 

--- a/src/libs/ErrorUtils.ts
+++ b/src/libs/ErrorUtils.ts
@@ -6,6 +6,7 @@ import type {ErrorFields, Errors, TranslationKeyError, TranslationKeyErrors} fro
 import type Response from '@src/types/onyx/Response';
 import type {ReceiptError} from '@src/types/onyx/Transaction';
 import DateUtils from './DateUtils';
+// eslint-disable-next-line @typescript-eslint/no-deprecated
 import {translateLocal} from './Localize';
 
 function getAuthenticateErrorMessage(response: Response): TranslationPaths {
@@ -42,6 +43,7 @@ function getAuthenticateErrorMessage(response: Response): TranslationPaths {
  * @param error - The translation key for the error message.
  */
 function getMicroSecondOnyxErrorWithTranslationKey(error: TranslationPaths, errorKey?: number): Errors {
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     return {[errorKey ?? DateUtils.getMicroseconds()]: translateLocal(error)};
 }
 

--- a/src/libs/Localize/index.ts
+++ b/src/libs/Localize/index.ts
@@ -13,6 +13,7 @@ import {isEmptyObject} from '@src/types/utils/EmptyObject';
 
 // Current user mail is needed for handling missing translations
 let userEmail = '';
+// eslint-disable-next-line @typescript-eslint/no-deprecated
 // TODO: Remove this Onyx.connectWithoutView after deprecating translateLocal (#64943) and completing Onyx.connect deprecation - see https://github.com/Expensify/App/issues/66329
 Onyx.connectWithoutView({
     key: ONYXKEYS.SESSION,
@@ -142,6 +143,7 @@ function translate<TPath extends TranslationPaths>(locale: Locale | undefined, p
  * Uses the locale in this file updated by the Onyx subscriber.
  * @deprecated This function uses imperative Onyx data access patterns, similar to `Onyx.connect`. Use `useLocalize` hook instead for reactive data access in React components.
  */
+// eslint-disable-next-line @typescript-eslint/no-deprecated
 function translateLocal<TPath extends TranslationPaths>(phrase: TPath, ...parameters: TranslationParameters<TPath>) {
     const currentLocale = IntlStore.getCurrentLocale();
     return translate(currentLocale, phrase, ...parameters);

--- a/src/libs/ModifiedExpenseMessage.ts
+++ b/src/libs/ModifiedExpenseMessage.ts
@@ -7,6 +7,7 @@ import ONYXKEYS from '@src/ONYXKEYS';
 import type {PolicyTagLists, Report, ReportAction} from '@src/types/onyx';
 import {convertToDisplayString} from './CurrencyUtils';
 import DateUtils from './DateUtils';
+// eslint-disable-next-line @typescript-eslint/no-deprecated
 import {translateLocal} from './Localize';
 import Log from './Log';
 import Parser from './Parser';
@@ -45,16 +46,20 @@ function buildMessageFragmentForValue(
     const newValueToDisplay = valueInQuotes ? `"${newValue}"` : newValue;
     const oldValueToDisplay = valueInQuotes ? `"${oldValue}"` : oldValue;
     const displayValueName = shouldConvertToLowercase ? valueName.toLowerCase() : valueName;
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     const isOldValuePartialMerchant = valueName === translateLocal('common.merchant') && oldValue === CONST.TRANSACTION.PARTIAL_TRANSACTION_MERCHANT;
 
     // In case of a partial merchant value, we want to avoid user seeing the "(none)" value in the message.
     if (!oldValue || isOldValuePartialMerchant) {
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         const fragment = translateLocal('iou.setTheRequest', {valueName: displayValueName, newValueToDisplay});
         setFragments.push(fragment);
     } else if (!newValue || newValue === CONST.TRANSACTION.PARTIAL_TRANSACTION_MERCHANT) {
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         const fragment = translateLocal('iou.removedTheRequest', {valueName: displayValueName, oldValueToDisplay});
         removalFragments.push(fragment);
     } else {
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         const fragment = translateLocal('iou.updatedTheRequest', {valueName: displayValueName, newValueToDisplay, oldValueToDisplay});
         changeFragments.push(fragment);
     }
@@ -81,8 +86,10 @@ function getMessageLine(prefix: string, messageFragments: string[]): string {
                 return `${acc} ${value}`;
             }
             if (messageFragments.length === 2) {
+                // eslint-disable-next-line @typescript-eslint/no-deprecated
                 return `${acc} ${translateLocal('common.and')} ${value}`;
             }
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             return `${acc}, ${translateLocal('common.and')} ${value}`;
         }
         if (index === 0) {
@@ -109,11 +116,13 @@ function getForDistanceRequest(newMerchant: string, oldMerchant: string, newAmou
     } else {
         Log.hmmm("Distance request merchant doesn't match NewDot format. Defaulting to showing as distance changed.", {newMerchant, oldMerchant});
     }
-
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     const translatedChangedField = translateLocal(`common.${changedField}`).toLowerCase();
     if (!oldMerchant.length) {
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         return translateLocal('iou.setTheDistanceMerchant', {translatedChangedField, newMerchant, newAmountToDisplay: newAmount});
     }
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     return translateLocal('iou.updatedTheDistanceMerchant', {
         translatedChangedField,
         newMerchant,
@@ -127,6 +136,7 @@ function getForExpenseMovedFromSelfDM(destinationReport: OnyxEntry<Report>) {
     const rootParentReport = getRootParentReport({report: destinationReport});
     // In OldDot, expenses could be moved to a self-DM. Return the corresponding message for this case.
     if (isSelfDM(rootParentReport)) {
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         return translateLocal('iou.movedToPersonalSpace');
     }
     // In NewDot, the "Move report" flow only supports moving expenses from self-DM to:
@@ -136,8 +146,10 @@ function getForExpenseMovedFromSelfDM(destinationReport: OnyxEntry<Report>) {
     const policyName = getPolicyName({report: rootParentReport, returnEmptyIfNotFound: true});
     // If we can't determine either the report name or policy name, return the default message
     if (isEmpty(policyName) && !reportName) {
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         return translateLocal('iou.changedTheExpense');
     }
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     return translateLocal('iou.movedFromPersonalSpace', {
         reportName,
         workspaceName: !isEmpty(policyName) ? policyName : undefined,
@@ -160,6 +172,7 @@ function getMovedFromOrToReportMessage(movedFromReport: OnyxEntry<Report> | unde
 
     if (movedFromReport) {
         const originReportName = getReportName(movedFromReport);
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         return translateLocal('iou.movedFromReport', {reportName: originReportName ?? ''});
     }
 }
@@ -219,7 +232,7 @@ function getForReportAction({
         if (hasModifiedMerchant && (reportActionOriginalMessage?.merchant ?? '').includes('@')) {
             return getForDistanceRequest(reportActionOriginalMessage?.merchant ?? '', reportActionOriginalMessage?.oldMerchant ?? '', amount, oldAmount);
         }
-
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         buildMessageFragmentForValue(amount, oldAmount, translateLocal('iou.amount'), false, setFragments, removalFragments, changeFragments);
     }
 
@@ -228,6 +241,7 @@ function getForReportAction({
         buildMessageFragmentForValue(
             Parser.htmlToMarkdown(reportActionOriginalMessage?.newComment ?? ''),
             Parser.htmlToMarkdown(reportActionOriginalMessage?.oldComment ?? ''),
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             translateLocal('common.description'),
             true,
             setFragments,
@@ -238,7 +252,7 @@ function getForReportAction({
 
     if (reportActionOriginalMessage?.oldCreated && reportActionOriginalMessage?.created) {
         const formattedOldCreated = DateUtils.formatWithUTCTimeZone(reportActionOriginalMessage.oldCreated, CONST.DATE.FNS_FORMAT_STRING);
-
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         buildMessageFragmentForValue(reportActionOriginalMessage.created, formattedOldCreated, translateLocal('common.date'), false, setFragments, removalFragments, changeFragments);
     }
 
@@ -246,6 +260,7 @@ function getForReportAction({
         buildMessageFragmentForValue(
             reportActionOriginalMessage?.merchant ?? '',
             reportActionOriginalMessage?.oldMerchant ?? '',
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             translateLocal('common.merchant'),
             true,
             setFragments,
@@ -259,6 +274,7 @@ function getForReportAction({
         buildMessageFragmentForValue(
             reportActionOriginalMessage?.category ?? '',
             reportActionOriginalMessage?.oldCategory ?? '',
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             translateLocal('common.category'),
             true,
             setFragments,
@@ -274,6 +290,7 @@ function getForReportAction({
         const oldTransactionTag = reportActionOriginalMessage?.oldTag ?? '';
         const splittedTag = getTagArrayFromName(transactionTag);
         const splittedOldTag = getTagArrayFromName(oldTransactionTag);
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         const localizedTagListName = translateLocal('common.tag');
         const sortedTagKeys = getSortedTagKeys(policyTags);
 
@@ -305,6 +322,7 @@ function getForReportAction({
         const taxAmount = convertToDisplayString(getTaxAmountAbsValue(reportActionOriginalMessage?.taxAmount ?? 0), currency);
         const oldTaxAmountValue = getTaxAmountAbsValue(reportActionOriginalMessage?.oldTaxAmount ?? 0);
         const oldTaxAmount = oldTaxAmountValue > 0 ? convertToDisplayString(oldTaxAmountValue, currency) : '';
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         buildMessageFragmentForValue(taxAmount, oldTaxAmount, translateLocal('iou.taxAmount'), false, setFragments, removalFragments, changeFragments);
     }
 
@@ -313,6 +331,7 @@ function getForReportAction({
         buildMessageFragmentForValue(
             reportActionOriginalMessage?.taxRate ?? '',
             reportActionOriginalMessage?.oldTaxRate ?? '',
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             translateLocal('iou.taxRate'),
             false,
             setFragments,
@@ -326,6 +345,7 @@ function getForReportAction({
         buildMessageFragmentForValue(
             reportActionOriginalMessage?.billable ?? '',
             reportActionOriginalMessage?.oldBillable ?? '',
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             translateLocal('iou.expense'),
             true,
             setFragments,
@@ -339,6 +359,7 @@ function getForReportAction({
         buildMessageFragmentForValue(
             reportActionOriginalMessage?.reimbursable ?? '',
             reportActionOriginalMessage?.oldReimbursable ?? '',
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             translateLocal('iou.expense'),
             true,
             setFragments,
@@ -350,15 +371,19 @@ function getForReportAction({
     const hasModifiedAttendees = isReportActionOriginalMessageAnObject && 'oldAttendees' in reportActionOriginalMessage && 'newAttendees' in reportActionOriginalMessage;
     if (hasModifiedAttendees) {
         const [oldAttendees, attendees] = getFormattedAttendees(reportActionOriginalMessage.newAttendees, reportActionOriginalMessage.oldAttendees);
-
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         buildMessageFragmentForValue(oldAttendees, attendees, translateLocal('iou.attendees'), false, setFragments, removalFragments, changeFragments);
     }
 
     const message =
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         getMessageLine(`\n${translateLocal('iou.changed')}`, changeFragments) +
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         getMessageLine(`\n${translateLocal('iou.set')}`, setFragments) +
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         getMessageLine(`\n${translateLocal('iou.removed')}`, removalFragments);
     if (message === '') {
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         return translateLocal('iou.changedTheExpense');
     }
     return `${message.substring(1, message.length)}`;

--- a/src/libs/Navigation/AppNavigator/createRootStackNavigator/RootStackRouter.ts
+++ b/src/libs/Navigation/AppNavigator/createRootStackNavigator/RootStackRouter.ts
@@ -60,6 +60,7 @@ function shouldPreventReset(state: StackNavigationState<ParamListBase>, action: 
 
     // We want to prevent the user from navigating back to a non-onboarding screen if they are currently on an onboarding screen
     if (isOnboardingFlowName(currentFocusedRoute?.name) && !isOnboardingFlowName(targetFocusedRoute?.name)) {
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         Welcome.setOnboardingErrorMessage(Localize.translateLocal('onboarding.purpose.errorBackButton'));
         return true;
     }

--- a/src/libs/OptionsListUtils/index.ts
+++ b/src/libs/OptionsListUtils/index.ts
@@ -12,6 +12,7 @@ import {getEnabledCategoriesCount} from '@libs/CategoryUtils';
 import filterArrayByMatch from '@libs/filterArrayByMatch';
 import {isReportMessageAttachment} from '@libs/isReportMessageAttachment';
 import {formatPhoneNumber} from '@libs/LocalePhoneNumber';
+// eslint-disable-next-line @typescript-eslint/no-deprecated
 import {translateLocal} from '@libs/Localize';
 import {appendCountryCode, appendCountryCodeWithCountryCode, getPhoneNumberWithoutSpecialChars} from '@libs/LoginUtils';
 import {MaxHeap} from '@libs/MaxHeap';
@@ -428,7 +429,8 @@ function getLastActorDisplayName(lastActorDetails: Partial<PersonalDetails> | nu
     return lastActorDetails.accountID !== currentUserAccountID
         ? // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
           lastActorDetails.firstName || formatPhoneNumber(getDisplayNameOrDefault(lastActorDetails))
-        : translateLocal('common.you');
+        : // eslint-disable-next-line @typescript-eslint/no-deprecated
+          translateLocal('common.you');
 }
 
 /**
@@ -475,10 +477,12 @@ function getAlternateText(
     const formattedLastMessageTextWithPrefix = reportPrefix + formattedLastMessageText;
 
     if (isExpenseThread || option.isMoneyRequestReport) {
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         return showChatPreviewLine && formattedLastMessageText ? formattedLastMessageTextWithPrefix : translateLocal('iou.expense');
     }
 
     if (option.isThread) {
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         return showChatPreviewLine && formattedLastMessageText ? formattedLastMessageTextWithPrefix : translateLocal('threads.thread');
     }
 
@@ -491,10 +495,12 @@ function getAlternateText(
     }
 
     if (option.isTaskReport) {
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         return showChatPreviewLine && formattedLastMessageText ? formattedLastMessageTextWithPrefix : translateLocal('task.task');
     }
 
     if (isGroupChat) {
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         return showChatPreviewLine && formattedLastMessageText ? formattedLastMessageTextWithPrefix : translateLocal('common.group');
     }
 
@@ -623,6 +629,7 @@ function getLastMessageTextForReport({
             case CONST.REPORT.ARCHIVE_REASON.ACCOUNT_CLOSED:
             case CONST.REPORT.ARCHIVE_REASON.REMOVED_FROM_POLICY:
             case CONST.REPORT.ARCHIVE_REASON.POLICY_DELETED: {
+                // eslint-disable-next-line @typescript-eslint/no-deprecated
                 lastMessageTextFromReport = translateLocal(`reportArchiveReasons.${archiveReason}`, {
                     displayName: formatPhoneNumber(getDisplayNameOrDefault(lastActorDetails)),
                     policyName: getPolicyName({report, policy}),
@@ -630,10 +637,12 @@ function getLastMessageTextForReport({
                 break;
             }
             case CONST.REPORT.ARCHIVE_REASON.BOOKING_END_DATE_HAS_PASSED: {
+                // eslint-disable-next-line @typescript-eslint/no-deprecated
                 lastMessageTextFromReport = translateLocal(`reportArchiveReasons.${archiveReason}`);
                 break;
             }
             default: {
+                // eslint-disable-next-line @typescript-eslint/no-deprecated
                 lastMessageTextFromReport = translateLocal(`reportArchiveReasons.default`);
             }
         }
@@ -672,10 +681,13 @@ function getLastMessageTextForReport({
     } else if (isDeletedParentAction(lastReportAction) && reportUtilsIsChatReport(report)) {
         lastMessageTextFromReport = getDeletedParentActionMessageForChatReport(lastReportAction);
     } else if (isPendingRemove(lastReportAction) && report?.reportID && isThreadParentMessage(lastReportAction, report.reportID)) {
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         lastMessageTextFromReport = translateLocal('parentReportAction.hiddenMessage');
     } else if (isActionOfType(lastReportAction, CONST.REPORT.ACTIONS.TYPE.MARKED_REIMBURSED)) {
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         lastMessageTextFromReport = translateLocal('iou.paidElsewhere');
     } else if (isReportMessageAttachment({text: report?.lastMessageText ?? '', html: report?.lastMessageHtml, type: ''})) {
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         lastMessageTextFromReport = `[${translateLocal('common.attachment')}]`;
     } else if (isModifiedExpenseAction(lastReportAction)) {
         const properSchemaForModifiedExpenseMessage = getForReportAction({
@@ -701,24 +713,31 @@ function getLastMessageTextForReport({
     ) {
         const wasSubmittedViaHarvesting = !isMarkAsClosedAction(lastReportAction) ? (getOriginalMessage(lastReportAction)?.harvesting ?? false) : false;
         if (wasSubmittedViaHarvesting) {
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             lastMessageTextFromReport = Parser.htmlToText(translateLocal('iou.automaticallySubmitted'));
         } else {
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             lastMessageTextFromReport = translateLocal('iou.submitted', {memo: getOriginalMessage(lastReportAction)?.message});
         }
     } else if (isActionOfType(lastReportAction, CONST.REPORT.ACTIONS.TYPE.APPROVED)) {
         const {automaticAction} = getOriginalMessage(lastReportAction) ?? {};
         if (automaticAction) {
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             lastMessageTextFromReport = Parser.htmlToText(translateLocal('iou.automaticallyApproved'));
         } else {
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             lastMessageTextFromReport = translateLocal('iou.approvedMessage');
         }
     } else if (isUnapprovedAction(lastReportAction)) {
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         lastMessageTextFromReport = translateLocal('iou.unapproved');
     } else if (isActionOfType(lastReportAction, CONST.REPORT.ACTIONS.TYPE.FORWARDED)) {
         const {automaticAction} = getOriginalMessage(lastReportAction) ?? {};
         if (automaticAction) {
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             lastMessageTextFromReport = Parser.htmlToText(translateLocal('iou.automaticallyForwarded'));
         } else {
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             lastMessageTextFromReport = translateLocal('iou.forwarded');
         }
     } else if (lastReportAction?.actionName === CONST.REPORT.ACTIONS.TYPE.REJECTED) {
@@ -740,6 +759,7 @@ function getLastMessageTextForReport({
     } else if (lastReportAction?.actionName === CONST.REPORT.ACTIONS.TYPE.ROOM_CHANGE_LOG.LEAVE_ROOM) {
         lastMessageTextFromReport = getLeaveRoomMessage();
     } else if (lastReportAction?.actionName === CONST.REPORT.ACTIONS.TYPE.RESOLVED_DUPLICATES) {
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         lastMessageTextFromReport = translateLocal('violations.resolvedDuplicates');
     } else if (isActionOfType(lastReportAction, CONST.REPORT.ACTIONS.TYPE.ROOM_CHANGE_LOG.UPDATE_ROOM_DESCRIPTION)) {
         lastMessageTextFromReport = getUpdateRoomDescriptionMessage(lastReportAction);
@@ -874,6 +894,7 @@ function createOption(
 
         // Set lastMessageText - use archived message if report is archived, otherwise use report's lastMessageText
         if (result.private_isArchived) {
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             result.lastMessageText = translateLocal('reportArchiveReasons.default');
         } else {
             result.lastMessageText = report.lastMessageText ?? '';
@@ -937,12 +958,15 @@ function getReportOption(participant: Participant, reportAttributesDerived?: Rep
 
     // Update text & alternateText because createOption returns workspace name only if report is owned by the user
     if (option.isSelfDM) {
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         option.alternateText = translateLocal('reportActionsView.yourSpace');
     } else if (option.isInvoiceRoom) {
         option.text = getReportName(report);
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         option.alternateText = translateLocal('workspace.common.invoices');
     } else {
         option.text = getPolicyName({report});
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         option.alternateText = translateLocal('workspace.common.workspace');
 
         if (report?.policyID) {
@@ -952,6 +976,7 @@ function getReportOption(participant: Participant, reportAttributesDerived?: Rep
             const subtitle = submitsToAccountDetails?.displayName ?? submitsToAccountDetails?.login;
 
             if (subtitle) {
+                // eslint-disable-next-line @typescript-eslint/no-deprecated
                 option.alternateText = translateLocal('iou.submitsTo', {name: subtitle ?? ''});
             }
         }
@@ -982,9 +1007,11 @@ function getReportDisplayOption(report: OnyxEntry<Report>, unknownUserDetails: O
 
     // Update text & alternateText because createOption returns workspace name only if report is owned by the user
     if (option.isSelfDM) {
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         option.alternateText = translateLocal('reportActionsView.yourSpace');
     } else if (option.isInvoiceRoom) {
         option.text = getReportName(report);
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         option.alternateText = translateLocal('workspace.common.invoices');
     } else if (unknownUserDetails) {
         option.text = unknownUserDetails.text ?? unknownUserDetails.login;
@@ -992,6 +1019,7 @@ function getReportDisplayOption(report: OnyxEntry<Report>, unknownUserDetails: O
         option.participantsList = [{...unknownUserDetails, displayName: unknownUserDetails.login, accountID: unknownUserDetails.accountID ?? CONST.DEFAULT_NUMBER_ID}];
     } else if (report?.ownerAccountID !== 0 || !option.text) {
         option.text = getPolicyName({report});
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         option.alternateText = translateLocal('workspace.common.workspace');
     }
     option.isDisabled = true;
@@ -1023,6 +1051,7 @@ function getPolicyExpenseReportOption(participant: Participant | SearchOptionDat
 
     // Update text & alternateText because createOption returns workspace name only if report is owned by the user
     option.text = getPolicyName({report: expenseReport});
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     option.alternateText = translateLocal('workspace.common.workspace');
     option.isSelected = participant.selected;
     option.selected = participant.selected; // Keep for backwards compatibility
@@ -1745,6 +1774,7 @@ function getValidReports(reports: OptionList['reports'], config: GetValidReports
 
         if (shouldSeparateWorkspaceChat && newReportOption.isPolicyExpenseChat && !newReportOption.private_isArchived) {
             newReportOption.text = getPolicyName({report});
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             newReportOption.alternateText = translateLocal('workspace.common.workspace');
             if (report?.policyID) {
                 const policy = allPolicies?.[`${ONYXKEYS.COLLECTION.POLICY}${report.policyID}`];
@@ -1753,6 +1783,7 @@ function getValidReports(reports: OptionList['reports'], config: GetValidReports
                 const subtitle = submitsToAccountDetails?.displayName ?? submitsToAccountDetails?.login;
 
                 if (subtitle) {
+                    // eslint-disable-next-line @typescript-eslint/no-deprecated
                     newReportOption.alternateText = translateLocal('iou.submitsTo', {name: subtitle ?? ''});
                 }
                 const canSubmitPerDiemExpense = canSubmitPerDiemExpenseFromWorkspace(policy);
@@ -2260,6 +2291,7 @@ function getHeaderMessage(
     const isValidEmail = Str.isValidEmail(searchValue);
 
     if (searchValue && CONST.REGEX.DIGITS_AND_PLUS.test(searchValue) && !isValidPhone && !hasSelectableOptions) {
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         return translateLocal('messages.errorMessageInvalidPhone');
     }
 
@@ -2267,14 +2299,17 @@ function getHeaderMessage(
     // Therefore, this skips the validation when there is no search value.
     if (searchValue && !hasSelectableOptions && !hasUserToInvite) {
         if (/^\d+$/.test(searchValue) && !isValidPhone) {
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             return translateLocal('messages.errorMessageInvalidPhone');
         }
         if (/@/.test(searchValue) && !isValidEmail) {
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             return translateLocal('messages.errorMessageInvalidEmail');
         }
         if (hasMatchedParticipant && (isValidEmail || isValidPhone)) {
             return '';
         }
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         return translateLocal('common.noResultsFound');
     }
 
@@ -2286,6 +2321,7 @@ function getHeaderMessage(
  */
 function getHeaderMessageForNonUserList(hasSelectableOptions: boolean, searchValue: string): string {
     if (searchValue && !hasSelectableOptions) {
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         return translateLocal('common.noResultsFound');
     }
     return '';
@@ -2376,6 +2412,7 @@ function getPersonalDetailSearchTerms(item: Partial<SearchOptionData>) {
 }
 
 function getCurrentUserSearchTerms(item: Partial<SearchOptionData>) {
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     return [item.text ?? '', item.login ?? '', item.login?.replace(CONST.EMAIL_SEARCH_REGEX, '') ?? '', translateLocal('common.you'), translateLocal('common.me')];
 }
 

--- a/src/libs/PaymentUtils.ts
+++ b/src/libs/PaymentUtils.ts
@@ -18,6 +18,7 @@ import type PaymentMethod from '@src/types/onyx/PaymentMethod';
 import type {ACHAccount} from '@src/types/onyx/Policy';
 import {setPersonalBankAccountContinueKYCOnSuccess} from './actions/BankAccounts';
 import {approveMoneyRequest} from './actions/IOU';
+// eslint-disable-next-line @typescript-eslint/no-deprecated
 import {translateLocal} from './Localize';
 import BankAccountModel from './models/BankAccount';
 import Navigation from './Navigation/Navigation';
@@ -51,12 +52,15 @@ function hasExpensifyPaymentMethod(fundList: Record<string, Fund>, bankAccountLi
 function getPaymentMethodDescription(accountType: AccountType, account: BankAccount['accountData'] | Fund['accountData'] | ACHAccount, bankCurrency?: string): string {
     if (account) {
         if (accountType === CONST.PAYMENT_METHODS.PERSONAL_BANK_ACCOUNT && 'accountNumber' in account) {
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             return `${bankCurrency ? `${bankCurrency} ${CONST.DOT_SEPARATOR} ` : ''}${translateLocal('paymentMethodList.accountLastFour')} ${account.accountNumber?.slice(-4)}`;
         }
         if (accountType === CONST.PAYMENT_METHODS.BUSINESS_BANK_ACCOUNT && 'accountNumber' in account) {
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             return `${translateLocal('paymentMethodList.accountLastFour')} ${account.accountNumber?.slice(-4)}`;
         }
         if (accountType === CONST.PAYMENT_METHODS.DEBIT_CARD && 'cardNumber' in account) {
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             return `${translateLocal('paymentMethodList.cardLastFour')} ${account.cardNumber?.slice(-4)}`;
         }
     }

--- a/src/libs/PerDiemRequestUtils.ts
+++ b/src/libs/PerDiemRequestUtils.ts
@@ -4,6 +4,7 @@ import type {OnyxEntry} from 'react-native-onyx';
 import CONST from '@src/CONST';
 import type {Report, Transaction} from '@src/types/onyx';
 import type {CustomUnit, Rate} from '@src/types/onyx/Policy';
+// eslint-disable-next-line @typescript-eslint/no-deprecated
 import {translateLocal} from './Localize';
 import type {OptionTree, SectionBase} from './OptionsListUtils';
 import {getPolicy} from './PolicyUtils';
@@ -154,6 +155,7 @@ function getDestinationListSections({
         const data = getDestinationOptionTree(cutRecentlyUsedDestinations);
         destinationSections.push({
             // "Recent" section
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             title: translateLocal('common.recent'),
             shouldShow: true,
             data,
@@ -164,6 +166,7 @@ function getDestinationListSections({
     const data = getDestinationOptionTree(sortedDestinations);
     destinationSections.push({
         // "All" section when items amount more than the threshold
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         title: translateLocal('common.all'),
         shouldShow: true,
         data,

--- a/src/libs/PersonalDetailsUtils.ts
+++ b/src/libs/PersonalDetailsUtils.ts
@@ -8,6 +8,7 @@ import type {OnyxInputOrEntry, PersonalDetails, PersonalDetailsList, PrivatePers
 import type {Address} from '@src/types/onyx/PrivatePersonalDetails';
 import type {OnyxData} from '@src/types/onyx/Request';
 import {isEmptyObject} from '@src/types/utils/EmptyObject';
+// eslint-disable-next-line @typescript-eslint/no-deprecated
 import {translateLocal} from './Localize';
 import {areEmailsFromSamePrivateDomain} from './LoginUtils';
 import {parsePhoneNumber} from './PhoneNumber';
@@ -45,7 +46,9 @@ Onyx.connect({
         if (value ?? true) {
             return;
         }
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         hiddenTranslation = translateLocal('common.hidden');
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         youTranslation = translateLocal('common.you').toLowerCase();
     },
 });
@@ -127,6 +130,7 @@ function getPersonalDetailsByIDs({
             if (shouldChangeUserDisplayName && currentUserAccountID === detail.accountID) {
                 return {
                     ...detail,
+                    // eslint-disable-next-line @typescript-eslint/no-deprecated
                     displayName: translateLocal('common.you'),
                 };
             }

--- a/src/libs/PolicyDistanceRatesUtils.ts
+++ b/src/libs/PolicyDistanceRatesUtils.ts
@@ -7,6 +7,7 @@ import type {CustomUnit, Rate, TaxRateAttributes} from '@src/types/onyx/Policy';
 import type {OnyxData} from '@src/types/onyx/Request';
 import {getMicroSecondOnyxErrorWithTranslationKey} from './ErrorUtils';
 import getPermittedDecimalSeparator from './getPermittedDecimalSeparator';
+// eslint-disable-next-line @typescript-eslint/no-deprecated
 import {translateLocal} from './Localize';
 import {replaceAllDigits} from './MoneyRequestUtils';
 import {parseFloatAnyLocale} from './NumberUtils';
@@ -23,8 +24,10 @@ function validateRateValue(values: FormOnyxValues<RateValueForm>, toLocaleDigit:
     // Allow one more decimal place for accuracy
     const rateValueRegex = RegExp(String.raw`^-?\d{0,8}([${getPermittedDecimalSeparator(decimalSeparator)}]\d{0,${CONST.MAX_TAX_RATE_DECIMAL_PLACES}})?$`, 'i');
     if (!rateValueRegex.test(parsedRate) || parsedRate === '') {
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         errors.rate = translateLocal('common.error.invalidRateError');
     } else if (parseFloatAnyLocale(parsedRate) <= 0) {
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         errors.rate = translateLocal('common.error.lowRateError');
     }
     return errors;
@@ -34,6 +37,7 @@ function validateTaxClaimableValue(values: FormOnyxValues<TaxReclaimableForm>, r
     const errors: FormInputErrors<TaxReclaimableForm> = {};
 
     if (rate?.rate && Number(values.taxClaimableValue) >= rate.rate / 100) {
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         errors.taxClaimableValue = translateLocal('workspace.taxes.error.updateTaxClaimableFailureMessage');
     }
     return errors;

--- a/src/libs/PolicyUtils.ts
+++ b/src/libs/PolicyUtils.ts
@@ -36,6 +36,7 @@ import {hasSynchronizationErrorMessage, isAuthenticationError} from './actions/c
 import {shouldShowQBOReimbursableExportDestinationAccountError} from './actions/connections/QuickbooksOnline';
 import {getCurrentUserAccountID, getCurrentUserEmail} from './actions/Report';
 import {getCategoryApproverRule} from './CategoryUtils';
+// eslint-disable-next-line @typescript-eslint/no-deprecated
 import {translateLocal} from './Localize';
 import Navigation from './Navigation/Navigation';
 import {isOffline as isOfflineNetworkStore} from './Network/NetworkStore';
@@ -1090,6 +1091,7 @@ function getNetSuiteApprovalAccountOptions(policy: Policy | undefined, selectedB
     const payableAccounts = policy?.connections?.netsuite?.options.data.payableList;
     const defaultApprovalAccount: NetSuiteAccount = {
         id: CONST.NETSUITE_APPROVAL_ACCOUNT_DEFAULT,
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         name: translateLocal('workspace.netsuite.advancedConfig.defaultApprovalAccount'),
         type: CONST.NETSUITE_ACCOUNT_TYPE.ACCOUNTS_PAYABLE,
     };
@@ -1393,10 +1395,13 @@ function getWorkflowApprovalsUnavailable(policy: OnyxEntry<Policy>) {
 function getUserFriendlyWorkspaceType(workspaceType: ValueOf<typeof CONST.POLICY.TYPE>) {
     switch (workspaceType) {
         case CONST.POLICY.TYPE.CORPORATE:
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             return translateLocal('workspace.type.control');
         case CONST.POLICY.TYPE.TEAM:
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             return translateLocal('workspace.type.collect');
         default:
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             return translateLocal('workspace.type.free');
     }
 }

--- a/src/libs/ReportActionsUtils.ts
+++ b/src/libs/ReportActionsUtils.ts
@@ -26,6 +26,7 @@ import getBase62ReportID from './getBase62ReportID';
 import {isReportMessageAttachment} from './isReportMessageAttachment';
 import {toLocaleOrdinal} from './LocaleDigitUtils';
 import {formatPhoneNumber} from './LocalePhoneNumber';
+// eslint-disable-next-line @typescript-eslint/no-deprecated
 import {formatMessageElementList, translateLocal} from './Localize';
 import Log from './Log';
 import type {MessageElementBase, MessageTextElement} from './MessageElement';
@@ -1446,8 +1447,10 @@ function getMemberChangeMessageElements(reportAction: OnyxEntry<ReportAction>, g
     }
 
     // Currently, we only render messages when members are invited
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     let verb = translateLocal('workspace.invite.removed');
     if (isInviteAction) {
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         verb = translateLocal('workspace.invite.invited');
     }
 
@@ -1461,6 +1464,7 @@ function getMemberChangeMessageElements(reportAction: OnyxEntry<ReportAction>, g
 
     const mentionElements = targetAccountIDs.map((accountID): MemberChangeMessageUserMentionElement => {
         const personalDetail = personalDetails.find((personal) => personal.accountID === accountID);
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         const handleText = getEffectiveDisplayName(formatPhoneNumber, personalDetail) ?? translateLocal('common.hidden');
 
         return {
@@ -1473,6 +1477,7 @@ function getMemberChangeMessageElements(reportAction: OnyxEntry<ReportAction>, g
     const buildRoomElements = (): readonly MemberChangeMessageElement[] => {
         const roomName = getReportNameCallback(allReports?.[`${ONYXKEYS.COLLECTION.REPORT}${originalMessage?.reportID}`]) || originalMessage?.roomName;
         if (roomName && originalMessage) {
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             const preposition = isInviteAction ? ` ${translateLocal('workspace.invite.to')} ` : ` ${translateLocal('workspace.invite.from')} `;
 
             if (originalMessage.reportID) {
@@ -1585,44 +1590,60 @@ function getMessageOfOldDotReportAction(oldDotAction: PartialReportAction | OldD
         case CONST.REPORT.ACTIONS.TYPE.CHANGE_FIELD: {
             const {oldValue, newValue, fieldName} = originalMessage;
             if (!oldValue) {
+                // eslint-disable-next-line @typescript-eslint/no-deprecated
                 return translateLocal('report.actions.type.changeFieldEmpty', {newValue, fieldName});
             }
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             return translateLocal('report.actions.type.changeField', {oldValue, newValue, fieldName});
         }
         case CONST.REPORT.ACTIONS.TYPE.EXPORTED_TO_CSV:
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             return translateLocal('report.actions.type.exportedToCSV');
         case CONST.REPORT.ACTIONS.TYPE.INTEGRATIONS_MESSAGE: {
             const {result, label} = originalMessage;
             const errorMessage = result?.messages?.join(', ') ?? '';
             const linkText = result?.link?.text ?? '';
             const linkURL = result?.link?.url ?? '';
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             return translateLocal('report.actions.type.integrationsMessage', {errorMessage, label, linkText, linkURL});
         }
         case CONST.REPORT.ACTIONS.TYPE.MANAGER_ATTACH_RECEIPT:
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             return translateLocal('report.actions.type.managerAttachReceipt');
         case CONST.REPORT.ACTIONS.TYPE.MANAGER_DETACH_RECEIPT:
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             return translateLocal('report.actions.type.managerDetachReceipt');
         case CONST.REPORT.ACTIONS.TYPE.MARK_REIMBURSED_FROM_INTEGRATION: {
             const {amount, currency} = originalMessage;
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             return translateLocal('report.actions.type.markedReimbursedFromIntegration', {amount, currency});
         }
         case CONST.REPORT.ACTIONS.TYPE.OUTDATED_BANK_ACCOUNT:
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             return translateLocal('report.actions.type.outdatedBankAccount');
         case CONST.REPORT.ACTIONS.TYPE.REIMBURSEMENT_ACH_BOUNCE:
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             return translateLocal('report.actions.type.reimbursementACHBounce');
         case CONST.REPORT.ACTIONS.TYPE.REIMBURSEMENT_ACH_CANCELED:
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             return translateLocal('report.actions.type.reimbursementACHCancelled');
         case CONST.REPORT.ACTIONS.TYPE.REIMBURSEMENT_ACCOUNT_CHANGED:
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             return translateLocal('report.actions.type.reimbursementAccountChanged');
         case CONST.REPORT.ACTIONS.TYPE.REIMBURSEMENT_DELAYED:
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             return translateLocal('report.actions.type.reimbursementDelayed');
         case CONST.REPORT.ACTIONS.TYPE.SELECTED_FOR_RANDOM_AUDIT:
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             return translateLocal(`report.actions.type.selectedForRandomAudit${withMarkdown ? 'Markdown' : ''}`);
         case CONST.REPORT.ACTIONS.TYPE.SHARE:
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             return translateLocal('report.actions.type.share', {to: originalMessage.to});
         case CONST.REPORT.ACTIONS.TYPE.UNSHARE:
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             return translateLocal('report.actions.type.unshare', {to: originalMessage.to});
         case CONST.REPORT.ACTIONS.TYPE.TAKE_CONTROL:
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             return translateLocal('report.actions.type.takeControl');
         default:
             return '';
@@ -1635,6 +1656,7 @@ function getTravelUpdateMessage(action: ReportAction<'TRAVEL_TRIP_ROOM_UPDATE'>,
 
     switch (details?.operation) {
         case CONST.TRAVEL.UPDATE_OPERATION_TYPE.BOOKING_TICKETED:
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             return translateLocal('travel.updates.bookingTicketed', {
                 airlineCode: details.route?.airlineCode ?? '',
                 origin: details.start.shortName ?? '',
@@ -1644,6 +1666,7 @@ function getTravelUpdateMessage(action: ReportAction<'TRAVEL_TRIP_ROOM_UPDATE'>,
             });
 
         case CONST.TRAVEL.UPDATE_OPERATION_TYPE.TICKET_VOIDED:
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             return translateLocal('travel.updates.ticketVoided', {
                 airlineCode: details.route?.airlineCode ?? '',
                 origin: details.start.shortName ?? '',
@@ -1652,6 +1675,7 @@ function getTravelUpdateMessage(action: ReportAction<'TRAVEL_TRIP_ROOM_UPDATE'>,
             });
 
         case CONST.TRAVEL.UPDATE_OPERATION_TYPE.TICKET_REFUNDED:
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             return translateLocal('travel.updates.ticketRefunded', {
                 airlineCode: details.route?.airlineCode ?? '',
                 origin: details.start.shortName ?? '',
@@ -1660,6 +1684,7 @@ function getTravelUpdateMessage(action: ReportAction<'TRAVEL_TRIP_ROOM_UPDATE'>,
             });
 
         case CONST.TRAVEL.UPDATE_OPERATION_TYPE.FLIGHT_CANCELLED:
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             return translateLocal('travel.updates.flightCancelled', {
                 airlineCode: details.route?.airlineCode ?? '',
                 origin: details.start.shortName ?? '',
@@ -1668,17 +1693,20 @@ function getTravelUpdateMessage(action: ReportAction<'TRAVEL_TRIP_ROOM_UPDATE'>,
             });
 
         case CONST.TRAVEL.UPDATE_OPERATION_TYPE.FLIGHT_SCHEDULE_CHANGE_PENDING:
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             return translateLocal('travel.updates.flightScheduleChangePending', {
                 airlineCode: details.route?.airlineCode ?? '',
             });
 
         case CONST.TRAVEL.UPDATE_OPERATION_TYPE.FLIGHT_SCHEDULE_CHANGE_CLOSED:
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             return translateLocal('travel.updates.flightScheduleChangeClosed', {
                 airlineCode: details.route?.airlineCode ?? '',
                 startDate: formattedStartDate,
             });
 
         case CONST.TRAVEL.UPDATE_OPERATION_TYPE.FLIGHT_CHANGED:
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             return translateLocal('travel.updates.flightUpdated', {
                 airlineCode: details.route?.airlineCode ?? '',
                 origin: details.start.shortName ?? '',
@@ -1687,65 +1715,77 @@ function getTravelUpdateMessage(action: ReportAction<'TRAVEL_TRIP_ROOM_UPDATE'>,
             });
 
         case CONST.TRAVEL.UPDATE_OPERATION_TYPE.FLIGHT_CABIN_CHANGED:
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             return translateLocal('travel.updates.flightCabinChanged', {
                 airlineCode: details.route?.airlineCode ?? '',
                 cabinClass: details.route?.class ?? '',
             });
 
         case CONST.TRAVEL.UPDATE_OPERATION_TYPE.FLIGHT_SEAT_CONFIRMED:
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             return translateLocal('travel.updates.flightSeatConfirmed', {
                 airlineCode: details.route?.airlineCode ?? '',
             });
 
         case CONST.TRAVEL.UPDATE_OPERATION_TYPE.FLIGHT_SEAT_CHANGED:
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             return translateLocal('travel.updates.flightSeatChanged', {
                 airlineCode: details.route?.airlineCode ?? '',
             });
 
         case CONST.TRAVEL.UPDATE_OPERATION_TYPE.FLIGHT_SEAT_CANCELLED:
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             return translateLocal('travel.updates.flightSeatCancelled', {
                 airlineCode: details.route?.airlineCode ?? '',
             });
 
         case CONST.TRAVEL.UPDATE_OPERATION_TYPE.PAYMENT_DECLINED:
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             return translateLocal('travel.updates.paymentDeclined');
 
         case CONST.TRAVEL.UPDATE_OPERATION_TYPE.BOOKING_CANCELED_BY_TRAVELER:
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             return translateLocal('travel.updates.bookingCancelledByTraveler', {
                 type: details.type,
                 id: details.reservationID,
             });
 
         case CONST.TRAVEL.UPDATE_OPERATION_TYPE.BOOKING_CANCELED_BY_VENDOR:
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             return translateLocal('travel.updates.bookingCancelledByVendor', {
                 type: details.type,
                 id: details.reservationID,
             });
 
         case CONST.TRAVEL.UPDATE_OPERATION_TYPE.BOOKING_REBOOKED:
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             return translateLocal('travel.updates.bookingRebooked', {
                 type: details.type,
                 id: details.confirmations?.at(0)?.value,
             });
 
         case CONST.TRAVEL.UPDATE_OPERATION_TYPE.BOOKING_UPDATED:
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             return translateLocal('travel.updates.bookingUpdated', {
                 type: details.type,
             });
 
         case CONST.TRAVEL.UPDATE_OPERATION_TYPE.TRIP_UPDATED:
             if (details.type === CONST.RESERVATION_TYPE.CAR || details.type === CONST.RESERVATION_TYPE.HOTEL) {
+                // eslint-disable-next-line @typescript-eslint/no-deprecated
                 return translateLocal('travel.updates.defaultUpdate', {
                     type: details.type,
                 });
             }
             if (details.type === CONST.RESERVATION_TYPE.TRAIN) {
+                // eslint-disable-next-line @typescript-eslint/no-deprecated
                 return translateLocal('travel.updates.railTicketUpdate', {
                     origin: details.start.cityName ?? details.start.shortName ?? '',
                     destination: details.end.cityName ?? details.end.shortName ?? '',
                     startDate: formattedStartDate,
                 });
             }
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             return translateLocal('travel.updates.flightUpdated', {
                 airlineCode: details.route?.airlineCode ?? '',
                 origin: details.start.shortName ?? '',
@@ -1754,17 +1794,20 @@ function getTravelUpdateMessage(action: ReportAction<'TRAVEL_TRIP_ROOM_UPDATE'>,
             });
         case CONST.TRAVEL.UPDATE_OPERATION_TYPE.BOOKING_OTHER_UPDATE:
             if (details.type === CONST.RESERVATION_TYPE.CAR || details.type === CONST.RESERVATION_TYPE.HOTEL) {
+                // eslint-disable-next-line @typescript-eslint/no-deprecated
                 return translateLocal('travel.updates.defaultUpdate', {
                     type: details.type,
                 });
             }
             if (details.type === CONST.RESERVATION_TYPE.TRAIN) {
+                // eslint-disable-next-line @typescript-eslint/no-deprecated
                 return translateLocal('travel.updates.railTicketUpdate', {
                     origin: details.start.cityName ?? details.start.shortName ?? '',
                     destination: details.end.cityName ?? details.end.shortName ?? '',
                     startDate: formattedStartDate,
                 });
             }
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             return translateLocal('travel.updates.flightUpdated', {
                 airlineCode: details.route?.airlineCode ?? '',
                 origin: details.start.shortName ?? '',
@@ -1773,6 +1816,7 @@ function getTravelUpdateMessage(action: ReportAction<'TRAVEL_TRIP_ROOM_UPDATE'>,
             });
 
         case CONST.TRAVEL.UPDATE_OPERATION_TYPE.REFUND:
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             return translateLocal('travel.updates.railTicketRefund', {
                 origin: details.start.cityName ?? details.start.shortName ?? '',
                 destination: details.end.cityName ?? details.end.shortName ?? '',
@@ -1780,6 +1824,7 @@ function getTravelUpdateMessage(action: ReportAction<'TRAVEL_TRIP_ROOM_UPDATE'>,
             });
 
         case CONST.TRAVEL.UPDATE_OPERATION_TYPE.EXCHANGE:
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             return translateLocal('travel.updates.railTicketExchange', {
                 origin: details.start.cityName ?? details.start.shortName ?? '',
                 destination: details.end.cityName ?? details.end.shortName ?? '',
@@ -1787,6 +1832,7 @@ function getTravelUpdateMessage(action: ReportAction<'TRAVEL_TRIP_ROOM_UPDATE'>,
             });
 
         default:
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             return translateLocal('travel.updates.defaultUpdate', {
                 type: details?.type ?? '',
             });
@@ -1816,14 +1862,17 @@ function getMemberChangeMessageFragment(reportAction: OnyxEntry<ReportAction>, g
 }
 
 function getLeaveRoomMessage() {
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     return translateLocal('report.actions.type.leftTheChat');
 }
 
 function getReopenedMessage(): string {
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     return translateLocal('iou.reopened');
 }
 
 function getReceiptScanFailedMessage() {
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     return translateLocal('iou.receiptScanningFailed');
 }
 
@@ -1920,6 +1969,7 @@ function getActionableMentionWhisperMessage(reportAction: OnyxEntry<ReportAction
     const mentionElements = targetAccountIDs.map((accountID): string => {
         const personalDetail = personalDetails.find((personal) => personal.accountID === accountID);
         const displayName = getEffectiveDisplayName(formatPhoneNumber, personalDetail);
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         const handleText = isEmpty(displayName) ? translateLocal('common.hidden') : displayName;
         return `<mention-user accountID=${accountID}>@${handleText}</mention-user>`;
     });
@@ -2005,6 +2055,7 @@ function getReportActionMessageText(reportAction: OnyxEntry<ReportAction>): stri
 function getDismissedViolationMessageText(originalMessage: ReportAction<typeof CONST.REPORT.ACTIONS.TYPE.DISMISSED_VIOLATION>['originalMessage']): string {
     const reason = originalMessage?.reason;
     const violationName = originalMessage?.violationName;
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     return translateLocal(`violationDismissal.${violationName}.${reason}` as TranslationPaths);
 }
 
@@ -2108,32 +2159,38 @@ function getExportIntegrationActionFragments(reportAction: OnyxEntry<ReportActio
     const result: Array<{text: string; url: string}> = [];
     if (isPending) {
         result.push({
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             text: translateLocal('report.actions.type.exportedToIntegration.pending', {label}),
             url: '',
         });
     } else if (markedManually) {
         result.push({
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             text: translateLocal('report.actions.type.exportedToIntegration.manual', {label}),
             url: '',
         });
     } else if (automaticAction) {
         result.push({
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             text: translateLocal('report.actions.type.exportedToIntegration.automaticActionOne', {label}),
             url: '',
         });
         const url = CONST.HELP_DOC_LINKS[label as keyof typeof CONST.HELP_DOC_LINKS];
         result.push({
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             text: translateLocal('report.actions.type.exportedToIntegration.automaticActionTwo'),
             url: url || '',
         });
     } else {
         result.push({
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             text: translateLocal('report.actions.type.exportedToIntegration.automatic', {label}),
             url: '',
         });
     }
     if (reimbursableUrls.length || nonReimbursableUrls.length) {
         result.push({
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             text: translateLocal('report.actions.type.exportedToIntegration.automaticActionThree'),
             url: '',
         });
@@ -2143,17 +2200,20 @@ function getExportIntegrationActionFragments(reportAction: OnyxEntry<ReportActio
         const shouldAddPeriod = nonReimbursableUrls.length === 0;
         const reimbursableUrl = reimbursableUrls.at(0) ?? '';
         result.push({
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             text: translateLocal('report.actions.type.exportedToIntegration.reimburseableLink') + (shouldAddPeriod ? '.' : ''),
             url: reimbursableUrl.startsWith('https://') ? reimbursableUrl : '',
         });
     }
     if (reimbursableUrls.length === 1 && nonReimbursableUrls.length) {
         result.push({
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             text: translateLocal('common.and'),
             url: '',
         });
     }
     if (nonReimbursableUrls.length) {
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         const text = translateLocal('report.actions.type.exportedToIntegration.nonReimbursableLink');
         let url = '';
 
@@ -2187,13 +2247,15 @@ function getExportIntegrationActionFragments(reportAction: OnyxEntry<ReportActio
 function getUpdateRoomDescriptionMessage(reportAction: ReportAction): string {
     const originalMessage = getOriginalMessage(reportAction) as OriginalMessageChangeLog;
     if (originalMessage?.description) {
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         return `${translateLocal('roomChangeLog.updateRoomDescription')} ${originalMessage?.description}`;
     }
-
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     return translateLocal('roomChangeLog.clearRoomDescription');
 }
 
 function getRetractedMessage(): string {
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     return translateLocal('iou.retracted');
 }
 
@@ -2208,8 +2270,10 @@ function getPolicyChangeLogAddEmployeeMessage(reportAction: OnyxInputOrEntry<Rep
 
     const originalMessage = getOriginalMessage(reportAction);
     const email = originalMessage?.email ?? '';
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     const role = translateLocal('workspace.common.roleName', {role: originalMessage?.role ?? ''}).toLowerCase();
     const formattedEmail = formatPhoneNumber(email);
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     return translateLocal('report.actions.type.addEmployee', {email: formattedEmail, role});
 }
 
@@ -2228,14 +2292,18 @@ function getPolicyChangeLogUpdateEmployee(reportAction: OnyxInputOrEntry<ReportA
     const customFieldType = Object.values(CONST.CUSTOM_FIELD_KEYS).find((value) => value === field);
     if (customFieldType) {
         const translationKey = field === CONST.CUSTOM_FIELD_KEYS.customField1 ? 'report.actions.type.updatedCustomField1' : 'report.actions.type.updatedCustomField2';
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         return translateLocal(translationKey, {
             email,
             newValue: typeof originalMessage?.newValue === 'string' ? originalMessage?.newValue : '',
             previousValue: typeof originalMessage?.oldValue === 'string' ? originalMessage?.oldValue : '',
         });
     }
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     const newRole = translateLocal('workspace.common.roleName', {role: typeof originalMessage?.newValue === 'string' ? originalMessage?.newValue : ''}).toLowerCase();
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     const oldRole = translateLocal('workspace.common.roleName', {role: typeof originalMessage?.oldValue === 'string' ? originalMessage?.oldValue : ''}).toLowerCase();
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     return translateLocal('report.actions.type.updateRole', {email, newRole, currentRole: oldRole});
 }
 
@@ -2250,6 +2318,7 @@ function getPolicyChangeLogEmployeeLeftMessage(reportAction: ReportAction, useNa
     }
     const nameOrEmail = useName && !!personalDetails?.firstName ? `${personalDetails?.firstName}:` : (originalMessage?.email ?? '');
     const formattedNameOrEmail = formatPhoneNumber(nameOrEmail);
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     return translateLocal('report.actions.type.leftWorkspace', {nameOrEmail: formattedNameOrEmail});
 }
 
@@ -2262,12 +2331,14 @@ function isPolicyChangeLogDeleteMemberMessage(
 function getWorkspaceDescriptionUpdatedMessage(action: ReportAction) {
     const {oldDescription, newDescription} = getOriginalMessage(action as ReportAction<typeof CONST.REPORT.ACTIONS.TYPE.POLICY_CHANGE_LOG.UPDATE_DESCRIPTION>) ?? {};
     const message =
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         typeof oldDescription === 'string' && newDescription ? translateLocal('workspaceActions.updateWorkspaceDescription', {newDescription, oldDescription}) : getReportActionText(action);
     return message;
 }
 
 function getWorkspaceCurrencyUpdateMessage(action: ReportAction) {
     const {oldCurrency, newCurrency} = getOriginalMessage(action as ReportAction<typeof CONST.REPORT.ACTIONS.TYPE.POLICY_CHANGE_LOG.UPDATE_CURRENCY>) ?? {};
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     const message = oldCurrency && newCurrency ? translateLocal('workspaceActions.updatedWorkspaceCurrencyAction', {oldCurrency, newCurrency}) : getReportActionText(action);
     return message;
 }
@@ -2276,12 +2347,19 @@ type AutoReportingFrequencyKey = ValueOf<typeof CONST.POLICY.AUTO_REPORTING_FREQ
 type AutoReportingFrequencyDisplayNames = Record<AutoReportingFrequencyKey, string>;
 
 const getAutoReportingFrequencyDisplayNames = (): AutoReportingFrequencyDisplayNames => ({
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     [CONST.POLICY.AUTO_REPORTING_FREQUENCIES.MONTHLY]: translateLocal('workflowsPage.frequencies.monthly'),
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     [CONST.POLICY.AUTO_REPORTING_FREQUENCIES.IMMEDIATE]: translateLocal('workflowsPage.frequencies.daily'),
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     [CONST.POLICY.AUTO_REPORTING_FREQUENCIES.WEEKLY]: translateLocal('workflowsPage.frequencies.weekly'),
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     [CONST.POLICY.AUTO_REPORTING_FREQUENCIES.SEMI_MONTHLY]: translateLocal('workflowsPage.frequencies.twiceAMonth'),
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     [CONST.POLICY.AUTO_REPORTING_FREQUENCIES.TRIP]: translateLocal('workflowsPage.frequencies.byTrip'),
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     [CONST.POLICY.AUTO_REPORTING_FREQUENCIES.MANUAL]: translateLocal('workflowsPage.frequencies.manually'),
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     [CONST.POLICY.AUTO_REPORTING_FREQUENCIES.INSTANT]: translateLocal('workflowsPage.frequencies.instant'),
 });
 
@@ -2299,7 +2377,7 @@ function getWorkspaceFrequencyUpdateMessage(action: ReportAction): string {
     if (!oldFrequencyTranslation || !newFrequencyTranslation) {
         return getReportActionText(action);
     }
-
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     return translateLocal('workspaceActions.updatedWorkspaceFrequencyAction', {
         oldFrequency: oldFrequencyTranslation,
         newFrequency: newFrequencyTranslation,
@@ -2311,12 +2389,14 @@ function getWorkspaceCategoryUpdateMessage(action: ReportAction, policy?: OnyxEn
         getOriginalMessage(action as ReportAction<typeof CONST.REPORT.ACTIONS.TYPE.POLICY_CHANGE_LOG.ADD_CATEGORY>) ?? {};
 
     if (action.actionName === CONST.REPORT.ACTIONS.TYPE.POLICY_CHANGE_LOG.ADD_CATEGORY && categoryName) {
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         return translateLocal('workspaceActions.addCategory', {
             categoryName,
         });
     }
 
     if (action.actionName === CONST.REPORT.ACTIONS.TYPE.POLICY_CHANGE_LOG.DELETE_CATEGORY && categoryName) {
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         return translateLocal('workspaceActions.deleteCategory', {
             categoryName,
         });
@@ -2324,6 +2404,7 @@ function getWorkspaceCategoryUpdateMessage(action: ReportAction, policy?: OnyxEn
 
     if (action.actionName === CONST.REPORT.ACTIONS.TYPE.POLICY_CHANGE_LOG.UPDATE_CATEGORY && categoryName) {
         if (updatedField === 'commentHint') {
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             return translateLocal('workspaceActions.updatedDescriptionHint', {
                 oldValue: oldValue as string | undefined,
                 newValue: newValue as string | undefined,
@@ -2332,6 +2413,7 @@ function getWorkspaceCategoryUpdateMessage(action: ReportAction, policy?: OnyxEn
         }
 
         if (updatedField === 'enabled') {
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             return translateLocal('workspaceActions.updateCategory', {
                 oldValue: !!oldValue,
                 categoryName,
@@ -2339,6 +2421,7 @@ function getWorkspaceCategoryUpdateMessage(action: ReportAction, policy?: OnyxEn
         }
 
         if (updatedField === 'areCommentsRequired' && typeof oldValue === 'boolean') {
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             return translateLocal('workspaceActions.updateAreCommentsRequired', {
                 oldValue,
                 categoryName,
@@ -2346,6 +2429,7 @@ function getWorkspaceCategoryUpdateMessage(action: ReportAction, policy?: OnyxEn
         }
 
         if (updatedField === 'Payroll Code' && typeof oldValue === 'string' && typeof newValue === 'string') {
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             return translateLocal('workspaceActions.updateCategoryPayrollCode', {
                 oldValue,
                 categoryName,
@@ -2354,6 +2438,7 @@ function getWorkspaceCategoryUpdateMessage(action: ReportAction, policy?: OnyxEn
         }
 
         if (updatedField === 'GL Code' && typeof oldValue === 'string' && typeof newValue === 'string') {
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             return translateLocal('workspaceActions.updateCategoryGLCode', {
                 oldValue,
                 categoryName,
@@ -2362,6 +2447,7 @@ function getWorkspaceCategoryUpdateMessage(action: ReportAction, policy?: OnyxEn
         }
 
         if (updatedField === 'maxExpenseAmount' && (typeof oldValue === 'string' || typeof oldValue === 'number')) {
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             return translateLocal('workspaceActions.updateCategoryMaxExpenseAmount', {
                 oldAmount: Number(oldValue) ? convertAmountToDisplayString(Number(oldValue), currency) : undefined,
                 newAmount: Number(newValue ?? 0) ? convertAmountToDisplayString(Number(newValue), currency) : undefined,
@@ -2370,9 +2456,12 @@ function getWorkspaceCategoryUpdateMessage(action: ReportAction, policy?: OnyxEn
         }
 
         if (updatedField === 'expenseLimitType' && typeof newValue === 'string' && typeof oldValue === 'string') {
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             return translateLocal('workspaceActions.updateCategoryExpenseLimitType', {
                 categoryName,
+                // eslint-disable-next-line @typescript-eslint/no-deprecated
                 oldValue: oldValue ? translateLocal(`workspace.rules.categoryRules.expenseLimitTypes.${oldValue}` as TranslationPaths) : undefined,
+                // eslint-disable-next-line @typescript-eslint/no-deprecated
                 newValue: translateLocal(`workspace.rules.categoryRules.expenseLimitTypes.${newValue}` as TranslationPaths),
             });
         }
@@ -2383,15 +2472,17 @@ function getWorkspaceCategoryUpdateMessage(action: ReportAction, policy?: OnyxEn
             const formatAmount = () => convertToShortDisplayString(maxExpenseAmountToDisplay, policy?.outputCurrency ?? CONST.CURRENCY.USD);
             const getTranslation = (value?: number | string) => {
                 if (value === CONST.DISABLED_MAX_EXPENSE_VALUE) {
+                    // eslint-disable-next-line @typescript-eslint/no-deprecated
                     return translateLocal('workspace.rules.categoryRules.requireReceiptsOverList.never');
                 }
                 if (value === 0) {
+                    // eslint-disable-next-line @typescript-eslint/no-deprecated
                     return translateLocal('workspace.rules.categoryRules.requireReceiptsOverList.always');
                 }
-
+                // eslint-disable-next-line @typescript-eslint/no-deprecated
                 return translateLocal('workspace.rules.categoryRules.requireReceiptsOverList.default', {defaultAmount: formatAmount()});
             };
-
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             return translateLocal('workspaceActions.updateCategoryMaxAmountNoReceipt', {
                 categoryName,
                 oldValue: getTranslation(oldValue),
@@ -2401,6 +2492,7 @@ function getWorkspaceCategoryUpdateMessage(action: ReportAction, policy?: OnyxEn
     }
 
     if (action.actionName === CONST.REPORT.ACTIONS.TYPE.POLICY_CHANGE_LOG.SET_CATEGORY_NAME && oldName && newName) {
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         return translateLocal('workspaceActions.setCategoryName', {
             oldName,
             newName,
@@ -2415,6 +2507,7 @@ function getWorkspaceTagUpdateMessage(action: ReportAction | undefined): string 
         getOriginalMessage(action as ReportAction<typeof CONST.REPORT.ACTIONS.TYPE.POLICY_CHANGE_LOG.ADD_CATEGORY>) ?? {};
 
     if (action?.actionName === CONST.REPORT.ACTIONS.TYPE.POLICY_CHANGE_LOG.ADD_TAG && tagListName && tagName) {
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         return translateLocal('workspaceActions.addTag', {
             tagListName,
             tagName,
@@ -2422,6 +2515,7 @@ function getWorkspaceTagUpdateMessage(action: ReportAction | undefined): string 
     }
 
     if (action?.actionName === CONST.REPORT.ACTIONS.TYPE.POLICY_CHANGE_LOG.DELETE_TAG && tagListName && tagName) {
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         return translateLocal('workspaceActions.deleteTag', {
             tagListName,
             tagName,
@@ -2429,6 +2523,7 @@ function getWorkspaceTagUpdateMessage(action: ReportAction | undefined): string 
     }
 
     if (action?.actionName === CONST.REPORT.ACTIONS.TYPE.POLICY_CHANGE_LOG.DELETE_MULTIPLE_TAGS && count && tagListName) {
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         return translateLocal('workspaceActions.deleteMultipleTags', {
             count,
             tagListName,
@@ -2436,6 +2531,7 @@ function getWorkspaceTagUpdateMessage(action: ReportAction | undefined): string 
     }
 
     if (action?.actionName === CONST.REPORT.ACTIONS.TYPE.POLICY_CHANGE_LOG.UPDATE_TAG_ENABLED && tagListName && tagName) {
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         return translateLocal('workspaceActions.updateTagEnabled', {
             tagListName,
             tagName,
@@ -2444,6 +2540,7 @@ function getWorkspaceTagUpdateMessage(action: ReportAction | undefined): string 
     }
 
     if (action?.actionName === CONST.REPORT.ACTIONS.TYPE.POLICY_CHANGE_LOG.UPDATE_TAG_NAME && tagListName && newName && oldName) {
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         return translateLocal('workspaceActions.updateTagName', {
             tagListName,
             newName,
@@ -2459,6 +2556,7 @@ function getWorkspaceTagUpdateMessage(action: ReportAction | undefined): string 
         tagName &&
         updatedField
     ) {
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         return translateLocal('workspaceActions.updateTag', {
             tagListName,
             oldValue,
@@ -2474,6 +2572,7 @@ function getWorkspaceTagUpdateMessage(action: ReportAction | undefined): string 
 function getTagListNameUpdatedMessage(action: ReportAction): string {
     const {oldName, newName} = getOriginalMessage(action as ReportAction<typeof CONST.REPORT.ACTIONS.TYPE.POLICY_CHANGE_LOG.UPDATE_TAG_LIST_NAME>) ?? {};
     if (newName && oldName) {
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         return translateLocal('workspaceActions.updateTagListName', {
             oldName,
             newName,
@@ -2486,12 +2585,14 @@ function getWorkspaceCustomUnitUpdatedMessage(action: ReportAction): string {
     const {oldValue, newValue, customUnitName, updatedField} = getOriginalMessage(action as ReportAction<typeof CONST.REPORT.ACTIONS.TYPE.POLICY_CHANGE_LOG.UPDATE_CUSTOM_UNIT>) ?? {};
 
     if (customUnitName === 'Distance' && updatedField === 'taxEnabled' && typeof newValue === 'boolean') {
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         return translateLocal('workspaceActions.updateCustomUnitTaxEnabled', {
             newValue,
         });
     }
 
     if (customUnitName && typeof oldValue === 'string' && typeof newValue === 'string' && updatedField) {
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         return translateLocal('workspaceActions.updateCustomUnit', {
             customUnitName,
             newValue,
@@ -2507,6 +2608,7 @@ function getWorkspaceCustomUnitRateAddedMessage(action: ReportAction): string {
     const {customUnitName, rateName} = getOriginalMessage(action as ReportAction<typeof CONST.REPORT.ACTIONS.TYPE.POLICY_CHANGE_LOG.ADD_CATEGORY>) ?? {};
 
     if (customUnitName && rateName) {
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         return translateLocal('workspaceActions.addCustomUnitRate', {
             customUnitName,
             rateName,
@@ -2521,6 +2623,7 @@ function getWorkspaceCustomUnitRateUpdatedMessage(action: ReportAction): string 
         getOriginalMessage(action as ReportAction<typeof CONST.REPORT.ACTIONS.TYPE.POLICY_CHANGE_LOG.UPDATE_CUSTOM_UNIT_RATE>) ?? {};
 
     if (customUnitName && customUnitRateName && updatedField === 'rate' && typeof oldValue === 'string' && typeof newValue === 'string') {
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         return translateLocal('workspaceActions.updatedCustomUnitRate', {
             customUnitName,
             customUnitRateName,
@@ -2531,6 +2634,7 @@ function getWorkspaceCustomUnitRateUpdatedMessage(action: ReportAction): string 
     }
 
     if (customUnitRateName && updatedField === 'taxRateExternalID' && typeof newValue === 'string' && newTaxPercentage) {
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         return translateLocal('workspaceActions.updatedCustomUnitTaxRateExternalID', {
             customUnitRateName,
             newValue,
@@ -2541,6 +2645,7 @@ function getWorkspaceCustomUnitRateUpdatedMessage(action: ReportAction): string 
     }
 
     if (customUnitRateName && updatedField === 'taxClaimablePercentage' && typeof newValue === 'number' && customUnitRateName) {
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         return translateLocal('workspaceActions.updatedCustomUnitTaxClaimablePercentage', {
             customUnitRateName,
             newValue: parseFloat(parseFloat(newValue ?? 0).toFixed(2)),
@@ -2554,6 +2659,7 @@ function getWorkspaceCustomUnitRateUpdatedMessage(action: ReportAction): string 
 function getWorkspaceCustomUnitRateDeletedMessage(action: ReportAction): string {
     const {customUnitName, rateName} = getOriginalMessage(action as ReportAction<typeof CONST.REPORT.ACTIONS.TYPE.POLICY_CHANGE_LOG.DELETE_CUSTOM_UNIT_RATE>) ?? {};
     if (customUnitName && rateName) {
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         return translateLocal('workspaceActions.deleteCustomUnitRate', {
             customUnitName,
             rateName,
@@ -2567,8 +2673,10 @@ function getWorkspaceReportFieldAddMessage(action: ReportAction): string {
     const {fieldName, fieldType} = getOriginalMessage(action as ReportAction<typeof CONST.REPORT.ACTIONS.TYPE.POLICY_CHANGE_LOG.ADD_CATEGORY>) ?? {};
 
     if (fieldName && fieldType) {
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         return translateLocal('workspaceActions.addedReportField', {
             fieldName,
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             fieldType: translateLocal(getReportFieldTypeTranslationKey(fieldType as PolicyReportFieldType)).toLowerCase(),
         });
     }
@@ -2581,6 +2689,7 @@ function getWorkspaceReportFieldUpdateMessage(action: ReportAction): string {
         getOriginalMessage(action as ReportAction<typeof CONST.REPORT.ACTIONS.TYPE.POLICY_CHANGE_LOG.UPDATE_REPORT_FIELD>) ?? {};
 
     if (updateType === 'updatedDefaultValue' && fieldName && defaultValue) {
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         return translateLocal('workspaceActions.updateReportFieldDefaultValue', {
             fieldName,
             defaultValue,
@@ -2588,6 +2697,7 @@ function getWorkspaceReportFieldUpdateMessage(action: ReportAction): string {
     }
 
     if (updateType === 'addedOption' && fieldName && optionName) {
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         return translateLocal('workspaceActions.addedReportFieldOption', {
             fieldName,
             optionName,
@@ -2595,6 +2705,7 @@ function getWorkspaceReportFieldUpdateMessage(action: ReportAction): string {
     }
 
     if (updateType === 'changedOptionDisabled' && fieldName && optionName) {
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         return translateLocal('workspaceActions.updateReportFieldOptionDisabled', {
             fieldName,
             optionName,
@@ -2603,6 +2714,7 @@ function getWorkspaceReportFieldUpdateMessage(action: ReportAction): string {
     }
 
     if (updateType === 'updatedAllDisabled' && fieldName && optionName) {
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         return translateLocal('workspaceActions.updateReportFieldAllOptionsDisabled', {
             fieldName,
             optionName,
@@ -2612,6 +2724,7 @@ function getWorkspaceReportFieldUpdateMessage(action: ReportAction): string {
     }
 
     if (updateType === 'removedOption' && fieldName && optionName) {
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         return translateLocal('workspaceActions.removedReportFieldOption', {
             fieldName,
             optionName,
@@ -2625,8 +2738,10 @@ function getWorkspaceReportFieldDeleteMessage(action: ReportAction): string {
     const {fieldType, fieldName} = getOriginalMessage(action as ReportAction<typeof CONST.REPORT.ACTIONS.TYPE.POLICY_CHANGE_LOG.ADD_CATEGORY>) ?? {};
 
     if (fieldType && fieldName) {
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         return translateLocal('workspaceActions.deleteReportField', {
             fieldName,
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             fieldType: translateLocal(getReportFieldTypeTranslationKey(fieldType as PolicyReportFieldType)).toLowerCase(),
         });
     }
@@ -2641,14 +2756,18 @@ function getWorkspaceUpdateFieldMessage(action: ReportAction): string {
     const oldValueTranslationKey = CONST.POLICY.APPROVAL_MODE_TRANSLATION_KEYS[oldValue as keyof typeof CONST.POLICY.APPROVAL_MODE_TRANSLATION_KEYS];
 
     if (updatedField && updatedField === CONST.POLICY.COLLECTION_KEYS.APPROVAL_MODE && oldValueTranslationKey && newValueTranslationKey) {
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         return translateLocal('workspaceActions.updateApprovalMode', {
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             newValue: translateLocal(`workspaceApprovalModes.${newValueTranslationKey}` as TranslationPaths),
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             oldValue: translateLocal(`workspaceApprovalModes.${oldValueTranslationKey}` as TranslationPaths),
             fieldName: updatedField,
         });
     }
 
     if (updatedField && updatedField === CONST.POLICY.EXPENSE_REPORT_RULES.PREVENT_SELF_APPROVAL && typeof oldValue === 'string' && typeof newValue === 'string') {
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         return translateLocal('workspaceActions.preventSelfApproval', {
             oldValue,
             newValue,
@@ -2656,6 +2775,7 @@ function getWorkspaceUpdateFieldMessage(action: ReportAction): string {
     }
 
     if (updatedField && updatedField === CONST.POLICY.EXPENSE_REPORT_RULES.MAX_EXPENSE_AGE && typeof oldValue === 'string' && typeof newValue === 'string') {
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         return translateLocal('workspaceActions.updateMaxExpenseAge', {
             oldValue,
             newValue,
@@ -2669,9 +2789,11 @@ function getWorkspaceUpdateFieldMessage(action: ReportAction): string {
     ) {
         const getAutoReportingOffsetToDisplay = (autoReportingOffset: string | number) => {
             if (autoReportingOffset === CONST.POLICY.AUTO_REPORTING_OFFSET.LAST_DAY_OF_MONTH) {
+                // eslint-disable-next-line @typescript-eslint/no-deprecated
                 return translateLocal('workflowsPage.frequencies.lastDayOfMonth');
             }
             if (autoReportingOffset === CONST.POLICY.AUTO_REPORTING_OFFSET.LAST_BUSINESS_DAY_OF_MONTH) {
+                // eslint-disable-next-line @typescript-eslint/no-deprecated
                 return translateLocal('workflowsPage.frequencies.lastBusinessDayOfMonth');
             }
             if (typeof autoReportingOffset === 'number') {
@@ -2679,6 +2801,7 @@ function getWorkspaceUpdateFieldMessage(action: ReportAction): string {
             }
             return '';
         };
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         return translateLocal('workspaceActions.updateMonthlyOffset', {
             newValue: getAutoReportingOffsetToDisplay(newValue),
             oldValue: getAutoReportingOffsetToDisplay(oldValue),
@@ -2692,6 +2815,7 @@ function getPolicyChangeLogMaxExpenseAmountNoReceiptMessage(action: ReportAction
         getOriginalMessage(action as ReportAction<typeof CONST.REPORT.ACTIONS.TYPE.POLICY_CHANGE_LOG.UPDATE_MAX_EXPENSE_AMOUNT_NO_RECEIPT>) ?? {};
 
     if (typeof oldMaxExpenseAmountNoReceipt === 'number' && typeof newMaxExpenseAmountNoReceipt === 'number') {
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         return translateLocal('workspaceActions.updateMaxExpenseAmountNoReceipt', {
             oldValue: convertToDisplayString(oldMaxExpenseAmountNoReceipt, currency),
             newValue: convertToDisplayString(newMaxExpenseAmountNoReceipt, currency),
@@ -2706,6 +2830,7 @@ function getPolicyChangeLogMaxExpenseAmountMessage(action: ReportAction): string
         getOriginalMessage(action as ReportAction<typeof CONST.REPORT.ACTIONS.TYPE.POLICY_CHANGE_LOG.UPDATE_MAX_EXPENSE_AMOUNT>) ?? {};
 
     if (typeof oldMaxExpenseAmount === 'number' && typeof newMaxExpenseAmount === 'number') {
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         return translateLocal('workspaceActions.updateMaxExpenseAmount', {
             oldValue: convertToDisplayString(oldMaxExpenseAmount, currency),
             newValue: convertToDisplayString(newMaxExpenseAmount, currency),
@@ -2719,6 +2844,7 @@ function getPolicyChangeLogDefaultBillableMessage(action: ReportAction): string 
     const {oldDefaultBillable, newDefaultBillable} = getOriginalMessage(action as ReportAction<typeof CONST.REPORT.ACTIONS.TYPE.POLICY_CHANGE_LOG.UPDATE_DEFAULT_BILLABLE>) ?? {};
 
     if (typeof oldDefaultBillable === 'string' && typeof newDefaultBillable === 'string') {
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         return translateLocal('workspaceActions.updateDefaultBillable', {
             oldValue: oldDefaultBillable,
             newValue: newDefaultBillable,
@@ -2732,6 +2858,7 @@ function getPolicyChangeLogDefaultReimbursableMessage(action: ReportAction): str
     const {oldDefaultReimbursable, newDefaultReimbursable} = getOriginalMessage(action as ReportAction<typeof CONST.REPORT.ACTIONS.TYPE.POLICY_CHANGE_LOG.UPDATE_DEFAULT_REIMBURSABLE>) ?? {};
 
     if (typeof oldDefaultReimbursable === 'string' && typeof newDefaultReimbursable === 'string') {
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         return translateLocal('workspaceActions.updateDefaultReimbursable', {
             oldValue: oldDefaultReimbursable,
             newValue: newDefaultReimbursable,
@@ -2745,6 +2872,7 @@ function getPolicyChangeLogDefaultTitleEnforcedMessage(action: ReportAction): st
     const {value} = getOriginalMessage(action as ReportAction<typeof CONST.REPORT.ACTIONS.TYPE.POLICY_CHANGE_LOG.UPDATE_DEFAULT_TITLE_ENFORCED>) ?? {};
 
     if (typeof value === 'boolean') {
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         return translateLocal('workspaceActions.updateDefaultTitleEnforced', {
             value,
         });
@@ -2759,7 +2887,9 @@ function getPolicyChangeLogDeleteMemberMessage(reportAction: OnyxInputOrEntry<Re
     }
     const originalMessage = getOriginalMessage(reportAction);
     const email = formatPhoneNumber(originalMessage?.email ?? '');
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     const role = translateLocal('workspace.common.roleName', {role: originalMessage?.role ?? ''}).toLowerCase();
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     return translateLocal('report.actions.type.removeMember', {email, role});
 }
 
@@ -2769,6 +2899,7 @@ function getAddedConnectionMessage(reportAction: OnyxEntry<ReportAction>): strin
     }
     const originalMessage = getOriginalMessage(reportAction);
     const connectionName = originalMessage?.connectionName;
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     return connectionName ? translateLocal('report.actions.type.addedConnection', {connectionName}) : '';
 }
 
@@ -2778,11 +2909,13 @@ function getRemovedConnectionMessage(reportAction: OnyxEntry<ReportAction>): str
     }
     const originalMessage = getOriginalMessage(reportAction);
     const connectionName = originalMessage?.connectionName;
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     return connectionName ? translateLocal('report.actions.type.removedConnection', {connectionName}) : '';
 }
 
 function getRenamedAction(reportAction: OnyxEntry<ReportAction<typeof CONST.REPORT.ACTIONS.TYPE.RENAMED>>, isExpenseReport: boolean, actorName?: string) {
     const originalMessage = getOriginalMessage(reportAction);
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     return translateLocal('newRoomPage.renamedRoomAction', {
         actorName,
         isExpenseReport,
@@ -2796,6 +2929,7 @@ function getAddedApprovalRuleMessage(reportAction: OnyxEntry<ReportAction>) {
         getOriginalMessage(reportAction as ReportAction<typeof CONST.REPORT.ACTIONS.TYPE.POLICY_CHANGE_LOG.ADD_APPROVER_RULE>) ?? {};
 
     if (name && approverAccountID && approverEmail && field && approverName) {
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         return translateLocal('workspaceActions.addApprovalRule', {
             approverEmail,
             approverName,
@@ -2812,6 +2946,7 @@ function getDeletedApprovalRuleMessage(reportAction: OnyxEntry<ReportAction>) {
         getOriginalMessage(reportAction as ReportAction<typeof CONST.REPORT.ACTIONS.TYPE.POLICY_CHANGE_LOG.DELETE_APPROVER_RULE>) ?? {};
 
     if (name && approverAccountID && approverEmail && field && approverName) {
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         return translateLocal('workspaceActions.deleteApprovalRule', {
             approverEmail,
             approverName,
@@ -2826,8 +2961,10 @@ function getDeletedApprovalRuleMessage(reportAction: OnyxEntry<ReportAction>) {
 function getActionableCardFraudAlertResolutionMessage(reportAction: OnyxEntry<ReportAction>) {
     const {maskedCardNumber, resolution} = getOriginalMessage(reportAction as ReportAction<typeof CONST.REPORT.ACTIONS.TYPE.ACTIONABLE_CARD_FRAUD_ALERT>) ?? {};
     if (resolution === CONST.CARD_FRAUD_ALERT_RESOLUTION.RECOGNIZED) {
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         return translateLocal('cardPage.cardFraudAlert.clearedMessage', {cardLastFour: maskedCardNumber?.slice(-4) ?? ''});
     }
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     return translateLocal('cardPage.cardFraudAlert.deactivatedMessage', {cardLastFour: maskedCardNumber?.slice(-4) ?? ''});
 }
 
@@ -2836,6 +2973,7 @@ function getUpdatedApprovalRuleMessage(reportAction: OnyxEntry<ReportAction>) {
         getOriginalMessage(reportAction as ReportAction<typeof CONST.REPORT.ACTIONS.TYPE.POLICY_CHANGE_LOG.UPDATE_APPROVER_RULE>) ?? {};
 
     if (field && oldApproverEmail && newApproverEmail && name) {
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         return translateLocal('workspaceActions.updateApprovalRule', {
             field,
             name,
@@ -2854,6 +2992,7 @@ function getRemovedFromApprovalChainMessage(reportAction: OnyxEntry<ReportAction
         accountIDs: originalMessage?.submittersAccountIDs ?? [],
         currentUserAccountID: currentUserAccountID ?? CONST.DEFAULT_NUMBER_ID,
     }).map(({displayName, login}) => displayName ?? login ?? 'Unknown Submitter');
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     return translateLocal('workspaceActions.removedFromApprovalWorkflow', {submittersNames, count: submittersNames.length});
 }
 
@@ -2869,13 +3008,15 @@ function getActionableCardFraudAlertMessage(
     const formattedDate = reportAction?.created ? format(getLocalDateFromDatetime(reportAction?.created), 'MMM. d - h:mma').replace(/am|pm/i, (match) => match.toUpperCase()) : '';
 
     if (resolution === CONST.CARD_FRAUD_ALERT_RESOLUTION.RECOGNIZED) {
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         return translateLocal('cardPage.cardFraudAlert.clearedMessage', {cardLastFour});
     }
 
     if (resolution === CONST.CARD_FRAUD_ALERT_RESOLUTION.FRAUD) {
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         return translateLocal('cardPage.cardFraudAlert.deactivatedMessage', {cardLastFour});
     }
-
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     return translateLocal('cardPage.cardFraudAlert.alertMessage', {
         cardLastFour,
         amount: formattedAmount,
@@ -2886,8 +3027,11 @@ function getActionableCardFraudAlertMessage(
 
 function getDemotedFromWorkspaceMessage(reportAction: OnyxEntry<ReportAction<typeof CONST.REPORT.ACTIONS.TYPE.DEMOTED_FROM_WORKSPACE>>) {
     const originalMessage = getOriginalMessage(reportAction);
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     const policyName = originalMessage?.policyName ?? translateLocal('workspace.common.workspace');
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     const oldRole = translateLocal('workspace.common.roleName', {role: originalMessage?.oldRole}).toLowerCase();
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     return translateLocal('workspaceActions.demotedFromWorkspace', {policyName, oldRole});
 }
 
@@ -2897,6 +3041,7 @@ function getUpdatedAuditRateMessage(reportAction: OnyxEntry<ReportAction>) {
     if (typeof oldAuditRate !== 'number' || typeof newAuditRate !== 'number') {
         return getReportActionText(reportAction);
     }
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     return translateLocal('workspaceActions.updatedAuditRate', {oldAuditRate, newAuditRate});
 }
 
@@ -2910,6 +3055,7 @@ function getUpdatedManualApprovalThresholdMessage(reportAction: OnyxEntry<Report
     if (typeof oldLimit !== 'number' || typeof oldLimit !== 'number') {
         return getReportActionText(reportAction);
     }
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     return translateLocal('workspaceActions.updatedManualApprovalThreshold', {oldLimit: convertToDisplayString(oldLimit, currency), newLimit: convertToDisplayString(newLimit, currency)});
 }
 
@@ -2918,6 +3064,7 @@ function getChangedApproverActionMessage<T extends typeof CONST.REPORT.ACTIONS.T
 
     // If mentionedAccountIDs exists and has values, use the first one
     if (mentionedAccountIDs?.length) {
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         return translateLocal('iou.changeApprover.changedApproverMessage', {managerID: mentionedAccountIDs.at(0) ?? CONST.DEFAULT_NUMBER_ID});
     }
 
@@ -2927,7 +3074,7 @@ function getChangedApproverActionMessage<T extends typeof CONST.REPORT.ACTIONS.T
     if (!actorAccountID) {
         return '';
     }
-
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     return translateLocal('iou.changeApprover.changedApproverMessage', {managerID: actorAccountID});
 }
 
@@ -2965,6 +3112,7 @@ function getJoinRequestMessage(reportAction: ReportAction<typeof CONST.REPORT.AC
     const policy = getPolicy(getOriginalMessage(reportAction)?.policyID);
     const userDetail = getPersonalDetailByEmail(getOriginalMessage(reportAction)?.email ?? '');
     const userName = userDetail?.firstName ? `${userDetail.displayName} (${userDetail.login})` : (userDetail?.login ?? getOriginalMessage(reportAction)?.email);
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     return translateLocal('workspace.inviteMessage.joinRequest', {user: userName ?? '', workspaceName: policy?.name ?? ''});
 }
 function isCardActive(card?: Card): boolean {
@@ -3000,21 +3148,28 @@ function getCardIssuedMessage({
 
     const isExpensifyCardActive = isCardActive(expensifyCard);
     const expensifyCardLink =
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         shouldRenderHTML && isExpensifyCardActive ? `<a href='${environmentURL}/${navigateRoute}'>${translateLocal('cardPage.expensifyCard')}</a>` : translateLocal('cardPage.expensifyCard');
     const isAssigneeCurrentUser = currentUserAccountID === assigneeAccountID;
     const companyCardLink =
         shouldRenderHTML && isAssigneeCurrentUser && companyCard
-            ? `<a href='${environmentURL}/${ROUTES.SETTINGS_WALLET}'>${translateLocal('workspace.companyCards.companyCard')}</a>`
-            : translateLocal('workspace.companyCards.companyCard');
+            ? // eslint-disable-next-line @typescript-eslint/no-deprecated
+              `<a href='${environmentURL}/${ROUTES.SETTINGS_WALLET}'>${translateLocal('workspace.companyCards.companyCard')}</a>`
+            : // eslint-disable-next-line @typescript-eslint/no-deprecated
+              translateLocal('workspace.companyCards.companyCard');
     const shouldShowAddMissingDetailsMessage = !isAssigneeCurrentUser || shouldShowAddMissingDetails(reportAction?.actionName, expensifyCard);
     switch (reportAction?.actionName) {
         case CONST.REPORT.ACTIONS.TYPE.CARD_ISSUED:
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             return translateLocal('workspace.expensifyCard.issuedCard', {assignee});
         case CONST.REPORT.ACTIONS.TYPE.CARD_ISSUED_VIRTUAL:
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             return translateLocal('workspace.expensifyCard.issuedCardVirtual', {assignee, link: expensifyCardLink});
         case CONST.REPORT.ACTIONS.TYPE.CARD_ASSIGNED:
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             return translateLocal('workspace.companyCards.assignedCard', {assignee, link: companyCardLink});
         case CONST.REPORT.ACTIONS.TYPE.CARD_MISSING_ADDRESS:
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             return translateLocal(`workspace.expensifyCard.${shouldShowAddMissingDetailsMessage ? 'issuedCardNoShippingDetails' : 'addedShippingDetails'}`, {assignee});
         default:
             return '';
@@ -3029,8 +3184,11 @@ function getRoomChangeLogMessage(reportAction: ReportAction) {
     const targetAccountIDs: number[] = originalMessage?.targetAccountIDs ?? [];
     const actionText =
         isActionOfType(reportAction, CONST.REPORT.ACTIONS.TYPE.ROOM_CHANGE_LOG.INVITE_TO_ROOM) || isActionOfType(reportAction, CONST.REPORT.ACTIONS.TYPE.POLICY_CHANGE_LOG.INVITE_TO_ROOM)
-            ? translateLocal('workspace.invite.invited')
-            : translateLocal('workspace.invite.removed');
+            ? // eslint-disable-next-line @typescript-eslint/no-deprecated
+              translateLocal('workspace.invite.invited')
+            : // eslint-disable-next-line @typescript-eslint/no-deprecated
+              translateLocal('workspace.invite.removed');
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     const userText = (targetAccountIDs.length === 1 ? translateLocal('common.member') : translateLocal('common.members')).toLowerCase();
     return `${actionText} ${targetAccountIDs.length} ${userText}`;
 }
@@ -3087,7 +3245,7 @@ function getIntegrationSyncFailedMessage(action: OnyxEntry<ReportAction>, policy
 
     const param = encodeURIComponent(`{"policyID": "${policyID}"}`);
     const workspaceAccountingLink = shouldShowOldDotLink ? `${oldDotEnvironmentURL}/policy?param=${param}#connections` : `${environmentURL}/${ROUTES.POLICY_ACCOUNTING.getRoute(policyID)}`;
-
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     return translateLocal('report.actions.type.integrationSyncFailed', {
         label,
         errorMessage,

--- a/src/libs/ReportFieldOptionsListUtils.ts
+++ b/src/libs/ReportFieldOptionsListUtils.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line @typescript-eslint/no-deprecated
 import {translateLocal} from './Localize';
 import type {Option} from './OptionsListUtils';
 import type {OptionData} from './ReportUtils';
@@ -68,6 +69,7 @@ function getReportFieldOptionsSection({
     if (filteredRecentlyUsedOptions.length > 0) {
         reportFieldOptionsSections.push({
             // "Recent" section
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             title: translateLocal('common.recent'),
             shouldShow: true,
             indexOffset,
@@ -79,6 +81,7 @@ function getReportFieldOptionsSection({
 
     reportFieldOptionsSections.push({
         // "All" section when items amount more than the threshold
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         title: translateLocal('common.all'),
         shouldShow: true,
         indexOffset,

--- a/src/libs/ReportUtils.ts
+++ b/src/libs/ReportUtils.ts
@@ -104,6 +104,7 @@ import getAttachmentDetails from './fileDownload/getAttachmentDetails';
 import getBase62ReportID from './getBase62ReportID';
 import {isReportMessageAttachment} from './isReportMessageAttachment';
 import {formatPhoneNumber} from './LocalePhoneNumber';
+// eslint-disable-next-line @typescript-eslint/no-deprecated
 import {translateLocal} from './Localize';
 import Log from './Log';
 import {isEmailPublicDomain} from './LoginUtils';
@@ -1162,7 +1163,9 @@ Onyx.connect({
         if (value ?? true) {
             return;
         }
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         hiddenTranslation = translateLocal('common.hidden');
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         unavailableTranslation = translateLocal('workspace.common.unavailable');
     },
 });
@@ -3192,7 +3195,7 @@ function getGroupChatName(participants?: SelectedParticipant[], shouldApplyLimit
             .slice(0, CONST.REPORT_NAME_LIMIT)
             .concat(shouldAddEllipsis ? '...' : '');
     }
-
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     return translateLocal('groupChat.defaultReportName', {displayName: getDisplayNameForParticipant({accountID: participantAccountIDs.at(0)})});
 }
 
@@ -3563,6 +3566,7 @@ function getDisplayNamesWithTooltips(
             let pronouns = user?.pronouns ?? undefined;
             if (pronouns?.startsWith(CONST.PRONOUNS.PREFIX)) {
                 const pronounTranslationKey = pronouns.replace(CONST.PRONOUNS.PREFIX, '');
+                // eslint-disable-next-line @typescript-eslint/no-deprecated
                 pronouns = translateLocal(`pronouns.${pronounTranslationKey}` as TranslationPaths);
             }
 
@@ -3602,9 +3606,11 @@ function getUserDetailTooltipText(accountID: number, fallbackUserDisplayName = '
  */
 function getDeletedParentActionMessageForChatReport(reportAction: OnyxEntry<ReportAction>): string {
     // By default, let us display [Deleted message]
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     let deletedMessageText = translateLocal('parentReportAction.deletedMessage');
     if (isCreatedTaskReportAction(reportAction)) {
         // For canceled task report, let us display [Deleted task]
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         deletedMessageText = translateLocal('parentReportAction.deletedTask');
     }
     return deletedMessageText;
@@ -3635,7 +3641,7 @@ function getReimbursementQueuedActionMessage({
     } else {
         messageKey = 'iou.waitingOnBankAccount';
     }
-
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     return translateLocal(messageKey, {submitterDisplayName});
 }
 
@@ -3652,9 +3658,11 @@ function getReimbursementDeQueuedOrCanceledActionMessage(
     const currency = originalMessage?.currency;
     const formattedAmount = convertToDisplayString(amount, currency);
     if (originalMessage?.cancellationReason === CONST.REPORT.CANCEL_PAYMENT_REASONS.ADMIN || originalMessage?.cancellationReason === CONST.REPORT.CANCEL_PAYMENT_REASONS.USER) {
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         return translateLocal('iou.adminCanceledRequest');
     }
     const submitterDisplayName = getDisplayNameForParticipant({accountID: report?.ownerAccountID, shouldUseShortForm: true}) ?? '';
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     return translateLocal('iou.canceledRequest', {submitterDisplayName, amount: formattedAmount});
 }
 
@@ -3987,6 +3995,7 @@ function getPolicyExpenseChatName({report, personalDetailsList}: {report: OnyxEn
     const reportOwnerDisplayName = getDisplayNameForParticipant({accountID: ownerAccountID, shouldRemoveDomain: true}) || login;
 
     if (reportOwnerDisplayName) {
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         return translateLocal('workspace.common.policyExpenseChatName', {displayName: reportOwnerDisplayName});
     }
 
@@ -4143,13 +4152,14 @@ function getMoneyRequestReportName({
     } else {
         payerOrApproverName = getDisplayNameForParticipant({accountID: report?.managerID}) ?? '';
     }
-
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     const payerPaidAmountMessage = translateLocal('iou.payerPaidAmount', {
         payer: payerOrApproverName,
         amount: formattedAmount,
     });
 
     if (isReportApproved({report})) {
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         return translateLocal('iou.managerApprovedAmount', {
             manager: payerOrApproverName,
             amount: formattedAmount,
@@ -4157,15 +4167,18 @@ function getMoneyRequestReportName({
     }
 
     if (report?.isWaitingOnBankAccount) {
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         return `${payerPaidAmountMessage} ${CONST.DOT_SEPARATOR} ${translateLocal('iou.pending')}`;
     }
 
     if (!isSettled(report?.reportID) && hasNonReimbursableTransactions(report?.reportID)) {
         payerOrApproverName = getDisplayNameForParticipant({accountID: report?.ownerAccountID}) ?? '';
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         return translateLocal('iou.payerSpentAmount', {payer: payerOrApproverName, amount: formattedAmount});
     }
 
     if (isProcessingReport(report) || isOpenExpenseReport(report) || isOpenInvoiceReport(report) || moneyRequestTotal === 0) {
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         return translateLocal('iou.payerOwesAmount', {payer: payerOrApproverName, amount: formattedAmount});
     }
 
@@ -4755,10 +4768,12 @@ function getTransactionReportName({
     reports?: SearchReport[];
 }): string {
     if (isReversedTransaction(reportAction)) {
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         return translateLocal('parentReportAction.reversedTransaction');
     }
 
     if (isDeletedAction(reportAction)) {
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         return translateLocal('parentReportAction.deletedExpense');
     }
 
@@ -4766,18 +4781,22 @@ function getTransactionReportName({
 
     if (isEmptyObject(transaction)) {
         // Transaction data might be empty on app's first load, if so we fallback to Expense/Track Expense
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         return isTrackExpenseAction(reportAction) ? translateLocal('iou.createExpense') : translateLocal('iou.expense');
     }
 
     if (isScanning(transaction)) {
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         return translateLocal('iou.receiptScanning', {count: 1});
     }
 
     if (hasMissingSmartscanFieldsTransactionUtils(transaction)) {
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         return translateLocal('iou.receiptMissingDetails');
     }
-
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     if (isFetchingWaypointsFromServer(transaction) && getMerchant(transaction) === translateLocal('iou.fieldPending')) {
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         return translateLocal('iou.fieldPending');
     }
 
@@ -4789,7 +4808,7 @@ function getTransactionReportName({
     const amount = getTransactionAmount(transaction, !isEmptyObject(report) && isExpenseReport(report), transaction?.reportID === CONST.REPORT.UNREPORTED_REPORT_ID) ?? 0;
     const formattedAmount = convertToDisplayString(amount, getCurrency(transaction)) ?? '';
     const comment = getMerchantOrDescription(transaction);
-
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     return translateLocal('iou.threadExpenseReportName', {formattedAmount, comment: Parser.htmlToText(comment)});
 }
 
@@ -4834,15 +4853,18 @@ function getReportPreviewMessage(
 
         if (!isEmptyObject(linkedTransaction)) {
             if (isScanning(linkedTransaction)) {
+                // eslint-disable-next-line @typescript-eslint/no-deprecated
                 return translateLocal('iou.receiptScanning', {count: 1});
             }
 
             if (hasMissingSmartscanFieldsTransactionUtils(linkedTransaction)) {
+                // eslint-disable-next-line @typescript-eslint/no-deprecated
                 return translateLocal('iou.receiptMissingDetails');
             }
 
             const amount = getTransactionAmount(linkedTransaction, !isEmptyObject(report) && isExpenseReport(report), linkedTransaction?.reportID === CONST.REPORT.UNREPORTED_REPORT_ID) ?? 0;
             const formattedAmount = convertToDisplayString(amount, getCurrency(linkedTransaction)) ?? '';
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             return translateLocal('iou.didSplitAmount', {formattedAmount, comment: getMerchantOrDescription(linkedTransaction)});
         }
     }
@@ -4856,15 +4878,18 @@ function getReportPreviewMessage(
 
         if (!isEmptyObject(linkedTransaction)) {
             if (isScanning(linkedTransaction)) {
+                // eslint-disable-next-line @typescript-eslint/no-deprecated
                 return translateLocal('iou.receiptScanning', {count: 1});
             }
 
             if (hasMissingSmartscanFieldsTransactionUtils(linkedTransaction)) {
+                // eslint-disable-next-line @typescript-eslint/no-deprecated
                 return translateLocal('iou.receiptMissingDetails');
             }
 
             const amount = getTransactionAmount(linkedTransaction, !isEmptyObject(report) && isExpenseReport(report), linkedTransaction?.reportID === CONST.REPORT.UNREPORTED_REPORT_ID) ?? 0;
             const formattedAmount = convertToDisplayString(amount, getCurrency(linkedTransaction)) ?? '';
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             return translateLocal('iou.trackedAmount', {formattedAmount, comment: getMerchantOrDescription(linkedTransaction)});
         }
     }
@@ -4879,6 +4904,7 @@ function getReportPreviewMessage(
     const formattedAmount = convertToDisplayString(totalAmount, report.currency);
 
     if (isReportApproved({report}) && isPaidGroupPolicy(report)) {
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         return translateLocal('iou.managerApprovedAmount', {
             manager: payerName ?? '',
             amount: formattedAmount,
@@ -4893,10 +4919,12 @@ function getReportPreviewMessage(
     }
 
     if (!isEmptyObject(linkedTransaction) && isScanning(linkedTransaction)) {
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         return translateLocal('iou.receiptScanning', {count: numberOfScanningReceipts});
     }
 
     if (!isEmptyObject(linkedTransaction) && isFetchingWaypointsFromServer(linkedTransaction) && !getTransactionAmount(linkedTransaction)) {
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         return translateLocal('iou.fieldPending');
     }
 
@@ -4927,7 +4955,7 @@ function getReportPreviewMessage(
 
         actualPayerName = actualPayerName && isForListPreview && !isPreviewMessageForParentChatReport ? `${actualPayerName}:` : actualPayerName;
         const payerDisplayName = isPreviewMessageForParentChatReport ? payerName : actualPayerName;
-
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         return translateLocal(translatePhraseKey, {
             amount: '',
             payer: payerDisplayName ?? '',
@@ -4937,6 +4965,7 @@ function getReportPreviewMessage(
 
     if (report.isWaitingOnBankAccount) {
         const submitterDisplayName = getDisplayNameForParticipant({accountID: report.ownerAccountID, shouldUseShortForm: true}) ?? '';
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         return translateLocal('iou.waitingOnBankAccount', {submitterDisplayName});
     }
 
@@ -4965,13 +4994,15 @@ function getReportPreviewMessage(
         // We only want to show the actor name in the preview if it's not the current user who took the action
         const requestorName =
             lastActorID && lastActorID !== currentUserAccountID ? getDisplayNameForParticipant({accountID: lastActorID, shouldUseShortForm: !isPreviewMessageForParentChatReport}) : '';
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         return `${requestorName ? `${requestorName}: ` : ''}${translateLocal('iou.expenseAmount', {formattedAmount: amountToDisplay, comment})}`;
     }
 
     if (containsNonReimbursable) {
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         return translateLocal('iou.payerSpentAmount', {payer: getDisplayNameForParticipant({accountID: report.ownerAccountID}) ?? '', amount: formattedAmount});
     }
-
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     return translateLocal('iou.payerOwesAmount', {payer: payerName ?? '', amount: formattedAmount, comment});
 }
 
@@ -5047,13 +5078,17 @@ function getModifiedExpenseOriginalMessage(
 
     if ('reimbursable' in transactionChanges) {
         const oldReimbursable = getReimbursable(oldTransaction);
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         originalMessage.oldReimbursable = oldReimbursable ? translateLocal('common.reimbursable').toLowerCase() : translateLocal('iou.nonReimbursable').toLowerCase();
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         originalMessage.reimbursable = transactionChanges?.reimbursable ? translateLocal('common.reimbursable').toLowerCase() : translateLocal('iou.nonReimbursable').toLowerCase();
     }
 
     if ('billable' in transactionChanges) {
         const oldBillable = getBillable(oldTransaction);
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         originalMessage.oldBillable = oldBillable ? translateLocal('common.billable').toLowerCase() : translateLocal('common.nonBillable').toLowerCase();
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         originalMessage.billable = transactionChanges?.billable ? translateLocal('common.billable').toLowerCase() : translateLocal('common.nonBillable').toLowerCase();
     }
 
@@ -5093,12 +5128,15 @@ function isChangeLogObject(originalMessage?: OriginalMessageChangeLog): Original
  */
 function getAdminRoomInvitedParticipants(parentReportAction: OnyxEntry<ReportAction>, parentReportActionMessage: string) {
     if (isEmptyObject(parentReportAction)) {
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         return parentReportActionMessage || translateLocal('parentReportAction.deletedMessage');
     }
     if (!getOriginalMessage(parentReportAction)) {
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         return parentReportActionMessage || translateLocal('parentReportAction.deletedMessage');
     }
     if (!isPolicyChangeLogAction(parentReportAction) && !isRoomChangeLogAction(parentReportAction)) {
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         return parentReportActionMessage || translateLocal('parentReportAction.deletedMessage');
     }
 
@@ -5110,8 +5148,10 @@ function getAdminRoomInvitedParticipants(parentReportAction: OnyxEntry<ReportAct
         if (name && name?.length > 0) {
             return name;
         }
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         return translateLocal('common.hidden');
     });
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     const users = participants.length > 1 ? participants.join(` ${translateLocal('common.and')} `) : participants.at(0);
     if (!users) {
         return parentReportActionMessage;
@@ -5121,8 +5161,9 @@ function getAdminRoomInvitedParticipants(parentReportAction: OnyxEntry<ReportAct
 
     const verbKey = isInviteAction ? 'workspace.invite.invited' : 'workspace.invite.removed';
     const prepositionKey = isInviteAction ? 'workspace.invite.to' : 'workspace.invite.from';
-
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     const verb = translateLocal(verbKey);
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     const preposition = translateLocal(prepositionKey);
 
     const roomName = originalMessage?.roomName ?? '';
@@ -5213,6 +5254,7 @@ function getReportActionMessage({
         return '';
     }
     if (reportAction.actionName === CONST.REPORT.ACTIONS.TYPE.HOLD) {
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         return translateLocal('iou.heldExpense');
     }
 
@@ -5221,14 +5263,17 @@ function getReportActionMessage({
     }
 
     if (reportAction.actionName === CONST.REPORT.ACTIONS.TYPE.UNHOLD) {
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         return translateLocal('iou.unheldExpense');
     }
 
     if (reportAction.actionName === CONST.REPORT.ACTIONS.TYPE.REJECTEDTRANSACTION_THREAD) {
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         return translateLocal('iou.reject.reportActions.rejectedExpense');
     }
 
     if (reportAction.actionName === CONST.REPORT.ACTIONS.TYPE.REJECTED_TRANSACTION_MARKASRESOLVED) {
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         return translateLocal('iou.reject.reportActions.markedAsResolved');
     }
 
@@ -5245,6 +5290,7 @@ function getReportActionMessage({
         });
     }
     if (reportAction.actionName === CONST.REPORT.ACTIONS.TYPE.RECEIPT_SCAN_FAILED) {
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         return translateLocal('iou.receiptScanningFailed');
     }
 
@@ -5361,15 +5407,19 @@ function getReportName(
     ) {
         const harvesting = !isMarkAsClosedAction(parentReportAction) ? (getOriginalMessage(parentReportAction)?.harvesting ?? false) : false;
         if (harvesting) {
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             return translateLocal('iou.automaticallySubmitted');
         }
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         return translateLocal('iou.submitted', {memo: getOriginalMessage(parentReportAction)?.message});
     }
     if (isActionOfType(parentReportAction, CONST.REPORT.ACTIONS.TYPE.FORWARDED)) {
         const {automaticAction} = getOriginalMessage(parentReportAction) ?? {};
         if (automaticAction) {
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             return translateLocal('iou.automaticallyForwarded');
         }
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         return translateLocal('iou.forwarded');
     }
     if (parentReportAction?.actionName === CONST.REPORT.ACTIONS.TYPE.REJECTED) {
@@ -5394,6 +5444,7 @@ function getReportName(
         return getWorkspaceUpdateFieldMessage(parentReportAction);
     }
     if (parentReportAction?.actionName === CONST.REPORT.ACTIONS.TYPE.MERGED_WITH_CASH_TRANSACTION) {
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         return translateLocal('systemMessage.mergedWithCashTransaction');
     }
     if (parentReportAction?.actionName === CONST.REPORT.ACTIONS.TYPE.POLICY_CHANGE_LOG.UPDATE_NAME) {
@@ -5435,6 +5486,7 @@ function getReportName(
     }
 
     if (isActionOfType(parentReportAction, CONST.REPORT.ACTIONS.TYPE.MARKED_REIMBURSED)) {
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         return translateLocal('iou.paidElsewhere');
     }
 
@@ -5461,18 +5513,23 @@ function getReportName(
 
         if (originalMessage?.type === CONST.IOU.REPORT_ACTION_TYPE.PAY) {
             if (originalMessage.paymentType === CONST.IOU.PAYMENT_TYPE.ELSEWHERE) {
+                // eslint-disable-next-line @typescript-eslint/no-deprecated
                 return translateLocal('iou.paidElsewhere');
             }
             if (originalMessage.paymentType === CONST.IOU.PAYMENT_TYPE.VBBA) {
                 if (originalMessage.automaticAction) {
+                    // eslint-disable-next-line @typescript-eslint/no-deprecated
                     return translateLocal('iou.automaticallyPaidWithBusinessBankAccount', {last4Digits});
                 }
+                // eslint-disable-next-line @typescript-eslint/no-deprecated
                 return translateLocal('iou.businessBankAccount', {last4Digits});
             }
             if (originalMessage.paymentType === CONST.IOU.PAYMENT_TYPE.EXPENSIFY) {
                 if (originalMessage.automaticAction) {
+                    // eslint-disable-next-line @typescript-eslint/no-deprecated
                     return translateLocal('iou.automaticallyPaidWithExpensify');
                 }
+                // eslint-disable-next-line @typescript-eslint/no-deprecated
                 return translateLocal('iou.paidWithExpensify');
             }
         }
@@ -5481,11 +5538,14 @@ function getReportName(
     if (isActionOfType(parentReportAction, CONST.REPORT.ACTIONS.TYPE.APPROVED)) {
         const {automaticAction} = getOriginalMessage(parentReportAction) ?? {};
         if (automaticAction) {
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             return translateLocal('iou.automaticallyApproved');
         }
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         return translateLocal('iou.approvedMessage');
     }
     if (isUnapprovedAction(parentReportAction)) {
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         return translateLocal('iou.unapproved');
     }
 
@@ -5494,6 +5554,7 @@ function getReportName(
     }
 
     if (isTaskReport(report) && isCanceledTaskReport(report, parentReportAction)) {
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         return translateLocal('parentReportAction.deletedTask');
     }
 
@@ -5528,10 +5589,12 @@ function getReportName(
         }
 
         if (parentReportActionMessage?.isDeletedParentAction) {
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             return translateLocal('parentReportAction.deletedMessage');
         }
 
         if (parentReportAction?.actionName === CONST.REPORT.ACTIONS.TYPE.RESOLVED_DUPLICATES) {
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             return translateLocal('violations.resolvedDuplicates');
         }
 
@@ -5544,6 +5607,7 @@ function getReportName(
             personalDetails,
         }).replace(/(\n+|\r\n|\n|\r)/gm, ' ');
         if (isAttachment && reportActionMessage) {
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             return `[${translateLocal('common.attachment')}]`;
         }
         if (
@@ -5551,6 +5615,7 @@ function getReportName(
             parentReportActionMessage?.moderationDecision?.decision === CONST.MODERATION.MODERATOR_DECISION_HIDDEN ||
             parentReportActionMessage?.moderationDecision?.decision === CONST.MODERATION.MODERATOR_DECISION_PENDING_REMOVE
         ) {
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             return translateLocal('parentReportAction.hiddenMessage');
         }
         if (isAdminRoom(report) || isUserCreatedPolicyRoom(report)) {
@@ -5583,6 +5648,7 @@ function getReportName(
     }
 
     if (isClosedExpenseReportWithNoExpenses(report, transactions)) {
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         return translateLocal('parentReportAction.deletedReport');
     }
 
@@ -5656,6 +5722,7 @@ function getInvoiceReportName(report: OnyxEntry<Report>, policy?: OnyxEntry<Poli
 }
 
 function generateArchivedReportName(reportName: string): string {
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     return `${reportName} (${translateLocal('common.archived')}) `;
 }
 
@@ -5702,12 +5769,15 @@ function getChatRoomSubtitle(report: OnyxEntry<Report>, isPolicyNamePreferred = 
         return '';
     }
     if (isSelfDM(report)) {
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         return translateLocal('reportActionsView.yourSpace');
     }
     if (isInvoiceRoom(report)) {
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         return translateLocal('workspace.common.invoices');
     }
     if (isConciergeChatReport(report)) {
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         return translateLocal('reportActionsView.conciergeSupport');
     }
     if (!isDefaultRoom(report) && !isUserCreatedPolicyRoom(report) && !isPolicyExpenseChat(report)) {
@@ -5726,7 +5796,7 @@ function getChatRoomSubtitle(report: OnyxEntry<Report>, isPolicyNamePreferred = 
         if (!subtitle || !isPolicyNamePreferred) {
             return getPolicyName({report});
         }
-
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         return `${getReportSubtitlePrefix(report)}${translateLocal('iou.submitsTo', {name: subtitle ?? ''})}`;
     }
 
@@ -5762,6 +5832,7 @@ function getParentNavigationSubtitle(report: OnyxEntry<Report>, isParentReportAr
 
         if (isExpenseReport(report)) {
             return {
+                // eslint-disable-next-line @typescript-eslint/no-deprecated
                 reportName: translateLocal('workspace.common.policyExpenseChatName', {displayName: reportOwnerDisplayName ?? ''}),
                 workspaceName: getPolicyName({report}),
             };
@@ -5776,6 +5847,7 @@ function getParentNavigationSubtitle(report: OnyxEntry<Report>, isParentReportAr
         let reportName = `${getPolicyName({report: parentReport})} & ${getInvoicePayerName(parentReport)}`;
 
         if (isArchivedNonExpenseReport(parentReport, isParentReportArchived)) {
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             reportName += ` (${translateLocal('common.archived')})`;
         }
 
@@ -6243,6 +6315,7 @@ function getHumanReadableStatus(statusNum: number): string {
 function populateOptimisticReportFormula(formula: string, report: OptimisticExpenseReport | OptimisticNewReport, policy: OnyxEntry<Policy>, isMoneyRequestConfirmation = false): string {
     // If this is a newly created report and it is from money request confirmation, we should use 'New report' as the report title
     if (!report.parentReportActionID && isMoneyRequestConfirmation) {
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         return translateLocal('iou.newReport');
     }
 
@@ -6456,19 +6529,23 @@ function buildOptimisticEmptyReport(reportID: string, accountID: number, parentR
 }
 
 function getRejectedReportMessage() {
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     return translateLocal('iou.rejectedThisReport');
 }
 
 function getUpgradeWorkspaceMessage() {
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     return translateLocal('workspaceActions.upgradedWorkspace');
 }
 
 function getDowngradeWorkspaceMessage() {
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     return translateLocal('workspaceActions.downgradedWorkspace');
 }
 
 function getWorkspaceNameUpdatedMessage(action: ReportAction) {
     const {oldName, newName} = getOriginalMessage(action as ReportAction<typeof CONST.REPORT.ACTIONS.TYPE.POLICY_CHANGE_LOG.UPDATE_NAME>) ?? {};
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     const message = oldName && newName ? translateLocal('workspaceActions.renamedWorkspaceNameAction', {oldName, newName}) : getReportActionText(action);
     return Str.htmlEncode(message);
 }
@@ -6478,6 +6555,7 @@ function getDeletedTransactionMessage(action: ReportAction) {
     const amount = -(deletedTransactionOriginalMessage.amount ?? 0);
     const currency = deletedTransactionOriginalMessage.currency ?? '';
     const formattedAmount = convertToDisplayString(amount, currency) ?? '';
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     const message = translateLocal('iou.deletedTransaction', {
         amount: formattedAmount,
         merchant: deletedTransactionOriginalMessage.merchant ?? '',
@@ -6488,12 +6566,14 @@ function getDeletedTransactionMessage(action: ReportAction) {
 function getMovedTransactionMessage(report: OnyxEntry<Report>) {
     const reportName = getReportName(report) ?? report?.reportName ?? '';
     const reportUrl = getReportURLForCurrentContext(report?.reportID);
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     return translateLocal('iou.movedTransaction', {reportUrl, reportName});
 }
 
 function getUnreportedTransactionMessage() {
     const selfDMReportID = findSelfDMReportID();
     const reportUrl = `${environmentURL}/r/${selfDMReportID}`;
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     const message = translateLocal('iou.unreportedTransaction', {
         reportUrl,
     });
@@ -6511,6 +6591,7 @@ function getMovedActionMessage(action: ReportAction, report: OnyxEntry<Report>) 
     }
     const {toPolicyID, newParentReportID, movedReportID} = movedActionOriginalMessage;
     const toPolicyName = getPolicyNameByID(toPolicyID);
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     return translateLocal('iou.movedAction', {
         shouldHideMovedReportUrl: !isDM(report),
         movedReportUrl: getReportURLForCurrentContext(movedReportID),
@@ -6522,6 +6603,7 @@ function getMovedActionMessage(action: ReportAction, report: OnyxEntry<Report>) 
 function getPolicyChangeMessage(action: ReportAction) {
     const PolicyChangeOriginalMessage = getOriginalMessage(action as ReportAction<typeof CONST.REPORT.ACTIONS.TYPE.CHANGE_POLICY>) ?? {};
     const {fromPolicy: fromPolicyID, toPolicy: toPolicyID} = PolicyChangeOriginalMessage as OriginalMessageChangePolicy;
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     const message = translateLocal('report.actions.type.changeReportPolicy', {
         fromPolicyName: fromPolicyID ? getPolicyNameByID(fromPolicyID) : undefined,
         toPolicyName: getPolicyNameByID(toPolicyID),
@@ -6596,13 +6678,16 @@ function getIOUReportActionMessage(
             if (isInvoice && isSettlingUp) {
                 iouMessage =
                     paymentType === CONST.IOU.PAYMENT_TYPE.ELSEWHERE
-                        ? translateLocal('iou.payElsewhere', {formattedAmount: amount})
-                        : translateLocal(payAsBusiness ? 'iou.settleInvoiceBusiness' : 'iou.settleInvoicePersonal', {amount, last4Digits: String(bankAccountID).slice(-4)});
+                        ? // eslint-disable-next-line @typescript-eslint/no-deprecated
+                          translateLocal('iou.payElsewhere', {formattedAmount: amount})
+                        : // eslint-disable-next-line @typescript-eslint/no-deprecated
+                          translateLocal(payAsBusiness ? 'iou.settleInvoiceBusiness' : 'iou.settleInvoicePersonal', {amount, last4Digits: String(bankAccountID).slice(-4)});
             } else {
                 iouMessage = isSettlingUp ? `paid ${amount}${paymentMethodMessage}` : `sent ${amount}${comment && ` for ${comment}`}${paymentMethodMessage}`;
             }
             break;
         case CONST.REPORT.ACTIONS.TYPE.SUBMITTED:
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             iouMessage = translateLocal('iou.expenseAmount', {formattedAmount: amount});
             break;
         default:
@@ -7527,6 +7612,7 @@ function buildOptimisticHoldReportAction(created = DateUtils.getDBTime()): Optim
             {
                 type: CONST.REPORT.MESSAGE.TYPE.TEXT,
                 style: 'normal',
+                // eslint-disable-next-line @typescript-eslint/no-deprecated
                 text: translateLocal('iou.heldExpense'),
             },
         ],
@@ -7589,6 +7675,7 @@ function buildOptimisticUnHoldReportAction(created = DateUtils.getDBTime()): Opt
             {
                 type: CONST.REPORT.MESSAGE.TYPE.TEXT,
                 style: 'normal',
+                // eslint-disable-next-line @typescript-eslint/no-deprecated
                 text: translateLocal('iou.unheldExpense'),
             },
         ],
@@ -7846,6 +7933,7 @@ function buildOptimisticResolvedDuplicatesReportAction(): OptimisticDismissedVio
             {
                 type: CONST.REPORT.MESSAGE.TYPE.TEXT,
                 style: 'normal',
+                // eslint-disable-next-line @typescript-eslint/no-deprecated
                 text: translateLocal('violations.resolvedDuplicates'),
             },
         ],
@@ -8621,6 +8709,7 @@ function hasReportErrorsOtherThanFailedReceipt(
     return (
         doesTransactionThreadReportHasViolations ||
         doesReportHaveViolations ||
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         Object.values(allReportErrors).some((error) => error?.[0] !== translateLocal('iou.error.genericSmartscanFailureMessage'))
     );
 }
@@ -9263,6 +9352,7 @@ function getWhisperDisplayNames(participantAccountIDs?: number[]): string | unde
 
     // When the current user is the only participant, the display name needs to be "you" because that's the only person reading it
     if (isWhisperOnlyVisibleToCurrentUser) {
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         return translateLocal('common.youAfterPreposition');
     }
 
@@ -9668,6 +9758,7 @@ function getIOUReportActionDisplayMessage(reportAction: OnyxEntry<ReportAction>,
             case CONST.IOU.PAYMENT_TYPE.EXPENSIFY:
             case CONST.IOU.PAYMENT_TYPE.VBBA:
                 if (isInvoice) {
+                    // eslint-disable-next-line @typescript-eslint/no-deprecated
                     return translateLocal(payAsBusiness ? 'iou.settleInvoiceBusiness' : 'iou.settleInvoicePersonal', {amount: '', last4Digits});
                 }
                 translationKey = 'iou.businessBankAccount';
@@ -9684,7 +9775,7 @@ function getIOUReportActionDisplayMessage(reportAction: OnyxEntry<ReportAction>,
                 translationKey = 'iou.payerPaidAmount';
                 break;
         }
-
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         return translateLocal(translationKey, {amount: '', payer: '', last4Digits});
     }
 
@@ -9693,11 +9784,13 @@ function getIOUReportActionDisplayMessage(reportAction: OnyxEntry<ReportAction>,
     const isRequestSettled = isSettled(IOUReportID);
     const isApproved = isReportApproved({report: iouReport});
     if (isRequestSettled) {
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         return translateLocal('iou.payerSettled', {
             amount: formattedAmount,
         });
     }
     if (isApproved) {
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         return translateLocal('iou.approvedAmount', {
             amount: formattedAmount,
         });
@@ -9709,6 +9802,7 @@ function getIOUReportActionDisplayMessage(reportAction: OnyxEntry<ReportAction>,
     } else {
         translationKey = 'iou.expenseAmount';
     }
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     return translateLocal(translationKey, {
         formattedAmount,
         comment: getMerchantOrDescription(transaction),
@@ -10750,6 +10844,7 @@ function prepareOnboardingOnyxData(
 
     // Sign-off welcome message
     const welcomeSignOffText =
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         engagementChoice === CONST.ONBOARDING_CHOICES.MANAGE_TEAM ? translateLocal('onboarding.welcomeSignOffTitleManageTeam') : translateLocal('onboarding.welcomeSignOffTitle');
     const welcomeSignOffComment = buildOptimisticAddCommentReportAction(welcomeSignOffText, undefined, actorAccountID, tasksData.length + 3);
     const welcomeSignOffCommentAction: OptimisticAddCommentReportAction = welcomeSignOffComment.reportAction;
@@ -11248,6 +11343,7 @@ function getFieldViolationTranslation(reportField: PolicyReportField, violation?
 
     switch (violation) {
         case 'fieldRequired':
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             return translateLocal('reportViolations.fieldRequired', {fieldName: reportField.name});
         default:
             return '';
@@ -11736,6 +11832,7 @@ function hasReportBeenRetracted(report: OnyxEntry<Report>, reportActions?: OnyxE
 function getMoneyReportPreviewName(action: ReportAction, iouReport: OnyxEntry<Report>, isInvoice?: boolean, reportAttributes?: ReportAttributesDerivedValue['reports']) {
     if (isInvoice && isActionOfType(action, CONST.REPORT.ACTIONS.TYPE.REPORT_PREVIEW)) {
         const originalMessage = getOriginalMessage(action);
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         return originalMessage && translateLocal('iou.invoiceReportName', originalMessage);
     }
     return getReportName(iouReport, undefined, undefined, undefined, undefined, reportAttributes) || action.childReportName;
@@ -11771,6 +11868,7 @@ function buildOptimisticRejectReportAction(created = DateUtils.getDBTime()): Opt
             {
                 type: CONST.REPORT.MESSAGE.TYPE.TEXT,
                 style: 'normal',
+                // eslint-disable-next-line @typescript-eslint/no-deprecated
                 text: translateLocal('iou.reject.reportActions.rejectedExpense'),
             },
         ],
@@ -11833,6 +11931,7 @@ function buildOptimisticMarkedAsResolvedReportAction(created = DateUtils.getDBTi
             {
                 type: CONST.REPORT.MESSAGE.TYPE.TEXT,
                 style: 'normal',
+                // eslint-disable-next-line @typescript-eslint/no-deprecated
                 text: translateLocal('iou.reject.reportActions.markedAsResolved'),
             },
         ],
@@ -11872,15 +11971,19 @@ function getReportStatusTranslation(stateNum?: number, statusNum?: number): stri
     }
 
     if (stateNum === CONST.REPORT.STATE_NUM.OPEN && statusNum === CONST.REPORT.STATUS_NUM.OPEN) {
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         return translateLocal('common.draft');
     }
     if (stateNum === CONST.REPORT.STATE_NUM.SUBMITTED && statusNum === CONST.REPORT.STATUS_NUM.SUBMITTED) {
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         return translateLocal('common.outstanding');
     }
     if (stateNum === CONST.REPORT.STATE_NUM.APPROVED && statusNum === CONST.REPORT.STATUS_NUM.CLOSED) {
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         return translateLocal('common.done');
     }
     if (stateNum === CONST.REPORT.STATE_NUM.APPROVED && statusNum === CONST.REPORT.STATUS_NUM.APPROVED) {
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         return translateLocal('iou.approved');
     }
     if (
@@ -11888,6 +11991,7 @@ function getReportStatusTranslation(stateNum?: number, statusNum?: number): stri
         (stateNum === CONST.REPORT.STATE_NUM.BILLING && statusNum === CONST.REPORT.STATUS_NUM.REIMBURSED) ||
         (stateNum === CONST.REPORT.STATE_NUM.AUTOREIMBURSED && statusNum === CONST.REPORT.STATUS_NUM.REIMBURSED)
     ) {
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         return translateLocal('iou.settledExpensify');
     }
 

--- a/src/libs/SearchUIUtils.ts
+++ b/src/libs/SearchUIUtils.ts
@@ -68,6 +68,7 @@ import {getCardFeedsForDisplay} from './CardFeedUtils';
 import {convertToDisplayString, getCurrencySymbol} from './CurrencyUtils';
 import DateUtils from './DateUtils';
 import interceptAnonymousUser from './interceptAnonymousUser';
+// eslint-disable-next-line @typescript-eslint/no-deprecated
 import {translateLocal} from './Localize';
 import Navigation from './Navigation/Navigation';
 import Parser from './Parser';
@@ -169,42 +170,59 @@ function isValidExpenseStatus(status: unknown): status is ValueOf<typeof CONST.S
 
 function getExpenseStatusOptions(): Array<MultiSelectItem<SingularSearchStatus>> {
     return [
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         {text: translateLocal('common.unreported'), value: CONST.SEARCH.STATUS.EXPENSE.UNREPORTED},
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         {text: translateLocal('common.draft'), value: CONST.SEARCH.STATUS.EXPENSE.DRAFTS},
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         {text: translateLocal('common.outstanding'), value: CONST.SEARCH.STATUS.EXPENSE.OUTSTANDING},
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         {text: translateLocal('iou.approved'), value: CONST.SEARCH.STATUS.EXPENSE.APPROVED},
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         {text: translateLocal('iou.settledExpensify'), value: CONST.SEARCH.STATUS.EXPENSE.PAID},
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         {text: translateLocal('iou.done'), value: CONST.SEARCH.STATUS.EXPENSE.DONE},
     ];
 }
 
 function getExpenseReportedStatusOptions(): Array<MultiSelectItem<SingularSearchStatus>> {
     return [
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         {text: translateLocal('common.draft'), value: CONST.SEARCH.STATUS.EXPENSE.DRAFTS},
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         {text: translateLocal('common.outstanding'), value: CONST.SEARCH.STATUS.EXPENSE.OUTSTANDING},
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         {text: translateLocal('iou.approved'), value: CONST.SEARCH.STATUS.EXPENSE.APPROVED},
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         {text: translateLocal('iou.settledExpensify'), value: CONST.SEARCH.STATUS.EXPENSE.PAID},
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         {text: translateLocal('iou.done'), value: CONST.SEARCH.STATUS.EXPENSE.DONE},
     ];
 }
 
 function getInvoiceStatusOptions(): Array<MultiSelectItem<SingularSearchStatus>> {
     return [
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         {text: translateLocal('common.outstanding'), value: CONST.SEARCH.STATUS.INVOICE.OUTSTANDING},
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         {text: translateLocal('iou.settledExpensify'), value: CONST.SEARCH.STATUS.INVOICE.PAID},
     ];
 }
 
 function getTripStatusOptions(): Array<MultiSelectItem<SingularSearchStatus>> {
     return [
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         {text: translateLocal('search.filters.current'), value: CONST.SEARCH.STATUS.TRIP.CURRENT},
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         {text: translateLocal('search.filters.past'), value: CONST.SEARCH.STATUS.TRIP.PAST},
     ];
 }
 
 function getTaskStatusOptions(): Array<MultiSelectItem<SingularSearchStatus>> {
     return [
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         {text: translateLocal('common.outstanding'), value: CONST.SEARCH.STATUS.TASK.OUTSTANDING},
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         {text: translateLocal('search.filters.completed'), value: CONST.SEARCH.STATUS.TASK.COMPLETED},
     ];
 }
@@ -906,12 +924,13 @@ function getIOUReportName(data: OnyxTypes.SearchResults['data'], reportItem: Sea
     const payerName = payerPersonalDetails?.displayName ?? payerPersonalDetails?.login ?? getDisplayNameOrDefault(getPersonalDetailsForAccountID(reportItem.managerID));
     const formattedAmount = convertToDisplayString(reportItem.total ?? 0, reportItem.currency ?? CONST.CURRENCY.USD);
     if (reportItem.action === CONST.SEARCH.ACTION_TYPES.PAID) {
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         return translateLocal('iou.payerPaidAmount', {
             payer: payerName,
             amount: formattedAmount,
         });
     }
-
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     return translateLocal('iou.payerOwesAmount', {
         payer: payerName,
         amount: formattedAmount,
@@ -1843,6 +1862,7 @@ function getExpenseTypeTranslationKey(expenseType: ValueOf<typeof CONST.SEARCH.T
 function getOverflowMenu(itemName: string, hash: number, inputQuery: string, showDeleteModal: (hash: number) => void, isMobileMenu?: boolean, closeMenu?: () => void) {
     return [
         {
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             text: translateLocal('common.rename'),
             onSelected: () => {
                 if (isMobileMenu && closeMenu) {
@@ -1856,6 +1876,7 @@ function getOverflowMenu(itemName: string, hash: number, inputQuery: string, sho
             shouldCallAfterModalHide: true,
         },
         {
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             text: translateLocal('common.delete'),
             onSelected: () => {
                 if (isMobileMenu && closeMenu) {
@@ -2131,14 +2152,20 @@ function getHasOptions(type: SearchDataTypes) {
     switch (type) {
         case CONST.SEARCH.DATA_TYPES.EXPENSE:
             return [
+                // eslint-disable-next-line @typescript-eslint/no-deprecated
                 {text: translateLocal('common.receipt'), value: CONST.SEARCH.HAS_VALUES.RECEIPT},
+                // eslint-disable-next-line @typescript-eslint/no-deprecated
                 {text: translateLocal('common.attachment'), value: CONST.SEARCH.HAS_VALUES.ATTACHMENT},
+                // eslint-disable-next-line @typescript-eslint/no-deprecated
                 {text: translateLocal('common.tag'), value: CONST.SEARCH.HAS_VALUES.TAG},
+                // eslint-disable-next-line @typescript-eslint/no-deprecated
                 {text: translateLocal('common.category'), value: CONST.SEARCH.HAS_VALUES.CATEGORY},
             ];
         case CONST.SEARCH.DATA_TYPES.CHAT:
             return [
+                // eslint-disable-next-line @typescript-eslint/no-deprecated
                 {text: translateLocal('common.link'), value: CONST.SEARCH.HAS_VALUES.LINK},
+                // eslint-disable-next-line @typescript-eslint/no-deprecated
                 {text: translateLocal('common.attachment'), value: CONST.SEARCH.HAS_VALUES.ATTACHMENT},
             ];
         default:
@@ -2148,10 +2175,15 @@ function getHasOptions(type: SearchDataTypes) {
 
 function getTypeOptions(policies: OnyxCollection<OnyxTypes.Policy>, currentUserLogin?: string) {
     const typeOptions: Array<SingleSelectItem<SearchDataTypes>> = [
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         {text: translateLocal('common.expense'), value: CONST.SEARCH.DATA_TYPES.EXPENSE},
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         {text: translateLocal('common.chat'), value: CONST.SEARCH.DATA_TYPES.CHAT},
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         {text: translateLocal('common.invoice'), value: CONST.SEARCH.DATA_TYPES.INVOICE},
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         {text: translateLocal('common.trip'), value: CONST.SEARCH.DATA_TYPES.TRIP},
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         {text: translateLocal('common.task'), value: CONST.SEARCH.DATA_TYPES.TASK},
     ];
     const shouldHideInvoiceOption = !canSendInvoice(policies, currentUserLogin) && !hasInvoiceReports();
@@ -2161,6 +2193,7 @@ function getTypeOptions(policies: OnyxCollection<OnyxTypes.Policy>, currentUserL
 }
 
 function getGroupByOptions() {
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     return Object.values(CONST.SEARCH.GROUP_BY).map<SingleSelectItem<SearchGroupBy>>((value) => ({text: translateLocal(`search.filters.groupBy.${value}`), value}));
 }
 

--- a/src/libs/SidebarUtils.ts
+++ b/src/libs/SidebarUtils.ts
@@ -938,8 +938,7 @@ function getOptionData({
     } else {
         if (!lastMessageText) {
             lastMessageText = formatReportLastMessageText(
-                // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-                // eslint-disable-next-line @typescript-eslint/no-deprecated
+                // eslint-disable-next-line @typescript-eslint/no-deprecated, @typescript-eslint/prefer-nullish-coalescing
                 getWelcomeMessage(report, policy, participantPersonalDetailListExcludeCurrentUser, localeCompare, isReportArchived).messageText || translateLocal('report.noActivityYet'),
             );
         }

--- a/src/libs/SidebarUtils.ts
+++ b/src/libs/SidebarUtils.ts
@@ -13,6 +13,7 @@ import type Policy from '@src/types/onyx/Policy';
 import type PriorityMode from '@src/types/onyx/PriorityMode';
 import type Report from '@src/types/onyx/Report';
 import type ReportAction from '@src/types/onyx/ReportAction';
+// eslint-disable-next-line @typescript-eslint/no-deprecated
 import {translateLocal} from './Localize';
 import {
     getLastActorDisplayName,
@@ -805,16 +806,21 @@ function getOptionData({
             const targetAccountIDsLength = targetAccountIDs.length !== 0 ? targetAccountIDs.length : (report.lastMessageHtml?.match(/<mention-user[^>]*><\/mention-user>/g)?.length ?? 0);
             const verb =
                 lastActionName === CONST.REPORT.ACTIONS.TYPE.ROOM_CHANGE_LOG.INVITE_TO_ROOM || lastActionName === CONST.REPORT.ACTIONS.TYPE.POLICY_CHANGE_LOG.INVITE_TO_ROOM
-                    ? translateLocal('workspace.invite.invited')
-                    : translateLocal('workspace.invite.removed');
+                    ? // eslint-disable-next-line @typescript-eslint/no-deprecated
+                      translateLocal('workspace.invite.invited')
+                    : // eslint-disable-next-line @typescript-eslint/no-deprecated
+                      translateLocal('workspace.invite.removed');
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             const users = translateLocal(targetAccountIDsLength > 1 ? 'common.members' : 'common.member')?.toLocaleLowerCase();
             result.alternateText = formatReportLastMessageText(`${actorDisplayName ?? lastActorDisplayName}: ${verb} ${targetAccountIDsLength} ${users}`);
             const roomName = getReportName(lastActionReport) || lastActionOriginalMessage?.roomName;
             if (roomName) {
                 const preposition =
                     lastAction.actionName === CONST.REPORT.ACTIONS.TYPE.ROOM_CHANGE_LOG.INVITE_TO_ROOM || lastAction.actionName === CONST.REPORT.ACTIONS.TYPE.POLICY_CHANGE_LOG.INVITE_TO_ROOM
-                        ? ` ${translateLocal('workspace.invite.to')}`
-                        : ` ${translateLocal('workspace.invite.from')}`;
+                        ? // eslint-disable-next-line @typescript-eslint/no-deprecated
+                          ` ${translateLocal('workspace.invite.to')}`
+                        : // eslint-disable-next-line @typescript-eslint/no-deprecated
+                          ` ${translateLocal('workspace.invite.from')}`;
                 result.alternateText += `${preposition} ${roomName}`;
             }
         } else if (isActionOfType(lastAction, CONST.REPORT.ACTIONS.TYPE.POLICY_CHANGE_LOG.UPDATE_NAME)) {
@@ -828,8 +834,10 @@ function getOptionData({
         } else if (isActionOfType(lastAction, CONST.REPORT.ACTIONS.TYPE.POLICY_CHANGE_LOG.UPDATE_AUTO_REPORTING_FREQUENCY)) {
             result.alternateText = getWorkspaceFrequencyUpdateMessage(lastAction);
         } else if (isActionOfType(lastAction, CONST.REPORT.ACTIONS.TYPE.POLICY_CHANGE_LOG.CORPORATE_UPGRADE)) {
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             result.alternateText = translateLocal('workspaceActions.upgradedWorkspace');
         } else if (isActionOfType(lastAction, CONST.REPORT.ACTIONS.TYPE.POLICY_CHANGE_LOG.TEAM_DOWNGRADE)) {
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             result.alternateText = translateLocal('workspaceActions.downgradedWorkspace');
         } else if (isActionOfType(lastAction, CONST.REPORT.ACTIONS.TYPE.INTEGRATION_SYNC_FAILED)) {
             result.alternateText = Parser.htmlToText(getIntegrationSyncFailedMessage(lastAction, report?.policyID));
@@ -921,6 +929,7 @@ function getOptionData({
 
             if (!result.alternateText) {
                 result.alternateText = formatReportLastMessageText(
+                    // eslint-disable-next-line @typescript-eslint/no-deprecated
                     getWelcomeMessage(report, policy, participantPersonalDetailListExcludeCurrentUser, localeCompare, isReportArchived).messageText ?? translateLocal('report.noActivityYet'),
                 );
             }
@@ -930,6 +939,7 @@ function getOptionData({
         if (!lastMessageText) {
             lastMessageText = formatReportLastMessageText(
                 // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+                // eslint-disable-next-line @typescript-eslint/no-deprecated
                 getWelcomeMessage(report, policy, participantPersonalDetailListExcludeCurrentUser, localeCompare, isReportArchived).messageText || translateLocal('report.noActivityYet'),
             );
         }
@@ -1001,6 +1011,7 @@ function getWelcomeMessage(
             welcomeMessage.messageHtml = policy.description;
             welcomeMessage.messageText = Parser.htmlToText(welcomeMessage.messageHtml);
         } else {
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             welcomeMessage.messageHtml = translateLocal('reportActionsView.beginningOfChatHistoryPolicyExpenseChat', {
                 submitterDisplayName: getDisplayNameForParticipant({accountID: report?.ownerAccountID}),
                 workspaceName: getPolicyName({report}),
@@ -1011,15 +1022,17 @@ function getWelcomeMessage(
     }
 
     if (isSelfDM(report)) {
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         welcomeMessage.messageText = translateLocal('reportActionsView.beginningOfChatHistorySelfDM');
         return welcomeMessage;
     }
 
     if (isSystemChatUtil(report)) {
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         welcomeMessage.messageText = translateLocal('reportActionsView.beginningOfChatHistorySystemDM');
         return welcomeMessage;
     }
-
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     welcomeMessage.phrase1 = translateLocal('reportActionsView.beginningOfChatHistory');
     const isMultipleParticipant = participantPersonalDetailList.length > 1;
     const displayNamesWithTooltips = getDisplayNamesWithTooltips(participantPersonalDetailList, isMultipleParticipant, localeCompare);
@@ -1029,6 +1042,7 @@ function getWelcomeMessage(
                 return `${displayName}.`;
             }
             if (index === displayNamesWithTooltips.length - 2) {
+                // eslint-disable-next-line @typescript-eslint/no-deprecated
                 return `${displayName} ${translateLocal('common.and')}`;
             }
             if (index < displayNamesWithTooltips.length - 2) {
@@ -1057,12 +1071,16 @@ function getRoomWelcomeMessage(report: OnyxEntry<Report>, isReportArchived = fal
     }
 
     if (isReportArchived) {
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         welcomeMessage.messageHtml = translateLocal('reportActionsView.beginningOfArchivedRoom', {reportName, reportDetailsLink});
     } else if (isDomainRoom(report)) {
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         welcomeMessage.messageHtml = translateLocal('reportActionsView.beginningOfChatHistoryDomainRoom', {domainRoom: report?.reportName ?? ''});
     } else if (isAdminRoom(report)) {
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         welcomeMessage.messageHtml = translateLocal('reportActionsView.beginningOfChatHistoryAdminRoom', {workspaceName});
     } else if (isAnnounceRoom(report)) {
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         welcomeMessage.messageHtml = translateLocal('reportActionsView.beginningOfChatHistoryAnnounceRoom', {workspaceName});
     } else if (isInvoiceRoom(report)) {
         const payer =
@@ -1072,12 +1090,14 @@ function getRoomWelcomeMessage(report: OnyxEntry<Report>, isReportArchived = fal
                   // eslint-disable-next-line @typescript-eslint/no-deprecated
                   getPolicy(report?.invoiceReceiver?.policyID)?.name;
         const receiver = getPolicyName({report});
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         welcomeMessage.messageHtml = translateLocal('reportActionsView.beginningOfChatHistoryInvoiceRoom', {
             invoicePayer: payer ?? '',
             invoiceReceiver: receiver,
         });
     } else {
         // Message for user created rooms or other room types.
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         welcomeMessage.messageHtml = translateLocal('reportActionsView.beginningOfChatHistoryUserRoom', {reportName, reportDetailsLink});
     }
     welcomeMessage.messageText = Parser.htmlToText(welcomeMessage.messageHtml);

--- a/src/libs/SubscriptionUtils.ts
+++ b/src/libs/SubscriptionUtils.ts
@@ -13,6 +13,7 @@ import ONYXKEYS from '@src/ONYXKEYS';
 import type {BillingGraceEndPeriod, BillingStatus, Fund, FundList, IntroSelected, Policy, StripeCustomerID} from '@src/types/onyx';
 import {isEmptyObject} from '@src/types/utils/EmptyObject';
 import {convertToShortDisplayString} from './CurrencyUtils';
+// eslint-disable-next-line @typescript-eslint/no-deprecated
 import {translateLocal} from './Localize';
 import {getOwnedPaidPolicies, isPolicyOwner} from './PolicyUtils';
 
@@ -489,9 +490,11 @@ function getFreeTrialText(policies: OnyxCollection<Policy> | null, introSelected
     }
 
     if (shouldShowPreTrialBillingBanner(introSelected)) {
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         return translateLocal('subscription.billingBanner.preTrial.title');
     }
     if (isUserOnFreeTrial()) {
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         return translateLocal('subscription.billingBanner.trialStarted.title', {numOfDays: calculateRemainingFreeTrialDays()});
     }
 
@@ -616,53 +619,79 @@ function getSubscriptionPlanInfo(
     const hasTeam2025Pricing = checkIfHasTeam2025Pricing();
 
     if (subscriptionPlan === CONST.POLICY.TYPE.TEAM) {
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         let subtitle = translateLocal('subscription.yourPlan.customPricing');
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         let note: string | undefined = translateLocal('subscription.yourPlan.asLowAs', {price});
 
         if (hasTeam2025Pricing) {
             if (isFromComparisonModal) {
                 subtitle = price;
+                // eslint-disable-next-line @typescript-eslint/no-deprecated
                 note = translateLocal('subscription.yourPlan.perMemberMonth');
             } else {
+                // eslint-disable-next-line @typescript-eslint/no-deprecated
                 subtitle = translateLocal('subscription.yourPlan.pricePerMemberMonth', {price});
                 note = undefined;
             }
         }
 
         return {
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             title: translateLocal('subscription.yourPlan.collect.title'),
             subtitle,
             note,
             benefits: [
+                // eslint-disable-next-line @typescript-eslint/no-deprecated
                 translateLocal('subscription.yourPlan.collect.benefit1'),
+                // eslint-disable-next-line @typescript-eslint/no-deprecated
                 translateLocal('subscription.yourPlan.collect.benefit2'),
+                // eslint-disable-next-line @typescript-eslint/no-deprecated
                 translateLocal('subscription.yourPlan.collect.benefit3'),
+                // eslint-disable-next-line @typescript-eslint/no-deprecated
                 translateLocal('subscription.yourPlan.collect.benefit4'),
+                // eslint-disable-next-line @typescript-eslint/no-deprecated
                 translateLocal('subscription.yourPlan.collect.benefit5'),
+                // eslint-disable-next-line @typescript-eslint/no-deprecated
                 translateLocal('subscription.yourPlan.collect.benefit6'),
+                // eslint-disable-next-line @typescript-eslint/no-deprecated
                 translateLocal('subscription.yourPlan.collect.benefit7'),
+                // eslint-disable-next-line @typescript-eslint/no-deprecated
                 translateLocal('subscription.yourPlan.collect.benefit8'),
             ],
             src: Illustrations.Mailbox,
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             description: translateLocal('subscription.yourPlan.collect.description'),
         };
     }
 
     return {
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         title: translateLocal('subscription.yourPlan.control.title'),
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         subtitle: translateLocal('subscription.yourPlan.customPricing'),
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         note: translateLocal('subscription.yourPlan.asLowAs', {price}),
         benefits: [
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             translateLocal('subscription.yourPlan.control.benefit1'),
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             translateLocal('subscription.yourPlan.control.benefit2'),
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             translateLocal('subscription.yourPlan.control.benefit3'),
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             translateLocal('subscription.yourPlan.control.benefit4'),
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             translateLocal('subscription.yourPlan.control.benefit5'),
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             translateLocal('subscription.yourPlan.control.benefit6'),
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             translateLocal('subscription.yourPlan.control.benefit7'),
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             translateLocal('subscription.yourPlan.control.benefit8'),
         ],
         src: Illustrations.ShieldYellow,
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         description: translateLocal('subscription.yourPlan.control.description'),
     };
 }

--- a/src/libs/TagsOptionsListUtils.ts
+++ b/src/libs/TagsOptionsListUtils.ts
@@ -3,6 +3,7 @@ import type {LocaleContextProps} from '@components/LocaleContextProvider';
 import CONST from '@src/CONST';
 import type {Policy, PolicyTag, PolicyTagLists, PolicyTags, Transaction} from '@src/types/onyx';
 import type {PendingAction} from '@src/types/onyx/OnyxCommon';
+// eslint-disable-next-line @typescript-eslint/no-deprecated
 import {translateLocal} from './Localize';
 import {hasEnabledOptions} from './OptionsListUtils';
 import type {Option} from './OptionsListUtils';
@@ -143,6 +144,7 @@ function getTagListSections({
 
         tagSections.push({
             // "Recent" section
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             title: translateLocal('common.recent'),
             shouldShow: true,
             data: getTagsOptions(cutRecentlyUsedTags, selectedOptions),
@@ -151,6 +153,7 @@ function getTagListSections({
 
     tagSections.push({
         // "All" section when items amount more than the threshold
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         title: translateLocal('common.all'),
         shouldShow: true,
         data: getTagsOptions(enabledTagsWithoutSelectedOptions, selectedOptions),

--- a/src/libs/TaskUtils.ts
+++ b/src/libs/TaskUtils.ts
@@ -4,6 +4,7 @@ import ROUTES from '@src/ROUTES';
 import type {Report} from '@src/types/onyx';
 import type {Message} from '@src/types/onyx/ReportAction';
 import type ReportAction from '@src/types/onyx/ReportAction';
+// eslint-disable-next-line @typescript-eslint/no-deprecated
 import {translateLocal} from './Localize';
 import Navigation from './Navigation/Navigation';
 import Parser from './Parser';
@@ -26,10 +27,13 @@ function isActiveTaskEditRoute(reportID: string | undefined): boolean {
 function getTaskReportActionMessage(action: OnyxEntry<ReportAction>): Pick<Message, 'text' | 'html'> {
     switch (action?.actionName) {
         case CONST.REPORT.ACTIONS.TYPE.TASK_COMPLETED:
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             return {text: translateLocal('task.messages.completed')};
         case CONST.REPORT.ACTIONS.TYPE.TASK_CANCELLED:
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             return {text: translateLocal('task.messages.canceled')};
         case CONST.REPORT.ACTIONS.TYPE.TASK_REOPENED:
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             return {text: translateLocal('task.messages.reopened')};
         case CONST.REPORT.ACTIONS.TYPE.TASK_EDITED:
             return {
@@ -37,6 +41,7 @@ function getTaskReportActionMessage(action: OnyxEntry<ReportAction>): Pick<Messa
                 html: getReportActionHtml(action),
             };
         default:
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             return {text: translateLocal('task.task')};
     }
 }
@@ -56,6 +61,7 @@ function getTaskTitle(taskReport?: OnyxEntry<Report>, fallbackTitle = '', should
 
 function getTaskCreatedMessage(reportAction: OnyxEntry<ReportAction>, taskReport?: OnyxEntry<Report>, shouldReturnMarkdown = false) {
     const taskTitle = getTaskTitle(taskReport, reportAction?.childReportName, shouldReturnMarkdown);
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     return taskTitle ? translateLocal('task.messages.created', {title: taskTitle}) : '';
 }
 

--- a/src/libs/TransactionUtils/index.ts
+++ b/src/libs/TransactionUtils/index.ts
@@ -14,6 +14,7 @@ import {convertToBackendAmount, getCurrencyDecimals} from '@libs/CurrencyUtils';
 import DateUtils from '@libs/DateUtils';
 import DistanceRequestUtils from '@libs/DistanceRequestUtils';
 import {toLocaleDigit} from '@libs/LocaleDigitUtils';
+// eslint-disable-next-line @typescript-eslint/no-deprecated
 import {translateLocal} from '@libs/Localize';
 import Log from '@libs/Log';
 import {rand64, roundToTwoDecimalPlaces} from '@libs/NumberUtils';
@@ -528,6 +529,7 @@ function getUpdatedTransaction({
             // The waypoints were changed, but there is no route – it is pending from the BE and we should mark the fields as pending
             updatedTransaction.amount = CONST.IOU.DEFAULT_AMOUNT;
             updatedTransaction.modifiedAmount = CONST.IOU.DEFAULT_AMOUNT;
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             updatedTransaction.modifiedMerchant = translateLocal('iou.fieldPending');
         } else {
             const mileageRate = DistanceRequestUtils.getRate({transaction: updatedTransaction, policy});
@@ -536,6 +538,7 @@ function getUpdatedTransaction({
             const distanceInMeters = getDistanceInMeters(transaction, unit);
             const amount = DistanceRequestUtils.getDistanceRequestAmount(distanceInMeters, unit, rate ?? 0);
             const updatedAmount = isFromExpenseReport || isUnReportedExpense ? -amount : amount;
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             const updatedMerchant = DistanceRequestUtils.getDistanceMerchant(true, distanceInMeters, unit, rate, transaction.currency, translateLocal, (digit) =>
                 toLocaleDigit(IntlStore.getCurrentLocale(), digit),
             );
@@ -576,6 +579,7 @@ function getUpdatedTransaction({
             const amount = DistanceRequestUtils.getDistanceRequestAmount(distanceInMeters, unit, rate ?? 0);
             const updatedAmount = isFromExpenseReport || isUnReportedExpense ? -amount : amount;
             const updatedCurrency = updatedMileageRate.currency ?? CONST.CURRENCY.USD;
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             const updatedMerchant = DistanceRequestUtils.getDistanceMerchant(true, distanceInMeters, unit, rate, updatedCurrency, translateLocal, (digit) =>
                 toLocaleDigit(IntlStore.getCurrentLocale(), digit),
             );
@@ -644,6 +648,7 @@ function getUpdatedTransaction({
         let amount = DistanceRequestUtils.getDistanceRequestAmount(distanceInMeters, unit, rate ?? 0);
         amount = isFromExpenseReport || isUnReportedExpense ? -amount : amount;
         const updatedCurrency = updatedMileageRate.currency ?? CONST.CURRENCY.USD;
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         const updatedMerchant = DistanceRequestUtils.getDistanceMerchant(true, distanceInMeters, unit, rate, updatedCurrency, translateLocal, (digit) =>
             toLocaleDigit(IntlStore.getCurrentLocale(), digit),
         );
@@ -824,6 +829,7 @@ function getMerchant(transaction: OnyxInputOrEntry<Transaction>, policyParam: On
         const {unit, rate} = mileageRate;
         const distanceInMeters = getDistanceInMeters(transaction, unit);
         if (!isUnreportedAndHasInvalidDistanceRateTransaction(transaction, policy)) {
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             return DistanceRequestUtils.getDistanceMerchant(true, distanceInMeters, unit, rate, transaction.currency, translateLocal, (digit) =>
                 toLocaleDigit(IntlStore.getCurrentLocale(), digit),
             );
@@ -1464,7 +1470,7 @@ function transformedTaxRates(policy: OnyxEntry<Policy> | undefined, transaction?
 
         return policy && getDefaultTaxCode(policy, transaction);
     };
-
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     const getModifiedName = (data: TaxRate, code: string) => `${data.name} (${data.value})${defaultTaxCode() === code ? ` ${CONST.DOT_SEPARATOR} ${translateLocal('common.default')}` : ''}`;
     const taxes = Object.fromEntries(Object.entries(taxRates?.taxes ?? {}).map(([code, data]) => [code, {...data, code, modifiedName: getModifiedName(data, code), name: data.name}]));
     return taxes;

--- a/src/libs/UserUtils.ts
+++ b/src/libs/UserUtils.ts
@@ -10,6 +10,7 @@ import {isEmptyObject} from '@src/types/utils/EmptyObject';
 import type IconAsset from '@src/types/utils/IconAsset';
 import hashCode from './hashCode';
 import {formatPhoneNumber} from './LocalePhoneNumber';
+// eslint-disable-next-line @typescript-eslint/no-deprecated
 import {translateLocal} from './Localize';
 
 type AvatarRange = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12 | 13 | 14 | 15 | 16 | 17 | 18 | 19 | 20 | 21 | 22 | 23 | 24;
@@ -275,10 +276,13 @@ function getContactMethodsOptions(loginList?: LoginList, defaultEmail?: string) 
 
         let description = '';
         if (defaultEmail === login?.partnerUserID) {
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             description = translateLocal('contacts.getInTouch');
         } else if (login?.errorFields?.addedLogin) {
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             description = translateLocal('contacts.failedNewContact');
         } else if (!login?.validatedDate) {
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             description = translateLocal('contacts.pleaseVerify');
         }
         let indicator;

--- a/src/libs/ValidationUtils.ts
+++ b/src/libs/ValidationUtils.ts
@@ -10,6 +10,7 @@ import type {OnyxFormKey} from '@src/ONYXKEYS';
 import type {Report, TaxRates} from '@src/types/onyx';
 import {getMonthFromExpirationDateString, getYearFromExpirationDateString} from './CardUtils';
 import DateUtils from './DateUtils';
+// eslint-disable-next-line @typescript-eslint/no-deprecated
 import {translateLocal} from './Localize';
 import {getPhoneNumberWithoutSpecialChars} from './LoginUtils';
 import {parsePhoneNumber} from './PhoneNumber';
@@ -127,7 +128,7 @@ function getFieldRequiredErrors<TFormID extends OnyxFormKey>(values: FormOnyxVal
         if (isRequiredFulfilled(values[fieldKey] as FormValue)) {
             return;
         }
-
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         errors[fieldKey] = translateLocal('common.error.fieldRequired');
     });
 
@@ -216,6 +217,7 @@ function getAgeRequirementError(date: string, minimumAge: number, maximumAge: nu
     const testDate = parse(date, CONST.DATE.FNS_FORMAT_STRING, currentDate);
 
     if (!isValid(testDate)) {
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         return translateLocal('common.error.dateInvalid');
     }
 
@@ -227,9 +229,10 @@ function getAgeRequirementError(date: string, minimumAge: number, maximumAge: nu
     }
 
     if (isSameDay(testDate, maximalDate) || isAfter(testDate, maximalDate)) {
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         return translateLocal('privatePersonalDetails.error.dateShouldBeBefore', {dateString: format(maximalDate, CONST.DATE.FNS_FORMAT_STRING)});
     }
-
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     return translateLocal('privatePersonalDetails.error.dateShouldBeAfter', {dateString: format(minimalDate, CONST.DATE.FNS_FORMAT_STRING)});
 }
 
@@ -242,6 +245,7 @@ function getDatePassedError(inputDate: string): string {
 
     // If input date is not valid, return an error
     if (!isValid(parsedDate)) {
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         return translateLocal('common.error.dateInvalid');
     }
 
@@ -249,6 +253,7 @@ function getDatePassedError(inputDate: string): string {
     currentDate.setHours(0, 0, 0, 0);
 
     if (parsedDate < currentDate) {
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         return translateLocal('common.error.dateInvalid');
     }
 

--- a/src/libs/WorkspaceReportFieldUtils.ts
+++ b/src/libs/WorkspaceReportFieldUtils.ts
@@ -5,6 +5,7 @@ import type ONYXKEYS from '@src/ONYXKEYS';
 import type {InputID} from '@src/types/form/WorkspaceReportFieldForm';
 import type {PolicyReportField, PolicyReportFieldType} from '@src/types/onyx/Policy';
 import {addErrorMessage} from './ErrorUtils';
+// eslint-disable-next-line @typescript-eslint/no-deprecated
 import {translateLocal} from './Localize';
 import {isRequiredFulfilled} from './ValidationUtils';
 
@@ -46,11 +47,14 @@ function validateReportFieldListValueName(
     const errors: FormInputErrors<typeof ONYXKEYS.FORMS.WORKSPACE_REPORT_FIELDS_FORM> = {};
 
     if (!isRequiredFulfilled(valueName)) {
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         errors[inputID] = translateLocal('workspace.reportFields.listValueRequiredError');
     } else if (priorValueName !== valueName && listValues.some((currentValueName) => currentValueName === valueName)) {
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         errors[inputID] = translateLocal('workspace.reportFields.existingListValueError');
     } else if ([...valueName].length > CONST.WORKSPACE_REPORT_FIELD_POLICY_MAX_LENGTH) {
         // Uses the spread syntax to count the number of Unicode code points instead of the number of UTF-16 code units.
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         addErrorMessage(errors, inputID, translateLocal('common.error.characterLimitExceedCounter', {length: [...valueName].length, limit: CONST.WORKSPACE_REPORT_FIELD_POLICY_MAX_LENGTH}));
     }
 
@@ -76,6 +80,7 @@ function getReportFieldInitialValue(reportField: PolicyReportField | null): stri
     }
 
     if (reportField.type === CONST.REPORT_FIELD_TYPES.DATE) {
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         return translateLocal('common.currentDate');
     }
 

--- a/src/libs/actions/BankAccounts.ts
+++ b/src/libs/actions/BankAccounts.ts
@@ -21,6 +21,7 @@ import type {SaveCorpayOnboardingCompanyDetails} from '@libs/API/parameters/Save
 import type SaveCorpayOnboardingDirectorInformationParams from '@libs/API/parameters/SaveCorpayOnboardingDirectorInformationParams';
 import {READ_COMMANDS, WRITE_COMMANDS} from '@libs/API/types';
 import {getMicroSecondOnyxErrorWithTranslationKey} from '@libs/ErrorUtils';
+// eslint-disable-next-line @typescript-eslint/no-deprecated
 import {translateLocal} from '@libs/Localize';
 import Navigation from '@libs/Navigation/Navigation';
 import {getPersonalPolicy} from '@libs/PolicyUtils';
@@ -1174,6 +1175,7 @@ function validatePlaidSelection(values: FormOnyxValues<AccountFormValues>): Form
     const errorFields: FormInputErrors<AccountFormValues> = {};
 
     if (!values.selectedPlaidAccountID) {
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         errorFields.selectedPlaidAccountID = translateLocal('bankAccount.error.youNeedToSelectAnOption');
     }
 

--- a/src/libs/actions/IOU.ts
+++ b/src/libs/actions/IOU.ts
@@ -1479,7 +1479,7 @@ function buildOnyxDataForTestDriveIOU(testDriveIOUParams: BuildOnyxDataForTestDr
         transactionID: testDriveIOUParams.transaction.transactionID,
         reportActionID: testDriveIOUParams.iouOptimisticParams.action.reportActionID,
     });
-
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     const text = Localize.translateLocal('testDrive.employeeInviteMessage', {name: personalDetailsList?.[userAccountID]?.firstName ?? ''});
     const textComment = buildOptimisticAddCommentReportAction(text, undefined, userAccountID, undefined, undefined, undefined, testDriveIOUParams.testDriveCommentReportActionID);
     textComment.reportAction.created = DateUtils.subtractMillisecondsFromDateTime(testDriveIOUParams.iouOptimisticParams.createdAction.created, 1);
@@ -4241,6 +4241,7 @@ function getUpdateMoneyRequestParams(params: GetUpdateMoneyRequestParamsType): U
     // Step 1: Set any "pending fields" (ones updated while the user was offline) to have error messages in the failureData
     const pendingFields: OnyxTypes.Transaction['pendingFields'] = Object.fromEntries(Object.keys(transactionChanges).map((key) => [key, CONST.RED_BRICK_ROAD_PENDING_ACTION.UPDATE]));
     const clearedPendingFields = getClearedPendingFields(transactionChanges);
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     const errorFields = Object.fromEntries(Object.keys(pendingFields).map((key) => [key, {[DateUtils.getMicroseconds()]: Localize.translateLocal('iou.error.genericEditFailureMessage')}]));
 
     // Step 2: Get all the collections being updated
@@ -4703,6 +4704,7 @@ function getUpdateTrackExpenseParams(
     // Step 1: Set any "pending fields" (ones updated while the user was offline) to have error messages in the failureData
     const pendingFields = Object.fromEntries(Object.keys(transactionChanges).map((key) => [key, CONST.RED_BRICK_ROAD_PENDING_ACTION.UPDATE]));
     const clearedPendingFields = getClearedPendingFields(transactionChanges);
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     const errorFields = Object.fromEntries(Object.keys(pendingFields).map((key) => [key, {[DateUtils.getMicroseconds()]: Localize.translateLocal('iou.error.genericEditFailureMessage')}]));
 
     // Step 2: Get all the collections being updated
@@ -6628,6 +6630,7 @@ function createSplitsAndOnyxData({
             reportID: CONST.REPORT.SPLIT_REPORT_ID,
             comment,
             created,
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             merchant: merchant || Localize.translateLocal('iou.expense'),
             receipt,
             category,
@@ -6912,6 +6915,7 @@ function createSplitsAndOnyxData({
                 reportID: oneOnOneIOUReport.reportID,
                 comment,
                 created,
+                // eslint-disable-next-line @typescript-eslint/no-deprecated
                 merchant: merchant || Localize.translateLocal('iou.expense'),
                 category,
                 tag,
@@ -8306,6 +8310,7 @@ function prepareToCleanUpMoneyRequest(
     }
 
     const hasNonReimbursableTransactions = hasNonReimbursableTransactionsReportUtils(iouReport?.reportID);
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     const messageText = Localize.translateLocal(hasNonReimbursableTransactions ? 'iou.payerSpentAmount' : 'iou.payerOwesAmount', {
         payer: getPersonalDetailsForAccountID(updatedIOUReport?.managerID ?? CONST.DEFAULT_NUMBER_ID).login ?? '',
         amount: convertToDisplayString(updatedIOUReport?.total, updatedIOUReport?.currency),
@@ -8817,6 +8822,7 @@ function deleteMoneyRequest(
                     ...reportAction,
                     pendingAction: null,
                     errors: {
+                        // eslint-disable-next-line @typescript-eslint/no-deprecated
                         [errorKey]: Localize.translateLocal('iou.error.genericDeleteFailureMessage'),
                     },
                 },
@@ -8844,6 +8850,7 @@ function deleteMoneyRequest(
                     ...reportPreviewAction,
                     pendingAction: null,
                     errors: {
+                        // eslint-disable-next-line @typescript-eslint/no-deprecated
                         [errorKey]: Localize.translateLocal('iou.error.genericDeleteFailureMessage'),
                     },
                 },

--- a/src/libs/actions/Policy/Category.ts
+++ b/src/libs/actions/Policy/Category.ts
@@ -23,6 +23,7 @@ import * as CurrencyUtils from '@libs/CurrencyUtils';
 import * as ErrorUtils from '@libs/ErrorUtils';
 import fileDownload from '@libs/fileDownload';
 import getIsNarrowLayout from '@libs/getIsNarrowLayout';
+// eslint-disable-next-line @typescript-eslint/no-deprecated
 import {translateLocal} from '@libs/Localize';
 import Log from '@libs/Log';
 import enhanceParameters from '@libs/Network/enhanceParameters';
@@ -258,7 +259,9 @@ function updateImportSpreadsheetData(categoriesLength: number) {
                 value: {
                     shouldFinalModalBeOpened: true,
                     importFinalModal: {
+                        // eslint-disable-next-line @typescript-eslint/no-deprecated
                         title: translateLocal('spreadsheet.importSuccessfulTitle'),
+                        // eslint-disable-next-line @typescript-eslint/no-deprecated
                         prompt: translateLocal('spreadsheet.importCategoriesSuccessfulDescription', {categories: categoriesLength}),
                     },
                 },
@@ -271,6 +274,7 @@ function updateImportSpreadsheetData(categoriesLength: number) {
                 key: ONYXKEYS.IMPORTED_SPREADSHEET,
                 value: {
                     shouldFinalModalBeOpened: true,
+                    // eslint-disable-next-line @typescript-eslint/no-deprecated
                     importFinalModal: {title: translateLocal('spreadsheet.importFailedTitle'), prompt: translateLocal('spreadsheet.importFailedDescription')},
                 },
             },

--- a/src/libs/actions/Policy/Member.ts
+++ b/src/libs/actions/Policy/Member.ts
@@ -16,6 +16,7 @@ import * as ApiUtils from '@libs/ApiUtils';
 import DateUtils from '@libs/DateUtils';
 import * as ErrorUtils from '@libs/ErrorUtils';
 import fileDownload from '@libs/fileDownload';
+// eslint-disable-next-line @typescript-eslint/no-deprecated
 import {translateLocal} from '@libs/Localize';
 import Log from '@libs/Log';
 import enhanceParameters from '@libs/Network/enhanceParameters';
@@ -230,7 +231,9 @@ function updateImportSpreadsheetData(addedMembersLength: number, updatedMembersL
                 value: {
                     shouldFinalModalBeOpened: true,
                     importFinalModal: {
+                        // eslint-disable-next-line @typescript-eslint/no-deprecated
                         title: translateLocal('spreadsheet.importSuccessfulTitle'),
+                        // eslint-disable-next-line @typescript-eslint/no-deprecated
                         prompt: translateLocal('spreadsheet.importMembersSuccessfulDescription', {added: addedMembersLength, updated: updatedMembersLength}),
                     },
                 },
@@ -243,6 +246,7 @@ function updateImportSpreadsheetData(addedMembersLength: number, updatedMembersL
                 key: ONYXKEYS.IMPORTED_SPREADSHEET,
                 value: {
                     shouldFinalModalBeOpened: true,
+                    // eslint-disable-next-line @typescript-eslint/no-deprecated
                     importFinalModal: {title: translateLocal('spreadsheet.importFailedTitle'), prompt: translateLocal('spreadsheet.importFailedDescription')},
                 },
             },

--- a/src/libs/actions/Policy/PerDiem.ts
+++ b/src/libs/actions/Policy/PerDiem.ts
@@ -6,6 +6,7 @@ import {READ_COMMANDS, WRITE_COMMANDS} from '@libs/API/types';
 import {getCommandURL} from '@libs/ApiUtils';
 import fileDownload from '@libs/fileDownload';
 import getIsNarrowLayout from '@libs/getIsNarrowLayout';
+// eslint-disable-next-line @typescript-eslint/no-deprecated
 import {translateLocal} from '@libs/Localize';
 import enhanceParameters from '@libs/Network/enhanceParameters';
 import {generateHexadecimalValue} from '@libs/NumberUtils';
@@ -111,7 +112,9 @@ function updateImportSpreadsheetData(ratesLength: number) {
                 value: {
                     shouldFinalModalBeOpened: true,
                     importFinalModal: {
+                        // eslint-disable-next-line @typescript-eslint/no-deprecated
                         title: translateLocal('spreadsheet.importSuccessfulTitle'),
+                        // eslint-disable-next-line @typescript-eslint/no-deprecated
                         prompt: translateLocal('spreadsheet.importPerDiemRatesSuccessfulDescription', {rates: ratesLength}),
                     },
                 },
@@ -124,6 +127,7 @@ function updateImportSpreadsheetData(ratesLength: number) {
                 key: ONYXKEYS.IMPORTED_SPREADSHEET,
                 value: {
                     shouldFinalModalBeOpened: true,
+                    // eslint-disable-next-line @typescript-eslint/no-deprecated
                     importFinalModal: {title: translateLocal('spreadsheet.importFailedTitle'), prompt: translateLocal('spreadsheet.importFailedDescription')},
                 },
             },

--- a/src/libs/actions/Policy/Policy.ts
+++ b/src/libs/actions/Policy/Policy.ts
@@ -79,6 +79,7 @@ import * as ErrorUtils from '@libs/ErrorUtils';
 import {createFile} from '@libs/fileDownload/FileUtils';
 import getIsNarrowLayout from '@libs/getIsNarrowLayout';
 import GoogleTagManager from '@libs/GoogleTagManager';
+// eslint-disable-next-line @typescript-eslint/no-deprecated
 import {translate, translateLocal} from '@libs/Localize';
 import Log from '@libs/Log';
 import * as NetworkStore from '@libs/Network/NetworkStore';
@@ -1869,10 +1870,12 @@ function generateDefaultWorkspaceName(email = ''): string {
 
     const isSMSDomain = `@${domain}` === CONST.SMS.DOMAIN;
     if (isSMSDomain) {
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         displayNameForWorkspace = translateLocal('workspace.new.myGroupWorkspace', {});
     }
 
     if (isEmptyObject(allPolicies)) {
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         return isSMSDomain ? translateLocal('workspace.new.myGroupWorkspace', {}) : translateLocal('workspace.new.workspaceName', {userName: displayNameForWorkspace});
     }
 
@@ -1891,8 +1894,10 @@ function generateDefaultWorkspaceName(email = ''): string {
     const lastWorkspaceNumber = workspaceNumbers.length > 0 ? Math.max(...workspaceNumbers) : undefined;
 
     if (isSMSDomain) {
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         return translateLocal('workspace.new.myGroupWorkspace', {workspaceNumber: lastWorkspaceNumber !== undefined ? lastWorkspaceNumber + 1 : undefined});
     }
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     return translateLocal('workspace.new.workspaceName', {userName: displayNameForWorkspace, workspaceNumber: lastWorkspaceNumber !== undefined ? lastWorkspaceNumber + 1 : undefined});
 }
 

--- a/src/libs/actions/Policy/Tag.ts
+++ b/src/libs/actions/Policy/Tag.ts
@@ -20,6 +20,7 @@ import * as ErrorUtils from '@libs/ErrorUtils';
 import fileDownload from '@libs/fileDownload';
 import {readFileAsync} from '@libs/fileDownload/FileUtils';
 import getIsNarrowLayout from '@libs/getIsNarrowLayout';
+// eslint-disable-next-line @typescript-eslint/no-deprecated
 import {translateLocal} from '@libs/Localize';
 import Log from '@libs/Log';
 import enhanceParameters from '@libs/Network/enhanceParameters';
@@ -96,7 +97,9 @@ function updateImportSpreadsheetData(tagsLength: number): OnyxData {
                 value: {
                     shouldFinalModalBeOpened: true,
                     importFinalModal: {
+                        // eslint-disable-next-line @typescript-eslint/no-deprecated
                         title: translateLocal('spreadsheet.importSuccessfulTitle'),
+                        // eslint-disable-next-line @typescript-eslint/no-deprecated
                         prompt: translateLocal('spreadsheet.importTagsSuccessfulDescription', {tags: tagsLength}),
                     },
                 },
@@ -109,6 +112,7 @@ function updateImportSpreadsheetData(tagsLength: number): OnyxData {
                 key: ONYXKEYS.IMPORTED_SPREADSHEET,
                 value: {
                     shouldFinalModalBeOpened: true,
+                    // eslint-disable-next-line @typescript-eslint/no-deprecated
                     importFinalModal: {title: translateLocal('spreadsheet.importFailedTitle'), prompt: translateLocal('spreadsheet.importFailedDescription')},
                 },
             },
@@ -805,6 +809,7 @@ function importMultiLevelTags(policyID: string, spreadsheet: ImportedSpreadsheet
                 key: ONYXKEYS.IMPORTED_SPREADSHEET,
                 value: {
                     shouldFinalModalBeOpened: true,
+                    // eslint-disable-next-line @typescript-eslint/no-deprecated
                     importFinalModal: {title: translateLocal('spreadsheet.importSuccessfulTitle'), prompt: translateLocal('spreadsheet.importMultiLevelTagsSuccessfulDescription')},
                 },
             },
@@ -822,6 +827,7 @@ function importMultiLevelTags(policyID: string, spreadsheet: ImportedSpreadsheet
                 key: ONYXKEYS.IMPORTED_SPREADSHEET,
                 value: {
                     shouldFinalModalBeOpened: true,
+                    // eslint-disable-next-line @typescript-eslint/no-deprecated
                     importFinalModal: {title: translateLocal('spreadsheet.importFailedTitle'), prompt: translateLocal('spreadsheet.importFailedDescription')},
                 },
             },

--- a/src/libs/actions/Report.ts
+++ b/src/libs/actions/Report.ts
@@ -3554,6 +3554,7 @@ function openReportFromDeepLink(
                             const currentFocusedRoute = findFocusedRoute(state);
 
                             if (isOnboardingFlowName(currentFocusedRoute?.name)) {
+                                // eslint-disable-next-line @typescript-eslint/no-deprecated
                                 setOnboardingErrorMessage(Localize.translateLocal('onboarding.purpose.errorBackButton'));
                                 return;
                             }
@@ -4559,6 +4560,7 @@ function resolveActionableMentionWhisper(
         if (actionOriginalMessage && policyID) {
             const currentUserDetails = allPersonalDetails?.[getCurrentUserAccountID()];
             const welcomeNoteSubject = `# ${currentUserDetails?.displayName ?? ''} invited you to ${policy?.name ?? 'a workspace'}`;
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             const welcomeNote = Localize.translateLocal('workspace.common.welcomeNote');
             const policyMemberAccountIDs = Object.values(getMemberAccountIDsForWorkspace(policy?.employeeList, false, false));
 

--- a/src/libs/actions/Search.ts
+++ b/src/libs/actions/Search.ts
@@ -680,6 +680,7 @@ function getExportTemplates(
     const exportTemplates: ExportTemplate[] = [
         normalizeTemplate(
             CONST.REPORT.EXPORT_OPTIONS.EXPENSE_LEVEL_EXPORT,
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             {name: Localize.translateLocal('export.expenseLevelExport')} as ExportTemplate,
             CONST.EXPORT_TEMPLATE_TYPES.INTEGRATIONS,
         ),
@@ -690,6 +691,7 @@ function getExportTemplates(
         exportTemplates.push(
             normalizeTemplate(
                 CONST.REPORT.EXPORT_OPTIONS.REPORT_LEVEL_EXPORT,
+                // eslint-disable-next-line @typescript-eslint/no-deprecated
                 {name: Localize.translateLocal('export.reportLevelExport')} as ExportTemplate,
                 CONST.EXPORT_TEMPLATE_TYPES.INTEGRATIONS,
             ),

--- a/src/libs/actions/Session/index.ts
+++ b/src/libs/actions/Session/index.ts
@@ -31,6 +31,7 @@ import * as ErrorUtils from '@libs/ErrorUtils';
 import FraudProtection from '@libs/FraudProtection';
 import Fullstory from '@libs/Fullstory';
 import HttpUtils from '@libs/HttpUtils';
+// eslint-disable-next-line @typescript-eslint/no-deprecated
 import {translateLocal} from '@libs/Localize';
 import Log from '@libs/Log';
 import Navigation from '@libs/Navigation/Navigation';
@@ -1407,6 +1408,7 @@ function MergeIntoAccountAndLogin(workEmail: string | undefined, validateCode: s
         if (response?.jsonCode === CONST.JSON_CODE.EXP_ERROR) {
             // If the error other than invalid code, we show a blocking screen
             if (response?.message === CONST.MERGE_ACCOUNT_INVALID_CODE_ERROR || response?.title === CONST.MERGE_ACCOUNT_INVALID_CODE_ERROR) {
+                // eslint-disable-next-line @typescript-eslint/no-deprecated
                 Onyx.merge(ONYXKEYS.ONBOARDING_ERROR_MESSAGE, translateLocal('contacts.genericFailureMessages.validateSecondaryLogin'));
             } else {
                 Onyx.merge(ONYXKEYS.NVP_ONBOARDING, {isMergingAccountBlocked: true});

--- a/src/libs/actions/TaxRate.ts
+++ b/src/libs/actions/TaxRate.ts
@@ -12,6 +12,7 @@ import type {
     UpdatePolicyTaxValueParams,
 } from '@libs/API/parameters';
 import {WRITE_COMMANDS} from '@libs/API/types';
+// eslint-disable-next-line @typescript-eslint/no-deprecated
 import {translateLocal} from '@libs/Localize';
 import {getDistanceRateCustomUnit} from '@libs/PolicyUtils';
 import {getFieldRequiredErrors, isExistingTaxCode, isExistingTaxName, isValidPercentage} from '@libs/ValidationUtils';
@@ -45,11 +46,13 @@ const validateTaxName = (policy: Policy, values: FormOnyxValues<typeof ONYXKEYS.
 
     const name = values[INPUT_IDS.NAME];
     if (name.length > CONST.TAX_RATES.NAME_MAX_LENGTH) {
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         errors[INPUT_IDS.NAME] = translateLocal('common.error.characterLimitExceedCounter', {
             length: name.length,
             limit: CONST.TAX_RATES.NAME_MAX_LENGTH,
         });
     } else if (policy?.taxRates?.taxes && isExistingTaxName(name, policy.taxRates.taxes)) {
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         errors[INPUT_IDS.NAME] = translateLocal('workspace.taxes.error.taxRateAlreadyExists');
     }
 
@@ -61,11 +64,13 @@ const validateTaxCode = (policy: Policy, values: FormOnyxValues<typeof ONYXKEYS.
 
     const taxCode = values[INPUT_IDS_TAX_CODE.TAX_CODE];
     if (taxCode.length > CONST.TAX_RATES.NAME_MAX_LENGTH) {
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         errors[INPUT_IDS_TAX_CODE.TAX_CODE] = translateLocal('common.error.characterLimitExceedCounter', {
             length: taxCode.length,
             limit: CONST.TAX_RATES.NAME_MAX_LENGTH,
         });
     } else if (policy?.taxRates?.taxes && isExistingTaxCode(taxCode, policy.taxRates.taxes)) {
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         errors[INPUT_IDS_TAX_CODE.TAX_CODE] = translateLocal('workspace.taxes.error.taxCodeAlreadyExists');
     }
 
@@ -80,6 +85,7 @@ const validateTaxValue = (values: FormOnyxValues<typeof ONYXKEYS.FORMS.WORKSPACE
 
     const value = values[INPUT_IDS.VALUE];
     if (!isValidPercentage(value)) {
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         errors[INPUT_IDS.VALUE] = translateLocal('workspace.taxes.error.valuePercentageRange');
     }
 

--- a/src/libs/fileDownload/FileUtils.ts
+++ b/src/libs/fileDownload/FileUtils.ts
@@ -7,7 +7,6 @@ import ImageSize from 'react-native-image-size';
 import type {TupleToUnion, ValueOf} from 'type-fest';
 import DateUtils from '@libs/DateUtils';
 import getPlatform from '@libs/getPlatform';
-// eslint-disable-next-line @typescript-eslint/no-deprecated
 import {translateLocal} from '@libs/Localize';
 import Log from '@libs/Log';
 import saveLastRoute from '@libs/saveLastRoute';
@@ -24,16 +23,12 @@ import type {ReadFileAsync, SplitExtensionFromFileName} from './types';
  */
 function showSuccessAlert(successMessage?: string) {
     Alert.alert(
-        // eslint-disable-next-line @typescript-eslint/no-deprecated
         translateLocal('fileDownload.success.title'),
-        // eslint-disable-next-line @typescript-eslint/no-deprecated
         // successMessage can be an empty string and we want to default to `Localize.translateLocal('fileDownload.success.message')`
         // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-        // eslint-disable-next-line @typescript-eslint/no-deprecated
         successMessage || translateLocal('fileDownload.success.message'),
         [
             {
-                // eslint-disable-next-line @typescript-eslint/no-deprecated
                 text: translateLocal('common.ok'),
                 style: 'cancel',
             },
@@ -46,10 +41,8 @@ function showSuccessAlert(successMessage?: string) {
  * Show alert on attachment download error
  */
 function showGeneralErrorAlert() {
-    // eslint-disable-next-line @typescript-eslint/no-deprecated
     Alert.alert(translateLocal('fileDownload.generalError.title'), translateLocal('fileDownload.generalError.message'), [
         {
-            // eslint-disable-next-line @typescript-eslint/no-deprecated
             text: translateLocal('common.cancel'),
             style: 'cancel',
         },
@@ -60,15 +53,12 @@ function showGeneralErrorAlert() {
  * Show alert on attachment download permissions error
  */
 function showPermissionErrorAlert() {
-    // eslint-disable-next-line @typescript-eslint/no-deprecated
     Alert.alert(translateLocal('fileDownload.permissionError.title'), translateLocal('fileDownload.permissionError.message'), [
         {
-            // eslint-disable-next-line @typescript-eslint/no-deprecated
             text: translateLocal('common.cancel'),
             style: 'cancel',
         },
         {
-            // eslint-disable-next-line @typescript-eslint/no-deprecated
             text: translateLocal('common.settings'),
             onPress: () => {
                 Linking.openSettings();
@@ -82,18 +72,14 @@ function showPermissionErrorAlert() {
  */
 function showCameraPermissionsAlert() {
     Alert.alert(
-        // eslint-disable-next-line @typescript-eslint/no-deprecated
         translateLocal('attachmentPicker.cameraPermissionRequired'),
-        // eslint-disable-next-line @typescript-eslint/no-deprecated
         translateLocal('attachmentPicker.expensifyDoesNotHaveAccessToCamera'),
         [
             {
-                // eslint-disable-next-line @typescript-eslint/no-deprecated
                 text: translateLocal('common.cancel'),
                 style: 'cancel',
             },
             {
-                // eslint-disable-next-line @typescript-eslint/no-deprecated
                 text: translateLocal('common.settings'),
                 onPress: () => {
                     Linking.openSettings();
@@ -611,79 +597,58 @@ const getFileValidationErrorText = (
     switch (validationError) {
         case CONST.FILE_VALIDATION_ERRORS.WRONG_FILE_TYPE:
             return {
-                // eslint-disable-next-line @typescript-eslint/no-deprecated
                 title: translateLocal('attachmentPicker.wrongFileType'),
-                // eslint-disable-next-line @typescript-eslint/no-deprecated
                 reason: translateLocal('attachmentPicker.notAllowedExtension'),
             };
         case CONST.FILE_VALIDATION_ERRORS.WRONG_FILE_TYPE_MULTIPLE:
             return {
-                // eslint-disable-next-line @typescript-eslint/no-deprecated
                 title: translateLocal('attachmentPicker.someFilesCantBeUploaded'),
-                // eslint-disable-next-line @typescript-eslint/no-deprecated
                 reason: translateLocal('attachmentPicker.unsupportedFileType', {fileType: additionalData.fileType ?? ''}),
             };
         case CONST.FILE_VALIDATION_ERRORS.FILE_TOO_LARGE:
             return {
-                // eslint-disable-next-line @typescript-eslint/no-deprecated
                 title: translateLocal('attachmentPicker.attachmentTooLarge'),
                 reason: isValidatingReceipt
-                    ? // eslint-disable-next-line @typescript-eslint/no-deprecated
-                      translateLocal('attachmentPicker.sizeExceededWithLimit', {
+                    ? translateLocal('attachmentPicker.sizeExceededWithLimit', {
                           maxUploadSizeInMB: additionalData.maxUploadSizeInMB ?? CONST.API_ATTACHMENT_VALIDATIONS.RECEIPT_MAX_SIZE / 1024 / 1024,
                       })
-                    : // eslint-disable-next-line @typescript-eslint/no-deprecated
-                      translateLocal('attachmentPicker.sizeExceeded'),
+                    : translateLocal('attachmentPicker.sizeExceeded'),
             };
         case CONST.FILE_VALIDATION_ERRORS.FILE_TOO_LARGE_MULTIPLE:
             return {
-                // eslint-disable-next-line @typescript-eslint/no-deprecated
                 title: translateLocal('attachmentPicker.someFilesCantBeUploaded'),
-                // eslint-disable-next-line @typescript-eslint/no-deprecated
                 reason: translateLocal('attachmentPicker.sizeLimitExceeded', {
                     maxUploadSizeInMB: additionalData.maxUploadSizeInMB ?? maxSize / 1024 / 1024,
                 }),
             };
         case CONST.FILE_VALIDATION_ERRORS.FILE_TOO_SMALL:
             return {
-                // eslint-disable-next-line @typescript-eslint/no-deprecated
                 title: translateLocal('attachmentPicker.attachmentTooSmall'),
-                // eslint-disable-next-line @typescript-eslint/no-deprecated
                 reason: translateLocal('attachmentPicker.sizeNotMet'),
             };
         case CONST.FILE_VALIDATION_ERRORS.FOLDER_NOT_ALLOWED:
             return {
-                // eslint-disable-next-line @typescript-eslint/no-deprecated
                 title: translateLocal('attachmentPicker.attachmentError'),
-                // eslint-disable-next-line @typescript-eslint/no-deprecated
                 reason: translateLocal('attachmentPicker.folderNotAllowedMessage'),
             };
         case CONST.FILE_VALIDATION_ERRORS.MAX_FILE_LIMIT_EXCEEDED:
             return {
-                // eslint-disable-next-line @typescript-eslint/no-deprecated
                 title: translateLocal('attachmentPicker.someFilesCantBeUploaded'),
-                // eslint-disable-next-line @typescript-eslint/no-deprecated
                 reason: translateLocal('attachmentPicker.maxFileLimitExceeded'),
             };
         case CONST.FILE_VALIDATION_ERRORS.FILE_CORRUPTED:
             return {
-                // eslint-disable-next-line @typescript-eslint/no-deprecated
                 title: translateLocal('attachmentPicker.attachmentError'),
-                // eslint-disable-next-line @typescript-eslint/no-deprecated
                 reason: translateLocal('attachmentPicker.errorWhileSelectingCorruptedAttachment'),
             };
         case CONST.FILE_VALIDATION_ERRORS.PROTECTED_FILE:
             return {
-                // eslint-disable-next-line @typescript-eslint/no-deprecated
                 title: translateLocal('attachmentPicker.attachmentError'),
-                // eslint-disable-next-line @typescript-eslint/no-deprecated
                 reason: translateLocal('attachmentPicker.protectedPDFNotSupported'),
             };
         default:
             return {
-                // eslint-disable-next-line @typescript-eslint/no-deprecated
                 title: translateLocal('attachmentPicker.attachmentError'),
-                // eslint-disable-next-line @typescript-eslint/no-deprecated
                 reason: translateLocal('attachmentPicker.errorWhileSelectingCorruptedAttachment'),
             };
     }
@@ -694,10 +659,8 @@ const getConfirmModalPrompt = (attachmentInvalidReason: TranslationPaths | undef
         return '';
     }
     if (attachmentInvalidReason === 'attachmentPicker.sizeExceededWithLimit') {
-        // eslint-disable-next-line @typescript-eslint/no-deprecated
         return translateLocal(attachmentInvalidReason, {maxUploadSizeInMB: CONST.API_ATTACHMENT_VALIDATIONS.RECEIPT_MAX_SIZE / (1024 * 1024)});
     }
-    // eslint-disable-next-line @typescript-eslint/no-deprecated
     return translateLocal(attachmentInvalidReason);
 };
 

--- a/src/libs/fileDownload/FileUtils.ts
+++ b/src/libs/fileDownload/FileUtils.ts
@@ -7,6 +7,7 @@ import ImageSize from 'react-native-image-size';
 import type {TupleToUnion, ValueOf} from 'type-fest';
 import DateUtils from '@libs/DateUtils';
 import getPlatform from '@libs/getPlatform';
+// eslint-disable-next-line @typescript-eslint/no-deprecated
 import {translateLocal} from '@libs/Localize';
 import Log from '@libs/Log';
 import saveLastRoute from '@libs/saveLastRoute';
@@ -23,12 +24,16 @@ import type {ReadFileAsync, SplitExtensionFromFileName} from './types';
  */
 function showSuccessAlert(successMessage?: string) {
     Alert.alert(
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         translateLocal('fileDownload.success.title'),
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         // successMessage can be an empty string and we want to default to `Localize.translateLocal('fileDownload.success.message')`
         // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         successMessage || translateLocal('fileDownload.success.message'),
         [
             {
+                // eslint-disable-next-line @typescript-eslint/no-deprecated
                 text: translateLocal('common.ok'),
                 style: 'cancel',
             },
@@ -41,8 +46,10 @@ function showSuccessAlert(successMessage?: string) {
  * Show alert on attachment download error
  */
 function showGeneralErrorAlert() {
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     Alert.alert(translateLocal('fileDownload.generalError.title'), translateLocal('fileDownload.generalError.message'), [
         {
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             text: translateLocal('common.cancel'),
             style: 'cancel',
         },
@@ -53,12 +60,15 @@ function showGeneralErrorAlert() {
  * Show alert on attachment download permissions error
  */
 function showPermissionErrorAlert() {
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     Alert.alert(translateLocal('fileDownload.permissionError.title'), translateLocal('fileDownload.permissionError.message'), [
         {
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             text: translateLocal('common.cancel'),
             style: 'cancel',
         },
         {
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             text: translateLocal('common.settings'),
             onPress: () => {
                 Linking.openSettings();
@@ -72,14 +82,18 @@ function showPermissionErrorAlert() {
  */
 function showCameraPermissionsAlert() {
     Alert.alert(
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         translateLocal('attachmentPicker.cameraPermissionRequired'),
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         translateLocal('attachmentPicker.expensifyDoesNotHaveAccessToCamera'),
         [
             {
+                // eslint-disable-next-line @typescript-eslint/no-deprecated
                 text: translateLocal('common.cancel'),
                 style: 'cancel',
             },
             {
+                // eslint-disable-next-line @typescript-eslint/no-deprecated
                 text: translateLocal('common.settings'),
                 onPress: () => {
                     Linking.openSettings();
@@ -597,58 +611,79 @@ const getFileValidationErrorText = (
     switch (validationError) {
         case CONST.FILE_VALIDATION_ERRORS.WRONG_FILE_TYPE:
             return {
+                // eslint-disable-next-line @typescript-eslint/no-deprecated
                 title: translateLocal('attachmentPicker.wrongFileType'),
+                // eslint-disable-next-line @typescript-eslint/no-deprecated
                 reason: translateLocal('attachmentPicker.notAllowedExtension'),
             };
         case CONST.FILE_VALIDATION_ERRORS.WRONG_FILE_TYPE_MULTIPLE:
             return {
+                // eslint-disable-next-line @typescript-eslint/no-deprecated
                 title: translateLocal('attachmentPicker.someFilesCantBeUploaded'),
+                // eslint-disable-next-line @typescript-eslint/no-deprecated
                 reason: translateLocal('attachmentPicker.unsupportedFileType', {fileType: additionalData.fileType ?? ''}),
             };
         case CONST.FILE_VALIDATION_ERRORS.FILE_TOO_LARGE:
             return {
+                // eslint-disable-next-line @typescript-eslint/no-deprecated
                 title: translateLocal('attachmentPicker.attachmentTooLarge'),
                 reason: isValidatingReceipt
-                    ? translateLocal('attachmentPicker.sizeExceededWithLimit', {
+                    ? // eslint-disable-next-line @typescript-eslint/no-deprecated
+                      translateLocal('attachmentPicker.sizeExceededWithLimit', {
                           maxUploadSizeInMB: additionalData.maxUploadSizeInMB ?? CONST.API_ATTACHMENT_VALIDATIONS.RECEIPT_MAX_SIZE / 1024 / 1024,
                       })
-                    : translateLocal('attachmentPicker.sizeExceeded'),
+                    : // eslint-disable-next-line @typescript-eslint/no-deprecated
+                      translateLocal('attachmentPicker.sizeExceeded'),
             };
         case CONST.FILE_VALIDATION_ERRORS.FILE_TOO_LARGE_MULTIPLE:
             return {
+                // eslint-disable-next-line @typescript-eslint/no-deprecated
                 title: translateLocal('attachmentPicker.someFilesCantBeUploaded'),
+                // eslint-disable-next-line @typescript-eslint/no-deprecated
                 reason: translateLocal('attachmentPicker.sizeLimitExceeded', {
                     maxUploadSizeInMB: additionalData.maxUploadSizeInMB ?? maxSize / 1024 / 1024,
                 }),
             };
         case CONST.FILE_VALIDATION_ERRORS.FILE_TOO_SMALL:
             return {
+                // eslint-disable-next-line @typescript-eslint/no-deprecated
                 title: translateLocal('attachmentPicker.attachmentTooSmall'),
+                // eslint-disable-next-line @typescript-eslint/no-deprecated
                 reason: translateLocal('attachmentPicker.sizeNotMet'),
             };
         case CONST.FILE_VALIDATION_ERRORS.FOLDER_NOT_ALLOWED:
             return {
+                // eslint-disable-next-line @typescript-eslint/no-deprecated
                 title: translateLocal('attachmentPicker.attachmentError'),
+                // eslint-disable-next-line @typescript-eslint/no-deprecated
                 reason: translateLocal('attachmentPicker.folderNotAllowedMessage'),
             };
         case CONST.FILE_VALIDATION_ERRORS.MAX_FILE_LIMIT_EXCEEDED:
             return {
+                // eslint-disable-next-line @typescript-eslint/no-deprecated
                 title: translateLocal('attachmentPicker.someFilesCantBeUploaded'),
+                // eslint-disable-next-line @typescript-eslint/no-deprecated
                 reason: translateLocal('attachmentPicker.maxFileLimitExceeded'),
             };
         case CONST.FILE_VALIDATION_ERRORS.FILE_CORRUPTED:
             return {
+                // eslint-disable-next-line @typescript-eslint/no-deprecated
                 title: translateLocal('attachmentPicker.attachmentError'),
+                // eslint-disable-next-line @typescript-eslint/no-deprecated
                 reason: translateLocal('attachmentPicker.errorWhileSelectingCorruptedAttachment'),
             };
         case CONST.FILE_VALIDATION_ERRORS.PROTECTED_FILE:
             return {
+                // eslint-disable-next-line @typescript-eslint/no-deprecated
                 title: translateLocal('attachmentPicker.attachmentError'),
+                // eslint-disable-next-line @typescript-eslint/no-deprecated
                 reason: translateLocal('attachmentPicker.protectedPDFNotSupported'),
             };
         default:
             return {
+                // eslint-disable-next-line @typescript-eslint/no-deprecated
                 title: translateLocal('attachmentPicker.attachmentError'),
+                // eslint-disable-next-line @typescript-eslint/no-deprecated
                 reason: translateLocal('attachmentPicker.errorWhileSelectingCorruptedAttachment'),
             };
     }
@@ -659,8 +694,10 @@ const getConfirmModalPrompt = (attachmentInvalidReason: TranslationPaths | undef
         return '';
     }
     if (attachmentInvalidReason === 'attachmentPicker.sizeExceededWithLimit') {
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         return translateLocal(attachmentInvalidReason, {maxUploadSizeInMB: CONST.API_ATTACHMENT_VALIDATIONS.RECEIPT_MAX_SIZE / (1024 * 1024)});
     }
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     return translateLocal(attachmentInvalidReason);
 };
 

--- a/src/pages/OnboardingWorkEmail/index.native.tsx
+++ b/src/pages/OnboardingWorkEmail/index.native.tsx
@@ -1,6 +1,7 @@
 import {useFocusEffect} from '@react-navigation/native';
 import React, {useCallback} from 'react';
 import {BackHandler} from 'react-native';
+// eslint-disable-next-line @typescript-eslint/no-deprecated
 import {translateLocal} from '@libs/Localize';
 import {setOnboardingErrorMessage} from '@userActions/Welcome';
 import BaseOnboardingWorkEmail from './BaseOnboardingWorkEmail';
@@ -12,6 +13,7 @@ function OnboardingWorkEmail(props: OnboardingWorkEmailProps) {
         useCallback(() => {
             // Return true to indicate that the back button press is handled here
             const backAction = () => {
+                // eslint-disable-next-line @typescript-eslint/no-deprecated
                 setOnboardingErrorMessage(translateLocal('onboarding.purpose.errorBackButton'));
                 return true;
             };

--- a/src/pages/home/report/ContextMenu/ContextMenuActions.tsx
+++ b/src/pages/home/report/ContextMenu/ContextMenuActions.tsx
@@ -16,6 +16,7 @@ import EmailUtils from '@libs/EmailUtils';
 import {getEnvironmentURL} from '@libs/Environment/Environment';
 import fileDownload from '@libs/fileDownload';
 import getAttachmentDetails from '@libs/fileDownload/getAttachmentDetails';
+// eslint-disable-next-line @typescript-eslint/no-deprecated
 import {translateLocal} from '@libs/Localize';
 import {getForReportAction} from '@libs/ModifiedExpenseMessage';
 import Navigation from '@libs/Navigation/Navigation';
@@ -597,6 +598,7 @@ const ContextMenuActions: ContextMenuAction[] = [
                 } else if (isActionOfType(reportAction, CONST.REPORT.ACTIONS.TYPE.UNREPORTED_TRANSACTION)) {
                     setClipboardMessage(getUnreportedTransactionMessage());
                 } else if (isActionOfType(reportAction, CONST.REPORT.ACTIONS.TYPE.MARKED_REIMBURSED)) {
+                    // eslint-disable-next-line @typescript-eslint/no-deprecated
                     Clipboard.setString(translateLocal('iou.paidElsewhere'));
                 } else if (isReimbursementQueuedAction(reportAction)) {
                     Clipboard.setString(getReimbursementQueuedActionMessage({reportAction, reportOrID: reportID, shouldUseShortDisplayName: false}));
@@ -614,24 +616,31 @@ const ContextMenuActions: ContextMenuAction[] = [
                 ) {
                     const harvesting = !isMarkAsClosedAction(reportAction) ? (getOriginalMessage(reportAction)?.harvesting ?? false) : false;
                     if (harvesting) {
+                        // eslint-disable-next-line @typescript-eslint/no-deprecated
                         setClipboardMessage(translateLocal('iou.automaticallySubmitted'));
                     } else {
+                        // eslint-disable-next-line @typescript-eslint/no-deprecated
                         Clipboard.setString(translateLocal('iou.submitted', {memo: getOriginalMessage(reportAction)?.message}));
                     }
                 } else if (isActionOfType(reportAction, CONST.REPORT.ACTIONS.TYPE.APPROVED)) {
                     const {automaticAction} = getOriginalMessage(reportAction) ?? {};
                     if (automaticAction) {
+                        // eslint-disable-next-line @typescript-eslint/no-deprecated
                         setClipboardMessage(translateLocal('iou.automaticallyApproved'));
                     } else {
+                        // eslint-disable-next-line @typescript-eslint/no-deprecated
                         Clipboard.setString(translateLocal('iou.approvedMessage'));
                     }
                 } else if (isUnapprovedAction(reportAction)) {
+                    // eslint-disable-next-line @typescript-eslint/no-deprecated
                     Clipboard.setString(translateLocal('iou.unapproved'));
                 } else if (isActionOfType(reportAction, CONST.REPORT.ACTIONS.TYPE.FORWARDED)) {
                     const {automaticAction} = getOriginalMessage(reportAction) ?? {};
                     if (automaticAction) {
+                        // eslint-disable-next-line @typescript-eslint/no-deprecated
                         setClipboardMessage(translateLocal('iou.automaticallyForwarded'));
                     } else {
+                        // eslint-disable-next-line @typescript-eslint/no-deprecated
                         Clipboard.setString(translateLocal('iou.forwarded'));
                     }
                 } else if (reportAction?.actionName === CONST.REPORT.ACTIONS.TYPE.REJECTED) {
@@ -644,14 +653,19 @@ const ContextMenuActions: ContextMenuAction[] = [
                     const displayMessage = getDowngradeWorkspaceMessage();
                     Clipboard.setString(displayMessage);
                 } else if (reportAction?.actionName === CONST.REPORT.ACTIONS.TYPE.HOLD) {
+                    // eslint-disable-next-line @typescript-eslint/no-deprecated
                     Clipboard.setString(translateLocal('iou.heldExpense'));
                 } else if (reportAction?.actionName === CONST.REPORT.ACTIONS.TYPE.UNHOLD) {
+                    // eslint-disable-next-line @typescript-eslint/no-deprecated
                     Clipboard.setString(translateLocal('iou.unheldExpense'));
                 } else if (reportAction?.actionName === CONST.REPORT.ACTIONS.TYPE.REJECTEDTRANSACTION_THREAD) {
+                    // eslint-disable-next-line @typescript-eslint/no-deprecated
                     Clipboard.setString(translateLocal('iou.reject.reportActions.rejectedExpense'));
                 } else if (reportAction?.actionName === CONST.REPORT.ACTIONS.TYPE.REJECTED_TRANSACTION_MARKASRESOLVED) {
+                    // eslint-disable-next-line @typescript-eslint/no-deprecated
                     Clipboard.setString(translateLocal('iou.reject.reportActions.markedAsResolved'));
                 } else if (reportAction?.actionName === CONST.REPORT.ACTIONS.TYPE.RETRACTED) {
+                    // eslint-disable-next-line @typescript-eslint/no-deprecated
                     Clipboard.setString(translateLocal('iou.retracted'));
                 } else if (isOldDotReportAction(reportAction)) {
                     const oldDotActionMessage = getMessageOfOldDotReportAction(reportAction);
@@ -660,8 +674,10 @@ const ContextMenuActions: ContextMenuAction[] = [
                     const originalMessage = getOriginalMessage(reportAction) as ReportAction<typeof CONST.REPORT.ACTIONS.TYPE.DISMISSED_VIOLATION>['originalMessage'];
                     const reason = originalMessage?.reason;
                     const violationName = originalMessage?.violationName;
+                    // eslint-disable-next-line @typescript-eslint/no-deprecated
                     Clipboard.setString(translateLocal(`violationDismissal.${violationName}.${reason}` as TranslationPaths));
                 } else if (reportAction?.actionName === CONST.REPORT.ACTIONS.TYPE.RESOLVED_DUPLICATES) {
+                    // eslint-disable-next-line @typescript-eslint/no-deprecated
                     Clipboard.setString(translateLocal('violations.resolvedDuplicates'));
                 } else if (reportAction?.actionName === CONST.REPORT.ACTIONS.TYPE.EXPORTED_TO_INTEGRATION) {
                     setClipboardMessage(getExportIntegrationMessageHTML(reportAction));

--- a/src/pages/workspace/accounting/utils.tsx
+++ b/src/pages/workspace/accounting/utils.tsx
@@ -12,6 +12,7 @@ import TextLink from '@components/TextLink';
 import {isAuthenticationError} from '@libs/actions/connections';
 import {getAdminPoliciesConnectedToSageIntacct} from '@libs/actions/Policy/Policy';
 import getPlatform from '@libs/getPlatform';
+// eslint-disable-next-line @typescript-eslint/no-deprecated
 import {translateLocal} from '@libs/Localize';
 import {canUseTaxNetSuite} from '@libs/PolicyUtils';
 import Navigation from '@navigation/Navigation';
@@ -339,7 +340,7 @@ function getSynchronizationErrorMessage(
             </Text>
         );
     }
-
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     const syncError = translateLocal('workspace.accounting.syncError', {connectionName});
 
     const connection = policy?.connections?.[connectionName];

--- a/tests/actions/IOUTest.ts
+++ b/tests/actions/IOUTest.ts
@@ -58,6 +58,7 @@ import {subscribeToUserEvents} from '@libs/actions/User';
 import type {ApiCommand} from '@libs/API/types';
 import {WRITE_COMMANDS} from '@libs/API/types';
 import {getMicroSecondOnyxErrorWithTranslationKey} from '@libs/ErrorUtils';
+// eslint-disable-next-line @typescript-eslint/no-deprecated
 import {translateLocal} from '@libs/Localize';
 import Navigation from '@libs/Navigation/Navigation';
 import {rand64} from '@libs/NumberUtils';
@@ -1641,6 +1642,7 @@ describe('actions/IOU', () => {
                                         Onyx.disconnect(connection);
                                         expect(transaction?.pendingAction).toBe(CONST.RED_BRICK_ROAD_PENDING_ACTION.ADD);
                                         expect(transaction?.errors).toBeTruthy();
+                                        // eslint-disable-next-line @typescript-eslint/no-deprecated
                                         expect(Object.values(transaction?.errors ?? {}).at(0)).toEqual(translateLocal('iou.error.genericCreateFailureMessage'));
                                         resolve();
                                     },
@@ -1943,6 +1945,7 @@ describe('actions/IOU', () => {
             const accountantEmployee = policyData?.employeeList?.[accountant.email];
             expect(accountantEmployee).toBeTruthy();
             expect(accountantEmployee?.errors).toBeTruthy();
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             expect(Object.values(accountantEmployee?.errors ?? {}).at(0)).toEqual(translateLocal('workspace.people.error.genericAdd'));
 
             // Cleanup
@@ -3459,6 +3462,7 @@ describe('actions/IOU', () => {
                                 callback: (allActions) => {
                                     Onyx.disconnect(connection);
                                     const erroredAction = Object.values(allActions ?? {}).find((action) => !isEmptyObject(action?.errors));
+                                    // eslint-disable-next-line @typescript-eslint/no-deprecated
                                     expect(Object.values(erroredAction?.errors ?? {}).at(0)).toEqual(translateLocal('iou.error.other'));
                                     resolve();
                                 },

--- a/tests/actions/PolicyMemberTest.ts
+++ b/tests/actions/PolicyMemberTest.ts
@@ -1,6 +1,7 @@
 import Onyx from 'react-native-onyx';
 import type {OnyxEntry} from 'react-native-onyx';
 import DateUtils from '@libs/DateUtils';
+// eslint-disable-next-line @typescript-eslint/no-deprecated
 import {translateLocal} from '@libs/Localize';
 import CONST from '@src/CONST';
 import OnyxUpdateManager from '@src/libs/actions/OnyxUpdateManager';
@@ -570,6 +571,7 @@ describe('actions/PolicyMember', () => {
             });
 
             // Then it should show the singular member added success message
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             expect(importedSpreadsheet?.importFinalModal.prompt).toBe(translateLocal('spreadsheet.importMembersSuccessfulDescription', {added: 1, updated: 0}));
         });
 
@@ -599,6 +601,7 @@ describe('actions/PolicyMember', () => {
             });
 
             // Then it should show the plural member added success message
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             expect(importedSpreadsheet?.importFinalModal.prompt).toBe(translateLocal('spreadsheet.importMembersSuccessfulDescription', {added: 2, updated: 0}));
         });
 
@@ -632,6 +635,7 @@ describe('actions/PolicyMember', () => {
             });
 
             // Then it should show the no member added/updated message
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             expect(importedSpreadsheet?.importFinalModal.prompt).toBe(translateLocal('spreadsheet.importMembersSuccessfulDescription', {added: 0, updated: 0}));
         });
 
@@ -665,6 +669,7 @@ describe('actions/PolicyMember', () => {
             });
 
             // Then it should show the singular member updated success message
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             expect(importedSpreadsheet?.importFinalModal.prompt).toBe(translateLocal('spreadsheet.importMembersSuccessfulDescription', {added: 0, updated: 1}));
         });
 
@@ -706,6 +711,7 @@ describe('actions/PolicyMember', () => {
             });
 
             // Then it should show the plural member updated success message
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             expect(importedSpreadsheet?.importFinalModal.prompt).toBe(translateLocal('spreadsheet.importMembersSuccessfulDescription', {added: 0, updated: 2}));
         });
 
@@ -742,6 +748,7 @@ describe('actions/PolicyMember', () => {
             });
 
             // Then it should show the singular member added and updated success message
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             expect(importedSpreadsheet?.importFinalModal.prompt).toBe(translateLocal('spreadsheet.importMembersSuccessfulDescription', {added: 1, updated: 1}));
         });
 
@@ -785,6 +792,7 @@ describe('actions/PolicyMember', () => {
             });
 
             // Then it should show the plural member added and updated success message
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             expect(importedSpreadsheet?.importFinalModal.prompt).toBe(translateLocal('spreadsheet.importMembersSuccessfulDescription', {added: 2, updated: 2}));
         });
     });

--- a/tests/actions/PolicyTest.ts
+++ b/tests/actions/PolicyTest.ts
@@ -2,6 +2,7 @@ import {Str} from 'expensify-common';
 import type {OnyxCollection, OnyxEntry} from 'react-native-onyx';
 import Onyx from 'react-native-onyx';
 import {getOnboardingMessages} from '@libs/actions/Welcome/OnboardingFlow';
+// eslint-disable-next-line @typescript-eslint/no-deprecated
 import {translateLocal} from '@libs/Localize';
 // eslint-disable-next-line no-restricted-syntax
 import * as PersonalDetailsUtils from '@libs/PersonalDetailsUtils';
@@ -1079,7 +1080,7 @@ describe('actions/Policy', () => {
             });
 
             const workspaceName = Policy.generateDefaultWorkspaceName(TEST_NON_PUBLIC_DOMAIN_EMAIL);
-
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             expect(workspaceName).toBe(translateLocal('workspace.new.workspaceName', {userName: displayNameForWorkspace}));
         });
 
@@ -1093,7 +1094,7 @@ describe('actions/Policy', () => {
             });
 
             const workspaceName = Policy.generateDefaultWorkspaceName(TEST_EMAIL);
-
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             expect(workspaceName).toBe(translateLocal('workspace.new.workspaceName', {userName: displayNameForWorkspace}));
         });
 
@@ -1109,7 +1110,7 @@ describe('actions/Policy', () => {
             });
 
             const workspaceName = Policy.generateDefaultWorkspaceName(TEST_EMAIL_2);
-
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             expect(workspaceName).toBe(translateLocal('workspace.new.workspaceName', {userName: displayNameForWorkspace}));
         });
 
@@ -1128,7 +1129,7 @@ describe('actions/Policy', () => {
             await Onyx.set(ONYXKEYS.COLLECTION.POLICY, existingPolicies);
 
             const workspaceName = Policy.generateDefaultWorkspaceName(TEST_EMAIL);
-
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             expect(workspaceName).toBe(translateLocal('workspace.new.workspaceName', {userName: TEST_DISPLAY_NAME, workspaceNumber: 2}));
         });
 
@@ -1140,7 +1141,7 @@ describe('actions/Policy', () => {
             });
 
             const workspaceName = Policy.generateDefaultWorkspaceName(TEST_SMS_DOMAIN_EMAIL);
-
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             expect(workspaceName).toBe(translateLocal('workspace.new.myGroupWorkspace', {}));
         });
 
@@ -1163,7 +1164,7 @@ describe('actions/Policy', () => {
             await Onyx.set(ONYXKEYS.COLLECTION.POLICY, existingPolicies);
 
             const workspaceName = Policy.generateDefaultWorkspaceName(TEST_EMAIL);
-
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             expect(workspaceName).toBe(translateLocal('workspace.new.workspaceName', {userName: TEST_DISPLAY_NAME, workspaceNumber: 2}));
         });
     });
@@ -1231,6 +1232,7 @@ describe('actions/Policy', () => {
 
             // The policy join should have the genericAdd error
             expect(policyJoinData?.errors).toBeTruthy();
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             expect(Object.values(policyJoinData?.errors ?? {}).at(0)).toEqual(translateLocal('workspace.people.error.genericAdd'));
 
             mockFetch.succeed?.();
@@ -1269,6 +1271,7 @@ describe('actions/Policy', () => {
 
             // The policy join should have the genericAdd error
             expect(policyJoinData?.errors).toBeTruthy();
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             expect(Object.values(policyJoinData?.errors ?? {}).at(0)).toEqual(translateLocal('workspace.people.error.genericAdd'));
 
             mockFetch.succeed?.();

--- a/tests/actions/ReportTest.ts
+++ b/tests/actions/ReportTest.ts
@@ -17,6 +17,7 @@ import * as PersistedRequests from '@src/libs/actions/PersistedRequests';
 import * as Report from '@src/libs/actions/Report';
 import * as User from '@src/libs/actions/User';
 import DateUtils from '@src/libs/DateUtils';
+// eslint-disable-next-line @typescript-eslint/no-deprecated
 import {translateLocal} from '@src/libs/Localize';
 import Log from '@src/libs/Log';
 import * as SequentialQueue from '@src/libs/Network/SequentialQueue';
@@ -2252,6 +2253,7 @@ describe('actions/Report', () => {
             const submitterEmployee = policyData?.employeeList?.[ownerEmail];
             expect(submitterEmployee).toBeTruthy();
             expect(submitterEmployee?.errors).toBeTruthy();
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             expect(Object.values(submitterEmployee?.errors ?? {}).at(0)).toEqual(translateLocal('workspace.people.error.genericAdd'));
 
             // Cleanup
@@ -2410,6 +2412,7 @@ describe('actions/Report', () => {
             const submitterEmployee = policyData?.employeeList?.[ownerEmail];
             expect(submitterEmployee).toBeTruthy();
             expect(submitterEmployee?.errors).toBeTruthy();
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             expect(Object.values(submitterEmployee?.errors ?? {}).at(0)).toEqual(translateLocal('workspace.people.error.genericAdd'));
 
             // Cleanup

--- a/tests/actions/TourTest.ts
+++ b/tests/actions/TourTest.ts
@@ -1,6 +1,7 @@
 import Onyx from 'react-native-onyx';
 import OnyxUpdateManager from '@libs/actions/OnyxUpdateManager';
 import {startTestDrive} from '@libs/actions/Tour';
+// eslint-disable-next-line @typescript-eslint/no-deprecated
 import {translateLocal} from '@libs/Localize';
 import Navigation from '@libs/Navigation/Navigation';
 import Parser from '@libs/Parser';
@@ -64,6 +65,7 @@ describe('actions/Tour', () => {
                 const testDriveTaskAction: ReportAction = {
                     ...LHNTestUtils.getFakeReportAction(),
                     childType: CONST.REPORT.TYPE.TASK,
+                    // eslint-disable-next-line @typescript-eslint/no-deprecated
                     childReportName: Parser.replace(translateLocal('onboarding.testDrive.name', {testDriveURL: `${CONST.STAGING_NEW_EXPENSIFY_URL}/${ROUTES.TEST_DRIVE_DEMO_ROOT}`})),
                     childReportID: testDriveTaskReport.reportID,
                 };

--- a/tests/perf-test/ReportActionCompose.perf-test.tsx
+++ b/tests/perf-test/ReportActionCompose.perf-test.tsx
@@ -105,6 +105,7 @@ test('[ReportActionCompose] should render Composer with text input interactions'
 test('[ReportActionCompose] should press create button', async () => {
     const scenario = async () => {
         // Query for the create button
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         const hintAttachmentButtonText = Localize.translateLocal('common.create');
         const createButton = await screen.findByLabelText(hintAttachmentButtonText);
 
@@ -118,6 +119,7 @@ test('[ReportActionCompose] should press create button', async () => {
 test('[ReportActionCompose] should press send message button', async () => {
     const scenario = async () => {
         // Query for the send button
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         const hintSendButtonText = Localize.translateLocal('common.send');
         const sendButton = await screen.findByLabelText(hintSendButtonText);
 

--- a/tests/ui/GroupChatNameTests.tsx
+++ b/tests/ui/GroupChatNameTests.tsx
@@ -6,6 +6,7 @@
 import {act, render, screen, waitFor} from '@testing-library/react-native';
 import React from 'react';
 import Onyx from 'react-native-onyx';
+// eslint-disable-next-line @typescript-eslint/no-deprecated
 import {translateLocal} from '@libs/Localize';
 import {setSidebarLoaded} from '@userActions/App';
 import {subscribeToUserEvents} from '@userActions/User';
@@ -186,6 +187,7 @@ function signInAndGetApp(reportName = '', participantAccountIDs?: number[]): Pro
     return waitForBatchedUpdatesWithAct()
         .then(async () => {
             await waitForBatchedUpdatesWithAct();
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             const hintText = translateLocal('loginForm.loginForm');
             const loginForm = screen.queryAllByLabelText(hintText);
             expect(loginForm).toHaveLength(1);
@@ -248,6 +250,7 @@ describe('Tests for group chat name', () => {
     it('Should show correctly in LHN', () =>
         signInAndGetApp('A, B, C, D', participantAccountIDs4).then(() => {
             // Verify the sidebar links are rendered
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             const sidebarLinksHintText = translateLocal('sidebarScreen.listOfChats');
             const sidebarLinks = screen.queryAllByLabelText(sidebarLinksHintText);
             expect(sidebarLinks).toHaveLength(1);
@@ -255,7 +258,7 @@ describe('Tests for group chat name', () => {
             // Verify there is only one option in the sidebar
             const optionRows = screen.queryAllByAccessibilityHint(TestHelper.getNavigateToChatHintRegex());
             expect(optionRows).toHaveLength(1);
-
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             const displayNameHintText = translateLocal('accessibilityHints.chatUserDisplayNames');
             const displayNameText = screen.queryByLabelText(displayNameHintText);
 
@@ -265,6 +268,7 @@ describe('Tests for group chat name', () => {
     it('Should show correctly in LHN when report name is not present', () =>
         signInAndGetApp('', participantAccountIDs4).then(() => {
             // Verify the sidebar links are rendered
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             const sidebarLinksHintText = translateLocal('sidebarScreen.listOfChats');
             const sidebarLinks = screen.queryAllByLabelText(sidebarLinksHintText);
             expect(sidebarLinks).toHaveLength(1);
@@ -272,7 +276,7 @@ describe('Tests for group chat name', () => {
             // Verify there is only one option in the sidebar
             const optionRows = screen.queryAllByAccessibilityHint(TestHelper.getNavigateToChatHintRegex());
             expect(optionRows).toHaveLength(1);
-
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             const displayNameHintText = translateLocal('accessibilityHints.chatUserDisplayNames');
             const displayNameText = screen.queryByLabelText(displayNameHintText);
 
@@ -282,6 +286,7 @@ describe('Tests for group chat name', () => {
     it('Should show limited names with ellipsis in LHN when 8 participants are present', () =>
         signInAndGetApp('', participantAccountIDs8).then(() => {
             // Verify the sidebar links are rendered
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             const sidebarLinksHintText = translateLocal('sidebarScreen.listOfChats');
             const sidebarLinks = screen.queryAllByLabelText(sidebarLinksHintText);
             expect(sidebarLinks).toHaveLength(1);
@@ -289,7 +294,7 @@ describe('Tests for group chat name', () => {
             // Verify there is only one option in the sidebar
             const optionRows = screen.queryAllByAccessibilityHint(TestHelper.getNavigateToChatHintRegex());
             expect(optionRows).toHaveLength(1);
-
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             const displayNameHintText = translateLocal('accessibilityHints.chatUserDisplayNames');
             const displayNameText = screen.queryByLabelText(displayNameHintText);
 
@@ -300,6 +305,7 @@ describe('Tests for group chat name', () => {
         signInAndGetApp('', participantAccountIDs4)
             .then(() => {
                 // Verify the sidebar links are rendered
+                // eslint-disable-next-line @typescript-eslint/no-deprecated
                 const sidebarLinksHintText = translateLocal('sidebarScreen.listOfChats');
                 const sidebarLinks = screen.queryAllByLabelText(sidebarLinksHintText);
                 expect(sidebarLinks).toHaveLength(1);
@@ -307,7 +313,7 @@ describe('Tests for group chat name', () => {
                 // Verify there is only one option in the sidebar
                 const optionRows = screen.queryAllByAccessibilityHint(TestHelper.getNavigateToChatHintRegex());
                 expect(optionRows).toHaveLength(1);
-
+                // eslint-disable-next-line @typescript-eslint/no-deprecated
                 const displayNameHintText = translateLocal('accessibilityHints.chatUserDisplayNames');
                 const displayNameText = screen.queryByLabelText(displayNameHintText);
 
@@ -327,8 +333,9 @@ describe('Tests for group chat name', () => {
             .then(async () => {
                 // Wait for sidebar to be rendered
                 await waitForBatchedUpdatesWithAct();
-
+                // eslint-disable-next-line @typescript-eslint/no-deprecated
                 const sidebarLinksHintText = translateLocal('sidebarScreen.listOfChats');
+                // eslint-disable-next-line @typescript-eslint/no-deprecated
                 const displayNameHintText = translateLocal('accessibilityHints.chatUserDisplayNames');
 
                 // Check sidebar links
@@ -361,6 +368,7 @@ describe('Tests for group chat name', () => {
         signInAndGetApp('Test chat', participantAccountIDs4)
             .then(() => {
                 // Verify the sidebar links are rendered
+                // eslint-disable-next-line @typescript-eslint/no-deprecated
                 const sidebarLinksHintText = translateLocal('sidebarScreen.listOfChats');
                 const sidebarLinks = screen.queryAllByLabelText(sidebarLinksHintText);
                 expect(sidebarLinks).toHaveLength(1);
@@ -368,7 +376,7 @@ describe('Tests for group chat name', () => {
                 // Verify there is only one option in the sidebar
                 const optionRows = screen.queryAllByAccessibilityHint(TestHelper.getNavigateToChatHintRegex());
                 expect(optionRows).toHaveLength(1);
-
+                // eslint-disable-next-line @typescript-eslint/no-deprecated
                 const displayNameHintText = translateLocal('accessibilityHints.chatUserDisplayNames');
                 const displayNameText = screen.queryByLabelText(displayNameHintText);
 
@@ -387,6 +395,7 @@ describe('Tests for group chat name', () => {
         signInAndGetApp("Let's talk", participantAccountIDs8)
             .then(() => {
                 // Verify the sidebar links are rendered
+                // eslint-disable-next-line @typescript-eslint/no-deprecated
                 const sidebarLinksHintText = translateLocal('sidebarScreen.listOfChats');
                 const sidebarLinks = screen.queryAllByLabelText(sidebarLinksHintText);
                 expect(sidebarLinks).toHaveLength(1);
@@ -394,7 +403,7 @@ describe('Tests for group chat name', () => {
                 // Verify there is only one option in the sidebar
                 const optionRows = screen.queryAllByAccessibilityHint(TestHelper.getNavigateToChatHintRegex());
                 expect(optionRows).toHaveLength(1);
-
+                // eslint-disable-next-line @typescript-eslint/no-deprecated
                 const displayNameHintText = translateLocal('accessibilityHints.chatUserDisplayNames');
                 const displayNameText = screen.queryByLabelText(displayNameHintText);
 
@@ -412,6 +421,7 @@ describe('Tests for group chat name', () => {
     it('Should show last message preview in LHN', () =>
         signInAndGetApp('A, B, C, D', participantAccountIDs4).then(() => {
             // Verify the sidebar links are rendered
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             const sidebarLinksHintText = translateLocal('sidebarScreen.listOfChats');
             const sidebarLinks = screen.queryAllByLabelText(sidebarLinksHintText);
             expect(sidebarLinks).toHaveLength(1);
@@ -419,7 +429,7 @@ describe('Tests for group chat name', () => {
             // Verify there is only one option in the sidebar
             const optionRows = screen.queryAllByAccessibilityHint(TestHelper.getNavigateToChatHintRegex());
             expect(optionRows).toHaveLength(1);
-
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             const lastChatHintText = translateLocal('accessibilityHints.lastChatMessagePreview');
             const lastChatText = screen.queryByLabelText(lastChatHintText);
 
@@ -429,6 +439,7 @@ describe('Tests for group chat name', () => {
     it('Should sort the names before displaying', () =>
         signInAndGetApp('', [USER_E_ACCOUNT_ID, ...participantAccountIDs4]).then(() => {
             // Verify the sidebar links are rendered
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             const sidebarLinksHintText = translateLocal('sidebarScreen.listOfChats');
             const sidebarLinks = screen.queryAllByLabelText(sidebarLinksHintText);
             expect(sidebarLinks).toHaveLength(1);
@@ -436,7 +447,7 @@ describe('Tests for group chat name', () => {
             // Verify there is only one option in the sidebar
             const optionRows = screen.queryAllByAccessibilityHint(TestHelper.getNavigateToChatHintRegex());
             expect(optionRows).toHaveLength(1);
-
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             const displayNameHintText = translateLocal('accessibilityHints.chatUserDisplayNames');
             const displayNameText = screen.queryByLabelText(displayNameHintText);
 

--- a/tests/ui/LHNItemsPresence.tsx
+++ b/tests/ui/LHNItemsPresence.tsx
@@ -7,6 +7,7 @@ import type {ValueOf} from 'type-fest';
 import type {WithCurrentUserPersonalDetailsProps} from '@components/withCurrentUserPersonalDetails';
 import initOnyxDerivedValues from '@libs/actions/OnyxDerived';
 import DateUtils from '@libs/DateUtils';
+// eslint-disable-next-line @typescript-eslint/no-deprecated
 import {translateLocal} from '@libs/Localize';
 import {buildOptimisticExpenseReport, buildOptimisticIOUReportAction, buildTransactionThread} from '@libs/ReportUtils';
 import {buildOptimisticTransaction} from '@libs/TransactionUtils';
@@ -99,6 +100,7 @@ const getOptionRows = () => {
 };
 
 const getDisplayNames = () => {
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     const hintText = translateLocal('accessibilityHints.chatUserDisplayNames');
     return screen.queryAllByLabelText(hintText);
 };

--- a/tests/ui/MoneyRequestReportPreview.test.tsx
+++ b/tests/ui/MoneyRequestReportPreview.test.tsx
@@ -12,6 +12,7 @@ import type {MoneyRequestReportPreviewProps} from '@components/ReportActionItem/
 import ScreenWrapper from '@components/ScreenWrapper';
 import {convertToDisplayString} from '@libs/CurrencyUtils';
 import DateUtils from '@libs/DateUtils';
+// eslint-disable-next-line @typescript-eslint/no-deprecated
 import {translateLocal} from '@libs/Localize';
 import {getFormattedCreated, isManagedCardTransaction} from '@libs/TransactionUtils';
 import CONST from '@src/CONST';
@@ -91,6 +92,7 @@ const getTransactionDisplayAmountAndHeaderText = (transaction: Transaction) => {
     const created = getFormattedCreated(transaction);
     const date = DateUtils.formatWithUTCTimeZone(created, DateUtils.doesDateBelongToAPastYear(created) ? CONST.DATE.MONTH_DAY_YEAR_ABBR_FORMAT : CONST.DATE.MONTH_DAY_ABBR_FORMAT);
     const isTransactionMadeWithCard = isManagedCardTransaction(transaction);
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     const cashOrCard = isTransactionMadeWithCard ? translateLocal('iou.card') : translateLocal('iou.cash');
     const transactionHeaderText = `${date} ${CONST.DOT_SEPARATOR} ${cashOrCard}`;
     const transactionDisplayAmount = convertToDisplayString(transaction.amount, transaction.currency);
@@ -174,6 +176,7 @@ describe('MoneyRequestReportPreview', () => {
             await Onyx.multiSet({...mockOnyxTransactions, ...mockOnyxViolations});
         });
         await waitForBatchedUpdatesWithAct();
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         expect(screen.getAllByText(translateLocal('violations.reviewRequired'))).toHaveLength(2);
     });
 
@@ -216,9 +219,11 @@ describe('MoneyRequestReportPreview', () => {
         await waitForBatchedUpdatesWithAct();
 
         // Verify the Review button is rendered
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         expect(screen.getByText(translateLocal('common.review'))).toBeOnTheScreen();
 
         // Verify the button has the correct styling (danger icon)
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         const reviewButton = screen.getByText(translateLocal('common.review'));
         expect(reviewButton).toBeOnTheScreen();
 
@@ -241,9 +246,11 @@ describe('MoneyRequestReportPreview', () => {
         await waitForBatchedUpdatesWithAct();
 
         // Verify the Review button is NOT rendered
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         expect(screen.queryByText(translateLocal('common.review'))).not.toBeOnTheScreen();
 
         // But View button should be rendered instead
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         expect(screen.getByText(translateLocal('common.view'))).toBeOnTheScreen();
 
         // Clean up mocks
@@ -267,6 +274,7 @@ describe('MoneyRequestReportPreview', () => {
         await waitForBatchedUpdatesWithAct();
 
         // Find and press the Review button
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         const reviewButton = screen.getByText(translateLocal('common.review'));
         expect(reviewButton).toBeOnTheScreen();
 

--- a/tests/ui/NewChatPageTest.tsx
+++ b/tests/ui/NewChatPageTest.tsx
@@ -8,6 +8,7 @@ import {LocaleContextProvider} from '@components/LocaleContextProvider';
 import OnyxListItemProvider from '@components/OnyxListItemProvider';
 import OptionsListContextProvider from '@components/OptionListContextProvider';
 import ScreenWrapper from '@components/ScreenWrapper';
+// eslint-disable-next-line @typescript-eslint/no-deprecated
 import {translateLocal} from '@libs/Localize';
 import NewChatPage from '@pages/NewChatPage';
 import CONST from '@src/CONST';
@@ -78,7 +79,7 @@ describe('NewChatPage', () => {
             (NativeNavigation as NativeNavigationMock).triggerTransitionEnd();
         });
         const spy = jest.spyOn(SectionList.prototype, 'scrollToLocation');
-
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         const addButton = await waitFor(() => screen.getAllByText(translateLocal('newChatPage.addToGroup')).at(0));
         if (addButton) {
             fireEvent.press(addButton);
@@ -116,6 +117,7 @@ describe('NewChatPage', () => {
 
             // Then "Add to group" button should not appear
             const userOption = screen.getByLabelText(email);
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             const addButton = within(userOption).queryByText(translateLocal('newChatPage.addToGroup'));
             expect(addButton).not.toBeOnTheScreen();
         });

--- a/tests/ui/OnboardingEmployees.tsx
+++ b/tests/ui/OnboardingEmployees.tsx
@@ -9,6 +9,7 @@ import OnyxListItemProvider from '@components/OnyxListItemProvider';
 import {CurrentReportIDContextProvider} from '@hooks/useCurrentReportID';
 import * as useResponsiveLayoutModule from '@hooks/useResponsiveLayout';
 import type ResponsiveLayoutResult from '@hooks/useResponsiveLayout/types';
+// eslint-disable-next-line @typescript-eslint/no-deprecated
 import {translateLocal} from '@libs/Localize';
 import createPlatformStackNavigator from '@libs/Navigation/PlatformStackNavigation/createPlatformStackNavigator';
 import type {OnboardingModalNavigatorParamList} from '@navigation/types';
@@ -92,6 +93,7 @@ describe('OnboardingEmployees Page', () => {
         await waitForBatchedUpdatesWithAct();
 
         await waitFor(() => {
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             expect(screen.getByText(translateLocal('onboarding.employees.1-10'))).toBeOnTheScreen();
         });
 
@@ -115,6 +117,7 @@ describe('OnboardingEmployees Page', () => {
         await waitForBatchedUpdatesWithAct();
 
         await waitFor(() => {
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             expect(screen.queryByText(translateLocal('onboarding.employees.1-10'))).not.toBeOnTheScreen();
         });
 

--- a/tests/ui/PaginationTest.tsx
+++ b/tests/ui/PaginationTest.tsx
@@ -4,6 +4,7 @@ import {act, fireEvent, render, screen, waitFor, within} from '@testing-library/
 import {addSeconds, format, subMinutes} from 'date-fns';
 import React from 'react';
 import Onyx from 'react-native-onyx';
+// eslint-disable-next-line @typescript-eslint/no-deprecated
 import {translateLocal} from '@libs/Localize';
 import {waitForIdle} from '@libs/Network/SequentialQueue';
 import {setSidebarLoaded} from '@userActions/App';
@@ -56,6 +57,7 @@ function getReportScreen(reportID = REPORT_ID) {
 }
 
 function scrollToOffset(offset: number) {
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     const hintText = translateLocal('sidebarScreen.listOfChatMessages');
     fireEvent.scroll(within(getReportScreen()).getByLabelText(hintText), {
         nativeEvent: {
@@ -87,8 +89,10 @@ function triggerListLayout(reportID?: string) {
 function getReportActions(reportID?: string) {
     const report = getReportScreen(reportID);
     return [
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         ...within(report).queryAllByLabelText(translateLocal('accessibilityHints.chatMessage')),
         // Created action has a different accessibility label.
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         ...within(report).queryAllByLabelText(translateLocal('accessibilityHints.chatWelcomeMessage')),
     ];
 }
@@ -197,6 +201,7 @@ async function signInAndGetApp(): Promise<void> {
     // Render the App and sign in as a test user.
     render(<App />);
     await waitForBatchedUpdatesWithAct();
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     const hintText = translateLocal('loginForm.loginForm');
     const loginForm = await screen.findAllByLabelText(hintText);
     expect(loginForm).toHaveLength(1);

--- a/tests/ui/PersonalDetailsOnboarding.tsx
+++ b/tests/ui/PersonalDetailsOnboarding.tsx
@@ -10,6 +10,7 @@ import OnyxListItemProvider from '@components/OnyxListItemProvider';
 import {CurrentReportIDContextProvider} from '@hooks/useCurrentReportID';
 import * as useResponsiveLayoutModule from '@hooks/useResponsiveLayout';
 import type ResponsiveLayoutResult from '@hooks/useResponsiveLayout/types';
+// eslint-disable-next-line @typescript-eslint/no-deprecated
 import {translateLocal} from '@libs/Localize';
 import Navigation from '@libs/Navigation/Navigation';
 import createPlatformStackNavigator from '@libs/Navigation/PlatformStackNavigation/createPlatformStackNavigator';
@@ -100,6 +101,7 @@ describe('OnboardingPersonalDetails Page', () => {
         await waitForBatchedUpdatesWithAct();
 
         // Submit the form
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         fireEvent.press(screen.getByText(translateLocal('common.continue')));
 
         await waitFor(() => {
@@ -131,6 +133,7 @@ describe('OnboardingPersonalDetails Page', () => {
         await waitForBatchedUpdatesWithAct();
 
         // Submit the form
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         fireEvent.press(screen.getByText(translateLocal('common.continue')));
 
         await waitFor(() => {

--- a/tests/ui/PureReportActionItemTest.tsx
+++ b/tests/ui/PureReportActionItemTest.tsx
@@ -9,6 +9,7 @@ import {LocaleContextProvider} from '@components/LocaleContextProvider';
 import OnyxListItemProvider from '@components/OnyxListItemProvider';
 import OptionsListContextProvider from '@components/OptionListContextProvider';
 import ScreenWrapper from '@components/ScreenWrapper';
+// eslint-disable-next-line @typescript-eslint/no-deprecated
 import {translateLocal} from '@libs/Localize';
 import {getIOUActionForReportID} from '@libs/ReportActionsUtils';
 import PureReportActionItem from '@pages/home/report/PureReportActionItem';
@@ -149,7 +150,7 @@ describe('PureReportActionItem', () => {
             await waitForBatchedUpdatesWithAct();
 
             expect(screen.getByText(actorEmail)).toBeOnTheScreen();
-
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             const parsedText = parseTextWithTrailingLink(translateLocal(translationKey as TranslationPaths));
             if (!parsedText) {
                 throw new Error('Text cannot be parsed, translation failed');
@@ -168,6 +169,7 @@ describe('PureReportActionItem', () => {
             await waitForBatchedUpdatesWithAct();
 
             expect(screen.getByText(actorEmail)).toBeOnTheScreen();
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             expect(screen.getByText(translateLocal('iou.approvedMessage'))).toBeOnTheScreen();
         });
 
@@ -177,6 +179,7 @@ describe('PureReportActionItem', () => {
             await waitForBatchedUpdatesWithAct();
 
             expect(screen.getByText(actorEmail)).toBeOnTheScreen();
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             expect(screen.getByText(translateLocal('iou.forwarded'))).toBeOnTheScreen();
         });
 
@@ -186,6 +189,7 @@ describe('PureReportActionItem', () => {
             await waitForBatchedUpdatesWithAct();
 
             expect(screen.getByText(actorEmail)).toBeOnTheScreen();
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             expect(screen.getByText(translateLocal('iou.submitted', {}))).toBeOnTheScreen();
         });
 
@@ -196,6 +200,7 @@ describe('PureReportActionItem', () => {
             await waitForBatchedUpdatesWithAct();
 
             expect(screen.getByText(actorEmail)).toBeOnTheScreen();
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             expect(screen.getByText(translateLocal('iou.submitted', {memo}))).toBeOnTheScreen();
         });
 
@@ -205,6 +210,7 @@ describe('PureReportActionItem', () => {
             await waitForBatchedUpdatesWithAct();
 
             expect(screen.getByText(actorEmail)).toBeOnTheScreen();
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             expect(screen.getByText(translateLocal('iou.submitted', {}))).toBeOnTheScreen();
         });
     });

--- a/tests/ui/ReportAttachments.tsx
+++ b/tests/ui/ReportAttachments.tsx
@@ -9,6 +9,7 @@ import OnyxListItemProvider from '@components/OnyxListItemProvider';
 import {PlaybackContextProvider} from '@components/VideoPlayerContexts/PlaybackContext';
 import {CurrentReportIDContextProvider} from '@hooks/useCurrentReportID';
 import {WRITE_COMMANDS} from '@libs/API/types';
+// eslint-disable-next-line @typescript-eslint/no-deprecated
 import {translateLocal} from '@libs/Localize';
 import createPlatformStackNavigator from '@libs/Navigation/PlatformStackNavigation/createPlatformStackNavigator';
 import {waitForIdle} from '@libs/Network/SequentialQueue';
@@ -196,6 +197,7 @@ describe('ReportAttachments', () => {
         await waitForBatchedUpdatesWithAct();
 
         // Then the not here page and the loading spinner should not appear.
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         expect(screen.queryByText(translateLocal('notFound.notHere'))).toBeNull();
         expect(screen.queryByTestId('attachment-loading-spinner')).toBeNull();
     });

--- a/tests/ui/ReportDetailsPageTest.tsx
+++ b/tests/ui/ReportDetailsPageTest.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import Onyx from 'react-native-onyx';
 import {LocaleContextProvider} from '@components/LocaleContextProvider';
 import OnyxListItemProvider from '@components/OnyxListItemProvider';
+// eslint-disable-next-line @typescript-eslint/no-deprecated
 import {translateLocal} from '@libs/Localize';
 import type Navigation from '@libs/Navigation/Navigation';
 import type {PlatformStackScreenProps} from '@libs/Navigation/PlatformStackNavigation/types';
@@ -89,12 +90,14 @@ describe('ReportDetailsPage', () => {
             </OnyxListItemProvider>,
         );
         await waitForBatchedUpdatesWithAct();
-
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         const submitText = translateLocal('actionableMentionTrackExpense.submit');
         await screen.findByText(submitText);
 
         // Categorize and share are temporarily disabled
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         // const categorizeText = translateLocal('actionableMentionTrackExpense.categorize');
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         // const shareText = translateLocal('actionableMentionTrackExpense.share');
         // await screen.findByText(categorizeText);
         // await screen.findByText(shareText);

--- a/tests/ui/SwitchToExpensifyClassicTest.tsx
+++ b/tests/ui/SwitchToExpensifyClassicTest.tsx
@@ -1,6 +1,7 @@
 import * as NativeNavigation from '@react-navigation/native';
 import {act, fireEvent, render, screen} from '@testing-library/react-native';
 import Onyx from 'react-native-onyx';
+// eslint-disable-next-line @typescript-eslint/no-deprecated
 import {translateLocal} from '@libs/Localize';
 import App from '@src/App';
 import ONYXKEYS from '@src/ONYXKEYS';
@@ -21,6 +22,7 @@ TestHelper.setupApp();
 TestHelper.setupGlobalFetchMock();
 
 function navigateToSetting() {
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     const hintText = translateLocal('sidebarScreen.buttonMySettings');
     const mySettingButton = screen.queryByAccessibilityHint(hintText);
     if (mySettingButton) {
@@ -30,6 +32,7 @@ function navigateToSetting() {
 }
 
 function navigateToExpensifyClassicFlow() {
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     const hintText = translateLocal('exitSurvey.goToExpensifyClassic');
     const switchToExpensifyClassicBtn = screen.queryByAccessibilityHint(hintText);
     if (switchToExpensifyClassicBtn) {
@@ -43,6 +46,7 @@ function signInAppAndEnterTestFlow(dismissedValue?: boolean): Promise<void> {
     return waitForBatchedUpdatesWithAct()
         .then(async () => {
             await waitForBatchedUpdatesWithAct();
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             const hintText = translateLocal('loginForm.loginForm');
             const loginForm = screen.queryAllByLabelText(hintText);
             expect(loginForm).toHaveLength(1);
@@ -75,6 +79,7 @@ describe('Switch to Expensify Classic flow', () => {
 
     test('Should navigate to exit survey reason page', () => {
         signInAppAndEnterTestFlow(true).then(() => {
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             expect(screen.getAllByText(translateLocal('exitSurvey.reasonPage.subtitle')).at(0)).toBeOnTheScreen();
         });
     });

--- a/tests/ui/UnreadIndicatorsTest.tsx
+++ b/tests/ui/UnreadIndicatorsTest.tsx
@@ -14,6 +14,7 @@ import {addComment, deleteReportComment, markCommentAsUnread, readNewestAction} 
 import {subscribeToUserEvents} from '@libs/actions/User';
 import {lastItem} from '@libs/CollectionUtils';
 import DateUtils from '@libs/DateUtils';
+// eslint-disable-next-line @typescript-eslint/no-deprecated
 import {translateLocal} from '@libs/Localize';
 import LocalNotification from '@libs/Notification/LocalNotification';
 import {rand64} from '@libs/NumberUtils';
@@ -55,6 +56,7 @@ afterEach(() => {
 });
 
 function scrollUpToRevealNewMessagesBadge() {
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     const hintText = translateLocal('sidebarScreen.listOfChatMessages');
     fireEvent.scroll(screen.getByLabelText(hintText), {
         nativeEvent: {
@@ -76,6 +78,7 @@ function scrollUpToRevealNewMessagesBadge() {
 }
 
 function isNewMessagesBadgeVisible(): boolean {
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     const hintText = translateLocal('accessibilityHints.scrollToNewestMessages');
     const badge = screen.queryByAccessibilityHint(hintText);
     const badgeProps = badge?.props as {style: ViewStyle};
@@ -85,6 +88,7 @@ function isNewMessagesBadgeVisible(): boolean {
 }
 
 function navigateToSidebar(): Promise<void> {
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     const hintText = translateLocal('accessibilityHints.navigateToChatsList');
     const reportHeaderBackButton = screen.queryByAccessibilityHint(hintText);
     if (reportHeaderBackButton) {
@@ -94,6 +98,7 @@ function navigateToSidebar(): Promise<void> {
 }
 
 function areYouOnChatListScreen(): boolean {
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     const hintText = translateLocal('sidebarScreen.listOfChats');
     const sidebarLinks = screen.queryAllByLabelText(hintText, {includeHiddenElements: true});
 
@@ -248,6 +253,7 @@ describe('Unread Indicators', () => {
                 expect((LocalNotification.showCommentNotification as jest.Mock).mock.calls).toHaveLength(0);
 
                 // Verify the sidebar links are rendered
+                // eslint-disable-next-line @typescript-eslint/no-deprecated
                 const sidebarLinksHintText = translateLocal('sidebarScreen.listOfChats');
                 const sidebarLinks = screen.queryAllByLabelText(sidebarLinksHintText);
                 expect(sidebarLinks).toHaveLength(1);
@@ -257,6 +263,7 @@ describe('Unread Indicators', () => {
                 expect(optionRows).toHaveLength(1);
 
                 // And that the text is bold
+                // eslint-disable-next-line @typescript-eslint/no-deprecated
                 const displayNameHintText = translateLocal('accessibilityHints.chatUserDisplayNames');
                 const displayNameText = screen.queryByLabelText(displayNameHintText);
                 expect((displayNameText?.props?.style as TextStyle)?.fontWeight).toBe(FontUtils.fontWeight.bold);
@@ -267,14 +274,17 @@ describe('Unread Indicators', () => {
                 act(() => (NativeNavigation as NativeNavigationMock).triggerTransitionEnd());
 
                 // That the report actions are visible along with the created action
+                // eslint-disable-next-line @typescript-eslint/no-deprecated
                 const welcomeMessageHintText = translateLocal('accessibilityHints.chatWelcomeMessage');
                 const createdAction = screen.queryByLabelText(welcomeMessageHintText);
                 expect(createdAction).toBeTruthy();
+                // eslint-disable-next-line @typescript-eslint/no-deprecated
                 const reportCommentsHintText = translateLocal('accessibilityHints.chatMessage');
                 const reportComments = screen.queryAllByLabelText(reportCommentsHintText);
                 expect(reportComments).toHaveLength(9);
                 // Since the last read timestamp is the timestamp of action 3 we should have an unread indicator above the next "unread" action which will
                 // have actionID of 4
+                // eslint-disable-next-line @typescript-eslint/no-deprecated
                 const newMessageLineIndicatorHintText = translateLocal('accessibilityHints.newMessageLineIndicator');
                 const unreadIndicator = screen.queryAllByLabelText(newMessageLineIndicatorHintText);
                 expect(unreadIndicator).toHaveLength(1);
@@ -291,6 +301,7 @@ describe('Unread Indicators', () => {
             .then(() => {
                 act(() => (NativeNavigation as NativeNavigationMock).triggerTransitionEnd());
                 // Verify the unread indicator is present
+                // eslint-disable-next-line @typescript-eslint/no-deprecated
                 const newMessageLineIndicatorHintText = translateLocal('accessibilityHints.newMessageLineIndicator');
                 const unreadIndicator = screen.queryAllByLabelText(newMessageLineIndicatorHintText);
                 expect(unreadIndicator).toHaveLength(1);
@@ -314,6 +325,7 @@ describe('Unread Indicators', () => {
             })
             .then(() => {
                 // Verify the unread indicator is not present
+                // eslint-disable-next-line @typescript-eslint/no-deprecated
                 const newMessageLineIndicatorHintText = translateLocal('accessibilityHints.newMessageLineIndicator');
                 const unreadIndicator = screen.queryAllByLabelText(newMessageLineIndicatorHintText);
                 expect(unreadIndicator).toHaveLength(0);
@@ -322,6 +334,7 @@ describe('Unread Indicators', () => {
             })
             .then(() => {
                 // Verify the unread indicator is not present
+                // eslint-disable-next-line @typescript-eslint/no-deprecated
                 const newMessageLineIndicatorHintText = translateLocal('accessibilityHints.newMessageLineIndicator');
                 const unreadIndicator = screen.queryAllByLabelText(newMessageLineIndicatorHintText);
                 expect(unreadIndicator).toHaveLength(0);
@@ -395,6 +408,7 @@ describe('Unread Indicators', () => {
                 const optionRows = screen.queryAllByAccessibilityHint(TestHelper.getNavigateToChatHintRegex());
                 expect(optionRows).toHaveLength(2);
                 // Verify the text for both chats are bold indicating that nothing has not yet been read
+                // eslint-disable-next-line @typescript-eslint/no-deprecated
                 const displayNameHintTexts = translateLocal('accessibilityHints.chatUserDisplayNames');
                 const displayNameTexts = screen.queryAllByLabelText(displayNameHintTexts);
                 expect(displayNameTexts).toHaveLength(2);
@@ -413,6 +427,7 @@ describe('Unread Indicators', () => {
             .then(() => {
                 act(() => (NativeNavigation as NativeNavigationMock).triggerTransitionEnd());
                 // Verify that report we navigated to appears in a "read" state while the original unread report still shows as unread
+                // eslint-disable-next-line @typescript-eslint/no-deprecated
                 const hintText = translateLocal('accessibilityHints.chatUserDisplayNames');
                 const displayNameTexts = screen.queryAllByLabelText(hintText, {includeHiddenElements: true});
                 expect(displayNameTexts).toHaveLength(2);
@@ -434,6 +449,7 @@ describe('Unread Indicators', () => {
             })
             .then(() => {
                 // Verify the indicator appears above the last action
+                // eslint-disable-next-line @typescript-eslint/no-deprecated
                 const newMessageLineIndicatorHintText = translateLocal('accessibilityHints.newMessageLineIndicator');
                 const unreadIndicator = screen.queryAllByLabelText(newMessageLineIndicatorHintText);
                 expect(unreadIndicator).toHaveLength(1);
@@ -447,6 +463,7 @@ describe('Unread Indicators', () => {
             .then(navigateToSidebar)
             .then(() => {
                 // Verify the report is marked as unread in the sidebar
+                // eslint-disable-next-line @typescript-eslint/no-deprecated
                 const hintText = translateLocal('accessibilityHints.chatUserDisplayNames');
                 const displayNameTexts = screen.queryAllByLabelText(hintText);
                 expect(displayNameTexts).toHaveLength(1);
@@ -459,6 +476,7 @@ describe('Unread Indicators', () => {
             .then(() => navigateToSidebar())
             .then(() => {
                 // Verify the report is now marked as read
+                // eslint-disable-next-line @typescript-eslint/no-deprecated
                 const hintText = translateLocal('accessibilityHints.chatUserDisplayNames');
                 const displayNameTexts = screen.queryAllByLabelText(hintText);
                 expect(displayNameTexts).toHaveLength(1);
@@ -469,6 +487,7 @@ describe('Unread Indicators', () => {
                 return navigateToSidebarOption(0);
             })
             .then(() => {
+                // eslint-disable-next-line @typescript-eslint/no-deprecated
                 const newMessageLineIndicatorHintText = translateLocal('accessibilityHints.newMessageLineIndicator');
                 const unreadIndicator = screen.queryAllByLabelText(newMessageLineIndicatorHintText);
                 expect(unreadIndicator).toHaveLength(0);
@@ -489,6 +508,7 @@ describe('Unread Indicators', () => {
             })
             .then(async () => {
                 act(() => (NativeNavigation as NativeNavigationMock).triggerTransitionEnd());
+                // eslint-disable-next-line @typescript-eslint/no-deprecated
                 const newMessageLineIndicatorHintText = translateLocal('accessibilityHints.newMessageLineIndicator');
                 const unreadIndicator = screen.queryAllByLabelText(newMessageLineIndicatorHintText);
                 expect(unreadIndicator).toHaveLength(1);
@@ -498,6 +518,7 @@ describe('Unread Indicators', () => {
                 return waitForBatchedUpdates();
             })
             .then(() => {
+                // eslint-disable-next-line @typescript-eslint/no-deprecated
                 const newMessageLineIndicatorHintText = translateLocal('accessibilityHints.newMessageLineIndicator');
                 const unreadIndicator = screen.queryAllByLabelText(newMessageLineIndicatorHintText);
                 expect(unreadIndicator).toHaveLength(1);
@@ -513,6 +534,7 @@ describe('Unread Indicators', () => {
                 return navigateToSidebarOption(0);
             })
             .then(() => {
+                // eslint-disable-next-line @typescript-eslint/no-deprecated
                 const newMessageLineIndicatorHintText = translateLocal('accessibilityHints.newMessageLineIndicator');
                 const unreadIndicator = screen.queryAllByLabelText(newMessageLineIndicatorHintText);
                 expect(unreadIndicator).toHaveLength(1);
@@ -522,6 +544,7 @@ describe('Unread Indicators', () => {
             })
             .then(() => navigateToSidebarOption(0))
             .then(() => {
+                // eslint-disable-next-line @typescript-eslint/no-deprecated
                 const newMessageLineIndicatorHintText = translateLocal('accessibilityHints.newMessageLineIndicator');
                 const unreadIndicator = screen.queryAllByLabelText(newMessageLineIndicatorHintText);
                 expect(unreadIndicator).toHaveLength(0);
@@ -531,6 +554,7 @@ describe('Unread Indicators', () => {
                 return waitForBatchedUpdates();
             })
             .then(() => {
+                // eslint-disable-next-line @typescript-eslint/no-deprecated
                 const newMessageLineIndicatorHintText = translateLocal('accessibilityHints.newMessageLineIndicator');
                 let unreadIndicator = screen.queryAllByLabelText(newMessageLineIndicatorHintText);
                 expect(unreadIndicator).toHaveLength(1);
@@ -572,6 +596,7 @@ describe('Unread Indicators', () => {
                 })
                 .then(() => {
                     // Verify the chat preview text matches the last comment from the current user
+                    // eslint-disable-next-line @typescript-eslint/no-deprecated
                     const hintText = translateLocal('accessibilityHints.lastChatMessagePreview');
                     const alternateText = screen.queryAllByLabelText(hintText, {includeHiddenElements: true});
                     expect(alternateText).toHaveLength(1);
@@ -585,6 +610,7 @@ describe('Unread Indicators', () => {
                     return waitForBatchedUpdates();
                 })
                 .then(() => {
+                    // eslint-disable-next-line @typescript-eslint/no-deprecated
                     const hintText = translateLocal('accessibilityHints.lastChatMessagePreview');
                     const alternateText = screen.queryAllByLabelText(hintText, {includeHiddenElements: true});
                     expect(alternateText).toHaveLength(1);
@@ -623,7 +649,7 @@ describe('Unread Indicators', () => {
         }
 
         const secondNewReportAction = reportActions ? lastItem(reportActions) : undefined;
-
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         const newMessageLineIndicatorHintText = translateLocal('accessibilityHints.newMessageLineIndicator');
         const unreadIndicator = screen.queryAllByLabelText(newMessageLineIndicatorHintText);
         expect(unreadIndicator).toHaveLength(1);
@@ -649,6 +675,7 @@ describe('Unread Indicators', () => {
         });
 
         // Then the new line indicator shouldn't be displayed
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         const newMessageLineIndicatorHintText = translateLocal('accessibilityHints.newMessageLineIndicator');
         const unreadIndicator = screen.queryAllByLabelText(newMessageLineIndicatorHintText);
         expect(unreadIndicator).toHaveLength(0);
@@ -717,6 +744,7 @@ describe('Unread Indicators', () => {
         await waitForBatchedUpdates();
 
         // Then the new line indicator shouldn't be displayed
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         const newMessageLineIndicatorHintText = translateLocal('accessibilityHints.newMessageLineIndicator');
         const unreadIndicator = screen.queryAllByLabelText(newMessageLineIndicatorHintText);
         expect(unreadIndicator).toHaveLength(0);
@@ -751,6 +779,7 @@ describe('Unread Indicators', () => {
         markCommentAsUnread(REPORT_ID, {reportActionID: -1} as unknown as ReportAction); // Marking the chat as unread from LHN passing a dummy reportActionID
 
         await waitForBatchedUpdates();
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         const hintText = translateLocal('accessibilityHints.chatUserDisplayNames');
         const displayNameTexts = screen.queryAllByLabelText(hintText);
         expect(displayNameTexts).toHaveLength(1);

--- a/tests/ui/WalletExpensifyCardPageTest.tsx
+++ b/tests/ui/WalletExpensifyCardPageTest.tsx
@@ -9,6 +9,7 @@ import OnyxListItemProvider from '@components/OnyxListItemProvider';
 import {CurrentReportIDContextProvider} from '@hooks/useCurrentReportID';
 import * as useResponsiveLayoutModule from '@hooks/useResponsiveLayout';
 import type ResponsiveLayoutResult from '@hooks/useResponsiveLayout/types';
+// eslint-disable-next-line @typescript-eslint/no-deprecated
 import {translateLocal} from '@libs/Localize';
 import createPlatformStackNavigator from '@libs/Navigation/PlatformStackNavigation/createPlatformStackNavigator';
 import type {SettingsNavigatorParamList} from '@navigation/types';
@@ -102,11 +103,13 @@ describe('ExpensifyCardPage', () => {
 
         // Verify that the "Report Fraud" option is displayed on the screen.
         await waitFor(() => {
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             expect(screen.getByText(translateLocal('cardPage.reportFraud'))).toBeOnTheScreen();
         });
 
         // Verify that the "Reveal Details" option is displayed on the screen.
         await waitFor(() => {
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             expect(screen.getByText(translateLocal('cardPage.cardDetails.revealDetails'))).toBeOnTheScreen();
         });
 
@@ -150,11 +153,13 @@ describe('ExpensifyCardPage', () => {
 
         // Verify that the "Report Fraud" option is NOT displayed on the screen.
         await waitFor(() => {
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             expect(screen.queryByText(translateLocal('cardPage.reportFraud'))).not.toBeOnTheScreen();
         });
 
         // Verify that the "Reveal Details" option is NOT displayed on the screen.
         await waitFor(() => {
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             expect(screen.queryByText(translateLocal('cardPage.cardDetails.revealDetails'))).not.toBeOnTheScreen();
         });
 
@@ -192,6 +197,7 @@ describe('ExpensifyCardPage', () => {
 
         // Verify that the "PIN" option is not displayed on the screen.
         await waitFor(() => {
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             expect(screen.queryByText(translateLocal('cardPage.physicalCardPin'))).not.toBeOnTheScreen();
         });
 
@@ -229,6 +235,7 @@ describe('ExpensifyCardPage', () => {
 
         // Verify that the "PIN" option is displayed on the screen.
         await waitFor(() => {
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             expect(screen.getByText(translateLocal('cardPage.physicalCardPin'))).toBeOnTheScreen();
         });
 

--- a/tests/ui/WorkEmailOnboarding.tsx
+++ b/tests/ui/WorkEmailOnboarding.tsx
@@ -13,6 +13,7 @@ import type ResponsiveLayoutResult from '@hooks/useResponsiveLayout/types';
 import {openOldDotLink} from '@libs/actions/Link';
 import {AddWorkEmail} from '@libs/actions/Session';
 import HttpUtils from '@libs/HttpUtils';
+// eslint-disable-next-line @typescript-eslint/no-deprecated
 import {translateLocal} from '@libs/Localize';
 import Navigation from '@libs/Navigation/Navigation';
 import createPlatformStackNavigator from '@libs/Navigation/PlatformStackNavigation/createPlatformStackNavigator';
@@ -252,13 +253,16 @@ describe('OnboardingWorkEmail Page', () => {
         await waitForBatchedUpdatesWithAct();
 
         await waitFor(() => {
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             expect(screen.getByText(translateLocal('onboarding.workEmail.title'))).toBeOnTheScreen();
         });
         await waitFor(() => {
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             expect(screen.getByText(translateLocal('onboarding.workEmail.addWorkEmail'))).toBeOnTheScreen();
         });
 
         await waitFor(() => {
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             expect(screen.getByText(translateLocal('common.skip'))).toBeOnTheScreen();
         });
 
@@ -422,6 +426,7 @@ describe('OnboardingWorkEmailValidation Page', () => {
         await waitForBatchedUpdatesWithAct();
 
         await waitFor(() => {
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             expect(screen.getByText(translateLocal('onboarding.workEmailValidation.magicCodeSent', {workEmail}))).toBeOnTheScreen();
         });
 
@@ -451,6 +456,7 @@ describe('OnboardingWorkEmailValidation Page', () => {
         await waitForBatchedUpdatesWithAct();
 
         await waitFor(() => {
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             expect(screen.getByText(translateLocal('onboarding.mergeBlockScreen.subtitle', {workEmail}))).toBeOnTheScreen();
         });
 
@@ -474,7 +480,7 @@ describe('OnboardingWorkEmailValidation Page', () => {
         const {unmount} = renderOnboardingWorkEmailValidationPage(SCREENS.ONBOARDING.WORK_EMAIL_VALIDATION, {backTo: ''});
 
         await waitForBatchedUpdatesWithAct();
-
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         const skipButton = screen.getByText(translateLocal('common.skip'));
 
         const mockEvent = {
@@ -630,6 +636,7 @@ describe('OnboardingWorkEmailValidation Page', () => {
         await waitForBatchedUpdatesWithAct();
 
         await waitFor(() => {
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             expect(screen.getByText(translateLocal('onboarding.mergeBlockScreen.subtitle', {workEmail}))).toBeOnTheScreen();
         });
 

--- a/tests/ui/WorkspaceCategoriesTest.tsx
+++ b/tests/ui/WorkspaceCategoriesTest.tsx
@@ -9,6 +9,7 @@ import OnyxListItemProvider from '@components/OnyxListItemProvider';
 import {CurrentReportIDContextProvider} from '@hooks/useCurrentReportID';
 import * as useResponsiveLayoutModule from '@hooks/useResponsiveLayout';
 import type ResponsiveLayoutResult from '@hooks/useResponsiveLayout/types';
+// eslint-disable-next-line @typescript-eslint/no-deprecated
 import {translateLocal} from '@libs/Localize';
 import createPlatformStackNavigator from '@libs/Navigation/PlatformStackNavigation/createPlatformStackNavigator';
 import type {WorkspaceSplitNavigatorParamList} from '@navigation/types';
@@ -130,6 +131,7 @@ describe('WorkspaceCategories', () => {
 
         // Wait for menu items to be visible
         await waitFor(() => {
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             const deleteText = translateLocal('workspace.categories.deleteCategories');
             expect(screen.getByText(deleteText)).toBeOnTheScreen();
         });
@@ -151,17 +153,20 @@ describe('WorkspaceCategories', () => {
 
         // After clicking delete categories dropdown menu item, verify the confirmation modal appears
         await waitFor(() => {
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             const confirmModalPrompt = translateLocal('workspace.categories.deleteCategoriesPrompt');
             expect(screen.getByText(confirmModalPrompt)).toBeOnTheScreen();
         });
 
         // Verify the delete button in the modal is visible
         await waitFor(() => {
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             const deleteConfirmButton = screen.getByLabelText(translateLocal('common.delete'));
             expect(deleteConfirmButton).toBeOnTheScreen();
         });
 
         // Click the delete button in the confirmation modal
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         const deleteConfirmButton = screen.getByLabelText(translateLocal('common.delete'));
         fireEvent.press(deleteConfirmButton);
 
@@ -236,6 +241,7 @@ describe('WorkspaceCategories', () => {
 
         // Wait for menu items to be visible
         await waitFor(() => {
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             const disableText = translateLocal('workspace.categories.disableCategories');
             expect(screen.getByText(disableText)).toBeOnTheScreen();
         });
@@ -257,6 +263,7 @@ describe('WorkspaceCategories', () => {
 
         // After clicking disable categories dropdown menu item, verify the blocking modal appears
         await waitFor(() => {
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             const blockingPrompt = translateLocal('workspace.categories.cannotDeleteOrDisableAllCategories.title');
             expect(screen.getByText(blockingPrompt)).toBeOnTheScreen();
         });

--- a/tests/ui/WorkspaceTagsTest.tsx
+++ b/tests/ui/WorkspaceTagsTest.tsx
@@ -9,6 +9,7 @@ import OnyxListItemProvider from '@components/OnyxListItemProvider';
 import {CurrentReportIDContextProvider} from '@hooks/useCurrentReportID';
 import * as useResponsiveLayoutModule from '@hooks/useResponsiveLayout';
 import type ResponsiveLayoutResult from '@hooks/useResponsiveLayout/types';
+// eslint-disable-next-line @typescript-eslint/no-deprecated
 import {translateLocal} from '@libs/Localize';
 import createPlatformStackNavigator from '@libs/Navigation/PlatformStackNavigation/createPlatformStackNavigator';
 import type {WorkspaceSplitNavigatorParamList} from '@navigation/types';
@@ -123,6 +124,7 @@ describe('WorkspaceTags', () => {
 
         // Wait for the "Select" option to appear
         await waitFor(() => {
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             expect(screen.getByText(translateLocal('common.select'))).toBeOnTheScreen();
         });
 
@@ -168,6 +170,7 @@ describe('WorkspaceTags', () => {
 
         fireEvent.press(screen.getByTestId(dropdownMenuButtonTestID));
         await waitFor(() => {
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             expect(screen.getByText(translateLocal('workspace.tags.disableTags'))).toBeOnTheScreen();
         });
 
@@ -176,6 +179,7 @@ describe('WorkspaceTags', () => {
         fireEvent.press(disableMenuItem, mockEvent);
 
         await waitFor(() => {
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             expect(screen.getByText(translateLocal('workspace.tags.cannotDeleteOrDisableAllTags.title'))).toBeOnTheScreen();
         });
 

--- a/tests/ui/components/EmptySearchViewTest.tsx
+++ b/tests/ui/components/EmptySearchViewTest.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import Onyx from 'react-native-onyx';
 import {LocaleContextProvider} from '@components/LocaleContextProvider';
 import OnyxListItemProvider from '@components/OnyxListItemProvider';
+// eslint-disable-next-line @typescript-eslint/no-deprecated
 import {translateLocal} from '@libs/Localize';
 import {buildQueryStringFromFilterFormValues, buildSearchQueryJSON} from '@libs/SearchQueryUtils';
 import EmptySearchView from '@pages/Search/EmptySearchView';
@@ -67,10 +68,13 @@ describe('EmptySearchView', () => {
             await waitForBatchedUpdatesWithAct();
 
             // Then it should display create expenses and take a test drive buttons
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             expect(await screen.findByText(translateLocal('iou.createExpense'))).toBeVisible();
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             expect(await screen.findByText(translateLocal('emptySearchView.takeATestDrive'))).toBeVisible();
 
             // And correct modal subtitle
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             expect(screen.getByText(translateLocal('search.searchResults.emptyExpenseResults.subtitle'))).toBeVisible();
         });
 
@@ -92,10 +96,13 @@ describe('EmptySearchView', () => {
             );
 
             // Then it should display create expenses button
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             expect(await screen.findByText(translateLocal('iou.createExpense'))).toBeVisible();
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             expect(screen.queryByText(translateLocal('emptySearchView.takeATestDrive'))).not.toBeOnTheScreen();
 
             // And correct modal subtitle
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             expect(screen.getByText(translateLocal('search.searchResults.emptyExpenseResults.subtitleWithOnlyCreateButton'))).toBeVisible();
         });
 
@@ -142,9 +149,11 @@ describe('EmptySearchView', () => {
                 await waitForBatchedUpdatesWithAct();
 
                 // Then it should display the submit empty results title
+                // eslint-disable-next-line @typescript-eslint/no-deprecated
                 expect(screen.getByText(translateLocal('search.searchResults.emptySubmitResults.title'))).toBeVisible();
 
                 // And it should display the "Create Report" button
+                // eslint-disable-next-line @typescript-eslint/no-deprecated
                 expect(screen.getByText(translateLocal('report.newReport.createReport'))).toBeVisible();
             });
 
@@ -178,9 +187,11 @@ describe('EmptySearchView', () => {
                 await waitForBatchedUpdatesWithAct();
 
                 // Then it should display the submit empty results title
+                // eslint-disable-next-line @typescript-eslint/no-deprecated
                 expect(screen.getByText(translateLocal('search.searchResults.emptySubmitResults.title'))).toBeVisible();
 
                 // And it should not display the "Create Report" button
+                // eslint-disable-next-line @typescript-eslint/no-deprecated
                 expect(screen.queryByText(translateLocal('report.newReport.createReport'))).not.toBeOnTheScreen();
             });
         });
@@ -207,10 +218,13 @@ describe('EmptySearchView', () => {
             );
 
             // Then it should display send invoice and take a test drive buttons
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             expect(await screen.findByText(translateLocal('workspace.invoices.sendInvoice'))).toBeVisible();
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             expect(await screen.findByText(translateLocal('emptySearchView.takeATestDrive'))).toBeVisible();
 
             // And correct modal subtitle
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             expect(screen.getByText(translateLocal('search.searchResults.emptyInvoiceResults.subtitle'))).toBeVisible();
         });
 
@@ -232,10 +246,13 @@ describe('EmptySearchView', () => {
             );
 
             // Then it should display Send invoice button
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             expect(await screen.findByText(translateLocal('workspace.invoices.sendInvoice'))).toBeVisible();
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             expect(screen.queryByText(translateLocal('emptySearchView.takeATestDrive'))).not.toBeOnTheScreen();
 
             // And correct modal subtitle
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             expect(screen.getByText(translateLocal('search.searchResults.emptyInvoiceResults.subtitleWithOnlyCreateButton'))).toBeVisible();
         });
     });

--- a/tests/ui/components/IOURequestStepConfirmationPageTest.tsx
+++ b/tests/ui/components/IOURequestStepConfirmationPageTest.tsx
@@ -4,6 +4,7 @@ import Onyx from 'react-native-onyx';
 import {CurrentUserPersonalDetailsProvider} from '@components/CurrentUserPersonalDetailsProvider';
 import {LocaleContextProvider} from '@components/LocaleContextProvider';
 import OnyxListItemProvider from '@components/OnyxListItemProvider';
+// eslint-disable-next-line @typescript-eslint/no-deprecated
 import {translateLocal} from '@libs/Localize';
 import IOURequestStepConfirmationWithWritableReportOrNotFound from '@pages/iou/request/step/IOURequestStepConfirmation';
 import ONYXKEYS from '@src/ONYXKEYS';
@@ -164,7 +165,7 @@ describe('IOURequestStepConfirmationPageTest', () => {
                 </CurrentUserPersonalDetailsProvider>
             </OnyxListItemProvider>,
         );
-
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         fireEvent.press(await screen.findByText(translateLocal('iou.splitExpense')));
         expect(IOU.startSplitBill).toHaveBeenCalledTimes(1);
     });
@@ -214,7 +215,7 @@ describe('IOURequestStepConfirmationPageTest', () => {
                 </CurrentUserPersonalDetailsProvider>
             </OnyxListItemProvider>,
         );
-
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         fireEvent.press(await screen.findByText(translateLocal('iou.createExpenses', {expensesNumber: 2})));
         expect(IOU.startSplitBill).toHaveBeenCalledTimes(2);
     });

--- a/tests/ui/components/OnboardingHelpDropdownButtonTest.tsx
+++ b/tests/ui/components/OnboardingHelpDropdownButtonTest.tsx
@@ -7,6 +7,7 @@ import OnboardingHelpDropdownButton from '@components/OnboardingHelpDropdownButt
 import OnyxListItemProvider from '@components/OnyxListItemProvider';
 import {openExternalLink} from '@libs/actions/Link';
 import {cancelBooking, clearBookingDraft, rescheduleBooking} from '@libs/actions/ScheduleCall';
+// eslint-disable-next-line @typescript-eslint/no-deprecated
 import {translateLocal} from '@libs/Localize';
 import Navigation from '@libs/Navigation/Navigation';
 import CONST from '@src/CONST';
@@ -116,10 +117,14 @@ describe('OnboardingHelpDropdownButton', () => {
         await waitForBatchedUpdatesWithAct();
 
         // Then only schedule call option is visible
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         const scheduleCallOption = screen.getByText(translateLocal('getAssistancePage.scheduleACall'));
         expect(scheduleCallOption).toBeOnTheScreen();
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         expect(screen.queryByText(translateLocal('getAssistancePage.registerForWebinar'))).not.toBeOnTheScreen();
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         expect(screen.queryByText(translateLocal('common.reschedule'))).not.toBeOnTheScreen();
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         expect(screen.queryByText(translateLocal('common.cancel'))).not.toBeOnTheScreen();
 
         // When schedule call option is pressed
@@ -148,10 +153,14 @@ describe('OnboardingHelpDropdownButton', () => {
         await waitForBatchedUpdatesWithAct();
 
         // Then only webinar registration option is visible
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         const registerOption = screen.getByText(translateLocal('getAssistancePage.registerForWebinar'));
         expect(registerOption).toBeOnTheScreen();
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         expect(screen.queryByText(translateLocal('getAssistancePage.scheduleACall'))).not.toBeOnTheScreen();
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         expect(screen.queryByText(translateLocal('common.reschedule'))).not.toBeOnTheScreen();
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         expect(screen.queryByText(translateLocal('common.cancel'))).not.toBeOnTheScreen();
 
         // When webinar registration option is pressed
@@ -186,6 +195,7 @@ describe('OnboardingHelpDropdownButton', () => {
         await waitForBatchedUpdatesWithAct();
 
         // Then dropdown button displays "Call scheduled" text
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         const dropdownButton = screen.getByText(translateLocal('scheduledCall.callScheduled'));
         expect(dropdownButton).toBeOnTheScreen();
 
@@ -197,9 +207,13 @@ describe('OnboardingHelpDropdownButton', () => {
         await waitForBatchedUpdatesWithAct();
 
         // Then all expected menu options are present
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         expect(screen.getByText(translateLocal('common.reschedule'))).toBeOnTheScreen();
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         expect(screen.getByText(translateLocal('common.cancel'))).toBeOnTheScreen();
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         expect(screen.getByText(translateLocal('getAssistancePage.registerForWebinar'))).toBeOnTheScreen();
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         expect(screen.queryByText(translateLocal('getAssistancePage.scheduleACall'))).not.toBeOnTheScreen();
     });
 
@@ -234,13 +248,14 @@ describe('OnboardingHelpDropdownButton', () => {
             renderOnboardingHelpDropdownButton(props);
 
             await waitForBatchedUpdatesWithAct();
-
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             const dropdownButton = screen.getByText(translateLocal('scheduledCall.callScheduled'));
             fireEvent.press(dropdownButton);
 
             await waitForBatchedUpdatesWithAct();
 
             // When webinar menu item is pressed
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             const webinarMenuItem = screen.getByText(translateLocal('getAssistancePage.registerForWebinar'));
             fireEvent.press(webinarMenuItem, createMockPressEvent(webinarMenuItem));
 
@@ -256,13 +271,14 @@ describe('OnboardingHelpDropdownButton', () => {
             renderOnboardingHelpDropdownButton(props);
 
             await waitForBatchedUpdatesWithAct();
-
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             const dropdownButton = screen.getByText(translateLocal('scheduledCall.callScheduled'));
             fireEvent.press(dropdownButton);
 
             await waitForBatchedUpdatesWithAct();
 
             // When reschedule option is pressed
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             const rescheduleMenuItem = screen.getByText(translateLocal('common.reschedule'));
             fireEvent.press(rescheduleMenuItem, createMockPressEvent(rescheduleMenuItem));
 
@@ -278,13 +294,14 @@ describe('OnboardingHelpDropdownButton', () => {
             renderOnboardingHelpDropdownButton(props);
 
             await waitForBatchedUpdatesWithAct();
-
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             const dropdownButton = screen.getByText(translateLocal('scheduledCall.callScheduled'));
             fireEvent.press(dropdownButton);
 
             await waitForBatchedUpdatesWithAct();
 
             // When cancel option is pressed
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             const cancelMenuItem = screen.getByText(translateLocal('common.cancel'));
             fireEvent.press(cancelMenuItem, createMockPressEvent(cancelMenuItem));
 

--- a/tests/unit/CardFeedUtilsTest.ts
+++ b/tests/unit/CardFeedUtilsTest.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/naming-convention */
 import type {OnyxCollection} from 'react-native-onyx';
 import {getCardFeedNamesWithType, getCardFeedsForDisplay, getCardFeedsForDisplayPerPolicy, getSelectedCardsFromFeeds} from '@libs/CardFeedUtils';
+// eslint-disable-next-line @typescript-eslint/no-deprecated
 import {translateLocal} from '@libs/Localize';
 import CONST from '@src/CONST';
 import IntlStore from '@src/languages/IntlStore';
@@ -100,6 +101,7 @@ describe('Card Feed Utils', () => {
         return waitForBatchedUpdates();
     });
     it('returns display name of workspace & domain cards', () => {
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         const cardFeedNamesWithType = getCardFeedNamesWithType({workspaceCardFeeds: fakeWorkspace, translate: translateLocal});
         expect(Object.keys(cardFeedNamesWithType).length).toBe(2);
         expect(Object.values(cardFeedNamesWithType).every((cardFeedName) => cardFeedName.name === 'All Expensify')).toBe(true);
@@ -113,6 +115,7 @@ describe('Card Feed Utils', () => {
     });
 
     it('returns empty object when workspaceCardFeeds is empty', () => {
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         const names = getCardFeedNamesWithType({workspaceCardFeeds: {key: {}}, translate: translateLocal});
         expect(names).toEqual({});
     });

--- a/tests/unit/CarouselItemTest.tsx
+++ b/tests/unit/CarouselItemTest.tsx
@@ -5,6 +5,7 @@ import CarouselItem from '@components/Attachments/AttachmentCarousel/CarouselIte
 import {LocaleContextProvider} from '@components/LocaleContextProvider';
 import OnyxListItemProvider from '@components/OnyxListItemProvider';
 import {PlaybackContextProvider} from '@components/VideoPlayerContexts/PlaybackContext';
+// eslint-disable-next-line @typescript-eslint/no-deprecated
 import {translateLocal} from '@libs/Localize';
 import {AttachmentModalContextProvider} from '@pages/media/AttachmentModalScreen/AttachmentModalContext';
 import ONYXKEYS from '@src/ONYXKEYS';
@@ -38,6 +39,7 @@ describe('CarouselItem', () => {
         await waitForBatchedUpdatesWithAct();
 
         // Then initially the attachment should be hidden so the reveal button should be displayed.
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         expect(screen.getByTestId('moderationButton')).toHaveTextContent(translateLocal('moderation.revealMessage'));
     });
 });

--- a/tests/unit/MergeTransactionUtilsTest.ts
+++ b/tests/unit/MergeTransactionUtilsTest.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line @typescript-eslint/no-deprecated
 import {translateLocal} from '@libs/Localize';
 import {
     buildMergedTransactionData,
@@ -618,6 +619,7 @@ describe('MergeTransactionUtils', () => {
             };
 
             // When we get display value for merchant
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             const result = getDisplayValue('merchant', transaction, translateLocal);
 
             // Then it should return empty string
@@ -633,7 +635,9 @@ describe('MergeTransactionUtils', () => {
             };
 
             // When we get display values for boolean fields
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             const reimbursableResult = getDisplayValue('reimbursable', transaction, translateLocal);
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             const billableResult = getDisplayValue('billable', transaction, translateLocal);
 
             // Then it should return translated Yes/No values
@@ -650,6 +654,7 @@ describe('MergeTransactionUtils', () => {
             };
 
             // When we get display value for amount
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             const result = getDisplayValue('amount', transaction, translateLocal);
 
             // Then it should return formatted currency string
@@ -666,6 +671,7 @@ describe('MergeTransactionUtils', () => {
             };
 
             // When we get display value for description
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             const result = getDisplayValue('description', transaction, translateLocal);
 
             // Then it should return cleaned text without HTML and with spaces instead of line breaks
@@ -680,6 +686,7 @@ describe('MergeTransactionUtils', () => {
             };
 
             // When we get display value for tag
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             const result = getDisplayValue('tag', transaction, translateLocal);
 
             // Then it should return sanitized tag names separated by commas
@@ -693,7 +700,7 @@ describe('MergeTransactionUtils', () => {
                 {email: 'test2@example.com', displayName: 'Test User 2', avatarUrl: '', login: 'test2'},
                 {email: 'test1@example.com', displayName: 'Test User 1', avatarUrl: '', login: 'test1'},
             ];
-
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             const result = getDisplayValue('attendees', transaction, translateLocal);
 
             expect(result).toBe('Test User 2, Test User 1');
@@ -709,7 +716,9 @@ describe('MergeTransactionUtils', () => {
             };
 
             // When we get display values for string fields
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             const merchantResult = getDisplayValue('merchant', transaction, translateLocal);
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             const categoryResult = getDisplayValue('category', transaction, translateLocal);
 
             // Then it should return the string values
@@ -728,9 +737,11 @@ describe('MergeTransactionUtils', () => {
             };
 
             // When we get the error text for attendees field
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             const result = getMergeFieldErrorText(translateLocal, mergeField);
 
             // Then it should return the specific attendees error message
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             expect(result).toBe(translateLocal('transactionMerge.detailsPage.pleaseSelectAttendees'));
         });
 
@@ -743,9 +754,11 @@ describe('MergeTransactionUtils', () => {
             };
 
             // When we get the error text for merchant field
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             const result = getMergeFieldErrorText(translateLocal, mergeField);
 
             // Then it should return the generic error message with lowercase field name
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             expect(result).toBe(translateLocal('transactionMerge.detailsPage.pleaseSelectError', {field: 'merchant'}));
         });
     });

--- a/tests/unit/ReportActionsUtilsTest.ts
+++ b/tests/unit/ReportActionsUtilsTest.ts
@@ -1,6 +1,7 @@
 import type {KeyValueMapping} from 'react-native-onyx';
 import Onyx from 'react-native-onyx';
 import {formatPhoneNumber} from '@libs/LocalePhoneNumber';
+// eslint-disable-next-line @typescript-eslint/no-deprecated
 import {translateLocal} from '@libs/Localize';
 import {isExpenseReport} from '@libs/ReportUtils';
 import IntlStore from '@src/languages/IntlStore';
@@ -1457,6 +1458,7 @@ describe('ReportActionsUtils', () => {
             };
 
             const actual = ReportActionsUtils.getPolicyChangeLogUpdateEmployee(action);
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             const expected = translateLocal('report.actions.type.updatedCustomField1', {email: formatPhoneNumber(email), newValue, previousValue});
             expect(actual).toBe(expected);
         });
@@ -1478,6 +1480,7 @@ describe('ReportActionsUtils', () => {
             };
 
             const actual = ReportActionsUtils.getPolicyChangeLogDeleteMemberMessage(action);
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             const expected = translateLocal('report.actions.type.removeMember', {email: formatPhoneNumber(email), role: translateLocal('workspace.common.roleName', {role}).toLowerCase()});
             expect(actual).toBe(expected);
         });

--- a/tests/unit/SidebarFilterTest.ts
+++ b/tests/unit/SidebarFilterTest.ts
@@ -1,6 +1,7 @@
 import {screen} from '@testing-library/react-native';
 import Onyx from 'react-native-onyx';
 import DateUtils from '@libs/DateUtils';
+// eslint-disable-next-line @typescript-eslint/no-deprecated
 import {translateLocal} from '@libs/Localize';
 import CONST from '@src/CONST';
 import type {Report} from '@src/types/onyx';
@@ -94,6 +95,7 @@ xdescribe('Sidebar', () => {
 
                     // Then no reports are rendered in the LHN
                     .then(() => {
+                        // eslint-disable-next-line @typescript-eslint/no-deprecated
                         const hintText = translateLocal('accessibilityHints.chatUserDisplayNames');
                         const displayNames = screen.queryAllByLabelText(hintText);
                         expect(displayNames).toHaveLength(0);
@@ -127,6 +129,7 @@ xdescribe('Sidebar', () => {
 
                     // Then the report should be rendered in the LHN since it has a draft
                     .then(() => {
+                        // eslint-disable-next-line @typescript-eslint/no-deprecated
                         const hintText = translateLocal('accessibilityHints.chatUserDisplayNames');
                         const displayNames = screen.queryAllByLabelText(hintText);
                         expect(displayNames).toHaveLength(1);
@@ -384,6 +387,7 @@ xdescribe('Sidebar', () => {
                             .then(() => {
                                 if (booleansWhichRemovesActiveReport.indexOf(JSON.stringify(boolArr)) > -1) {
                                     // Only one report visible
+                                    // eslint-disable-next-line @typescript-eslint/no-deprecated
                                     const displayNamesHintText = translateLocal('accessibilityHints.chatUserDisplayNames');
                                     const displayNames = screen.queryAllByLabelText(displayNamesHintText);
 
@@ -430,6 +434,7 @@ xdescribe('Sidebar', () => {
 
                     // Then the reports 1 and 2 are shown and 3 is not
                     .then(() => {
+                        // eslint-disable-next-line @typescript-eslint/no-deprecated
                         const hintText = translateLocal('accessibilityHints.chatUserDisplayNames');
                         const displayNames = screen.queryAllByLabelText(hintText);
                         expect(displayNames).toHaveLength(2);
@@ -502,6 +507,7 @@ xdescribe('Sidebar', () => {
 
                     // Then both reports are visible
                     .then(() => {
+                        // eslint-disable-next-line @typescript-eslint/no-deprecated
                         const hintText = translateLocal('accessibilityHints.chatUserDisplayNames');
                         const displayNames = screen.queryAllByLabelText(hintText);
                         expect(displayNames).toHaveLength(2);
@@ -556,6 +562,7 @@ xdescribe('Sidebar', () => {
 
                     // Then neither reports are visible
                     .then(() => {
+                        // eslint-disable-next-line @typescript-eslint/no-deprecated
                         const hintText = translateLocal('accessibilityHints.chatUserDisplayNames');
                         const displayNames = screen.queryAllByLabelText(hintText);
                         expect(displayNames).toHaveLength(0);
@@ -581,6 +588,7 @@ xdescribe('Sidebar', () => {
 
                     // Then they are all visible
                     .then(() => {
+                        // eslint-disable-next-line @typescript-eslint/no-deprecated
                         const hintText = translateLocal('accessibilityHints.chatUserDisplayNames');
                         const displayNames = screen.queryAllByLabelText(hintText);
                         expect(displayNames).toHaveLength(3);
@@ -622,6 +630,7 @@ xdescribe('Sidebar', () => {
 
                     // Then neither reports are visible
                     .then(() => {
+                        // eslint-disable-next-line @typescript-eslint/no-deprecated
                         const hintText = translateLocal('accessibilityHints.chatUserDisplayNames');
                         const displayNames = screen.queryAllByLabelText(hintText);
                         expect(displayNames).toHaveLength(0);
@@ -642,6 +651,7 @@ xdescribe('Sidebar', () => {
 
                     // Then both rooms are visible
                     .then(() => {
+                        // eslint-disable-next-line @typescript-eslint/no-deprecated
                         const hintText = translateLocal('accessibilityHints.chatUserDisplayNames');
                         const displayNames = screen.queryAllByLabelText(hintText);
                         expect(displayNames).toHaveLength(2);
@@ -728,6 +738,7 @@ xdescribe('Sidebar', () => {
                         .then(() => {
                             if (booleansWhichRemovesActiveReport.indexOf(JSON.stringify(boolArr)) > -1) {
                                 // Only one report visible
+                                // eslint-disable-next-line @typescript-eslint/no-deprecated
                                 const displayNamesHintText = translateLocal('accessibilityHints.chatUserDisplayNames');
                                 const displayNames = screen.queryAllByLabelText(displayNamesHintText);
 
@@ -964,6 +975,7 @@ xdescribe('Sidebar', () => {
                         )
 
                         .then(() => {
+                            // eslint-disable-next-line @typescript-eslint/no-deprecated
                             expect(screen.getByText(translateLocal('common.emptyLHN.title'))).toBeOnTheScreen();
                         })
                 );

--- a/tests/unit/SidebarOrderTest.ts
+++ b/tests/unit/SidebarOrderTest.ts
@@ -3,6 +3,7 @@ import {screen} from '@testing-library/react-native';
 import Onyx from 'react-native-onyx';
 import {addComment} from '@libs/actions/Report';
 import DateUtils from '@libs/DateUtils';
+// eslint-disable-next-line @typescript-eslint/no-deprecated
 import {translateLocal} from '@libs/Localize';
 import initOnyxDerivedValues from '@userActions/OnyxDerived';
 import CONST from '@src/CONST';
@@ -84,6 +85,7 @@ describe('Sidebar', () => {
             LHNTestUtils.getDefaultRenderedSidebarLinks();
 
             // Then it should render with the empty state message and not show the reports list
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             expect(screen.getByText(translateLocal('common.emptyLHN.title'))).toBeOnTheScreen();
             expect(screen.queryByTestId('lhn-options-list')).not.toBeOnTheScreen();
         });
@@ -169,6 +171,7 @@ describe('Sidebar', () => {
 
                     // Then the component should be rendered with the mostly recently updated report first
                     .then(() => {
+                        // eslint-disable-next-line @typescript-eslint/no-deprecated
                         const hintText = translateLocal('accessibilityHints.chatUserDisplayNames');
                         const displayNames = screen.queryAllByLabelText(hintText);
                         expect(displayNames).toHaveLength(3);
@@ -222,7 +225,7 @@ describe('Sidebar', () => {
                     .then(() => {
                         const pencilIcon = screen.queryAllByTestId('Pencil Icon');
                         expect(pencilIcon).toHaveLength(1);
-
+                        // eslint-disable-next-line @typescript-eslint/no-deprecated
                         const hintText = translateLocal('accessibilityHints.chatUserDisplayNames');
                         const displayNames = screen.queryAllByLabelText(hintText);
                         expect(displayNames).toHaveLength(3);
@@ -329,6 +332,7 @@ describe('Sidebar', () => {
 
                     // Then the order of the reports should be 4 > 3 > 2 > 1
                     .then(() => {
+                        // eslint-disable-next-line @typescript-eslint/no-deprecated
                         const hintText = translateLocal('accessibilityHints.chatUserDisplayNames');
                         const displayNames = screen.queryAllByLabelText(hintText);
                         expect(displayNames).toHaveLength(4);
@@ -403,6 +407,7 @@ describe('Sidebar', () => {
 
                     // Then the order of the reports should be 4 > 3 > 2 > 1
                     .then(() => {
+                        // eslint-disable-next-line @typescript-eslint/no-deprecated
                         const hintText = translateLocal('accessibilityHints.chatUserDisplayNames');
                         const displayNames = screen.queryAllByLabelText(hintText);
                         expect(displayNames).toHaveLength(4);
@@ -483,6 +488,7 @@ describe('Sidebar', () => {
 
                     // Then the order of the reports should be 4 > 3 > 2 > 1
                     .then(() => {
+                        // eslint-disable-next-line @typescript-eslint/no-deprecated
                         const hintText = translateLocal('accessibilityHints.chatUserDisplayNames');
                         const displayNames = screen.queryAllByLabelText(hintText);
                         expect(displayNames).toHaveLength(4);
@@ -543,6 +549,7 @@ describe('Sidebar', () => {
                     // Then the order of the reports should be 2 > 3 > 1
                     //                                         ^--- (2 goes to the front and pushes 3 down)
                     .then(() => {
+                        // eslint-disable-next-line @typescript-eslint/no-deprecated
                         const hintText = translateLocal('accessibilityHints.chatUserDisplayNames');
                         const displayNames = screen.queryAllByLabelText(hintText);
                         expect(displayNames).toHaveLength(3);
@@ -709,6 +716,7 @@ describe('Sidebar', () => {
                     // there is a pencil icon
                     // there is a pinned icon
                     .then(() => {
+                        // eslint-disable-next-line @typescript-eslint/no-deprecated
                         const hintText = translateLocal('accessibilityHints.chatUserDisplayNames');
                         const displayNames = screen.queryAllByLabelText(hintText);
                         expect(displayNames).toHaveLength(4);
@@ -764,6 +772,7 @@ describe('Sidebar', () => {
 
                     // Then the reports are in alphabetical order
                     .then(() => {
+                        // eslint-disable-next-line @typescript-eslint/no-deprecated
                         const hintText = translateLocal('accessibilityHints.chatUserDisplayNames');
                         const displayNames = screen.queryAllByLabelText(hintText);
                         expect(displayNames).toHaveLength(3);
@@ -827,6 +836,7 @@ describe('Sidebar', () => {
 
                     // Then the reports are in alphabetical order
                     .then(() => {
+                        // eslint-disable-next-line @typescript-eslint/no-deprecated
                         const hintText = translateLocal('accessibilityHints.chatUserDisplayNames');
                         const displayNames = screen.queryAllByLabelText(hintText);
                         expect(displayNames).toHaveLength(3);
@@ -899,6 +909,7 @@ describe('Sidebar', () => {
 
                     // Then the first report is in last position
                     .then(() => {
+                        // eslint-disable-next-line @typescript-eslint/no-deprecated
                         const hintText = translateLocal('accessibilityHints.chatUserDisplayNames');
                         const displayNames = screen.queryAllByLabelText(hintText);
                         expect(displayNames).toHaveLength(3);
@@ -942,6 +953,7 @@ describe('Sidebar', () => {
 
                     // Then the reports are ordered alphabetically since their lastVisibleActionCreated are the same
                     .then(() => {
+                        // eslint-disable-next-line @typescript-eslint/no-deprecated
                         const hintText = translateLocal('accessibilityHints.chatUserDisplayNames');
                         const displayNames = screen.queryAllByLabelText(hintText);
                         expect(displayNames).toHaveLength(3);
@@ -982,6 +994,7 @@ describe('Sidebar', () => {
 
                     // Then the reports are in alphabetical order
                     .then(() => {
+                        // eslint-disable-next-line @typescript-eslint/no-deprecated
                         const hintText = translateLocal('accessibilityHints.chatUserDisplayNames');
                         const displayNames = screen.queryAllByLabelText(hintText);
                         expect(displayNames).toHaveLength(3);
@@ -1046,6 +1059,7 @@ describe('Sidebar', () => {
 
                     // Then the first report is in last position
                     .then(() => {
+                        // eslint-disable-next-line @typescript-eslint/no-deprecated
                         const hintText = translateLocal('accessibilityHints.chatUserDisplayNames');
                         const displayNames = screen.queryAllByLabelText(hintText);
                         expect(displayNames).toHaveLength(3);

--- a/tests/unit/SidebarTest.ts
+++ b/tests/unit/SidebarTest.ts
@@ -105,10 +105,11 @@ describe('Sidebar', () => {
                         });
                     })
                     .then(() => {
+                        // eslint-disable-next-line @typescript-eslint/no-deprecated
                         const hintText = Localize.translateLocal('accessibilityHints.chatUserDisplayNames');
                         const displayNames = screen.queryAllByLabelText(hintText);
                         expect(displayNames.at(0)).toHaveTextContent('Report (archived)');
-
+                        // eslint-disable-next-line @typescript-eslint/no-deprecated
                         const hintMessagePreviewText = Localize.translateLocal('accessibilityHints.lastChatMessagePreview');
                         const messagePreviewTexts = screen.queryAllByLabelText(hintMessagePreviewText);
                         expect(messagePreviewTexts.at(0)).toHaveTextContent('This chat room has been archived.');
@@ -169,10 +170,11 @@ describe('Sidebar', () => {
                         });
                     })
                     .then(() => {
+                        // eslint-disable-next-line @typescript-eslint/no-deprecated
                         const hintText = Localize.translateLocal('accessibilityHints.chatUserDisplayNames');
                         const displayNames = screen.queryAllByLabelText(hintText);
                         expect(displayNames.at(0)).toHaveTextContent('Report (archived)');
-
+                        // eslint-disable-next-line @typescript-eslint/no-deprecated
                         const hintMessagePreviewText = Localize.translateLocal('accessibilityHints.lastChatMessagePreview');
                         const messagePreviewTexts = screen.queryAllByLabelText(hintMessagePreviewText);
                         expect(messagePreviewTexts.at(0)).toHaveTextContent('This chat is no longer active because Vikings Policy is no longer an active workspace.');

--- a/tests/unit/ValidationUtilsTest.ts
+++ b/tests/unit/ValidationUtilsTest.ts
@@ -1,5 +1,6 @@
 import {addDays, format, startOfDay, subYears} from 'date-fns';
 import {TextEncoder} from 'util';
+// eslint-disable-next-line @typescript-eslint/no-deprecated
 import {translateLocal} from '@libs/Localize';
 import CONST from '@src/CONST';
 import type {Country} from '@src/CONST';
@@ -215,6 +216,7 @@ describe('ValidationUtils', () => {
             const invalidDate: string = format(subYears(new Date(), 17), CONST.DATE.FNS_FORMAT_STRING); // Date of birth 17 years ago
             const error = getAgeRequirementError(invalidDate, 18, 150);
             expect(error).toEqual(
+                // eslint-disable-next-line @typescript-eslint/no-deprecated
                 translateLocal('privatePersonalDetails.error.dateShouldBeBefore', {dateString: format(startOfDay(subYears(new Date(), 18)), CONST.DATE.FNS_FORMAT_STRING)}),
             );
         });
@@ -223,6 +225,7 @@ describe('ValidationUtils', () => {
             const invalidDate: string = format(subYears(new Date(), 160), CONST.DATE.FNS_FORMAT_STRING); // Date of birth 160 years ago
             const error = getAgeRequirementError(invalidDate, 18, 150);
             expect(error).toEqual(
+                // eslint-disable-next-line @typescript-eslint/no-deprecated
                 translateLocal('privatePersonalDetails.error.dateShouldBeAfter', {dateString: format(startOfDay(subYears(new Date(), 150)), CONST.DATE.FNS_FORMAT_STRING)}),
             );
         });
@@ -230,6 +233,7 @@ describe('ValidationUtils', () => {
         test('Should return an error message for an invalid date', () => {
             const invalidDate = '2023-07-32'; // Invalid date
             const error = getAgeRequirementError(invalidDate, 18, 150);
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             expect(error).toBe(translateLocal('common.error.dateInvalid'));
         });
     });

--- a/tests/unit/ViolationUtilsTest.ts
+++ b/tests/unit/ViolationUtilsTest.ts
@@ -1,6 +1,7 @@
 import {beforeEach} from '@jest/globals';
 import Onyx from 'react-native-onyx';
 import {convertAmountToDisplayString} from '@libs/CurrencyUtils';
+// eslint-disable-next-line @typescript-eslint/no-deprecated
 import {translateLocal} from '@libs/Localize';
 import {getTransactionViolations, hasWarningTypeViolation, isViolationDismissed} from '@libs/TransactionUtils';
 import ViolationsUtils from '@libs/Violations/ViolationsUtils';
@@ -658,22 +659,23 @@ const brokenCardConnection530Violation: TransactionViolation = {
 
 describe('getViolationTranslation', () => {
     it('should return the correct message for broken card connection violation', () => {
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         const brokenCardConnectionViolationExpected = translateLocal('violations.rter', {
             brokenBankConnection: true,
             isAdmin: true,
             rterType: CONST.RTER_VIOLATION_TYPES.BROKEN_CARD_CONNECTION,
             isTransactionOlderThan7Days: false,
         });
-
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         expect(ViolationsUtils.getViolationTranslation(brokenCardConnectionViolation, translateLocal)).toBe(brokenCardConnectionViolationExpected);
-
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         const brokenCardConnection530ViolationExpected = translateLocal('violations.rter', {
             brokenBankConnection: true,
             isAdmin: false,
             rterType: CONST.RTER_VIOLATION_TYPES.BROKEN_CARD_CONNECTION_530,
             isTransactionOlderThan7Days: false,
         });
-
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         expect(ViolationsUtils.getViolationTranslation(brokenCardConnection530Violation, translateLocal)).toBe(brokenCardConnection530ViolationExpected);
     });
 });
@@ -701,16 +703,18 @@ describe('getRBRMessages', () => {
 
     it('should return all violations and missing field error', () => {
         const missingFieldError = 'Missing required field';
-
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         const result = ViolationsUtils.getRBRMessages(mockTransaction, mockViolations, translateLocal, missingFieldError, []);
-
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         const expectedResult = `Missing required field. ${translateLocal('violations.missingCategory')}. ${translateLocal('violations.missingTag')}.`;
 
         expect(result).toBe(expectedResult);
     });
 
     it('should filter out empty strings', () => {
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         const result = ViolationsUtils.getRBRMessages(mockTransaction, mockViolations, translateLocal, undefined, []);
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         const expectedResult = `${translateLocal('violations.missingCategory')}. ${translateLocal('violations.missingTag')}.`;
 
         expect(result).toBe(expectedResult);

--- a/tests/utils/TestHelper.ts
+++ b/tests/utils/TestHelper.ts
@@ -5,6 +5,7 @@ import Onyx from 'react-native-onyx';
 import type {ConnectOptions, OnyxEntry, OnyxKey} from 'react-native-onyx/dist/types';
 import type {ApiCommand, ApiRequestCommandParameters} from '@libs/API/types';
 import {formatPhoneNumberWithCountryCode} from '@libs/LocalePhoneNumber';
+// eslint-disable-next-line @typescript-eslint/no-deprecated
 import {translateLocal} from '@libs/Localize';
 import Pusher from '@libs/Pusher';
 import PusherConnectionManager from '@libs/PusherConnectionManager';
@@ -345,6 +346,7 @@ function assertFormDataMatchesObject(obj: Report, formData?: FormData) {
 }
 
 function getNavigateToChatHintRegex(): RegExp {
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     const hintTextPrefix = translateLocal('accessibilityHints.navigatesToChat');
     return new RegExp(hintTextPrefix, 'i');
 }


### PR DESCRIPTION
### Explanation of Change
We recently marked `translateLocal` as deprecated to avoid adding new usages, but have received complaints that it's resulting in too many lint errors in unrelated changes. This PR suppresses lint on all existing usages of translateLocal so we don't disrupt development of unrelated stuff, but still prevent new usages from being added.

Slack context: https://expensify.slack.com/archives/C01GTK53T8Q/p1761040802004759

### Fixed Issues
$ n/a

### Tests
None.

- [x] Verify that no errors appear in the JS console

### Offline tests
n/a

### QA Steps
None.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I verified there are no new alerts related to the `canBeMissing` param for `useOnyx`
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Desktop</summary>

<!-- add screenshots or videos here -->

</details>
