### PR TITLE
Improve onyx state export masking

### DIFF
--- a/src/libs/ExportOnyxState/common.ts
+++ b/src/libs/ExportOnyxState/common.ts
@@ -131,19 +131,9 @@ const keysToMask = [
     'zipCode',
 ];
 
-const amountKeysToRandomize = [
-    'amount',
-    'modifiedAmount',
-    'originalAmount',
-    'total',
-    'unheldTotal',
-    'unheldNonReimbursableTotal',
-    'nonReimbursableTotal',
-];
+const amountKeysToRandomize = ['amount', 'modifiedAmount', 'originalAmount', 'total', 'unheldTotal', 'unheldNonReimbursableTotal', 'nonReimbursableTotal'];
 
-const nodesToFullyMask = [
-    'reservationList',
-];
+const nodesToFullyMask = ['reservationList'];
 
 const emailRegex = /[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}/;
 
@@ -169,7 +159,7 @@ function maskValuePreservingLength(value: unknown) {
 
 function randomizeAmount(amount: number): number {
     const randomizedValue = Math.floor(Math.random() * 999999) + 1;
-    
+
     return amount < 0 ? -randomizedValue : randomizedValue;
 }
 
@@ -309,13 +299,13 @@ const maskFragileData = (data: OnyxState | unknown[] | null, parentKey?: string)
         } else if (key.startsWith(ONYXKEYS.COLLECTION.TRANSACTION) && typeof value === 'object') {
             maskedData[propertyName] = maskFragileData(value as OnyxState, key);
         } else if (amountKeysToRandomize.includes(key) && typeof value === 'number') {
-            maskedData[propertyName] = randomizeAmount(value); 
-        // Handle expensify_text_title masking
+            maskedData[propertyName] = randomizeAmount(value);
+            // Handle expensify_text_title masking
         } else if (parentKey === 'expensify_text_title' && key === 'value' && typeof value === 'string') {
             maskedData[propertyName] = maskValuePreservingLength(value);
         } else if (key === 'expensify_text_title' && typeof value === 'object') {
             maskedData[propertyName] = maskFragileData(value as OnyxState, 'expensify_text_title');
-        // Handle nodes that need full masking
+            // Handle nodes that need full masking
         } else if (nodesToFullyMask.includes(key) && typeof value === 'object') {
             maskedData[propertyName] = maskFragileData(value as OnyxState, key);
         } else if (parentKey && nodesToFullyMask.includes(parentKey) && typeof value === 'string' && isDateValue(value)) {

--- a/src/libs/ExportOnyxState/common.ts
+++ b/src/libs/ExportOnyxState/common.ts
@@ -98,7 +98,6 @@ const keysToMask = [
     'childReportName',
     'city',
     'comment',
-    'currency',
     'description',
     'displayName',
     'edits',
@@ -136,8 +135,6 @@ const amountKeysToRandomize = ['amount', 'modifiedAmount', 'originalAmount', 'to
 const nodesToFullyMask = ['reservationList'];
 
 const emailRegex = /[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}/;
-
-const emailMap = new Map<string, string>();
 
 const getRandomLetter = () => String.fromCharCode(97 + Math.floor(Math.random() * 26));
 
@@ -205,13 +202,13 @@ const getCurrentDate = (): string => {
     return new Date().toISOString();
 };
 
-const processOnyxKeyWithRule = (key: string, data: unknown, rule: ExportRule, shouldMask: boolean): unknown => {
+const processOnyxKeyWithRule = (key: string, data: unknown, rule: ExportRule): unknown => {
     if (data === null || data === undefined) {
         return data;
     }
 
     if (Array.isArray(data)) {
-        return data.map((item: unknown) => (typeof item === 'object' ? processOnyxKeyWithRule(key, item, rule, shouldMask) : item));
+        return data.map((item: unknown) => (typeof item === 'object' ? processOnyxKeyWithRule(key, item, rule) : item));
     }
 
     if (typeof data === 'object') {
@@ -226,7 +223,7 @@ const processOnyxKeyWithRule = (key: string, data: unknown, rule: ExportRule, sh
                 processedData[fieldKey] = fieldValue;
             } else if (typeof fieldValue === 'object' && fieldValue !== null) {
                 // If it's an object and not in allowList/maskList, recursively process it
-                processedData[fieldKey] = processOnyxKeyWithRule(key, fieldValue, rule, shouldMask);
+                processedData[fieldKey] = processOnyxKeyWithRule(key, fieldValue, rule);
             } else if (typeof fieldValue === 'number') {
                 processedData[fieldKey] = randomizeAmount(fieldValue);
             } else if (typeof fieldValue === 'string' && isDateValue(fieldValue)) {
@@ -245,7 +242,7 @@ const processOnyxKeyWithRule = (key: string, data: unknown, rule: ExportRule, sh
     return data;
 };
 
-const maskEmail = (email: string) => {
+const maskEmail = (email: string, emailMap: Map<string, string>) => {
     let maskedEmail = '';
     if (!emailMap.has(email)) {
         maskedEmail = randomizeEmail(email);
@@ -257,7 +254,7 @@ const maskEmail = (email: string) => {
     return maskedEmail;
 };
 
-const maskFragileData = (data: OnyxState | unknown[] | null, parentKey?: string): OnyxState | unknown[] | null => {
+const maskFragileData = (data: OnyxState | unknown[] | null, emailMap: Map<string, string>, parentKey?: string): OnyxState | unknown[] | null => {
     if (data === null) {
         return data;
     }
@@ -265,74 +262,74 @@ const maskFragileData = (data: OnyxState | unknown[] | null, parentKey?: string)
     if (Array.isArray(data)) {
         return data.map((item): unknown => {
             if (typeof item === 'string' && Str.isValidEmail(item)) {
-                return maskEmail(item);
+                return maskEmail(item, emailMap);
             }
-            return typeof item === 'object' ? maskFragileData(item as OnyxState, parentKey) : item;
+            return typeof item === 'object' ? maskFragileData(item as OnyxState, emailMap, parentKey) : item;
         });
     }
 
     const maskedData: OnyxState = {};
 
-    Object.keys(data).forEach((key) => {
-        if (!Object.prototype.hasOwnProperty.call(data, key)) {
+    Object.keys(data).forEach((sourceKey) => {
+        if (!Object.prototype.hasOwnProperty.call(data, sourceKey)) {
             return;
         }
 
-        // loginList is an object that contains emails as keys, the keys should be masked as well
-        let propertyName = '';
-        if (Str.isValidEmail(key)) {
-            propertyName = maskEmail(key);
-        } else {
-            propertyName = key;
-        }
+        // Read value from source using the original key
+        const value = (data as Record<string, unknown>)[sourceKey];
 
-        const value = (data as Record<string, unknown>)[key];
+        // Determine the destination key - mask it if it's an email
+        // (e.g., in loginList where email addresses are used as object keys)
+        const destinationKey = Str.isValidEmail(sourceKey) ? maskEmail(sourceKey, emailMap) : sourceKey;
 
         // Skip values that are already masked as MASKING_PATTERN
         if (value === MASKING_PATTERN) {
-            maskedData[propertyName] = value;
+            maskedData[destinationKey] = value;
             return;
         }
 
         // Handle collection nodes (reportActions, reports, transactions)
-        if (key.startsWith(ONYXKEYS.COLLECTION.REPORT_ACTIONS) && typeof value === 'object') {
-            maskedData[propertyName] = maskFragileData(value as OnyxState, key);
-        } else if (key.startsWith(ONYXKEYS.COLLECTION.REPORT) && typeof value === 'object') {
-            maskedData[propertyName] = maskFragileData(value as OnyxState, key);
-        } else if (key.startsWith(ONYXKEYS.COLLECTION.TRANSACTION) && typeof value === 'object') {
-            maskedData[propertyName] = maskFragileData(value as OnyxState, key);
-        } else if (amountKeysToRandomize.includes(key) && typeof value === 'number') {
-            maskedData[propertyName] = randomizeAmount(value);
+        if (sourceKey.startsWith(ONYXKEYS.COLLECTION.REPORT_ACTIONS) && typeof value === 'object') {
+            maskedData[destinationKey] = maskFragileData(value as OnyxState, emailMap, sourceKey);
+        } else if (sourceKey.startsWith(ONYXKEYS.COLLECTION.REPORT) && typeof value === 'object') {
+            maskedData[destinationKey] = maskFragileData(value as OnyxState, emailMap, sourceKey);
+        } else if (sourceKey.startsWith(ONYXKEYS.COLLECTION.TRANSACTION) && typeof value === 'object') {
+            maskedData[destinationKey] = maskFragileData(value as OnyxState, emailMap, sourceKey);
+        } else if (amountKeysToRandomize.includes(sourceKey) && typeof value === 'number') {
+            maskedData[destinationKey] = randomizeAmount(value);
             // Handle expensify_text_title masking
-        } else if (parentKey === 'expensify_text_title' && key === 'value' && typeof value === 'string') {
-            maskedData[propertyName] = maskValuePreservingLength(value);
-        } else if (key === 'expensify_text_title' && typeof value === 'object') {
-            maskedData[propertyName] = maskFragileData(value as OnyxState, 'expensify_text_title');
+        } else if (parentKey === 'expensify_text_title' && sourceKey === 'value' && typeof value === 'string') {
+            maskedData[destinationKey] = maskValuePreservingLength(value);
+        } else if (sourceKey === 'expensify_text_title' && typeof value === 'object') {
+            maskedData[destinationKey] = maskFragileData(value as OnyxState, emailMap, 'expensify_text_title');
             // Handle nodes that need full masking
-        } else if (nodesToFullyMask.includes(key) && typeof value === 'object') {
-            maskedData[propertyName] = maskFragileData(value as OnyxState, key);
+        } else if (nodesToFullyMask.includes(sourceKey) && typeof value === 'object') {
+            maskedData[destinationKey] = maskFragileData(value as OnyxState, emailMap, sourceKey);
         } else if (parentKey && nodesToFullyMask.includes(parentKey) && typeof value === 'string' && isDateValue(value)) {
-            maskedData[propertyName] = getCurrentDate();
+            maskedData[destinationKey] = getCurrentDate();
         } else if (parentKey && nodesToFullyMask.includes(parentKey) && typeof value === 'string') {
-            maskedData[propertyName] = maskValuePreservingLength(value);
+            maskedData[destinationKey] = maskValuePreservingLength(value);
         } else if (parentKey && nodesToFullyMask.includes(parentKey) && typeof value === 'object') {
-            maskedData[propertyName] = maskFragileData(value as OnyxState, parentKey);
-        } else if (keysToMask.includes(key)) {
+            maskedData[destinationKey] = maskFragileData(value as OnyxState, emailMap, parentKey);
+        } else if (keysToMask.includes(sourceKey)) {
             if (Array.isArray(value)) {
-                maskedData[key] = value.map(() => MASKING_PATTERN);
+                maskedData[destinationKey] = value.map(() => MASKING_PATTERN);
+            } else if (typeof value === 'object') {
+                // If the value is an object, don't mask it as a string - recursively process it
+                maskedData[destinationKey] = maskFragileData(value as OnyxState, emailMap, sourceKey);
             } else {
-                maskedData[key] = maskValuePreservingLength(value);
+                maskedData[destinationKey] = maskValuePreservingLength(value);
             }
         } else if (typeof value === 'string' && Str.isValidEmail(value)) {
-            maskedData[propertyName] = maskEmail(value);
+            maskedData[destinationKey] = maskEmail(value, emailMap);
         } else if (typeof value === 'string' && stringContainsEmail(value)) {
-            maskedData[propertyName] = replaceEmailInString(value, maskEmail(extractEmail(value) ?? ''));
-        } else if (parentKey && parentKey.includes(ONYXKEYS.COLLECTION.REPORT_ACTIONS) && (propertyName === 'text' || propertyName === 'html')) {
-            maskedData[key] = MASKING_PATTERN;
+            maskedData[destinationKey] = replaceEmailInString(value, maskEmail(extractEmail(value) ?? '', emailMap));
+        } else if (parentKey && parentKey.includes(ONYXKEYS.COLLECTION.REPORT_ACTIONS) && (destinationKey === 'text' || destinationKey === 'html')) {
+            maskedData[destinationKey] = MASKING_PATTERN;
         } else if (typeof value === 'object') {
-            maskedData[propertyName] = maskFragileData(value as OnyxState, propertyName.includes(ONYXKEYS.COLLECTION.REPORT_ACTIONS) ? propertyName : parentKey);
+            maskedData[destinationKey] = maskFragileData(value as OnyxState, emailMap, destinationKey.includes(ONYXKEYS.COLLECTION.REPORT_ACTIONS) ? destinationKey : parentKey);
         } else {
-            maskedData[propertyName] = value;
+            maskedData[destinationKey] = value;
         }
     });
 
@@ -353,43 +350,49 @@ const removePrivateOnyxKeys = (onyxState: OnyxState): OnyxState => {
 };
 
 const maskOnyxState: MaskOnyxState = (data, isMaskingFragileDataEnabled) => {
-    let onyxState = {...data};
+    const emailMap = new Map<string, string>();
 
-    onyxState = removePrivateOnyxKeys(onyxState);
+    try {
+        let onyxState = {...data};
 
-    const keysWithRules = new Set<string>();
+        onyxState = removePrivateOnyxKeys(onyxState);
 
-    Object.keys(onyxState).forEach((key) => {
-        let ruleKey = key;
-        const collectionKey = Object.values(ONYXKEYS.COLLECTION).find((cKey) => key.startsWith(cKey));
-        if (collectionKey) {
-            ruleKey = collectionKey;
-        }
+        const keysWithRules = new Set<string>();
 
-        const rule = ONYX_KEY_EXPORT_RULES[ruleKey];
-
-        if (rule) {
-            onyxState[key] = processOnyxKeyWithRule(key, onyxState[key], rule, !!isMaskingFragileDataEnabled);
-            keysWithRules.add(key);
-        }
-    });
-
-    if (isMaskingFragileDataEnabled) {
-        // Only apply maskFragileData to keys that don't have export rules
-        const maskedState: OnyxState = {};
         Object.keys(onyxState).forEach((key) => {
-            if (keysWithRules.has(key)) {
-                maskedState[key] = onyxState[key];
-            } else {
-                const masked = maskFragileData({[key]: onyxState[key]}) as OnyxState;
-                maskedState[key] = masked[key];
+            let ruleKey = key;
+            const collectionKey = Object.values(ONYXKEYS.COLLECTION).find((cKey) => key.startsWith(cKey));
+            if (collectionKey) {
+                ruleKey = collectionKey;
+            }
+
+            const rule = ONYX_KEY_EXPORT_RULES[ruleKey];
+
+            if (rule) {
+                onyxState[key] = processOnyxKeyWithRule(key, onyxState[key], rule);
+                keysWithRules.add(key);
             }
         });
-        onyxState = maskedState;
-    }
 
-    emailMap.clear();
-    return onyxState;
+        if (isMaskingFragileDataEnabled) {
+            // Only apply maskFragileData to keys that don't have export rules
+            const maskedState: OnyxState = {};
+            Object.keys(onyxState).forEach((key) => {
+                if (keysWithRules.has(key)) {
+                    maskedState[key] = onyxState[key];
+                } else {
+                    const masked = maskFragileData({[key]: onyxState[key]}, emailMap) as OnyxState;
+                    maskedState[key] = masked[key];
+                }
+            });
+            onyxState = maskedState;
+        }
+
+        return onyxState;
+    } finally {
+        // Always clear the email map, even if an error occurred
+        emailMap.clear();
+    }
 };
 
 export {maskOnyxState, emailRegex};

--- a/src/libs/ExportOnyxState/common.ts
+++ b/src/libs/ExportOnyxState/common.ts
@@ -189,6 +189,22 @@ function replaceEmailInString(text: string, emailReplacement: string) {
     return text.replace(emailRegex, emailReplacement);
 }
 
+const isDateValue = (value: unknown): boolean => {
+    if (typeof value !== 'string') {
+        return false;
+    }
+
+    const datePatterns = [
+        /^\d{4}-\d{2}-\d{2}/, // ISO date
+        /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/, // ISO datetime
+    ];
+    return datePatterns.some((pattern) => pattern.test(value));
+};
+
+const getCurrentDate = (): string => {
+    return new Date().toISOString();
+};
+
 const processOnyxKeyWithRule = (key: string, data: unknown, rule: ExportRule, shouldMask: boolean): unknown => {
     if (data === null || data === undefined) {
         return data;
@@ -239,22 +255,6 @@ const maskEmail = (email: string) => {
         maskedEmail = emailMap.get(email) as string;
     }
     return maskedEmail;
-};
-
-const isDateValue = (value: unknown): boolean => {
-    if (typeof value !== 'string') {
-        return false;
-    }
-
-    const datePatterns = [
-        /^\d{4}-\d{2}-\d{2}/, // ISO date
-        /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/, // ISO datetime
-    ];
-    return datePatterns.some((pattern) => pattern.test(value));
-};
-
-const getCurrentDate = (): string => {
-    return new Date().toISOString();
 };
 
 const maskFragileData = (data: OnyxState | unknown[] | null, parentKey?: string): OnyxState | unknown[] | null => {

--- a/src/libs/ExportOnyxState/common.ts
+++ b/src/libs/ExportOnyxState/common.ts
@@ -158,8 +158,10 @@ function maskValuePreservingLength(value: unknown) {
 }
 
 function randomizeAmount(amount: number): number {
+    if (!Number.isFinite(amount)) {
+        return 0;
+    }
     const randomizedValue = Math.floor(Math.random() * 999999) + 1;
-
     return amount < 0 ? -randomizedValue : randomizedValue;
 }
 

--- a/src/libs/ExportOnyxState/common.ts
+++ b/src/libs/ExportOnyxState/common.ts
@@ -97,8 +97,10 @@ const keysToMask = [
     'bank',
     'cardName',
     'cardNumber',
+    'childReportName',
     'city',
     'comment',
+    'currency',
     'description',
     'displayName',
     'edits',
@@ -125,9 +127,24 @@ const keysToMask = [
     'source',
     'state',
     'street',
+    'title',
     'validateCode',
     'zip',
     'zipCode',
+];
+
+const amountKeysToRandomize = [
+    'amount',
+    'modifiedAmount',
+    'originalAmount',
+    'total',
+    'unheldTotal',
+    'unheldNonReimbursableTotal',
+    'nonReimbursableTotal',
+];
+
+const nodesToFullyMask = [
+    'reservationList',
 ];
 
 const emailRegex = /[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}/;
@@ -150,6 +167,12 @@ function maskValuePreservingLength(value: unknown) {
     }
 
     return getRandomString(value.length);
+}
+
+function randomizeAmount(amount: number): number {
+    const randomizedValue = Math.floor(Math.random() * 999999) + 1;
+    
+    return amount < 0 ? -randomizedValue : randomizedValue;
 }
 
 function stringContainsEmail(text: string) {
@@ -218,6 +241,22 @@ const maskEmail = (email: string) => {
     return maskedEmail;
 };
 
+const isDateValue = (value: unknown): boolean => {
+    if (typeof value !== 'string') {
+        return false;
+    }
+
+    const datePatterns = [
+        /^\d{4}-\d{2}-\d{2}/, // ISO date
+        /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/, // ISO datetime
+    ];
+    return datePatterns.some((pattern) => pattern.test(value));
+};
+
+const getCurrentDate = (): string => {
+    return new Date().toISOString();
+};
+
 const maskFragileData = (data: OnyxState | unknown[] | null, parentKey?: string): OnyxState | unknown[] | null => {
     if (data === null) {
         return data;
@@ -249,7 +288,30 @@ const maskFragileData = (data: OnyxState | unknown[] | null, parentKey?: string)
 
         const value = data[propertyName];
 
-        if (keysToMask.includes(key)) {
+        // Handle collection nodes (reportActions, reports, transactions)
+        if (key.startsWith(ONYXKEYS.COLLECTION.REPORT_ACTIONS) && typeof value === 'object') {
+            maskedData[propertyName] = maskFragileData(value as OnyxState, key);
+        } else if (key.startsWith(ONYXKEYS.COLLECTION.REPORT) && typeof value === 'object') {
+            maskedData[propertyName] = maskFragileData(value as OnyxState, key);
+        } else if (key.startsWith(ONYXKEYS.COLLECTION.TRANSACTION) && typeof value === 'object') {
+            maskedData[propertyName] = maskFragileData(value as OnyxState, key);
+        } else if (amountKeysToRandomize.includes(key) && typeof value === 'number') {
+            maskedData[propertyName] = randomizeAmount(value); 
+        // Handle expensify_text_title masking
+        } else if (parentKey === 'expensify_text_title' && key === 'value' && typeof value === 'string') {
+            maskedData[propertyName] = maskValuePreservingLength(value);
+        } else if (key === 'expensify_text_title' && typeof value === 'object') {
+            maskedData[propertyName] = maskFragileData(value as OnyxState, 'expensify_text_title');
+        // Handle nodes that need full masking
+        } else if (nodesToFullyMask.includes(key) && typeof value === 'object') {
+            maskedData[propertyName] = maskFragileData(value as OnyxState, key);
+        } else if (parentKey && nodesToFullyMask.includes(parentKey) && typeof value === 'string' && isDateValue(value)) {
+            maskedData[propertyName] = getCurrentDate();
+        } else if (parentKey && nodesToFullyMask.includes(parentKey) && typeof value === 'string') {
+            maskedData[propertyName] = maskValuePreservingLength(value);
+        } else if (parentKey && nodesToFullyMask.includes(parentKey) && typeof value === 'object') {
+            maskedData[propertyName] = maskFragileData(value as OnyxState, parentKey);
+        } else if (keysToMask.includes(key)) {
             if (Array.isArray(value)) {
                 maskedData[key] = value.map(() => MASKING_PATTERN);
             } else {

--- a/src/libs/ExportOnyxState/common.ts
+++ b/src/libs/ExportOnyxState/common.ts
@@ -289,7 +289,7 @@ const maskFragileData = (data: OnyxState | unknown[] | null, parentKey?: string)
             propertyName = key;
         }
 
-        const value = data[propertyName];
+        const value = (data as Record<string, unknown>)[key];
 
         // Handle collection nodes (reportActions, reports, transactions)
         if (key.startsWith(ONYXKEYS.COLLECTION.REPORT_ACTIONS) && typeof value === 'object') {

--- a/src/libs/ExportOnyxState/common.ts
+++ b/src/libs/ExportOnyxState/common.ts
@@ -314,6 +314,9 @@ const maskFragileData = (data: OnyxState | unknown[] | null, parentKey?: string)
         } else if (keysToMask.includes(key)) {
             if (Array.isArray(value)) {
                 maskedData[key] = value.map(() => MASKING_PATTERN);
+            } else if (typeof value === 'object') {
+                // If the value is an object, don't mask it as a string - recursively process it
+                maskedData[propertyName] = maskFragileData(value as OnyxState, key);
             } else {
                 maskedData[key] = maskValuePreservingLength(value);
             }

--- a/tests/unit/ExportOnyxStateTest.ts
+++ b/tests/unit/ExportOnyxStateTest.ts
@@ -28,9 +28,11 @@ describe('maskOnyxState', () => {
             expect(result.session.loading).toBe(false);
             expect(result.session.creationDate).toBe('2024-01-01');
 
-            // Non-whitelisted fields should be redacted
-            expect(result.session.authToken).toBe('***');
-            expect(result.session.encryptedAuthToken).toBe('***');
+            // Non-whitelisted fields should be intelligently redacted
+            expect(result.session.authToken).not.toBe('sensitive-auth-token');
+            expect(result.session.authToken).toHaveLength('sensitive-auth-token'.length);
+            expect(result.session.encryptedAuthToken).not.toBe('sensitive-encrypted-token');
+            expect(result.session.encryptedAuthToken).toHaveLength('sensitive-encrypted-token'.length);
         });
 
         it('should mask fields in maskList while preserving structure', () => {
@@ -72,9 +74,11 @@ describe('maskOnyxState', () => {
             expect(result.session.email).toBe('user@example.com');
             expect(result.session.accountID).toBe(12345);
 
-            // Non-whitelisted fields should be redacted
-            expect(result.session.customField).toBe('***');
-            expect(result.session.anotherField).toBe('***');
+            // Non-whitelisted fields should be intelligently redacted
+            expect(result.session.customField).not.toBe('should-be-redacted');
+            expect(result.session.customField).toHaveLength('should-be-redacted'.length);
+            expect(result.session.anotherField).not.toBe('also-redacted');
+            expect(result.session.anotherField).toHaveLength('also-redacted'.length);
         });
 
         it('should handle collection keys correctly', () => {
@@ -109,8 +113,9 @@ describe('maskOnyxState', () => {
             expect(processedReport.reportName).toHaveLength('Test Report'.length);
             expect(processedReport.description).not.toBe('Test Description');
 
-            // Non-whitelisted, non-masked fields should be redacted
-            expect(processedReport.customField).toBe('***');
+            // Non-whitelisted, non-masked fields should be intelligently redacted
+            expect(processedReport.customField).not.toBe('should-be-redacted');
+            expect(processedReport.customField).toHaveLength('should-be-redacted'.length);
         });
 
         it('should remove sensitive keys from export', () => {
@@ -155,8 +160,10 @@ describe('maskOnyxState', () => {
         const input = {session: mockSession};
         const result = maskOnyxState(input) as ExampleOnyxState;
 
-        expect(result.session.authToken).toBe('***');
-        expect(result.session.encryptedAuthToken).toBe('***');
+        expect(result.session.authToken).not.toBe('sensitive-auth-token');
+        expect(result.session.authToken).toHaveLength('sensitive-auth-token'.length);
+        expect(result.session.encryptedAuthToken).not.toBe('sensitive-encrypted-token');
+        expect(result.session.encryptedAuthToken).toHaveLength('sensitive-encrypted-token'.length);
     });
 
     it('should not mask fragile data when isMaskingFragileDataEnabled is false', () => {
@@ -165,8 +172,10 @@ describe('maskOnyxState', () => {
         };
         const result = maskOnyxState(input) as ExampleOnyxState;
 
-        expect(result.session.authToken).toBe('***');
-        expect(result.session.encryptedAuthToken).toBe('***');
+        expect(result.session.authToken).not.toBe('sensitive-auth-token');
+        expect(result.session.authToken).toHaveLength('sensitive-auth-token'.length);
+        expect(result.session.encryptedAuthToken).not.toBe('sensitive-encrypted-token');
+        expect(result.session.encryptedAuthToken).toHaveLength('sensitive-encrypted-token'.length);
         expect(result.session.email).toBe('user@example.com');
     });
 
@@ -176,8 +185,10 @@ describe('maskOnyxState', () => {
         };
         const result = maskOnyxState(input, true) as ExampleOnyxState;
 
-        expect(result.session.authToken).toBe('***');
-        expect(result.session.encryptedAuthToken).toBe('***');
+        expect(result.session.authToken).not.toBe('sensitive-auth-token');
+        expect(result.session.authToken).toHaveLength('sensitive-auth-token'.length);
+        expect(result.session.encryptedAuthToken).not.toBe('sensitive-encrypted-token');
+        expect(result.session.encryptedAuthToken).toHaveLength('sensitive-encrypted-token'.length);
     });
 
     it('should mask emails as a string value in property with a random email', () => {


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
- Added onyx export masking to additional fields, including report/transaction amount and titles
- Added the ability to mask while maintaining the field type - i.e. number will stay a number, date will stay a date
- Added the ability to mask every field within a node while maintaining types and structures
- Added full masking to reservationList

Additionally, improves on #72932, which made masking a little bit trigger happy in some circumstances

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$
PROPOSAL:


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
Manual tests:

1. Go to "Troubleshoot"
2. Turn on "Mask fragile member data while exporting Onyx state"
3. Export onyx state
4. Check if the transaction and report amounts and titles are randomized 
5. Check if every field within the `reservationList` node is randomized, travel itineraries and confirmation codes are masked or randomized (all the dates should be set to today)
6. Turn off "Mask fragile member data while exporting Onyx state"
7. Check if the transaction and report fields are exported without masking
8. Check if fields in the `reservationList` node are not randomized
9. In another browser window, import the onyx state
10. Check if the state has been imported without errors

- [ ] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

### QA Steps
Same as tests

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
  - [x] I added steps for local testing in the `Tests` section
  - [x] I added steps for the expected offline behavior in the `Offline steps` section
  - [x] I added steps for Staging and/or Production testing in the `QA steps` section
  - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
  - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
  - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
  - [x] Android: Native
  - [x] Android: mWeb Chrome
  - [x] iOS: Native
  - [x] iOS: mWeb Safari
  - [x] MacOS: Chrome / Safari
  - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I verified there are no new alerts related to the `canBeMissing` param for `useOnyx`
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
  - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
  - [x] I verified that comments were added to code that is not self explanatory
  - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
  - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
    - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
  - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
  - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
  - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
  - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
  - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
  - [x] A similar style doesn't already exist
  - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
  - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
  - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
  - [x] I verified that all the inputs inside a form are aligned with each other.
  - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
