### PR TITLE
[No QA] Update Track-Expenses.md

### DIFF
--- a/docs/articles/new-expensify/reports-and-expenses/Track-Expenses.md
+++ b/docs/articles/new-expensify/reports-and-expenses/Track-Expenses.md
@@ -1,11 +1,11 @@
 ---
 title: Track Expenses
-description: Learn how to create and manage expenses in Expensify without submitting them for reimbursement or approval.
+description: Learn how to create and manage expenses in New Expensify without submitting them for reimbursement or approval.
 keywords: track expenses, create expense, scan receipt, enter mileage, expense chat, just track it
 ---
 
 
-Tracking expenses in Expensify allows you to save receipts and costs for your own records, without sending them for approval or reimbursement. This is useful if you're:
+Tracking expenses in New Expensify allows you to save receipts and costs for your own records, without sending them for approval or reimbursement. This is useful if you're:
 - Monitoring personal spending
 - Logging out-of-pocket business expenses for future use
 - Storing receipts you’re not ready to submit yet
@@ -16,46 +16,48 @@ Use this guide to create expenses that stay in your account for later reference.
 
 # How to Track an Expense Without Submitting
 
-**Follow these steps to create an expense that stays in your records but isn't submitted:**
-
 1. Click the **big green + button**.
 2. Select **Create Expense**.
 3. Choose how to create the expense:
    - **Scan a receipt**
-   - **Enter mileage**
    - **Enter manually**
 4. Fill in the required details based on your selection.
 5. Click **Next**.
 6. Choose yourself under Personal.
 7. Update or edit fields based on your Workspace configuration.
-8. Click **Create expense**.
+   - Members with a default workspace will see expense fields that mirror their workspace's rules.
+   - Members without a default workspace will see the expense fields: Amount, Description, Merchant, Category, Date, Report.
+9. Click **Create expense**.
 
 ---
 
-# Locate and Manage Tracked Expenses
+# Where to Find Tracked Expenses
+
+   - All tracked expenses are stored in your **SelfDM** in the left-hand navigation menu.
+   - You can also find them under Reports > Expenses, using filters like date, amount, or category.
+
+# What You Can Do With Tracked Expenses
+
+When you create a tracked expense in your **SelfDM** with the **+** button, Concierge will show an actionable message with options:
+   - **Submit it to someone** – Send it for approval or reimbursement.
+   - **Do nothing** – Leave it stored for later.
+
+If you belong to a workspace, you can also:
+   - **Categorize** – Assign to a workspace category.
+   - **Share with your accountant** – Give access to financial contacts.
+   - **Move expense(s)** – Add the expense to an existing report or create a new report on the spot.
 
 After tracking an expense, it appears in an **Expense Chat** in the left-hand navigation menu.
-
-Within the Expense Chat, you can:
-- **Submit it to someone** – Send it for approval or processing.
-- **Categorize it** – Assign it to a category for better organization.
-- **Share it with my accountant** – Grant access to financial contacts.
-- **Nothing for now** – Leave it as-is for later.
-
-You can also find tracked expenses this way:
-
-1. From the navigation tabs, go to **Reports > Expenses**.
-2. Use filters to narrow your search by date, amount, or category.
 
 ---
 
 # FAQ
 
+## Where are my tracked expenses stored?
+
+All tracked expenses are saved in your selfDM in the left-hand navigation menu. You can also view them under Reports > Expenses with filters applied.
+
 ## Can I edit an expense after tracking it?
 
-Yes! Open the expense from your expense chat or **Reports > Expenses**, then click into it to edit any field.
-
-## Why can’t I find my expense?
-
-Make sure you’re filtering by the correct date or amount. You can easily find unsubmitted expenses in an **Expense Chat** in your Inbox in the navigation tabs.
+Yes! Open the expense from your SelfDM or go to **Reports > Expenses**, then click into it to edit any field.
 


### PR DESCRIPTION
### Fixed Issues

https://github.com/Expensify/Expensify/issues/533133

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->
- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android / native
    - [x] Android / Chrome
    - [x] iOS / native
    - [x] iOS / Safari
    - [x] MacOS / Chrome / Safari
    - [x] MacOS / Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60)
      - [x] If any non-english text was added/modified, I verified the translation was requested/reviewed in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4bd99402cebdf4d7394e0d1f260879ea238197eb/src/components/withLocalize.js#L60-L68)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is approved by marketing by adding the `Waiting for Copy` label for a copy review on the original GH to get the correct copy.
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
    - [x] A similar component doesn't exist in the codebase
    - [x] All props are defined accurately and each prop has a `/** comment above it */`
    - [x] The file is named correctly
    - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
    - [x] The only data being stored in the state is data necessary for rendering and nothing else
    - [x] If we are not using the full Onyx data that we loaded, I've added the proper selector in order to ensure the component only re-renders when the data it is using changes
    - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
    - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
    - [x] All JSX used for rendering exists in the render method
    - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/StyleUtils.js) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(themeColors.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.
