### PR TITLE
[NO QA] Render transaction thread report mentions

### DIFF
--- a/src/components/HTMLEngineProvider/HTMLRenderers/MentionReportRenderer/index.tsx
+++ b/src/components/HTMLEngineProvider/HTMLRenderers/MentionReportRenderer/index.tsx
@@ -26,12 +26,12 @@ function MentionReportRenderer({style, tnode, TDefaultRenderer, ...defaultRender
     const StyleUtils = useStyleUtils();
     const htmlAttributeReportID = tnode.attributes.reportid;
     const {currentReportID: currentReportIDContext, exactlyMatch} = useContext(MentionReportContext);
-    const [reports] = useOnyx(ONYXKEYS.COLLECTION.REPORT);
+    const [reports] = useOnyx(ONYXKEYS.COLLECTION.REPORT, {canBeMissing: true});
 
     const currentReportID = useCurrentReportID();
     // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
     const currentReportIDValue = currentReportIDContext || currentReportID?.currentReportID;
-    const [currentReport] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT}${currentReportIDValue}`);
+    const [currentReport] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT}${currentReportIDValue}`, {canBeMissing: true});
 
     // When we invite someone to a room they don't have the policy object, but we still want them to be able to see and click on report mentions, so we only check if the policyID in the report is from a workspace
     const isGroupPolicyReport = useMemo(() => currentReport && !isEmptyObject(currentReport) && !!currentReport.policyID && currentReport.policyID !== CONST.POLICY.ID_FAKE, [currentReport]);

--- a/src/components/HTMLEngineProvider/HTMLRenderers/MentionReportRenderer/index.tsx
+++ b/src/components/HTMLEngineProvider/HTMLRenderers/MentionReportRenderer/index.tsx
@@ -10,6 +10,7 @@ import useStyleUtils from '@hooks/useStyleUtils';
 import useThemeStyles from '@hooks/useThemeStyles';
 import {getReportMentionDetails} from '@libs/MentionUtils';
 import isSearchTopmostFullScreenRoute from '@libs/Navigation/helpers/isSearchTopmostFullScreenRoute';
+import {isDefaultRoom, isUserCreatedPolicyRoom} from '@libs/ReportUtils';
 import Navigation from '@navigation/Navigation';
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
@@ -40,6 +41,10 @@ function MentionReportRenderer({style, tnode, TDefaultRenderer, ...defaultRender
         return null;
     }
     const {reportID, mentionDisplayText} = mentionDetails;
+    const mentionedReport = reportID ? reports?.[`${ONYXKEYS.COLLECTION.REPORT}${reportID}`] : undefined;
+    const normalizedMentionDisplayText = mentionDisplayText?.replace(/^#/, '') ?? '';
+    const shouldPrefixWithHash = !!(mentionedReport && !isEmptyObject(mentionedReport) && (isDefaultRoom(mentionedReport) || isUserCreatedPolicyRoom(mentionedReport)));
+    const renderedMentionText = shouldPrefixWithHash ? `#${normalizedMentionDisplayText}` : normalizedMentionDisplayText;
 
     let navigationRoute: Route | undefined = reportID ? ROUTES.REPORT_WITH_ID.getRoute(reportID) : undefined;
     const backTo = Navigation.getActiveRoute();
@@ -74,7 +79,7 @@ function MentionReportRenderer({style, tnode, TDefaultRenderer, ...defaultRender
                     role={isGroupPolicyReport ? CONST.ROLE.LINK : undefined}
                     accessibilityLabel={isGroupPolicyReport ? `/${navigationRoute}` : undefined}
                 >
-                    #{mentionDisplayText}
+                    {renderedMentionText}
                 </Text>
             )}
         </ShowContextMenuContext.Consumer>

--- a/src/libs/MentionUtils.ts
+++ b/src/libs/MentionUtils.ts
@@ -26,6 +26,12 @@ const getReportMentionDetails = (htmlAttributeReportID: string, currentReport: O
         Object.values(reports ?? {}).forEach((report) => {
             const resolvedReportName = report ? (getReportName(report) ?? report.reportName) : undefined;
             const normalizedReportName = removeLeadingLTRAndHash(resolvedReportName ?? '');
+            if (report?.policyID !== currentReport?.policyID || !isChatRoom(report)) {
+                return;
+            }
+            if (normalizedReportName !== mentionDisplayText) {
+                return;
+            }
             if (report?.policyID !== currentReport?.policyID || !isChatRoom(report) || normalizedReportName !== mentionDisplayText) {
                 return;
             }

--- a/src/libs/MentionUtils.ts
+++ b/src/libs/MentionUtils.ts
@@ -5,7 +5,7 @@ import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
 import type {Report} from '@src/types/onyx';
 import {isEmptyObject} from '@src/types/utils/EmptyObject';
-import {isChatRoom} from './ReportUtils';
+import {getReportName, isChatRoom} from './ReportUtils';
 
 const removeLeadingLTRAndHash = (value: string) => value.replace(CONST.UNICODE.LTR, '').replace('#', '');
 
@@ -17,16 +17,20 @@ const getReportMentionDetails = (htmlAttributeReportID: string, currentReport: O
     if (!isEmpty(htmlAttributeReportID)) {
         const report = reports?.[`${ONYXKEYS.COLLECTION.REPORT}${htmlAttributeReportID}`];
         reportID = report?.reportID ?? htmlAttributeReportID;
-        mentionDisplayText = removeLeadingLTRAndHash(report?.reportName ?? htmlAttributeReportID);
+        const resolvedReportName = report ? (getReportName(report) ?? report.reportName) : undefined;
+        mentionDisplayText = removeLeadingLTRAndHash(resolvedReportName ?? htmlAttributeReportID);
         // Get mention details from name inside tnode
     } else if ('data' in tnode && !isEmptyObject(tnode.data)) {
         mentionDisplayText = removeLeadingLTRAndHash(tnode.data);
 
         Object.values(reports ?? {}).forEach((report) => {
-            if (report?.policyID !== currentReport?.policyID || !isChatRoom(report) || removeLeadingLTRAndHash(report?.reportName ?? '') !== mentionDisplayText) {
+            const resolvedReportName = report ? (getReportName(report) ?? report.reportName) : undefined;
+            const normalizedReportName = removeLeadingLTRAndHash(resolvedReportName ?? '');
+            if (report?.policyID !== currentReport?.policyID || !isChatRoom(report) || normalizedReportName !== mentionDisplayText) {
                 return;
             }
             reportID = report?.reportID;
+            mentionDisplayText = normalizedReportName;
         });
     } else {
         return null;

--- a/tests/unit/MentionUtilsTest.ts
+++ b/tests/unit/MentionUtilsTest.ts
@@ -1,8 +1,8 @@
 import type {TText} from 'react-native-render-html';
-import type {Report} from '@src/types/onyx';
-import CONST from '@src/CONST';
 import {getReportMentionDetails} from '@libs/MentionUtils';
+import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
+import type {Report} from '@src/types/onyx';
 
 jest.mock('@libs/ReportUtils', () => ({
     __esModule: true,

--- a/tests/unit/MentionUtilsTest.ts
+++ b/tests/unit/MentionUtilsTest.ts
@@ -1,30 +1,23 @@
 import type {TText} from 'react-native-render-html';
+import * as ReportUtils from '@libs/ReportUtils';
 import {getReportMentionDetails} from '@libs/MentionUtils';
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
 import type {Report} from '@src/types/onyx';
 
-jest.mock('@libs/ReportUtils', () => ({
-    __esModule: true,
-    getReportName: jest.fn(),
-    isChatRoom: jest.fn(() => true),
-    isDefaultRoom: jest.fn(() => false),
-    isUserCreatedPolicyRoom: jest.fn(() => false),
-}));
-
-jest.mock('@libs/MentionUtils', () => {
-    const actual = jest.requireActual('@libs/MentionUtils');
+jest.mock('@libs/ReportUtils', () => {
+    const actual = jest.requireActual('@libs/ReportUtils');
     return {
-        __esModule: true,
         ...actual,
-        getReportMentionDetails: jest.fn(actual.getReportMentionDetails),
+        getReportName: jest.fn(),
+        isChatRoom: jest.fn(() => true),
+        isDefaultRoom: jest.fn(() => false),
+        isUserCreatedPolicyRoom: jest.fn(() => false),
     };
 });
 
-const mockGetReportName = jest.requireMock('@libs/ReportUtils').getReportName as jest.Mock;
-const mockIsChatRoom = jest.requireMock('@libs/ReportUtils').isChatRoom as jest.Mock;
-const actualMentionUtils = jest.requireActual('@libs/MentionUtils');
-const actualGetReportMentionDetails = actualMentionUtils.getReportMentionDetails;
+const mockedReportUtils = ReportUtils as jest.Mocked<typeof import('@libs/ReportUtils')>;
+const {getReportName: mockGetReportName, isChatRoom: mockIsChatRoom} = mockedReportUtils;
 
 describe('MentionUtils', () => {
     afterEach(() => {
@@ -70,7 +63,7 @@ describe('MentionUtils integration', () => {
         mockIsChatRoom.mockReturnValue(true);
         mockGetReportName.mockReturnValue('#hello');
         const reportID = '1';
-        const mentionDetails = actualGetReportMentionDetails(
+        const mentionDetails = getReportMentionDetails(
             '',
             {policyID: '1'} as Report,
             {[reportID]: {reportID, reportName: '#hello', policyID: '1', chatType: CONST.REPORT.CHAT_TYPE.POLICY_ROOM}},
@@ -82,7 +75,7 @@ describe('MentionUtils integration', () => {
         mockIsChatRoom.mockReturnValue(false);
         mockGetReportName.mockReturnValue('#hello');
         const reportID = '1';
-        const mentionDetails = actualGetReportMentionDetails('', {policyID: '1'} as Report, {[reportID]: {reportID, reportName: '#hello', policyID: '1'}}, {data: '#hello'} as TText);
+        const mentionDetails = getReportMentionDetails('', {policyID: '1'} as Report, {[reportID]: {reportID, reportName: '#hello', policyID: '1'}}, {data: '#hello'} as TText);
         expect(mentionDetails?.reportID).toBeUndefined();
     });
 });


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
<!-- Explain what your change does and how it addresses the linked issue -->

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
Part of https://github.com/Expensify/App/issues/73297
PROPOSAL:


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
This is only testable with https://github.com/Expensify/Auth/pull/17972, but needs to be merged before it too, so we can only test this internally on dev for now

1. Create a fresh account
2. Create a workspace on this account
3. Submit two identical expenses (merchant/amount)
4. Comment on one of the transaction threads.
5. Click "Review duplicates" and keep the transaction that doesn't have any comments on the transaction thread.
6. Navigate to the transaction thread for the deleted transaction.
7. Verify that the system message renders correctly.

<img width="1927" height="933" alt="Screenshot 2025-10-31 at 3 34 39 PM" src="https://github.com/user-attachments/assets/b7300a9b-8dd2-4765-aab3-42a4a1aab6b5" />


- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
9. Upload an image via copy paste
10. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->
// TODO: These must be filled out, or the issue title must include "[No QA]."

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I verified there are no new alerts related to the `canBeMissing` param for `useOnyx`
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I verified that similar component doesn't exist in the codebase
- [x] I verified that all props are defined accurately and each prop has a `/** comment above it */`
- [x] I verified that each file is named correctly
- [x] I verified that each component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
- [x] I verified that the only data being stored in component state is data necessary for rendering and nothing else
- [x] In component if we are not using the full Onyx data that we loaded, I've added the proper selector in order to ensure the component only re-renders when the data it is using changes
- [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
- [x] I verified that component internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
- [x] I verified that all JSX used for rendering exists in the render method
- [x] I verified that each component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Desktop</summary>

<!-- add screenshots or videos here -->

</details>
