### PR TITLE
[CP STaging] fix: search header alignment and chevron press functionality.

### DIFF
--- a/src/components/MoneyRequestReportView/MoneyRequestReportTransactionItem.tsx
+++ b/src/components/MoneyRequestReportView/MoneyRequestReportTransactionItem.tsx
@@ -61,7 +61,7 @@ type MoneyRequestReportTransactionItemProps = ForwardedFSClassProps & {
     scrollToNewTransaction?: (offset: number) => void;
 
     /** Callback function that navigates to the transaction thread */
-    onArrowRightPress?: () => void;
+    onArrowRightPress?: (transactionID: string) => void;
 };
 
 const expenseHeaders = getExpenseHeaders();
@@ -158,7 +158,7 @@ function MoneyRequestReportTransactionItem({
                     onButtonPress={() => {
                         handleOnPress(transaction.transactionID);
                     }}
-                    onArrowRightPress={() => onArrowRightPress?.()}
+                    onArrowRightPress={() => onArrowRightPress?.(transaction.transactionID)}
                 />
             </PressableWithFeedback>
         </OfflineWithFeedback>

--- a/src/components/MoneyRequestReportView/MoneyRequestReportTransactionItem.tsx
+++ b/src/components/MoneyRequestReportView/MoneyRequestReportTransactionItem.tsx
@@ -59,6 +59,9 @@ type MoneyRequestReportTransactionItemProps = ForwardedFSClassProps & {
 
     /** Callback function that scrolls to this transaction in case it is newly added */
     scrollToNewTransaction?: (offset: number) => void;
+
+    /** Callback function that navigates to the transaction thread */
+    onArrowRightPress?: () => void;
 };
 
 const expenseHeaders = getExpenseHeaders();
@@ -78,6 +81,7 @@ function MoneyRequestReportTransactionItem({
     taxAmountColumnSize,
     scrollToNewTransaction,
     forwardedFSClass,
+    onArrowRightPress,
 }: MoneyRequestReportTransactionItemProps) {
     const {translate} = useLocalize();
     const styles = useThemeStyles();
@@ -154,6 +158,7 @@ function MoneyRequestReportTransactionItem({
                     onButtonPress={() => {
                         handleOnPress(transaction.transactionID);
                     }}
+                    onArrowRightPress={() => onArrowRightPress?.()}
                 />
             </PressableWithFeedback>
         </OfflineWithFeedback>

--- a/src/components/MoneyRequestReportView/MoneyRequestReportTransactionList.tsx
+++ b/src/components/MoneyRequestReportView/MoneyRequestReportTransactionList.tsx
@@ -392,6 +392,7 @@ function MoneyRequestReportTransactionList({
                             // if we add few new transactions, then we need to scroll to the first one
                             scrollToNewTransaction={transaction.transactionID === newTransactions?.at(0)?.transactionID ? scrollToNewTransaction : undefined}
                             forwardedFSClass={transactionItemFSClass}
+                            onArrowRightPress={() => navigateToTransaction(transaction.transactionID)}
                         />
                     );
                 })}

--- a/src/components/MoneyRequestReportView/MoneyRequestReportTransactionList.tsx
+++ b/src/components/MoneyRequestReportView/MoneyRequestReportTransactionList.tsx
@@ -312,6 +312,13 @@ function MoneyRequestReportTransactionList({
         [isMobileSelectionModeEnabled, toggleTransaction, navigateToTransaction],
     );
 
+    const handleArrowRightPress = useCallback(
+        (transactionID: string) => {
+            navigateToTransaction(transactionID);
+        },
+        [navigateToTransaction],
+    );
+
     const listHorizontalPadding = styles.ph5;
 
     const transactionItemFSClass = FS.getChatFSClass(personalDetailsList, report);
@@ -392,7 +399,7 @@ function MoneyRequestReportTransactionList({
                             // if we add few new transactions, then we need to scroll to the first one
                             scrollToNewTransaction={transaction.transactionID === newTransactions?.at(0)?.transactionID ? scrollToNewTransaction : undefined}
                             forwardedFSClass={transactionItemFSClass}
-                            onArrowRightPress={() => navigateToTransaction(transaction.transactionID)}
+                            onArrowRightPress={handleArrowRightPress}
                         />
                     );
                 })}

--- a/src/components/Search/index.tsx
+++ b/src/components/Search/index.tsx
@@ -919,7 +919,7 @@ function Search({
                     onDEWModalOpen={handleDEWModalOpen}
                     SearchTableHeader={
                         !shouldShowTableHeader ? undefined : (
-                            <View style={[styles.pr8, styles.flex1]}>
+                            <View style={[!isTask && styles.pr8, styles.flex1]}>
                                 <SearchTableHeader
                                     canSelectMultiple={canSelectMultiple}
                                     columns={columnsToShow}

--- a/src/components/SelectionListWithSections/Search/TransactionGroupListExpanded.tsx
+++ b/src/components/SelectionListWithSections/Search/TransactionGroupListExpanded.tsx
@@ -208,6 +208,7 @@ function TransactionGroupListExpanded<TItem extends ListItem>({
                             isInSingleTransactionReport={isInSingleTransactionReport}
                             areAllOptionalColumnsHidden={areAllOptionalColumnsHidden}
                             shouldShowBottomBorder={shouldShowBottomBorder}
+                            onArrowRightPress={() => openReportInRHP(transaction)}
                         />
                     </OfflineWithFeedback>
                 );

--- a/src/components/SelectionListWithSections/Search/TransactionListItem.tsx
+++ b/src/components/SelectionListWithSections/Search/TransactionListItem.tsx
@@ -197,6 +197,7 @@ function TransactionListItem<TItem extends ListItem>({
                     style={[styles.p3, styles.pv2, shouldUseNarrowLayout ? styles.pt2 : {}, isLargeScreenWidth && styles.pr0]}
                     areAllOptionalColumnsHidden={areAllOptionalColumnsHidden}
                     violations={transactionViolations}
+                    onArrowRightPress={onPress}
                 />
             </PressableWithFeedback>
         </OfflineWithFeedback>

--- a/src/components/TransactionItemRow/index.tsx
+++ b/src/components/TransactionItemRow/index.tsx
@@ -113,6 +113,7 @@ type TransactionItemRowProps = {
     areAllOptionalColumnsHidden?: boolean;
     violations?: TransactionViolation[];
     shouldShowBottomBorder?: boolean;
+    onArrowRightPress?: () => void;
 };
 
 function getMerchantName(transactionItem: TransactionWithOptionalSearchFields, translate: (key: TranslationPaths) => string) {
@@ -153,6 +154,7 @@ function TransactionItemRow({
     areAllOptionalColumnsHidden = false,
     violations,
     shouldShowBottomBorder,
+    onArrowRightPress,
 }: TransactionItemRowProps) {
     const styles = useThemeStyles();
     const {translate} = useLocalize();
@@ -554,9 +556,9 @@ function TransactionItemRow({
                             />
                         </View>
                     )}
-                    {!!isLargeScreenWidth && (
+                    {!!isLargeScreenWidth && !!onArrowRightPress && (
                         <PressableWithFeedback
-                            onPress={() => onButtonPress()}
+                            onPress={() => onArrowRightPress?.()}
                             style={[styles.p3Half, styles.pl0half, styles.justifyContentCenter, styles.alignItemsEnd]}
                             accessibilityRole={CONST.ROLE.BUTTON}
                             accessibilityLabel={CONST.ROLE.BUTTON}


### PR DESCRIPTION
### Explanation of Change
- This PR solved 2 regressions from https://github.com/Expensify/App/pull/71448. The header alignment issue occurred because of the padding applied to the task list item even though they don't have arrows, and the second one was due to the chevron using the same `onPress` function as the action button.



### Fixed Issues
$ https://github.com/Expensify/App/issues/74006
$ https://github.com/Expensify/App/issues/73999
PROPOSAL:

### Tests
#### TEST 1
- Precondition: Account has tasks from Concierge.

1. Go to staging.new.expensify.com
2. Go to Reports.
3. Click Type filter.
4. Select Task and click Apply.
5. Verify the task item and header is aligned

#### TEST 2 

1. Create a workspace, add an expense in the workspace chat
2. Navigate to Reports - Expenses
3. Click on the arrow on the right of the Submit button on the workspace expense
4. Verify the expense details page is opened


- [x] Verify that no errors appear in the JS console

### Offline tests
- Requires internet to see reports on reports page

### QA Steps
- Same as tests

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I verified there are no new alerts related to the `canBeMissing` param for `useOnyx`
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

https://github.com/user-attachments/assets/9475c04e-e166-40ad-a186-50e952d21d77

</details>

<details>
<summary>Android: mWeb Chrome</summary>

https://github.com/user-attachments/assets/b68560cd-aad1-40c8-a7a5-2704aa1141fc

</details>

<details>
<summary>iOS: Native</summary>

https://github.com/user-attachments/assets/f0cc2362-8e11-47c2-82e1-1056c3aa358e

</details>

<details>
<summary>iOS: mWeb Safari</summary>

https://github.com/user-attachments/assets/18aebff6-cfc2-4574-948b-03bb83861a33

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

https://github.com/user-attachments/assets/6178c44b-dbd5-4f8c-bfe4-ddb382b6dae2

</details>

<details>
<summary>MacOS: Desktop</summary>

https://github.com/user-attachments/assets/a8a94f7d-ecbe-40c2-aa21-94478d56323d

</details>
