### PR TITLE
[CP Staging] Revert "Bump onyx to 3.0.10"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -118,7 +118,7 @@
         "react-native-localize": "^3.5.4",
         "react-native-nitro-modules": "0.29.4",
         "react-native-nitro-sqlite": "9.1.11",
-        "react-native-onyx": "3.0.10",
+        "react-native-onyx": "3.0.8",
         "react-native-pager-view": "6.9.1",
         "react-native-pdf": "7.0.2",
         "react-native-performance": "^5.1.4",
@@ -33531,9 +33531,9 @@
       }
     },
     "node_modules/react-native-onyx": {
-      "version": "3.0.10",
-      "resolved": "https://registry.npmjs.org/react-native-onyx/-/react-native-onyx-3.0.10.tgz",
-      "integrity": "sha512-n1B+cghElMH6tVg4kTTlnQC/+EZAi9TZPydynTKc87XIg4yxJCU81xbr0udHOH/WRQIENsR572dX1XUfosj8eQ==",
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/react-native-onyx/-/react-native-onyx-3.0.8.tgz",
+      "integrity": "sha512-KOLD9K2aBFq7v2bbqUhntNC3TdpSIUOQebrLjbPOk0qdYZ2cGSFlXcZb+qaEeR2MKSzpT1kLRIKzEWyedzPhWQ==",
       "license": "MIT",
       "dependencies": {
         "ascii-table": "0.0.9",

--- a/package.json
+++ b/package.json
@@ -188,7 +188,7 @@
     "react-native-localize": "^3.5.4",
     "react-native-nitro-modules": "0.29.4",
     "react-native-nitro-sqlite": "9.1.11",
-    "react-native-onyx": "3.0.10",
+    "react-native-onyx": "3.0.8",
     "react-native-pager-view": "6.9.1",
     "react-native-pdf": "7.0.2",
     "react-native-performance": "^5.1.4",


### PR DESCRIPTION
Reverts Expensify/App#74174 to fixes 2 blockers:

fixes https://github.com/Expensify/App/issues/74385
fixes https://github.com/Expensify/App/issues/74405
fixes https://github.com/Expensify/App/issues/74406

BE returns correct data, but we have wrong Onyx data

### QA

Can you retest the linked issues please?