### PR TITLE
refactor: improve controlled checkbox state handling for terms 

### DIFF
--- a/contributingGuides/FORMS.md
+++ b/contributingGuides/FORMS.md
@@ -19,6 +19,25 @@ Any form input needs to be wrapped in [InputWrapper](https://github.com/Expensif
 />
 ```
 
+### Checkbox Inputs
+
+When using `CheckboxWithLabel` in a form, it should be wrapped with `InputWrapper` just like other form inputs. The `CheckboxWithLabel` component automatically handles controlled/uncontrolled behavior when used with `FormProvider`:
+
+- When used within a `FormProvider`, the `value` prop is automatically provided by `InputWrapper`, making the checkbox a controlled component
+- The checkbox will always synchronize with the form's state, ensuring the visual state matches the actual form value
+- This prevents issues where the checkbox state could diverge from the form state during validation or state updates
+
+```jsx
+<InputWrapper
+    InputComponent={CheckboxWithLabel}
+    inputID={INPUT_IDS.ACCEPT_TERMS}
+    label="I accept the Terms of Service"
+/>
+```
+
+> [!NOTE]
+> The `CheckboxWithLabel` component prioritizes the `value` prop (provided by `FormProvider`) over internal state when the `value` prop is defined. This ensures proper synchronization between the checkbox's visual state and the form's actual state, preventing scenarios where a checkbox might appear unchecked even though the form state indicates it should be checked.
+
 ### Labels, Placeholders, & Hints
 
 Labels are required for each input and should clearly mark the field. Optional text may appear below a field when a hint, suggestion, or context feels necessary. If validation fails on such a field, its error should clearly explain why without relying on the hint. Inline errors should always replace the microcopy hints. Placeholders should not be used as it’s customary for labels to appear inside form fields and animate them above the field when focused.

--- a/src/components/CheckboxWithLabel.tsx
+++ b/src/components/CheckboxWithLabel.tsx
@@ -69,16 +69,22 @@ function CheckboxWithLabel(
     // https://github.com/Expensify/App/issues/16885#issuecomment-1520846065
     const [isChecked, setIsChecked] = useState(() => [value, defaultValue, isCheckedProp].find((item) => typeof item === 'boolean'));
 
+    const isActuallyChecked = value !== undefined && typeof value === 'boolean' ? value : isChecked;
+
     const toggleCheckbox = () => {
-        onInputChange(!isChecked);
-        setIsChecked(!isChecked);
+        const newValue = !isActuallyChecked;
+        onInputChange(newValue);
+        // Only update internal state if not controlled by value prop
+        if (value === undefined) {
+            setIsChecked(newValue);
+        }
     };
 
     return (
         <View style={style}>
             <View style={[styles.flexRow, styles.alignItemsCenter, styles.breakWord]}>
                 <Checkbox
-                    isChecked={isChecked}
+                    isChecked={isActuallyChecked}
                     onPress={toggleCheckbox}
                     style={[styles.checkboxWithLabelCheckboxStyle]}
                     hasError={!!errorText}

--- a/tests/ui/components/CheckboxWithLabel.tsx
+++ b/tests/ui/components/CheckboxWithLabel.tsx
@@ -76,4 +76,76 @@ describe('CheckboxWithLabel Component', () => {
         const checkbox = screen.getByLabelText(accessibilityLabel);
         expect(checkbox).toBeOnTheScreen();
     });
+
+    it('works as controlled component when value prop is provided', () => {
+        // Given the component is rendered as controlled with value=false
+        const {rerender} = renderCheckboxWithLabel({value: false});
+
+        // When the checkbox is pressed
+        const checkbox = screen.getByText(LABEL);
+        fireEvent.press(checkbox);
+
+        // Then onInputChange should be called with true
+        expect(mockOnInputChange).toHaveBeenCalledWith(true);
+
+        // When the component is re-rendered with value=true
+        rerender(
+            <CheckboxWithLabel
+                label={LABEL}
+                onInputChange={mockOnInputChange}
+                value
+            />,
+        );
+
+        // And the checkbox is pressed again
+        fireEvent.press(checkbox);
+
+        // Then onInputChange should be called with false
+        expect(mockOnInputChange).toHaveBeenCalledWith(false);
+    });
+
+    it('works as uncontrolled component when value prop is not provided', () => {
+        // Given the component is rendered as uncontrolled (no value prop)
+        renderCheckboxWithLabel();
+
+        // When the checkbox is pressed
+        const checkbox = screen.getByText(LABEL);
+        fireEvent.press(checkbox);
+
+        // Then onInputChange should be called with true
+        expect(mockOnInputChange).toHaveBeenCalledWith(true);
+
+        // When the checkbox is pressed again
+        fireEvent.press(checkbox);
+
+        // Then onInputChange should be called with false
+        expect(mockOnInputChange).toHaveBeenCalledWith(false);
+    });
+
+    it('maintains correct checked state in controlled mode', () => {
+        // Given the component is rendered as controlled with value=true
+        const {rerender} = renderCheckboxWithLabel({value: true});
+
+        // When the checkbox is pressed
+        const checkbox = screen.getByText(LABEL);
+        fireEvent.press(checkbox);
+
+        // Then onInputChange should be called with false
+        expect(mockOnInputChange).toHaveBeenCalledWith(false);
+
+        // When the component is re-rendered with the same value (parent doesn't update)
+        rerender(
+            <CheckboxWithLabel
+                label={LABEL}
+                onInputChange={mockOnInputChange}
+                value
+            />,
+        );
+
+        // And the checkbox is pressed again
+        fireEvent.press(checkbox);
+
+        // Then onInputChange should still be called with false (controlled by parent)
+        expect(mockOnInputChange).toHaveBeenCalledWith(false);
+    });
 });


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
<!-- Explain what your change does and how it addresses the linked issue -->

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/73894
PROPOSAL: https://github.com/Expensify/App/issues/73894#issuecomment-3470702134


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

1. Go to https://staging.new.expensify.com./
2. Log in with a Gmail address
3. Navigate to Account > Wallet
4. Click Add bank account
5. On the Where's your bank account located? screen, select India
6. Complete the flow until the final screen where you must accept the Terms
7. Tick the checkbox I accept the Expensify Terms of Service
8. Add an extra digit to the Swift Code (optional) field and click Confirm
9. Click Confirm again. (note that the I accept the Expensify Terms of Service checkbox appears unticked)
10. Verify “I accept Expensify Terms of Service” is still checked and cannot process while unchecked

- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->
the same as tests

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I verified there are no new alerts related to the `canBeMissing` param for `useOnyx`
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/0d3d913d-8d2d-4875-b9cc-7bc7758f7a5b



</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/84f21cd4-83fa-47ce-bbfd-0aaada09a24b


</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/664ce5bd-343e-4ce9-8907-4d27d68d3ca6


</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/8fc1e665-c29f-494b-80df-6311080a5b68



</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/beb2d1c8-f59a-49b4-ac17-7b4743fa5391



</details>

<details>
<summary>MacOS: Desktop</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/659f76bc-04ab-4766-81a0-5a60f793eb8b



</details>
