### PR TITLE
Add optimistic metadata updates when deleting expenses from search

### DIFF
--- a/src/libs/actions/Search.ts
+++ b/src/libs/actions/Search.ts
@@ -598,12 +598,10 @@ function deleteMoneyRequestOnSearch(hash: number, transactionIDList: string[], c
     const currentMetadata = currentSearchResults?.search;
 
     // Calculate total amount of transactions being deleted
-    // Note: convertedAmount is stored as negative for expenses, so we add them to reduce the total
-    let deletedTotal = 0;
-    transactionIDList.forEach((transactionID) => {
+    const deletedTotal = transactionIDList.reduce((sum, transactionID) => {
         const transaction = currentSearchResults?.data?.[`${ONYXKEYS.COLLECTION.TRANSACTION}${transactionID}`];
-        deletedTotal -= (transaction?.convertedAmount ?? 0);
-    });
+        return sum - (transaction?.convertedAmount ?? 0);
+    }, 0);
 
     const {optimisticData: loadingOptimisticData, finallyData} = getOnyxLoadingData(hash);
     // @ts-expect-error - will be solved in https://github.com/Expensify/App/issues/73830

--- a/src/libs/actions/Search.ts
+++ b/src/libs/actions/Search.ts
@@ -602,7 +602,7 @@ function deleteMoneyRequestOnSearch(hash: number, transactionIDList: string[], c
     let deletedTotal = 0;
     transactionIDList.forEach((transactionID) => {
         const transaction = currentSearchResults?.data?.[`${ONYXKEYS.COLLECTION.TRANSACTION}${transactionID}`];
-        deletedTotal += -(transaction?.convertedAmount ?? 0);
+        deletedTotal -= (transaction?.convertedAmount ?? 0);
     });
 
     const {optimisticData: loadingOptimisticData, finallyData} = getOnyxLoadingData(hash);

--- a/src/libs/actions/Search.ts
+++ b/src/libs/actions/Search.ts
@@ -611,13 +611,13 @@ function deleteMoneyRequestOnSearch(hash: number, transactionIDList: string[]) {
     // Read current search snapshot from cache
     const currentSearchResults = searchSnapshots?.[`${ONYXKEYS.COLLECTION.SNAPSHOT}${hash}`];
     const currentMetadata = currentSearchResults?.search;
-    
+
     // Calculate total amount of transactions being deleted
     // Note: convertedAmount is stored as negative for expenses, so we add them to reduce the total
     let deletedTotal = 0;
     transactionIDList.forEach((transactionID) => {
-        const transaction = currentSearchResults?.data?.[`${ONYXKEYS.COLLECTION.TRANSACTION}${transactionID}`] as SearchTransaction | undefined;
-        deletedTotal += - (transaction?.convertedAmount ?? 0);
+        const transaction = currentSearchResults?.data?.[`${ONYXKEYS.COLLECTION.TRANSACTION}${transactionID}`];
+        deletedTotal += -(transaction?.convertedAmount ?? 0);
     });
 
     const {optimisticData: loadingOptimisticData, finallyData} = getOnyxLoadingData(hash);
@@ -633,7 +633,7 @@ function deleteMoneyRequestOnSearch(hash: number, transactionIDList: string[]) {
                     transactionIDList.map((transactionID) => [`${ONYXKEYS.COLLECTION.TRANSACTION}${transactionID}`, {pendingAction: CONST.RED_BRICK_ROAD_PENDING_ACTION.DELETE}]),
                 ) as Partial<SearchTransaction>,
                 search: {
-                    ...(currentMetadata || {}),
+                    ...(currentMetadata ?? {}),
                     count: Math.max(0, (currentMetadata?.count ?? 0) - transactionIDList.length),
                     total: (currentMetadata?.total ?? 0) - deletedTotal,
                 },

--- a/src/libs/actions/Search.ts
+++ b/src/libs/actions/Search.ts
@@ -52,19 +52,6 @@ import {setPersonalBankAccountContinueKYCOnSuccess} from './BankAccounts';
 import {setOptimisticTransactionThread} from './Report';
 import {saveLastSearchParams} from './ReportNavigation';
 
-/**
- * We use a module-level variable to cache all search snapshots.
- * This allows us to read the current state synchronously when performing optimistic updates.
- */
-let searchSnapshots: OnyxCollection<SearchResults> = {};
-Onyx.connect({
-    key: ONYXKEYS.COLLECTION.SNAPSHOT,
-    waitForCollectionCallback: true,
-    callback: (value) => {
-        searchSnapshots = value;
-    },
-});
-
 type OnyxSearchResponse = {
     data: [];
     search: {
@@ -607,9 +594,7 @@ function unholdMoneyRequestOnSearch(hash: number, transactionIDList: string[]) {
     API.write(WRITE_COMMANDS.UNHOLD_MONEY_REQUEST_ON_SEARCH, {hash, transactionIDList}, {optimisticData, finallyData});
 }
 
-function deleteMoneyRequestOnSearch(hash: number, transactionIDList: string[]) {
-    // Read current search snapshot from cache
-    const currentSearchResults = searchSnapshots?.[`${ONYXKEYS.COLLECTION.SNAPSHOT}${hash}`];
+function deleteMoneyRequestOnSearch(hash: number, transactionIDList: string[], currentSearchResults?: SearchResults) {
     const currentMetadata = currentSearchResults?.search;
 
     // Calculate total amount of transactions being deleted

--- a/src/pages/Search/SearchPage.tsx
+++ b/src/pages/Search/SearchPage.tsx
@@ -653,7 +653,7 @@ function SearchPage({route}: SearchPageProps) {
         // We need to wait for modal to fully disappear before clearing them to avoid translation flicker between singular vs plural
         // eslint-disable-next-line @typescript-eslint/no-deprecated
         InteractionManager.runAfterInteractions(() => {
-            deleteMoneyRequestOnSearch(hash, selectedTransactionsKeys);
+            deleteMoneyRequestOnSearch(hash, selectedTransactionsKeys, currentSearchResults);
             clearSelectedTransactions();
         });
     };


### PR DESCRIPTION
### Explanation of Change
This PR adds optimistic updates for search metadata (count and total) when deleting expenses from search results. Previously, the footer displayed stale server data after deleting expenses, showing incorrect expense counts and totals until the server response arrived.

**Implementation:**
- Added module-level Onyx cache using `Onyx.connect()` to synchronously access current search results
- Modified `deleteMoneyRequestOnSearch` to optimistically update search metadata:
  - Decrements `count` by the number of deleted transactions (with safeguard to prevent negative values)
  - Reduces `total` by the sum of deleted transaction amounts
  - Preserves all other metadata properties using spread operator
- Handles negative expense amounts correctly (expenses are stored as negative values)
- Includes failure data to revert metadata if the API call fails

### Fixed Issues
$ https://github.com/Expensify/App/issues/69798
PROPOSAL: https://github.com/Expensify/App/issues/69798#issuecomment-3254611532

### Tests

1. Open any workspace chat
2. Create a manual expense
3. Navigate to Reports > Submit 
4. Delete all the expenses with netork throttling enabled
5. Verify the footer disappears (no "Expenses: <count> Total spend: <amount>" shown)
6. Create 2-3 new expenses with different currencies
7. Navigate to Reports > Submit
8. Verify footer shows correct count and total in correct currency
9. Delete one expense
10. Verify footer updates immediately with new count/total (excluding the deleted expense)
11. Select one or more expenses using checkboxes
12. Verify footer shows count/total for only selected expenses
13. Deselect all expenses
14. Verify footer reverts to showing count for all expenses
15. Delete all remaining expenses
16. Verify empty state is shown without footer

- [x] Verify that no errors appear in the JS console

### Offline tests
1. Add 2-3 expenses in same report/chat and navigate to Reports > Submit
2. Enable airplane/offline mode 
3. Verify offline indicator is visible correctly and delete operation can not be performed

### QA Steps

Same as Tests

- [x] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I verified there are no new alerts related to the `canBeMissing` param for `useOnyx`
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

https://github.com/user-attachments/assets/0afb1a83-eac9-4082-9194-983c61b4710e

</details>

<details>
<summary>MacOS: Desktop</summary>

<!-- add screenshots or videos here -->

</details>
