### PR TITLE
implemented HTML parsing for getReportNames()/ Conditional Parsing for Displaynames

### DIFF
--- a/src/components/DisplayNames/index.native.tsx
+++ b/src/components/DisplayNames/index.native.tsx
@@ -8,8 +8,11 @@ import TextWithEmojiFragment from '@pages/home/report/comment/TextWithEmojiFragm
 import type DisplayNamesProps from './types';
 
 // As we don't have to show tooltips of the Native platform so we simply render the full display names list.
-function DisplayNames({accessibilityLabel, fullTitle, textStyles = [], numberOfLines = 1, renderAdditionalText, forwardedFSClass, testID}: DisplayNamesProps) {
+function DisplayNames({accessibilityLabel, fullTitle, textStyles = [], numberOfLines = 1, renderAdditionalText, forwardedFSClass, testID, shouldParseHtml = false}: DisplayNamesProps) {
     const {translate} = useLocalize();
+    const title = shouldParseHtml
+        ? StringUtils.lineBreaksToSpaces(Parser.htmlToText(fullTitle)) || translate('common.hidden')
+        : StringUtils.lineBreaksToSpaces(fullTitle) || translate('common.hidden');
     const titleContainsTextAndCustomEmoji = useMemo(() => containsCustomEmoji(fullTitle) && !containsOnlyCustomEmoji(fullTitle), [fullTitle]);
     return (
         <Text
@@ -21,11 +24,11 @@ function DisplayNames({accessibilityLabel, fullTitle, textStyles = [], numberOfL
         >
             {titleContainsTextAndCustomEmoji ? (
                 <TextWithEmojiFragment
-                    message={StringUtils.lineBreaksToSpaces(Parser.htmlToText(fullTitle)) || translate('common.hidden')}
+                    message={title}
                     style={textStyles}
                 />
             ) : (
-                StringUtils.lineBreaksToSpaces(Parser.htmlToText(fullTitle)) || translate('common.hidden')
+                title
             )}
             {renderAdditionalText?.()}
         </Text>

--- a/src/components/DisplayNames/index.tsx
+++ b/src/components/DisplayNames/index.tsx
@@ -16,9 +16,12 @@ function DisplayNames({
     displayNamesWithTooltips,
     renderAdditionalText,
     forwardedFSClass,
+    shouldParseHtml = false,
 }: DisplayNamesProps) {
     const {translate} = useLocalize();
-    const title = StringUtils.lineBreaksToSpaces(Parser.htmlToText(fullTitle)) || translate('common.hidden');
+    const title = shouldParseHtml
+        ? StringUtils.lineBreaksToSpaces(Parser.htmlToText(fullTitle)) || translate('common.hidden')
+        : StringUtils.lineBreaksToSpaces(fullTitle) || translate('common.hidden');
 
     if (!tooltipEnabled) {
         return (

--- a/src/components/DisplayNames/types.ts
+++ b/src/components/DisplayNames/types.ts
@@ -1,6 +1,6 @@
 import type {StyleProp, TextStyle} from 'react-native';
 import type {ForwardedFSClassProps} from '@libs/Fullstory/types';
-import type {AvatarSource} from '@libs/UserUtils';
+import type {AvatarSource} from '@libs/UserAvatarUtils';
 
 type DisplayNameWithTooltip = {
     /** The name to display in bold */

--- a/src/components/DisplayNames/types.ts
+++ b/src/components/DisplayNames/types.ts
@@ -1,6 +1,6 @@
 import type {StyleProp, TextStyle} from 'react-native';
 import type {ForwardedFSClassProps} from '@libs/Fullstory/types';
-import type {AvatarSource} from '@libs/UserAvatarUtils';
+import type {AvatarSource} from '@libs/UserUtils';
 
 type DisplayNameWithTooltip = {
     /** The name to display in bold */
@@ -49,6 +49,9 @@ type DisplayNamesProps = ForwardedFSClassProps & {
 
     /** TestID indicating order */
     testID?: number;
+
+    /** Whether to parse HTML in the fullTitle */
+    shouldParseHtml?: boolean;
 };
 
 export default DisplayNamesProps;

--- a/src/libs/ReportUtils.ts
+++ b/src/libs/ReportUtils.ts
@@ -5598,7 +5598,7 @@ function getReportName(
     }
 
     if (isActionOfType(parentReportAction, CONST.REPORT.ACTIONS.TYPE.UNREPORTED_TRANSACTION)) {
-        return getUnreportedTransactionMessage();
+        return Parser.htmlToText(getUnreportedTransactionMessage());
     }
 
     if (isActionOfType(parentReportAction, CONST.REPORT.ACTIONS.TYPE.POLICY_CHANGE_LOG.UPDATE_MAX_EXPENSE_AMOUNT_NO_RECEIPT)) {

--- a/src/pages/ReportDetailsPage.tsx
+++ b/src/pages/ReportDetailsPage.tsx
@@ -10,7 +10,6 @@ import ConfirmModal from '@components/ConfirmModal';
 import DisplayNames from '@components/DisplayNames';
 import HeaderWithBackButton from '@components/HeaderWithBackButton';
 import MentionReportContext from '@components/HTMLEngineProvider/HTMLRenderers/MentionReportRenderer/MentionReportContext';
-import * as Expensicons from '@components/Icon/Expensicons';
 import MenuItem from '@components/MenuItem';
 import MenuItemWithTopDescription from '@components/MenuItemWithTopDescription';
 import OfflineWithFeedback from '@components/OfflineWithFeedback';
@@ -27,6 +26,7 @@ import useCurrentUserPersonalDetails from '@hooks/useCurrentUserPersonalDetails'
 import useDeleteTransactions from '@hooks/useDeleteTransactions';
 import useDuplicateTransactionsAndViolations from '@hooks/useDuplicateTransactionsAndViolations';
 import useGetIOUReportFromReportAction from '@hooks/useGetIOUReportFromReportAction';
+import {useMemoizedLazyExpensifyIcons} from '@hooks/useLazyAsset';
 import useLocalize from '@hooks/useLocalize';
 import useNetwork from '@hooks/useNetwork';
 import useOnyx from '@hooks/useOnyx';
@@ -148,6 +148,7 @@ const CASES = {
 type CaseID = ValueOf<typeof CASES>;
 
 function ReportDetailsPage({policy, report, route, reportMetadata}: ReportDetailsPageProps) {
+    const Expensicons = useMemoizedLazyExpensifyIcons(['Bug', 'Building', 'Camera', 'Checkmark', 'Exit', 'Folder', 'Gear', 'Pencil', 'Send', 'Trashcan', 'UserPlus', 'Users'] as const);
     const {translate, localeCompare} = useLocalize();
     const {isOffline} = useNetwork();
     const {isRestrictedToPreferredPolicy, preferredPolicyID} = usePreferredPolicy();
@@ -576,6 +577,7 @@ function ReportDetailsPage({policy, report, route, reportMetadata}: ReportDetail
         isRestrictedToPreferredPolicy,
         preferredPolicyID,
         introSelected,
+        Expensicons,
     ]);
 
     const displayNamesWithTooltips = useMemo(() => {
@@ -658,6 +660,7 @@ function ReportDetailsPage({policy, report, route, reportMetadata}: ReportDetail
         policy,
         participants,
         moneyRequestReport?.reportID,
+        Expensicons,
     ]);
 
     const canJoin = canJoinChat(report, parentReportAction, policy, !!reportNameValuePairs?.private_isArchived);

--- a/src/pages/ReportDetailsPage.tsx
+++ b/src/pages/ReportDetailsPage.tsx
@@ -41,7 +41,6 @@ import Navigation from '@libs/Navigation/Navigation';
 import type {PlatformStackScreenProps} from '@libs/Navigation/PlatformStackNavigation/types';
 import type {ReportDetailsNavigatorParamList} from '@libs/Navigation/types';
 import {getPersonalDetailsForAccountIDs} from '@libs/OptionsListUtils';
-import Parser from '@libs/Parser';
 import Permissions from '@libs/Permissions';
 import {isPolicyAdmin as isPolicyAdminUtil, isPolicyEmployee as isPolicyEmployeeUtil, shouldShowPolicy} from '@libs/PolicyUtils';
 import {getOneTransactionThreadReportID, getOriginalMessage, getTrackExpenseActionableWhisper, isDeletedAction, isMoneyRequestAction, isTrackExpenseAction} from '@libs/ReportActionsUtils';

--- a/src/pages/ReportDetailsPage.tsx
+++ b/src/pages/ReportDetailsPage.tsx
@@ -331,12 +331,9 @@ function ReportDetailsPage({policy, report, route, reportMetadata}: ReportDetail
 
     const shouldShowLeaveButton = canLeaveChat(report, policy, !!reportNameValuePairs?.private_isArchived);
     const shouldShowGoToWorkspace = shouldShowPolicy(policy, false, currentUserPersonalDetails?.email) && !policy?.isJoinRequestPending;
-<<<<<<< HEAD
-
-    const reportName = Parser.htmlToText(getReportName(report, undefined, undefined, undefined, undefined, reportAttributes));
-=======
     const reportName = getReportName(report, undefined, undefined, undefined, undefined, reportAttributes);
->>>>>>> 3905bf74ba4 (Update src/pages/ReportDetailsPage.tsx)
+
+
 
     const additionalRoomDetails =
         (isPolicyExpenseChat && !!report?.isOwnPolicyExpenseChat) || isExpenseReportUtil(report) || isPolicyExpenseChat || isInvoiceRoom

--- a/src/pages/ReportDetailsPage.tsx
+++ b/src/pages/ReportDetailsPage.tsx
@@ -690,7 +690,7 @@ function ReportDetailsPage({policy, report, route, reportMetadata}: ReportDetail
                             numberOfLines={isChatRoom && !isChatThread ? 0 : 1}
                             textStyles={[styles.textHeadline, styles.textAlignCenter, isChatRoom && !isChatThread ? undefined : styles.pre]}
                             shouldUseFullTitle={shouldUseFullTitle}
-                            shouldParseHtml
+
                         />
                     </View>
                     {isPolicyAdmin ? (

--- a/src/pages/ReportDetailsPage.tsx
+++ b/src/pages/ReportDetailsPage.tsx
@@ -332,8 +332,12 @@ function ReportDetailsPage({policy, report, route, reportMetadata}: ReportDetail
 
     const shouldShowLeaveButton = canLeaveChat(report, policy, !!reportNameValuePairs?.private_isArchived);
     const shouldShowGoToWorkspace = shouldShowPolicy(policy, false, currentUserPersonalDetails?.email) && !policy?.isJoinRequestPending;
+<<<<<<< HEAD
 
     const reportName = Parser.htmlToText(getReportName(report, undefined, undefined, undefined, undefined, reportAttributes));
+=======
+    const reportName = getReportName(report, undefined, undefined, undefined, undefined, reportAttributes);
+>>>>>>> 3905bf74ba4 (Update src/pages/ReportDetailsPage.tsx)
 
     const additionalRoomDetails =
         (isPolicyExpenseChat && !!report?.isOwnPolicyExpenseChat) || isExpenseReportUtil(report) || isPolicyExpenseChat || isInvoiceRoom

--- a/src/pages/ReportDetailsPage.tsx
+++ b/src/pages/ReportDetailsPage.tsx
@@ -333,8 +333,6 @@ function ReportDetailsPage({policy, report, route, reportMetadata}: ReportDetail
     const shouldShowGoToWorkspace = shouldShowPolicy(policy, false, currentUserPersonalDetails?.email) && !policy?.isJoinRequestPending;
     const reportName = getReportName(report, undefined, undefined, undefined, undefined, reportAttributes);
 
-
-
     const additionalRoomDetails =
         (isPolicyExpenseChat && !!report?.isOwnPolicyExpenseChat) || isExpenseReportUtil(report) || isPolicyExpenseChat || isInvoiceRoom
             ? chatRoomSubtitle
@@ -692,6 +690,7 @@ function ReportDetailsPage({policy, report, route, reportMetadata}: ReportDetail
                             numberOfLines={isChatRoom && !isChatThread ? 0 : 1}
                             textStyles={[styles.textHeadline, styles.textAlignCenter, isChatRoom && !isChatThread ? undefined : styles.pre]}
                             shouldUseFullTitle={shouldUseFullTitle}
+                            shouldParseHtml
                         />
                     </View>
                     {isPolicyAdmin ? (

--- a/src/pages/ReportDetailsPage.tsx
+++ b/src/pages/ReportDetailsPage.tsx
@@ -690,7 +690,6 @@ function ReportDetailsPage({policy, report, route, reportMetadata}: ReportDetail
                             numberOfLines={isChatRoom && !isChatThread ? 0 : 1}
                             textStyles={[styles.textHeadline, styles.textAlignCenter, isChatRoom && !isChatThread ? undefined : styles.pre]}
                             shouldUseFullTitle={shouldUseFullTitle}
-
                         />
                     </View>
                     {isPolicyAdmin ? (

--- a/tests/unit/DisplayNamesShouldParseHTMLTest.tsx
+++ b/tests/unit/DisplayNamesShouldParseHTMLTest.tsx
@@ -42,7 +42,13 @@ describe('DisplayNames - shouldParseHtml prop', () => {
     });
 
     it('should NOT parse HTML by default (shouldParseHtml defaults to false)', () => {
-        render(<DisplayNames fullTitle={testTitle} numberOfLines={1} tooltipEnabled={false} />);
+        render(
+            <DisplayNames
+                fullTitle={testTitle}
+                numberOfLines={1}
+                tooltipEnabled={false}
+            />,
+        );
 
         // With shouldParseHtml = false (default), "< >" should be preserved
         expect(screen.getByText('< >')).toBeTruthy();
@@ -50,7 +56,14 @@ describe('DisplayNames - shouldParseHtml prop', () => {
 
     it('should parse HTML when shouldParseHtml is explicitly set to true', () => {
         const htmlTitle = '<b>Bold Text</b>';
-        render(<DisplayNames fullTitle={htmlTitle} numberOfLines={1} tooltipEnabled={false} shouldParseHtml />);
+        render(
+            <DisplayNames
+                fullTitle={htmlTitle}
+                numberOfLines={1}
+                tooltipEnabled={false}
+                shouldParseHtml
+            />,
+        );
 
         // With shouldParseHtml = true, HTML tags should be stripped
         expect(screen.getByText('Bold Text')).toBeTruthy();
@@ -59,21 +72,40 @@ describe('DisplayNames - shouldParseHtml prop', () => {
 
     it('should preserve special characters when shouldParseHtml is false', () => {
         const specialCharsTitle = '< > & " \' test';
-        render(<DisplayNames fullTitle={specialCharsTitle} numberOfLines={1} tooltipEnabled={false} />);
+        render(
+            <DisplayNames
+                fullTitle={specialCharsTitle}
+                numberOfLines={1}
+                tooltipEnabled={false}
+            />,
+        );
 
         // Special characters should be preserved when not parsing HTML
         expect(screen.getByText(specialCharsTitle)).toBeTruthy();
     });
 
     it('should show "hidden" when title is empty and HTML parsing is disabled', () => {
-        render(<DisplayNames fullTitle="" numberOfLines={1} tooltipEnabled={false} />);
+        render(
+            <DisplayNames
+                fullTitle=""
+                numberOfLines={1}
+                tooltipEnabled={false}
+            />,
+        );
 
         expect(screen.getByText('hidden')).toBeTruthy();
     });
 
     it('should show "hidden" when title becomes empty after HTML parsing', () => {
         const onlyTagsTitle = '<div></div>';
-        render(<DisplayNames fullTitle={onlyTagsTitle} numberOfLines={1} tooltipEnabled={false} shouldParseHtml />);
+        render(
+            <DisplayNames
+                fullTitle={onlyTagsTitle}
+                numberOfLines={1}
+                tooltipEnabled={false}
+                shouldParseHtml
+            />,
+        );
 
         // After parsing, only tags remain which get stripped to empty string
         expect(screen.getByText('hidden')).toBeTruthy();

--- a/tests/unit/DisplayNamesShouldParseHTMLTest.tsx
+++ b/tests/unit/DisplayNamesShouldParseHTMLTest.tsx
@@ -1,0 +1,81 @@
+import {render, screen} from '@testing-library/react-native';
+import React from 'react';
+import DisplayNames from '@components/DisplayNames';
+
+jest.mock('@hooks/useLocalize', () => ({
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    __esModule: true,
+    default: () => ({
+        translate: jest.fn((key: string): string => {
+            if (key === 'common.hidden') {
+                return 'hidden';
+            }
+            return key;
+        }),
+    }),
+}));
+
+jest.mock('@libs/Parser', () => ({
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    __esModule: true,
+    default: {
+        htmlToText: jest.fn((html: string) => {
+            // Simulate stripTag behavior: remove anything that looks like HTML tags
+            return html.replace(/(<([^>]+)>)/gi, '');
+        }),
+    },
+}));
+
+jest.mock('@libs/StringUtils', () => ({
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    __esModule: true,
+    default: {
+        lineBreaksToSpaces: jest.fn((text: string) => text),
+    },
+}));
+
+describe('DisplayNames - shouldParseHtml prop', () => {
+    const testTitle = '< >';
+
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('should NOT parse HTML by default (shouldParseHtml defaults to false)', () => {
+        render(<DisplayNames fullTitle={testTitle} numberOfLines={1} tooltipEnabled={false} />);
+
+        // With shouldParseHtml = false (default), "< >" should be preserved
+        expect(screen.getByText('< >')).toBeTruthy();
+    });
+
+    it('should parse HTML when shouldParseHtml is explicitly set to true', () => {
+        const htmlTitle = '<b>Bold Text</b>';
+        render(<DisplayNames fullTitle={htmlTitle} numberOfLines={1} tooltipEnabled={false} shouldParseHtml />);
+
+        // With shouldParseHtml = true, HTML tags should be stripped
+        expect(screen.getByText('Bold Text')).toBeTruthy();
+        expect(screen.queryByText('<b>Bold Text</b>')).toBeNull();
+    });
+
+    it('should preserve special characters when shouldParseHtml is false', () => {
+        const specialCharsTitle = '< > & " \' test';
+        render(<DisplayNames fullTitle={specialCharsTitle} numberOfLines={1} tooltipEnabled={false} />);
+
+        // Special characters should be preserved when not parsing HTML
+        expect(screen.getByText(specialCharsTitle)).toBeTruthy();
+    });
+
+    it('should show "hidden" when title is empty and HTML parsing is disabled', () => {
+        render(<DisplayNames fullTitle="" numberOfLines={1} tooltipEnabled={false} />);
+
+        expect(screen.getByText('hidden')).toBeTruthy();
+    });
+
+    it('should show "hidden" when title becomes empty after HTML parsing', () => {
+        const onlyTagsTitle = '<div></div>';
+        render(<DisplayNames fullTitle={onlyTagsTitle} numberOfLines={1} tooltipEnabled={false} shouldParseHtml />);
+
+        // After parsing, only tags remain which get stripped to empty string
+        expect(screen.getByText('hidden')).toBeTruthy();
+    });
+});

--- a/tests/unit/ReportUtilsTest.ts
+++ b/tests/unit/ReportUtilsTest.ts
@@ -1114,6 +1114,33 @@ describe('ReportUtils', () => {
                 );
             });
         });
+
+        describe('Unreported transaction thread', () => {
+            test('HTML is stripped from unreported transaction message', () => {
+                const transactionThread = {
+                    ...LHNTestUtils.getFakeReport(),
+                    type: CONST.REPORT.TYPE.CHAT,
+                    reportID: '123',
+                    parentReportID: '456',
+                };
+
+                const unreportedTransactionAction = {
+                    actionName: CONST.REPORT.ACTIONS.TYPE.UNREPORTED_TRANSACTION,
+                    originalMessage: {
+                        fromReportID: '789',
+                    },
+                } as ReportAction;
+
+                const reportName = getReportName(transactionThread, undefined, unreportedTransactionAction);
+
+                // Should NOT contain HTML tags
+                expect(reportName).not.toContain('<a href');
+                expect(reportName).not.toContain('</a>');
+                // Should contain the text content
+                expect(reportName).toContain('moved this expense');
+                expect(reportName).toContain('personal space');
+            });
+        });
     });
 
     // Need to merge the same tests


### PR DESCRIPTION
…from issue 74713

<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
<!-- Explain what your change does and how it addresses the linked issue -->
This change Parses HTML of`unReportedTransactionMessages`  in the` getreportNames()` solving the regression that pull request from https://github.com/Expensify/App/issues/68721#issuecomment-3465856135 created as well as implementing the original changes of the PR:  conditional Parsing of HTML at the` displayNames` component
### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/68721#issuecomment-3465856135
$ https://github.com/Expensify/App/issues/74713
PROPOSAL: https://github.com/Expensify/App/issues/68721#issuecomment-3445280927


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

1. Launch app
2. 2 click actions button on left of screen marked +
3. select create chat from the menu
4. in the form field that appears enter a user name, email, or phone
5. matching user will appear below form field
6. click button right side of the user entry which will be labeled add to group
7. on bottom Left of screen click green button labeled next
8. Click on Group Name
9. Delete previous entry
10. Enter < > as the group name
11. Click Save
12. note preview contains the saved group name < >
13. Click Create group
14. Note Header will have New Group name < >
15. Click Header
16. Note detail will show group name: < >
### Additional steps to cover Regression bug

1. Go to staging.new.expensify.com
2. Go to workspace chat.
3. Create an expense.
4. Open the transaction thread.
5. Click Report.
6. Click Remove from report.
7. Go to self DM.
8. Open the unreported expense.
9. Right click on "moved this expense to your personal space" system message.
10. Click Reply in thread.
11. Note "moved this expense to your personal space" system message will not show HTML tags in thread header.

- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->
1. Launch app
2. 2 click actions button on left of screen marked +
3. select create chat from the menu
4. in the form field that appears enter a user name, email, or phone
5. matching user will appear below form field
6. click button right side of the user entry which will be labeled add to group
7. on bottom Left of screen click green button labeled next
8. Click on Group Name
9. Delete previous entry
10. Enter < > as the group name
11. Click Save
12. note preview contains the saved group name < >
13. Click Create group
14. Note Header will have New Group name < >
15. Click Header
16. Note detail will show group name: < >
### Additional steps to cover Regression bug

1. Go to staging.new.expensify.com
2. Go to workspace chat.
3. Create an expense.
4. Open the transaction thread.
5. Click Report.
6. Click Remove from report.
7. Go to self DM.
8. Open the unreported expense.
9. Right click on "moved this expense to your personal space" system message.
10. Click Reply in thread.
11. Note "moved this expense to your personal space" system message will not show HTML tags in thread header.
### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->
Same as tests
// TODO: These must be filled out, or the issue title must include "[No QA]."

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I verified there are no new alerts related to the `canBeMissing` param for `useOnyx`
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.



### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/86f06c48-34fb-4d57-a699-775ffa9a5a8e

<img width="1080" height="2400" alt="androidreg" src="https://github.com/user-attachments/assets/62124ec2-868f-4768-8951-c74757bfa79e" />


</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/53e1d96a-87b0-4398-a31c-3c836a915ce7

<img width="864" height="1939" alt="androidmobileweb" src="https://github.com/user-attachments/assets/3a76a85d-2e23-45e5-8fa9-2be67c1bf386" />

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/eac92ad5-a240-4806-b536-873cacaaf449

<img width="1080" height="2400" alt="iosmobileregress" src="https://github.com/user-attachments/assets/1debc337-c831-4197-a825-d68daf955a5a" />

</details>

<details>
<summary>iOS: mWeb Safari</summary>

https://github.com/user-attachments/assets/0dccbb0c-a373-4fa3-a62a-89bc2cc9d196

<img width="1080" height="2400" alt="mobilesafariweb" src="https://github.com/user-attachments/assets/d0c4a11c-f8e9-4763-b29c-397695ac904a" />

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

https://github.com/user-attachments/assets/716a5766-0d36-472b-9343-60a778990f03

<img width="2560" height="1392" alt="regressionscreenshot" src="https://github.com/user-attachments/assets/5d2d0232-f926-4003-a8e4-de653edcb678" />

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Desktop</summary>



<!-- add screenshots or videos here -->
https://github.com/user-attachments/assets/6785b659-ba50-4119-bf95-ba2bfd2cc3c1

<img width="1224" height="914" alt="macdesk" src="https://github.com/user-attachments/assets/b89ffefa-9ec7-4882-836f-d6706f5460bb" />


</details>
