### PR TITLE
[CP Staging] Revert "Fix - Expense - Error submitting expense after changing submission frequency from Manual to Instant"

### DIFF
--- a/src/libs/ReportUtils.ts
+++ b/src/libs/ReportUtils.ts
@@ -2615,18 +2615,14 @@ function canAddOrDeleteTransactions(moneyRequestReport: OnyxEntry<Report>, isRep
  * Returns false if:
  * - if current user is not the submitter of an expense report
  */
-function canAddTransaction(moneyRequestReport: OnyxEntry<Report>, isReportArchived = false, isMovingTransaction = false): boolean {
+function canAddTransaction(moneyRequestReport: OnyxEntry<Report>, isReportArchived = false): boolean {
     if (!isMoneyRequestReport(moneyRequestReport) || (isExpenseReport(moneyRequestReport) && !isCurrentUserSubmitter(moneyRequestReport))) {
         return false;
     }
     // This will be fixed as part of https://github.com/Expensify/Expensify/issues/507850
     // eslint-disable-next-line @typescript-eslint/no-deprecated
     const policy = getPolicy(moneyRequestReport?.policyID);
-    if (
-        isInstantSubmitEnabled(policy) &&
-        isSubmitAndClose(policy) &&
-        (hasOnlyNonReimbursableTransactions(moneyRequestReport?.reportID) || (!isMovingTransaction && policy?.reimbursementChoice === CONST.POLICY.REIMBURSEMENT_CHOICES.REIMBURSEMENT_NO))
-    ) {
+    if (isInstantSubmitEnabled(policy) && isSubmitAndClose(policy) && hasOnlyNonReimbursableTransactions(moneyRequestReport?.reportID)) {
         return false;
     }
 

--- a/src/pages/iou/request/step/IOURequestEditReportCommon.tsx
+++ b/src/pages/iou/request/step/IOURequestEditReportCommon.tsx
@@ -158,7 +158,7 @@ function IOURequestEditReportCommon({
                 return true;
             })
             .filter((report) => {
-                if (canAddTransaction(report, undefined, true)) {
+                if (canAddTransaction(report)) {
                     return true;
                 }
 

--- a/tests/unit/ReportUtilsTest.ts
+++ b/tests/unit/ReportUtilsTest.ts
@@ -5725,55 +5725,6 @@ describe('ReportUtils', () => {
             // Then the result is false
             expect(result).toBe(false);
         });
-
-        it('should return false for a submitted report when the policy is submit and close with payment disabled', async () => {
-            // Given the policy is submit and close with payment disabled
-            const workflowDisabledPolicy: Policy = {
-                ...createRandomPolicy(2962),
-                autoReporting: true,
-                autoReportingFrequency: CONST.POLICY.AUTO_REPORTING_FREQUENCIES.INSTANT,
-                approvalMode: CONST.POLICY.APPROVAL_MODE.OPTIONAL,
-                reimbursementChoice: CONST.POLICY.REIMBURSEMENT_CHOICES.REIMBURSEMENT_NO,
-                employeeList: {
-                    [currentUserEmail]: {email: currentUserEmail, submitsTo: currentUserEmail},
-                },
-                approver: currentUserEmail,
-            };
-            const report: Report = {
-                ...createRandomReport(10002, undefined),
-                type: CONST.REPORT.TYPE.EXPENSE,
-                statusNum: CONST.REPORT.STATUS_NUM.SUBMITTED,
-                stateNum: CONST.REPORT.STATE_NUM.SUBMITTED,
-                policyID: workflowDisabledPolicy.id,
-                ownerAccountID: currentUserAccountID,
-                managerID: currentUserAccountID,
-            };
-            await Onyx.set(`${ONYXKEYS.COLLECTION.REPORT}${report.reportID}`, report);
-            await Onyx.set(`${ONYXKEYS.COLLECTION.POLICY}${workflowDisabledPolicy.id}`, workflowDisabledPolicy);
-            await Onyx.set(`${ONYXKEYS.PERSONAL_DETAILS_LIST}`, {
-                [currentUserAccountID]: {
-                    accountID: currentUserAccountID,
-                    displayName: 'Lagertha Lothbrok',
-                    firstName: 'Lagertha',
-                    login: currentUserEmail,
-                    pronouns: 'She/her',
-                },
-            });
-
-            const {result: isReportArchived} = renderHook(() => useReportIsArchived(report?.reportID));
-
-            // If the canAddTransaction is used for the case of adding expense into the report
-            const result = canAddTransaction(report, isReportArchived.current);
-
-            // Then the result should be false
-            expect(result).toBe(false);
-
-            // If the canAddTransaction is used for the case of moving transaction into the report
-            const result2 = canAddTransaction(report, isReportArchived.current, true);
-
-            // Then the result should be true
-            expect(result2).toBe(true);
-        });
     });
 
     describe('canDeleteTransaction', () => {


### PR DESCRIPTION
Reverts Expensify/App#73463

Reverting a PR that fixes an issue that already exists in prod. We're reverting because it introduces another regression in a more common scenario.

$ https://github.com/Expensify/App/issues/74989