### PR TITLE
[CP Staging] Revert "fix: use correct receipt files with URIs when multi-scan via QAB"

### DIFF
--- a/src/pages/iou/request/step/IOURequestStepScan/ReceiptPreviews/index.tsx
+++ b/src/pages/iou/request/step/IOURequestStepScan/ReceiptPreviews/index.tsx
@@ -15,6 +15,7 @@ import useTheme from '@hooks/useTheme';
 import useThemeStyles from '@hooks/useThemeStyles';
 import useWindowDimensions from '@hooks/useWindowDimensions';
 import Navigation from '@libs/Navigation/Navigation';
+import type {ReceiptFile} from '@pages/iou/request/step/IOURequestStepScan/types';
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
 import ROUTES from '@src/ROUTES';
@@ -25,7 +26,7 @@ type ReceiptWithTransactionID = Receipt & {transactionID: string};
 
 type ReceiptPreviewsProps = {
     /** Submit method */
-    submit: () => void;
+    submit: (files: ReceiptFile[]) => void;
 
     /** If the receipts preview should be shown */
     isMultiScanEnabled: boolean;
@@ -116,6 +117,11 @@ function ReceiptPreviews({submit, isMultiScanEnabled}: ReceiptPreviewsProps) {
         };
     });
 
+    const submitReceipts = () => {
+        const transactionReceipts = (optimisticTransactionsReceipts ?? []).filter((receipt): receipt is ReceiptWithTransactionID & {source: string} => !!receipt.source);
+        submit(transactionReceipts);
+    };
+
     return (
         <Animated.View style={slideInStyle}>
             <View style={styles.pr4}>
@@ -138,7 +144,7 @@ function ReceiptPreviews({submit, isMultiScanEnabled}: ReceiptPreviewsProps) {
                         innerStyles={[styles.singleAvatarMedium, styles.bgGreenSuccess]}
                         icon={Expensicons.ArrowRight}
                         iconFill={theme.white}
-                        onPress={submit}
+                        onPress={submitReceipts}
                     />
                 </SubmitButtonShadow>
             </View>

--- a/src/pages/iou/request/step/IOURequestStepScan/index.native.tsx
+++ b/src/pages/iou/request/step/IOURequestStepScan/index.native.tsx
@@ -8,10 +8,9 @@ import ReactNativeBlobUtil from 'react-native-blob-util';
 import {Gesture, GestureDetector} from 'react-native-gesture-handler';
 import type {OnyxEntry} from 'react-native-onyx';
 import {RESULTS} from 'react-native-permissions';
-import Animated, {useAnimatedStyle, useSharedValue, withDelay, withSequence, withSpring, withTiming} from 'react-native-reanimated';
+import Animated, {runOnJS, useAnimatedStyle, useSharedValue, withDelay, withSequence, withSpring, withTiming} from 'react-native-reanimated';
 import type {Camera, PhotoFile, Point} from 'react-native-vision-camera';
 import {useCameraDevice} from 'react-native-vision-camera';
-import {scheduleOnRN} from 'react-native-worklets';
 import MultiScan from '@assets/images/educational-illustration__multi-scan.svg';
 import TestReceipt from '@assets/images/fake-receipt.png';
 import Hand from '@assets/images/hand.svg';
@@ -230,7 +229,7 @@ function IOURequestStepScan({
             focusIndicatorScale.set(withSpring(1, {damping: 10, stiffness: 200}));
             focusIndicatorPosition.set(point);
 
-            scheduleOnRN(focusCamera, point);
+            runOnJS(focusCamera)(point);
         });
 
     useFocusEffect(
@@ -650,8 +649,6 @@ function IOURequestStepScan({
         [shouldSkipConfirmation, navigateToConfirmationStep, initialTransaction, iouType, shouldStartLocationPermissionFlow],
     );
 
-    const submitMultiScanReceipts = useCallback(() => submitReceipts(receiptFiles), [receiptFiles, submitReceipts]);
-
     const viewfinderLayout = useRef<LayoutRectangle>(null);
 
     const capturePhoto = useCallback(() => {
@@ -966,7 +963,7 @@ function IOURequestStepScan({
                 {canUseMultiScan && (
                     <ReceiptPreviews
                         isMultiScanEnabled={isMultiScanEnabled}
-                        submit={submitMultiScanReceipts}
+                        submit={submitReceipts}
                     />
                 )}
 

--- a/src/pages/iou/request/step/IOURequestStepScan/index.tsx
+++ b/src/pages/iou/request/step/IOURequestStepScan/index.tsx
@@ -707,8 +707,6 @@ function IOURequestStepScan({
         [initialTransaction, iouType, shouldStartLocationPermissionFlow, navigateToConfirmationStep, shouldSkipConfirmation],
     );
 
-    const submitMultiScanReceipts = useCallback(() => submitReceipts(receiptFiles), [receiptFiles, submitReceipts]);
-
     const viewfinderLayout = useRef<LayoutRectangle>(null);
 
     const getScreenshot = useCallback(() => {
@@ -1010,7 +1008,7 @@ function IOURequestStepScan({
             {canUseMultiScan && (
                 <ReceiptPreviews
                     isMultiScanEnabled={isMultiScanEnabled}
-                    submit={submitMultiScanReceipts}
+                    submit={submitReceipts}
                 />
             )}
         </>


### PR DESCRIPTION
Reverts Expensify/App#74402

Reverting the PR because it not only breaks functionality, but also messes up the App cache, and the functionality is broken even with the production code afterwards, unless the user signs out or explicitly clears cache. See [this](https://expensify.slack.com/archives/C01GTK53T8Q/p1763003911500649) Slack thread for more context.

$ https://github.com/Expensify/App/issues/75013

**NOTE for QA**: Before you retest the fixed issue, please logout and login again, or Clear the cache and restart