### PR TITLE
[CP staging] Revert "fix: expense turn to empty report when switch to most recent"

### DIFF
--- a/src/libs/actions/Report.ts
+++ b/src/libs/actions/Report.ts
@@ -1007,7 +1007,6 @@ function openReport(
                 hasLoadingOlderReportActionsError: false,
                 isLoadingNewerReportActions: false,
                 hasLoadingNewerReportActionsError: false,
-                hasOnceLoadedReportActions: false,
             },
         },
     ];


### PR DESCRIPTION
Reverts Expensify/App#74668. It reintroduces the issue solved by that PR, but I don't believe the fix was proper and the issue is an edge case. Switching from focus mode to most recent is not a very common action

# Fixed Issues
$ https://github.com/Expensify/App/issues/75069

# Tests
Run the test steps in the linked issue and verify the expected result; the report doesn't show a loading skeleton.


https://github.com/user-attachments/assets/f6c2ab47-b991-4d85-8b43-4b7aed4da48d

