### PR TITLE
[NoQA] Revert "feat: add elf alignment check to CI"

### DIFF
--- a/.github/workflows/remote-build-android.yml
+++ b/.github/workflows/remote-build-android.yml
@@ -59,10 +59,3 @@ jobs:
           variant: ${{ matrix.variant }}
           rock-build-extra-params: '--extra-params -PreactNativeArchitectures=arm64-v8a,x86_64'
           comment-bot: false
-
-      - name: Verify ELF alignment
-        run: |
-          APK_PATH=$(find android/app/build/outputs/apk -type f -name "*.apk" | head -n 1)
-          echo "Using APK: $APK_PATH"
-
-          scripts/check-elf-alignment.sh "$APK_PATH"

--- a/scripts/check-elf-alignment.sh
+++ b/scripts/check-elf-alignment.sh
@@ -1,7 +1,4 @@
 #!/bin/bash
-
-# Original source https://cs.android.com/android/platform/superproject/main/+/main:system/extras/tools/check_elf_alignment.sh
-
 set -o pipefail
 
 progname="${0##*/}"
@@ -114,18 +111,4 @@ if [ "${#unaligned_libs[@]}" -gt 0 ]; then
 elif [ -n "${dir_filename:-}" ]; then
   success "ELF Verification Successful"
 fi
-
-arm64_unaligned=0
-for lib in "${unaligned_libs[@]}"; do
-  if [[ "$lib" == *"arm64-v8a"* ]]; then
-    arm64_unaligned=1
-    break
-  fi
-done
-
-if [ "$arm64_unaligned" -eq 1 ]; then
-  printf "%s arm64-v8a ELF misalignment detected. %s\n" "$RED" "$RESET"
-  exit 1
-fi
-
 echo "====================="


### PR DESCRIPTION
Reverts Expensify/App#75050

The Android rock builds are failing as this check is not adjusted for the rock flow, lets revert and try again in the v2 and make sure it works fine with the rock flow https://expensify.slack.com/archives/C01GTK53T8Q/p1763460542927489 cc @Kureev 