### PR TITLE
[NoQA] Revert "fix: adapt elf workflow to remote rock build"

### DIFF
--- a/.github/workflows/remote-build-android.yml
+++ b/.github/workflows/remote-build-android.yml
@@ -59,29 +59,3 @@ jobs:
           variant: ${{ matrix.variant }}
           rock-build-extra-params: '--extra-params -PreactNativeArchitectures=arm64-v8a,x86_64'
           comment-bot: false
-
-      - name: Download Rock artifact
-        env:
-          ARTIFACT_URL: ${{ env.ARTIFACT_URL }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          echo "Downloading artifact from: $ARTIFACT_URL"
-          curl -L \
-            -H "Authorization: Bearer $GITHUB_TOKEN" \
-            -H "Accept: application/octet-stream" \
-            "$ARTIFACT_URL" -o artifact.zip
-          unzip artifact.zip -d artifact_contents
-
-      - name: Find APK
-        run: |
-          APK=$(find artifact_contents -type f -name "*.apk" | head -n 1)
-          if [ -z "$APK" ]; then
-            echo "No APK found in artifact"
-            exit 1
-          fi
-          echo "APK_PATH=$APK" >> "$GITHUB_ENV"
-          echo "Using APK: $APK"
-
-      - name: Verify ELF alignment
-        run: |
-          scripts/check-elf-alignment.sh "$APK_PATH"


### PR DESCRIPTION
Reverts Expensify/App#75341

Straight revert

There was some confusion on this one and it broke the rock builds https://expensify.slack.com/archives/C01GTK53T8Q/p1763650909890079 for android, the tests on the original pr were not completed successfully 