### PR TITLE
[CP Staging] Revert "Previous selection is cleared when selecting another member in Expenses From"

### DIFF
--- a/src/components/ApproverSelectionList.tsx
+++ b/src/components/ApproverSelectionList.tsx
@@ -1,4 +1,4 @@
-import React, {useMemo} from 'react';
+import React, {useMemo, useState} from 'react';
 import type {SectionListData} from 'react-native';
 import useDebouncedState from '@hooks/useDebouncedState';
 import {useMemoizedLazyIllustrations} from '@hooks/useLazyAsset';
@@ -84,7 +84,7 @@ function ApproverSelectionList({
     const shouldShowTextInput = shouldShowTextInputProp ?? allApprovers?.length >= CONST.STANDARD_LIST_ITEM_LIMIT;
     const lazyIllustrations = useMemoizedLazyIllustrations(['TurtleInShell']);
 
-    const selectedMembers = useMemo(() => allApprovers.filter((approver) => approver.isSelected), [allApprovers]);
+    const [selectedMembers, setSelectedMembers] = useState<SelectionListApprover[]>([]);
 
     // eslint-disable-next-line rulesdir/no-negated-variables
     const shouldShowNotFoundView = (isEmptyObject(policy) && !isLoadingReportData) || !isPolicyAdmin(policy) || isPendingDeletePolicy(policy) || shouldShowNotFoundViewProp;
@@ -117,6 +117,7 @@ function ApproverSelectionList({
                 ? selectedMembers.filter((selectedOption) => selectedOption.login !== member.login)
                 : [...selectedMembers, {...member, isSelected: true}];
         }
+        setSelectedMembers(newSelectedApprovers);
         if (onSelectApprover) {
             onSelectApprover(newSelectedApprovers);
         }


### PR DESCRIPTION
Reverts Expensify/App#75410

$ https://github.com/Expensify/App/issues/75951