### PR TITLE
[NO QA] Revert "Replace WebView in SAML sign in implementation"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -73,7 +73,6 @@
         "expo-image-manipulator": "^13.1.5",
         "expo-modules-core": "3.0.18",
         "expo-secure-store": "~14.2.4",
-        "expo-web-browser": "14.2.0",
         "fast-equals": "^5.2.2",
         "focus-trap-react": "^11.0.3",
         "group-ib-fp": "file:modules/group-ib-fp",
@@ -25010,16 +25009,6 @@
       "license": "MIT",
       "peerDependencies": {
         "expo": "*"
-      }
-    },
-    "node_modules/expo-web-browser": {
-      "version": "14.2.0",
-      "resolved": "https://registry.npmjs.org/expo-web-browser/-/expo-web-browser-14.2.0.tgz",
-      "integrity": "sha512-6S51d8pVlDRDsgGAp8BPpwnxtyKiMWEFdezNz+5jVIyT+ctReW42uxnjRgtsdn5sXaqzhaX+Tzk/CWaKCyC0hw==",
-      "license": "MIT",
-      "peerDependencies": {
-        "expo": "*",
-        "react-native": "*"
       }
     },
     "node_modules/expo/node_modules/@expo/cli": {

--- a/package.json
+++ b/package.json
@@ -140,7 +140,6 @@
     "expo-image-manipulator": "^13.1.5",
     "expo-modules-core": "3.0.18",
     "expo-secure-store": "~14.2.4",
-    "expo-web-browser": "14.2.0",
     "fast-equals": "^5.2.2",
     "focus-trap-react": "^11.0.3",
     "group-ib-fp": "file:modules/group-ib-fp",

--- a/src/CONST/index.ts
+++ b/src/CONST/index.ts
@@ -953,7 +953,6 @@ const CONST = {
     GOOGLE_DOC_IMAGE_LINK_MATCH: 'googleusercontent.com',
     IMAGE_BASE64_MATCH: 'base64',
     DEEPLINK_BASE_URL: 'new-expensify://',
-    SAML_REDIRECT_URL: 'expensify://open',
     PDF_VIEWER_URL: '/pdf/web/viewer.html',
     CLOUDFRONT_DOMAIN_REGEX: /^https:\/\/\w+\.cloudfront\.net/i,
     EXPENSIFY_ICON_URL: `${CLOUDFRONT_URL}/images/favicon-2019.png`,

--- a/src/libs/actions/Session/index.ts
+++ b/src/libs/actions/Session/index.ts
@@ -1,5 +1,4 @@
 import HybridAppModule from '@expensify/react-native-hybrid-app';
-import {openAuthSessionAsync} from 'expo-web-browser';
 import throttle from 'lodash/throttle';
 import type {ChannelAuthorizationData} from 'pusher-js/types/src/core/auth/options';
 import type {ChannelAuthorizationCallback} from 'pusher-js/with-encryption';
@@ -67,7 +66,6 @@ import type Locale from '@src/types/onyx/Locale';
 import type Response from '@src/types/onyx/Response';
 import type Session from '@src/types/onyx/Session';
 import type {AutoAuthState} from '@src/types/onyx/Session';
-import pkg from '../../../../package.json';
 import clearCache from './clearCache';
 import updateSessionAuthTokens from './updateSessionAuthTokens';
 
@@ -165,7 +163,6 @@ function getShortLivedLoginParams(isSupportAuthTokenUsed = false, isSAML = false
             key: ONYXKEYS.SESSION,
             value: {
                 signedInWithShortLivedAuthToken: true,
-                signedInWithSAML: isSAML,
                 isAuthenticatingWithShortLivedToken: true,
                 isSupportAuthTokenUsed,
             },
@@ -186,7 +183,6 @@ function getShortLivedLoginParams(isSupportAuthTokenUsed = false, isSAML = false
             key: ONYXKEYS.SESSION,
             value: {
                 signedInWithShortLivedAuthToken: null,
-                signedInWithSAML: isSAML,
                 isSupportAuthTokenUsed: null,
                 isAuthenticatingWithShortLivedToken: false,
             },
@@ -241,19 +237,8 @@ function signOut(): Promise<void | Response> {
         skipReauthentication: true,
     };
 
-    if (session.signedInWithSAML) {
-        return callSAMLSignOut(params);
-    }
     // eslint-disable-next-line rulesdir/no-api-side-effects-method
     return API.makeRequestWithSideEffects(SIDE_EFFECT_REQUEST_COMMANDS.LOG_OUT, params, {});
-}
-
-function callSAMLSignOut(params: LogOutParams): Promise<void | Response> {
-    const queryString = `appversion=${pkg.version}&referer=ecash&authToken=${session.authToken}`;
-    return openAuthSessionAsync(`${CONST.EXPENSIFY_URL}/authentication/saml/logout?${queryString}`).then(() => {
-        // eslint-disable-next-line rulesdir/no-api-side-effects-method
-        API.makeRequestWithSideEffects(SIDE_EFFECT_REQUEST_COMMANDS.LOG_OUT, params, {});
-    });
 }
 
 /**

--- a/src/pages/signin/SAMLSignInPage/index.native.tsx
+++ b/src/pages/signin/SAMLSignInPage/index.native.tsx
@@ -1,6 +1,6 @@
-import type {WebBrowserAuthSessionResult} from 'expo-web-browser';
-import {openAuthSessionAsync} from 'expo-web-browser';
 import React, {useCallback, useEffect, useRef, useState} from 'react';
+import WebView from 'react-native-webview';
+import type {WebViewNativeEvent} from 'react-native-webview/lib/WebViewTypes';
 import FullPageOfflineBlockingView from '@components/BlockingViews/FullPageOfflineBlockingView';
 import HeaderWithBackButton from '@components/HeaderWithBackButton';
 import SAMLLoadingIndicator from '@components/SAMLLoadingIndicator';
@@ -8,12 +8,12 @@ import ScreenWrapper from '@components/ScreenWrapper';
 import useLocalize from '@hooks/useLocalize';
 import useOnyx from '@hooks/useOnyx';
 import getPlatform from '@libs/getPlatform';
+import getUAForWebView from '@libs/getUAForWebView';
 import Log from '@libs/Log';
 import {handleSAMLLoginError, postSAMLLogin} from '@libs/LoginUtils';
 import Navigation from '@libs/Navigation/Navigation';
 import {clearSignInData, setAccountError, signInWithShortLivedAuthToken} from '@userActions/Session';
 import CONFIG from '@src/CONFIG';
-import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
 import ROUTES from '@src/ROUTES';
 
@@ -22,75 +22,8 @@ function SAMLSignInPage() {
     const [credentials] = useOnyx(ONYXKEYS.CREDENTIALS, {canBeMissing: false});
     const [showNavigation, shouldShowNavigation] = useState(true);
     const [SAMLUrl, setSAMLUrl] = useState('');
+    const webViewRef = useRef<WebView>(null);
     const {translate} = useLocalize();
-    const hasOpenedAuthSession = useRef(false);
-
-    /**
-     * Handles in-app navigation once we get a response back from Expensify
-     */
-    const handleNavigationStateChange = useCallback(
-        (url: string) => {
-            // If we've gotten a callback then remove the option to navigate back to the sign-in page
-            if (url.includes('loginCallback')) {
-                shouldShowNavigation(false);
-            }
-
-            const searchParams = new URLSearchParams(new URL(url).search);
-            const jsonParam = searchParams.get('json');
-
-            if (!jsonParam) {
-                Log.hmmm('SAMLSignInPage - No JSON parameter found in callback URL');
-                return;
-            }
-
-            let shortLivedAuthToken: string | null = null;
-            let error: string | null = null;
-
-            try {
-                const decodedData = JSON.parse(jsonParam) as Record<string, string | null>;
-                shortLivedAuthToken = decodedData.shortLivedAuthToken ?? null;
-                error = decodedData.error ?? null;
-                Log.info('SAMLSignInPage - Parsed data from JSON parameter');
-            } catch {
-                // We need to come generate translation for message indicating parsing error
-                Log.hmmm(`SAMLSignInPage - Failed to parse JSON parameter`);
-                error = 'Failed to parse JSON';
-            }
-
-            if (!account?.isLoading && credentials?.login && !!shortLivedAuthToken) {
-                Log.info('SAMLSignInPage - Successfully received shortLivedAuthToken. Signing in...');
-                signInWithShortLivedAuthToken(shortLivedAuthToken, true);
-                return;
-            }
-
-            if (error) {
-                clearSignInData();
-                setAccountError(error);
-
-                Navigation.isNavigationReady().then(() => {
-                    // We must call goBack() to remove the /transition route from history
-                    Navigation.goBack();
-                    Navigation.navigate(ROUTES.HOME);
-                });
-            }
-        },
-        [credentials?.login, shouldShowNavigation, account?.isLoading],
-    );
-
-    useEffect(() => {
-        // Don't open auth session more than once. If user cancels it we should navigate back to ROUTES.HOME
-        if (!SAMLUrl || hasOpenedAuthSession.current) {
-            return;
-        }
-        hasOpenedAuthSession.current = true;
-        openAuthSessionAsync(SAMLUrl, CONST.SAML_REDIRECT_URL).then((response: WebBrowserAuthSessionResult) => {
-            if (response.type !== 'success') {
-                Navigation.goBack();
-                return;
-            }
-            handleNavigationStateChange(response.url);
-        });
-    }, [SAMLUrl, handleNavigationStateChange]);
 
     useEffect(() => {
         // If we don't have a valid login to pass here, direct the user back to a clean sign in state to try again
@@ -108,7 +41,6 @@ function SAMLSignInPage() {
         body.append('email', credentials.login);
         body.append('referer', CONFIG.EXPENSIFY.EXPENSIFY_CASH_REFERER);
         body.append('platform', getPlatform());
-        body.append('useBrowser', 'true');
         postSAMLLogin(body)
             .then((response) => {
                 if (!response || !response.url) {
@@ -121,6 +53,38 @@ function SAMLSignInPage() {
                 handleSAMLLoginError(error.message ?? translate('common.error.login'), false);
             });
     }, [credentials?.login, SAMLUrl, translate]);
+
+    /**
+     * Handles in-app navigation once we get a response back from Expensify
+     */
+    const handleNavigationStateChange = useCallback(
+        ({url}: WebViewNativeEvent) => {
+            // If we've gotten a callback then remove the option to navigate back to the sign-in page
+            if (url.includes('loginCallback')) {
+                shouldShowNavigation(false);
+            }
+
+            const searchParams = new URLSearchParams(new URL(url).search);
+            const shortLivedAuthToken = searchParams.get('shortLivedAuthToken');
+            if (!account?.isLoading && credentials?.login && !!shortLivedAuthToken) {
+                Log.info('SAMLSignInPage - Successfully received shortLivedAuthToken. Signing in...');
+                signInWithShortLivedAuthToken(shortLivedAuthToken, true);
+            }
+
+            // If the login attempt is unsuccessful, set the error message for the account and redirect to sign in page
+            if (searchParams.has('error')) {
+                clearSignInData();
+                setAccountError(searchParams.get('error') ?? '');
+
+                Navigation.isNavigationReady().then(() => {
+                    // We must call goBack() to remove the /transition route from history
+                    Navigation.goBack();
+                    Navigation.navigate(ROUTES.HOME);
+                });
+            }
+        },
+        [credentials?.login, shouldShowNavigation, account?.isLoading],
+    );
 
     return (
         <ScreenWrapper
@@ -140,7 +104,20 @@ function SAMLSignInPage() {
                 />
             )}
             <FullPageOfflineBlockingView>
-                <SAMLLoadingIndicator />
+                {!SAMLUrl ? (
+                    <SAMLLoadingIndicator />
+                ) : (
+                    <WebView
+                        ref={webViewRef}
+                        originWhitelist={['https://*']}
+                        source={{uri: SAMLUrl}}
+                        userAgent={getUAForWebView()}
+                        incognito // 'incognito' prop required for Android, issue here https://github.com/react-native-webview/react-native-webview/issues/1352
+                        startInLoadingState
+                        renderLoading={() => <SAMLLoadingIndicator />}
+                        onNavigationStateChange={handleNavigationStateChange}
+                    />
+                )}
             </FullPageOfflineBlockingView>
         </ScreenWrapper>
     );

--- a/src/types/onyx/Session.ts
+++ b/src/types/onyx/Session.ts
@@ -37,9 +37,6 @@ type Session = {
     /** User signed in with short lived token */
     signedInWithShortLivedAuthToken?: boolean;
 
-    /** User signed in with SAML */
-    signedInWithSAML?: boolean;
-
     /** Indicates whether the user is re-authenticating with shortLivedToken */
     isAuthenticatingWithShortLivedToken?: boolean;
 


### PR DESCRIPTION
Reverts Expensify/App#73410 as a SAML [issue](https://github.com/Expensify/App/issues/71676#issuecomment-3576809026) remains after merging HybridApp PRs

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I verified there are no new alerts related to the `canBeMissing` param for `useOnyx`
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>
