### PR TITLE
Add Super Wide RHP config

### DIFF
--- a/src/SCREENS.ts
+++ b/src/SCREENS.ts
@@ -244,6 +244,11 @@ const SCREENS = {
         TRANSACTION_DUPLICATE: 'TransactionDuplicate',
         TRAVEL: 'Travel',
         SEARCH_REPORT: 'SearchReport',
+        SEARCH_REPORT_ACTIONS: 'SearchReportActions',
+        // These two routes will be added in a separate PR adding Super Wide RHP routes
+        EXPENSE_REPORT: 'ExpenseReport',
+        SEARCH_MONEY_REQUEST_REPORT: 'SearchMoneyRequestReport',
+
         SEARCH_ADVANCED_FILTERS: 'SearchAdvancedFilters',
         SEARCH_SAVED_SEARCH: 'SearchSavedSearch',
         SETTINGS_CATEGORIES: 'SettingsCategories',

--- a/src/components/WideRHPContextProvider/default.ts
+++ b/src/components/WideRHPContextProvider/default.ts
@@ -1,19 +1,25 @@
-// We use Animated for all functionality related to wide RHP to make it easier
-// to interact with react-navigation components (e.g., CardContainer, interpolator), which also use Animated.
-// eslint-disable-next-line no-restricted-imports
-import {Animated} from 'react-native';
 import type {WideRHPContextType} from './types';
 
 const defaultWideRHPContextValue: WideRHPContextType = {
     wideRHPRouteKeys: [],
-    expandedRHPProgress: new Animated.Value(0),
-    secondOverlayProgress: new Animated.Value(0),
     shouldRenderSecondaryOverlay: false,
     showWideRHPVersion: () => {},
-    cleanWideRHPRouteKey: () => {},
+    removeWideRHPRouteKey: () => {},
     markReportIDAsExpense: () => {},
+    markReportIDAsMultiTransactionExpense: () => {},
+    unmarkReportIDAsMultiTransactionExpense: () => {},
     isReportIDMarkedAsExpense: () => false,
-    dismissToWideReport: () => {},
+    isReportIDMarkedAsMultiTransactionExpense: () => false,
+    isWideRHPClosing: false,
+    setIsWideRHPClosing: () => {},
+    isWideRHPFocused: false,
+    shouldRenderTertiaryOverlay: false,
+    superWideRHPRouteKeys: [],
+    showSuperWideRHPVersion: () => {},
+    removeSuperWideRHPRouteKey: () => {},
+    syncWideRHPKeys: () => {},
+    syncSuperWideRHPKeys: () => {},
+    clearWideRHPKeys: () => {},
 };
 
 export default defaultWideRHPContextValue;

--- a/src/components/WideRHPContextProvider/getIsWideRHPOpenedBelow.ts
+++ b/src/components/WideRHPContextProvider/getIsWideRHPOpenedBelow.ts
@@ -1,0 +1,14 @@
+import type {NavigationRoute} from '@libs/Navigation/types';
+import getVisibleWideRHPKeys from './getVisibleRHPRouteKeys';
+
+function getIsWideRHPOpenedBelow(focusedRoute: NavigationRoute | undefined, allWideRHPKeys: string[]) {
+    // Shouldn't ever happen but for type safety
+    if (!focusedRoute?.key) {
+        return false;
+    }
+
+    const visibleWideRHPRouteKeys = getVisibleWideRHPKeys(allWideRHPKeys);
+    return visibleWideRHPRouteKeys.length > 0 && !visibleWideRHPRouteKeys.includes(focusedRoute.key);
+}
+
+export default getIsWideRHPOpenedBelow;

--- a/src/components/WideRHPContextProvider/getVisibleRHPRouteKeys.ts
+++ b/src/components/WideRHPContextProvider/getVisibleRHPRouteKeys.ts
@@ -1,0 +1,30 @@
+import extractNavigationKeys from '@libs/Navigation/helpers/extractNavigationKeys';
+import getLastVisibleRHPRouteKey from '@libs/Navigation/helpers/getLastVisibleRHPRouteKey';
+import {navigationRef} from '@libs/Navigation/Navigation';
+
+/**
+ * Extracts the keys of the screens that are currently displayed from the array of all Wide/Super Wide RHP keys
+ *
+ * @param allWideRHPKeys - an array of all Wide/Super Wide RHP keys
+ */
+function getVisibleWideRHPKeys(allWideRHPKeys: string[]) {
+    const rootState = navigationRef.getRootState();
+
+    if (!rootState) {
+        return [];
+    }
+
+    const lastVisibleRHPRouteKey = getLastVisibleRHPRouteKey(rootState);
+    const lastRHPRoute = rootState.routes.find((route) => route.key === lastVisibleRHPRouteKey);
+
+    if (!lastRHPRoute) {
+        return [];
+    }
+
+    const lastRHPKeys = extractNavigationKeys(lastRHPRoute.state);
+    const currentKeys = allWideRHPKeys.filter((key) => lastRHPKeys.has(key));
+
+    return currentKeys;
+}
+
+export default getVisibleWideRHPKeys;

--- a/src/components/WideRHPContextProvider/index.native.tsx
+++ b/src/components/WideRHPContextProvider/index.native.tsx
@@ -3,25 +3,48 @@ import React, {createContext} from 'react';
 // to interact with react-navigation components (e.g., CardContainer, interpolator), which also use Animated.
 // eslint-disable-next-line no-restricted-imports
 import {Animated} from 'react-native';
+import SCREENS from '@src/SCREENS';
 import defaultWideRHPContextValue from './default';
 import type {WideRHPContextType} from './types';
 
-const expandedRHPProgress = new Animated.Value(0);
 const secondOverlayProgress = new Animated.Value(0);
-const receiptPaneRHPWidth = new Animated.Value(0);
+const thirdOverlayProgress = new Animated.Value(0);
+
+const animatedReceiptPaneRHPWidth = new Animated.Value(0);
+const animatedWideRHPWidth = new Animated.Value(0);
+const animatedSuperWideRHPWidth = new Animated.Value(0);
+
+const modalStackOverlaySuperWideRHPPositionLeft = new Animated.Value(0);
+const modalStackOverlayWideRHPPositionLeft = new Animated.Value(0);
+
+const expandedRHPProgress = new Animated.Value(0);
+const innerRHPProgress = new Animated.Value(0);
 
 const WideRHPContext = createContext<WideRHPContextType>(defaultWideRHPContextValue);
+
+const WIDE_RIGHT_MODALS = new Set<string>([SCREENS.RIGHT_MODAL.SEARCH_MONEY_REQUEST_REPORT, SCREENS.RIGHT_MODAL.EXPENSE_REPORT, SCREENS.RIGHT_MODAL.SEARCH_REPORT]);
+
+const SUPER_WIDE_RIGHT_MODALS = new Set<string>([SCREENS.RIGHT_MODAL.SEARCH_MONEY_REQUEST_REPORT, SCREENS.RIGHT_MODAL.EXPENSE_REPORT]);
 
 function WideRHPContextProvider({children}: React.PropsWithChildren) {
     return <WideRHPContext.Provider value={defaultWideRHPContextValue}>{children}</WideRHPContext.Provider>;
 }
 
-// Wide RHP is not displayed on native platforms
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-function useShowWideRHPVersion(condition: boolean) {}
-
 WideRHPContextProvider.displayName = 'WideRHPContextProvider';
 
 export default WideRHPContextProvider;
 export type {WideRHPContextType};
-export {expandedRHPProgress, secondOverlayProgress, WideRHPContext, useShowWideRHPVersion, receiptPaneRHPWidth};
+export {
+    animatedReceiptPaneRHPWidth,
+    animatedSuperWideRHPWidth,
+    animatedWideRHPWidth,
+    expandedRHPProgress,
+    innerRHPProgress,
+    modalStackOverlaySuperWideRHPPositionLeft,
+    modalStackOverlayWideRHPPositionLeft,
+    secondOverlayProgress,
+    thirdOverlayProgress,
+    WideRHPContext,
+    WIDE_RIGHT_MODALS,
+    SUPER_WIDE_RIGHT_MODALS,
+};

--- a/src/components/WideRHPContextProvider/types.ts
+++ b/src/components/WideRHPContextProvider/types.ts
@@ -1,34 +1,62 @@
-// eslint-disable-next-line no-restricted-imports
-import type {Animated} from 'react-native';
 import type {NavigationRoute} from '@libs/Navigation/types';
 
 type WideRHPContextType = {
     // Route keys of screens that should be displayed in wide format
     wideRHPRouteKeys: string[];
 
-    // Progress of changing format: 0 - narrow, 1 - wide
-    expandedRHPProgress: Animated.Value;
-
-    // Progress of the secondary overlay, the one covering wider RHP screen
-    secondOverlayProgress: Animated.Value;
+    // Route keys of screens that should be displayed in super wide format
+    superWideRHPRouteKeys: string[];
 
     // If the secondary overlay should be rendered. This value takes into account the delay of closing transition.
     shouldRenderSecondaryOverlay: boolean;
 
+    // If the tertiary overlay should be rendered. This value takes into account the delay of closing transition.
+    shouldRenderTertiaryOverlay: boolean;
+
     // Show given route as in wide format
     showWideRHPVersion: (route: NavigationRoute) => void;
 
+    // Show given route as in super wide format
+    showSuperWideRHPVersion: (route: NavigationRoute) => void;
+
     // Remove given route from the array
-    cleanWideRHPRouteKey: (route: NavigationRoute) => void;
+    removeWideRHPRouteKey: (route: NavigationRoute) => void;
+
+    // Remove given route from the array
+    removeSuperWideRHPRouteKey: (route: NavigationRoute) => void;
 
     // Mark reportID as expense before condition check
     markReportIDAsExpense: (reportID: string) => void;
 
+    // Mark reportID as multi-transaction expense before condition check
+    markReportIDAsMultiTransactionExpense: (reportID: string) => void;
+
+    // Unmark reportID as multi-transaction expense before condition check
+    unmarkReportIDAsMultiTransactionExpense: (reportID: string) => void;
+
     // Check if reportID is marked as expense
     isReportIDMarkedAsExpense: (reportID: string) => boolean;
 
-    // Navigate to the last element in wideRHPRouteKeys array
-    dismissToWideReport: () => void;
+    // Check if reportID is marked as multi-transaction expense
+    isReportIDMarkedAsMultiTransactionExpense: (reportID: string) => boolean;
+
+    // Whether the currently focused route is inside the wide RHP set
+    isWideRHPFocused: boolean;
+
+    // Whether the wide rhp modal is closing
+    isWideRHPClosing: boolean;
+
+    // Mark that wide rhp is being closed
+    setIsWideRHPClosing: (isClosing: boolean) => void;
+
+    // Sync wide RHP keys with the visible RHP screens
+    syncWideRHPKeys: () => void;
+
+    // Sync super wide RHP keys with the visible RHP screens
+    syncSuperWideRHPKeys: () => void;
+
+    // Clear the arrays of wide and super wide rhp keys
+    clearWideRHPKeys: () => void;
 };
 
 // eslint-disable-next-line import/prefer-default-export

--- a/src/components/WideRHPContextProvider/useShouldRenderOverlay.ts
+++ b/src/components/WideRHPContextProvider/useShouldRenderOverlay.ts
@@ -1,0 +1,34 @@
+import {useEffect, useState} from 'react';
+// We use Animated for all functionality related to wide RHP to make it easier
+// to interact with react-navigation components (e.g., CardContainer, interpolator), which also use Animated.
+// eslint-disable-next-line no-restricted-imports
+import {Animated} from 'react-native';
+
+const OVERLAY_TIMING_DURATION = 300;
+
+function useShouldRenderOverlay(condition: boolean, overlayProgress: Animated.Value) {
+    const [shouldRenderOverlay, setShouldRenderOverlay] = useState(false);
+
+    useEffect(() => {
+        if (condition) {
+            setShouldRenderOverlay(true);
+            Animated.timing(overlayProgress, {
+                toValue: 1,
+                duration: OVERLAY_TIMING_DURATION,
+                useNativeDriver: false,
+            }).start();
+        } else {
+            Animated.timing(overlayProgress, {
+                toValue: 0,
+                duration: OVERLAY_TIMING_DURATION,
+                useNativeDriver: false,
+            }).start(() => {
+                setShouldRenderOverlay(false);
+            });
+        }
+    }, [condition, overlayProgress]);
+
+    return shouldRenderOverlay;
+}
+
+export default useShouldRenderOverlay;

--- a/src/components/WideRHPContextProvider/useShowSuperWideRHPVersion/index.native.ts
+++ b/src/components/WideRHPContextProvider/useShowSuperWideRHPVersion/index.native.ts
@@ -1,0 +1,5 @@
+// Super Wide RHP is not displayed on native platforms
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+function useShowSuperWideRHPVersion(condition: boolean) {}
+
+export default useShowSuperWideRHPVersion;

--- a/src/components/WideRHPContextProvider/useShowSuperWideRHPVersion/index.ts
+++ b/src/components/WideRHPContextProvider/useShowSuperWideRHPVersion/index.ts
@@ -1,0 +1,44 @@
+import {useRoute} from '@react-navigation/native';
+import {useCallback, useContext, useEffect} from 'react';
+import {InteractionManager} from 'react-native';
+import useBeforeRemove from '@hooks/useBeforeRemove';
+import {WideRHPContext} from '..';
+
+/**
+ * Hook that manages super wide RHP display for a screen based on condition or optimistic state.
+ * Automatically registers the route for super wide RHP when condition is met or report is marked as multi-transaction expense.
+ * Cleans up the route registration when the screen is removed.
+ *
+ * @param condition - Boolean condition determining if the screen should display as wide RHP
+ */
+function useShowSuperWideRHPVersion(condition: boolean) {
+    const route = useRoute();
+    const reportID = route.params && 'reportID' in route.params && typeof route.params.reportID === 'string' ? route.params.reportID : '';
+    const {showWideRHPVersion, showSuperWideRHPVersion, removeWideRHPRouteKey, removeSuperWideRHPRouteKey, isReportIDMarkedAsExpense, isReportIDMarkedAsMultiTransactionExpense} =
+        useContext(WideRHPContext);
+
+    const onSuperWideRHPClose = useCallback(() => {
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
+        InteractionManager.runAfterInteractions(() => {
+            removeWideRHPRouteKey(route);
+            removeSuperWideRHPRouteKey(route);
+        });
+    }, [removeSuperWideRHPRouteKey, removeWideRHPRouteKey, route]);
+
+    useBeforeRemove(onSuperWideRHPClose);
+
+    /**
+     * Effect that determines whether to show wide RHP based on condition or optimistic state.
+     * Shows wide RHP if either the condition is true OR the reportID is marked as an expense.
+     */
+    useEffect(() => {
+        // Check if we should show wide RHP based on condition OR if reportID is in optimistic set
+        if (condition || (reportID && isReportIDMarkedAsMultiTransactionExpense(reportID))) {
+            showSuperWideRHPVersion(route);
+            return;
+        }
+        showWideRHPVersion(route);
+    }, [condition, reportID, isReportIDMarkedAsExpense, route, showWideRHPVersion, showSuperWideRHPVersion, isReportIDMarkedAsMultiTransactionExpense]);
+}
+
+export default useShowSuperWideRHPVersion;

--- a/src/components/WideRHPContextProvider/useShowWideRHPVersion/index.native.ts
+++ b/src/components/WideRHPContextProvider/useShowWideRHPVersion/index.native.ts
@@ -1,0 +1,5 @@
+// Wide RHP is not displayed on native platforms
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+function useShowWideRHPVersion(condition: boolean) {}
+
+export default useShowWideRHPVersion;

--- a/src/components/WideRHPContextProvider/useShowWideRHPVersion/index.ts
+++ b/src/components/WideRHPContextProvider/useShowWideRHPVersion/index.ts
@@ -1,0 +1,53 @@
+import {useRoute} from '@react-navigation/native';
+import {useCallback, useContext, useEffect} from 'react';
+import {InteractionManager} from 'react-native';
+import useBeforeRemove from '@hooks/useBeforeRemove';
+import {WideRHPContext} from '..';
+
+/**
+ * Hook that manages wide RHP display for a screen based on condition or optimistic state.
+ * Automatically registers the route for wide RHP when condition is met or report is marked as expense.
+ * Cleans up the route registration when the screen is removed.
+ *
+ * @param condition - Boolean condition determining if the screen should display as wide RHP
+ */
+function useShowWideRHPVersion(condition: boolean) {
+    const route = useRoute();
+    const reportID = route.params && 'reportID' in route.params && typeof route.params.reportID === 'string' ? route.params.reportID : '';
+    const {showWideRHPVersion, removeWideRHPRouteKey, isReportIDMarkedAsExpense, setIsWideRHPClosing} = useContext(WideRHPContext);
+
+    // beforeRemove event is not called when closing nested Wide RHP using the browser back button.
+    // This hook removes the route key from the array in the following case.
+    useEffect(() => () => removeWideRHPRouteKey(route), [removeWideRHPRouteKey, route]);
+
+    const onWideRHPClose = useCallback(() => {
+        setIsWideRHPClosing(true);
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
+        InteractionManager.runAfterInteractions(() => {
+            removeWideRHPRouteKey(route);
+            setIsWideRHPClosing(false);
+        });
+    }, [removeWideRHPRouteKey, route, setIsWideRHPClosing]);
+
+    /**
+     * Effect that sets up cleanup when the screen is about to be removed.
+     * Uses InteractionManager to ensure cleanup happens after closing animation.
+     */
+    useBeforeRemove(onWideRHPClose);
+
+    /**
+     * Effect that determines whether to show wide RHP based on condition or optimistic state.
+     * Shows wide RHP if either the condition is true OR the reportID is marked as an expense.
+     */
+    useEffect(() => {
+        // Check if we should show wide RHP based on condition OR if reportID is in optimistic set
+        const shouldShow = condition || (reportID && isReportIDMarkedAsExpense(reportID));
+
+        if (!shouldShow) {
+            return;
+        }
+        showWideRHPVersion(route);
+    }, [condition, reportID, isReportIDMarkedAsExpense, route, showWideRHPVersion]);
+}
+
+export default useShowWideRHPVersion;

--- a/src/libs/Navigation/AppNavigator/AuthScreens.tsx
+++ b/src/libs/Navigation/AppNavigator/AuthScreens.tsx
@@ -154,7 +154,7 @@ function AuthScreens() {
     const {initialURL, isAuthenticatedAtStartup, setIsAuthenticatedAtStartup} = useContext(InitialURLContext);
     const modalCardStyleInterpolator = useModalCardStyleInterpolator();
     const archivedReportsIdSet = useArchivedReportsIdSet();
-    const {shouldRenderSecondaryOverlay, dismissToWideReport} = useContext(WideRHPContext);
+    const {shouldRenderSecondaryOverlay, shouldRenderTertiaryOverlay} = useContext(WideRHPContext);
 
     // State to track whether the delegator's authentication is completed before displaying data
     const [isDelegatorFromOldDotIsReady, setIsDelegatorFromOldDotIsReady] = useState(false);
@@ -342,7 +342,12 @@ function AuthScreens() {
                 }
 
                 if (shouldRenderSecondaryOverlay) {
-                    dismissToWideReport();
+                    Navigation.dismissToFirstRHP();
+                    return;
+                }
+
+                if (shouldRenderTertiaryOverlay) {
+                    Navigation.dismissToSecondRHP();
                     return;
                 }
 
@@ -354,7 +359,7 @@ function AuthScreens() {
             true,
         );
         return () => unsubscribeEscapeKey();
-    }, [dismissToWideReport, modal?.disableDismissOnEscape, modal?.willAlertModalBecomeVisible, shouldRenderSecondaryOverlay]);
+    }, [modal?.disableDismissOnEscape, modal?.willAlertModalBecomeVisible, shouldRenderSecondaryOverlay, shouldRenderTertiaryOverlay]);
 
     // Animation is disabled when navigating to the sidebar screen
     const getWorkspaceOrDomainSplitNavigatorOptions = ({route}: {route: RouteProp<AuthScreensParamList>}) => {

--- a/src/libs/Navigation/AppNavigator/ModalStackNavigators/index.tsx
+++ b/src/libs/Navigation/AppNavigator/ModalStackNavigators/index.tsx
@@ -1,8 +1,15 @@
-import {useRoute} from '@react-navigation/native';
+import {useIsFocused, useRoute} from '@react-navigation/native';
 import type {ParamListBase} from '@react-navigation/routers';
-import React, {useCallback, useContext} from 'react';
+import React, {useCallback, useContext, useMemo} from 'react';
 import {View} from 'react-native';
-import {WideRHPContext} from '@components/WideRHPContextProvider';
+import {
+    animatedReceiptPaneRHPWidth,
+    modalStackOverlaySuperWideRHPPositionLeft,
+    modalStackOverlayWideRHPPositionLeft,
+    secondOverlayProgress,
+    thirdOverlayProgress,
+    WideRHPContext,
+} from '@components/WideRHPContextProvider';
 import useResponsiveLayout from '@hooks/useResponsiveLayout';
 import useThemeStyles from '@hooks/useThemeStyles';
 import Overlay from '@libs/Navigation/AppNavigator/Navigators/Overlay';
@@ -36,6 +43,7 @@ import type {
     RoomMembersNavigatorParamList,
     ScheduleCallParamList,
     SearchAdvancedFiltersParamList,
+    SearchReportActionsParamList,
     SearchReportParamList,
     SearchSavedSearchParamList,
     SettingsNavigatorParamList,
@@ -84,6 +92,14 @@ const OPTIONS_PER_SCREEN: Partial<Record<Screen, PlatformStackNavigationOptions>
     },
 };
 
+function isSuperWideRHPRouteName(routeName: string) {
+    return routeName === SCREENS.RIGHT_MODAL.SEARCH_MONEY_REQUEST_REPORT || routeName === SCREENS.RIGHT_MODAL.EXPENSE_REPORT;
+}
+
+function isWideRHPRouteName(routeName: string) {
+    return routeName === SCREENS.RIGHT_MODAL.SEARCH_REPORT;
+}
+
 /**
  * Create a modal stack navigator with an array of sub-screens.
  *
@@ -95,8 +111,10 @@ function createModalStackNavigator<ParamList extends ParamListBase>(screens: Scr
     function ModalStack() {
         const styles = useThemeStyles();
         const screenOptions = useModalStackScreenOptions();
-        const {secondOverlayProgress, shouldRenderSecondaryOverlay} = useContext(WideRHPContext);
+        const {shouldRenderSecondaryOverlay, shouldRenderTertiaryOverlay, isWideRHPFocused, superWideRHPRouteKeys, isWideRHPClosing} = useContext(WideRHPContext);
         const route = useRoute();
+
+        const isFocused = useIsFocused();
 
         // We have to use the isSmallScreenWidth instead of shouldUseNarrow layout, because we want to have information about screen width without the context of side modal.
         // eslint-disable-next-line rulesdir/prefer-shouldUseNarrowLayout-instead-of-isSmallScreenWidth
@@ -113,6 +131,16 @@ function createModalStackNavigator<ParamList extends ParamListBase>(screens: Scr
             [screenOptions],
         );
 
+        const isRHPDisplayedOnWideRHP = useMemo(
+            () => !isSmallScreenWidth && !isWideRHPFocused && !isWideRHPClosing && shouldRenderSecondaryOverlay && (isSuperWideRHPRouteName(route.name) || isWideRHPRouteName(route.name)),
+            [isSmallScreenWidth, isWideRHPClosing, isWideRHPFocused, route.name, shouldRenderSecondaryOverlay],
+        );
+
+        const isWideRHPDisplayedOnSuperWideRHP = useMemo(
+            () => !isSmallScreenWidth && !isFocused && !!isWideRHPFocused && shouldRenderSecondaryOverlay && isSuperWideRHPRouteName(route.name),
+            [isFocused, isSmallScreenWidth, isWideRHPFocused, route.name, shouldRenderSecondaryOverlay],
+        );
+
         return (
             // This container is necessary to hide card translation during transition. Without it the user would see un-clipped cards.
             <View style={[styles.modalStackNavigatorContainer, styles.modalStackNavigatorContainerWidth(isSmallScreenWidth)]}>
@@ -127,11 +155,32 @@ function createModalStackNavigator<ParamList extends ParamListBase>(screens: Scr
                         />
                     ))}
                 </ModalStackNavigator.Navigator>
-                {!isSmallScreenWidth && shouldRenderSecondaryOverlay && route.name === SCREENS.RIGHT_MODAL.SEARCH_REPORT ? (
-                    // This overlay is necessary to cover the gap under the narrow format RHP screen
+                {/* These overlays are used to cover the space under the narrower RHP screen when more than one RHP width is displayed on the screen */}
+                {/* Their position is calculated as follows: */}
+                {/* The width of the window for which we calculate the overlay positions is the width of the RHP window, for example for Super Wide RHP it will be 1260 px on a wide layout. */}
+                {/* We need to move the overlay left from the left edge of the RHP below to the left edge of the RHP above. */}
+                {/* To calculate this, subtract the width of the widest RHP from the width of the RHP above. */}
+                {/* Two cases were described for the secondary overlay: */}
+                {/* 1. Single RHP is displayed on Wide RHP (Super Wide or Wide) - here we additionally check the length of superWideRHPRouteKeys because Super Wide RHP route can also be displayed in Wide RHP when the number of visible transactions is less than 2.  */}
+                {/* 2. Wide RHP is displayed on Super Wide RHP route. */}
+                {/* Please note that in these cases, the overlay is rendered from the RHP screen displayed below. For example, if we display RHP on Wide RHP, the secondary overlay is rendered from Wide RHP, etc. */}
+                {/* There is also a special case where three different RHP widths are displayed at the same time. In this case, an overlay under RHP should be rendered from Wide RHP. */}
+                {isRHPDisplayedOnWideRHP ? (
                     <Overlay
                         progress={secondOverlayProgress}
-                        hasMarginLeft
+                        positionLeftValue={superWideRHPRouteKeys.length > 0 ? modalStackOverlaySuperWideRHPPositionLeft : animatedReceiptPaneRHPWidth}
+                    />
+                ) : null}
+                {isWideRHPDisplayedOnSuperWideRHP ? (
+                    <Overlay
+                        progress={secondOverlayProgress}
+                        positionLeftValue={modalStackOverlayWideRHPPositionLeft}
+                    />
+                ) : null}
+                {!isSmallScreenWidth && shouldRenderTertiaryOverlay && isWideRHPRouteName(route.name) ? (
+                    <Overlay
+                        progress={thirdOverlayProgress}
+                        positionLeftValue={modalStackOverlaySuperWideRHPPositionLeft}
                     />
                 ) : null}
             </View>
@@ -842,13 +891,17 @@ const MergeTransactionStackNavigator = createModalStackNavigator<MergeTransactio
     [SCREENS.MERGE_TRANSACTION.CONFIRMATION_PAGE]: () => require<ReactComponentModule>('../../../../pages/TransactionMerge/ConfirmationPage').default,
 });
 
-const SearchReportModalStackNavigator = createModalStackNavigator<SearchReportParamList>({
-    [SCREENS.SEARCH.REPORT_RHP]: () => require<ReactComponentModule>('../../../../pages/home/ReportScreen').default,
+const SearchReportActionsModalStackNavigator = createModalStackNavigator<SearchReportActionsParamList>({
     [SCREENS.SEARCH.ROOT_VERIFY_ACCOUNT]: () => require<ReactComponentModule>('../../../../pages/Search/SearchRootVerifyAccountPage').default,
     [SCREENS.SEARCH.MONEY_REQUEST_REPORT_VERIFY_ACCOUNT]: () => require<ReactComponentModule>('../../../../pages/Search/SearchMoneyRequestReportVerifyAccountPage').default,
     [SCREENS.SEARCH.MONEY_REQUEST_REPORT_HOLD_TRANSACTIONS]: () => require<ReactComponentModule>('../../../../pages/Search/SearchHoldReasonPage').default,
     [SCREENS.SEARCH.TRANSACTION_HOLD_REASON_RHP]: () => require<ReactComponentModule>('../../../../pages/Search/SearchHoldReasonPage').default,
     [SCREENS.SEARCH.TRANSACTIONS_CHANGE_REPORT_SEARCH_RHP]: () => require<ReactComponentModule>('../../../../pages/Search/SearchTransactionsChangeReport').default,
+});
+
+// This navigator is reserved for the screen that can be displayed as Wide RHP, other screens should not be added here.
+const SearchReportModalStackNavigator = createModalStackNavigator<SearchReportParamList>({
+    [SCREENS.SEARCH.REPORT_RHP]: () => require<ReactComponentModule>('../../../../pages/home/ReportScreen').default,
 });
 
 const SearchAdvancedFiltersModalStackNavigator = createModalStackNavigator<SearchAdvancedFiltersParamList>({
@@ -973,6 +1026,7 @@ export {
     ReportVerifyAccountModalStackNavigator,
     WalletStatementStackNavigator,
     TransactionDuplicateStackNavigator,
+    SearchReportActionsModalStackNavigator,
     SearchReportModalStackNavigator,
     RestrictedActionModalStackNavigator,
     SearchAdvancedFiltersModalStackNavigator,

--- a/src/libs/Navigation/AppNavigator/ModalStackNavigators/useModalStackScreenOptions.ts
+++ b/src/libs/Navigation/AppNavigator/ModalStackNavigators/useModalStackScreenOptions.ts
@@ -16,13 +16,17 @@ function useModalStackScreenOptions() {
     // https://github.com/Expensify/App/issues/63747
     // eslint-disable-next-line rulesdir/prefer-shouldUseNarrowLayout-instead-of-isSmallScreenWidth
     const {isSmallScreenWidth} = useResponsiveLayout();
-    const {wideRHPRouteKeys} = useContext(WideRHPContext);
+    const {wideRHPRouteKeys, superWideRHPRouteKeys} = useContext(WideRHPContext);
 
     return useCallback<({route}: {route: PlatformStackRouteProp<ParamListBase, string>}) => PlatformStackNavigationOptions>(
         ({route}) => {
             let cardStyleInterpolator;
 
-            if (wideRHPRouteKeys.includes(route.key) && !isSmallScreenWidth) {
+            if (superWideRHPRouteKeys.includes(route.key) && !isSmallScreenWidth) {
+                cardStyleInterpolator = enhanceCardStyleInterpolator(CardStyleInterpolators.forHorizontalIOS, {
+                    cardStyle: styles.superWideRHPExtendedCardInterpolatorStyles,
+                });
+            } else if (wideRHPRouteKeys.includes(route.key) && !isSmallScreenWidth) {
                 // We need to use interpolator styles instead of regular card styles so we can use animated value for width.
                 // It is necessary to have responsive width of the wide RHP for range 800px to 840px.
                 cardStyleInterpolator = enhanceCardStyleInterpolator(CardStyleInterpolators.forHorizontalIOS, {
@@ -45,7 +49,7 @@ function useModalStackScreenOptions() {
                 },
             };
         },
-        [isSmallScreenWidth, styles.navigationScreenCardStyle, styles.wideRHPExtendedCardInterpolatorStyles, wideRHPRouteKeys],
+        [isSmallScreenWidth, styles, superWideRHPRouteKeys, wideRHPRouteKeys],
     );
 }
 

--- a/src/libs/Navigation/AppNavigator/Navigators/Overlay/BaseOverlay.tsx
+++ b/src/libs/Navigation/AppNavigator/Navigators/Overlay/BaseOverlay.tsx
@@ -4,41 +4,35 @@ import React from 'react';
 import {Animated, View} from 'react-native';
 import PressableWithoutFeedback from '@components/Pressable/PressableWithoutFeedback';
 import useLocalize from '@hooks/useLocalize';
-import useSidePanel from '@hooks/useSidePanel';
 import useThemeStyles from '@hooks/useThemeStyles';
 import type {OverlayStylesParams} from '@styles/index';
+import variables from '@styles/variables';
 import CONST from '@src/CONST';
 
 type BaseOverlayProps = {
     /* Callback to close the modal */
     onPress?: () => void;
 
-    /* Whether there should be a gap on the right side. Necessary for the overlay that covers wider part of RHP. */
-    hasMarginRight?: boolean;
-
-    /* Whether there should be a gap on the left. Necessary for the overlay in modal stack navigator. */
-    hasMarginLeft?: boolean;
-
     /* Override the progress from useCardAnimation. Necessary for the secondary overlay */
     progress?: OverlayStylesParams;
+
+    /* Overlay position from the left edge of the container */
+    positionLeftValue?: number | Animated.Value;
+
+    /* Overlay position from the right edge of the container */
+    positionRightValue?: number | Animated.Value;
 };
 
-function BaseOverlay({onPress, hasMarginRight = false, progress, hasMarginLeft = false}: BaseOverlayProps) {
+// The default value of positionLeftValue is equal to -2 * variables.sideBarWidth, because we need to stretch the overlay to cover the sidebar and the translate animation distance.
+function BaseOverlay({onPress, progress, positionLeftValue = -2 * variables.sideBarWidth, positionRightValue = 0}: BaseOverlayProps) {
     const styles = useThemeStyles();
     const {current} = useCardAnimation();
     const {translate} = useLocalize();
-    const {sidePanelTranslateX} = useSidePanel();
 
     return (
         <Animated.View
             id="BaseOverlay"
-            style={[
-                styles.pFixed,
-                styles.t0,
-                styles.b0,
-                styles.overlayBackground,
-                styles.overlayStyles({progress: progress ?? current.progress, hasMarginRight, hasMarginLeft, sidePanelTranslateX}),
-            ]}
+            style={[styles.pFixed, styles.t0, styles.b0, styles.overlayBackground, styles.overlayStyles({progress: progress ?? current.progress, positionLeftValue, positionRightValue})]}
         >
             <View style={[styles.flex1, styles.flexColumn]}>
                 {/* In the latest Electron version buttons can't be both clickable and draggable.

--- a/src/libs/Navigation/AppNavigator/Navigators/RightModalNavigator.tsx
+++ b/src/libs/Navigation/AppNavigator/Navigators/RightModalNavigator.tsx
@@ -1,21 +1,28 @@
 import type {NavigatorScreenParams} from '@react-navigation/native';
+import {useFocusEffect} from '@react-navigation/native';
+import type {StackCardInterpolationProps} from '@react-navigation/stack';
 import React, {useCallback, useContext, useMemo, useRef} from 'react';
-// We use Animated for all functionality related to wide RHP to make it easier
-// to interact with react-navigation components (e.g., CardContainer, interpolator), which also use Animated.
 // eslint-disable-next-line no-restricted-imports
 import {Animated, InteractionManager} from 'react-native';
 import NoDropZone from '@components/DragAndDrop/NoDropZone';
-import {expandedRHPProgress, WideRHPContext} from '@components/WideRHPContextProvider';
+import {animatedWideRHPWidth, expandedRHPProgress, innerRHPProgress, secondOverlayProgress, thirdOverlayProgress, WideRHPContext} from '@components/WideRHPContextProvider';
 import useResponsiveLayout from '@hooks/useResponsiveLayout';
 import useThemeStyles from '@hooks/useThemeStyles';
+import useWindowDimensions from '@hooks/useWindowDimensions';
 import {abandonReviewDuplicateTransactions} from '@libs/actions/Transaction';
 import {clearTwoFactorAuthData} from '@libs/actions/TwoFactorAuthActions';
 import hideKeyboardOnSwipe from '@libs/Navigation/AppNavigator/hideKeyboardOnSwipe';
 import * as ModalStackNavigators from '@libs/Navigation/AppNavigator/ModalStackNavigators';
+import useModalCardStyleInterpolator from '@libs/Navigation/AppNavigator/useModalCardStyleInterpolator';
 import useRHPScreenOptions from '@libs/Navigation/AppNavigator/useRHPScreenOptions';
+import calculateReceiptPaneRHPWidth from '@libs/Navigation/helpers/calculateReceiptPaneRHPWidth';
+import calculateSuperWideRHPWidth from '@libs/Navigation/helpers/calculateSuperWideRHPWidth';
+import {isFullScreenName} from '@libs/Navigation/helpers/isNavigatorName';
+import Navigation, {navigationRef} from '@libs/Navigation/Navigation';
 import createPlatformStackNavigator from '@libs/Navigation/PlatformStackNavigation/createPlatformStackNavigator';
 import type {PlatformStackScreenProps} from '@libs/Navigation/PlatformStackNavigation/types';
 import type {AuthScreensParamList, RightModalNavigatorParamList} from '@navigation/types';
+import variables from '@styles/variables';
 import CONST from '@src/CONST';
 import NAVIGATORS from '@src/NAVIGATORS';
 import SCREENS from '@src/SCREENS';
@@ -26,12 +33,32 @@ type RightModalNavigatorProps = PlatformStackScreenProps<AuthScreensParamList, t
 
 const Stack = createPlatformStackNavigator<RightModalNavigatorParamList, string>();
 
+const singleRHPWidth = variables.sideBarWidth;
+const getWideRHPWidth = (windowWidth: number) => variables.sideBarWidth + calculateReceiptPaneRHPWidth(windowWidth);
+
 function RightModalNavigator({navigation, route}: RightModalNavigatorProps) {
-    const styles = useThemeStyles();
-    const {shouldUseNarrowLayout} = useResponsiveLayout();
+    // eslint-disable-next-line rulesdir/prefer-shouldUseNarrowLayout-instead-of-isSmallScreenWidth
+    const {shouldUseNarrowLayout, isSmallScreenWidth} = useResponsiveLayout();
     const isExecutingRef = useRef<boolean>(false);
     const screenOptions = useRHPScreenOptions();
-    const {shouldRenderSecondaryOverlay, secondOverlayProgress, dismissToWideReport} = useContext(WideRHPContext);
+    const {shouldRenderSecondaryOverlay, isWideRHPFocused, shouldRenderTertiaryOverlay, isWideRHPClosing, clearWideRHPKeys, syncWideRHPKeys, syncSuperWideRHPKeys} =
+        useContext(WideRHPContext);
+    const {windowWidth} = useWindowDimensions();
+    const modalCardStyleInterpolator = useModalCardStyleInterpolator();
+    const styles = useThemeStyles();
+
+    const animatedWidth = expandedRHPProgress.interpolate({
+        inputRange: [0, 1, 2],
+        outputRange: [singleRHPWidth, getWideRHPWidth(windowWidth), calculateSuperWideRHPWidth(windowWidth)],
+    });
+
+    const animatedWidthStyle = useMemo(() => {
+        return {
+            width: shouldUseNarrowLayout ? '100%' : animatedWidth,
+        } as const;
+    }, [animatedWidth, shouldUseNarrowLayout]);
+
+    const overlayPositionLeft = useMemo(() => -1 * calculateSuperWideRHPWidth(windowWidth), [windowWidth]);
 
     const screenListeners = useMemo(
         () => ({
@@ -65,13 +92,37 @@ function RightModalNavigator({navigation, route}: RightModalNavigatorProps) {
         }, CONST.ANIMATED_TRANSITION);
     }, [navigation]);
 
+    const clearWideRHPKeysAfterTabChanged = useCallback(() => {
+        const isRhpOpened = navigationRef?.getRootState()?.routes?.some((rootStateRoute) => rootStateRoute.key === route.key);
+        const isFullScreenTopmostRoute = isFullScreenName(navigationRef.getRootState()?.routes?.at(-1)?.name);
+        const hasTabChanged = isRhpOpened && isFullScreenTopmostRoute;
+        if (!hasTabChanged) {
+            return;
+        }
+        clearWideRHPKeys();
+    }, [clearWideRHPKeys, route.key]);
+
+    useFocusEffect(
+        useCallback(() => {
+            syncWideRHPKeys();
+            syncSuperWideRHPKeys();
+
+            return () => clearWideRHPKeysAfterTabChanged();
+        }, [syncWideRHPKeys, syncSuperWideRHPKeys, clearWideRHPKeysAfterTabChanged]),
+    );
+
     return (
         <NarrowPaneContextProvider>
             <NoDropZone>
-                {!shouldUseNarrowLayout && <Overlay onPress={handleOverlayPress} />}
+                {!shouldUseNarrowLayout && (
+                    <Overlay
+                        positionLeftValue={overlayPositionLeft}
+                        onPress={handleOverlayPress}
+                    />
+                )}
                 {/* This one is to limit the outer Animated.View and allow the background to be pressable */}
                 {/* Without it, the transparent half of the narrow format RHP card would cover the pressable part of the overlay */}
-                <Animated.View style={[styles.animatedRHPNavigatorContainer, styles.animatedRHPNavigatorContainerWidth(shouldUseNarrowLayout, expandedRHPProgress)]}>
+                <Animated.View style={[styles.pAbsolute, styles.r0, styles.h100, styles.overflowHidden, animatedWidthStyle]}>
                     <Stack.Navigator
                         screenOptions={screenOptions}
                         screenListeners={screenListeners}
@@ -229,8 +280,28 @@ function RightModalNavigator({navigation, route}: RightModalNavigatorProps) {
                             component={ModalStackNavigators.TravelModalStackNavigator}
                         />
                         <Stack.Screen
+                            name={SCREENS.RIGHT_MODAL.SEARCH_REPORT_ACTIONS}
+                            component={ModalStackNavigators.SearchReportActionsModalStackNavigator}
+                        />
+                        <Stack.Screen
                             name={SCREENS.RIGHT_MODAL.SEARCH_REPORT}
                             component={ModalStackNavigators.SearchReportModalStackNavigator}
+                            options={{
+                                web: {
+                                    cardStyleInterpolator: (props: StackCardInterpolationProps) =>
+                                        // Add 1 to change range from [0, 1] to [1, 2]
+                                        // Don't use outputMultiplier for the narrow layout
+                                        modalCardStyleInterpolator({
+                                            props,
+                                            shouldAnimateSidePanel: true,
+
+                                            // Adjust output range to match the wide RHP size
+                                            outputRangeMultiplier: isSmallScreenWidth
+                                                ? undefined
+                                                : Animated.add(Animated.multiply(innerRHPProgress, variables.receiptPaneRHPMaxWidth / variables.sideBarWidth), 1),
+                                        }),
+                                },
+                            }}
                         />
                         <Stack.Screen
                             name={SCREENS.RIGHT_MODAL.RESTRICTED_ACTION}
@@ -262,13 +333,28 @@ function RightModalNavigator({navigation, route}: RightModalNavigatorProps) {
                         />
                     </Stack.Navigator>
                 </Animated.View>
-                {/* The second overlay is here to cover the wide rhp screen underneath */}
-                {/* It has a gap on the right to make the last rhp route (narrow) visible and pressable */}
-                {shouldRenderSecondaryOverlay && !shouldUseNarrowLayout && (
+                {/* The third and second overlays are displayed here to cover RHP screens wider than the currently focused screen. */}
+                {/* Clicking on these overlays redirects you to the RHP screen below them. */}
+                {/* The width of these overlays is equal to the width of the screen minus the width of the currently focused RHP screen (positionRightValue) */}
+                {shouldRenderSecondaryOverlay && !shouldUseNarrowLayout && !isWideRHPFocused && !isWideRHPClosing && (
                     <Overlay
-                        hasMarginRight
                         progress={secondOverlayProgress}
-                        onPress={dismissToWideReport}
+                        positionRightValue={variables.sideBarWidth}
+                        onPress={Navigation.dismissToFirstRHP}
+                    />
+                )}
+                {shouldRenderSecondaryOverlay && !shouldUseNarrowLayout && !!isWideRHPFocused && (
+                    <Overlay
+                        progress={secondOverlayProgress}
+                        positionRightValue={animatedWideRHPWidth}
+                        onPress={Navigation.dismissToFirstRHP}
+                    />
+                )}
+                {shouldRenderTertiaryOverlay && !shouldUseNarrowLayout && (
+                    <Overlay
+                        progress={thirdOverlayProgress}
+                        positionRightValue={variables.sideBarWidth}
+                        onPress={Navigation.dismissToSecondRHP}
                     />
                 )}
             </NoDropZone>

--- a/src/libs/Navigation/AppNavigator/useRootNavigatorScreenOptions.ts
+++ b/src/libs/Navigation/AppNavigator/useRootNavigatorScreenOptions.ts
@@ -7,6 +7,8 @@ import {expandedRHPProgress} from '@components/WideRHPContextProvider';
 import useResponsiveLayout from '@hooks/useResponsiveLayout';
 import useStyleUtils from '@hooks/useStyleUtils';
 import useThemeStyles from '@hooks/useThemeStyles';
+import useWindowDimensions from '@hooks/useWindowDimensions';
+import calculateSuperWideRHPWidth from '@libs/Navigation/helpers/calculateSuperWideRHPWidth';
 import Animations from '@libs/Navigation/PlatformStackNavigation/navigationOptions/animation';
 import Presentation from '@libs/Navigation/PlatformStackNavigation/navigationOptions/presentation';
 import type {PlatformStackNavigationOptions} from '@libs/Navigation/PlatformStackNavigation/types';
@@ -28,12 +30,21 @@ const commonScreenOptions: PlatformStackNavigationOptions = {
     },
 };
 
+function abs(a: Animated.AnimatedSubtraction<number | string>) {
+    const b = Animated.multiply(a, -1);
+    const clampedA = Animated.diffClamp(a, 0, Number.MAX_SAFE_INTEGER);
+    const clampedB = Animated.diffClamp(b, 0, Number.MAX_SAFE_INTEGER);
+
+    return Animated.add(clampedA, clampedB);
+}
+
 const useRootNavigatorScreenOptions = () => {
     const StyleUtils = useStyleUtils();
     const modalCardStyleInterpolator = useModalCardStyleInterpolator();
     // eslint-disable-next-line rulesdir/prefer-shouldUseNarrowLayout-instead-of-isSmallScreenWidth
     const {isSmallScreenWidth, shouldUseNarrowLayout} = useResponsiveLayout();
     const themeStyles = useThemeStyles();
+    const {windowWidth} = useWindowDimensions();
 
     return {
         rightModalNavigator: {
@@ -45,16 +56,31 @@ const useRootNavigatorScreenOptions = () => {
             web: {
                 presentation: Presentation.TRANSPARENT_MODAL,
                 cardStyleInterpolator: (props: StackCardInterpolationProps) =>
-                    // Add 1 to change range from [0, 1] to [1, 2]
                     // Don't use outputMultiplier for the narrow layout
                     modalCardStyleInterpolator({
                         props,
                         shouldAnimateSidePanel: true,
-
-                        // Adjust output range to match the wide RHP size
+                        // On a wide layout, the output range multiplier is multiplied inside useModalCardStyleInterpolator by the width of a single RHP.
+                        // Depending on the value of expandedRHPProgress, after multiplication the appropriate RHP width should be obtained.
+                        // To achieve this, the following function was used:
+                        // y = (1 - |x - 1|) * receiptPaneWidth/sidebarWidth + Max((x - 1), 0)) * (superWideRHPWidth / sidebarWidth - 1) + 1
+                        // For expandedRHPProgress equal to:
+                        // 0 - Single RHP, y = 1
+                        // 1 - Wide RHP, y = receiptPaneWidth / sidebarWidth + 1
+                        // 2 - Super Wide RHP, y = superWideRHPWidth / sidebarWidth
+                        // For the given values, after multiplying by sidebarWidth inside useModalCardStyleInterpolator, the correct widths are obtained.
                         outputRangeMultiplier: isSmallScreenWidth
                             ? undefined
-                            : Animated.add(Animated.multiply(expandedRHPProgress, variables.receiptPaneRHPMaxWidth / variables.sideBarWidth), 1),
+                            : Animated.add(
+                                  Animated.add(
+                                      Animated.multiply(Animated.subtract(1, abs(Animated.subtract(1, expandedRHPProgress))), variables.receiptPaneRHPMaxWidth / variables.sideBarWidth),
+                                      Animated.multiply(
+                                          expandedRHPProgress.interpolate({inputRange: [1, 2], outputRange: [0, 1], extrapolate: 'clamp'}),
+                                          calculateSuperWideRHPWidth(windowWidth) / variables.sideBarWidth - 1,
+                                      ),
+                                  ),
+                                  1,
+                              ),
                     }),
             },
         },

--- a/src/libs/Navigation/helpers/calculateReceiptPaneRHPWidth/index.native.ts
+++ b/src/libs/Navigation/helpers/calculateReceiptPaneRHPWidth/index.native.ts
@@ -1,0 +1,5 @@
+// Wide RHP is not displayed on native platforms
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+function calculateReceiptPaneRHPWidth(windowWidth: number) {}
+
+export default calculateReceiptPaneRHPWidth;

--- a/src/libs/Navigation/helpers/calculateReceiptPaneRHPWidth/index.ts
+++ b/src/libs/Navigation/helpers/calculateReceiptPaneRHPWidth/index.ts
@@ -1,0 +1,19 @@
+import variables from '@styles/variables';
+
+const singleRHPWidth = variables.sideBarWidth;
+const wideRHPMaxWidth = variables.receiptPaneRHPMaxWidth + singleRHPWidth;
+
+/**
+ * Calculates the optimal width for the receipt pane RHP based on window width.
+ * Ensures the RHP doesn't exceed maximum width and maintains minimum responsive width.
+ *
+ * @param windowWidth - Current window width in pixels
+ * @returns Calculated RHP width with constraints applied
+ */
+function calculateReceiptPaneRHPWidth(windowWidth: number) {
+    const calculatedWidth = windowWidth < wideRHPMaxWidth ? variables.receiptPaneRHPMaxWidth - (wideRHPMaxWidth - windowWidth) : variables.receiptPaneRHPMaxWidth;
+
+    return Math.max(calculatedWidth, variables.mobileResponsiveWidthBreakpoint - singleRHPWidth);
+}
+
+export default calculateReceiptPaneRHPWidth;

--- a/src/libs/Navigation/helpers/calculateSuperWideRHPWidth/index.native.ts
+++ b/src/libs/Navigation/helpers/calculateSuperWideRHPWidth/index.native.ts
@@ -1,0 +1,5 @@
+// Super Wide RHP is not displayed on native platforms
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+function calculateSuperWideRHPWidth(windowWidth: number) {}
+
+export default calculateSuperWideRHPWidth;

--- a/src/libs/Navigation/helpers/calculateSuperWideRHPWidth/index.ts
+++ b/src/libs/Navigation/helpers/calculateSuperWideRHPWidth/index.ts
@@ -1,0 +1,18 @@
+import calculateReceiptPaneRHPWidth from '@libs/Navigation/helpers/calculateReceiptPaneRHPWidth';
+import variables from '@styles/variables';
+
+/**
+ * Calculates the optimal width for the super wide RHP based on window width.
+ * Ensures the RHP doesn't exceed maximum width and maintains minimum responsive width.
+ *
+ * @param windowWidth - Current window width in pixels
+ * @returns Calculated super wide RHP width with constraints applied
+ */
+function calculateSuperWideRHPWidth(windowWidth: number) {
+    const superWideRHPWidth = windowWidth - variables.navigationTabBarSize - variables.sideBarWithLHBWidth;
+    const wideRHPWidth = calculateReceiptPaneRHPWidth(windowWidth) + variables.sideBarWidth;
+
+    return Math.max(Math.min(superWideRHPWidth, variables.superWideRHPMaxWidth), wideRHPWidth);
+}
+
+export default calculateSuperWideRHPWidth;

--- a/src/libs/Navigation/helpers/extractNavigationKeys.ts
+++ b/src/libs/Navigation/helpers/extractNavigationKeys.ts
@@ -1,0 +1,38 @@
+import type {NavigationState, PartialState} from '@react-navigation/native';
+
+/**
+ * Utility function that extracts all unique navigation keys from a React Navigation state.
+ * Recursively traverses the navigation state tree and collects all route keys.
+ *
+ * @param state - The React Navigation state (can be partial or complete)
+ * @returns Set of unique route keys found in the navigation state
+ */
+function extractNavigationKeys(state: NavigationState | PartialState<NavigationState> | undefined): Set<string> {
+    if (!state || !state.routes) {
+        return new Set();
+    }
+
+    const keys = new Set<string>();
+    const routesToProcess = [...state.routes];
+
+    while (routesToProcess.length > 0) {
+        const route = routesToProcess.pop();
+        if (!route) {
+            continue;
+        }
+
+        // Add the current route key to the set
+        if (route.key) {
+            keys.add(route.key);
+        }
+
+        // If the route has a nested state, add its routes to the processing queue
+        if (route.state && 'routes' in route.state && Array.isArray(route.state.routes)) {
+            routesToProcess.push(...route.state.routes);
+        }
+    }
+
+    return keys;
+}
+
+export default extractNavigationKeys;

--- a/src/libs/Navigation/helpers/getLastVisibleRHPRouteKey.ts
+++ b/src/libs/Navigation/helpers/getLastVisibleRHPRouteKey.ts
@@ -1,0 +1,21 @@
+import type {NavigationState} from '@react-navigation/native';
+import NAVIGATORS from '@src/NAVIGATORS';
+import {isFullScreenName} from './isNavigatorName';
+
+function getLastVisibleRHPRouteKey(state: NavigationState | undefined) {
+    // Safe handling when navigation is not yet initialized
+    if (!state) {
+        return undefined;
+    }
+    const lastFullScreenRouteIndex = state?.routes.findLastIndex((route) => isFullScreenName(route.name));
+    const lastRHPRouteIndex = state?.routes.findLastIndex((route) => route.name === NAVIGATORS.RIGHT_MODAL_NAVIGATOR);
+
+    // Both routes have to be present and the RHP have to be after last full screen for it to be visible.
+    if (lastFullScreenRouteIndex === -1 || lastRHPRouteIndex === -1 || lastFullScreenRouteIndex > lastRHPRouteIndex) {
+        return undefined;
+    }
+
+    return state?.routes.at(lastRHPRouteIndex)?.key;
+}
+
+export default getLastVisibleRHPRouteKey;

--- a/src/libs/Navigation/linkingConfig/config.ts
+++ b/src/libs/Navigation/linkingConfig/config.ts
@@ -1569,8 +1569,12 @@ const config: LinkingOptions<RootNavigatorParamList>['config'] = {
                 },
                 [SCREENS.RIGHT_MODAL.SEARCH_REPORT]: {
                     screens: {
-                        [SCREENS.SEARCH.ROOT_VERIFY_ACCOUNT]: ROUTES.SEARCH_ROOT_VERIFY_ACCOUNT,
                         [SCREENS.SEARCH.REPORT_RHP]: ROUTES.SEARCH_REPORT.route,
+                    },
+                },
+                [SCREENS.RIGHT_MODAL.SEARCH_REPORT_ACTIONS]: {
+                    screens: {
+                        [SCREENS.SEARCH.ROOT_VERIFY_ACCOUNT]: ROUTES.SEARCH_ROOT_VERIFY_ACCOUNT,
                         [SCREENS.SEARCH.MONEY_REQUEST_REPORT_VERIFY_ACCOUNT]: ROUTES.SEARCH_MONEY_REQUEST_REPORT_VERIFY_ACCOUNT.route,
                         [SCREENS.SEARCH.MONEY_REQUEST_REPORT_HOLD_TRANSACTIONS]: ROUTES.SEARCH_MONEY_REQUEST_REPORT_HOLD_TRANSACTIONS.route,
                         [SCREENS.SEARCH.TRANSACTION_HOLD_REASON_RHP]: ROUTES.TRANSACTION_HOLD_REASON_RHP,

--- a/src/libs/Navigation/types.ts
+++ b/src/libs/Navigation/types.ts
@@ -2113,6 +2113,7 @@ type RightModalNavigatorParamList = {
     [SCREENS.RIGHT_MODAL.PRIVATE_NOTES]: NavigatorScreenParams<PrivateNotesNavigatorParamList>;
     [SCREENS.RIGHT_MODAL.TRANSACTION_DUPLICATE]: NavigatorScreenParams<TransactionDuplicateNavigatorParamList>;
     [SCREENS.RIGHT_MODAL.TRAVEL]: NavigatorScreenParams<TravelNavigatorParamList>;
+    [SCREENS.RIGHT_MODAL.SEARCH_REPORT_ACTIONS]: NavigatorScreenParams<SearchReportActionsParamList>;
     [SCREENS.RIGHT_MODAL.SEARCH_REPORT]: NavigatorScreenParams<SearchReportParamList>;
     [SCREENS.RIGHT_MODAL.RESTRICTED_ACTION]: NavigatorScreenParams<RestrictedActionParamList>;
     [SCREENS.RIGHT_MODAL.SEARCH_ADVANCED_FILTERS]: NavigatorScreenParams<SearchAdvancedFiltersParamList>;
@@ -2592,13 +2593,7 @@ type AuthScreensParamList = SharedScreensParamList &
         [NAVIGATORS.TEST_TOOLS_MODAL_NAVIGATOR]: NavigatorScreenParams<TestToolsModalModalNavigatorParamList>;
     };
 
-type SearchReportParamList = {
-    [SCREENS.SEARCH.REPORT_RHP]: {
-        reportID: string;
-        reportActionID?: string;
-        // eslint-disable-next-line no-restricted-syntax -- `backTo` usages in this file are legacy. Do not add new `backTo` params to screens. See contributingGuides/NAVIGATION.md
-        backTo?: Routes;
-    };
+type SearchReportActionsParamList = {
     [SCREENS.SEARCH.REPORT_VERIFY_ACCOUNT]: {
         reportID: string;
     };
@@ -2625,6 +2620,15 @@ type SearchReportParamList = {
         backTo: Routes;
         /** Selected transactions' report ID  */
         reportID: string;
+    };
+};
+
+type SearchReportParamList = {
+    [SCREENS.SEARCH.REPORT_RHP]: {
+        reportID: string;
+        reportActionID?: string;
+        // eslint-disable-next-line no-restricted-syntax -- `backTo` usages in this file are legacy. Do not add new `backTo` params to screens. See contributingGuides/NAVIGATION.md
+        backTo?: Routes;
     };
 };
 
@@ -2816,6 +2820,7 @@ export type {
     RoomMembersNavigatorParamList,
     RootNavigatorParamList,
     SearchAdvancedFiltersParamList,
+    SearchReportActionsParamList,
     SearchReportParamList,
     SearchSavedSearchParamList,
     SearchFullscreenNavigatorParamList,

--- a/src/pages/Search/SearchHoldReasonPage.tsx
+++ b/src/pages/Search/SearchHoldReasonPage.tsx
@@ -8,7 +8,7 @@ import {holdMoneyRequestOnSearch} from '@libs/actions/Search';
 import Navigation from '@libs/Navigation/Navigation';
 import type {PlatformStackScreenProps} from '@libs/Navigation/PlatformStackNavigation/types';
 import {getFieldRequiredErrors} from '@libs/ValidationUtils';
-import type {SearchReportParamList} from '@navigation/types';
+import type {SearchReportActionsParamList} from '@navigation/types';
 import HoldReasonFormView from '@pages/iou/HoldReasonFormView';
 import {putTransactionsOnHold} from '@userActions/IOU';
 import ONYXKEYS from '@src/ONYXKEYS';
@@ -16,8 +16,8 @@ import SCREENS from '@src/SCREENS';
 import INPUT_IDS from '@src/types/form/MoneyRequestHoldReasonForm';
 
 type SearchHoldReasonPageProps =
-    | PlatformStackScreenProps<SearchReportParamList, typeof SCREENS.SEARCH.MONEY_REQUEST_REPORT_HOLD_TRANSACTIONS>
-    | PlatformStackScreenProps<SearchReportParamList, typeof SCREENS.SEARCH.TRANSACTION_HOLD_REASON_RHP>;
+    | PlatformStackScreenProps<SearchReportActionsParamList, typeof SCREENS.SEARCH.MONEY_REQUEST_REPORT_HOLD_TRANSACTIONS>
+    | PlatformStackScreenProps<SearchReportActionsParamList, typeof SCREENS.SEARCH.TRANSACTION_HOLD_REASON_RHP>;
 
 function SearchHoldReasonPage({route}: SearchHoldReasonPageProps) {
     const {translate} = useLocalize();

--- a/src/pages/Search/SearchMoneyRequestReportVerifyAccountPage.tsx
+++ b/src/pages/Search/SearchMoneyRequestReportVerifyAccountPage.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import type {PlatformStackScreenProps} from '@libs/Navigation/PlatformStackNavigation/types';
-import type {SearchReportParamList} from '@libs/Navigation/types';
+import type {SearchReportActionsParamList} from '@libs/Navigation/types';
 import VerifyAccountPageBase from '@pages/settings/VerifyAccountPageBase';
 import ROUTES from '@src/ROUTES';
 import type SCREENS from '@src/SCREENS';
 
-type SearchMoneyRequestReportVerifyAccountPageProps = PlatformStackScreenProps<SearchReportParamList, typeof SCREENS.SEARCH.MONEY_REQUEST_REPORT_VERIFY_ACCOUNT>;
+type SearchMoneyRequestReportVerifyAccountPageProps = PlatformStackScreenProps<SearchReportActionsParamList, typeof SCREENS.SEARCH.MONEY_REQUEST_REPORT_VERIFY_ACCOUNT>;
 
 function SearchMoneyRequestReportVerifyAccountPage({route}: SearchMoneyRequestReportVerifyAccountPageProps) {
     return <VerifyAccountPageBase navigateBackTo={ROUTES.SEARCH_MONEY_REQUEST_REPORT.getRoute({reportID: route.params.reportID})} />;

--- a/src/pages/Search/SearchReportVerifyAccountPage.tsx
+++ b/src/pages/Search/SearchReportVerifyAccountPage.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import type {PlatformStackScreenProps} from '@libs/Navigation/PlatformStackNavigation/types';
-import type {SearchReportParamList} from '@libs/Navigation/types';
+import type {SearchReportActionsParamList} from '@libs/Navigation/types';
 import VerifyAccountPageBase from '@pages/settings/VerifyAccountPageBase';
 import ROUTES from '@src/ROUTES';
 import type SCREENS from '@src/SCREENS';
 
-type SearchReportVerifyAccountPageProps = PlatformStackScreenProps<SearchReportParamList, typeof SCREENS.SEARCH.REPORT_VERIFY_ACCOUNT>;
+type SearchReportVerifyAccountPageProps = PlatformStackScreenProps<SearchReportActionsParamList, typeof SCREENS.SEARCH.REPORT_VERIFY_ACCOUNT>;
 
 function SearchReportVerifyAccountPage({route}: SearchReportVerifyAccountPageProps) {
     return <VerifyAccountPageBase navigateBackTo={ROUTES.SEARCH_REPORT.getRoute({reportID: route.params.reportID})} />;

--- a/src/pages/home/ReportScreen.tsx
+++ b/src/pages/home/ReportScreen.tsx
@@ -20,7 +20,7 @@ import MoneyRequestReceiptView from '@components/ReportActionItem/MoneyRequestRe
 import ReportActionsSkeletonView from '@components/ReportActionsSkeletonView';
 import ScreenWrapper from '@components/ScreenWrapper';
 import ScrollView from '@components/ScrollView';
-import {useShowWideRHPVersion} from '@components/WideRHPContextProvider';
+import useShowWideRHPVersion from '@components/WideRHPContextProvider/useShowWideRHPVersion';
 import useAppFocusEvent from '@hooks/useAppFocusEvent';
 import useCurrentReportID from '@hooks/useCurrentReportID';
 import useDeepCompareRef from '@hooks/useDeepCompareRef';

--- a/src/pages/iou/HoldReasonPage.tsx
+++ b/src/pages/iou/HoldReasonPage.tsx
@@ -6,7 +6,7 @@ import useOnyx from '@hooks/useOnyx';
 import {addErrorMessage} from '@libs/ErrorUtils';
 import Navigation from '@libs/Navigation/Navigation';
 import type {PlatformStackScreenProps} from '@libs/Navigation/PlatformStackNavigation/types';
-import type {MoneyRequestNavigatorParamList, SearchReportParamList} from '@libs/Navigation/types';
+import type {MoneyRequestNavigatorParamList, SearchReportActionsParamList} from '@libs/Navigation/types';
 import {getReportAction, isMoneyRequestAction} from '@libs/ReportActionsUtils';
 import {canEditMoneyRequest, isReportInGroupPolicy} from '@libs/ReportUtils';
 import {getFieldRequiredErrors} from '@libs/ValidationUtils';
@@ -19,7 +19,7 @@ import HoldReasonFormView from './HoldReasonFormView';
 
 type HoldReasonPageProps =
     | PlatformStackScreenProps<MoneyRequestNavigatorParamList, typeof SCREENS.MONEY_REQUEST.HOLD>
-    | PlatformStackScreenProps<SearchReportParamList, typeof SCREENS.SEARCH.TRANSACTION_HOLD_REASON_RHP>;
+    | PlatformStackScreenProps<SearchReportActionsParamList, typeof SCREENS.SEARCH.TRANSACTION_HOLD_REASON_RHP>;
 
 function HoldReasonPage({route}: HoldReasonPageProps) {
     const {translate} = useLocalize();

--- a/src/pages/iou/RejectReasonPage.tsx
+++ b/src/pages/iou/RejectReasonPage.tsx
@@ -4,7 +4,7 @@ import {useSearchContext} from '@components/Search/SearchContext';
 import useLocalize from '@hooks/useLocalize';
 import Navigation from '@libs/Navigation/Navigation';
 import type {PlatformStackScreenProps} from '@libs/Navigation/PlatformStackNavigation/types';
-import type {MoneyRequestNavigatorParamList, SearchReportParamList} from '@libs/Navigation/types';
+import type {MoneyRequestNavigatorParamList, SearchReportActionsParamList} from '@libs/Navigation/types';
 import {getFieldRequiredErrors} from '@libs/ValidationUtils';
 import {clearErrorFields, clearErrors} from '@userActions/FormActions';
 import {rejectMoneyRequest} from '@userActions/IOU';
@@ -15,7 +15,7 @@ import RejectReasonFormView from './RejectReasonFormView';
 
 type RejectReasonPageProps =
     | PlatformStackScreenProps<MoneyRequestNavigatorParamList, typeof SCREENS.MONEY_REQUEST.REJECT>
-    | PlatformStackScreenProps<SearchReportParamList, typeof SCREENS.SEARCH.TRANSACTION_HOLD_REASON_RHP>;
+    | PlatformStackScreenProps<SearchReportActionsParamList, typeof SCREENS.SEARCH.TRANSACTION_HOLD_REASON_RHP>;
 
 function RejectReasonPage({route}: RejectReasonPageProps) {
     const {translate} = useLocalize();

--- a/src/styles/index.ts
+++ b/src/styles/index.ts
@@ -3,11 +3,10 @@
 /* eslint-disable @typescript-eslint/naming-convention */
 import type {LineLayerStyleProps} from '@rnmapbox/maps/src/utils/MapboxStyles';
 import lodashClamp from 'lodash/clamp';
-import type {RefObject} from 'react';
 import type {LineLayer} from 'react-map-gl';
-import type {ImageStyle, TextStyle, ViewStyle} from 'react-native';
 // eslint-disable-next-line no-restricted-imports
-import {Animated, Platform, StyleSheet} from 'react-native';
+import type {Animated, ImageStyle, TextStyle, ViewStyle} from 'react-native';
+import {Platform, StyleSheet} from 'react-native';
 import type {PickerStyle} from 'react-native-picker-select';
 import {interpolate} from 'react-native-reanimated';
 import type {SharedValue} from 'react-native-reanimated';
@@ -15,7 +14,7 @@ import type {MixedStyleDeclaration, MixedStyleRecord} from 'react-native-render-
 import type {ValueOf} from 'type-fest';
 import type DotLottieAnimation from '@components/LottieAnimations/types';
 import {ACTIVE_LABEL_SCALE} from '@components/TextInput/styleConst';
-import {receiptPaneRHPWidth} from '@components/WideRHPContextProvider';
+import {animatedReceiptPaneRHPWidth, animatedSuperWideRHPWidth, animatedWideRHPWidth} from '@components/WideRHPContextProvider';
 import {getBrowser, isMobile, isMobileSafari, isSafari} from '@libs/Browser';
 import getPlatform from '@libs/getPlatform';
 import CONST from '@src/CONST';
@@ -5358,7 +5357,14 @@ const staticStyles = (theme: ThemeColors) =>
             position: Platform.OS === 'web' ? 'fixed' : 'absolute',
             height: '100%',
             right: 0,
-            width: Animated.add(variables.sideBarWidth, receiptPaneRHPWidth),
+            width: animatedWideRHPWidth,
+        },
+
+        superWideRHPExtendedCardInterpolatorStyles: {
+            position: Platform.OS === 'web' ? 'fixed' : 'absolute',
+            height: '100%',
+            right: 0,
+            width: animatedSuperWideRHPWidth,
         },
 
         flexibleHeight: {
@@ -5372,7 +5378,7 @@ const staticStyles = (theme: ThemeColors) =>
 
         wideRHPMoneyRequestReceiptViewContainer: {
             backgroundColor: theme.appBG,
-            width: receiptPaneRHPWidth,
+            width: animatedReceiptPaneRHPWidth,
             height: '100%',
             borderRightWidth: 1,
             borderColor: theme.border,
@@ -5577,11 +5583,6 @@ const dynamicStyles = (theme: ThemeColors) =>
                 width: isSmallScreenWidth ? '100%' : variables.sideBarWidth,
             }) satisfies ViewStyle,
 
-        animatedRHPNavigatorContainerWidth: (shouldUseNarrowLayout: boolean, expandedRHPProgress: Animated.Value) =>
-            ({
-                width: shouldUseNarrowLayout ? '100%' : Animated.add(variables.sideBarWidth, Animated.multiply(expandedRHPProgress, receiptPaneRHPWidth)),
-            }) satisfies ViewStyle,
-
         OnboardingNavigatorInnerView: (shouldUseNarrowLayout: boolean) =>
             ({
                 width: shouldUseNarrowLayout ? variables.onboardingModalWidth : '100%',
@@ -5620,19 +5621,17 @@ const dynamicStyles = (theme: ThemeColors) =>
 
         overlayStyles: ({
             progress,
-            hasMarginRight = false,
-            hasMarginLeft = false,
-            sidePanelTranslateX,
+            positionLeftValue,
+            positionRightValue,
         }: {
             progress: OverlayStylesParams;
-            hasMarginRight?: boolean;
-            hasMarginLeft?: boolean;
-            sidePanelTranslateX?: RefObject<Animated.Value>;
+            positionLeftValue: number | Animated.Value;
+            positionRightValue: number | Animated.Value;
         }) =>
             ({
                 // We need to stretch the overlay to cover the sidebar and the translate animation distance.
-                left: hasMarginLeft ? receiptPaneRHPWidth : -2 * variables.sideBarWidth,
-                right: hasMarginRight ? Animated.add(variables.sideBarWidth, sidePanelTranslateX ? Animated.subtract(variables.sideBarWidth, sidePanelTranslateX.current) : 0) : 0,
+                left: positionLeftValue,
+                right: positionRightValue,
                 opacity: progress.interpolate({
                     inputRange: [0, 1],
                     outputRange: [0, variables.overlayOpacity],

--- a/src/styles/variables.ts
+++ b/src/styles/variables.ts
@@ -103,6 +103,7 @@ export default {
     androidSafeAreaInsetsPercentage: 1,
     sideBarWidth: 375,
     receiptPaneRHPMaxWidth: 465,
+    superWideRHPMaxWidth: 1260,
     minScanTooltipWidth: 320,
     uploadViewMargin: 20,
     chooseFilesViewMargin: 8,


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
<!-- Explain what your change does and how it addresses the linked issue -->


This PR includes the initial setup for Super Wide RHP. Pages that will be displayed this way will be added in a separate PR. 

#### Super Wide RHP 

This PR introduces a third width of RHP called **Super Wide RHP**.

The maximum width of this RHP is `1260px`.


#### Overlays
There are two levels of nesting in RHP:
1. RightModalNavigator displays ModalStackNavigators (RHP flows).
2. ModalStackNavigators contain screens displayed in RHP.

After adding the third RHP width, it became necessary to add a third overlay displayed when we overlap Super Wide RHP -> Wide RHP -> RHP.

There are two levels of nesting in RHP:
1. Right Modal Navigator displays ModalStackNavigators (RHP flows).
2. ModalStackNavigators contain screens displayed in RHP.

This information is important for correctly adding a new overlay.

When a new overlay is added, it is needed to be adjusted in 2 files:
- `src/libs/Navigation/AppNavigator/Navigators/RightModalNavigator.tsx`

    Here, an overlay occupying the space outside the screen displayed in RHP must be added, when clicking on this overlay, the screen in RHP is closed.

- `src/libs/Navigation/AppNavigator/ModalStackNavigators/index.tsx`

    In case 2 or more RHPs of different widths are displayed, the RHP should also be added here.
    
    In `RightModalNavigator`, an overlay is shown from the left edge of the screen to the edge of the screen displayed as the modal. In `ModalStackNavigator`, the overlay should be displayed below the currently displayed modal. This way, when opening another modal, you can see that there's also an overlay underneath it.

More information about how overlays are displayed and their positioning can be found directly in the comments in the files mentioned above.

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/71821
PROPOSAL:


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

- [ ] Verify that no errors appear in the JS console

1. Verify if the Wide RHP is displayed correctly.

 **Without a receipt**
 
 1. Open reports tab
 2. Select expenses
 3. Open expense without a receipt
 4. See if it renders properly (aspect ratio, borders, positioning)
 
 **With a distance receipt**
 
 1. Open reports tab
 2. Select expenses
 3. Open expense with a distance receipt
 4. See if it renders properly (aspect ratio, borders, positioning)
 
 **With an e-receipt receipt**
 
 1. Open reports tab
 2. Select expenses
 3. Open expense with an e-receipt
 4. See if it renders properly (aspect ratio, borders, positioning)

 **With a pdf receipt**
 
 1. Open reports tab
 2. Select expenses
 3. Open expense with a pdf receipt
 4. See if it renders properly (aspect ratio, borders, positioning)

 **With a photo receipt**

 1. Open reports tab
 2. Select expenses
 3. Open expense with a photo receipt
 4. See if it renders properly (aspect ratio, borders, positioning)


### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I verified there are no new alerts related to the `canBeMissing` param for `useOnyx`
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/f5ff2420-b58e-4e05-99da-cbc64b48114c


</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/37271f64-b1ef-4ca8-bafe-7e4697deebf4


</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/1cae6ca8-02a6-4b05-ab35-ef88bd9f4b51


</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/30460729-4083-4f21-8c3c-f45a43c4bbed


</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/0666377f-2213-4176-8683-2d1a3fe7c9a5


</details>