### PR TITLE
fix: reset employee submitsTo when re-enabling approvals (#76719)

### DIFF
--- a/src/libs/actions/Policy/Policy.ts
+++ b/src/libs/actions/Policy/Policy.ts
@@ -1,11 +1,11 @@
 /* eslint-disable max-lines */
-import {PUBLIC_DOMAINS_SET, Str} from 'expensify-common';
+import { PUBLIC_DOMAINS_SET, Str } from 'expensify-common';
 import escapeRegExp from 'lodash/escapeRegExp';
 import lodashUnion from 'lodash/union';
-import type {OnyxCollection, OnyxEntry, OnyxUpdate} from 'react-native-onyx';
+import type { OnyxCollection, OnyxEntry, OnyxUpdate } from 'react-native-onyx';
 import Onyx from 'react-native-onyx';
-import type {TupleToUnion, ValueOf} from 'type-fest';
-import type {ReportExportType} from '@components/ButtonWithDropdownMenu/types';
+import type { TupleToUnion, ValueOf } from 'type-fest';
+import type { ReportExportType } from '@components/ButtonWithDropdownMenu/types';
 import * as API from '@libs/API';
 import type {
     AddBillingCardAndRequestWorkspaceOwnerChangeParams,
@@ -71,16 +71,16 @@ import type {
 } from '@libs/API/parameters';
 import type SetPolicyCashExpenseModeParams from '@libs/API/parameters/SetPolicyCashExpenseModeParams';
 import type UpdatePolicyMembersCustomFieldsParams from '@libs/API/parameters/UpdatePolicyMembersCustomFieldsParams';
-import {READ_COMMANDS, SIDE_EFFECT_REQUEST_COMMANDS, WRITE_COMMANDS} from '@libs/API/types';
-import type {CustomRNImageManipulatorResult} from '@libs/cropOrRotateImage/types';
+import { READ_COMMANDS, SIDE_EFFECT_REQUEST_COMMANDS, WRITE_COMMANDS } from '@libs/API/types';
+import type { CustomRNImageManipulatorResult } from '@libs/cropOrRotateImage/types';
 import * as CurrencyUtils from '@libs/CurrencyUtils';
 import DateUtils from '@libs/DateUtils';
 import * as ErrorUtils from '@libs/ErrorUtils';
-import {createFile} from '@libs/fileDownload/FileUtils';
+import { createFile } from '@libs/fileDownload/FileUtils';
 import getIsNarrowLayout from '@libs/getIsNarrowLayout';
 import GoogleTagManager from '@libs/GoogleTagManager';
 // eslint-disable-next-line @typescript-eslint/no-deprecated
-import {translate, translateLocal} from '@libs/Localize';
+import { translate, translateLocal } from '@libs/Localize';
 import Log from '@libs/Log';
 import * as NetworkStore from '@libs/Network/NetworkStore';
 import * as NumberUtils from '@libs/NumberUtils';
@@ -96,15 +96,15 @@ import {
     navigateToReceiptPartnersPage,
 } from '@libs/PolicyUtils';
 import * as ReportUtils from '@libs/ReportUtils';
-import type {PolicySelector} from '@pages/home/sidebar/FloatingActionButtonAndPopover';
-import type {Feature} from '@pages/OnboardingInterestedFeatures/types';
+import type { PolicySelector } from '@pages/home/sidebar/FloatingActionButtonAndPopover';
+import type { Feature } from '@pages/OnboardingInterestedFeatures/types';
 import * as PaymentMethods from '@userActions/PaymentMethods';
 import * as PersistedRequests from '@userActions/PersistedRequests';
-import {buildTaskData} from '@userActions/Task';
-import {getOnboardingMessages} from '@userActions/Welcome/OnboardingFlow';
-import type {OnboardingCompanySize, OnboardingPurpose} from '@userActions/Welcome/OnboardingFlow';
+import { buildTaskData } from '@userActions/Task';
+import { getOnboardingMessages } from '@userActions/Welcome/OnboardingFlow';
+import type { OnboardingCompanySize, OnboardingPurpose } from '@userActions/Welcome/OnboardingFlow';
 import CONST from '@src/CONST';
-import type {OnboardingAccounting} from '@src/CONST';
+import type { OnboardingAccounting } from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
 import type {
     BankAccountList,
@@ -126,14 +126,14 @@ import type {
     Transaction,
     TransactionViolations,
 } from '@src/types/onyx';
-import type {Participant} from '@src/types/onyx/IOU';
-import type {ErrorFields, Errors, PendingAction} from '@src/types/onyx/OnyxCommon';
-import type {Attributes, CompanyAddress, CustomUnit, NetSuiteCustomList, NetSuiteCustomSegment, ProhibitedExpenses, Rate, TaxRate, UberReceiptPartner} from '@src/types/onyx/Policy';
-import type {CustomFieldType} from '@src/types/onyx/PolicyEmployee';
-import type {NotificationPreference} from '@src/types/onyx/Report';
-import type {OnyxData} from '@src/types/onyx/Request';
-import {isEmptyObject} from '@src/types/utils/EmptyObject';
-import {buildOptimisticMccGroup, buildOptimisticPolicyCategories, buildOptimisticPolicyWithExistingCategories} from './Category';
+import type { Participant } from '@src/types/onyx/IOU';
+import type { ErrorFields, Errors, PendingAction } from '@src/types/onyx/OnyxCommon';
+import type { Attributes, CompanyAddress, CustomUnit, NetSuiteCustomList, NetSuiteCustomSegment, ProhibitedExpenses, Rate, TaxRate, UberReceiptPartner } from '@src/types/onyx/Policy';
+import type { CustomFieldType, PolicyEmployeeList } from '@src/types/onyx/PolicyEmployee';
+import type { NotificationPreference } from '@src/types/onyx/Report';
+import type { OnyxData } from '@src/types/onyx/Request';
+import { isEmptyObject } from '@src/types/utils/EmptyObject';
+import { buildOptimisticMccGroup, buildOptimisticPolicyCategories, buildOptimisticPolicyWithExistingCategories } from './Category';
 
 type ReportCreationData = Record<
     string,
@@ -414,23 +414,23 @@ function deleteWorkspace(params: DeleteWorkspaceActionParams) {
         },
         ...(filteredBankAccountList !== bankAccountList
             ? [
-                  {
-                      onyxMethod: Onyx.METHOD.SET,
-                      key: ONYXKEYS.BANK_ACCOUNT_LIST,
-                      value: filteredBankAccountList,
-                  },
-              ]
+                {
+                    onyxMethod: Onyx.METHOD.SET,
+                    key: ONYXKEYS.BANK_ACCOUNT_LIST,
+                    value: filteredBankAccountList,
+                },
+            ]
             : []),
         ...(!hasActiveChatEnabledPolicies(filteredPolicies, true)
             ? [
-                  {
-                      onyxMethod: Onyx.METHOD.MERGE,
-                      key: ONYXKEYS.REIMBURSEMENT_ACCOUNT,
-                      value: {
-                          errors: null,
-                      },
-                  },
-              ]
+                {
+                    onyxMethod: Onyx.METHOD.MERGE,
+                    key: ONYXKEYS.REIMBURSEMENT_ACCOUNT,
+                    value: {
+                        errors: null,
+                    },
+                },
+            ]
             : []),
     ];
 
@@ -459,12 +459,12 @@ function deleteWorkspace(params: DeleteWorkspaceActionParams) {
         },
         ...(filteredBankAccountList !== bankAccountList
             ? [
-                  {
-                      onyxMethod: Onyx.METHOD.SET,
-                      key: ONYXKEYS.BANK_ACCOUNT_LIST,
-                      value: bankAccountList ?? {},
-                  },
-              ]
+                {
+                    onyxMethod: Onyx.METHOD.SET,
+                    key: ONYXKEYS.BANK_ACCOUNT_LIST,
+                    value: bankAccountList ?? {},
+                },
+            ]
             : []),
     ];
 
@@ -488,7 +488,7 @@ function deleteWorkspace(params: DeleteWorkspaceActionParams) {
     const currentTime = DateUtils.getDBTime();
     // eslint-disable-next-line unicorn/no-array-for-each
     reportsToArchive.forEach((report) => {
-        const {reportID, ownerAccountID, oldPolicyName} = report ?? {};
+        const { reportID, ownerAccountID, oldPolicyName } = report ?? {};
         const isInvoiceReceiverReport = report?.invoiceReceiver && 'policyID' in report.invoiceReceiver && report.invoiceReceiver.policyID === policyID;
         optimisticData.push({
             onyxMethod: Onyx.METHOD.MERGE,
@@ -619,9 +619,9 @@ function deleteWorkspace(params: DeleteWorkspaceActionParams) {
         }
     });
 
-    const apiParams: DeleteWorkspaceParams = {policyID};
+    const apiParams: DeleteWorkspaceParams = { policyID };
 
-    API.write(WRITE_COMMANDS.DELETE_WORKSPACE, apiParams, {optimisticData, finallyData, failureData});
+    API.write(WRITE_COMMANDS.DELETE_WORKSPACE, apiParams, { optimisticData, finallyData, failureData });
 
     // Reset the lastAccessedWorkspacePolicyID
     if (policyID === lastAccessedWorkspacePolicyID) {
@@ -641,7 +641,7 @@ function setWorkspaceAutoHarvesting(policy: Policy, enabled: boolean) {
             key: `${ONYXKEYS.COLLECTION.POLICY}${policyID}`,
             value: {
                 autoReporting: enabled,
-                harvesting: {enabled},
+                harvesting: { enabled },
                 pendingFields: {
                     autoReporting: CONST.RED_BRICK_ROAD_PENDING_ACTION.UPDATE,
                 },
@@ -681,8 +681,8 @@ function setWorkspaceAutoHarvesting(policy: Policy, enabled: boolean) {
         },
     ];
 
-    const params: SetWorkspaceAutoHarvestingParams = {policyID, enabled};
-    API.write(WRITE_COMMANDS.SET_WORKSPACE_AUTO_HARVESTING, params, {optimisticData, failureData, successData});
+    const params: SetWorkspaceAutoHarvestingParams = { policyID, enabled };
+    API.write(WRITE_COMMANDS.SET_WORKSPACE_AUTO_HARVESTING, params, { optimisticData, failureData, successData });
 }
 
 function setWorkspaceAutoReportingFrequency(policyID: string, frequency: ValueOf<typeof CONST.POLICY.AUTO_REPORTING_FREQUENCIES>) {
@@ -699,7 +699,7 @@ function setWorkspaceAutoReportingFrequency(policyID: string, frequency: ValueOf
             value: {
                 // Recall that the "daily" and "manual" frequencies don't actually exist in Onyx or the DB (see PolicyUtils.getCorrectedAutoReportingFrequency)
                 autoReportingFrequency: frequency === CONST.POLICY.AUTO_REPORTING_FREQUENCIES.MANUAL ? CONST.POLICY.AUTO_REPORTING_FREQUENCIES.IMMEDIATE : frequency,
-                pendingFields: {autoReportingFrequency: CONST.RED_BRICK_ROAD_PENDING_ACTION.UPDATE},
+                pendingFields: { autoReportingFrequency: CONST.RED_BRICK_ROAD_PENDING_ACTION.UPDATE },
 
                 // To set the frequency to "manual", we really must set it to "immediate" with harvesting disabled
                 ...(frequency === CONST.POLICY.AUTO_REPORTING_FREQUENCIES.MANUAL && {
@@ -712,10 +712,10 @@ function setWorkspaceAutoReportingFrequency(policyID: string, frequency: ValueOf
                 // then we must re-enable harvesting
                 ...(wasPolicyOnManualReporting &&
                     frequency !== CONST.POLICY.AUTO_REPORTING_FREQUENCIES.MANUAL && {
-                        harvesting: {
-                            enabled: true,
-                        },
-                    }),
+                    harvesting: {
+                        enabled: true,
+                    },
+                }),
             },
         },
     ];
@@ -727,8 +727,8 @@ function setWorkspaceAutoReportingFrequency(policyID: string, frequency: ValueOf
             value: {
                 autoReportingFrequency: policy?.autoReportingFrequency ?? null,
                 harvesting: policy?.harvesting ?? null,
-                pendingFields: {autoReportingFrequency: null},
-                errorFields: {autoReportingFrequency: ErrorUtils.getMicroSecondOnyxErrorWithTranslationKey('workflowsDelayedSubmissionPage.autoReportingFrequencyErrorMessage')},
+                pendingFields: { autoReportingFrequency: null },
+                errorFields: { autoReportingFrequency: ErrorUtils.getMicroSecondOnyxErrorWithTranslationKey('workflowsDelayedSubmissionPage.autoReportingFrequencyErrorMessage') },
             },
         },
     ];
@@ -738,20 +738,20 @@ function setWorkspaceAutoReportingFrequency(policyID: string, frequency: ValueOf
             onyxMethod: Onyx.METHOD.MERGE,
             key: `${ONYXKEYS.COLLECTION.POLICY}${policyID}`,
             value: {
-                pendingFields: {autoReportingFrequency: null},
+                pendingFields: { autoReportingFrequency: null },
             },
         },
     ];
 
-    const params: SetWorkspaceAutoReportingFrequencyParams = {policyID, frequency};
-    API.write(WRITE_COMMANDS.SET_WORKSPACE_AUTO_REPORTING_FREQUENCY, params, {optimisticData, failureData, successData});
+    const params: SetWorkspaceAutoReportingFrequencyParams = { policyID, frequency };
+    API.write(WRITE_COMMANDS.SET_WORKSPACE_AUTO_REPORTING_FREQUENCY, params, { optimisticData, failureData, successData });
 }
 
 function setWorkspaceAutoReportingMonthlyOffset(policyID: string | undefined, autoReportingOffset: number | ValueOf<typeof CONST.POLICY.AUTO_REPORTING_OFFSET>) {
     if (!policyID) {
         return;
     }
-    const value = JSON.stringify({autoReportingOffset});
+    const value = JSON.stringify({ autoReportingOffset });
     // This will be fixed as part of https://github.com/Expensify/Expensify/issues/507850
     // eslint-disable-next-line @typescript-eslint/no-deprecated
     const policy = getPolicy(policyID);
@@ -762,7 +762,7 @@ function setWorkspaceAutoReportingMonthlyOffset(policyID: string | undefined, au
             key: `${ONYXKEYS.COLLECTION.POLICY}${policyID}`,
             value: {
                 autoReportingOffset,
-                pendingFields: {autoReportingOffset: CONST.RED_BRICK_ROAD_PENDING_ACTION.UPDATE},
+                pendingFields: { autoReportingOffset: CONST.RED_BRICK_ROAD_PENDING_ACTION.UPDATE },
             },
         },
     ];
@@ -773,8 +773,8 @@ function setWorkspaceAutoReportingMonthlyOffset(policyID: string | undefined, au
             key: `${ONYXKEYS.COLLECTION.POLICY}${policyID}`,
             value: {
                 autoReportingOffset: policy?.autoReportingOffset ?? null,
-                pendingFields: {autoReportingOffset: null},
-                errorFields: {autoReportingOffset: ErrorUtils.getMicroSecondOnyxErrorWithTranslationKey('workflowsDelayedSubmissionPage.monthlyOffsetErrorMessage')},
+                pendingFields: { autoReportingOffset: null },
+                errorFields: { autoReportingOffset: ErrorUtils.getMicroSecondOnyxErrorWithTranslationKey('workflowsDelayedSubmissionPage.monthlyOffsetErrorMessage') },
             },
         },
     ];
@@ -784,13 +784,13 @@ function setWorkspaceAutoReportingMonthlyOffset(policyID: string | undefined, au
             onyxMethod: Onyx.METHOD.MERGE,
             key: `${ONYXKEYS.COLLECTION.POLICY}${policyID}`,
             value: {
-                pendingFields: {autoReportingOffset: null},
+                pendingFields: { autoReportingOffset: null },
             },
         },
     ];
 
-    const params: SetWorkspaceAutoReportingMonthlyOffsetParams = {policyID, value};
-    API.write(WRITE_COMMANDS.SET_WORKSPACE_AUTO_REPORTING_MONTHLY_OFFSET, params, {optimisticData, failureData, successData});
+    const params: SetWorkspaceAutoReportingMonthlyOffsetParams = { policyID, value };
+    API.write(WRITE_COMMANDS.SET_WORKSPACE_AUTO_REPORTING_MONTHLY_OFFSET, params, { optimisticData, failureData, successData });
 }
 
 function setWorkspaceApprovalMode(policyID: string, approver: string, approvalMode: ValueOf<typeof CONST.POLICY.APPROVAL_MODE>) {
@@ -803,13 +803,43 @@ function setWorkspaceApprovalMode(policyID: string, approver: string, approvalMo
         approvalMode,
     };
 
+    // When enabling approvals (switching from OPTIONAL to BASIC/ADVANCED),
+    // we need to update all employees' submitsTo to point to the new approver
+    // to prevent duplicate workflows from being created (fixes #76719)
+    const previousApprovalMode = policy?.approvalMode;
+    const isEnablingApprovals = previousApprovalMode === CONST.POLICY.APPROVAL_MODE.OPTIONAL && approvalMode !== CONST.POLICY.APPROVAL_MODE.OPTIONAL;
+
+    let updatedEmployeeList: PolicyEmployeeList | undefined;
+    if (isEnablingApprovals && policy?.employeeList) {
+        updatedEmployeeList = {};
+        for (const [email, employee] of Object.entries(policy.employeeList)) {
+            // Only update if the employee has a submitsTo that is different from the new approver
+            if (employee.submitsTo && employee.submitsTo !== approver) {
+                updatedEmployeeList[email] = {
+                    ...employee,
+                    submitsTo: approver,
+                    pendingAction: CONST.RED_BRICK_ROAD_PENDING_ACTION.UPDATE,
+                    pendingFields: {
+                        ...employee.pendingFields,
+                        submitsTo: CONST.RED_BRICK_ROAD_PENDING_ACTION.UPDATE,
+                    },
+                };
+            }
+        }
+        // If no employees need updating, set to undefined to avoid unnecessary updates
+        if (Object.keys(updatedEmployeeList).length === 0) {
+            updatedEmployeeList = undefined;
+        }
+    }
+
     const optimisticData: OnyxUpdate[] = [
         {
             onyxMethod: Onyx.METHOD.MERGE,
             key: `${ONYXKEYS.COLLECTION.POLICY}${policyID}`,
             value: {
                 ...value,
-                pendingFields: {approvalMode: CONST.RED_BRICK_ROAD_PENDING_ACTION.UPDATE},
+                pendingFields: { approvalMode: CONST.RED_BRICK_ROAD_PENDING_ACTION.UPDATE },
+                ...(updatedEmployeeList ? { employeeList: updatedEmployeeList } : {}),
             },
         },
     ];
@@ -821,8 +851,8 @@ function setWorkspaceApprovalMode(policyID: string, approver: string, approvalMo
             value: {
                 approver: policy?.approver,
                 approvalMode: policy?.approvalMode,
-                pendingFields: {approvalMode: null},
-                errorFields: {approvalMode: ErrorUtils.getMicroSecondOnyxErrorWithTranslationKey('workflowsApproverPage.genericErrorMessage')},
+                pendingFields: { approvalMode: null },
+                errorFields: { approvalMode: ErrorUtils.getMicroSecondOnyxErrorWithTranslationKey('workflowsApproverPage.genericErrorMessage') },
                 employeeList: policy?.employeeList,
             },
         },
@@ -833,7 +863,14 @@ function setWorkspaceApprovalMode(policyID: string, approver: string, approvalMo
             onyxMethod: Onyx.METHOD.MERGE,
             key: `${ONYXKEYS.COLLECTION.POLICY}${policyID}`,
             value: {
-                pendingFields: {approvalMode: null},
+                pendingFields: { approvalMode: null },
+                ...(updatedEmployeeList
+                    ? {
+                        employeeList: Object.fromEntries(
+                            Object.keys(updatedEmployeeList).map((email) => [email, { pendingAction: null, pendingFields: { submitsTo: null } }]),
+                        ),
+                    }
+                    : {}),
             },
         },
     ];
@@ -846,8 +883,9 @@ function setWorkspaceApprovalMode(policyID: string, approver: string, approvalMo
             isAutoApprovalEnabled: false,
         }),
     };
-    API.write(WRITE_COMMANDS.SET_WORKSPACE_APPROVAL_MODE, params, {optimisticData, failureData, successData});
+    API.write(WRITE_COMMANDS.SET_WORKSPACE_APPROVAL_MODE, params, { optimisticData, failureData, successData });
 }
+
 
 function setWorkspacePayer(policyID: string, reimburserEmail: string) {
     // This will be fixed as part of https://github.com/Expensify/Expensify/issues/507850
@@ -860,9 +898,9 @@ function setWorkspacePayer(policyID: string, reimburserEmail: string) {
             key: `${ONYXKEYS.COLLECTION.POLICY}${policyID}`,
             value: {
                 reimburser: reimburserEmail,
-                achAccount: {reimburser: reimburserEmail},
-                errorFields: {reimburser: null},
-                pendingFields: {reimburser: CONST.RED_BRICK_ROAD_PENDING_ACTION.UPDATE},
+                achAccount: { reimburser: reimburserEmail },
+                errorFields: { reimburser: null },
+                pendingFields: { reimburser: CONST.RED_BRICK_ROAD_PENDING_ACTION.UPDATE },
             },
         },
     ];
@@ -872,8 +910,8 @@ function setWorkspacePayer(policyID: string, reimburserEmail: string) {
             onyxMethod: Onyx.METHOD.MERGE,
             key: `${ONYXKEYS.COLLECTION.POLICY}${policyID}`,
             value: {
-                errorFields: {reimburser: null},
-                pendingFields: {reimburser: null},
+                errorFields: { reimburser: null },
+                pendingFields: { reimburser: null },
             },
         },
     ];
@@ -883,55 +921,55 @@ function setWorkspacePayer(policyID: string, reimburserEmail: string) {
             onyxMethod: Onyx.METHOD.MERGE,
             key: `${ONYXKEYS.COLLECTION.POLICY}${policyID}`,
             value: {
-                achAccount: {reimburser: policy?.achAccount?.reimburser ?? null},
-                errorFields: {reimburser: ErrorUtils.getMicroSecondOnyxErrorWithTranslationKey('workflowsPayerPage.genericErrorMessage')},
-                pendingFields: {reimburser: null},
+                achAccount: { reimburser: policy?.achAccount?.reimburser ?? null },
+                errorFields: { reimburser: ErrorUtils.getMicroSecondOnyxErrorWithTranslationKey('workflowsPayerPage.genericErrorMessage') },
+                pendingFields: { reimburser: null },
             },
         },
     ];
 
-    const params: SetWorkspacePayerParams = {policyID, reimburserEmail};
+    const params: SetWorkspacePayerParams = { policyID, reimburserEmail };
 
-    API.write(WRITE_COMMANDS.SET_WORKSPACE_PAYER, params, {optimisticData, failureData, successData});
+    API.write(WRITE_COMMANDS.SET_WORKSPACE_PAYER, params, { optimisticData, failureData, successData });
 }
 
 function clearPolicyErrorField(policyID: string | undefined, fieldName: string) {
     if (!policyID) {
         return;
     }
-    Onyx.merge(`${ONYXKEYS.COLLECTION.POLICY}${policyID}`, {errorFields: {[fieldName]: null}});
+    Onyx.merge(`${ONYXKEYS.COLLECTION.POLICY}${policyID}`, { errorFields: { [fieldName]: null } });
 }
 
 function clearQBOErrorField(policyID: string | undefined, fieldName: string) {
     if (!policyID) {
         return;
     }
-    Onyx.merge(`${ONYXKEYS.COLLECTION.POLICY}${policyID}`, {connections: {quickbooksOnline: {config: {errorFields: {[fieldName]: null}}}}});
+    Onyx.merge(`${ONYXKEYS.COLLECTION.POLICY}${policyID}`, { connections: { quickbooksOnline: { config: { errorFields: { [fieldName]: null } } } } });
 }
 
 function clearQBDErrorField(policyID: string | undefined, fieldName: string) {
     if (!policyID) {
         return;
     }
-    Onyx.merge(`${ONYXKEYS.COLLECTION.POLICY}${policyID}`, {connections: {quickbooksDesktop: {config: {errorFields: {[fieldName]: null}}}}});
+    Onyx.merge(`${ONYXKEYS.COLLECTION.POLICY}${policyID}`, { connections: { quickbooksDesktop: { config: { errorFields: { [fieldName]: null } } } } });
 }
 
 function clearXeroErrorField(policyID: string | undefined, fieldName: string) {
     if (!policyID) {
         return;
     }
-    Onyx.merge(`${ONYXKEYS.COLLECTION.POLICY}${policyID}`, {connections: {xero: {config: {errorFields: {[fieldName]: null}}}}});
+    Onyx.merge(`${ONYXKEYS.COLLECTION.POLICY}${policyID}`, { connections: { xero: { config: { errorFields: { [fieldName]: null } } } } });
 }
 
 function clearNetSuiteErrorField(policyID: string | undefined, fieldName: string) {
     if (!policyID) {
         return;
     }
-    Onyx.merge(`${ONYXKEYS.COLLECTION.POLICY}${policyID}`, {connections: {netsuite: {options: {config: {errorFields: {[fieldName]: null}}}}}});
+    Onyx.merge(`${ONYXKEYS.COLLECTION.POLICY}${policyID}`, { connections: { netsuite: { options: { config: { errorFields: { [fieldName]: null } } } } } });
 }
 
 function clearNetSuitePendingField(policyID: string, fieldName: string) {
-    Onyx.merge(`${ONYXKEYS.COLLECTION.POLICY}${policyID}`, {connections: {netsuite: {options: {config: {pendingFields: {[fieldName]: null}}}}}});
+    Onyx.merge(`${ONYXKEYS.COLLECTION.POLICY}${policyID}`, { connections: { netsuite: { options: { config: { pendingFields: { [fieldName]: null } } } } } });
 }
 
 function removeNetSuiteCustomFieldByIndex(allRecords: NetSuiteCustomSegment[] | NetSuiteCustomList[], policyID: string, importCustomField: string, valueIndex: number) {
@@ -956,18 +994,18 @@ function clearSageIntacctErrorField(policyID: string | undefined, fieldName: str
     if (!policyID) {
         return;
     }
-    Onyx.merge(`${ONYXKEYS.COLLECTION.POLICY}${policyID}`, {connections: {intacct: {config: {errorFields: {[fieldName]: null}}}}});
+    Onyx.merge(`${ONYXKEYS.COLLECTION.POLICY}${policyID}`, { connections: { intacct: { config: { errorFields: { [fieldName]: null } } } } });
 }
 
 function clearNetSuiteAutoSyncErrorField(policyID: string | undefined) {
-    Onyx.merge(`${ONYXKEYS.COLLECTION.POLICY}${policyID}`, {connections: {netsuite: {config: {errorFields: {autoSync: null}}}}});
+    Onyx.merge(`${ONYXKEYS.COLLECTION.POLICY}${policyID}`, { connections: { netsuite: { config: { errorFields: { autoSync: null } } } } });
 }
 
 function clearQuickbooksOnlineAutoSyncErrorField(policyID: string | undefined) {
-    Onyx.merge(`${ONYXKEYS.COLLECTION.POLICY}${policyID}`, {connections: {quickbooksOnline: {config: {errorFields: {autoSync: null}}}}});
+    Onyx.merge(`${ONYXKEYS.COLLECTION.POLICY}${policyID}`, { connections: { quickbooksOnline: { config: { errorFields: { autoSync: null } } } } });
 }
 
-function setWorkspaceReimbursement({policyID, reimbursementChoice, bankAccountID, reimburserEmail, lastPaymentMethod, shouldUpdateLastPaymentMethod}: SetWorkspaceReimbursementActionParams) {
+function setWorkspaceReimbursement({ policyID, reimbursementChoice, bankAccountID, reimburserEmail, lastPaymentMethod, shouldUpdateLastPaymentMethod }: SetWorkspaceReimbursementActionParams) {
     // This will be fixed as part of https://github.com/Expensify/Expensify/issues/507850
     // eslint-disable-next-line @typescript-eslint/no-deprecated
     const policy = getPolicy(policyID);
@@ -981,9 +1019,9 @@ function setWorkspaceReimbursement({policyID, reimbursementChoice, bankAccountID
                 reimbursementChoice,
                 isLoadingWorkspaceReimbursement: true,
                 reimburser: reimburserEmail,
-                achAccount: {reimburser: reimburserEmail, bankAccountID},
-                errorFields: {reimbursementChoice: null},
-                pendingFields: {reimbursementChoice: CONST.RED_BRICK_ROAD_PENDING_ACTION.UPDATE},
+                achAccount: { reimburser: reimburserEmail, bankAccountID },
+                errorFields: { reimbursementChoice: null },
+                pendingFields: { reimbursementChoice: CONST.RED_BRICK_ROAD_PENDING_ACTION.UPDATE },
             },
         },
     ];
@@ -994,8 +1032,8 @@ function setWorkspaceReimbursement({policyID, reimbursementChoice, bankAccountID
             key: `${ONYXKEYS.COLLECTION.POLICY}${policyID}`,
             value: {
                 isLoadingWorkspaceReimbursement: false,
-                errorFields: {reimbursementChoice: null},
-                pendingFields: {reimbursementChoice: null},
+                errorFields: { reimbursementChoice: null },
+                pendingFields: { reimbursementChoice: null },
             },
         },
     ];
@@ -1027,16 +1065,16 @@ function setWorkspaceReimbursement({policyID, reimbursementChoice, bankAccountID
             value: {
                 isLoadingWorkspaceReimbursement: false,
                 reimbursementChoice: policy?.reimbursementChoice ?? null,
-                achAccount: {reimburser: policy?.achAccount?.reimburser ?? null, bankAccountID: null},
-                errorFields: {reimbursementChoice: ErrorUtils.getMicroSecondOnyxErrorWithTranslationKey('common.genericErrorMessage')},
-                pendingFields: {reimbursementChoice: null},
+                achAccount: { reimburser: policy?.achAccount?.reimburser ?? null, bankAccountID: null },
+                errorFields: { reimbursementChoice: ErrorUtils.getMicroSecondOnyxErrorWithTranslationKey('common.genericErrorMessage') },
+                pendingFields: { reimbursementChoice: null },
             },
         },
     ];
 
-    const params: SetWorkspaceReimbursementParams = {policyID, reimbursementChoice, bankAccountID};
+    const params: SetWorkspaceReimbursementParams = { policyID, reimbursementChoice, bankAccountID };
 
-    API.write(WRITE_COMMANDS.SET_WORKSPACE_REIMBURSEMENT, params, {optimisticData, failureData, successData});
+    API.write(WRITE_COMMANDS.SET_WORKSPACE_REIMBURSEMENT, params, { optimisticData, failureData, successData });
 }
 
 function leaveWorkspace(policyID?: string) {
@@ -1088,7 +1126,7 @@ function leaveWorkspace(policyID?: string) {
 
     // eslint-disable-next-line unicorn/no-array-for-each
     workspaceChats.forEach((report) => {
-        const parentReport = ReportUtils.getRootParentReport({report});
+        const parentReport = ReportUtils.getRootParentReport({ report });
         const reportToCheckOwner = isEmptyObject(parentReport) ? report : parentReport;
 
         if (ReportUtils.isPolicyExpenseChat(report) && !ReportUtils.isReportOwner(reportToCheckOwner)) {
@@ -1150,7 +1188,7 @@ function leaveWorkspace(policyID?: string) {
         policyID,
         email: deprecatedSessionEmail,
     };
-    API.write(WRITE_COMMANDS.LEAVE_POLICY, params, {optimisticData, successData, failureData});
+    API.write(WRITE_COMMANDS.LEAVE_POLICY, params, { optimisticData, successData, failureData });
 }
 
 function addBillingCardAndRequestPolicyOwnerChange(
@@ -1169,7 +1207,7 @@ function addBillingCardAndRequestPolicyOwnerChange(
         return;
     }
 
-    const {cardNumber, cardYear, cardMonth, cardCVV, addressName, addressZip, currency} = cardData;
+    const { cardNumber, cardYear, cardMonth, cardCVV, addressName, addressZip, currency } = cardData;
 
     const optimisticData: OnyxUpdate[] = [
         {
@@ -1234,7 +1272,7 @@ function addBillingCardAndRequestPolicyOwnerChange(
             currency: currency as ValueOf<typeof CONST.PAYMENT_CARD_CURRENCY>,
         };
         // eslint-disable-next-line rulesdir/no-multiple-api-calls
-        API.write(WRITE_COMMANDS.ADD_BILLING_CARD_AND_REQUEST_WORKSPACE_OWNER_CHANGE, params, {optimisticData, successData, failureData});
+        API.write(WRITE_COMMANDS.ADD_BILLING_CARD_AND_REQUEST_WORKSPACE_OWNER_CHANGE, params, { optimisticData, successData, failureData });
     }
 }
 
@@ -1281,7 +1319,7 @@ function verifySetupIntentAndRequestPolicyOwnerChange(policyID: string) {
             },
         },
     ];
-    API.write(WRITE_COMMANDS.VERIFY_SETUP_INTENT_AND_REQUEST_POLICY_OWNER_CHANGE, {accountID: deprecatedSessionAccountID, policyID}, {optimisticData, successData, failureData});
+    API.write(WRITE_COMMANDS.VERIFY_SETUP_INTENT_AND_REQUEST_POLICY_OWNER_CHANGE, { accountID: deprecatedSessionAccountID, policyID }, { optimisticData, successData, failureData });
 }
 
 /**
@@ -1406,7 +1444,7 @@ function createPolicyExpenseChats(
         workspaceMembersChats.onyxOptimisticData.push({
             onyxMethod: Onyx.METHOD.SET,
             key: `${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${optimisticReport.reportID}`,
-            value: {[optimisticCreatedAction.reportActionID]: optimisticCreatedAction},
+            value: { [optimisticCreatedAction.reportActionID]: optimisticCreatedAction },
         });
 
         workspaceMembersChats.onyxSuccessData.push(
@@ -1437,7 +1475,7 @@ function createPolicyExpenseChats(
         workspaceMembersChats.onyxSuccessData.push({
             onyxMethod: Onyx.METHOD.MERGE,
             key: `${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${optimisticReport.reportID}`,
-            value: {[optimisticCreatedAction.reportActionID]: {pendingAction: null}},
+            value: { [optimisticCreatedAction.reportActionID]: { pendingAction: null } },
         });
 
         workspaceMembersChats.onyxFailureData.push({
@@ -1507,7 +1545,7 @@ function updateWorkspaceAvatar(policyID: string, file: File) {
         file,
     };
 
-    API.write(WRITE_COMMANDS.UPDATE_WORKSPACE_AVATAR, params, {optimisticData, finallyData, failureData});
+    API.write(WRITE_COMMANDS.UPDATE_WORKSPACE_AVATAR, params, { optimisticData, finallyData, failureData });
 }
 
 /**
@@ -1558,9 +1596,9 @@ function deleteWorkspaceAvatar(policyID: string) {
         },
     ];
 
-    const params: DeleteWorkspaceAvatarParams = {policyID};
+    const params: DeleteWorkspaceAvatarParams = { policyID };
 
-    API.write(WRITE_COMMANDS.DELETE_WORKSPACE_AVATAR, params, {optimisticData, finallyData, failureData});
+    API.write(WRITE_COMMANDS.DELETE_WORKSPACE_AVATAR, params, { optimisticData, finallyData, failureData });
 }
 
 /**
@@ -1607,18 +1645,18 @@ function updateGeneralSettings(policyID: string | undefined, name: string, curre
         for (const rateID of Object.keys(currentRates)) {
             optimisticRates[rateID] = {
                 ...currentRates[rateID],
-                pendingFields: {currency: CONST.RED_BRICK_ROAD_PENDING_ACTION.UPDATE},
+                pendingFields: { currency: CONST.RED_BRICK_ROAD_PENDING_ACTION.UPDATE },
                 currency,
             };
             finallyRates[rateID] = {
                 ...currentRates[rateID],
-                pendingFields: {currency: null},
+                pendingFields: { currency: null },
                 currency,
             };
             failureRates[rateID] = {
                 ...currentRates[rateID],
-                pendingFields: {currency: null},
-                errorFields: {currency: ErrorUtils.getMicroSecondOnyxErrorWithTranslationKey('common.genericErrorMessage')},
+                pendingFields: { currency: null },
+                errorFields: { currency: ErrorUtils.getMicroSecondOnyxErrorWithTranslationKey('common.genericErrorMessage') },
             };
         }
     }
@@ -1633,8 +1671,8 @@ function updateGeneralSettings(policyID: string | undefined, name: string, curre
 
                 pendingFields: {
                     ...policy.pendingFields,
-                    ...(namePendingAction !== undefined && {name: namePendingAction}),
-                    ...(currencyPendingAction !== undefined && {outputCurrency: currencyPendingAction}),
+                    ...(namePendingAction !== undefined && { name: namePendingAction }),
+                    ...(currencyPendingAction !== undefined && { outputCurrency: currencyPendingAction }),
                 },
 
                 // Clear errorFields in case the user didn't dismiss the general settings error
@@ -1799,8 +1837,8 @@ function setWorkspaceErrors(policyID: string, errors: Errors) {
         return;
     }
 
-    Onyx.merge(`${ONYXKEYS.COLLECTION.POLICY}${policyID}`, {errors: null});
-    Onyx.merge(`${ONYXKEYS.COLLECTION.POLICY}${policyID}`, {errors});
+    Onyx.merge(`${ONYXKEYS.COLLECTION.POLICY}${policyID}`, { errors: null });
+    Onyx.merge(`${ONYXKEYS.COLLECTION.POLICY}${policyID}`, { errors });
 }
 
 function hideWorkspaceAlertMessage(policyID: string) {
@@ -1808,7 +1846,7 @@ function hideWorkspaceAlertMessage(policyID: string) {
         return;
     }
 
-    Onyx.merge(`${ONYXKEYS.COLLECTION.POLICY}${policyID}`, {alertMessage: ''});
+    Onyx.merge(`${ONYXKEYS.COLLECTION.POLICY}${policyID}`, { alertMessage: '' });
 }
 
 function updateAddress(policyID: string, newAddress: CompanyAddress) {
@@ -1881,7 +1919,7 @@ function removeWorkspace(policyID: string) {
 }
 
 function setDuplicateWorkspaceData(data: Partial<DuplicateWorkspace>) {
-    Onyx.merge(ONYXKEYS.DUPLICATE_WORKSPACE, {...data});
+    Onyx.merge(ONYXKEYS.DUPLICATE_WORKSPACE, { ...data });
 }
 
 function clearDuplicateWorkspace() {
@@ -1921,7 +1959,7 @@ function generateDefaultWorkspaceName(email = ''): string {
 
     if (isEmptyObject(deprecatedAllPolicies)) {
         // eslint-disable-next-line @typescript-eslint/no-deprecated
-        return isSMSDomain ? translateLocal('workspace.new.myGroupWorkspace', {}) : translateLocal('workspace.new.workspaceName', {userName: displayNameForWorkspace});
+        return isSMSDomain ? translateLocal('workspace.new.myGroupWorkspace', {}) : translateLocal('workspace.new.workspaceName', { userName: displayNameForWorkspace });
     }
 
     // find default named workspaces and increment the last number
@@ -1940,10 +1978,10 @@ function generateDefaultWorkspaceName(email = ''): string {
 
     if (isSMSDomain) {
         // eslint-disable-next-line @typescript-eslint/no-deprecated
-        return translateLocal('workspace.new.myGroupWorkspace', {workspaceNumber: lastWorkspaceNumber !== undefined ? lastWorkspaceNumber + 1 : undefined});
+        return translateLocal('workspace.new.myGroupWorkspace', { workspaceNumber: lastWorkspaceNumber !== undefined ? lastWorkspaceNumber + 1 : undefined });
     }
     // eslint-disable-next-line @typescript-eslint/no-deprecated
-    return translateLocal('workspace.new.workspaceName', {userName: displayNameForWorkspace, workspaceNumber: lastWorkspaceNumber !== undefined ? lastWorkspaceNumber + 1 : undefined});
+    return translateLocal('workspace.new.workspaceName', { userName: displayNameForWorkspace, workspaceNumber: lastWorkspaceNumber !== undefined ? lastWorkspaceNumber + 1 : undefined });
 }
 
 /**
@@ -2013,7 +2051,7 @@ function createDraftInitialWorkspace(
     file?: File,
 ) {
     const workspaceName = policyName || generateDefaultWorkspaceName(policyOwnerEmail);
-    const {customUnits, outputCurrency} = buildOptimisticDistanceRateCustomUnits(currency);
+    const { customUnits, outputCurrency } = buildOptimisticDistanceRateCustomUnits(currency);
     const shouldEnableWorkflowsByDefault =
         !introSelected?.choice || introSelected.choice === CONST.ONBOARDING_CHOICES.MANAGE_TEAM || introSelected.choice === CONST.ONBOARDING_CHOICES.LOOKING_AROUND;
 
@@ -2061,7 +2099,7 @@ function createDraftInitialWorkspace(
                 areWorkflowsEnabled: shouldEnableWorkflowsByDefault,
                 defaultBillable: false,
                 defaultReimbursable: true,
-                disabledFields: {defaultBillable: true, reimbursable: false},
+                disabledFields: { defaultBillable: true, reimbursable: false },
                 requiresCategory: true,
             },
         },
@@ -2104,7 +2142,7 @@ function buildPolicyData(options: BuildPolicyDataOptions = {}) {
     } = options;
     const workspaceName = policyName || generateDefaultWorkspaceName(policyOwnerEmail);
 
-    const {customUnits, customUnitID, customUnitRateID, outputCurrency} = buildOptimisticDistanceRateCustomUnits(currency);
+    const { customUnits, customUnitID, customUnitRateID, outputCurrency } = buildOptimisticDistanceRateCustomUnits(currency);
 
     const {
         adminsChatReportID,
@@ -2178,13 +2216,13 @@ function buildPolicyData(options: BuildPolicyDataOptions = {}) {
                     },
                     ...(adminParticipant?.login
                         ? {
-                              [adminParticipant.login]: {
-                                  submitsTo: deprecatedSessionEmail,
-                                  email: adminParticipant.login,
-                                  role: CONST.POLICY.ROLE.ADMIN,
-                                  errors: {},
-                              },
-                          }
+                            [adminParticipant.login]: {
+                                submitsTo: deprecatedSessionEmail,
+                                email: adminParticipant.login,
+                                role: CONST.POLICY.ROLE.ADMIN,
+                                errors: {},
+                            },
+                        }
                         : {}),
                 },
                 chatReportIDAdmins: makeMeAdmin ? Number(adminsChatReportID) : undefined,
@@ -2202,7 +2240,7 @@ function buildPolicyData(options: BuildPolicyDataOptions = {}) {
                 },
                 defaultBillable: false,
                 defaultReimbursable: true,
-                disabledFields: {defaultBillable: true, reimbursable: false},
+                disabledFields: { defaultBillable: true, reimbursable: false },
                 avatarURL: file?.uri,
                 originalFileName: file?.name,
                 ...optimisticMccGroupData.optimisticData,
@@ -2210,7 +2248,7 @@ function buildPolicyData(options: BuildPolicyDataOptions = {}) {
                 fieldList: {
                     [CONST.POLICY.FIELDS.FIELD_LIST_TITLE]: {
                         defaultValue: CONST.POLICY.DEFAULT_REPORT_NAME_PATTERN,
-                        pendingFields: {defaultValue: CONST.RED_BRICK_ROAD_PENDING_ACTION.ADD, deletable: CONST.RED_BRICK_ROAD_PENDING_ACTION.ADD},
+                        pendingFields: { defaultValue: CONST.RED_BRICK_ROAD_PENDING_ACTION.ADD, deletable: CONST.RED_BRICK_ROAD_PENDING_ACTION.ADD },
                         type: CONST.POLICY.DEFAULT_FIELD_LIST_TYPE,
                         target: CONST.POLICY.DEFAULT_FIELD_LIST_TARGET,
                         name: CONST.POLICY.DEFAULT_FIELD_LIST_NAME,
@@ -2377,7 +2415,7 @@ function buildPolicyData(options: BuildPolicyDataOptions = {}) {
         {
             onyxMethod: Onyx.METHOD.MERGE,
             key: `${ONYXKEYS.COLLECTION.POLICY}${policyID}`,
-            value: {employeeList: null, ...optimisticMccGroupData.failureData},
+            value: { employeeList: null, ...optimisticMccGroupData.failureData },
         },
         {
             onyxMethod: Onyx.METHOD.SET,
@@ -2485,12 +2523,12 @@ function buildPolicyData(options: BuildPolicyDataOptions = {}) {
         engagementChoice &&
         shouldAddOnboardingTasks
     ) {
-        const {onboardingMessages} = getOnboardingMessages();
+        const { onboardingMessages } = getOnboardingMessages();
         const onboardingData = ReportUtils.prepareOnboardingOnyxData(deprecatedIntroSelected, engagementChoice, onboardingMessages[engagementChoice], adminsChatReportID, policyID);
         if (!onboardingData) {
-            return {successData, optimisticData, failureData, params};
+            return { successData, optimisticData, failureData, params };
         }
-        const {guidedSetupData, optimisticData: taskOptimisticData, successData: taskSuccessData, failureData: taskFailureData} = onboardingData;
+        const { guidedSetupData, optimisticData: taskOptimisticData, successData: taskSuccessData, failureData: taskFailureData } = onboardingData;
 
         params.guidedSetupData = JSON.stringify(guidedSetupData);
         params.engagementChoice = engagementChoice;
@@ -2502,7 +2540,7 @@ function buildPolicyData(options: BuildPolicyDataOptions = {}) {
 
     // For test drive receivers, we want to complete the createWorkspace task in concierge, instead of #admin room
     if (deprecatedIntroSelected?.choice === CONST.ONBOARDING_CHOICES.TEST_DRIVE_RECEIVER && deprecatedIntroSelected.createWorkspace) {
-        const createWorkspaceTaskReport = {reportID: deprecatedIntroSelected.createWorkspace};
+        const createWorkspaceTaskReport = { reportID: deprecatedIntroSelected.createWorkspace };
         const {
             optimisticData: optimisticCreateWorkspaceTaskData,
             successData: successCreateWorkspaceTaskData,
@@ -2514,7 +2552,7 @@ function buildPolicyData(options: BuildPolicyDataOptions = {}) {
     }
 
     if (adminParticipant?.login) {
-        const employeeWorkspaceChat = createPolicyExpenseChats(policyID, {[adminParticipant.login]: adminParticipant.accountID ?? CONST.DEFAULT_NUMBER_ID}, hasOutstandingChildRequest);
+        const employeeWorkspaceChat = createPolicyExpenseChats(policyID, { [adminParticipant.login]: adminParticipant.accountID ?? CONST.DEFAULT_NUMBER_ID }, hasOutstandingChildRequest);
         params.memberData = JSON.stringify({
             accountID: Number(adminParticipant.accountID),
             email: adminParticipant.login,
@@ -2527,7 +2565,7 @@ function buildPolicyData(options: BuildPolicyDataOptions = {}) {
         failureData.push(...employeeWorkspaceChat.onyxFailureData);
     }
 
-    return {successData, optimisticData, failureData, params};
+    return { successData, optimisticData, failureData, params };
 }
 
 function createWorkspace(options: BuildPolicyDataOptions = {}): CreateWorkspaceParams {
@@ -2537,9 +2575,9 @@ function createWorkspace(options: BuildPolicyDataOptions = {}): CreateWorkspaceP
         ...options,
     };
 
-    const {optimisticData, failureData, successData, params} = buildPolicyData(optionsWithDefaults);
+    const { optimisticData, failureData, successData, params } = buildPolicyData(optionsWithDefaults);
 
-    API.write(WRITE_COMMANDS.CREATE_WORKSPACE, params, {optimisticData, successData, failureData});
+    API.write(WRITE_COMMANDS.CREATE_WORKSPACE, params, { optimisticData, successData, failureData });
 
     // Publish a workspace created event if this is their first policy
     if (getAdminPolicies().length === 0) {
@@ -2568,9 +2606,9 @@ function createDraftWorkspace(
 ): CreateWorkspaceParams {
     const workspaceName = policyName || generateDefaultWorkspaceName(policyOwnerEmail);
 
-    const {customUnits, customUnitID, customUnitRateID, outputCurrency} = buildOptimisticDistanceRateCustomUnits(currency);
+    const { customUnits, customUnitID, customUnitRateID, outputCurrency } = buildOptimisticDistanceRateCustomUnits(currency);
 
-    const {expenseChatData, adminsChatReportID, adminsCreatedReportActionID, expenseChatReportID, expenseCreatedReportActionID} = ReportUtils.buildOptimisticWorkspaceChats(
+    const { expenseChatData, adminsChatReportID, adminsCreatedReportActionID, expenseChatReportID, expenseCreatedReportActionID } = ReportUtils.buildOptimisticWorkspaceChats(
         policyID,
         workspaceName,
     );
@@ -2623,13 +2661,13 @@ function createDraftWorkspace(
                     reimbursementChoice: CONST.RED_BRICK_ROAD_PENDING_ACTION.ADD,
                 },
                 defaultBillable: false,
-                disabledFields: {defaultBillable: true, reimbursable: false},
+                disabledFields: { defaultBillable: true, reimbursable: false },
                 requiresCategory: true,
                 defaultReimbursable: true,
                 fieldList: {
                     [CONST.POLICY.FIELDS.FIELD_LIST_TITLE]: {
                         defaultValue: CONST.POLICY.DEFAULT_REPORT_NAME_PATTERN,
-                        pendingFields: {defaultValue: CONST.RED_BRICK_ROAD_PENDING_ACTION.ADD, deletable: CONST.RED_BRICK_ROAD_PENDING_ACTION.ADD},
+                        pendingFields: { defaultValue: CONST.RED_BRICK_ROAD_PENDING_ACTION.ADD, deletable: CONST.RED_BRICK_ROAD_PENDING_ACTION.ADD },
                         type: CONST.POLICY.DEFAULT_FIELD_LIST_TYPE,
                         target: CONST.POLICY.DEFAULT_FIELD_LIST_TARGET,
                         name: CONST.POLICY.DEFAULT_FIELD_LIST_NAME,
@@ -2683,7 +2721,7 @@ function createDraftWorkspace(
 }
 
 function buildDuplicatePolicyData(policy: Policy, options: DuplicatePolicyDataOptions) {
-    const {policyName = '', policyID = generatePolicyID(), file, welcomeNote, parts, targetPolicyID = generatePolicyID(), policyCategories} = options;
+    const { policyName = '', policyID = generatePolicyID(), file, welcomeNote, parts, targetPolicyID = generatePolicyID(), policyCategories } = options;
 
     const {
         adminsChatReportID,
@@ -2708,7 +2746,7 @@ function buildDuplicatePolicyData(policy: Policy, options: DuplicatePolicyDataOp
     const isWorkflowsOptionSelected = parts?.exportLayouts;
     const isPerDiemOptionSelected = parts?.perDiem;
     const policyMemberAccountIDs = isMemberOptionSelected ? Object.values(getMemberAccountIDsForWorkspace(policy?.employeeList, false, false)) : [];
-    const {customUnitID, customUnitRateID} = buildOptimisticDistanceRateCustomUnits(policy?.outputCurrency);
+    const { customUnitID, customUnitRateID } = buildOptimisticDistanceRateCustomUnits(policy?.outputCurrency);
 
     const optimisticAnnounceChat = ReportUtils.buildOptimisticAnnounceChat(targetPolicyID, [...policyMemberAccountIDs]);
     const announceRoomChat = optimisticAnnounceChat.announceChatData;
@@ -2738,7 +2776,7 @@ function buildDuplicatePolicyData(policy: Policy, options: DuplicatePolicyDataOp
                 arePerDiemRatesEnabled: isPerDiemOptionSelected,
                 workspaceAccountID: undefined,
                 tax: isTaxesOptionSelected ? policy?.tax : undefined,
-                employeeList: isMemberOptionSelected ? policy.employeeList : {[policy.owner]: policy?.employeeList?.[policy.owner]},
+                employeeList: isMemberOptionSelected ? policy.employeeList : { [policy.owner]: policy?.employeeList?.[policy.owner] },
                 id: targetPolicyID,
                 name: policyName,
                 fieldList: isReportsOptionSelected ? policy?.fieldList : undefined,
@@ -2906,7 +2944,7 @@ function buildDuplicatePolicyData(policy: Policy, options: DuplicatePolicyDataOp
         {
             onyxMethod: Onyx.METHOD.MERGE,
             key: `${ONYXKEYS.COLLECTION.POLICY}${targetPolicyID}`,
-            value: {employeeList: null, errors: ErrorUtils.getMicroSecondOnyxErrorWithTranslationKey('workspace.duplicateWorkspace.error')},
+            value: { employeeList: null, errors: ErrorUtils.getMicroSecondOnyxErrorWithTranslationKey('workspace.duplicateWorkspace.error') },
         },
         {
             onyxMethod: Onyx.METHOD.SET,
@@ -2963,20 +3001,20 @@ function buildDuplicatePolicyData(policy: Policy, options: DuplicatePolicyDataOp
         file: clonedFile,
     };
 
-    return {successData, optimisticData, failureData, params};
+    return { successData, optimisticData, failureData, params };
 }
 
 function duplicateWorkspace(policy: Policy, options: DuplicatePolicyDataOptions): DuplicateWorkspaceParams {
-    const {optimisticData, failureData, successData, params} = buildDuplicatePolicyData(policy, options);
+    const { optimisticData, failureData, successData, params } = buildDuplicatePolicyData(policy, options);
 
-    API.write(WRITE_COMMANDS.DUPLICATE_POLICY, params, {optimisticData, successData, failureData});
+    API.write(WRITE_COMMANDS.DUPLICATE_POLICY, params, { optimisticData, successData, failureData });
 
     return params;
 }
 
 function openPolicyWorkflowsPage(policyID: string) {
     if (!policyID) {
-        Log.warn('openPolicyWorkflowsPage invalid params', {policyID});
+        Log.warn('openPolicyWorkflowsPage invalid params', { policyID });
         return;
     }
 
@@ -3010,18 +3048,18 @@ function openPolicyWorkflowsPage(policyID: string) {
         ],
     };
 
-    const params: OpenPolicyWorkflowsPageParams = {policyID};
+    const params: OpenPolicyWorkflowsPageParams = { policyID };
 
     API.read(READ_COMMANDS.OPEN_POLICY_WORKFLOWS_PAGE, params, onyxData);
 }
 
 function openPolicyReceiptPartnersPage(policyID?: string) {
     if (!policyID) {
-        Log.warn('openPolicyReceiptPartnersPage invalid params', {policyID});
+        Log.warn('openPolicyReceiptPartnersPage invalid params', { policyID });
         return;
     }
 
-    const params: OpenPolicyReceiptPartnersPageParams = {policyID};
+    const params: OpenPolicyReceiptPartnersPageParams = { policyID };
 
     API.read(READ_COMMANDS.OPEN_POLICY_RECEIPT_PARTNERS_PAGE, params);
 }
@@ -3033,7 +3071,7 @@ function removePolicyReceiptPartnersConnection(policyID: string, partnerName: st
             key: `${ONYXKEYS.COLLECTION.POLICY}${policyID}`,
             value: {
                 receiptPartners: {
-                    [partnerName]: {pendingAction: CONST.RED_BRICK_ROAD_PENDING_ACTION.DELETE, enabled: false},
+                    [partnerName]: { pendingAction: CONST.RED_BRICK_ROAD_PENDING_ACTION.DELETE, enabled: false },
                 },
             },
         },
@@ -3057,7 +3095,7 @@ function removePolicyReceiptPartnersConnection(policyID: string, partnerName: st
             key: `${ONYXKEYS.COLLECTION.POLICY}${policyID}`,
             value: {
                 receiptPartners: {
-                    [partnerName]: {...receiptPartnerData, errorFields: {name: ErrorUtils.getMicroSecondOnyxErrorWithTranslationKey('common.genericErrorMessage')}, pendingAction: null},
+                    [partnerName]: { ...receiptPartnerData, errorFields: { name: ErrorUtils.getMicroSecondOnyxErrorWithTranslationKey('common.genericErrorMessage') }, pendingAction: null },
                 },
             },
         },
@@ -3067,12 +3105,12 @@ function removePolicyReceiptPartnersConnection(policyID: string, partnerName: st
         policyID,
         partnerName,
     };
-    API.write(WRITE_COMMANDS.DISCONNECT_WORKSPACE_RECEIPT_PARTNER, parameters, {optimisticData, failureData, successData});
+    API.write(WRITE_COMMANDS.DISCONNECT_WORKSPACE_RECEIPT_PARTNER, parameters, { optimisticData, failureData, successData });
 }
 
 function togglePolicyUberAutoInvite(policyID: string | undefined, enabled: boolean) {
     if (!policyID) {
-        Log.warn('togglePolicyUberAutoInvite invalid params', {policyID});
+        Log.warn('togglePolicyUberAutoInvite invalid params', { policyID });
         return;
     }
 
@@ -3081,7 +3119,7 @@ function togglePolicyUberAutoInvite(policyID: string | undefined, enabled: boole
             key: `${ONYXKEYS.COLLECTION.POLICY}${policyID}`,
             onyxMethod: Onyx.METHOD.MERGE,
             value: {
-                receiptPartners: {uber: {autoInvite: enabled, pendingFields: {autoInvite: CONST.RED_BRICK_ROAD_PENDING_ACTION.UPDATE}}},
+                receiptPartners: { uber: { autoInvite: enabled, pendingFields: { autoInvite: CONST.RED_BRICK_ROAD_PENDING_ACTION.UPDATE } } },
             },
         },
     ];
@@ -3089,25 +3127,25 @@ function togglePolicyUberAutoInvite(policyID: string | undefined, enabled: boole
         {
             key: `${ONYXKEYS.COLLECTION.POLICY}${policyID}`,
             onyxMethod: Onyx.METHOD.MERGE,
-            value: {receiptPartners: {uber: {pendingFields: {autoInvite: null}}}},
+            value: { receiptPartners: { uber: { pendingFields: { autoInvite: null } } } },
         },
     ];
     const failureData: OnyxUpdate[] = [
         {
             key: `${ONYXKEYS.COLLECTION.POLICY}${policyID}`,
             onyxMethod: Onyx.METHOD.MERGE,
-            value: {receiptPartners: {uber: {autoInvite: !enabled, pendingFields: null}}},
+            value: { receiptPartners: { uber: { autoInvite: !enabled, pendingFields: null } } },
         },
     ];
 
-    const params: TogglePolicyUberAutoInvitePageParams = {policyID, enabled};
+    const params: TogglePolicyUberAutoInvitePageParams = { policyID, enabled };
 
-    API.write(WRITE_COMMANDS.TOGGLE_WORKSPACE_UBER_AUTO_INVITE, params, {optimisticData, successData, failureData});
+    API.write(WRITE_COMMANDS.TOGGLE_WORKSPACE_UBER_AUTO_INVITE, params, { optimisticData, successData, failureData });
 }
 
 function changePolicyUberBillingAccount(policyID: string | undefined, email: string, oldEmail: string) {
     if (!policyID) {
-        Log.warn('changePolicyUberBillingAccount invalid params', {policyID});
+        Log.warn('changePolicyUberBillingAccount invalid params', { policyID });
         return;
     }
 
@@ -3116,7 +3154,7 @@ function changePolicyUberBillingAccount(policyID: string | undefined, email: str
             key: `${ONYXKEYS.COLLECTION.POLICY}${policyID}`,
             onyxMethod: Onyx.METHOD.MERGE,
             value: {
-                receiptPartners: {uber: {centralBillingAccountEmail: email, pendingFields: {centralBillingAccountEmail: CONST.RED_BRICK_ROAD_PENDING_ACTION.UPDATE}}},
+                receiptPartners: { uber: { centralBillingAccountEmail: email, pendingFields: { centralBillingAccountEmail: CONST.RED_BRICK_ROAD_PENDING_ACTION.UPDATE } } },
             },
         },
     ];
@@ -3124,25 +3162,25 @@ function changePolicyUberBillingAccount(policyID: string | undefined, email: str
         {
             key: `${ONYXKEYS.COLLECTION.POLICY}${policyID}`,
             onyxMethod: Onyx.METHOD.MERGE,
-            value: {receiptPartners: {uber: {pendingFields: {centralBillingAccountEmail: null}}}},
+            value: { receiptPartners: { uber: { pendingFields: { centralBillingAccountEmail: null } } } },
         },
     ];
     const failureData: OnyxUpdate[] = [
         {
             key: `${ONYXKEYS.COLLECTION.POLICY}${policyID}`,
             onyxMethod: Onyx.METHOD.MERGE,
-            value: {receiptPartners: {uber: {centralBillingAccountEmail: oldEmail, pendingFields: null}}},
+            value: { receiptPartners: { uber: { centralBillingAccountEmail: oldEmail, pendingFields: null } } },
         },
     ];
 
-    const params: ChangePolicyUberBillingAccountPageParams = {policyID, email};
+    const params: ChangePolicyUberBillingAccountPageParams = { policyID, email };
 
-    API.write(WRITE_COMMANDS.SET_WORKSPACE_UBER_CENTRAL_BILL, params, {optimisticData, successData, failureData});
+    API.write(WRITE_COMMANDS.SET_WORKSPACE_UBER_CENTRAL_BILL, params, { optimisticData, successData, failureData });
 }
 
 function togglePolicyUberAutoRemove(policyID: string | undefined, enabled: boolean) {
     if (!policyID) {
-        Log.warn('togglePolicyUberAutoRemove invalid params', {policyID});
+        Log.warn('togglePolicyUberAutoRemove invalid params', { policyID });
         return;
     }
 
@@ -3151,7 +3189,7 @@ function togglePolicyUberAutoRemove(policyID: string | undefined, enabled: boole
             key: `${ONYXKEYS.COLLECTION.POLICY}${policyID}`,
             onyxMethod: Onyx.METHOD.MERGE,
             value: {
-                receiptPartners: {uber: {autoRemove: enabled, pendingFields: {autoRemove: CONST.RED_BRICK_ROAD_PENDING_ACTION.UPDATE}}},
+                receiptPartners: { uber: { autoRemove: enabled, pendingFields: { autoRemove: CONST.RED_BRICK_ROAD_PENDING_ACTION.UPDATE } } },
             },
         },
     ];
@@ -3159,20 +3197,20 @@ function togglePolicyUberAutoRemove(policyID: string | undefined, enabled: boole
         {
             key: `${ONYXKEYS.COLLECTION.POLICY}${policyID}`,
             onyxMethod: Onyx.METHOD.MERGE,
-            value: {receiptPartners: {uber: {pendingFields: {autoRemove: null}}}},
+            value: { receiptPartners: { uber: { pendingFields: { autoRemove: null } } } },
         },
     ];
     const failureData: OnyxUpdate[] = [
         {
             key: `${ONYXKEYS.COLLECTION.POLICY}${policyID}`,
             onyxMethod: Onyx.METHOD.MERGE,
-            value: {receiptPartners: {uber: {autoRemove: !enabled, pendingFields: null}}},
+            value: { receiptPartners: { uber: { autoRemove: !enabled, pendingFields: null } } },
         },
     ];
 
-    const params: TogglePolicyUberAutoRemovePageParams = {policyID, enabled};
+    const params: TogglePolicyUberAutoRemovePageParams = { policyID, enabled };
 
-    API.write(WRITE_COMMANDS.TOGGLE_WORKSPACE_UBER_AUTO_REMOVE, params, {optimisticData, successData, failureData});
+    API.write(WRITE_COMMANDS.TOGGLE_WORKSPACE_UBER_AUTO_REMOVE, params, { optimisticData, successData, failureData });
 }
 
 /**
@@ -3180,7 +3218,7 @@ function togglePolicyUberAutoRemove(policyID: string | undefined, enabled: boole
  */
 function inviteWorkspaceEmployeesToUber(policyID: string, emails: string[]) {
     if (!policyID || emails.length === 0) {
-        Log.warn('inviteWorkspaceEmployeesToUber invalid params', {policyID, emails});
+        Log.warn('inviteWorkspaceEmployeesToUber invalid params', { policyID, emails });
         return;
     }
 
@@ -3190,7 +3228,7 @@ function inviteWorkspaceEmployeesToUber(policyID: string, emails: string[]) {
     };
 
     // Build optimistic employees mapping: mark invited emails as invited with pending action
-    const invitedEmployees = emails.reduce<Record<string, {status: string; pendingAction: PendingAction}>>((acc, email) => {
+    const invitedEmployees = emails.reduce<Record<string, { status: string; pendingAction: PendingAction }>>((acc, email) => {
         acc[email] = {
             status: CONST.POLICY.RECEIPT_PARTNERS.UBER_EMPLOYEE_STATUS.INVITED,
             pendingAction: CONST.RED_BRICK_ROAD_PENDING_ACTION.UPDATE,
@@ -3199,7 +3237,7 @@ function inviteWorkspaceEmployeesToUber(policyID: string, emails: string[]) {
     }, {});
 
     // Build map for clearing pending actions on success
-    const successEmployees = emails.reduce<Record<string, {pendingAction: PendingAction}>>((acc, email) => {
+    const successEmployees = emails.reduce<Record<string, { pendingAction: PendingAction }>>((acc, email) => {
         acc[email] = {
             pendingAction: null,
         };
@@ -3207,7 +3245,7 @@ function inviteWorkspaceEmployeesToUber(policyID: string, emails: string[]) {
     }, {});
 
     // Build map for resetting employees on failure with individual errors
-    const resetEmployeesOnFailure = emails.reduce<Record<string, {status?: string; errors: Errors}>>((acc, email) => {
+    const resetEmployeesOnFailure = emails.reduce<Record<string, { status?: string; errors: Errors }>>((acc, email) => {
         acc[email] = {
             errors: ErrorUtils.getMicroSecondOnyxErrorWithTranslationKey('workspace.receiptPartners.uber.invitationFailure'),
         };
@@ -3254,7 +3292,7 @@ function inviteWorkspaceEmployeesToUber(policyID: string, emails: string[]) {
         },
     ];
 
-    API.write(WRITE_COMMANDS.INVITE_WORKSPACE_EMPLOYEES_TO_UBER, params, {optimisticData, successData, failureData});
+    API.write(WRITE_COMMANDS.INVITE_WORKSPACE_EMPLOYEES_TO_UBER, params, { optimisticData, successData, failureData });
 }
 
 /**
@@ -3265,7 +3303,7 @@ function clearUberEmployeeError(policyID: string, email: string) {
         receiptPartners: {
             uber: {
                 employees: {
-                    [email]: {errors: null, pendingAction: null},
+                    [email]: { errors: null, pendingAction: null },
                 },
             },
         },
@@ -3277,7 +3315,7 @@ function clearUberEmployeeError(policyID: string, email: string) {
  */
 function openWorkspace(policyID: string, clientMemberAccountIDs: number[]) {
     if (!policyID || !clientMemberAccountIDs) {
-        Log.warn('openWorkspace invalid params', {policyID, clientMemberAccountIDs});
+        Log.warn('openWorkspace invalid params', { policyID, clientMemberAccountIDs });
         return;
     }
 
@@ -3291,7 +3329,7 @@ function openWorkspace(policyID: string, clientMemberAccountIDs: number[]) {
 
 function openPolicyTaxesPage(policyID: string) {
     if (!policyID) {
-        Log.warn('openPolicyTaxesPage invalid params', {policyID});
+        Log.warn('openPolicyTaxesPage invalid params', { policyID });
         return;
     }
 
@@ -3340,7 +3378,7 @@ function openPolicyExpensifyCardsPage(policyID: string, workspaceAccountID: numb
         authToken,
     };
 
-    API.read(READ_COMMANDS.OPEN_POLICY_EXPENSIFY_CARDS_PAGE, params, {optimisticData, successData, failureData});
+    API.read(READ_COMMANDS.OPEN_POLICY_EXPENSIFY_CARDS_PAGE, params, { optimisticData, successData, failureData });
 }
 
 function openPolicyEditCardLimitTypePage(policyID: string, cardID: number) {
@@ -3357,7 +3395,7 @@ function openPolicyEditCardLimitTypePage(policyID: string, cardID: number) {
 
 function openWorkspaceInvitePage(policyID: string, clientMemberEmails: string[]) {
     if (!policyID || !clientMemberEmails) {
-        Log.warn('openWorkspaceInvitePage invalid params', {policyID, clientMemberEmails});
+        Log.warn('openWorkspaceInvitePage invalid params', { policyID, clientMemberEmails });
         return;
     }
 
@@ -3371,11 +3409,11 @@ function openWorkspaceInvitePage(policyID: string, clientMemberEmails: string[])
 
 function openDraftWorkspaceRequest(policyID: string) {
     if (policyID === '-1' || policyID === CONST.POLICY.ID_FAKE) {
-        Log.warn('openDraftWorkspaceRequest invalid params', {policyID});
+        Log.warn('openDraftWorkspaceRequest invalid params', { policyID });
         return;
     }
 
-    const params: OpenDraftWorkspaceRequestParams = {policyID};
+    const params: OpenDraftWorkspaceRequestParams = { policyID };
 
     API.read(READ_COMMANDS.OPEN_DRAFT_WORKSPACE_REQUEST, params);
 }
@@ -3411,7 +3449,7 @@ function updateMemberCustomField(policyID: string, login: string, customFieldTyp
             key: `${ONYXKEYS.COLLECTION.POLICY}${policyID}`,
             onyxMethod: Onyx.METHOD.MERGE,
             value: {
-                employeeList: {[login]: {[customFieldKey]: value, pendingFields: {[customFieldKey]: CONST.RED_BRICK_ROAD_PENDING_ACTION.UPDATE}}},
+                employeeList: { [login]: { [customFieldKey]: value, pendingFields: { [customFieldKey]: CONST.RED_BRICK_ROAD_PENDING_ACTION.UPDATE } } },
             },
         },
     ];
@@ -3420,7 +3458,7 @@ function updateMemberCustomField(policyID: string, login: string, customFieldTyp
             key: `${ONYXKEYS.COLLECTION.POLICY}${policyID}`,
             onyxMethod: Onyx.METHOD.MERGE,
             value: {
-                employeeList: {[login]: {pendingFields: {[customFieldKey]: null}}},
+                employeeList: { [login]: { pendingFields: { [customFieldKey]: null } } },
             },
         },
     ];
@@ -3429,14 +3467,14 @@ function updateMemberCustomField(policyID: string, login: string, customFieldTyp
             key: `${ONYXKEYS.COLLECTION.POLICY}${policyID}`,
             onyxMethod: Onyx.METHOD.MERGE,
             value: {
-                employeeList: {[login]: {[customFieldKey]: previousValue, pendingFields: {[customFieldKey]: null}}},
+                employeeList: { [login]: { [customFieldKey]: previousValue, pendingFields: { [customFieldKey]: null } } },
             },
         },
     ];
 
-    const params: UpdatePolicyMembersCustomFieldsParams = {policyID, employees: JSON.stringify([{email: login, [customFieldType]: value}])};
+    const params: UpdatePolicyMembersCustomFieldsParams = { policyID, employees: JSON.stringify([{ email: login, [customFieldType]: value }]) };
 
-    API.write(WRITE_COMMANDS.UPDATE_POLICY_MEMBERS_CUSTOM_FIELDS, params, {optimisticData, successData, failureData});
+    API.write(WRITE_COMMANDS.UPDATE_POLICY_MEMBERS_CUSTOM_FIELDS, params, { optimisticData, successData, failureData });
 }
 
 function setWorkspaceInviteMessageDraft(policyID: string, message: string | null) {
@@ -3444,7 +3482,7 @@ function setWorkspaceInviteMessageDraft(policyID: string, message: string | null
 }
 
 function clearErrors(policyID: string) {
-    Onyx.merge(`${ONYXKEYS.COLLECTION.POLICY}${policyID}`, {errors: null});
+    Onyx.merge(`${ONYXKEYS.COLLECTION.POLICY}${policyID}`, { errors: null });
     hideWorkspaceAlertMessage(policyID);
 }
 
@@ -3452,7 +3490,7 @@ function clearErrors(policyID: string) {
  * Dismiss the informative messages about which policy members were added with primary logins when invited with their secondary login.
  */
 function dismissAddedWithPrimaryLoginMessages(policyID: string) {
-    Onyx.merge(`${ONYXKEYS.COLLECTION.POLICY}${policyID}`, {primaryLoginsInvited: null});
+    Onyx.merge(`${ONYXKEYS.COLLECTION.POLICY}${policyID}`, { primaryLoginsInvited: null });
 }
 
 /**
@@ -3485,7 +3523,7 @@ function createWorkspaceFromIOUPayment(iouReport: OnyxEntry<Report>): WorkspaceF
     const policyID = generatePolicyID();
     const workspaceName = generateDefaultWorkspaceName(deprecatedSessionEmail);
     const employeeAccountID = iouReport.ownerAccountID;
-    const {customUnits, customUnitID, customUnitRateID} = buildOptimisticDistanceRateCustomUnits(iouReport.currency);
+    const { customUnits, customUnitID, customUnitRateID } = buildOptimisticDistanceRateCustomUnits(iouReport.currency);
     const oldPersonalPolicyID = iouReport.policyID;
     const iouReportID = iouReport.reportID;
 
@@ -3508,7 +3546,7 @@ function createWorkspaceFromIOUPayment(iouReport: OnyxEntry<Report>): WorkspaceF
     const employeeEmail = deprecatedAllPersonalDetails?.[employeeAccountID]?.login ?? '';
 
     // Create the expense chat for the employee whose IOU is being paid
-    const employeeWorkspaceChat = createPolicyExpenseChats(policyID, {[employeeEmail]: employeeAccountID}, true);
+    const employeeWorkspaceChat = createPolicyExpenseChats(policyID, { [employeeEmail]: employeeAccountID }, true);
     const newWorkspace = {
         id: policyID,
 
@@ -3548,13 +3586,13 @@ function createWorkspaceFromIOUPayment(iouReport: OnyxEntry<Report>): WorkspaceF
             },
             ...(employeeEmail
                 ? {
-                      [employeeEmail]: {
-                          email: employeeEmail,
-                          submitsTo: deprecatedSessionEmail,
-                          role: CONST.POLICY.ROLE.USER,
-                          errors: {},
-                      },
-                  }
+                    [employeeEmail]: {
+                        email: employeeEmail,
+                        submitsTo: deprecatedSessionEmail,
+                        role: CONST.POLICY.ROLE.USER,
+                        errors: {},
+                    },
+                }
                 : {}),
         },
         pendingFields: {
@@ -3563,7 +3601,7 @@ function createWorkspaceFromIOUPayment(iouReport: OnyxEntry<Report>): WorkspaceF
             reimbursementChoice: CONST.RED_BRICK_ROAD_PENDING_ACTION.ADD,
         },
         defaultBillable: false,
-        disabledFields: {defaultBillable: true, reimbursable: false},
+        disabledFields: { defaultBillable: true, reimbursable: false },
         requiresCategory: true,
         defaultReimbursable: true,
     };
@@ -3802,12 +3840,12 @@ function createWorkspaceFromIOUPayment(iouReport: OnyxEntry<Report>): WorkspaceF
         optimisticData.push({
             onyxMethod: Onyx.METHOD.MERGE,
             key: `${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${oldChatReportID}`,
-            value: {[reportPreview.reportActionID]: null},
+            value: { [reportPreview.reportActionID]: null },
         });
         failureData.push({
             onyxMethod: Onyx.METHOD.MERGE,
             key: `${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${oldChatReportID}`,
-            value: {[reportPreview.reportActionID]: reportPreview},
+            value: { [reportPreview.reportActionID]: reportPreview },
         });
     }
 
@@ -3848,7 +3886,7 @@ function createWorkspaceFromIOUPayment(iouReport: OnyxEntry<Report>): WorkspaceF
         failureData.push({
             onyxMethod: Onyx.METHOD.MERGE,
             key: `${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${memberData.workspaceChatReportID}`,
-            value: {[reportPreview.reportActionID]: null},
+            value: { [reportPreview.reportActionID]: null },
         });
     }
 
@@ -3860,7 +3898,7 @@ function createWorkspaceFromIOUPayment(iouReport: OnyxEntry<Report>): WorkspaceF
     optimisticData.push({
         onyxMethod: Onyx.METHOD.MERGE,
         key: `${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${iouReport.reportID}`,
-        value: {[movedIouReportAction.reportActionID]: movedIouReportAction},
+        value: { [movedIouReportAction.reportActionID]: movedIouReportAction },
     });
 
     successData.push({
@@ -3877,13 +3915,13 @@ function createWorkspaceFromIOUPayment(iouReport: OnyxEntry<Report>): WorkspaceF
     failureData.push({
         onyxMethod: Onyx.METHOD.MERGE,
         key: `${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${iouReport.reportID}`,
-        value: {[movedIouReportAction.reportActionID]: null},
+        value: { [movedIouReportAction.reportActionID]: null },
     });
 
     optimisticData.push({
         onyxMethod: Onyx.METHOD.MERGE,
         key: `${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${oldChatReportID}`,
-        value: {[movedReportAction.reportActionID]: movedReportAction},
+        value: { [movedReportAction.reportActionID]: movedReportAction },
     });
     successData.push({
         onyxMethod: Onyx.METHOD.MERGE,
@@ -3898,7 +3936,7 @@ function createWorkspaceFromIOUPayment(iouReport: OnyxEntry<Report>): WorkspaceF
     failureData.push({
         onyxMethod: Onyx.METHOD.MERGE,
         key: `${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${oldChatReportID}`,
-        value: {[movedReportAction.reportActionID]: null},
+        value: { [movedReportAction.reportActionID]: null },
     });
 
     // We know that this new workspace has no BankAccount yet, so we can set
@@ -3939,9 +3977,9 @@ function createWorkspaceFromIOUPayment(iouReport: OnyxEntry<Report>): WorkspaceF
         expenseMovedReportActionID: movedIouReportAction.reportActionID,
     };
 
-    API.write(WRITE_COMMANDS.CREATE_WORKSPACE_FROM_IOU_PAYMENT, params, {optimisticData, successData, failureData});
+    API.write(WRITE_COMMANDS.CREATE_WORKSPACE_FROM_IOU_PAYMENT, params, { optimisticData, successData, failureData });
 
-    return {policyID, workspaceChatReportID: memberData.workspaceChatReportID, reportPreviewReportActionID: reportPreview?.reportActionID, adminsChatReportID};
+    return { policyID, workspaceChatReportID: memberData.workspaceChatReportID, reportPreviewReportActionID: reportPreview?.reportActionID, adminsChatReportID };
 }
 
 function enablePolicyConnections(policyID: string, enabled: boolean) {
@@ -3983,7 +4021,7 @@ function enablePolicyConnections(policyID: string, enabled: boolean) {
         ],
     };
 
-    const parameters: EnablePolicyConnectionsParams = {policyID, enabled};
+    const parameters: EnablePolicyConnectionsParams = { policyID, enabled };
 
     API.writeWithNoDuplicatesEnableFeatureConflicts(WRITE_COMMANDS.ENABLE_POLICY_CONNECTIONS, parameters, onyxData);
 
@@ -4000,7 +4038,7 @@ function enablePolicyReceiptPartners(policyID: string, enabled: boolean, shouldN
                 onyxMethod: Onyx.METHOD.MERGE,
                 key: `${ONYXKEYS.COLLECTION.POLICY}${policyID}`,
                 value: {
-                    receiptPartners: {enabled},
+                    receiptPartners: { enabled },
                     pendingFields: {
                         receiptPartners: CONST.RED_BRICK_ROAD_PENDING_ACTION.UPDATE,
                     },
@@ -4024,7 +4062,7 @@ function enablePolicyReceiptPartners(policyID: string, enabled: boolean, shouldN
                 onyxMethod: Onyx.METHOD.MERGE,
                 key: `${ONYXKEYS.COLLECTION.POLICY}${policyID}`,
                 value: {
-                    receiptPartners: {enabled: !enabled},
+                    receiptPartners: { enabled: !enabled },
                     pendingFields: {
                         receiptPartners: null,
                     },
@@ -4033,7 +4071,7 @@ function enablePolicyReceiptPartners(policyID: string, enabled: boolean, shouldN
         ],
     };
 
-    const parameters: TogglePolicyReceiptPartnersParams = {policyID, enabled};
+    const parameters: TogglePolicyReceiptPartnersParams = { policyID, enabled };
 
     API.write(WRITE_COMMANDS.TOGGLE_RECEIPT_PARTNERS, parameters, onyxData);
 
@@ -4049,7 +4087,7 @@ function enablePolicyReceiptPartners(policyID: string, enabled: boolean, shouldN
 
 /** Save the preferred export method for a policy */
 function savePreferredExportMethod(policyID: string, exportMethod: ReportExportType) {
-    Onyx.merge(`${ONYXKEYS.LAST_EXPORT_METHOD}`, {[policyID]: exportMethod});
+    Onyx.merge(`${ONYXKEYS.LAST_EXPORT_METHOD}`, { [policyID]: exportMethod });
 }
 
 function enableExpensifyCard(policyID: string, enabled: boolean, shouldNavigateToExpensifyCardPage = false) {
@@ -4095,7 +4133,7 @@ function enableExpensifyCard(policyID: string, enabled: boolean, shouldNavigateT
         ],
     };
 
-    const parameters: EnablePolicyExpensifyCardsParams = {authToken, policyID, enabled};
+    const parameters: EnablePolicyExpensifyCardsParams = { authToken, policyID, enabled };
 
     API.writeWithNoDuplicatesEnableFeatureConflicts(WRITE_COMMANDS.ENABLE_POLICY_EXPENSIFY_CARDS, parameters, onyxData);
 
@@ -4150,7 +4188,7 @@ function enableCompanyCards(policyID: string, enabled: boolean, shouldGoBack = t
         ],
     };
 
-    const parameters: EnablePolicyCompanyCardsParams = {authToken, policyID, enabled};
+    const parameters: EnablePolicyCompanyCardsParams = { authToken, policyID, enabled };
 
     API.writeWithNoDuplicatesEnableFeatureConflicts(WRITE_COMMANDS.ENABLE_POLICY_COMPANY_CARDS, parameters, onyxData);
 
@@ -4198,7 +4236,7 @@ function enablePolicyReportFields(policyID: string, enabled: boolean) {
         ],
     };
 
-    const parameters: EnablePolicyReportFieldsParams = {policyID, enabled};
+    const parameters: EnablePolicyReportFieldsParams = { policyID, enabled };
 
     API.writeWithNoDuplicatesEnableFeatureConflicts(WRITE_COMMANDS.ENABLE_POLICY_REPORT_FIELDS, parameters, onyxData);
 }
@@ -4222,7 +4260,7 @@ function enablePolicyTaxes(policyID: string, enabled: boolean) {
                                     };
                                     return acc;
                                 },
-                                {} as Record<string, TaxRate & {pendingAction: typeof CONST.RED_BRICK_ROAD_PENDING_ACTION.ADD}>,
+                                {} as Record<string, TaxRate & { pendingAction: typeof CONST.RED_BRICK_ROAD_PENDING_ACTION.ADD }>,
                             ),
                         },
                     },
@@ -4238,10 +4276,10 @@ function enablePolicyTaxes(policyID: string, enabled: boolean) {
                         taxes: {
                             ...Object.keys(defaultTaxRates.taxes).reduce(
                                 (acc, taxKey) => {
-                                    acc[taxKey] = {pendingAction: null};
+                                    acc[taxKey] = { pendingAction: null };
                                     return acc;
                                 },
-                                {} as Record<string, {pendingAction: null}>,
+                                {} as Record<string, { pendingAction: null }>,
                             ),
                         },
                     },
@@ -4314,7 +4352,7 @@ function enablePolicyTaxes(policyID: string, enabled: boolean) {
         failureData,
     };
 
-    const parameters: EnablePolicyTaxesParams = {policyID, enabled};
+    const parameters: EnablePolicyTaxesParams = { policyID, enabled };
     if (shouldAddDefaultTaxRatesData) {
         parameters.taxFields = JSON.stringify(defaultTaxRates);
     }
@@ -4338,25 +4376,25 @@ function enablePolicyWorkflows(policyID: string, enabled: boolean) {
                     areWorkflowsEnabled: enabled,
                     ...(!enabled
                         ? {
-                              approvalMode: CONST.POLICY.APPROVAL_MODE.OPTIONAL,
-                              autoReporting: false,
-                              autoReportingFrequency: CONST.POLICY.AUTO_REPORTING_FREQUENCIES.INSTANT,
-                              harvesting: {
-                                  enabled: false,
-                              },
-                              reimbursementChoice: CONST.POLICY.REIMBURSEMENT_CHOICES.REIMBURSEMENT_NO,
-                          }
+                            approvalMode: CONST.POLICY.APPROVAL_MODE.OPTIONAL,
+                            autoReporting: false,
+                            autoReportingFrequency: CONST.POLICY.AUTO_REPORTING_FREQUENCIES.INSTANT,
+                            harvesting: {
+                                enabled: false,
+                            },
+                            reimbursementChoice: CONST.POLICY.REIMBURSEMENT_CHOICES.REIMBURSEMENT_NO,
+                        }
                         : {}),
                     pendingFields: {
                         areWorkflowsEnabled: CONST.RED_BRICK_ROAD_PENDING_ACTION.UPDATE,
                         ...(!enabled
                             ? {
-                                  approvalMode: CONST.RED_BRICK_ROAD_PENDING_ACTION.UPDATE,
-                                  autoReporting: CONST.RED_BRICK_ROAD_PENDING_ACTION.UPDATE,
-                                  autoReportingFrequency: CONST.RED_BRICK_ROAD_PENDING_ACTION.UPDATE,
-                                  harvesting: CONST.RED_BRICK_ROAD_PENDING_ACTION.UPDATE,
-                                  reimbursementChoice: CONST.RED_BRICK_ROAD_PENDING_ACTION.UPDATE,
-                              }
+                                approvalMode: CONST.RED_BRICK_ROAD_PENDING_ACTION.UPDATE,
+                                autoReporting: CONST.RED_BRICK_ROAD_PENDING_ACTION.UPDATE,
+                                autoReportingFrequency: CONST.RED_BRICK_ROAD_PENDING_ACTION.UPDATE,
+                                harvesting: CONST.RED_BRICK_ROAD_PENDING_ACTION.UPDATE,
+                                reimbursementChoice: CONST.RED_BRICK_ROAD_PENDING_ACTION.UPDATE,
+                            }
                             : {}),
                     },
                 },
@@ -4371,12 +4409,12 @@ function enablePolicyWorkflows(policyID: string, enabled: boolean) {
                         areWorkflowsEnabled: null,
                         ...(!enabled
                             ? {
-                                  approvalMode: null,
-                                  autoReporting: null,
-                                  autoReportingFrequency: null,
-                                  harvesting: null,
-                                  reimbursementChoice: null,
-                              }
+                                approvalMode: null,
+                                autoReporting: null,
+                                autoReportingFrequency: null,
+                                harvesting: null,
+                                reimbursementChoice: null,
+                            }
                             : {}),
                     },
                 },
@@ -4390,23 +4428,23 @@ function enablePolicyWorkflows(policyID: string, enabled: boolean) {
                     areWorkflowsEnabled: !enabled,
                     ...(!enabled
                         ? {
-                              approvalMode: policy?.approvalMode,
-                              autoReporting: policy?.autoReporting,
-                              autoReportingFrequency: policy?.autoReportingFrequency,
-                              harvesting: policy?.harvesting,
-                              reimbursementChoice: policy?.reimbursementChoice,
-                          }
+                            approvalMode: policy?.approvalMode,
+                            autoReporting: policy?.autoReporting,
+                            autoReportingFrequency: policy?.autoReportingFrequency,
+                            harvesting: policy?.harvesting,
+                            reimbursementChoice: policy?.reimbursementChoice,
+                        }
                         : {}),
                     pendingFields: {
                         areWorkflowsEnabled: null,
                         ...(!enabled
                             ? {
-                                  approvalMode: null,
-                                  autoReporting: null,
-                                  autoReportingFrequency: null,
-                                  harvesting: null,
-                                  reimbursementChoice: null,
-                              }
+                                approvalMode: null,
+                                autoReporting: null,
+                                autoReportingFrequency: null,
+                                harvesting: null,
+                                reimbursementChoice: null,
+                            }
                             : {}),
                     },
                 },
@@ -4414,7 +4452,7 @@ function enablePolicyWorkflows(policyID: string, enabled: boolean) {
         ],
     };
 
-    const parameters: EnablePolicyWorkflowsParams = {policyID, enabled};
+    const parameters: EnablePolicyWorkflowsParams = { policyID, enabled };
 
     // When disabling workflows, set autoreporting back to "immediately"
     if (!enabled) {
@@ -4474,10 +4512,10 @@ function enablePolicyRules(policyID: string, enabled: boolean, shouldGoBack = tr
                     preventSelfApproval: policy?.preventSelfApproval,
                     ...(!enabled
                         ? {
-                              maxExpenseAmountNoReceipt: policy?.maxExpenseAmountNoReceipt,
-                              maxExpenseAmount: policy?.maxExpenseAmount,
-                              maxExpenseAge: policy?.maxExpenseAge,
-                          }
+                            maxExpenseAmountNoReceipt: policy?.maxExpenseAmountNoReceipt,
+                            maxExpenseAmount: policy?.maxExpenseAmount,
+                            maxExpenseAge: policy?.maxExpenseAge,
+                        }
                         : {}),
                     pendingFields: {
                         areRulesEnabled: null,
@@ -4494,7 +4532,7 @@ function enablePolicyRules(policyID: string, enabled: boolean, shouldGoBack = tr
         onyxData.failureData?.push(...(eReceiptsOnyxData.failureData ?? []));
     }
 
-    const parameters: SetPolicyRulesEnabledParams = {policyID, enabled};
+    const parameters: SetPolicyRulesEnabledParams = { policyID, enabled };
 
     // We can't use writeWithNoDuplicatesEnableFeatureConflicts because the expense rule values are also changed when disabling/enabling this feature
     API.write(WRITE_COMMANDS.SET_POLICY_RULES_ENABLED, parameters, onyxData);
@@ -4608,7 +4646,7 @@ function enablePolicyInvoicing(policyID: string, enabled: boolean) {
         ],
     };
 
-    const parameters: EnablePolicyInvoicingParams = {policyID, enabled};
+    const parameters: EnablePolicyInvoicingParams = { policyID, enabled };
 
     API.writeWithNoDuplicatesEnableFeatureConflicts(WRITE_COMMANDS.ENABLE_POLICY_INVOICING, parameters, onyxData);
 
@@ -4618,25 +4656,25 @@ function enablePolicyInvoicing(policyID: string, enabled: boolean) {
 }
 
 function openPolicyMoreFeaturesPage(policyID: string) {
-    const params: OpenPolicyMoreFeaturesPageParams = {policyID};
+    const params: OpenPolicyMoreFeaturesPageParams = { policyID };
 
     API.read(READ_COMMANDS.OPEN_POLICY_MORE_FEATURES_PAGE, params);
 }
 
 function openPolicyProfilePage(policyID: string) {
-    const params: OpenPolicyProfilePageParams = {policyID};
+    const params: OpenPolicyProfilePageParams = { policyID };
 
     API.read(READ_COMMANDS.OPEN_POLICY_PROFILE_PAGE, params);
 }
 
 function openDuplicatePolicyPage(policyID: string) {
-    const params: OpenDuplicatePolicyPageParams = {policyID};
+    const params: OpenDuplicatePolicyPageParams = { policyID };
 
     API.read(READ_COMMANDS.OPEN_DUPLICATE_POLICY_PAGE, params);
 }
 
 function openPolicyInitialPage(policyID: string) {
-    const params: OpenPolicyInitialPageParams = {policyID};
+    const params: OpenPolicyInitialPageParams = { policyID };
 
     API.read(READ_COMMANDS.OPEN_POLICY_INITIAL_PAGE, params);
 }
@@ -4654,7 +4692,7 @@ function setPolicyCustomTaxName(policyID: string, customTaxName: string) {
                 value: {
                     taxRates: {
                         name: customTaxName,
-                        pendingFields: {name: CONST.RED_BRICK_ROAD_PENDING_ACTION.UPDATE},
+                        pendingFields: { name: CONST.RED_BRICK_ROAD_PENDING_ACTION.UPDATE },
                         errorFields: null,
                     },
                 },
@@ -4666,7 +4704,7 @@ function setPolicyCustomTaxName(policyID: string, customTaxName: string) {
                 key: `${ONYXKEYS.COLLECTION.POLICY}${policyID}`,
                 value: {
                     taxRates: {
-                        pendingFields: {name: null},
+                        pendingFields: { name: null },
                         errorFields: null,
                     },
                 },
@@ -4679,8 +4717,8 @@ function setPolicyCustomTaxName(policyID: string, customTaxName: string) {
                 value: {
                     taxRates: {
                         name: originalCustomTaxName,
-                        pendingFields: {name: null},
-                        errorFields: {name: ErrorUtils.getMicroSecondOnyxErrorWithTranslationKey('common.genericErrorMessage')},
+                        pendingFields: { name: null },
+                        errorFields: { name: ErrorUtils.getMicroSecondOnyxErrorWithTranslationKey('common.genericErrorMessage') },
                     },
                 },
             },
@@ -4708,7 +4746,7 @@ function setWorkspaceCurrencyDefault(policyID: string, taxCode: string) {
                 value: {
                     taxRates: {
                         defaultExternalID: taxCode,
-                        pendingFields: {defaultExternalID: CONST.RED_BRICK_ROAD_PENDING_ACTION.UPDATE},
+                        pendingFields: { defaultExternalID: CONST.RED_BRICK_ROAD_PENDING_ACTION.UPDATE },
                         errorFields: null,
                     },
                 },
@@ -4720,7 +4758,7 @@ function setWorkspaceCurrencyDefault(policyID: string, taxCode: string) {
                 key: `${ONYXKEYS.COLLECTION.POLICY}${policyID}`,
                 value: {
                     taxRates: {
-                        pendingFields: {defaultExternalID: null},
+                        pendingFields: { defaultExternalID: null },
                         errorFields: null,
                     },
                 },
@@ -4733,8 +4771,8 @@ function setWorkspaceCurrencyDefault(policyID: string, taxCode: string) {
                 value: {
                     taxRates: {
                         defaultExternalID: originalDefaultExternalID,
-                        pendingFields: {defaultExternalID: null},
-                        errorFields: {defaultExternalID: ErrorUtils.getMicroSecondOnyxErrorWithTranslationKey('common.genericErrorMessage')},
+                        pendingFields: { defaultExternalID: null },
+                        errorFields: { defaultExternalID: ErrorUtils.getMicroSecondOnyxErrorWithTranslationKey('common.genericErrorMessage') },
                     },
                 },
             },
@@ -4762,7 +4800,7 @@ function setForeignCurrencyDefault(policyID: string, taxCode: string) {
                 value: {
                     taxRates: {
                         foreignTaxDefault: taxCode,
-                        pendingFields: {foreignTaxDefault: CONST.RED_BRICK_ROAD_PENDING_ACTION.UPDATE},
+                        pendingFields: { foreignTaxDefault: CONST.RED_BRICK_ROAD_PENDING_ACTION.UPDATE },
                         errorFields: null,
                     },
                 },
@@ -4774,7 +4812,7 @@ function setForeignCurrencyDefault(policyID: string, taxCode: string) {
                 key: `${ONYXKEYS.COLLECTION.POLICY}${policyID}`,
                 value: {
                     taxRates: {
-                        pendingFields: {foreignTaxDefault: null},
+                        pendingFields: { foreignTaxDefault: null },
                         errorFields: null,
                     },
                 },
@@ -4787,8 +4825,8 @@ function setForeignCurrencyDefault(policyID: string, taxCode: string) {
                 value: {
                     taxRates: {
                         foreignTaxDefault: originalDefaultForeignCurrencyID,
-                        pendingFields: {foreignTaxDefault: null},
-                        errorFields: {foreignTaxDefault: ErrorUtils.getMicroSecondOnyxErrorWithTranslationKey('common.genericErrorMessage')},
+                        pendingFields: { foreignTaxDefault: null },
+                        errorFields: { foreignTaxDefault: ErrorUtils.getMicroSecondOnyxErrorWithTranslationKey('common.genericErrorMessage') },
                     },
                 },
             },
@@ -4855,9 +4893,9 @@ function upgradeToCorporate(policyID: string, featureName?: string) {
         },
     ];
 
-    const parameters: UpgradeToCorporateParams = {policyID, ...(featureName ? {featureName} : {})};
+    const parameters: UpgradeToCorporateParams = { policyID, ...(featureName ? { featureName } : {}) };
 
-    API.write(WRITE_COMMANDS.UPGRADE_TO_CORPORATE, parameters, {optimisticData, successData, failureData});
+    API.write(WRITE_COMMANDS.UPGRADE_TO_CORPORATE, parameters, { optimisticData, successData, failureData });
 }
 
 function downgradeToTeam(policyID: string) {
@@ -4898,9 +4936,9 @@ function downgradeToTeam(policyID: string) {
         },
     ];
 
-    const parameters: DowngradeToTeamParams = {policyID};
+    const parameters: DowngradeToTeamParams = { policyID };
 
-    API.write(WRITE_COMMANDS.DOWNGRADE_TO_TEAM, parameters, {optimisticData, successData, failureData});
+    API.write(WRITE_COMMANDS.DOWNGRADE_TO_TEAM, parameters, { optimisticData, successData, failureData });
 }
 
 function setWorkspaceDefaultSpendCategory(policyID: string, groupID: string, category: string) {
@@ -4911,62 +4949,62 @@ function setWorkspaceDefaultSpendCategory(policyID: string, groupID: string, cat
         return;
     }
 
-    const {mccGroup} = policy;
+    const { mccGroup } = policy;
 
     const optimisticData: OnyxUpdate[] = mccGroup
         ? [
-              {
-                  onyxMethod: Onyx.METHOD.MERGE,
-                  key: `policy_${policyID}`,
-                  value: {
-                      mccGroup: {
-                          ...mccGroup,
-                          [groupID]: {
-                              category,
-                              groupID,
-                              pendingAction: CONST.RED_BRICK_ROAD_PENDING_ACTION.UPDATE,
-                          },
-                      },
-                  },
-              },
-          ]
+            {
+                onyxMethod: Onyx.METHOD.MERGE,
+                key: `policy_${policyID}`,
+                value: {
+                    mccGroup: {
+                        ...mccGroup,
+                        [groupID]: {
+                            category,
+                            groupID,
+                            pendingAction: CONST.RED_BRICK_ROAD_PENDING_ACTION.UPDATE,
+                        },
+                    },
+                },
+            },
+        ]
         : [];
 
     const failureData: OnyxUpdate[] = mccGroup
         ? [
-              {
-                  onyxMethod: Onyx.METHOD.MERGE,
-                  key: `policy_${policyID}`,
-                  value: {
-                      mccGroup: {
-                          ...mccGroup,
-                          [groupID]: {
-                              ...mccGroup[groupID],
-                              pendingAction: null,
-                          },
-                      },
-                  },
-              },
-          ]
+            {
+                onyxMethod: Onyx.METHOD.MERGE,
+                key: `policy_${policyID}`,
+                value: {
+                    mccGroup: {
+                        ...mccGroup,
+                        [groupID]: {
+                            ...mccGroup[groupID],
+                            pendingAction: null,
+                        },
+                    },
+                },
+            },
+        ]
         : [];
 
     const successData: OnyxUpdate[] = mccGroup
         ? [
-              {
-                  onyxMethod: Onyx.METHOD.MERGE,
-                  key: `policy_${policyID}`,
-                  value: {
-                      mccGroup: {
-                          [groupID]: {
-                              pendingAction: null,
-                          },
-                      },
-                  },
-              },
-          ]
+            {
+                onyxMethod: Onyx.METHOD.MERGE,
+                key: `policy_${policyID}`,
+                value: {
+                    mccGroup: {
+                        [groupID]: {
+                            pendingAction: null,
+                        },
+                    },
+                },
+            },
+        ]
         : [];
 
-    API.write(WRITE_COMMANDS.SET_WORKSPACE_DEFAULT_SPEND_CATEGORY, {policyID, groupID, category}, {optimisticData, successData, failureData});
+    API.write(WRITE_COMMANDS.SET_WORKSPACE_DEFAULT_SPEND_CATEGORY, { policyID, groupID, category }, { optimisticData, successData, failureData });
 }
 
 /**
@@ -4999,7 +5037,7 @@ function setPolicyMaxExpenseAmountNoReceipt(policyID: string, maxExpenseAmountNo
                 onyxMethod: Onyx.METHOD.MERGE,
                 key: `${ONYXKEYS.COLLECTION.POLICY}${policyID}`,
                 value: {
-                    pendingFields: {maxExpenseAmountNoReceipt: null},
+                    pendingFields: { maxExpenseAmountNoReceipt: null },
                     errorFields: null,
                 },
             },
@@ -5010,8 +5048,8 @@ function setPolicyMaxExpenseAmountNoReceipt(policyID: string, maxExpenseAmountNo
                 key: `${ONYXKEYS.COLLECTION.POLICY}${policyID}`,
                 value: {
                     maxExpenseAmountNoReceipt: originalMaxExpenseAmountNoReceipt,
-                    pendingFields: {maxExpenseAmountNoReceipt: null},
-                    errorFields: {maxExpenseAmountNoReceipt: ErrorUtils.getMicroSecondOnyxErrorWithTranslationKey('common.genericErrorMessage')},
+                    pendingFields: { maxExpenseAmountNoReceipt: null },
+                    errorFields: { maxExpenseAmountNoReceipt: ErrorUtils.getMicroSecondOnyxErrorWithTranslationKey('common.genericErrorMessage') },
                 },
             },
         ],
@@ -5055,7 +5093,7 @@ function setPolicyMaxExpenseAmount(policyID: string, maxExpenseAmount: string) {
                 onyxMethod: Onyx.METHOD.MERGE,
                 key: `${ONYXKEYS.COLLECTION.POLICY}${policyID}`,
                 value: {
-                    pendingFields: {maxExpenseAmount: null},
+                    pendingFields: { maxExpenseAmount: null },
                     errorFields: null,
                 },
             },
@@ -5066,8 +5104,8 @@ function setPolicyMaxExpenseAmount(policyID: string, maxExpenseAmount: string) {
                 key: `${ONYXKEYS.COLLECTION.POLICY}${policyID}`,
                 value: {
                     maxExpenseAmount: originalMaxExpenseAmount,
-                    pendingFields: {maxExpenseAmount: null},
-                    errorFields: {maxExpenseAmount: ErrorUtils.getMicroSecondOnyxErrorWithTranslationKey('common.genericErrorMessage')},
+                    pendingFields: { maxExpenseAmount: null },
+                    errorFields: { maxExpenseAmount: ErrorUtils.getMicroSecondOnyxErrorWithTranslationKey('common.genericErrorMessage') },
                 },
             },
         ],
@@ -5131,14 +5169,14 @@ function setPolicyProhibitedExpense(policyID: string, prohibitedExpense: keyof P
                 key: `${ONYXKEYS.COLLECTION.POLICY}${policyID}`,
                 value: {
                     prohibitedExpenses: originalProhibitedExpenses,
-                    errorFields: {prohibitedExpenses: ErrorUtils.getMicroSecondOnyxErrorWithTranslationKey('common.genericErrorMessage')},
+                    errorFields: { prohibitedExpenses: ErrorUtils.getMicroSecondOnyxErrorWithTranslationKey('common.genericErrorMessage') },
                 },
             },
         ],
     };
 
     // Remove pendingFields before sending to the API
-    const {pendingFields, ...prohibitedExpensesWithoutPendingFields} = prohibitedExpenses;
+    const { pendingFields, ...prohibitedExpensesWithoutPendingFields } = prohibitedExpenses;
     const parameters: SetPolicyProhibitedExpensesParams = {
         policyID,
         prohibitedExpenses: JSON.stringify(prohibitedExpensesWithoutPendingFields),
@@ -5189,8 +5227,8 @@ function setPolicyMaxExpenseAge(policyID: string, maxExpenseAge: string) {
                 key: `${ONYXKEYS.COLLECTION.POLICY}${policyID}`,
                 value: {
                     maxExpenseAge: originalMaxExpenseAge,
-                    pendingFields: {maxExpenseAge: null},
-                    errorFields: {maxExpenseAge: ErrorUtils.getMicroSecondOnyxErrorWithTranslationKey('common.genericErrorMessage')},
+                    pendingFields: { maxExpenseAge: null },
+                    errorFields: { maxExpenseAge: ErrorUtils.getMicroSecondOnyxErrorWithTranslationKey('common.genericErrorMessage') },
                 },
             },
         ],
@@ -5251,8 +5289,8 @@ function updateCustomRules(policyID: string, customRules: string) {
                 key: `${ONYXKEYS.COLLECTION.POLICY}${policyID}`,
                 value: {
                     customRules: originalCustomRules,
-                    pendingFields: {customRules: null},
-                    errorFields: {customRules: ErrorUtils.getMicroSecondOnyxErrorWithTranslationKey('common.genericErrorMessage')},
+                    pendingFields: { customRules: null },
+                    errorFields: { customRules: ErrorUtils.getMicroSecondOnyxErrorWithTranslationKey('common.genericErrorMessage') },
                     // TODO
                     // pendingFields: {maxExpenseAge: null},
                     // errorFields: {maxExpenseAge: ErrorUtils.getMicroSecondOnyxErrorWithTranslationKey('common.genericErrorMessage')},
@@ -5317,10 +5355,10 @@ function setPolicyBillableMode(policyID: string, defaultBillable: boolean) {
                 onyxMethod: Onyx.METHOD.MERGE,
                 key: `${ONYXKEYS.COLLECTION.POLICY}${policyID}`,
                 value: {
-                    disabledFields: {defaultBillable: originalDefaultBillableDisabled},
+                    disabledFields: { defaultBillable: originalDefaultBillableDisabled },
                     defaultBillable: originalDefaultBillable,
-                    pendingFields: {defaultBillable: null, disabledFields: null},
-                    errorFields: {defaultBillable: ErrorUtils.getMicroSecondOnyxErrorWithTranslationKey('common.genericErrorMessage')},
+                    pendingFields: { defaultBillable: null, disabledFields: null },
+                    errorFields: { defaultBillable: ErrorUtils.getMicroSecondOnyxErrorWithTranslationKey('common.genericErrorMessage') },
                 },
             },
         ],
@@ -5409,10 +5447,10 @@ function setPolicyReimbursableMode(policyID: string, reimbursableMode: PolicyCas
                 onyxMethod: Onyx.METHOD.MERGE,
                 key: `${ONYXKEYS.COLLECTION.POLICY}${policyID}`,
                 value: {
-                    disabledFields: {reimbursable: originalDefaultReimbursableDisabled},
+                    disabledFields: { reimbursable: originalDefaultReimbursableDisabled },
                     defaultReimbursable: originalDefaultReimbursable,
-                    pendingFields: {defaultReimbursable: null, disabledFields: null},
-                    errorFields: {defaultReimbursable: ErrorUtils.getMicroSecondOnyxErrorWithTranslationKey('common.genericErrorMessage')},
+                    pendingFields: { defaultReimbursable: null, disabledFields: null },
+                    errorFields: { defaultReimbursable: ErrorUtils.getMicroSecondOnyxErrorWithTranslationKey('common.genericErrorMessage') },
                 },
             },
         ],
@@ -5470,8 +5508,8 @@ function disableWorkspaceBillableExpenses(policyID: string) {
                 onyxMethod: Onyx.METHOD.MERGE,
                 key: `${ONYXKEYS.COLLECTION.POLICY}${policyID}`,
                 value: {
-                    pendingFields: {disabledFields: null},
-                    disabledFields: {defaultBillable: originalDefaultBillableDisabled},
+                    pendingFields: { disabledFields: null },
+                    disabledFields: { defaultBillable: originalDefaultBillableDisabled },
                 },
             },
         ],
@@ -5521,8 +5559,8 @@ function getWorkspaceEReceiptsEnabledOnyxData(policyID: string, enabled: boolean
                 key: `${ONYXKEYS.COLLECTION.POLICY}${policyID}`,
                 value: {
                     eReceipts: originalEReceipts,
-                    pendingFields: {defaultBillable: null},
-                    errorFields: {defaultBillable: ErrorUtils.getMicroSecondOnyxErrorWithTranslationKey('common.genericErrorMessage')},
+                    pendingFields: { defaultBillable: null },
+                    errorFields: { defaultBillable: ErrorUtils.getMicroSecondOnyxErrorWithTranslationKey('common.genericErrorMessage') },
                 },
             },
         ],
@@ -5578,8 +5616,8 @@ function setPolicyAttendeeTrackingEnabled(policyID: string, isAttendeeTrackingEn
                 key: `${ONYXKEYS.COLLECTION.POLICY}${policyID}`,
                 value: {
                     isAttendeeTrackingEnabled: originalIsAttendeeTrackingEnabled,
-                    pendingFields: {isAttendeeTrackingEnabled: null},
-                    errorFields: {isAttendeeTrackingEnabled: ErrorUtils.getMicroSecondOnyxErrorWithTranslationKey('common.genericErrorMessage')},
+                    pendingFields: { isAttendeeTrackingEnabled: null },
+                    errorFields: { isAttendeeTrackingEnabled: ErrorUtils.getMicroSecondOnyxErrorWithTranslationKey('common.genericErrorMessage') },
                 },
             },
         ],
@@ -5631,7 +5669,7 @@ function setPolicyDefaultReportTitle(policyID: string, customName: string) {
                 fieldList: {
                     [CONST.POLICY.FIELDS.FIELD_LIST_TITLE]: {
                         defaultValue: customName,
-                        pendingFields: {defaultValue: CONST.RED_BRICK_ROAD_PENDING_ACTION.UPDATE},
+                        pendingFields: { defaultValue: CONST.RED_BRICK_ROAD_PENDING_ACTION.UPDATE },
                     },
                 },
             },
@@ -5644,7 +5682,7 @@ function setPolicyDefaultReportTitle(policyID: string, customName: string) {
             key: `${ONYXKEYS.COLLECTION.POLICY}${policyID}`,
             value: {
                 fieldList: {
-                    [CONST.POLICY.FIELDS.FIELD_LIST_TITLE]: {pendingFields: {defaultValue: null}},
+                    [CONST.POLICY.FIELDS.FIELD_LIST_TITLE]: { pendingFields: { defaultValue: null } },
                 },
                 errorFields: null,
             },
@@ -5657,7 +5695,7 @@ function setPolicyDefaultReportTitle(policyID: string, customName: string) {
             key: `${ONYXKEYS.COLLECTION.POLICY}${policyID}`,
             value: {
                 fieldList: {
-                    [CONST.POLICY.FIELDS.FIELD_LIST_TITLE]: {...previousReportTitleField, pendingFields: {defaultValue: null}},
+                    [CONST.POLICY.FIELDS.FIELD_LIST_TITLE]: { ...previousReportTitleField, pendingFields: { defaultValue: null } },
                 },
                 errorFields: {
                     fieldList: {
@@ -5704,7 +5742,7 @@ function setPolicyPreventMemberCreatedTitle(policyID: string, enforced: boolean)
             key: `${ONYXKEYS.COLLECTION.POLICY}${policyID}`,
             value: {
                 fieldList: {
-                    [CONST.POLICY.FIELDS.FIELD_LIST_TITLE]: {...previousReportTitleField, deletable: !enforced, pendingFields: {deletable: CONST.RED_BRICK_ROAD_PENDING_ACTION.UPDATE}},
+                    [CONST.POLICY.FIELDS.FIELD_LIST_TITLE]: { ...previousReportTitleField, deletable: !enforced, pendingFields: { deletable: CONST.RED_BRICK_ROAD_PENDING_ACTION.UPDATE } },
                 },
             },
         },
@@ -5716,7 +5754,7 @@ function setPolicyPreventMemberCreatedTitle(policyID: string, enforced: boolean)
             key: `${ONYXKEYS.COLLECTION.POLICY}${policyID}`,
             value: {
                 fieldList: {
-                    [CONST.POLICY.FIELDS.FIELD_LIST_TITLE]: {pendingFields: {deletable: null}},
+                    [CONST.POLICY.FIELDS.FIELD_LIST_TITLE]: { pendingFields: { deletable: null } },
                 },
                 errorFields: null,
             },
@@ -5729,7 +5767,7 @@ function setPolicyPreventMemberCreatedTitle(policyID: string, enforced: boolean)
             key: `${ONYXKEYS.COLLECTION.POLICY}${policyID}`,
             value: {
                 fieldList: {
-                    [CONST.POLICY.FIELDS.FIELD_LIST_TITLE]: {...previousReportTitleField, pendingFields: {deletable: null}},
+                    [CONST.POLICY.FIELDS.FIELD_LIST_TITLE]: { ...previousReportTitleField, pendingFields: { deletable: null } },
                 },
                 errorFields: {
                     fieldList: ErrorUtils.getMicroSecondOnyxErrorWithTranslationKey('common.genericErrorMessage'),
@@ -5842,7 +5880,7 @@ function setPolicyAutomaticApprovalLimit(policyID: string, limit: string) {
             value: {
                 autoApproval: {
                     limit: parsedLimit,
-                    pendingFields: {limit: CONST.RED_BRICK_ROAD_PENDING_ACTION.UPDATE},
+                    pendingFields: { limit: CONST.RED_BRICK_ROAD_PENDING_ACTION.UPDATE },
                 },
             },
         },
@@ -5988,7 +6026,7 @@ function enableAutoApprovalOptions(policyID: string, enabled: boolean) {
         auditRate: enabled ? CONST.POLICY.RANDOM_AUDIT_SUGGESTED_PERCENTAGE : 0,
         limit: enabled ? CONST.POLICY.AUTO_APPROVE_REPORTS_UNDER_SUGGESTED_CENTS : 0,
     };
-    const autoApprovalFailureValues = {autoApproval: {limit: policy?.autoApproval?.limit, auditRate: policy?.autoApproval?.auditRate, pendingFields: null}};
+    const autoApprovalFailureValues = { autoApproval: { limit: policy?.autoApproval?.limit, auditRate: policy?.autoApproval?.auditRate, pendingFields: null } };
     const optimisticData: OnyxUpdate[] = [
         {
             onyxMethod: Onyx.METHOD.MERGE,
@@ -6014,7 +6052,7 @@ function enableAutoApprovalOptions(policyID: string, enabled: boolean) {
             onyxMethod: Onyx.METHOD.MERGE,
             key: `${ONYXKEYS.COLLECTION.POLICY}${policyID}`,
             value: {
-                autoApproval: {pendingFields: null},
+                autoApproval: { pendingFields: null },
                 pendingFields: {
                     shouldShowAutoApprovalOptions: null,
                 },
@@ -6100,7 +6138,7 @@ function setPolicyAutoReimbursementLimit(policyID: string, limit: string) {
             onyxMethod: Onyx.METHOD.MERGE,
             key: `${ONYXKEYS.COLLECTION.POLICY}${policyID}`,
             value: {
-                autoReimbursement: {limit: policy?.autoReimbursement?.limit ?? policy?.autoReimbursementLimit, pendingFields: {limit: null}},
+                autoReimbursement: { limit: policy?.autoReimbursement?.limit ?? policy?.autoReimbursementLimit, pendingFields: { limit: null } },
                 errorFields: {
                     autoReimbursement: ErrorUtils.getMicroSecondOnyxErrorWithTranslationKey('common.genericErrorMessage'),
                 },
@@ -6135,8 +6173,8 @@ function enablePolicyAutoReimbursementLimit(policyID: string, enabled: boolean) 
         return;
     }
 
-    const autoReimbursementFailureValues = {autoReimbursement: {limit: policy?.autoReimbursement?.limit, pendingFields: null}};
-    const autoReimbursementValues = {limit: enabled ? CONST.POLICY.AUTO_REIMBURSEMENT_LIMIT_SUGGESTED_CENTS : CONST.POLICY.AUTO_REIMBURSEMENT_LIMIT_DEFAULT_CENTS};
+    const autoReimbursementFailureValues = { autoReimbursement: { limit: policy?.autoReimbursement?.limit, pendingFields: null } };
+    const autoReimbursementValues = { limit: enabled ? CONST.POLICY.AUTO_REIMBURSEMENT_LIMIT_SUGGESTED_CENTS : CONST.POLICY.AUTO_REIMBURSEMENT_LIMIT_DEFAULT_CENTS };
     const optimisticData: OnyxUpdate[] = [
         {
             onyxMethod: Onyx.METHOD.MERGE,
@@ -6161,7 +6199,7 @@ function enablePolicyAutoReimbursementLimit(policyID: string, enabled: boolean) 
             onyxMethod: Onyx.METHOD.MERGE,
             key: `${ONYXKEYS.COLLECTION.POLICY}${policyID}`,
             value: {
-                autoReimbursement: {pendingFields: null},
+                autoReimbursement: { pendingFields: null },
                 pendingFields: {
                     shouldShowAutoReimbursementLimitOption: null,
                 },
@@ -6265,7 +6303,7 @@ function updateInvoiceCompanyName(policyID: string, companyName: string) {
         companyName,
     };
 
-    API.write(WRITE_COMMANDS.UPDATE_INVOICE_COMPANY_NAME, parameters, {optimisticData, successData, failureData});
+    API.write(WRITE_COMMANDS.UPDATE_INVOICE_COMPANY_NAME, parameters, { optimisticData, successData, failureData });
 }
 
 function updateInvoiceCompanyWebsite(policyID: string, companyWebsite: string) {
@@ -6329,7 +6367,7 @@ function updateInvoiceCompanyWebsite(policyID: string, companyWebsite: string) {
         companyWebsite,
     };
 
-    API.write(WRITE_COMMANDS.UPDATE_INVOICE_COMPANY_WEBSITE, parameters, {optimisticData, successData, failureData});
+    API.write(WRITE_COMMANDS.UPDATE_INVOICE_COMPANY_WEBSITE, parameters, { optimisticData, successData, failureData });
 }
 
 /**
@@ -6370,14 +6408,14 @@ function getAccessiblePolicies(validateCode?: string) {
 
     const command = validateCode ? WRITE_COMMANDS.VALIDATE_USER_AND_GET_ACCESSIBLE_POLICIES : WRITE_COMMANDS.GET_ACCESSIBLE_POLICIES;
 
-    API.write(command, validateCode ? {validateCode} : null, {optimisticData, successData, failureData});
+    API.write(command, validateCode ? { validateCode } : null, { optimisticData, successData, failureData });
 }
 
 /**
  * Clear the errors from the get accessible policies request
  */
 function clearGetAccessiblePoliciesErrors() {
-    Onyx.merge(ONYXKEYS.VALIDATE_USER_AND_GET_ACCESSIBLE_POLICIES, {errors: null});
+    Onyx.merge(ONYXKEYS.VALIDATE_USER_AND_GET_ACCESSIBLE_POLICIES, { errors: null });
 }
 
 /**
@@ -6447,11 +6485,11 @@ function payAndDowngrade() {
             },
         },
     ];
-    API.write(WRITE_COMMANDS.PAY_AND_DOWNGRADE, null, {optimisticData, successData, failureData});
+    API.write(WRITE_COMMANDS.PAY_AND_DOWNGRADE, null, { optimisticData, successData, failureData });
 }
 
 function clearBillingReceiptDetailsErrors() {
-    Onyx.merge(ONYXKEYS.BILLING_RECEIPT_DETAILS, {errors: null});
+    Onyx.merge(ONYXKEYS.BILLING_RECEIPT_DETAILS, { errors: null });
 }
 
 function setIsForcedToChangeCurrency(value: boolean) {
@@ -6479,7 +6517,7 @@ function clearPolicyTitleFieldError(policyID: string) {
  * Set the workspace currency for the workspace confirmation form
  */
 function setWorkspaceConfirmationCurrency(currency: string) {
-    Onyx.merge(ONYXKEYS.FORMS.WORKSPACE_CONFIRMATION_FORM_DRAFT, {currency});
+    Onyx.merge(ONYXKEYS.FORMS.WORKSPACE_CONFIRMATION_FORM_DRAFT, { currency });
 }
 
 export {

--- a/tests/actions/PolicyTest.ts
+++ b/tests/actions/PolicyTest.ts
@@ -1,8 +1,8 @@
-import {Str} from 'expensify-common';
-import type {OnyxCollection, OnyxEntry} from 'react-native-onyx';
+import { Str } from 'expensify-common';
+import type { OnyxCollection, OnyxEntry } from 'react-native-onyx';
 import Onyx from 'react-native-onyx';
-import {getOnboardingMessages} from '@libs/actions/Welcome/OnboardingFlow';
-import {WRITE_COMMANDS} from '@libs/API/types';
+import { getOnboardingMessages } from '@libs/actions/Welcome/OnboardingFlow';
+import { WRITE_COMMANDS } from '@libs/API/types';
 // eslint-disable-next-line no-restricted-syntax
 import * as PersonalDetailsUtils from '@libs/PersonalDetailsUtils';
 // eslint-disable-next-line no-restricted-syntax
@@ -10,22 +10,22 @@ import * as PolicyUtils from '@libs/PolicyUtils';
 import CONST from '@src/CONST';
 import IntlStore from '@src/languages/IntlStore';
 import OnyxUpdateManager from '@src/libs/actions/OnyxUpdateManager';
-import {askToJoinPolicy, joinAccessiblePolicy} from '@src/libs/actions/Policy/Member';
+import { askToJoinPolicy, joinAccessiblePolicy } from '@src/libs/actions/Policy/Member';
 import * as Policy from '@src/libs/actions/Policy/Policy';
 import ONYXKEYS from '@src/ONYXKEYS';
-import type {Onboarding, PolicyJoinMember, Policy as PolicyType, Report, ReportAction, ReportActions, TransactionViolations} from '@src/types/onyx';
-import type {Participant} from '@src/types/onyx/Report';
+import type { Onboarding, PolicyJoinMember, Policy as PolicyType, Report, ReportAction, ReportActions, TransactionViolations } from '@src/types/onyx';
+import type { Participant } from '@src/types/onyx/Report';
 import createRandomPolicy from '../utils/collections/policies';
-import {createRandomReport} from '../utils/collections/reports';
+import { createRandomReport } from '../utils/collections/reports';
 import getOnyxValue from '../utils/getOnyxValue';
 import * as TestHelper from '../utils/TestHelper';
-import type {MockFetch} from '../utils/TestHelper';
+import type { MockFetch } from '../utils/TestHelper';
 import waitForBatchedUpdates from '../utils/waitForBatchedUpdates';
 
 const ESH_EMAIL = 'eshgupta1217@gmail.com';
 const ESH_ACCOUNT_ID = 1;
-const ESH_PARTICIPANT_ADMINS_ROOM: Participant = {notificationPreference: CONST.REPORT.NOTIFICATION_PREFERENCE.ALWAYS};
-const ESH_PARTICIPANT_EXPENSE_CHAT = {notificationPreference: CONST.REPORT.NOTIFICATION_PREFERENCE.ALWAYS};
+const ESH_PARTICIPANT_ADMINS_ROOM: Participant = { notificationPreference: CONST.REPORT.NOTIFICATION_PREFERENCE.ALWAYS };
+const ESH_PARTICIPANT_EXPENSE_CHAT = { notificationPreference: CONST.REPORT.NOTIFICATION_PREFERENCE.ALWAYS };
 const WORKSPACE_NAME = "Esh's Workspace";
 const EMPLOYEE_EMAIL = 'employee@example.com';
 const TEST_EMAIL = 'esh@gmail.com';
@@ -59,11 +59,11 @@ describe('actions/Policy', () => {
 
         it('creates a new workspace', async () => {
             (fetch as MockFetch)?.pause?.();
-            await Onyx.set(ONYXKEYS.SESSION, {email: ESH_EMAIL, accountID: ESH_ACCOUNT_ID});
+            await Onyx.set(ONYXKEYS.SESSION, { email: ESH_EMAIL, accountID: ESH_ACCOUNT_ID });
             const fakePolicy = createRandomPolicy(0, CONST.POLICY.TYPE.PERSONAL);
             await Onyx.set(`${ONYXKEYS.COLLECTION.POLICY}${fakePolicy.id}`, fakePolicy);
             await Onyx.set(`${ONYXKEYS.NVP_ACTIVE_POLICY_ID}`, fakePolicy.id);
-            await Onyx.set(`${ONYXKEYS.NVP_INTRO_SELECTED}`, {choice: CONST.ONBOARDING_CHOICES.MANAGE_TEAM});
+            await Onyx.set(`${ONYXKEYS.NVP_INTRO_SELECTED}`, { choice: CONST.ONBOARDING_CHOICES.MANAGE_TEAM });
             await waitForBatchedUpdates();
 
             let adminReportID;
@@ -113,7 +113,7 @@ describe('actions/Policy', () => {
             expect(policy?.approver).toBe(ESH_EMAIL);
             expect(policy?.isPolicyExpenseChatEnabled).toBe(true);
             expect(policy?.pendingAction).toBe(CONST.RED_BRICK_ROAD_PENDING_ACTION.ADD);
-            expect(policy?.employeeList).toEqual({[ESH_EMAIL]: {email: ESH_EMAIL, submitsTo: ESH_EMAIL, errors: {}, role: CONST.POLICY.ROLE.ADMIN}});
+            expect(policy?.employeeList).toEqual({ [ESH_EMAIL]: { email: ESH_EMAIL, submitsTo: ESH_EMAIL, errors: {}, role: CONST.POLICY.ROLE.ADMIN } });
             expect(policy?.mccGroup).toBeDefined();
             expect(policy?.requiresCategory).toBe(true);
 
@@ -137,12 +137,12 @@ describe('actions/Policy', () => {
                 expect(report?.pendingFields?.addWorkspaceRoom).toBe(CONST.RED_BRICK_ROAD_PENDING_ACTION.ADD);
                 switch (report?.chatType) {
                     case CONST.REPORT.CHAT_TYPE.POLICY_ADMINS: {
-                        expect(report?.participants).toEqual({[ESH_ACCOUNT_ID]: ESH_PARTICIPANT_ADMINS_ROOM});
+                        expect(report?.participants).toEqual({ [ESH_ACCOUNT_ID]: ESH_PARTICIPANT_ADMINS_ROOM });
                         adminReportID = report.reportID;
                         break;
                     }
                     case CONST.REPORT.CHAT_TYPE.POLICY_EXPENSE_CHAT: {
-                        expect(report?.participants).toEqual({[ESH_ACCOUNT_ID]: ESH_PARTICIPANT_EXPENSE_CHAT});
+                        expect(report?.participants).toEqual({ [ESH_ACCOUNT_ID]: ESH_PARTICIPANT_EXPENSE_CHAT });
                         expenseReportID = report.reportID;
                         break;
                     }
@@ -174,7 +174,7 @@ describe('actions/Policy', () => {
             }
 
             // Following tasks are filtered in prepareOnboardingOnyxData: 'viewTour', 'addAccountingIntegration' and 'setupCategoriesAndTags' (-3)
-            const {onboardingMessages} = getOnboardingMessages();
+            const { onboardingMessages } = getOnboardingMessages();
             const expectedManageTeamDefaultTasksCount = onboardingMessages[CONST.ONBOARDING_CHOICES.MANAGE_TEAM].tasks.length - 3;
 
             // After filtering, two actions are added to the list =- signoff message (+1) and default create action (+1)
@@ -261,11 +261,11 @@ describe('actions/Policy', () => {
 
         it('duplicate workspace', async () => {
             (fetch as MockFetch)?.pause?.();
-            await Onyx.set(ONYXKEYS.SESSION, {email: ESH_EMAIL, accountID: ESH_ACCOUNT_ID});
+            await Onyx.set(ONYXKEYS.SESSION, { email: ESH_EMAIL, accountID: ESH_ACCOUNT_ID });
             const fakePolicy = createRandomPolicy(10, CONST.POLICY.TYPE.PERSONAL);
             await Onyx.set(`${ONYXKEYS.COLLECTION.POLICY}${fakePolicy.id}`, fakePolicy);
             await Onyx.set(`${ONYXKEYS.NVP_ACTIVE_POLICY_ID}`, fakePolicy.id);
-            await Onyx.set(`${ONYXKEYS.NVP_INTRO_SELECTED}`, {choice: CONST.ONBOARDING_CHOICES.MANAGE_TEAM});
+            await Onyx.set(`${ONYXKEYS.NVP_INTRO_SELECTED}`, { choice: CONST.ONBOARDING_CHOICES.MANAGE_TEAM });
             await waitForBatchedUpdates();
 
             let adminReportID;
@@ -347,12 +347,12 @@ describe('actions/Policy', () => {
                 expect(report?.pendingFields?.addWorkspaceRoom).toBe(CONST.RED_BRICK_ROAD_PENDING_ACTION.ADD);
                 switch (report?.chatType) {
                     case CONST.REPORT.CHAT_TYPE.POLICY_ADMINS: {
-                        expect(report?.participants).toEqual({[ESH_ACCOUNT_ID]: ESH_PARTICIPANT_ADMINS_ROOM});
+                        expect(report?.participants).toEqual({ [ESH_ACCOUNT_ID]: ESH_PARTICIPANT_ADMINS_ROOM });
                         adminReportID = report.reportID;
                         break;
                     }
                     case CONST.REPORT.CHAT_TYPE.POLICY_EXPENSE_CHAT: {
-                        expect(report?.participants).toEqual({[ESH_ACCOUNT_ID]: ESH_PARTICIPANT_EXPENSE_CHAT});
+                        expect(report?.participants).toEqual({ [ESH_ACCOUNT_ID]: ESH_PARTICIPANT_EXPENSE_CHAT });
                         expenseReportID = report.reportID;
                         break;
                     }
@@ -510,8 +510,8 @@ describe('actions/Policy', () => {
 
         it('create a new workspace fails will reset hasCompletedGuidedSetupFlow to the correct value', async () => {
             (fetch as MockFetch)?.pause?.();
-            await Onyx.set(ONYXKEYS.SESSION, {email: ESH_EMAIL, accountID: ESH_ACCOUNT_ID});
-            await Onyx.set(ONYXKEYS.NVP_ONBOARDING, {hasCompletedGuidedSetupFlow: true, chatReportID: '12345'});
+            await Onyx.set(ONYXKEYS.SESSION, { email: ESH_EMAIL, accountID: ESH_ACCOUNT_ID });
+            await Onyx.set(ONYXKEYS.NVP_ONBOARDING, { hasCompletedGuidedSetupFlow: true, chatReportID: '12345' });
             await waitForBatchedUpdates();
 
             (fetch as MockFetch)?.fail?.();
@@ -696,7 +696,7 @@ describe('actions/Policy', () => {
         });
 
         it('should pass areDistanceRatesEnabled as true when creating workspace with distance rates feature enabled', async () => {
-            await Onyx.set(ONYXKEYS.SESSION, {email: ESH_EMAIL, accountID: ESH_ACCOUNT_ID});
+            await Onyx.set(ONYXKEYS.SESSION, { email: ESH_EMAIL, accountID: ESH_ACCOUNT_ID });
             await waitForBatchedUpdates();
 
             const apiWriteSpy = jest.spyOn(require('@libs/API'), 'write').mockImplementation(() => Promise.resolve());
@@ -734,12 +734,12 @@ describe('actions/Policy', () => {
 
     describe('createDraftInitialWorkspace', () => {
         it('creates a policy draft with disabled workflows when onboarding choice does not enable workflows', async () => {
-            await Onyx.set(ONYXKEYS.SESSION, {email: ESH_EMAIL, accountID: ESH_ACCOUNT_ID});
+            await Onyx.set(ONYXKEYS.SESSION, { email: ESH_EMAIL, accountID: ESH_ACCOUNT_ID });
             await waitForBatchedUpdates();
 
             const policyID = Policy.generatePolicyID();
 
-            Policy.createDraftInitialWorkspace({choice: CONST.ONBOARDING_CHOICES.TRACK_WORKSPACE}, ESH_EMAIL, WORKSPACE_NAME, policyID, false, CONST.CURRENCY.EUR);
+            Policy.createDraftInitialWorkspace({ choice: CONST.ONBOARDING_CHOICES.TRACK_WORKSPACE }, ESH_EMAIL, WORKSPACE_NAME, policyID, false, CONST.CURRENCY.EUR);
             await waitForBatchedUpdates();
 
             const draft = await getOnyxValue(`${ONYXKEYS.COLLECTION.POLICY_DRAFTS}${policyID}`);
@@ -751,13 +751,13 @@ describe('actions/Policy', () => {
         });
 
         it('uses generated workspace name when policyName is not provided', async () => {
-            await Onyx.set(ONYXKEYS.SESSION, {email: ESH_EMAIL, accountID: ESH_ACCOUNT_ID});
+            await Onyx.set(ONYXKEYS.SESSION, { email: ESH_EMAIL, accountID: ESH_ACCOUNT_ID });
             await waitForBatchedUpdates();
 
             const policyID = Policy.generatePolicyID();
             const expectedName = Policy.generateDefaultWorkspaceName(ESH_EMAIL);
 
-            Policy.createDraftInitialWorkspace({choice: CONST.ONBOARDING_CHOICES.MANAGE_TEAM}, ESH_EMAIL, '', policyID, false);
+            Policy.createDraftInitialWorkspace({ choice: CONST.ONBOARDING_CHOICES.MANAGE_TEAM }, ESH_EMAIL, '', policyID, false);
             await waitForBatchedUpdates();
 
             const draft = await getOnyxValue(`${ONYXKEYS.COLLECTION.POLICY_DRAFTS}${policyID}`);
@@ -768,11 +768,11 @@ describe('actions/Policy', () => {
 
     describe('createDraftWorkspace', () => {
         it('sets key defaults and related drafts when onboarding choice enables workflows', async () => {
-            await Onyx.set(ONYXKEYS.SESSION, {email: ESH_EMAIL, accountID: ESH_ACCOUNT_ID});
+            await Onyx.set(ONYXKEYS.SESSION, { email: ESH_EMAIL, accountID: ESH_ACCOUNT_ID });
             await waitForBatchedUpdates();
 
             const policyID = Policy.generatePolicyID();
-            const params = Policy.createDraftWorkspace({choice: CONST.ONBOARDING_CHOICES.MANAGE_TEAM}, ESH_EMAIL, true, WORKSPACE_NAME, policyID, CONST.CURRENCY.USD);
+            const params = Policy.createDraftWorkspace({ choice: CONST.ONBOARDING_CHOICES.MANAGE_TEAM }, ESH_EMAIL, true, WORKSPACE_NAME, policyID, CONST.CURRENCY.USD);
             await waitForBatchedUpdates();
 
             const draft = await getOnyxValue(`${ONYXKEYS.COLLECTION.POLICY_DRAFTS}${policyID}`);
@@ -796,11 +796,11 @@ describe('actions/Policy', () => {
         });
 
         it('disables workflows and sets approval to OPTIONAL when onboarding choice does not enable workflows', async () => {
-            await Onyx.set(ONYXKEYS.SESSION, {email: ESH_EMAIL, accountID: ESH_ACCOUNT_ID});
+            await Onyx.set(ONYXKEYS.SESSION, { email: ESH_EMAIL, accountID: ESH_ACCOUNT_ID });
             await waitForBatchedUpdates();
 
             const policyID = Policy.generatePolicyID();
-            Policy.createDraftWorkspace({choice: CONST.ONBOARDING_CHOICES.TRACK_WORKSPACE}, ESH_EMAIL, false, WORKSPACE_NAME, policyID, CONST.CURRENCY.EUR);
+            Policy.createDraftWorkspace({ choice: CONST.ONBOARDING_CHOICES.TRACK_WORKSPACE }, ESH_EMAIL, false, WORKSPACE_NAME, policyID, CONST.CURRENCY.EUR);
             await waitForBatchedUpdates();
 
             const draft = await getOnyxValue(`${ONYXKEYS.COLLECTION.POLICY_DRAFTS}${policyID}`);
@@ -933,7 +933,7 @@ describe('actions/Policy', () => {
     describe('enablePolicyRules', () => {
         it('should disable preventSelfApproval when the rule feature is turned off', async () => {
             (fetch as MockFetch)?.pause?.();
-            Onyx.set(ONYXKEYS.SESSION, {email: ESH_EMAIL, accountID: ESH_ACCOUNT_ID});
+            Onyx.set(ONYXKEYS.SESSION, { email: ESH_EMAIL, accountID: ESH_ACCOUNT_ID });
             const fakePolicy: PolicyType = {
                 ...createRandomPolicy(0, CONST.POLICY.TYPE.TEAM),
                 areRulesEnabled: true,
@@ -982,7 +982,7 @@ describe('actions/Policy', () => {
     describe('setWorkspaceApprovalMode', () => {
         it('should not change employee list when disabling approval', async () => {
             (fetch as MockFetch)?.pause?.();
-            await Onyx.set(ONYXKEYS.SESSION, {email: ESH_EMAIL, accountID: ESH_ACCOUNT_ID});
+            await Onyx.set(ONYXKEYS.SESSION, { email: ESH_EMAIL, accountID: ESH_ACCOUNT_ID });
 
             const policyID = Policy.generatePolicyID();
             const employeeList = {
@@ -1042,6 +1042,84 @@ describe('actions/Policy', () => {
             expect(policy?.pendingFields?.approvalMode).toBeFalsy();
             expect(policy?.employeeList).toEqual(employeeList);
             expect(policy?.approvalMode).toBe(CONST.POLICY.APPROVAL_MODE.OPTIONAL);
+        });
+
+        it('should update employee submitsTo when re-enabling approval (fixes #76719)', async () => {
+            // This test verifies the fix for the duplicate workflows bug
+            // Scenario: User changes approver, disables approvals, then re-enables - should show 1 workflow not 2
+            (fetch as MockFetch)?.pause?.();
+            await Onyx.set(ONYXKEYS.SESSION, { email: ESH_EMAIL, accountID: ESH_ACCOUNT_ID });
+
+            const policyID = Policy.generatePolicyID();
+            const oldApprover = 'oldapprover@example.com';
+            const newApprover = ESH_EMAIL;
+
+            // Setup: Employee submits to old approver, but policy was in OPTIONAL mode
+            const employeeList = {
+                [ESH_EMAIL]: {
+                    email: ESH_EMAIL,
+                    submitsTo: oldApprover, // Stale submitsTo from before approvals were disabled
+                    role: CONST.POLICY.ROLE.ADMIN,
+                },
+                [EMPLOYEE_EMAIL]: {
+                    email: EMPLOYEE_EMAIL,
+                    submitsTo: oldApprover, // Stale submitsTo from before approvals were disabled
+                    role: CONST.POLICY.ROLE.USER,
+                },
+            };
+
+            const fakePolicy: PolicyType = {
+                ...createRandomPolicy(0, CONST.POLICY.TYPE.TEAM),
+                id: policyID,
+                approvalMode: CONST.POLICY.APPROVAL_MODE.OPTIONAL, // Approvals are currently disabled
+                approver: oldApprover,
+                owner: ESH_EMAIL,
+                employeeList,
+            };
+            await Onyx.set(`${ONYXKEYS.COLLECTION.POLICY}${policyID}`, fakePolicy);
+            await waitForBatchedUpdates();
+
+            // Action: Re-enable approvals with new approver
+            Policy.setWorkspaceApprovalMode(policyID, newApprover, CONST.POLICY.APPROVAL_MODE.BASIC);
+            await waitForBatchedUpdates();
+
+            let policy: OnyxEntry<PolicyType> = await new Promise((resolve) => {
+                const connection = Onyx.connect({
+                    key: `${ONYXKEYS.COLLECTION.POLICY}${policyID}`,
+                    callback: (workspace) => {
+                        Onyx.disconnect(connection);
+                        resolve(workspace);
+                    },
+                });
+            });
+
+            // Verify: Approval mode changed to BASIC
+            expect(policy?.approvalMode).toBe(CONST.POLICY.APPROVAL_MODE.BASIC);
+            expect(policy?.approver).toBe(newApprover);
+
+            // The key fix: Employee submitsTo should be updated to new approver
+            expect(policy?.employeeList?.[ESH_EMAIL]?.submitsTo).toBe(newApprover);
+            expect(policy?.employeeList?.[EMPLOYEE_EMAIL]?.submitsTo).toBe(newApprover);
+            expect(policy?.employeeList?.[ESH_EMAIL]?.pendingAction).toBe(CONST.RED_BRICK_ROAD_PENDING_ACTION.UPDATE);
+            expect(policy?.employeeList?.[EMPLOYEE_EMAIL]?.pendingAction).toBe(CONST.RED_BRICK_ROAD_PENDING_ACTION.UPDATE);
+
+            (fetch as MockFetch)?.resume?.();
+            await waitForBatchedUpdates();
+
+            policy = await new Promise((resolve) => {
+                const connection = Onyx.connect({
+                    key: `${ONYXKEYS.COLLECTION.POLICY}${policyID}`,
+                    callback: (workspace) => {
+                        Onyx.disconnect(connection);
+                        resolve(workspace);
+                    },
+                });
+            });
+
+            // Verify: Pending action should be cleared after success
+            expect(policy?.pendingFields?.approvalMode).toBeFalsy();
+            expect(policy?.employeeList?.[ESH_EMAIL]?.pendingAction).toBeFalsy();
+            expect(policy?.employeeList?.[EMPLOYEE_EMAIL]?.pendingAction).toBeFalsy();
         });
     });
 
@@ -1146,8 +1224,8 @@ describe('actions/Policy', () => {
             });
 
             await Onyx.merge(`${ONYXKEYS.COLLECTION.TRANSACTION_VIOLATIONS}${transactionID}`, [
-                {name: 'cashExpenseWithNoReceipt', type: CONST.VIOLATION_TYPES.VIOLATION},
-                {name: 'hold', type: CONST.VIOLATION_TYPES.WARNING},
+                { name: 'cashExpenseWithNoReceipt', type: CONST.VIOLATION_TYPES.VIOLATION },
+                { name: 'hold', type: CONST.VIOLATION_TYPES.WARNING },
             ]);
 
             Policy.deleteWorkspace({
@@ -1160,8 +1238,8 @@ describe('actions/Policy', () => {
                 transactionViolations: {
                     // eslint-disable-next-line @typescript-eslint/naming-convention
                     transactionViolations_3: [
-                        {name: 'cashExpenseWithNoReceipt', type: CONST.VIOLATION_TYPES.VIOLATION},
-                        {name: 'hold', type: CONST.VIOLATION_TYPES.WARNING},
+                        { name: 'cashExpenseWithNoReceipt', type: CONST.VIOLATION_TYPES.VIOLATION },
+                        { name: 'hold', type: CONST.VIOLATION_TYPES.WARNING },
                     ],
                 },
                 reimbursementAccountError: undefined,
@@ -1308,7 +1386,7 @@ describe('actions/Policy', () => {
             });
 
             const workspaceName = Policy.generateDefaultWorkspaceName(TEST_NON_PUBLIC_DOMAIN_EMAIL);
-            expect(workspaceName).toBe(TestHelper.translateLocal('workspace.new.workspaceName', {userName: displayNameForWorkspace}));
+            expect(workspaceName).toBe(TestHelper.translateLocal('workspace.new.workspaceName', { userName: displayNameForWorkspace }));
         });
 
         it('should generate a workspace name based on the display name when the domain is public and display name is available', () => {
@@ -1321,7 +1399,7 @@ describe('actions/Policy', () => {
             });
 
             const workspaceName = Policy.generateDefaultWorkspaceName(TEST_EMAIL);
-            expect(workspaceName).toBe(TestHelper.translateLocal('workspace.new.workspaceName', {userName: displayNameForWorkspace}));
+            expect(workspaceName).toBe(TestHelper.translateLocal('workspace.new.workspaceName', { userName: displayNameForWorkspace }));
         });
 
         it('should generate a workspace name based on the username when the domain is public and display name is not available', () => {
@@ -1336,7 +1414,7 @@ describe('actions/Policy', () => {
             });
 
             const workspaceName = Policy.generateDefaultWorkspaceName(TEST_EMAIL_2);
-            expect(workspaceName).toBe(TestHelper.translateLocal('workspace.new.workspaceName', {userName: displayNameForWorkspace}));
+            expect(workspaceName).toBe(TestHelper.translateLocal('workspace.new.workspaceName', { userName: displayNameForWorkspace }));
         });
 
         it('should generate a workspace name with an incremented number when there are existing policies with similar names', async () => {
@@ -1354,7 +1432,7 @@ describe('actions/Policy', () => {
             await Onyx.set(ONYXKEYS.COLLECTION.POLICY, existingPolicies);
 
             const workspaceName = Policy.generateDefaultWorkspaceName(TEST_EMAIL);
-            expect(workspaceName).toBe(TestHelper.translateLocal('workspace.new.workspaceName', {userName: TEST_DISPLAY_NAME, workspaceNumber: 2}));
+            expect(workspaceName).toBe(TestHelper.translateLocal('workspace.new.workspaceName', { userName: TEST_DISPLAY_NAME, workspaceNumber: 2 }));
         });
 
         it('should return "My Group Workspace" when the domain is SMS', () => {
@@ -1387,14 +1465,14 @@ describe('actions/Policy', () => {
             await Onyx.set(ONYXKEYS.COLLECTION.POLICY, existingPolicies);
 
             const workspaceName = Policy.generateDefaultWorkspaceName(TEST_EMAIL);
-            expect(workspaceName).toBe(TestHelper.translateLocal('workspace.new.workspaceName', {userName: TEST_DISPLAY_NAME, workspaceNumber: 2}));
+            expect(workspaceName).toBe(TestHelper.translateLocal('workspace.new.workspaceName', { userName: TEST_DISPLAY_NAME, workspaceNumber: 2 }));
         });
     });
 
     describe('enablePolicyWorkflows', () => {
         it('should update delayed submission to instant when disabling the workflows feature', async () => {
             (fetch as MockFetch)?.pause?.();
-            Onyx.set(ONYXKEYS.SESSION, {email: ESH_EMAIL, accountID: ESH_ACCOUNT_ID});
+            Onyx.set(ONYXKEYS.SESSION, { email: ESH_EMAIL, accountID: ESH_ACCOUNT_ID });
             const fakePolicy: PolicyType = {
                 ...createRandomPolicy(0, CONST.POLICY.TYPE.TEAM),
                 areWorkflowsEnabled: true,


### PR DESCRIPTION
## Details
Fixes #76719 

When re-enabling the "Add approvals" workflow toggle after changing the approver and disabling approvals, two workflows were displayed instead of one.

**Root Cause:** [setWorkspaceApprovalMode](cci:1://file:///Users/Shailesh/Applications/Cursor/OSS_Contributions/Expensify/App/src/libs/actions/Policy/Policy.ts:795:0-886:1) only updated `policy.approver` but not employees' `submitsTo` fields, causing stale data to create duplicate workflows via [convertPolicyEmployeesToApprovalWorkflows](cci:1://file:///Users/Shailesh/Applications/Cursor/OSS_Contributions/Expensify/App/src/libs/WorkflowUtils.ts:101:0-174:1).

**Fix:** When enabling approvals (OPTIONAL → BASIC/ADVANCED), update all employees' `submitsTo` fields to the new default approver.

### Fixed Issues
- https://github.com/Expensify/App/issues/76719

### Tests
- Added test case for the bug scenario in [PolicyTest.ts](cci:7://file:///Users/Shailesh/Applications/Cursor/OSS_Contributions/Expensify/App/tests/actions/PolicyTest.ts:0:0-0:0)
- All existing tests pass (38/38 PolicyTest, 22/22 WorkflowUtilsTest, 3/3 WorkflowTest)
- TypeScript compilation passes

### QA Steps
1. Go to Workspaces → select a Collect workspace → Workflows
2. Change the Approver to a different person
3. Disable "Add approvals" toggle
4. Re-enable "Add approvals" toggle
5. ✅ Verify only ONE approval workflow is displayed