### PR TITLE
[No QA] feat: add Sentry debug controls to Troubleshoot page

### DIFF
--- a/src/ONYXKEYS.ts
+++ b/src/ONYXKEYS.ts
@@ -453,6 +453,12 @@ const ONYXKEYS = {
     /** Indicates whether the debug mode is currently enabled */
     IS_DEBUG_MODE_ENABLED: 'isDebugModeEnabled',
 
+    /** Indicates whether Sentry debug mode is enabled - logs Sentry requests to console */
+    IS_SENTRY_DEBUG_ENABLED: 'isSentryDebugEnabled',
+
+    /** List of span operations to highlight in Sentry debug logs */
+    SENTRY_DEBUG_HIGHLIGHTED_SPAN_OPS: 'sentryDebugHighlightedSpanOps',
+
     /** Stores new group chat draft */
     NEW_GROUP_CHAT_DRAFT: 'newGroupChatDraft',
 
@@ -1254,6 +1260,8 @@ type OnyxValuesMapping = {
     [ONYXKEYS.SHOULD_MASK_ONYX_STATE]: boolean;
     [ONYXKEYS.SHOULD_USE_STAGING_SERVER]: boolean;
     [ONYXKEYS.IS_DEBUG_MODE_ENABLED]: boolean;
+    [ONYXKEYS.IS_SENTRY_DEBUG_ENABLED]: boolean;
+    [ONYXKEYS.SENTRY_DEBUG_HIGHLIGHTED_SPAN_OPS]: string[];
     [ONYXKEYS.CACHED_PDF_PATHS]: Record<string, string>;
     [ONYXKEYS.POLICY_OWNERSHIP_CHANGE_CHECKS]: Record<string, OnyxTypes.PolicyOwnershipChangeChecks>;
     [ONYXKEYS.NVP_QUICK_ACTION_GLOBAL_CREATE]: OnyxTypes.QuickAction;

--- a/src/components/SentryDebugToolMenu.tsx
+++ b/src/components/SentryDebugToolMenu.tsx
@@ -1,0 +1,82 @@
+import React, {useState} from 'react';
+import {View} from 'react-native';
+import useLocalize from '@hooks/useLocalize';
+import useOnyx from '@hooks/useOnyx';
+import useThemeStyles from '@hooks/useThemeStyles';
+import {setIsSentryDebugEnabled, setSentryDebugHighlightedSpanOps} from '@libs/actions/SentryDebug';
+import ONYXKEYS from '@src/ONYXKEYS';
+import Switch from './Switch';
+import TestToolRow from './TestToolRow';
+import Text from './Text';
+import TextInput from './TextInput';
+
+type SentryDebugToggleProps = {
+    isEnabled: boolean;
+};
+
+function SentryDebugToggle({isEnabled}: SentryDebugToggleProps) {
+    const {translate} = useLocalize();
+
+    return (
+        <TestToolRow title={translate('initialSettingsPage.troubleshoot.sentryDebugDescription')}>
+            <Switch
+                accessibilityLabel={translate('initialSettingsPage.troubleshoot.sentryDebug')}
+                isOn={isEnabled}
+                onToggle={() => setIsSentryDebugEnabled(!isEnabled)}
+            />
+        </TestToolRow>
+    );
+}
+
+function HighlightedSpanOpsInput() {
+    const styles = useThemeStyles();
+    const {translate} = useLocalize();
+    const [highlightedSpanOps] = useOnyx(ONYXKEYS.SENTRY_DEBUG_HIGHLIGHTED_SPAN_OPS, {canBeMissing: true});
+    const [inputValue, setInputValue] = useState(() => highlightedSpanOps?.join(', '));
+
+    const handleChange = (text: string) => {
+        setInputValue(text);
+        const spanOps = text
+            .split(',')
+            .map((op) => op.trim())
+            .filter((op) => op.length > 0);
+        setSentryDebugHighlightedSpanOps(spanOps);
+    };
+
+    return (
+        <View style={styles.mt4}>
+            <Text style={[styles.textLabelSupporting, styles.mb2]}>{translate('initialSettingsPage.troubleshoot.sentryHighlightedSpanOps')}</Text>
+            <TextInput
+                accessibilityLabel={translate('initialSettingsPage.troubleshoot.sentryHighlightedSpanOps')}
+                value={inputValue}
+                onChangeText={handleChange}
+                placeholder={translate('initialSettingsPage.troubleshoot.sentryHighlightedSpanOpsDescription')}
+            />
+        </View>
+    );
+}
+
+function SentryDebugToolMenu() {
+    const styles = useThemeStyles();
+    const {translate} = useLocalize();
+    const [isSentryDebugEnabled = false] = useOnyx(ONYXKEYS.IS_SENTRY_DEBUG_ENABLED, {canBeMissing: true});
+
+    return (
+        <>
+            <Text
+                style={[styles.textLabelSupporting, styles.mb4, styles.mt6]}
+                numberOfLines={1}
+            >
+                {translate('initialSettingsPage.troubleshoot.sentryDebug')}
+            </Text>
+
+            <SentryDebugToggle isEnabled={isSentryDebugEnabled} />
+
+            {isSentryDebugEnabled && <HighlightedSpanOpsInput />}
+        </>
+    );
+}
+
+SentryDebugToolMenu.displayName = 'SentryDebugToolMenu';
+
+export default SentryDebugToolMenu;

--- a/src/components/SentryDebugToolMenu.tsx
+++ b/src/components/SentryDebugToolMenu.tsx
@@ -50,7 +50,7 @@ function HighlightedSpanOpsInput() {
                 accessibilityLabel={translate('initialSettingsPage.troubleshoot.sentryHighlightedSpanOps')}
                 value={inputValue}
                 onChangeText={handleChange}
-                placeholder={translate('initialSettingsPage.troubleshoot.sentryHighlightedSpanOpsDescription')}
+                placeholder={translate('initialSettingsPage.troubleshoot.sentryHighlightedSpanOpsPlaceholder')}
             />
         </View>
     );

--- a/src/components/SentryDebugToolMenu.tsx
+++ b/src/components/SentryDebugToolMenu.tsx
@@ -47,6 +47,7 @@ function HighlightedSpanOpsInput() {
         <View style={styles.mt4}>
             <Text style={[styles.textLabelSupporting, styles.mb2]}>{translate('initialSettingsPage.troubleshoot.sentryHighlightedSpanOps')}</Text>
             <TextInput
+                autoCapitalize="none"
                 accessibilityLabel={translate('initialSettingsPage.troubleshoot.sentryHighlightedSpanOps')}
                 value={inputValue}
                 onChangeText={handleChange}

--- a/src/languages/de.ts
+++ b/src/languages/de.ts
@@ -1927,6 +1927,10 @@ const translations: TranslationDeepObject<typeof en> = {
             recordTroubleshootData: 'Fehlerdaten aufzeichnen',
             softKillTheApp: 'App sanft beenden',
             kill: 'Beenden',
+            sentryDebug: 'Sentry-Debug',
+            sentryDebugDescription: 'Sentry-Anfragen in der Konsole protokollieren',
+            sentryHighlightedSpanOps: 'Hervorgehobene Span-Namen',
+            sentryHighlightedSpanOpsPlaceholder: 'ui.interaction.click, navigation, ui.load',
         },
         debugConsole: {
             saveLog: 'Protokoll speichern',

--- a/src/languages/en.ts
+++ b/src/languages/en.ts
@@ -1900,8 +1900,8 @@ const translations = {
             kill: 'Kill',
             sentryDebug: 'Sentry debug',
             sentryDebugDescription: 'Log Sentry requests to console',
-            sentryHighlightedSpanOps: 'Highlighted span operations',
-            sentryHighlightedSpanOpsDescription: 'Comma-separated list of span operations to highlight (e.g. ui.interaction.click, navigation)',
+            sentryHighlightedSpanOps: 'Highlighted span names',
+            sentryHighlightedSpanOpsPlaceholder: 'ui.interaction.click, navigation, ui.load',
         },
         debugConsole: {
             saveLog: 'Save log',

--- a/src/languages/en.ts
+++ b/src/languages/en.ts
@@ -1898,6 +1898,10 @@ const translations = {
             recordTroubleshootData: 'Record Troubleshoot Data',
             softKillTheApp: 'Soft kill the app',
             kill: 'Kill',
+            sentryDebug: 'Sentry debug',
+            sentryDebugDescription: 'Log Sentry requests to console',
+            sentryHighlightedSpanOps: 'Highlighted span operations',
+            sentryHighlightedSpanOpsDescription: 'Comma-separated list of span operations to highlight (e.g. ui.interaction.click, navigation)',
         },
         debugConsole: {
             saveLog: 'Save log',

--- a/src/languages/es.ts
+++ b/src/languages/es.ts
@@ -1516,6 +1516,10 @@ const translations: TranslationDeepObject<typeof en> = {
             recordTroubleshootData: 'Registrar datos de resolución de problemas',
             softKillTheApp: 'Desactivar la aplicación',
             kill: 'Matar',
+            sentryDebug: 'Depuración de Sentry',
+            sentryDebugDescription: 'Registrar las solicitudes de Sentry en la consola',
+            sentryHighlightedSpanOps: 'Nombres de spans resaltados',
+            sentryHighlightedSpanOpsPlaceholder: 'ui.interaction.click, navigation, ui.load',
         },
         debugConsole: {
             saveLog: 'Guardar registro',

--- a/src/languages/fr.ts
+++ b/src/languages/fr.ts
@@ -1927,6 +1927,10 @@ const translations: TranslationDeepObject<typeof en> = {
             recordTroubleshootData: 'Enregistrer les données de dépannage',
             softKillTheApp: 'Fermer l’application en douceur',
             kill: 'Tuer',
+            sentryDebug: 'Débogage Sentry',
+            sentryDebugDescription: 'Enregistrer les requêtes Sentry dans la console',
+            sentryHighlightedSpanOps: 'Noms de spans mis en valeur',
+            sentryHighlightedSpanOpsPlaceholder: 'ui.interaction.click, navigation, ui.load',
         },
         debugConsole: {
             saveLog: 'Enregistrer le journal',

--- a/src/languages/it.ts
+++ b/src/languages/it.ts
@@ -1922,6 +1922,10 @@ const translations: TranslationDeepObject<typeof en> = {
             recordTroubleshootData: 'Registrare dati di risoluzione problemi',
             softKillTheApp: "Termina l'app in modo non forzato",
             kill: 'Termina',
+            sentryDebug: 'Debug Sentry',
+            sentryDebugDescription: 'Registra le richieste Sentry nella console',
+            sentryHighlightedSpanOps: 'Nomi degli span evidenziati',
+            sentryHighlightedSpanOpsPlaceholder: 'ui.interaction.click, navigation, ui.load',
         },
         debugConsole: {
             saveLog: 'Salva registro',

--- a/src/languages/ja.ts
+++ b/src/languages/ja.ts
@@ -1922,6 +1922,10 @@ const translations: TranslationDeepObject<typeof en> = {
             recordTroubleshootData: 'トラブルシュートデータを記録',
             softKillTheApp: 'アプリをソフト終了する',
             kill: '強制終了',
+            sentryDebug: 'Sentryデバッグ',
+            sentryDebugDescription: 'Sentryリクエストをコンソールに記録',
+            sentryHighlightedSpanOps: 'ハイライト表示するspan名',
+            sentryHighlightedSpanOpsPlaceholder: 'ui.interaction.click, navigation, ui.load',
         },
         debugConsole: {
             saveLog: 'ログを保存',

--- a/src/languages/nl.ts
+++ b/src/languages/nl.ts
@@ -1920,6 +1920,10 @@ const translations: TranslationDeepObject<typeof en> = {
             recordTroubleshootData: 'Gegevens voor probleemoplossing vastleggen',
             softKillTheApp: 'De app zacht afsluiten',
             kill: 'Beëindigen',
+            sentryDebug: 'Sentry-debug',
+            sentryDebugDescription: 'Sentry-verzoeken naar console loggen',
+            sentryHighlightedSpanOps: 'Geresalteerde spannamen',
+            sentryHighlightedSpanOpsPlaceholder: 'ui.interaction.click, navigation, ui.load',
         },
         debugConsole: {
             saveLog: 'Log opslaan',

--- a/src/languages/pl.ts
+++ b/src/languages/pl.ts
@@ -1918,6 +1918,10 @@ const translations: TranslationDeepObject<typeof en> = {
             recordTroubleshootData: 'Rejestruj dane diagnostyczne',
             softKillTheApp: 'Delikatnie zakończ działanie aplikacji',
             kill: 'Zakończ',
+            sentryDebug: 'Debugowanie Sentry',
+            sentryDebugDescription: 'Rejestruj żądania Sentry w konsoli',
+            sentryHighlightedSpanOps: 'Nazwy wyróżnionych spanów',
+            sentryHighlightedSpanOpsPlaceholder: 'ui.interaction.click, navigation, ui.load',
         },
         debugConsole: {
             saveLog: 'Zapisz log',

--- a/src/languages/pt-BR.ts
+++ b/src/languages/pt-BR.ts
@@ -1917,6 +1917,10 @@ const translations: TranslationDeepObject<typeof en> = {
             recordTroubleshootData: 'Registrar Dados de Solução de Problemas',
             softKillTheApp: 'Encerrar o aplicativo sem forçar',
             kill: 'Encerrar',
+            sentryDebug: 'Depuração do Sentry',
+            sentryDebugDescription: 'Registrar solicitações do Sentry no console',
+            sentryHighlightedSpanOps: 'Nomes de spans destacados',
+            sentryHighlightedSpanOpsPlaceholder: 'ui.interaction.click, navigation, ui.load',
         },
         debugConsole: {
             saveLog: 'Salvar log',

--- a/src/languages/zh-hans.ts
+++ b/src/languages/zh-hans.ts
@@ -1892,6 +1892,10 @@ const translations: TranslationDeepObject<typeof en> = {
             recordTroubleshootData: '记录故障排查数据',
             softKillTheApp: '软关闭应用',
             kill: '终止',
+            sentryDebug: 'Sentry调试',
+            sentryDebugDescription: '将Sentry请求记录到控制台',
+            sentryHighlightedSpanOps: '突出显示的Span名称',
+            sentryHighlightedSpanOpsPlaceholder: 'ui.interaction.click, navigation, ui.load',
         },
         debugConsole: {
             saveLog: '保存日志',

--- a/src/libs/actions/SentryDebug.ts
+++ b/src/libs/actions/SentryDebug.ts
@@ -1,0 +1,19 @@
+import Onyx from 'react-native-onyx';
+import ONYXKEYS from '@src/ONYXKEYS';
+
+/**
+ * Set whether Sentry debug mode is enabled
+ * When enabled, Sentry requests are logged to console
+ */
+function setIsSentryDebugEnabled(isEnabled: boolean) {
+    Onyx.set(ONYXKEYS.IS_SENTRY_DEBUG_ENABLED, isEnabled);
+}
+
+/**
+ * Set the list of span operations to highlight in Sentry debug logs
+ */
+function setSentryDebugHighlightedSpanOps(spanOps: string[]) {
+    Onyx.set(ONYXKEYS.SENTRY_DEBUG_HIGHLIGHTED_SPAN_OPS, spanOps);
+}
+
+export {setIsSentryDebugEnabled, setSentryDebugHighlightedSpanOps};

--- a/src/pages/settings/Troubleshoot/TroubleshootPage.tsx
+++ b/src/pages/settings/Troubleshoot/TroubleshootPage.tsx
@@ -13,6 +13,7 @@ import ScreenWrapper from '@components/ScreenWrapper';
 import ScrollView from '@components/ScrollView';
 import {useSearchContext} from '@components/Search/SearchContext';
 import Section from '@components/Section';
+import SentryDebugToolMenu from '@components/SentryDebugToolMenu';
 import Switch from '@components/Switch';
 import TestToolMenu from '@components/TestToolMenu';
 import TestToolRow from '@components/TestToolRow';
@@ -51,7 +52,7 @@ function TroubleshootPage() {
     const troubleshootIllustration = useTroubleshootSectionIllustration();
     const {translate} = useLocalize();
     const styles = useThemeStyles();
-    const {isProduction} = useEnvironment();
+    const {isProduction, isDevelopment} = useEnvironment();
     const [isConfirmationModalVisible, setIsConfirmationModalVisible] = useState(false);
     const waitForNavigate = useWaitForNavigation();
     const {shouldUseNarrowLayout} = useResponsiveLayout();
@@ -216,6 +217,12 @@ function TroubleshootPage() {
                                     <TestToolMenu />
                                 </View>
                             )}
+                            {isDevelopment && (
+                                <View style={[styles.mt6]}>
+                                    <SentryDebugToolMenu />
+                                </View>
+                            )}
+
                             <ConfirmModal
                                 title={translate('common.areYouSure')}
                                 isVisible={isConfirmationModalVisible}

--- a/src/setup/telemetry/debugTransport.ts
+++ b/src/setup/telemetry/debugTransport.ts
@@ -23,11 +23,13 @@ Onyx.connectWithoutView({
     },
 });
 
+const SENTRY_LOG_PREFIX = '[SENTRY]';
+
 function formatLogPrefix(category: string, op?: string): string {
     if (op) {
-        return `[SENTRY][${category}][${op}]`;
+        return `${SENTRY_LOG_PREFIX}[${category}][${op}]`;
     }
-    return `[SENTRY][${category}]`;
+    return `${SENTRY_LOG_PREFIX}[${category}]`;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -101,7 +103,7 @@ function isSentryDebugLogEntry(logEntry: unknown): boolean {
     if (!isRecord(logEntry) || !('body' in logEntry) || !isString(logEntry.body)) {
         return false;
     }
-    return logEntry.body.startsWith('[SENTRY]');
+    return logEntry.body.startsWith(SENTRY_LOG_PREFIX);
 }
 
 /**

--- a/src/setup/telemetry/index.ts
+++ b/src/setup/telemetry/index.ts
@@ -7,13 +7,9 @@ import processBeforeSendTransactions from '@libs/telemetry/middlewares';
 import CONFIG from '@src/CONFIG';
 import CONST from '@src/CONST';
 import pkg from '../../../package.json';
-import makeDebugTransport, {DEBUG_SENTRY_ENABLED} from './debugTransport';
+import makeDebugTransport from './debugTransport';
 
 export default function (): void {
-    if (isDevelopment() && !DEBUG_SENTRY_ENABLED) {
-        return;
-    }
-
     const integrations = [navigationIntegration, tracingIntegration, browserProfilingIntegration, browserTracingIntegration].filter((integration) => !!integration);
 
     Sentry.init({


### PR DESCRIPTION

### Explanation of Change
Add UI controls to enable/disable Sentry debug logging at runtime without
code changes. Previously debugging Sentry required modifying constants in
debugTransport.ts and rebuilding the app.

Changes:
- Add SentryDebugToolMenu component with toggle and span filter input
- Store debug settings in Onyx (IS_SENTRY_DEBUG_ENABLED, SENTRY_DEBUG_HIGHLIGHTED_SPAN_OPS)
- Update debugTransport to read settings from Onyx instead of hardcoded constants
- Remove early return in telemetry/index.ts so Sentry initializes in dev mode
- Show Sentry debug section only in development environment

### Fixed Issues

$ https://github.com/Expensify/App/issues/76428
PROPOSAL:



### Tests

1. Launch the development environment
2. Go to the Troubleshoot panel
3. Enable "Log Sentry requests to console"
4. Set "Highlighted span operations" to `navigation.processing`
5. Do some navigation

- [x] Check if the `[SENTRY]` logs appear in the console
- [x] Check if `[SENTRY]` logs are not looping
- [x] Verify that no errors appear in the JS console

### Offline tests

### QA Steps

### PR Author Checklist


- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I verified there are no new alerts related to the `canBeMissing` param for `useOnyx`
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
        - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos

<details>
<summary>MacOS: Chrome / Safari</summary>

https://github.com/user-attachments/assets/78f72dcf-c0f6-4ee2-8f9d-2161b674097b


</details>

<details>
<summary>Android: Native</summary>

<img width="3466" height="1996" alt="image" src="https://github.com/user-attachments/assets/ea615b5e-e37b-4bfa-b6e5-0fbb223fbc0c" />

</details>


<details>
<summary>iOS: Native</summary>

<img width="1579" height="1014" alt="Screenshot 2025-12-10 at 18 08 21" src="https://github.com/user-attachments/assets/5ecdb729-da81-46ef-9273-9963696889e7" />


</details>



