### PR TITLE
Revert "[CP staging] Hide Change approver option when Add approvals is disabled in Workflows"

### DIFF
--- a/src/libs/SearchUIUtils.ts
+++ b/src/libs/SearchUIUtils.ts
@@ -1307,8 +1307,7 @@ function getActions(
         allActions.push(CONST.SEARCH.ACTION_TYPES.SUBMIT);
     }
 
-    const isApprovalEnabled = policy?.approvalMode && policy.approvalMode !== CONST.POLICY.APPROVAL_MODE.OPTIONAL;
-    if (report && policy && isPolicyAdmin(policy) && isExpenseReportUtil(report) && isProcessingReport(report) && !isMoneyRequestReportPendingDeletion(report) && isApprovalEnabled) {
+    if (report && policy && isPolicyAdmin(policy) && isExpenseReportUtil(report) && isProcessingReport(report) && !isMoneyRequestReportPendingDeletion(report)) {
         allActions.push(CONST.SEARCH.ACTION_TYPES.CHANGE_APPROVER);
     }
 


### PR DESCRIPTION
@jasperhuangg please review

I need to revert this hotfix PR so that I can revert the actual PR (https://github.com/Expensify/App/pull/75729)  that caused 3+ blockers in the deploy. 

Reverts Expensify/App#77321

Next time, please follow this StackOverflow: https://stackoverflowteams.com/c/expensify/questions/11964