### PR TITLE
Add tooltip on Global 'Create (+)' Button and Global Green 'Scan' Button

### DIFF
--- a/src/components/FloatingActionButton.tsx
+++ b/src/components/FloatingActionButton.tsx
@@ -16,6 +16,7 @@ import Icon from './Icon';
 import {PlusCircle} from './Icon/Expensicons';
 import {PressableWithFeedback, PressableWithoutFeedback} from './Pressable';
 import Text from './Text';
+import Tooltip from './Tooltip';
 
 const FAB_PATH = 'M12,3c0-1.1-0.9-2-2-2C8.9,1,8,1.9,8,3v5H3c-1.1,0-2,0.9-2,2c0,1.1,0.9,2,2,2h5v5c0,1.1,0.9,2,2,2c1.1,0,2-0.9,2-2v-5h5c1.1,0,2-0.9,2-2c0-1.1-0.9-2-2-2h-5V3z';
 const SMALL_FAB_PATH =
@@ -95,48 +96,50 @@ function FloatingActionButton({onPress, onLongPress, isActive, accessibilityLabe
 
     if (isLHBVisible) {
         return (
-            <PressableWithoutFeedback
-                ref={(el) => {
-                    fabPressable.current = el ?? null;
-                    if (buttonRef && 'current' in buttonRef) {
-                        buttonRef.current = el ?? null;
-                    }
-                }}
-                style={[
-                    styles.navigationTabBarFABItem,
+            <Tooltip text={accessibilityLabel}>
+                <PressableWithoutFeedback
+                    ref={(el) => {
+                        fabPressable.current = el ?? null;
+                        if (buttonRef && 'current' in buttonRef) {
+                            buttonRef.current = el ?? null;
+                        }
+                    }}
+                    style={[
+                        styles.navigationTabBarFABItem,
 
-                    // Prevent text selection on touch devices (e.g. on long press)
-                    canUseTouchScreen() && styles.userSelectNone,
-                    styles.flex1,
-                ]}
-                accessibilityLabel={accessibilityLabel}
-                onPress={toggleFabAction}
-                onLongPress={longPressFabAction}
-                role={role}
-                shouldUseHapticsOnLongPress
-                testID="floating-action-button"
-            >
-                {({hovered}) => {
-                    isHovered.set(hovered);
+                        // Prevent text selection on touch devices (e.g. on long press)
+                        canUseTouchScreen() && styles.userSelectNone,
+                        styles.flex1,
+                    ]}
+                    accessibilityLabel={accessibilityLabel}
+                    onPress={toggleFabAction}
+                    onLongPress={longPressFabAction}
+                    role={role}
+                    shouldUseHapticsOnLongPress
+                    testID="floating-action-button"
+                >
+                    {({hovered}) => {
+                        isHovered.set(hovered);
 
-                    return (
-                        <Animated.View
-                            style={[styles.floatingActionButton, {borderRadius}, styles.floatingActionButtonSmall, animatedStyle]}
-                            testID="fab-animated-container"
-                        >
-                            <Svg
-                                width={fabSize}
-                                height={fabSize}
+                        return (
+                            <Animated.View
+                                style={[styles.floatingActionButton, {borderRadius}, styles.floatingActionButtonSmall, animatedStyle]}
+                                testID="fab-animated-container"
                             >
-                                <AnimatedPath
-                                    d={isLHBVisible ? SMALL_FAB_PATH : FAB_PATH}
-                                    fill={icon}
-                                />
-                            </Svg>
-                        </Animated.View>
-                    );
-                }}
-            </PressableWithoutFeedback>
+                                <Svg
+                                    width={fabSize}
+                                    height={fabSize}
+                                >
+                                    <AnimatedPath
+                                        d={isLHBVisible ? SMALL_FAB_PATH : FAB_PATH}
+                                        fill={icon}
+                                    />
+                                </Svg>
+                            </Animated.View>
+                        );
+                    }}
+                </PressableWithoutFeedback>
+            </Tooltip>
         );
     }
 

--- a/src/components/FloatingActionButton.tsx
+++ b/src/components/FloatingActionButton.tsx
@@ -96,7 +96,7 @@ function FloatingActionButton({onPress, onLongPress, isActive, accessibilityLabe
 
     if (isLHBVisible) {
         return (
-            <Tooltip text={accessibilityLabel}>
+            <Tooltip text={translate('common.create')}>
                 <PressableWithoutFeedback
                     ref={(el) => {
                         fabPressable.current = el ?? null;

--- a/src/components/FloatingReceiptButton.tsx
+++ b/src/components/FloatingReceiptButton.tsx
@@ -9,6 +9,7 @@ import variables from '@styles/variables';
 import Icon from './Icon';
 import {ReceiptPlus} from './Icon/Expensicons';
 import {PressableWithoutFeedback} from './Pressable';
+import Tooltip from './Tooltip';
 
 type FloatingReceiptButtonProps = {
     /* Callback to fire on request to toggle the FloatingReceiptButton */
@@ -34,36 +35,38 @@ function FloatingReceiptButton({onPress, accessibilityLabel, role}: FloatingRece
     };
 
     return (
-        <PressableWithoutFeedback
-            ref={(el) => {
-                fabPressable.current = el ?? null;
-            }}
-            style={[
-                styles.navigationTabBarFABItem,
+        <Tooltip text={accessibilityLabel}>
+            <PressableWithoutFeedback
+                ref={(el) => {
+                    fabPressable.current = el ?? null;
+                }}
+                style={[
+                    styles.navigationTabBarFABItem,
 
-                // Prevent text selection on touch devices (e.g. on long press)
-                canUseTouchScreen() && styles.userSelectNone,
-            ]}
-            accessibilityLabel={accessibilityLabel}
-            onPress={toggleFabAction}
-            role={role}
-            shouldUseHapticsOnLongPress
-            testID="floating-receipt-button"
-        >
-            {({hovered}) => (
-                <View
-                    style={[styles.floatingActionButton, {borderRadius}, styles.floatingActionButtonSmall, hovered && {backgroundColor: successHover}]}
-                    testID="floating-receipt-button-container"
-                >
-                    <Icon
-                        fill={textLight}
-                        src={ReceiptPlus}
-                        width={variables.iconSizeSmall}
-                        height={variables.iconSizeSmall}
-                    />
-                </View>
-            )}
-        </PressableWithoutFeedback>
+                    // Prevent text selection on touch devices (e.g. on long press)
+                    canUseTouchScreen() && styles.userSelectNone,
+                ]}
+                accessibilityLabel={accessibilityLabel}
+                onPress={toggleFabAction}
+                role={role}
+                shouldUseHapticsOnLongPress
+                testID="floating-receipt-button"
+            >
+                {({hovered}) => (
+                    <View
+                        style={[styles.floatingActionButton, {borderRadius}, styles.floatingActionButtonSmall, hovered && {backgroundColor: successHover}]}
+                        testID="floating-receipt-button-container"
+                    >
+                        <Icon
+                            fill={textLight}
+                            src={ReceiptPlus}
+                            width={variables.iconSizeSmall}
+                            height={variables.iconSizeSmall}
+                        />
+                    </View>
+                )}
+            </PressableWithoutFeedback>
+        </Tooltip>
     );
 }
 

--- a/src/components/FloatingReceiptButton.tsx
+++ b/src/components/FloatingReceiptButton.tsx
@@ -2,6 +2,7 @@ import React, {useRef} from 'react';
 // eslint-disable-next-line no-restricted-imports
 import type {GestureResponderEvent, Role, Text, View as ViewType} from 'react-native';
 import {View} from 'react-native';
+import useLocalize from '@hooks/useLocalize';
 import useTheme from '@hooks/useTheme';
 import useThemeStyles from '@hooks/useThemeStyles';
 import {canUseTouchScreen} from '@libs/DeviceCapabilities';
@@ -27,6 +28,7 @@ function FloatingReceiptButton({onPress, accessibilityLabel, role}: FloatingRece
     const styles = useThemeStyles();
     const borderRadius = styles.floatingActionButton.borderRadius;
     const fabPressable = useRef<HTMLDivElement | ViewType | Text | null>(null);
+    const {translate} = useLocalize();
 
     const toggleFabAction = (event: GestureResponderEvent | KeyboardEvent | undefined) => {
         // Drop focus to avoid blue focus ring.
@@ -35,7 +37,7 @@ function FloatingReceiptButton({onPress, accessibilityLabel, role}: FloatingRece
     };
 
     return (
-        <Tooltip text={accessibilityLabel}>
+        <Tooltip text={translate('tabSelector.scan')}>
             <PressableWithoutFeedback
                 ref={(el) => {
                     fabPressable.current = el ?? null;


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
Add a tooltip on the Global Create ('Create') and Global Scan ('Scan') buttons when hovering

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/77472
PROPOSAL: https://github.com/Expensify/App/issues/77472#issuecomment-3644378686


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
Same as QA Steps

- [x] Verify that no errors appear in the JS console

### Offline tests
Same as QA Steps

### QA Steps

1. Log into New Expensify (Web)
2. Locate the global Create (+) button in the UI
3. Hover over the button
4. Verify that the tooltip "Create" is displayed
5. Locate the global Green Scan button
6. Hover over the button
7. Verify that the tooltip "Scan" is displayed

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I verified there are no new alerts related to the `canBeMissing` param for `useOnyx`
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

https://github.com/user-attachments/assets/32cbaeeb-9146-4f7f-93f3-25c0c0c9bc43

<!-- add screenshots or videos here -->

</details>