### PR TITLE
Fix/72129 follow up - Resolve regression from PR 74964 - No checkmark displayed for selected recipient in choose recipient page

### DIFF
--- a/src/libs/OptionsListUtils/index.ts
+++ b/src/libs/OptionsListUtils/index.ts
@@ -393,6 +393,7 @@ function getParticipantsOption(participant: OptionData | Participant, personalDe
         isSelected: participant.selected,
         selected: participant.selected, // Keep for backwards compatibility
         searchText: participant.searchText ?? undefined,
+        isSelfDM: !!detail?.accountID && detail?.accountID === currentUserAccountID,
     };
 }
 

--- a/src/pages/iou/request/MoneyRequestParticipantsSelector.tsx
+++ b/src/pages/iou/request/MoneyRequestParticipantsSelector.tsx
@@ -218,7 +218,7 @@ function MoneyRequestParticipantsSelector({
         [isIOUSplit, iouType, onParticipantsAdded],
     );
 
-    const {searchTerm, setSearchTerm, availableOptions, selectedOptions, toggleSelection, areOptionsInitialized, onListEndReached, contactState} = useSearchSelector({
+    const {searchTerm, setSearchTerm, availableOptions, selectedOptions, setSelectedOptions, toggleSelection, areOptionsInitialized, onListEndReached, contactState} = useSearchSelector({
         selectionMode: isIOUSplit ? CONST.SEARCH_SELECTOR.SELECTION_MODE_MULTI : CONST.SEARCH_SELECTOR.SELECTION_MODE_SINGLE,
         searchContext: CONST.SEARCH_SELECTOR.SEARCH_CONTEXT_GENERAL,
         includeUserToInvite: !isCategorizeOrShareAction && !isPerDiemRequest,
@@ -500,9 +500,10 @@ function MoneyRequestParticipantsSelector({
                 return;
             }
 
+            setSelectedOptions([{...option, isSelected: true, reportID: option.reportID ?? ''}]);
             addSingleParticipant(option);
         },
-        [isIOUSplit, addParticipantToSelection, addSingleParticipant],
+        [isIOUSplit, addParticipantToSelection, addSingleParticipant, setSelectedOptions],
     );
 
     const footerContentAbovePaginationComponent = useMemo(() => {

--- a/src/pages/iou/request/MoneyRequestParticipantsSelector.tsx
+++ b/src/pages/iou/request/MoneyRequestParticipantsSelector.tsx
@@ -500,6 +500,7 @@ function MoneyRequestParticipantsSelector({
                 return;
             }
 
+            // eslint-disable-next-line rulesdir/no-default-id-values
             setSelectedOptions([{...option, isSelected: true, reportID: option.reportID ?? ''}]);
             addSingleParticipant(option);
         },

--- a/src/pages/iou/request/step/IOURequestStepAmount.tsx
+++ b/src/pages/iou/request/step/IOURequestStepAmount.tsx
@@ -33,6 +33,7 @@ import {
     sendMoneyWithWallet,
     setDraftSplitTransaction,
     setMoneyRequestAmount,
+    setMoneyRequestParticipants,
     setMoneyRequestParticipantsFromReport,
     setSplitShares,
     trackExpense,
@@ -269,6 +270,10 @@ function IOURequestStepAmount({
 
         // Starting from global + menu means no participant context exists yet,
         // so we need to handle participant selection based on available workspace settings
+        const isReturningFromConfirmationPage = !!transaction?.participants?.length;
+        const firstParticipant = transaction?.participants?.at(0);
+        const isP2PChat = isParticipantP2P(firstParticipant, currentUserPersonalDetails.accountID);
+        const isNegativeAmount = convertToBackendAmount(Number.parseFloat(amount)) < 0;
         if (
             iouType === CONST.IOU.TYPE.CREATE &&
             isPaidGroupPolicy(defaultExpensePolicy) &&
@@ -278,7 +283,6 @@ function IOURequestStepAmount({
             const activePolicyExpenseChat = getPolicyExpenseChat(currentUserAccountIDParam, defaultExpensePolicy?.id);
             const shouldAutoReport = !!defaultExpensePolicy?.autoReporting || !!personalPolicy?.autoReporting;
             const transactionReportID = shouldAutoReport ? activePolicyExpenseChat?.reportID : CONST.REPORT.UNREPORTED_REPORT_ID;
-            const isReturningFromConfirmationPage = !!transaction?.participants?.length;
 
             const resetToDefaultWorkspace = () => {
                 setTransactionReport(transactionID, {reportID: transactionReportID}, true);
@@ -288,10 +292,6 @@ function IOURequestStepAmount({
             };
 
             if (isReturningFromConfirmationPage) {
-                const firstParticipant = transaction?.participants?.at(0);
-                const isP2PChat = isParticipantP2P(firstParticipant);
-                const isNegativeAmount = convertToBackendAmount(Number.parseFloat(amount)) < 0;
-
                 // P2P chats don't support negative amounts, so reset to default workspace when amount is negative.
                 if (isP2PChat && isNegativeAmount) {
                     resetToDefaultWorkspace();
@@ -310,6 +310,11 @@ function IOURequestStepAmount({
             } else {
                 resetToDefaultWorkspace();
             }
+        } else if (iouType === CONST.IOU.TYPE.CREATE && isP2PChat && isNegativeAmount && isReturningFromConfirmationPage) {
+            setTransactionReport(transactionID, {reportID: undefined}, true);
+            setMoneyRequestParticipants(transactionID, [], true).then(() => {
+                navigateToParticipantPage(iouType, transactionID, reportID);
+            });
         } else {
             Navigation.setNavigationActionToMicrotaskQueue(() => {
                 navigateToParticipantPage(iouType, transactionID, reportID);
@@ -403,8 +408,8 @@ IOURequestStepAmount.displayName = 'IOURequestStepAmount';
 /**
  * Check if the participant is a P2P chat
  */
-function isParticipantP2P(participant: {accountID?: number; isPolicyExpenseChat?: boolean} | undefined): boolean {
-    return !!(participant?.accountID && !participant.isPolicyExpenseChat);
+function isParticipantP2P(participant: {accountID?: number; isPolicyExpenseChat?: boolean} | undefined, currentUserAccountID?: number): boolean {
+    return !!(participant?.accountID && !participant.isPolicyExpenseChat && (!currentUserAccountID || participant?.accountID !== currentUserAccountID));
 }
 
 const IOURequestStepAmountWithCurrentUserPersonalDetails = withCurrentUserPersonalDetails(IOURequestStepAmount);

--- a/src/pages/iou/request/step/IOURequestStepParticipants.tsx
+++ b/src/pages/iou/request/step/IOURequestStepParticipants.tsx
@@ -73,11 +73,11 @@ function IOURequestStepParticipants({
     },
     transaction: initialTransaction,
 }: IOURequestStepParticipantsProps) {
-    const participants = useMemo(
-        () =>
-            iouType === CONST.IOU.TYPE.SPLIT ? initialTransaction?.participants : initialTransaction?.participants?.filter((participant) => !participant.isSender && participant.selected),
-        [initialTransaction?.participants, iouType],
-    );
+    const isSplitRequest = iouType === CONST.IOU.TYPE.SPLIT;
+    const participants = useMemo(() => {
+        const allParticipants = initialTransaction?.participants;
+        return isSplitRequest ? allParticipants : allParticipants?.filter((participant) => !participant.isSender && participant.selected);
+    }, [initialTransaction?.participants, isSplitRequest]);
     const {translate} = useLocalize();
     const styles = useThemeStyles();
     const isFocused = useIsFocused();
@@ -104,7 +104,6 @@ function IOURequestStepParticipants({
     const shouldAutoReport = useRef(true);
     const numberOfParticipants = useRef(participants?.length ?? 0);
     const iouRequestType = getRequestType(initialTransaction);
-    const isSplitRequest = iouType === CONST.IOU.TYPE.SPLIT;
     const isMovingTransactionFromTrackExpense = isMovingTransactionFromTrackExpenseIOUUtils(action);
     const headerTitle = useMemo(() => {
         if (action === CONST.IOU.ACTION.CATEGORIZE) {

--- a/src/pages/iou/request/step/IOURequestStepParticipants.tsx
+++ b/src/pages/iou/request/step/IOURequestStepParticipants.tsx
@@ -73,7 +73,11 @@ function IOURequestStepParticipants({
     },
     transaction: initialTransaction,
 }: IOURequestStepParticipantsProps) {
-    const participants = initialTransaction?.participants;
+    const participants = useMemo(
+        () =>
+            iouType === CONST.IOU.TYPE.SPLIT ? initialTransaction?.participants : initialTransaction?.participants?.filter((participant) => !participant.isSender && participant.selected),
+        [initialTransaction?.participants, iouType],
+    );
     const {translate} = useLocalize();
     const styles = useThemeStyles();
     const isFocused = useIsFocused();


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
The follow-up PR #74964
Fix the regressions reported as being caused by PR #74964.

### Fixed Issues
$ https://github.com/Expensify/App/issues/72129
$ https://github.com/Expensify/App/issues/77603
$ https://github.com/Expensify/App/issues/77604
$ https://github.com/Expensify/App/issues/77618
$ https://github.com/Expensify/App/issues/77619
$ https://github.com/Expensify/App/issues/77620
PROPOSAL: https://github.com/Expensify/App/issues/72129#issuecomment-3450670915

### Tests
Same as QA Steps

- [x] Verify that no errors appear in the JS console

### Offline tests
Same as QA Steps

### QA Steps
**Test 1:**

1. Click the global plus > Create expense
2. Choose "Manual", Click Next after entering an amount
3. In Confirm details page, click "To" field
4. Choose any recipient
5. Click "To" field
6. Observe the "Choose recipient" page
7. Note that the checkmark displayed for the recipient selected


**Test 2:**
_Precondition:_ Invoice is enabled.

1. Go to staging.new.expensify.com
2. Open FAB > Send invoice.
3. Enter amount > Next.
4. On confirm page, click To field.
5. Note that "Hidden" user will not show up on recipient list.

**Test 3:**
_Precondition:_ User has workspace chat and self DM.

1. Go to staging.new.expensify.com
2. Open FAB > Create expense > Manual.
3. Enter amount > Next.
4. On confirm page, click To field.
5. Select self DM.
6. On confirm page, click To field.
7. Select self DM again.
8. Verify that on confirm page, Category and Reimbursable field will NOT disappear after reselecting self DM.
9. Click Create expense.
10. Verify that Expense will be created in self DM.

**Test 4:**
_Precondition:_ Account has self DM and a workspace.

1. Go to staging.new.expensify.com
2. Open FAB > Create expense > Manual.
3. Enter negative amount > Next.
4. On confirm page, click To field.
5. Select self DM.
6. Click RHP back buton.
7. Click Next.
8. Note that To field selection is preserved.

**Test 5:**
_Precondition:_ Account has no workspace.

1. Go to staging.new.expensify.com
2. Open FAB > Create expense > Manual.
3. Enter amount > Next.
4. Select any user (not workspace chat).
5. On confirm page, click RHP back button twice.
6. Add negative sign to the amount > Next.
7. Verify that the selected user is hidden from the recipient list


**Test 6:**
_Precondition:_ Log in with new account and do not create workspace.

1. Go to staging.new.expensify.com
2. Open FAB > Create expense > Manual.
3. Enter amount > Next.
4. Select Manager McTest.
5. On confirm page, click RHP back button.
6. Click RHP back button again.
7. On amount page, click Next.
8. Enter email of any user and select it.
9. On confirm page, click RHP back button.
10. Clear the search field.
11. Verify that the Manager McTest will appear in the recipient list.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I verified there are no new alerts related to the `canBeMissing` param for `useOnyx`
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
**Test 1:**

<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->


https://github.com/user-attachments/assets/f3079fbf-751f-4f60-997d-78374833d83b





</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->



https://github.com/user-attachments/assets/8400636c-3299-4762-86d0-66c3e68ee82e




</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->




https://github.com/user-attachments/assets/fcde4123-0e9f-448b-865f-e43bd44f22be



</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->


https://github.com/user-attachments/assets/bb460002-6e35-456c-b5ef-38fedfc422b4





</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->


https://github.com/user-attachments/assets/ca2083b2-30d6-4203-8e2c-b413475d1d2c





</details>


**Test 2:**


https://github.com/user-attachments/assets/7d17a479-e72b-4341-b4a4-e9015b66a463


**Test 3:**



https://github.com/user-attachments/assets/b78dceae-cb3f-44cf-b8ea-57f7dc5a771a


**Test 4:**


https://github.com/user-attachments/assets/e6307019-b986-44a0-bbb2-a32e1bc74789


**Test 5:**


https://github.com/user-attachments/assets/cd7794a8-23d0-4f10-ae1b-9f168a1c42e6



**Test 6:**

https://github.com/user-attachments/assets/ef43317f-84d3-4d92-b196-fbcd067f6771


