### PR TITLE
[NoQA] Revert "Refactor: Deprecate getPolicy (part 2)"

### DIFF
--- a/src/hooks/useGetExpensifyCardFromReportAction.ts
+++ b/src/hooks/useGetExpensifyCardFromReportAction.ts
@@ -1,22 +1,22 @@
 import {useCardList, useWorkspaceCardList} from '@components/OnyxListItemProvider';
-import {getWorkspaceAccountID, isPolicyAdmin} from '@libs/PolicyUtils';
+import {getPolicy, getWorkspaceAccountID, isPolicyAdmin} from '@libs/PolicyUtils';
 import {getOriginalMessage, isCardIssuedAction} from '@libs/ReportActionsUtils';
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
 import type {Card, ReportAction} from '@src/types/onyx';
-import usePolicy from './usePolicy';
 
 function useGetExpensifyCardFromReportAction({reportAction, policyID}: {reportAction?: ReportAction; policyID?: string}): Card | undefined {
     const allUserCards = useCardList();
     const workspaceAccountID = getWorkspaceAccountID(policyID);
     const allExpensifyCards = useWorkspaceCardList();
-    const policy = usePolicy(policyID);
     const expensifyCards = allExpensifyCards?.[`${ONYXKEYS.COLLECTION.WORKSPACE_CARDS_LIST}${workspaceAccountID}_${CONST.EXPENSIFY_CARD.BANK}`] ?? {};
 
     const cardIssuedActionOriginalMessage = isCardIssuedAction(reportAction) ? getOriginalMessage(reportAction) : undefined;
 
     const cardID = cardIssuedActionOriginalMessage?.cardID ?? CONST.DEFAULT_NUMBER_ID;
-    return isPolicyAdmin(policy) ? expensifyCards?.[cardID] : allUserCards?.[cardID];
+    // This will be fixed as part of https://github.com/Expensify/Expensify/issues/507850
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
+    return isPolicyAdmin(getPolicy(policyID)) ? expensifyCards?.[cardID] : allUserCards?.[cardID];
 }
 
 export default useGetExpensifyCardFromReportAction;

--- a/src/libs/actions/Policy/Category.ts
+++ b/src/libs/actions/Policy/Category.ts
@@ -27,7 +27,7 @@ import getIsNarrowLayout from '@libs/getIsNarrowLayout';
 import Log from '@libs/Log';
 import enhanceParameters from '@libs/Network/enhanceParameters';
 import {hasEnabledOptions} from '@libs/OptionsListUtils';
-import {goBackWhenEnableFeature} from '@libs/PolicyUtils';
+import {getPolicy, goBackWhenEnableFeature} from '@libs/PolicyUtils';
 import {pushTransactionViolationsOnyxData} from '@libs/ReportUtils';
 import {getFinishOnboardingTaskOnyxData} from '@userActions/Task';
 import CONST from '@src/CONST';
@@ -1451,11 +1451,10 @@ function setPolicyCategoryApprover(policyID: string, categoryName: string, appro
     API.write(WRITE_COMMANDS.SET_POLICY_CATEGORY_APPROVER, parameters, onyxData);
 }
 
-function setPolicyCategoryTax(policy: OnyxEntry<Policy>, categoryName: string, taxID: string) {
-    if (!policy?.id) {
-        return;
-    }
-    const policyID = policy.id;
+function setPolicyCategoryTax(policyID: string, categoryName: string, taxID: string) {
+    // This will be fixed as part of https://github.com/Expensify/Expensify/issues/507850
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
+    const policy = getPolicy(policyID);
     const expenseRules = policy?.rules?.expenseRules ?? [];
     const updatedExpenseRules: ExpenseRule[] = lodashCloneDeep(expenseRules);
     const existingCategoryExpenseRule = updatedExpenseRules.find((rule) => rule.applyWhen.some((when) => when.value === categoryName));
@@ -1471,7 +1470,7 @@ function setPolicyCategoryTax(policy: OnyxEntry<Policy>, categoryName: string, t
             applyWhen: [
                 {
                     condition: CONST.POLICY.RULE_CONDITIONS.MATCHES,
-                    field: CONST.POLICY.FIELDS.CATEGORY,
+                    field: 'category',
                     value: categoryName,
                 },
             ],

--- a/src/libs/actions/Policy/Tag.ts
+++ b/src/libs/actions/Policy/Tag.ts
@@ -1164,11 +1164,10 @@ function setPolicyTagGLCode({policyID, tagName, tagListIndex, glCode, policyTags
     API.write(WRITE_COMMANDS.UPDATE_POLICY_TAG_GL_CODE, parameters, onyxData);
 }
 
-function setPolicyTagApprover(policy: OnyxEntry<Policy>, tag: string, approver: string) {
-    if (!policy?.id) {
-        return;
-    }
-    const policyID = policy.id;
+function setPolicyTagApprover(policyID: string, tag: string, approver: string) {
+    // This will be fixed as part of https://github.com/Expensify/Expensify/issues/507850
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
+    const policy = PolicyUtils.getPolicy(policyID);
     const prevApprovalRules = policy?.rules?.approvalRules ?? [];
     const approverRuleToUpdate = PolicyUtils.getTagApproverRule(policyID, tag);
     const filteredApprovalRules = approverRuleToUpdate ? prevApprovalRules.filter((rule) => rule.id !== approverRuleToUpdate.id) : prevApprovalRules;

--- a/src/libs/actions/TeachersUnite.ts
+++ b/src/libs/actions/TeachersUnite.ts
@@ -6,6 +6,7 @@ import {WRITE_COMMANDS} from '@libs/API/types';
 import {getMicroSecondOnyxErrorWithTranslationKey} from '@libs/ErrorUtils';
 import Navigation from '@libs/Navigation/Navigation';
 import {addSMSDomainIfPhoneNumber} from '@libs/PhoneNumber';
+import {getPolicy} from '@libs/PolicyUtils';
 import {buildOptimisticChatReport, buildOptimisticCreatedReportAction} from '@libs/ReportUtils';
 import type {OptimisticCreatedReportAction} from '@libs/ReportUtils';
 import CONST from '@src/CONST';
@@ -117,7 +118,9 @@ function addSchoolPrincipal(
                 name: policyName,
                 role: CONST.POLICY.ROLE.USER,
                 owner: sessionEmail,
-                outputCurrency: localCurrencyCode ?? CONST.CURRENCY.USD,
+                // This will be fixed as part of https://github.com/Expensify/Expensify/issues/507850
+                // eslint-disable-next-line @typescript-eslint/no-deprecated
+                outputCurrency: getPolicy(policyID)?.outputCurrency ?? localCurrencyCode ?? CONST.CURRENCY.USD,
                 employeeList: {
                     [sessionEmail]: {
                         role: CONST.POLICY.ROLE.USER,

--- a/src/pages/TransactionDuplicate/ReviewTaxCode.tsx
+++ b/src/pages/TransactionDuplicate/ReviewTaxCode.tsx
@@ -4,7 +4,6 @@ import HeaderWithBackButton from '@components/HeaderWithBackButton';
 import ScreenWrapper from '@components/ScreenWrapper';
 import useLocalize from '@hooks/useLocalize';
 import useOnyx from '@hooks/useOnyx';
-import usePolicy from '@hooks/usePolicy';
 import useReviewDuplicatesNavigation from '@hooks/useReviewDuplicatesNavigation';
 import useTransactionsByID from '@hooks/useTransactionsByID';
 import {setReviewDuplicatesKey} from '@libs/actions/Transaction';
@@ -12,7 +11,7 @@ import {convertToBackendAmount} from '@libs/CurrencyUtils';
 import getNonEmptyStringOnyxID from '@libs/getNonEmptyStringOnyxID';
 import type {PlatformStackRouteProp} from '@libs/Navigation/PlatformStackNavigation/types';
 import type {TransactionDuplicateNavigatorParamList} from '@libs/Navigation/types';
-import {getTaxByID} from '@libs/PolicyUtils';
+import {getPolicy, getTaxByID} from '@libs/PolicyUtils';
 import {calculateTaxAmount, compareDuplicateTransactionFields, getAmount, getDefaultTaxCode, getTaxValue, getTransactionID} from '@libs/TransactionUtils';
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
@@ -26,7 +25,9 @@ function ReviewTaxRate() {
     const {translate} = useLocalize();
     const [reviewDuplicates] = useOnyx(ONYXKEYS.REVIEW_DUPLICATES, {canBeMissing: true});
     const [report] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT}${reviewDuplicates?.reportID ?? route.params.threadReportID}`, {canBeMissing: true});
-    const policy = usePolicy(report?.policyID);
+    // This will be fixed as part of https://github.com/Expensify/Expensify/issues/507850
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
+    const policy = getPolicy(report?.policyID);
     const transactionID = getTransactionID(route.params.threadReportID);
     const [transaction] = useOnyx(`${ONYXKEYS.COLLECTION.TRANSACTION}${getNonEmptyStringOnyxID(transactionID)}`, {canBeMissing: true});
     const [transactionViolations] = useOnyx(`${ONYXKEYS.COLLECTION.TRANSACTION_VIOLATIONS}${transactionID}`, {

--- a/src/pages/home/report/SystemChatReportFooterMessage.tsx
+++ b/src/pages/home/report/SystemChatReportFooterMessage.tsx
@@ -8,7 +8,7 @@ import {useMemoizedLazyExpensifyIcons} from '@hooks/useLazyAsset';
 import useLocalize from '@hooks/useLocalize';
 import useOnyx from '@hooks/useOnyx';
 import useThemeStyles from '@hooks/useThemeStyles';
-import {shouldShowPolicy} from '@libs/PolicyUtils';
+import {getPolicy, shouldShowPolicy} from '@libs/PolicyUtils';
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
 import ROUTES from '@src/ROUTES';
@@ -25,10 +25,12 @@ function SystemChatReportFooterMessage() {
 
     const adminChatReportID = useMemo(() => {
         const adminPolicy = activePolicyID
-            ? policies?.[`${ONYXKEYS.COLLECTION.POLICY}${activePolicyID}`]
+            ? // This will be fixed as part of https://github.com/Expensify/Expensify/issues/507850
+              // eslint-disable-next-line @typescript-eslint/no-deprecated
+              getPolicy(activePolicyID)
             : Object.values(policies ?? {}).find((policy) => shouldShowPolicy(policy, false, currentUserLogin) && policy?.role === CONST.POLICY.ROLE.ADMIN && policy?.chatReportIDAdmins);
 
-        return adminPolicy?.chatReportIDAdmins ?? CONST.DEFAULT_NUMBER_ID;
+        return String(adminPolicy?.chatReportIDAdmins ?? -1);
     }, [activePolicyID, policies, currentUserLogin]);
 
     const [adminChatReport] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT}${adminChatReportID}`, {canBeMissing: true});

--- a/src/pages/iou/request/step/IOURequestStepPerDiemWorkspace.tsx
+++ b/src/pages/iou/request/step/IOURequestStepPerDiemWorkspace.tsx
@@ -12,7 +12,7 @@ import useOnyx from '@hooks/useOnyx';
 import useSearchResults from '@hooks/useSearchResults';
 import useThemeStyles from '@hooks/useThemeStyles';
 import Navigation from '@libs/Navigation/Navigation';
-import {getActivePoliciesWithExpenseChatAndPerDiemEnabled, getPerDiemCustomUnit, sortWorkspacesBySelected} from '@libs/PolicyUtils';
+import {getActivePoliciesWithExpenseChatAndPerDiemEnabled, getPerDiemCustomUnit, getPolicy, sortWorkspacesBySelected} from '@libs/PolicyUtils';
 import {getDefaultWorkspaceAvatar, getPolicyExpenseChat} from '@libs/ReportUtils';
 import tokenizedSearch from '@libs/tokenizedSearch';
 import {setCustomUnitID, setMoneyRequestCategory, setMoneyRequestParticipants} from '@userActions/IOU';
@@ -92,7 +92,9 @@ function IOURequestStepPerDiemWorkspace({
         if (!policyExpenseReportID) {
             return;
         }
-        const selectedPolicy = allPolicies?.[`${ONYXKEYS.COLLECTION.POLICY}${item.value}`];
+        // This will be fixed as part of https://github.com/Expensify/Expensify/issues/507850
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
+        const selectedPolicy = getPolicy(item.value, allPolicies);
         const perDiemUnit = getPerDiemCustomUnit(selectedPolicy);
         setMoneyRequestParticipants(transactionID, [
             {

--- a/src/pages/workspace/categories/CategoryDefaultTaxRatePage.tsx
+++ b/src/pages/workspace/categories/CategoryDefaultTaxRatePage.tsx
@@ -59,10 +59,10 @@ function CategoryDefaultTaxRatePage({
                 return;
             }
 
-            setPolicyCategoryTax(policy, categoryName, item.keyForList);
+            setPolicyCategoryTax(policyID, categoryName, item.keyForList);
             Navigation.setNavigationActionToMicrotaskQueue(() => Navigation.goBack(ROUTES.WORKSPACE_CATEGORY_SETTINGS.getRoute(policyID, categoryName)));
         },
-        [policyID, policy, categoryName, selectedTaxRate],
+        [policyID, categoryName, selectedTaxRate],
     );
 
     return (

--- a/src/pages/workspace/members/WorkspaceMemberNewCardPage.tsx
+++ b/src/pages/workspace/members/WorkspaceMemberNewCardPage.tsx
@@ -14,7 +14,6 @@ import {useCompanyCardFeedIcons} from '@hooks/useCompanyCardIcons';
 import {useMemoizedLazyIllustrations} from '@hooks/useLazyAsset';
 import useLocalize from '@hooks/useLocalize';
 import useOnyx from '@hooks/useOnyx';
-import usePolicy from '@hooks/usePolicy';
 import useThemeIllustrations from '@hooks/useThemeIllustrations';
 import useThemeStyles from '@hooks/useThemeStyles';
 import {
@@ -32,6 +31,7 @@ import {
 } from '@libs/CardUtils';
 import type {PlatformStackScreenProps} from '@libs/Navigation/PlatformStackNavigation/types';
 import type {SettingsNavigatorParamList} from '@libs/Navigation/types';
+import {getPolicy} from '@libs/PolicyUtils';
 import Navigation from '@navigation/Navigation';
 import AccessOrNotFoundWrapper from '@pages/workspace/AccessOrNotFoundWrapper';
 import type {WithPolicyAndFullscreenLoadingProps} from '@pages/workspace/withPolicyAndFullscreenLoading';
@@ -58,7 +58,9 @@ type WorkspaceMemberNewCardPageProps = WithPolicyAndFullscreenLoadingProps & Pla
 
 function WorkspaceMemberNewCardPage({route, personalDetails}: WorkspaceMemberNewCardPageProps) {
     const {policyID} = route.params;
-    const policy = usePolicy(policyID);
+    // This will be fixed as part of https://github.com/Expensify/Expensify/issues/507850
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
+    const policy = getPolicy(policyID);
     const workspaceAccountID = policy?.workspaceAccountID ?? CONST.DEFAULT_NUMBER_ID;
 
     const {translate} = useLocalize();

--- a/src/pages/workspace/tags/TagApproverPage.tsx
+++ b/src/pages/workspace/tags/TagApproverPage.tsx
@@ -55,7 +55,7 @@ function TagApproverPage({route}: TagApproverPageProps) {
                     policyID={policyID}
                     selectedApprover={tagApprover ?? ''}
                     setApprover={(email) => {
-                        setPolicyTagApprover(policy, tagName, email);
+                        setPolicyTagApprover(policyID, tagName, email);
                         Navigation.setNavigationActionToMicrotaskQueue(goBack);
                     }}
                 />

--- a/tests/actions/PolicyCategoryTest.ts
+++ b/tests/actions/PolicyCategoryTest.ts
@@ -1,6 +1,5 @@
 import {act, renderHook} from '@testing-library/react-native';
 import Onyx from 'react-native-onyx';
-import OnyxUtils from 'react-native-onyx/dist/OnyxUtils';
 import OnyxListItemProvider from '@components/OnyxListItemProvider';
 import usePolicyData from '@hooks/usePolicyData';
 import {
@@ -8,7 +7,6 @@ import {
     deleteWorkspaceCategories,
     enablePolicyCategories,
     renamePolicyCategory,
-    setPolicyCategoryTax,
     setWorkspaceCategoryEnabled,
     setWorkspaceRequiresCategory,
 } from '@libs/actions/Policy/Category';
@@ -394,107 +392,6 @@ describe('actions/PolicyCategory', () => {
                     },
                 });
             });
-        });
-    });
-
-    describe('SetPolicyCategoryTax', () => {
-        it('should set expense rule when category expense rule is not present', async () => {
-            // Given a policy
-            const fakePolicy = createRandomPolicy(0);
-            fakePolicy.areCategoriesEnabled = true;
-            const categoryName = 'Fake category';
-            const fakePolicyCategories = {
-                [categoryName]: {
-                    name: categoryName,
-                    enabled: false,
-                    // eslint-disable-next-line @typescript-eslint/naming-convention
-                    'GL Code': '',
-                    unencodedName: categoryName,
-                    externalID: '',
-                    areCommentsRequired: false,
-                    origin: '',
-                },
-            };
-
-            mockFetch.pause();
-
-            await Onyx.set(`${ONYXKEYS.COLLECTION.POLICY}${fakePolicy.id}`, fakePolicy);
-            await Onyx.set(`${ONYXKEYS.COLLECTION.POLICY_CATEGORIES}${fakePolicy.id}`, fakePolicyCategories);
-
-            setPolicyCategoryTax(fakePolicy, categoryName, 'VAT');
-            await waitForBatchedUpdates();
-
-            // Then the approval rule should be created with the tag name
-            const updatedPolicy = await OnyxUtils.get(`${ONYXKEYS.COLLECTION.POLICY}${fakePolicy.id}`);
-
-            expect(updatedPolicy?.rules?.expenseRules).toHaveLength(1);
-            expect(updatedPolicy?.rules?.expenseRules?.[0]?.applyWhen?.[0]?.value).toBe(categoryName);
-            expect(updatedPolicy?.rules?.expenseRules?.[0]?.applyWhen?.[0]?.condition).toBe(CONST.POLICY.RULE_CONDITIONS.MATCHES);
-            expect(updatedPolicy?.rules?.expenseRules?.[0]?.applyWhen?.[0]?.field).toBe(CONST.POLICY.FIELDS.CATEGORY);
-            expect(updatedPolicy?.rules?.expenseRules?.[0].tax.field_id_TAX.externalID).toBe('VAT');
-
-            mockFetch.resume();
-            await waitForBatchedUpdates();
-        });
-
-        it('should update expense rule when category expense rule is present', async () => {
-            // Given a policy with approval rules that reference a tag
-            const fakePolicy = createRandomPolicy(0);
-            fakePolicy.areCategoriesEnabled = true;
-            const categoryName = 'Fake category';
-            const fakePolicyCategories = {
-                [categoryName]: {
-                    name: categoryName,
-                    enabled: false,
-                    // eslint-disable-next-line @typescript-eslint/naming-convention
-                    'GL Code': '',
-                    unencodedName: categoryName,
-                    externalID: '',
-                    areCommentsRequired: false,
-                    origin: '',
-                },
-            };
-
-            // Create expense rule that uses the tag
-            fakePolicy.rules = {
-                expenseRules: [
-                    {
-                        tax: {
-                            // eslint-disable-next-line @typescript-eslint/naming-convention
-                            field_id_TAX: {
-                                externalID: 'GST',
-                            },
-                        },
-                        applyWhen: [
-                            {
-                                condition: CONST.POLICY.RULE_CONDITIONS.MATCHES,
-                                field: CONST.POLICY.FIELDS.CATEGORY,
-                                value: categoryName,
-                            },
-                        ],
-                    },
-                ],
-            };
-
-            mockFetch.pause();
-
-            await Onyx.set(`${ONYXKEYS.COLLECTION.POLICY}${fakePolicy.id}`, fakePolicy);
-            await Onyx.set(`${ONYXKEYS.COLLECTION.POLICY_CATEGORIES}${fakePolicy.id}`, fakePolicyCategories);
-
-            setPolicyCategoryTax(fakePolicy, categoryName, 'VAT');
-            await waitForBatchedUpdates();
-
-            // Then the approval rule should be created with the tag name
-            const updatedPolicy = await OnyxUtils.get(`${ONYXKEYS.COLLECTION.POLICY}${fakePolicy.id}`);
-
-            expect(updatedPolicy?.rules?.expenseRules).toHaveLength(1);
-            expect(updatedPolicy?.rules?.expenseRules?.[0]?.applyWhen?.[0]?.value).toBe(categoryName);
-            expect(updatedPolicy?.rules?.expenseRules?.[0]?.applyWhen?.[0]?.condition).toBe(CONST.POLICY.RULE_CONDITIONS.MATCHES);
-            expect(updatedPolicy?.rules?.expenseRules?.[0]?.applyWhen?.[0]?.field).toBe(CONST.POLICY.FIELDS.CATEGORY);
-            expect(updatedPolicy?.rules?.expenseRules?.[0].tax.field_id_TAX.externalID).toBe('VAT');
-
-            mockFetch.resume();
-            await waitForBatchedUpdates();
         });
     });
 });

--- a/tests/actions/PolicyTagTest.ts
+++ b/tests/actions/PolicyTagTest.ts
@@ -16,7 +16,6 @@ import {
     renamePolicyTag,
     renamePolicyTagList,
     setPolicyRequiresTag,
-    setPolicyTagApprover,
     setPolicyTagGLCode,
     setPolicyTagsRequired,
     setWorkspaceTagEnabled,
@@ -825,84 +824,6 @@ describe('actions/Policy', () => {
             expect(successTags?.[oldTagName]).toBeFalsy();
             expect(successTags?.[newTagName]?.name).toBe(newTagName);
             expect(successTags?.[newTagName]?.pendingAction).toBeFalsy();
-        });
-    });
-
-    describe('SetPolicyTagApprover', () => {
-        it('should set approval rule when tag approval rule is not present', async () => {
-            // Given a policy
-            const fakePolicy = createRandomPolicy(0);
-            fakePolicy.areTagsEnabled = true;
-            const tagListName = 'Fake tag';
-            const fakePolicyTags = createRandomPolicyTags(tagListName, 1);
-            const tagName = Object.keys(fakePolicyTags?.[tagListName]?.tags).at(0) ?? '';
-
-            mockFetch.pause();
-
-            await Onyx.set(`${ONYXKEYS.COLLECTION.POLICY}${fakePolicy.id}`, fakePolicy);
-            await Onyx.set(`${ONYXKEYS.COLLECTION.POLICY_TAGS}${fakePolicy.id}`, fakePolicyTags);
-
-            setPolicyTagApprover(fakePolicy, tagName, 'admin@company.com');
-            await waitForBatchedUpdates();
-
-            // Then the approval rule should be created with the tag name
-            const updatedPolicy = await OnyxUtils.get(`${ONYXKEYS.COLLECTION.POLICY}${fakePolicy.id}`);
-
-            expect(updatedPolicy?.rules?.approvalRules).toHaveLength(1);
-            expect(updatedPolicy?.rules?.approvalRules?.[0]?.applyWhen?.[0]?.value).toBe(tagName);
-            expect(updatedPolicy?.rules?.approvalRules?.[0]?.applyWhen?.[0]?.condition).toBe(CONST.POLICY.RULE_CONDITIONS.MATCHES);
-            expect(updatedPolicy?.rules?.approvalRules?.[0]?.applyWhen?.[0]?.field).toBe(CONST.POLICY.FIELDS.TAG);
-            expect(updatedPolicy?.rules?.approvalRules?.[0]?.approver).toBe('admin@company.com');
-
-            mockFetch.resume();
-            await waitForBatchedUpdates();
-        });
-
-        it('should update approval rule when tag approval rule is present', async () => {
-            // Given a policy with approval rules that reference a tag
-            const fakePolicy = createRandomPolicy(0);
-            fakePolicy.areTagsEnabled = true;
-            const tagListName = 'Fake tag';
-            const fakePolicyTags = createRandomPolicyTags(tagListName, 1);
-            const tagName = Object.keys(fakePolicyTags?.[tagListName]?.tags).at(0) ?? '';
-
-            // Create approval rule that uses the tag
-            fakePolicy.rules = {
-                approvalRules: [
-                    {
-                        id: 'rule-1',
-                        applyWhen: [
-                            {
-                                condition: CONST.POLICY.RULE_CONDITIONS.MATCHES,
-                                field: CONST.POLICY.FIELDS.TAG,
-                                value: tagName,
-                            },
-                        ],
-                        approver: 'admin2@company.com',
-                    },
-                ],
-            };
-
-            mockFetch.pause();
-
-            await Onyx.set(`${ONYXKEYS.COLLECTION.POLICY}${fakePolicy.id}`, fakePolicy);
-            await Onyx.set(`${ONYXKEYS.COLLECTION.POLICY_TAGS}${fakePolicy.id}`, fakePolicyTags);
-
-            setPolicyTagApprover(fakePolicy, tagName, 'admin@company.com');
-            await waitForBatchedUpdates();
-
-            // Then the approval rule should be created with the tag name
-            const updatedPolicy = await OnyxUtils.get(`${ONYXKEYS.COLLECTION.POLICY}${fakePolicy.id}`);
-
-            expect(updatedPolicy?.rules?.approvalRules).toHaveLength(1);
-            expect(updatedPolicy?.rules?.approvalRules?.[0]?.id).toBe('rule-1');
-            expect(updatedPolicy?.rules?.approvalRules?.[0]?.applyWhen?.[0]?.value).toBe(tagName);
-            expect(updatedPolicy?.rules?.approvalRules?.[0]?.applyWhen?.[0]?.condition).toBe(CONST.POLICY.RULE_CONDITIONS.MATCHES);
-            expect(updatedPolicy?.rules?.approvalRules?.[0]?.applyWhen?.[0]?.field).toBe(CONST.POLICY.FIELDS.TAG);
-            expect(updatedPolicy?.rules?.approvalRules?.[0]?.approver).toBe('admin@company.com');
-
-            mockFetch.resume();
-            await waitForBatchedUpdates();
         });
     });
 

--- a/tests/unit/useGetExpensifyCardFromReportActionTest.ts
+++ b/tests/unit/useGetExpensifyCardFromReportActionTest.ts
@@ -1,8 +1,7 @@
 import {renderHook} from '@testing-library/react-native';
 import Onyx from 'react-native-onyx';
 import {useCardList, useWorkspaceCardList} from '@components/OnyxListItemProvider';
-import usePolicy from '@hooks/usePolicy';
-import {getWorkspaceAccountID, isPolicyAdmin} from '@libs/PolicyUtils';
+import {getPolicy, getWorkspaceAccountID, isPolicyAdmin} from '@libs/PolicyUtils';
 import {getOriginalMessage, isCardIssuedAction} from '@libs/ReportActionsUtils';
 import CONST from '@src/CONST';
 import useGetExpensifyCardFromReportAction from '@src/hooks/useGetExpensifyCardFromReportAction';
@@ -18,9 +17,10 @@ jest.mock('@components/OnyxListItemProvider', () => ({
     useCardList: jest.fn(),
     useWorkspaceCardList: jest.fn(),
 }));
-jest.mock('@hooks/usePolicy');
 
-const mockUsePolicy = usePolicy as jest.MockedFunction<typeof usePolicy>;
+// This will be fixed as part of https://github.com/Expensify/Expensify/issues/507850
+// eslint-disable-next-line @typescript-eslint/no-deprecated
+const mockGetPolicy = getPolicy as jest.MockedFunction<typeof getPolicy>;
 const mockGetWorkspaceAccountID = getWorkspaceAccountID as jest.MockedFunction<typeof getWorkspaceAccountID>;
 const mockIsPolicyAdmin = isPolicyAdmin as jest.MockedFunction<typeof isPolicyAdmin>;
 const mockGetOriginalMessage = getOriginalMessage as jest.MockedFunction<typeof getOriginalMessage>;
@@ -78,7 +78,7 @@ describe('useGetExpensifyCardFromReportAction', () => {
         await Onyx.clear();
         jest.clearAllMocks();
 
-        mockUsePolicy.mockReturnValue(mockPolicy);
+        mockGetPolicy.mockReturnValue(mockPolicy);
         mockGetWorkspaceAccountID.mockReturnValue(123);
         mockIsPolicyAdmin.mockReturnValue(false);
         mockGetOriginalMessage.mockReturnValue({cardID: 123, assigneeAccountID: 1});
@@ -134,7 +134,7 @@ describe('useGetExpensifyCardFromReportAction', () => {
                 mockIsPolicyAdmin.mockReturnValue(true);
                 mockGetWorkspaceAccountID.mockReturnValue(123);
                 // Override the default policy for admin tests
-                mockUsePolicy.mockReturnValue({
+                mockGetPolicy.mockReturnValue({
                     id: 'policy123',
                     name: 'Test Policy',
                     role: CONST.POLICY.ROLE.ADMIN,
@@ -193,7 +193,7 @@ describe('useGetExpensifyCardFromReportAction', () => {
 
         it('updates when allExpensifyCards changes for policy admin', async () => {
             mockIsPolicyAdmin.mockReturnValue(true);
-            mockUsePolicy.mockReturnValue({
+            mockGetPolicy.mockReturnValue({
                 id: 'policy123',
                 name: 'Test Policy',
                 role: CONST.POLICY.ROLE.ADMIN,
@@ -250,7 +250,7 @@ describe('useGetExpensifyCardFromReportAction', () => {
                 isPolicyExpenseChatEnabled: false,
                 workspaceAccountID: 123,
             };
-            mockUsePolicy.mockReturnValue(testPolicy);
+            mockGetPolicy.mockReturnValue(testPolicy);
 
             // eslint-disable-next-line @typescript-eslint/naming-convention
             mockUseCardList.mockReturnValue({'123': mockCard});
@@ -258,7 +258,7 @@ describe('useGetExpensifyCardFromReportAction', () => {
             const {result} = renderHook(() => useGetExpensifyCardFromReportAction({reportAction: createMockReportAction(), policyID: 'policy123'}));
             await waitForBatchedUpdatesWithAct();
 
-            expect(mockUsePolicy).toHaveBeenCalledWith('policy123');
+            expect(mockGetPolicy).toHaveBeenCalledWith('policy123');
             expect(mockIsPolicyAdmin).toHaveBeenCalledWith(testPolicy);
             expect(result.current).toEqual(mockCard);
         });


### PR DESCRIPTION
Reverts Expensify/App#76836 because we found that it caused some unit tests to start timing out. [See this slack thread](https://expensify.slack.com/archives/C01GTK53T8Q/p1765825373495939)