### PR TITLE
[NoQA] Revert "Fix/75364 - Double violation briefly visible when removing a disabled category from report"

### DIFF
--- a/src/libs/actions/IOU.ts
+++ b/src/libs/actions/IOU.ts
@@ -4762,15 +4762,10 @@ function getUpdateMoneyRequestParams(params: GetUpdateMoneyRequestParamsType): U
     ) {
         const currentTransactionViolations = allTransactionViolations[`${ONYXKEYS.COLLECTION.TRANSACTION_VIOLATIONS}${transactionID}`] ?? [];
         // If the amount, currency or date have been modified, we remove the duplicate violations since they would be out of date as the transaction has changed
-        let optimisticViolations =
+        const optimisticViolations =
             hasModifiedAmount || hasModifiedDate || hasModifiedCurrency
                 ? currentTransactionViolations.filter((violation) => violation.name !== CONST.VIOLATIONS.DUPLICATED_TRANSACTION)
                 : currentTransactionViolations;
-        optimisticViolations =
-            hasModifiedCategory && transactionChanges.category === ''
-                ? optimisticViolations.filter((violation) => violation.name !== CONST.VIOLATIONS.CATEGORY_OUT_OF_POLICY)
-                : optimisticViolations;
-
         const violationsOnyxData = ViolationsUtils.getViolationsOnyxData(
             updatedTransaction,
             optimisticViolations,

--- a/tests/actions/IOUTest.ts
+++ b/tests/actions/IOUTest.ts
@@ -6467,60 +6467,6 @@ describe('actions/IOU', () => {
                 });
             });
         });
-
-        it('should remove all existing category violations when the transaction "Category" is unset', async () => {
-            const transactionID = '1';
-            const policyID = '2';
-            const transactionThreadReportID = '3';
-            const category = '';
-            const fakePolicy: Policy = {
-                ...createRandomPolicy(Number(policyID)),
-                requiresCategory: true,
-            };
-            await Onyx.merge(`${ONYXKEYS.COLLECTION.TRANSACTION}${transactionID}`, {
-                amount: 100,
-                transactionID,
-            });
-            await Onyx.merge(`${ONYXKEYS.COLLECTION.TRANSACTION_VIOLATIONS}${transactionID}`, [
-                {
-                    type: CONST.VIOLATION_TYPES.VIOLATION,
-                    name: CONST.VIOLATIONS.CATEGORY_OUT_OF_POLICY,
-                    data: {},
-                    showInReview: true,
-                },
-            ]);
-            await Onyx.merge(`${ONYXKEYS.COLLECTION.POLICY}${policyID}`, fakePolicy);
-            await Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT}${transactionThreadReportID}`, {reportID: transactionThreadReportID});
-
-            // When updating a money request category
-            updateMoneyRequestCategory({
-                transactionID,
-                transactionThreadReportID,
-                category,
-                policy: fakePolicy,
-                policyTagList: undefined,
-                policyCategories: undefined,
-                policyRecentlyUsedCategories: [],
-                currentUserAccountIDParam: 123,
-                currentUserEmailParam: 'existing@example.com',
-                isASAPSubmitBetaEnabled: false,
-            });
-
-            await waitForBatchedUpdates();
-
-            // Any existing category violations will be removed, leaving only the MISSING_CATEGORY violation in the end
-            await new Promise<void>((resolve) => {
-                const connection = Onyx.connect({
-                    key: `${ONYXKEYS.COLLECTION.TRANSACTION_VIOLATIONS}${transactionID}`,
-                    callback: (transactionViolations) => {
-                        Onyx.disconnect(connection);
-                        expect(transactionViolations).toHaveLength(1);
-                        expect(transactionViolations?.at(0)?.name).toEqual(CONST.VIOLATIONS.MISSING_CATEGORY);
-                        resolve();
-                    },
-                });
-            });
-        });
     });
 
     describe('setDraftSplitTransaction', () => {


### PR DESCRIPTION
Reverts Expensify/App#76706

Broke the test suite. See https://expensify.slack.com/archives/C01GTK53T8Q/p1765825373495939