### PR TITLE
Prevent Vacation Delegate error when online

### DIFF
--- a/scripts/lintChanged.sh
+++ b/scripts/lintChanged.sh
@@ -15,10 +15,10 @@ if [[ -z "${npm_lifecycle_event:-}" ]]; then
 fi
 
 # Fetch the commit history to include the merge-base commit
-info "Fetching origin/main"
-git fetch origin main --no-tags
+info "Fetching upstream/main"
+git fetch upstream main --no-tags
 
-MERGE_BASE_SHA_HASH="$(git merge-base origin/main HEAD)"
+MERGE_BASE_SHA_HASH="$(git merge-base upstream/main HEAD)"
 readonly MERGE_BASE_SHA_HASH
 
 # Check if output is empty or malformed

--- a/scripts/lintChanged.sh
+++ b/scripts/lintChanged.sh
@@ -15,10 +15,10 @@ if [[ -z "${npm_lifecycle_event:-}" ]]; then
 fi
 
 # Fetch the commit history to include the merge-base commit
-info "Fetching upstream/main"
-git fetch upstream main --no-tags
+info "Fetching origin/main"
+git fetch origin main --no-tags
 
-MERGE_BASE_SHA_HASH="$(git merge-base upstream/main HEAD)"
+MERGE_BASE_SHA_HASH="$(git merge-base origin/main HEAD)"
 readonly MERGE_BASE_SHA_HASH
 
 # Check if output is empty or malformed

--- a/src/pages/settings/Profile/CustomStatus/VacationDelegatePage.tsx
+++ b/src/pages/settings/Profile/CustomStatus/VacationDelegatePage.tsx
@@ -8,6 +8,7 @@ import SelectionList from '@components/SelectionListWithSections';
 import UserListItem from '@components/SelectionListWithSections/UserListItem';
 import useCurrentUserPersonalDetails from '@hooks/useCurrentUserPersonalDetails';
 import useLocalize from '@hooks/useLocalize';
+import useNetwork from '@hooks/useNetwork';
 import useOnyx from '@hooks/useOnyx';
 import useSearchSelector from '@hooks/useSearchSelector';
 import useThemeStyles from '@hooks/useThemeStyles';
@@ -34,6 +35,7 @@ function VacationDelegatePage() {
     const [vacationDelegate] = useOnyx(ONYXKEYS.NVP_PRIVATE_VACATION_DELEGATE, {canBeMissing: true});
     const currentVacationDelegate = vacationDelegate?.delegate;
     const delegatePersonalDetails = getPersonalDetailByEmail(currentVacationDelegate ?? '');
+    const {isOffline} = useNetwork();
 
     const excludeLogins = useMemo(
         () => ({
@@ -52,6 +54,11 @@ function VacationDelegatePage() {
         getValidOptionsConfig: {
             excludeLogins,
         },
+        // When offline, we want to allow inviting optimistic users
+        // because we can't check if they already exist on the server.
+        // When online, we rely on the server to know if a user exists.
+        // Vacation delegate users must exist on the server before being assigned.
+        includeUserToInvite: isOffline ? true : false,
     });
 
     const headerMessage = useMemo(() => {

--- a/src/pages/settings/Profile/CustomStatus/VacationDelegatePage.tsx
+++ b/src/pages/settings/Profile/CustomStatus/VacationDelegatePage.tsx
@@ -58,7 +58,7 @@ function VacationDelegatePage() {
         // because we can't check if they already exist on the server.
         // When online, we rely on the server to know if a user exists.
         // Vacation delegate users must exist on the server before being assigned.
-        includeUserToInvite: isOffline ? true : false,
+        includeUserToInvite: isOffline,
     });
 
     const headerMessage = useMemo(() => {


### PR DESCRIPTION
### Explanation of Change
We're filtering out optimistic users when online, so that only users that already exist appear, preventing the "Account doesn't exist" error. When offline, we let the user select optimistic users as we can't check if they exist or not.

### Fixed Issues
$ https://github.com/Expensify/App/issues/77509
PROPOSAL: https://github.com/Expensify/App/issues/77509#issuecomment-3646696229

### Tests
1. Navigate to Profile > Status > Vacation Delegate.
2. Enter an Expensify account that doesn't exist.
3. Verify it does not show up in the search.
4. Enter an Expensify account that already exists.
5. Verify it does show up in the search.

### Offline tests
1. Navigate to Profile > Status > Vacation Delegate.
2. Enter an Expensify account that doesn't exist.
3. Verify it does show up in the search.

### QA Steps
Same as tests and offline tests.

### PR Author Checklist
- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I verified there are no new alerts related to the `canBeMissing` param for `useOnyx`
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

https://github.com/user-attachments/assets/c7d45edc-62a6-4814-9ac9-ce74f95a4d8b

</details>

<details>
<summary>Android: mWeb Chrome</summary>

https://github.com/user-attachments/assets/b051be65-00ff-4094-9f97-7d93061f34a7

</details>

<details>
<summary>iOS: Native</summary>

https://github.com/user-attachments/assets/594e5370-a6ab-400c-a651-0a17f8e55845

</details>

<details>
<summary>iOS: mWeb Safari</summary>

https://github.com/user-attachments/assets/86fc1c5f-bcc8-45b4-99f7-eebf3295aee5

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

https://github.com/user-attachments/assets/175b0a85-37c4-49c8-af32-9cc857565d76

</details>