### PR TITLE
Bulk moving per diem expenses, alert popup

### DIFF
--- a/src/hooks/useHasPerDiemTransactions.ts
+++ b/src/hooks/useHasPerDiemTransactions.ts
@@ -1,8 +1,8 @@
 import type {OnyxCollection} from 'react-native-onyx';
-import useOnyx from '@hooks/useOnyx';
 import {isPerDiemRequest} from '@libs/TransactionUtils';
 import ONYXKEYS from '@src/ONYXKEYS';
 import type {Transaction} from '@src/types/onyx';
+import useOnyx from './useOnyx';
 
 const hasPerDiemTransactionsSelector = (transactions: OnyxCollection<Transaction>, transactionIDs: string[]) => {
     return transactionIDs.some((transactionID) => {

--- a/src/hooks/useHasPerDiemTransactions.ts
+++ b/src/hooks/useHasPerDiemTransactions.ts
@@ -1,3 +1,4 @@
+import {useCallback} from 'react';
 import type {OnyxCollection} from 'react-native-onyx';
 import {isPerDiemRequest} from '@libs/TransactionUtils';
 import ONYXKEYS from '@src/ONYXKEYS';
@@ -12,13 +13,15 @@ const hasPerDiemTransactionsSelector = (transactions: OnyxCollection<Transaction
 };
 
 function useHasPerDiemTransactions(transactionIDs: string[]) {
+    const selector = useCallback((transactions: OnyxCollection<Transaction>) => hasPerDiemTransactionsSelector(transactions, transactionIDs), [transactionIDs]);
+
     const [hasPerDiemTransactions] = useOnyx(
         ONYXKEYS.COLLECTION.TRANSACTION,
         {
-            selector: (transactions) => hasPerDiemTransactionsSelector(transactions, transactionIDs),
+            selector,
             canBeMissing: true,
         },
-        [hasPerDiemTransactionsSelector],
+        [selector],
     );
 
     return hasPerDiemTransactions ?? false;

--- a/src/hooks/useHasPerDiemTransactions.ts
+++ b/src/hooks/useHasPerDiemTransactions.ts
@@ -1,0 +1,27 @@
+import type {OnyxCollection} from 'react-native-onyx';
+import useOnyx from '@hooks/useOnyx';
+import {isPerDiemRequest} from '@libs/TransactionUtils';
+import ONYXKEYS from '@src/ONYXKEYS';
+import type {Transaction} from '@src/types/onyx';
+
+const hasPerDiemTransactionsSelector = (transactions: OnyxCollection<Transaction>, transactionIDs: string[]) => {
+    return transactionIDs.some((transactionID) => {
+        const transaction = transactions?.[`${ONYXKEYS.COLLECTION.TRANSACTION}${transactionID}`];
+        return transaction && isPerDiemRequest(transaction);
+    });
+};
+
+function useHasPerDiemTransactions(transactionIDs: string[]) {
+    const [hasPerDiemTransactions] = useOnyx(
+        ONYXKEYS.COLLECTION.TRANSACTION,
+        {
+            selector: (transactions) => hasPerDiemTransactionsSelector(transactions, transactionIDs),
+            canBeMissing: true,
+        },
+        [hasPerDiemTransactionsSelector],
+    );
+
+    return hasPerDiemTransactions ?? false;
+}
+
+export default useHasPerDiemTransactions;

--- a/src/languages/de.ts
+++ b/src/languages/de.ts
@@ -1531,6 +1531,7 @@ const translations: TranslationDeepObject<typeof en> = {
             },
         },
         moveExpenses: () => ({one: 'Auslage verschieben', other: 'Ausgaben verschieben'}),
+        moveExpensesError: 'Sie können Per Diem-Ausgaben nicht in Berichte auf anderen Arbeitsbereichen verschieben, da sich die Tagessätze zwischen Arbeitsbereichen unterscheiden können.',
         changeApprover: {
             title: 'Genehmigenden ändern',
             subtitle: 'Wählen Sie eine Option, um den Genehmiger für diesen Bericht zu ändern.',

--- a/src/languages/en.ts
+++ b/src/languages/en.ts
@@ -1501,6 +1501,7 @@ const translations = {
             },
         },
         moveExpenses: () => ({one: 'Move expense', other: 'Move expenses'}),
+        moveExpensesError: "You can't move per diem expenses to reports on other workspaces, because the per diem rates may differ between workspaces.",
         changeApprover: {
             title: 'Change approver',
             subtitle: 'Choose an option to change the approver for this report.',

--- a/src/languages/es.ts
+++ b/src/languages/es.ts
@@ -1157,6 +1157,7 @@ const translations: TranslationDeepObject<typeof en> = {
         },
 
         moveExpenses: () => ({one: 'Mover gasto', other: 'Mover gastos'}),
+        moveExpensesError: 'No puedes mover gastos per diem a informes de otros espacios de trabajo, porque las tarifas de dietas pueden diferir entre espacios de trabajo.',
         changeApprover: {
             title: 'Cambiar aprobador',
             subtitle: 'Elige una opción para cambiar el aprobador de este informe.',

--- a/src/languages/fr.ts
+++ b/src/languages/fr.ts
@@ -1533,7 +1533,8 @@ const translations: TranslationDeepObject<typeof en> = {
             },
         },
         moveExpenses: () => ({one: 'Déplacer la dépense', other: 'Déplacer des dépenses'}),
-        moveExpensesError: "Vous ne pouvez pas déplacer les dépenses de per diem vers des rapports sur d'autres espaces de travail, car les taux de per diem peuvent différer entre les espaces de travail.",
+        moveExpensesError:
+            "Vous ne pouvez pas déplacer les dépenses de per diem vers des rapports sur d'autres espaces de travail, car les taux de per diem peuvent différer entre les espaces de travail.",
         changeApprover: {
             title: 'Changer d’approbateur',
             subtitle: 'Choisissez une option pour changer l’approbateur de ce rapport.',

--- a/src/languages/fr.ts
+++ b/src/languages/fr.ts
@@ -1533,6 +1533,7 @@ const translations: TranslationDeepObject<typeof en> = {
             },
         },
         moveExpenses: () => ({one: 'Déplacer la dépense', other: 'Déplacer des dépenses'}),
+        moveExpensesError: "Vous ne pouvez pas déplacer les dépenses de per diem vers des rapports sur d'autres espaces de travail, car les taux de per diem peuvent différer entre les espaces de travail.",
         changeApprover: {
             title: 'Changer d’approbateur',
             subtitle: 'Choisissez une option pour changer l’approbateur de ce rapport.',

--- a/src/languages/it.ts
+++ b/src/languages/it.ts
@@ -1527,6 +1527,7 @@ const translations: TranslationDeepObject<typeof en> = {
             },
         },
         moveExpenses: () => ({one: 'Sposta spesa', other: 'Sposta spese'}),
+        moveExpensesError: 'Non puoi spostare le spese per diaria su report in altri workspace, perché le tariffe per diaria possono differire tra workspace.',
         changeApprover: {
             title: 'Cambia approvatore',
             subtitle: "Scegli un'opzione per cambiare l'approvatore di questo report.",

--- a/src/languages/ja.ts
+++ b/src/languages/ja.ts
@@ -1528,6 +1528,7 @@ const translations: TranslationDeepObject<typeof en> = {
             },
         },
         moveExpenses: () => ({one: '経費を移動', other: '経費を移動'}),
+        moveExpensesError: '日当経費は他のワークスペースのレポートに移動できません。ワークスペース間で日当レートが異なる可能性があるためです。',
         changeApprover: {
             title: '承認者を変更',
             subtitle: 'このレポートの承認者を変更する方法を選択してください。',

--- a/src/languages/nl.ts
+++ b/src/languages/nl.ts
@@ -1525,6 +1525,7 @@ const translations: TranslationDeepObject<typeof en> = {
             },
         },
         moveExpenses: () => ({one: 'Onkosten verplaatsen', other: 'Onkosten verplaatsen'}),
+        moveExpensesError: 'U kunt geen dagvergoedingskosten verplaatsen naar rapporten op andere werkruimtes, omdat de dagvergoedingstarieven tussen werkruimtes kunnen verschillen.',
         changeApprover: {
             title: 'Fiatteur wijzigen',
             subtitle: 'Kies een optie om de fiatteur voor dit rapport te wijzigen.',

--- a/src/languages/pl.ts
+++ b/src/languages/pl.ts
@@ -1524,6 +1524,7 @@ const translations: TranslationDeepObject<typeof en> = {
             },
         },
         moveExpenses: () => ({one: 'Przenieś wydatek', other: 'Przenieś wydatki'}),
+        moveExpensesError: 'Nie możesz przenosić wydatków do raportów w innych obszarach roboczych, ponieważ stawki diety mogą się różnić między obszarami roboczymi.',
         changeApprover: {
             title: 'Zmień akceptującego',
             subtitle: 'Wybierz opcję, aby zmienić osobę zatwierdzającą ten raport.',

--- a/src/languages/pt-BR.ts
+++ b/src/languages/pt-BR.ts
@@ -1523,6 +1523,7 @@ const translations: TranslationDeepObject<typeof en> = {
             },
         },
         moveExpenses: () => ({one: 'Mover despesa', other: 'Mover despesas'}),
+        moveExpensesError: 'Você não pode mover despesas de diária para relatórios em outros espaços de trabalho, porque as taxas de diária podem diferir entre espaços de trabalho.',
         changeApprover: {
             title: 'Alterar aprovador',
             subtitle: 'Escolha uma opção para alterar o aprovador deste relatório.',

--- a/src/languages/zh-hans.ts
+++ b/src/languages/zh-hans.ts
@@ -1502,6 +1502,7 @@ const translations: TranslationDeepObject<typeof en> = {
             },
         },
         moveExpenses: () => ({one: '移动报销', other: '移动报销费用'}),
+        moveExpensesError: '您无法将每日津贴费用移至其他工作区的报告，因为不同工作区之间的每日津贴费率可能有所不同。',
         changeApprover: {
             title: '更改审批人',
             subtitle: '选择一个选项以更改此报表的审批人。',

--- a/src/pages/Search/SearchTransactionsChangeReport.tsx
+++ b/src/pages/Search/SearchTransactionsChangeReport.tsx
@@ -1,11 +1,11 @@
-import React, {useCallback, useMemo} from 'react';
+import React, {useMemo} from 'react';
 import {InteractionManager} from 'react-native';
-import type {OnyxCollection} from 'react-native-onyx';
 import {useSession} from '@components/OnyxListItemProvider';
 import {useSearchContext} from '@components/Search/SearchContext';
 import type {ListItem} from '@components/SelectionListWithSections/types';
 import useConditionalCreateEmptyReportConfirmation from '@hooks/useConditionalCreateEmptyReportConfirmation';
 import useCurrentUserPersonalDetails from '@hooks/useCurrentUserPersonalDetails';
+import useHasPerDiemTransactions from '@hooks/useHasPerDiemTransactions';
 import useOnyx from '@hooks/useOnyx';
 import usePermissions from '@hooks/usePermissions';
 import usePolicyForMovingExpenses from '@hooks/usePolicyForMovingExpenses';
@@ -15,12 +15,10 @@ import setNavigationActionToMicrotaskQueue from '@libs/Navigation/helpers/setNav
 import Navigation from '@libs/Navigation/Navigation';
 import {getReportOrDraftReport, hasViolations as hasViolationsReportUtils} from '@libs/ReportUtils';
 import {shouldRestrictUserBillableActions} from '@libs/SubscriptionUtils';
-import {isPerDiemRequest} from '@libs/TransactionUtils';
 import IOURequestEditReportCommon from '@pages/iou/request/step/IOURequestEditReportCommon';
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
 import ROUTES from '@src/ROUTES';
-import type {Transaction} from '@src/types/onyx';
 
 type TransactionGroupListItem = ListItem & {
     /** reportID of the report */
@@ -34,24 +32,7 @@ function SearchTransactionsChangeReport() {
     const [allReports] = useOnyx(ONYXKEYS.COLLECTION.REPORT, {canBeMissing: false});
     const [allPolicies] = useOnyx(ONYXKEYS.COLLECTION.POLICY, {canBeMissing: true});
     const [allPolicyCategories] = useOnyx(`${ONYXKEYS.COLLECTION.POLICY_CATEGORIES}`, {canBeMissing: true});
-    const hasPerDiemTransactionsSelector = useCallback(
-        (transactions: OnyxCollection<Transaction>) => {
-            return selectedTransactionsKeys.some((transactionID) => {
-                const transaction = transactions?.[`${ONYXKEYS.COLLECTION.TRANSACTION}${transactionID}`];
-                return transaction && isPerDiemRequest(transaction);
-            });
-        },
-        [selectedTransactionsKeys],
-    );
-    const [hasPerDiemTransactions] = useOnyx(
-        ONYXKEYS.COLLECTION.TRANSACTION,
-        {
-            selector: hasPerDiemTransactionsSelector,
-            canBeMissing: true,
-        },
-        [hasPerDiemTransactionsSelector],
-    );
-
+    const hasPerDiemTransactions = useHasPerDiemTransactions(selectedTransactionsKeys);
     const {policyForMovingExpensesID, shouldSelectPolicy} = usePolicyForMovingExpenses(hasPerDiemTransactions);
     const [transactionViolations] = useOnyx(ONYXKEYS.COLLECTION.TRANSACTION_VIOLATIONS, {canBeMissing: true});
     const {isBetaEnabled} = usePermissions();
@@ -176,7 +157,7 @@ function SearchTransactionsChangeReport() {
                 isEditing
                 isUnreported={areAllTransactionsUnreported}
                 targetOwnerAccountID={targetOwnerAccountID}
-                isPerDiemRequest={!!hasPerDiemTransactions}
+                isPerDiemRequest={hasPerDiemTransactions}
             />
         </>
     );

--- a/src/pages/iou/request/step/IOURequestEditReport.tsx
+++ b/src/pages/iou/request/step/IOURequestEditReport.tsx
@@ -1,10 +1,11 @@
-import React, {useMemo} from 'react';
+import React from 'react';
 import type {OnyxEntry} from 'react-native-onyx';
 import {useSession} from '@components/OnyxListItemProvider';
 import {useSearchContext} from '@components/Search/SearchContext';
 import type {ListItem} from '@components/SelectionListWithSections/types';
 import useConditionalCreateEmptyReportConfirmation from '@hooks/useConditionalCreateEmptyReportConfirmation';
 import useCurrentUserPersonalDetails from '@hooks/useCurrentUserPersonalDetails';
+import useHasPerDiemTransactions from '@hooks/useHasPerDiemTransactions';
 import useOnyx from '@hooks/useOnyx';
 import usePermissions from '@hooks/usePermissions';
 import usePolicyForMovingExpenses from '@hooks/usePolicyForMovingExpenses';
@@ -14,7 +15,6 @@ import setNavigationActionToMicrotaskQueue from '@libs/Navigation/helpers/setNav
 import Navigation from '@libs/Navigation/Navigation';
 import {hasViolations as hasViolationsReportUtils} from '@libs/ReportUtils';
 import {shouldRestrictUserBillableActions} from '@libs/SubscriptionUtils';
-import {isPerDiemRequest} from '@libs/TransactionUtils';
 import {createNewReport} from '@userActions/Report';
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
@@ -44,15 +44,8 @@ function IOURequestEditReport({route}: IOURequestEditReportProps) {
     const session = useSession();
     const [allPolicies] = useOnyx(ONYXKEYS.COLLECTION.POLICY, {canBeMissing: true});
     const [allPolicyCategories] = useOnyx(`${ONYXKEYS.COLLECTION.POLICY_CATEGORIES}`, {canBeMissing: true});
-    const [allTransactions] = useOnyx(ONYXKEYS.COLLECTION.TRANSACTION, {canBeMissing: true});
     const currentUserPersonalDetails = useCurrentUserPersonalDetails();
-
-    const hasPerDiemTransactions = useMemo(() => {
-        return selectedTransactionIDs.some((transactionID) => {
-            const transaction = allTransactions?.[`${ONYXKEYS.COLLECTION.TRANSACTION}${transactionID}`];
-            return transaction && isPerDiemRequest(transaction);
-        });
-    }, [selectedTransactionIDs, allTransactions]);
+    const hasPerDiemTransactions = useHasPerDiemTransactions(selectedTransactionIDs);
 
     const {policyForMovingExpensesID, shouldSelectPolicy} = usePolicyForMovingExpenses(hasPerDiemTransactions);
     const [transactionViolations] = useOnyx(ONYXKEYS.COLLECTION.TRANSACTION_VIOLATIONS, {canBeMissing: true});

--- a/src/pages/iou/request/step/IOURequestEditReportCommon.tsx
+++ b/src/pages/iou/request/step/IOURequestEditReportCommon.tsx
@@ -194,16 +194,7 @@ function IOURequestEditReportCommon({
                     policyID: matchingOption?.policyID ?? report.policyID,
                 };
             });
-    }, [
-        outstandingReportsByPolicyID,
-        debouncedSearchValue,
-        expenseReports,
-        selectedReportID,
-        options.reports,
-        localeCompare,
-        allPolicies,
-        currentUserPersonalDetails.accountID,
-    ]);
+    }, [outstandingReportsByPolicyID, debouncedSearchValue, expenseReports, selectedReportID, options.reports, localeCompare, allPolicies, currentUserPersonalDetails.accountID]);
 
     const navigateBack = () => {
         Navigation.goBack(backTo);

--- a/src/pages/iou/request/step/IOURequestEditReportCommon.tsx
+++ b/src/pages/iou/request/step/IOURequestEditReportCommon.tsx
@@ -18,7 +18,7 @@ import usePolicy from '@hooks/usePolicy';
 import usePolicyForMovingExpenses from '@hooks/usePolicyForMovingExpenses';
 import useReportTransactions from '@hooks/useReportTransactions';
 import Navigation from '@libs/Navigation/Navigation';
-import {canSubmitPerDiemExpenseFromWorkspace, getPersonalPolicy, isPolicyAdmin} from '@libs/PolicyUtils';
+import {getPersonalPolicy, isPolicyAdmin} from '@libs/PolicyUtils';
 import {
     canAddTransaction,
     getOutstandingReportsForUser,
@@ -202,7 +202,6 @@ function IOURequestEditReportCommon({
         options.reports,
         localeCompare,
         allPolicies,
-        isPerDiemRequest,
         currentUserPersonalDetails.accountID,
     ]);
 

--- a/src/pages/iou/request/step/IOURequestEditReportCommon.tsx
+++ b/src/pages/iou/request/step/IOURequestEditReportCommon.tsx
@@ -169,13 +169,6 @@ function IOURequestEditReportCommon({
             .filter((report) => !debouncedSearchValue || report?.reportName?.toLowerCase().includes(debouncedSearchValue.toLowerCase()))
             .filter((report): report is NonNullable<typeof report> => report !== undefined)
             .filter((report) => {
-                if (isPerDiemRequest && report?.policyID && selectedReportID !== report?.reportID) {
-                    const policy = allPolicies?.[`${ONYXKEYS.COLLECTION.POLICY}${report.policyID}`];
-                    return canSubmitPerDiemExpenseFromWorkspace(policy);
-                }
-                return true;
-            })
-            .filter((report) => {
                 if (canAddTransaction(report, undefined, true)) {
                     return true;
                 }

--- a/src/pages/iou/request/step/IOURequestEditReportCommon.tsx
+++ b/src/pages/iou/request/step/IOURequestEditReportCommon.tsx
@@ -242,11 +242,7 @@ function IOURequestEditReportCommon({
                 return !customUnitID || !destinationPolicy?.customUnits?.[customUnitID];
             });
 
-            if (invalidPerDiemTransaction) {
-                return false;
-            }
-
-            return true;
+            return !invalidPerDiemTransaction;
         },
         [transactionIDs, allPolicies, allTransactions],
     );
@@ -255,7 +251,14 @@ function IOURequestEditReportCommon({
         if (transactionIDs?.length === 0) {
             return false;
         }
-
+        if (isPerDiemRequest) {
+            const canTransactionsBeMoved = checkIfPerDiemTransactionsCanBeMoved(policyID);
+            if (canTransactionsBeMoved) {
+                return true;
+            }
+            setPerDiemWarningModalVisible(true);
+            return false;
+        }
         return true;
     };
 

--- a/src/pages/iou/request/step/IOURequestEditReportCommon.tsx
+++ b/src/pages/iou/request/step/IOURequestEditReportCommon.tsx
@@ -247,20 +247,22 @@ function IOURequestEditReportCommon({
         [transactionIDs, allPolicies, allTransactions],
     );
 
-    const validatePerDiemMove = (policyID: string | undefined): boolean => {
-        if (transactionIDs?.length === 0) {
-            return false;
-        }
-        if (isPerDiemRequest) {
-            const canTransactionsBeMoved = checkIfPerDiemTransactionsCanBeMoved(policyID);
-            if (canTransactionsBeMoved) {
-                return true;
+    const validatePerDiemMove = useCallback(
+        (policyID: string | undefined): boolean => {
+            if (transactionIDs?.length === 0) {
+                return false;
             }
-            setPerDiemWarningModalVisible(true);
-            return false;
-        }
-        return true;
-    };
+            if (isPerDiemRequest) {
+                if (checkIfPerDiemTransactionsCanBeMoved(policyID)) {
+                    return true;
+                }
+                setPerDiemWarningModalVisible(true);
+                return false;
+            }
+            return true;
+        },
+        [transactionIDs?.length, isPerDiemRequest, checkIfPerDiemTransactionsCanBeMoved],
+    );
 
     const handleSelectReport = (item: TransactionGroupListItem) => {
         if (!validatePerDiemMove(item.policyID)) {


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
<!-- Explain what your change does and how it addresses the linked issue -->

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/76990
$ https://github.com/Expensify/App/issues/76991
PROPOSAL: - 


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

Prerequisites:
- self DM
- at least 2 workspaces with per diem enabled (with different rates)
- a few per diem expenses created on both workspaces
- remove some of the per diem expenses from their workspaces

Moving transactions from the Reports page
1. Go to Reports > Expenses
2. Select a few per diem expenses (from different workspaces)
3. Click X Selected > Move Expenses
4. Verify that you see reports from different workspaces
5. Verify that the secondary text on the Create Report button is the name of the default workspace
6. Click one of the reports
7. Verify that a modal with "You can't move per diem expenses to reports on other workspaces, because the per diem rates may differ between workspaces" message appears.
8. Click "Got it."
9. Click on Create Report 
10. Verify that you see the modal mentioned in step 7
11. Close the RHP (go back to Reports page on mobile)

1. Select one or more per diem expenses that were created FOR THE SAME workspace
2. Repeat steps 3-5 from the previous case
3. Click on the report from another workspace where the expenses were created in
4. Verify that you see the modal mentioned in step 7 in the previous case
5. Click "Got it."
6. Now, click the report from the same workspace that the expenses were created in
7. Verify that the expenses are moved to the selected report and RHP closes (you're navigated back to the Reports page)

1. Select one or more per diem expenses that were created FOR THE SAME workspace.
2. Repeat steps 3-5 from the first case
3. Click on Create Report 
4. If the expenses were created on the default workspace - verify that the expenses are moved to the newly created report and RHP closes (you're navigated back to the Reports page)
5. If the expenses were created on the non-default workspace - verify that you see the modal mentioned in step 7 in the first case
6. Repeat steps 1-5 for the default and non-default workspace case

Moving transactions from the Report View
1. Go to one of the workspaces with per diem expenses (make sure you have at least one report with several expenses)
2. Go to the report with several expenses
3. Select a few per diem expenses
4. Click XSelected > Move Expenses
5. Verify that you see reports from different workspaces
6. Verify that the secondary text on the Create Report button is the name of the default workspace
7. Click on the report from another workspace
8. Verify that you see the modal mentioned in step 7 in the first test case
5. Click "Got it."
6. Now, click the report from the same workspace
7. Verify that the expenses are moved to the selected report and RHP closes (you're navigated back to Report view)

Moving transactions from the Transaction thread View
1. Go to any transaction
2. Click the Report field
3. Verify that you see reports from different workspaces
4. Verify that the secondary text on the Create Report button is the name of the default workspace
5. Click on the report from another workspace where the expenses were created in
6. Verify that you see the modal mentioned in step 7 in the first case
7. 5. Click "Got it."
6. Now, click the report from the same workspace that the expenses were created in
7. Verify that the expenses are moved to the selected report and RHP closes (you're navigated backto the transaction view)


- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

n/a

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
21. Upload an image via copy paste
22. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->
// TODO: These must be filled out, or the issue title must include "[No QA]."

Same as tests.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I verified there are no new alerts related to the `canBeMissing` param for `useOnyx`
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/03794cad-7bc0-4054-baea-23309e65524d


https://github.com/user-attachments/assets/0da6b85f-030d-4b75-a406-ca28deda6160


https://github.com/user-attachments/assets/8d536e44-6575-4b29-a658-75c31b5b31be


</details>