### PR TITLE
[NO QA] Introducing eslint rule and updated docs regarding forwardRef removal

### DIFF
--- a/contributingGuides/STYLE.md
+++ b/contributingGuides/STYLE.md
@@ -1146,31 +1146,33 @@ export default function <TProps extends WithCurrentUserPersonalDetailsProps>(Wra
 
 ### Forwarding refs
 
-When forwarding a ref define named component and pass it directly to the `forwardRef`. By doing this, we remove potential extra layer in React tree in the form of anonymous component.
+In React 19, `forwardRef` is no longer necessary. Simply pass `ref` as a prop instead of using `forwardRef`.
+
+***Note:*** *prop must be named `ref` explicitly (it's a special prop like `children`)*
 
 ```tsx
-import type {ForwarderRef} from 'react';
+import type {Ref} from 'react';
 
 type FancyInputProps = {
+    ref?: Ref<TextInput>; // Note: prop must be named "ref" explicitly
     ...
 };
 
-function FancyInput(props: FancyInputProps, ref: ForwardedRef<TextInput>) {
+function FancyInput({ ref, ...props }: FancyInputProps) {
     ...
-    return <input {...props} ref={ref} />
+    return <TextInput ref={myRef} {...props} />
 };
 
-export default React.forwardRef(FancyInput)
+export default FancyInput
 ```
 
-If the ref handle is not available (e.g. `useImperativeHandle` is used) you can define a custom handle type above the component.
+For imperative handles using `useImperativeHandle`, now you can also just pass `ref` as a prop:
 
 ```tsx
-import type {ForwarderRef} from 'react';
 import {useImperativeHandle} from 'react';
 
 type FancyInputProps = {
-    ...
+    ref?: React.Ref<FancyInputHandle>; // Note: prop must be named "ref" explicitly
     onButtonPressed: () => void;
 };
 
@@ -1178,14 +1180,14 @@ type FancyInputHandle = {
   onButtonPressed: () => void;
 }
 
-function FancyInput(props: FancyInputProps, ref: ForwardedRef<FancyInputHandle>) {
+function FancyInput({ ref, ...props }: FancyInputProps) {
     useImperativeHandle(ref, () => ({onButtonPressed}));
 
     ...
-    return <input {...props} ref={ref} />;
+    return <TextInput {...props} />;
 };
 
-export default React.forwardRef(FancyInput)
+export default FancyInput
 ```
 
 ### Hooks and HOCs

--- a/contributingGuides/STYLE.md
+++ b/contributingGuides/STYLE.md
@@ -1146,7 +1146,7 @@ export default function <TProps extends WithCurrentUserPersonalDetailsProps>(Wra
 
 ### Forwarding refs
 
-In React 19, `forwardRef` is no longer necessary. Simply pass `ref` as a prop instead of using `forwardRef`.
+In React 19, `forwardRef` is deprecated and no longer necessary. Simply pass `ref` as a prop instead of using `forwardRef`.
 
 ***Note:*** *prop must be named `ref` explicitly (it's a special prop like `children`)*
 

--- a/contributingGuides/TS_CHEATSHEET.md
+++ b/contributingGuides/TS_CHEATSHEET.md
@@ -4,7 +4,7 @@
 
 - [CheatSheet](#cheatsheet)
   - [1.1 `props.children`](#children-prop)
-  - [1.2 `forwardRef`](#forwardRef)
+  - [1.2 Refs as Props](#references)
   - [1.3 Style Props](#style-props)
   - [1.4 Animated styles](#animated-style)
   - [1.5 Render Prop](#render-prop)
@@ -40,22 +40,25 @@
   }
   ```
 
-<a name="forwardRef"></a><a name="1.2"></a>
+<a name="references"></a><a name="1.2"></a>
 
-- [1.2](#forwardRef) **`forwardRef`**
+- [1.2](#references) **Refs as Props**
 
-  ```ts
+  In React 19, `forwardRef` is deprecated and no longer necessary. Simply pass `ref` as a prop instead.
+
+  ```tsx
   // CustomTextInput.tsx
 
-  import { forwardRef, useRef, ReactNode, ForwardedRef } from "react";
+  import type { Ref, ReactNode } from "react";
   import { TextInput, View } from "react-native";
 
   export type CustomTextInputProps = {
     label: string;
     children?: ReactNode;
+    ref?: Ref<TextInput>; // Note: prop must be named "ref" explicitly
   };
 
-  function CustomTextInput(props: CustomTextInputProps, ref: ForwardedRef<TextInput>) {
+  function CustomTextInput({ ref, ...props }: CustomTextInputProps) {
     return (
       <View>
         <TextInput ref={ref} />
@@ -64,14 +67,41 @@
     );
   };
 
-  export default forwardRef(CustomTextInput);
+  export default CustomTextInput;
 
   // ParentComponent.tsx
+
+  import { useRef } from "react";
+  import { TextInput } from "react-native";
 
   function ParentComponent() {
     const ref = useRef<TextInput>();
     return <CustomTextInput ref={ref} label="Press me" />;
   }
+  ```
+
+  For imperative handles, now you can also just pass `ref` as a prop:
+
+  ```tsx
+  import { useImperativeHandle } from "react";
+
+  type CustomInputProps = {
+    ref?: React.Ref<CustomHandle>; // Note: prop must be named "ref" explicitly
+  };
+
+  type CustomHandle = {
+    focus: () => void;
+  };
+
+  function CustomInput({ ref, ...props }: CustomInputProps) {
+    useImperativeHandle(ref, () => ({
+      focus: () => {/* implementation */}
+    }));
+
+    return <TextInput {...props} />;
+  }
+
+  export default CustomInput;
   ```
 
 <a name="style-props"></a><a name="1.3"></a>

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -68,7 +68,7 @@ const restrictedImportPaths = [
     {
         name: 'react',
         importNames: ['forwardRef'],
-        message: "forwardRef is deprecated. Please use ref as a prop instead. See: contributingGuides/STYLE.md#forwarding-refs",
+        message: 'forwardRef is deprecated. Please use ref as a prop instead. See: contributingGuides/STYLE.md#forwarding-refs',
     },
     {
         name: '@styles/index',

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -66,6 +66,11 @@ const restrictedImportPaths = [
         message: "Please use 'ViewStyle', 'TextStyle', 'ImageStyle' from 'react-native' instead.",
     },
     {
+        name: 'react',
+        importNames: ['forwardRef'],
+        message: "forwardRef is deprecated. Please use alternative patterns instead.",
+    },
+    {
         name: '@styles/index',
         importNames: ['default', 'defaultStyles'],
         message: 'Do not import styles directly. Please use the `useThemeStyles` hook instead.',

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -333,7 +333,7 @@ const config = defineConfig([
                 },
                 {
                     selector: 'CallExpression[callee.object.name="React"][callee.property.name="forwardRef"]',
-                    message: "forwardRef is deprecated. Please use ref as a prop instead. See: contributingGuides/STYLE.md#forwarding-refs",
+                    message: 'forwardRef is deprecated. Please use ref as a prop instead. See: contributingGuides/STYLE.md#forwarding-refs',
                 },
                 {
                     selector: 'CallExpression[callee.name="getUrlWithBackToParam"]',

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -332,6 +332,10 @@ const config = defineConfig([
                     message: "Please don't declare enums, use union types instead.",
                 },
                 {
+                    selector: 'CallExpression[callee.object.name="React"][callee.property.name="forwardRef"]',
+                    message: "forwardRef is deprecated. Please use ref as a prop instead. See: contributingGuides/STYLE.md#forwarding-refs",
+                },
+                {
                     selector: 'CallExpression[callee.name="getUrlWithBackToParam"]',
                     message:
                         'Usage of getUrlWithBackToParam function is prohibited. This is legacy code and no new occurrences should be added. Please look into the `How to remove backTo from URL` section in contributingGuides/NAVIGATION.md. and use alternative routing methods instead.',

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -68,7 +68,7 @@ const restrictedImportPaths = [
     {
         name: 'react',
         importNames: ['forwardRef'],
-        message: "forwardRef is deprecated. Please use alternative patterns instead.",
+        message: "forwardRef is deprecated. Please use ref as a prop instead. See: contributingGuides/STYLE.md#forwarding-refs",
     },
     {
         name: '@styles/index',

--- a/src/components/AnimatedFlatListWithCellRenderer.tsx
+++ b/src/components/AnimatedFlatListWithCellRenderer.tsx
@@ -3,6 +3,7 @@
  * This should be updated when the original implementation updates
  * Taken from: https://github.com/software-mansion/react-native-reanimated/blob/main/packages/react-native-reanimated/src/component/FlatList.tsx
  */
+// eslint-disable-next-line no-restricted-imports
 import React, {forwardRef, useRef} from 'react';
 import type {FlatListProps, CellRendererProps as RNCellRendererProps} from 'react-native';
 import {FlatList} from 'react-native';

--- a/src/components/FlatList/FlatListWithScrollKey/BaseFlatListWithScrollKey.tsx
+++ b/src/components/FlatList/FlatListWithScrollKey/BaseFlatListWithScrollKey.tsx
@@ -1,4 +1,5 @@
 import type {ForwardedRef} from 'react';
+// eslint-disable-next-line no-restricted-imports
 import React, {forwardRef, useEffect, useRef} from 'react';
 import type {FlatList as RNFlatList} from 'react-native';
 import useFlatListScrollKey from '@hooks/useFlatListScrollKey';

--- a/src/components/FlatList/FlatListWithScrollKey/index.ios.tsx
+++ b/src/components/FlatList/FlatListWithScrollKey/index.ios.tsx
@@ -1,4 +1,5 @@
 import type {ForwardedRef} from 'react';
+// eslint-disable-next-line no-restricted-imports
 import React, {forwardRef, useCallback, useRef} from 'react';
 import type {LayoutChangeEvent, FlatList as RNFlatList} from 'react-native';
 import mergeRefs from '@libs/mergeRefs';

--- a/src/components/FlatList/FlatListWithScrollKey/index.tsx
+++ b/src/components/FlatList/FlatListWithScrollKey/index.tsx
@@ -1,4 +1,5 @@
 import type {ForwardedRef} from 'react';
+// eslint-disable-next-line no-restricted-imports
 import React, {forwardRef} from 'react';
 import type {FlatList as RNFlatList} from 'react-native';
 import BaseFlatListWithScrollKey from './BaseFlatListWithScrollKey';

--- a/src/components/KeyboardDismissibleFlatList/index.ios.tsx
+++ b/src/components/KeyboardDismissibleFlatList/index.ios.tsx
@@ -1,4 +1,5 @@
 import type {ForwardedRef} from 'react';
+// eslint-disable-next-line no-restricted-imports
 import {forwardRef, useEffect} from 'react';
 import type {FlatList} from 'react-native';
 import {useAnimatedProps, useComposedEventHandler} from 'react-native-reanimated';

--- a/src/components/KeyboardDismissibleFlatList/index.tsx
+++ b/src/components/KeyboardDismissibleFlatList/index.tsx
@@ -28,4 +28,5 @@ function KeyboardDismissibleFlatList<T>({onScroll: onScrollProp, inverted, ...re
     );
 }
 
+// eslint-disable-next-line no-restricted-syntax
 export default React.forwardRef(KeyboardDismissibleFlatList);

--- a/src/pages/signin/ValidateCodeCountdown/index.tsx
+++ b/src/pages/signin/ValidateCodeCountdown/index.tsx
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-restricted-imports
 import React, {forwardRef, useEffect, useImperativeHandle, useRef, useState} from 'react';
 import RenderHTML from '@components/RenderHTML';
 import useLocalize from '@hooks/useLocalize';


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->
@mountiny I've disabled eslint for the remaining `forwardRef`'s added in the meantime and will remove them in the next PR as we agreed. Merry Christmas! 🎄 

### Explanation of Change
<!-- Explain what your change does and how it addresses the linked issue -->

**What Changed:**
This PR introduces ESLint rules and documentation updates to align with React 19's new ref handling approach, where `forwardRef` is no longer necessary.

**Context:**
In React 19, `forwardRef` has been deprecated and refs can now be passed directly as props. This simplifies ref handling by eliminating the need for the `forwardRef` wrapper function.

**Changes Made:**

1. ESLint Configuration (_eslint.config.mjs_)
- Added a new restricted import rule that blocks importing forwardRef from React
- Error message guides developers to use the new ref-as-prop approach instead
```
{
    name: 'react',
    importNames: ['forwardRef'],
    message: 'forwardRef is deprecated. Please use ref as a prop instead. See: contributingGuides/STYLE.md#forwarding-refs',
},
```

2. Documentation updates
_contributingGuides/STYLE.md_: Updated "Forwarding refs" section to show React 19 approach
_contributingGuides/TS_CHEATSHEET.md_: Updated examples to demonstrate ref-as-prop pattern


**Before (React 18):**
```
const MyComponent = forwardRef((props, ref) => (  <input ref={ref} {...props} />));
```

**After (React 19):**
```
function MyComponent({ ref, ...props }) {
  return <input ref={ref} {...props} />;
}
function MyComponent({ ref, ...props }) {  return <input ref={ref} {...props} />;
```

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/67033
PROPOSAL: N/A


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->
// TODO: These must be filled out, or the issue title must include "[No QA]."

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I verified there are no new alerts related to the `canBeMissing` param for `useOnyx`
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>