### PR TITLE
[CP Staging] [Share Bank Account] Fix share bank account share button and filtering

### DIFF
--- a/src/components/SelectionList/BaseSelectionList.tsx
+++ b/src/components/SelectionList/BaseSelectionList.tsx
@@ -80,6 +80,7 @@ function BaseSelectionList<TItem extends ListItem>({
     shouldSingleExecuteRowSelect = false,
     shouldPreventDefaultFocusOnSelectRow = false,
     shouldShowTextInput = !!textInputOptions?.label,
+    shouldClearInputOnSelect = false,
     shouldHighlightSelectedItem = true,
     shouldUseDefaultRightHandSideCheckmark,
     shouldDisableHoverStyle = false,
@@ -187,7 +188,7 @@ function BaseSelectionList<TItem extends ListItem>({
                 return;
             }
             if (canSelectMultiple) {
-                if (shouldShowTextInput) {
+                if (shouldShowTextInput && shouldClearInputOnSelect) {
                     textInputOptions?.onChangeText?.('');
                 } else if (isSmallScreenWidth) {
                     if (!item.isDisabledCheckbox) {
@@ -211,6 +212,7 @@ function BaseSelectionList<TItem extends ListItem>({
             shouldUpdateFocusedIndex,
             onSelectRow,
             shouldShowTextInput,
+            shouldClearInputOnSelect,
             shouldPreventDefaultFocusOnSelectRow,
             isSmallScreenWidth,
             textInputOptions,

--- a/src/components/SelectionList/types.ts
+++ b/src/components/SelectionList/types.ts
@@ -151,6 +151,9 @@ type SelectionListProps<TItem extends ListItem> = Partial<ChildrenProps> & {
     /** Whether to show the text input */
     shouldShowTextInput?: boolean;
 
+    /** Whether to clear the text input when a row is selected */
+    shouldClearInputOnSelect?: boolean;
+
     /** Whether to highlight the selected item */
     shouldHighlightSelectedItem?: boolean;
 

--- a/src/pages/settings/Wallet/ShareBankAccount/ShareBankAccount.tsx
+++ b/src/pages/settings/Wallet/ShareBankAccount/ShareBankAccount.tsx
@@ -6,8 +6,8 @@ import FormAlertWithSubmitButton from '@components/FormAlertWithSubmitButton';
 import HeaderWithBackButton from '@components/HeaderWithBackButton';
 import ScreenWrapper from '@components/ScreenWrapper';
 import ScrollView from '@components/ScrollView';
-import SelectionList from '@components/SelectionList';
-import UserListItem from '@components/SelectionList/ListItem/UserListItem';
+import SelectionList from '@components/SelectionListWithSections';
+import UserListItem from '@components/SelectionListWithSections/UserListItem';
 import Text from '@components/Text';
 import useCurrentUserPersonalDetails from '@hooks/useCurrentUserPersonalDetails';
 import useDebouncedState from '@hooks/useDebouncedState';
@@ -180,13 +180,12 @@ function ShareBankAccount({route}: ShareBankAccountProps) {
                     <Text style={[styles.ph5, styles.pb3]}>{translate('walletPage.shareBankAccountTitle')}</Text>
                     <SelectionList
                         canSelectMultiple
-                        textInputOptions={{
-                            headerMessage,
-                            value: searchTerm,
-                            label: textInputLabel,
-                            onChangeText: setSearchTerm,
-                        }}
-                        data={adminsList}
+                        sections={sections}
+                        textInputValue={searchTerm}
+                        textInputLabel={textInputLabel}
+                        onChangeText={setSearchTerm}
+                        headerMessage={headerMessage}
+                        shouldClearInputOnSelect={false}
                         onSelectAll={toggleSelectAll}
                         shouldUpdateFocusedIndex
                         listEmptyContent={
@@ -200,6 +199,7 @@ function ShareBankAccount({route}: ShareBankAccountProps) {
                         }
                         ListItem={UserListItem}
                         shouldUseDefaultRightHandSideCheckmark
+                        onCheckboxPress={toggleOption}
                         onSelectRow={toggleOption}
                         footerContent={
                             <FormAlertWithSubmitButton

--- a/src/pages/settings/Wallet/ShareBankAccount/ShareBankAccount.tsx
+++ b/src/pages/settings/Wallet/ShareBankAccount/ShareBankAccount.tsx
@@ -118,7 +118,7 @@ function ShareBankAccount({route}: ShareBankAccountProps) {
         // Apply search filter if there's a search term
         if (debouncedSearchTerm) {
             const searchValue = getSearchValueForPhoneOrEmail(debouncedSearchTerm, countryCode).toLowerCase();
-            adminsToDisplay = tokenizedSearch(admins, searchValue, (option) => [option.text ?? '', option.alternateText ?? '']);
+            adminsToDisplay = tokenizedSearch(adminsToDisplay, searchValue, (option) => [option.text ?? '', option.alternateText ?? '']);
         }
 
         return adminsToDisplay;

--- a/src/pages/settings/Wallet/ShareBankAccount/ShareBankAccount.tsx
+++ b/src/pages/settings/Wallet/ShareBankAccount/ShareBankAccount.tsx
@@ -6,8 +6,8 @@ import FormAlertWithSubmitButton from '@components/FormAlertWithSubmitButton';
 import HeaderWithBackButton from '@components/HeaderWithBackButton';
 import ScreenWrapper from '@components/ScreenWrapper';
 import ScrollView from '@components/ScrollView';
-import SelectionList from '@components/SelectionListWithSections';
-import UserListItem from '@components/SelectionListWithSections/UserListItem';
+import SelectionList from '@components/SelectionList';
+import UserListItem from '@components/SelectionList/ListItem/UserListItem';
 import Text from '@components/Text';
 import useCurrentUserPersonalDetails from '@hooks/useCurrentUserPersonalDetails';
 import useDebouncedState from '@hooks/useDebouncedState';
@@ -136,9 +136,7 @@ function ShareBankAccount({route}: ShareBankAccountProps) {
             setSelectedOptions(selectedOptions.filter((option) => !filteredLogins.has(option.login)));
         } else {
             const existingLogins = new Set(selectedOptions.map((option) => option.login));
-            const newSelections = adminsList
-                .filter((admin) => !existingLogins.has(admin.login))
-                .map((admin) => ({...admin, isSelected: true}));
+            const newSelections = adminsList.filter((admin) => !existingLogins.has(admin.login)).map((admin) => ({...admin, isSelected: true}));
             setSelectedOptions([...selectedOptions, ...newSelections]);
         }
     };
@@ -180,12 +178,13 @@ function ShareBankAccount({route}: ShareBankAccountProps) {
                     <Text style={[styles.ph5, styles.pb3]}>{translate('walletPage.shareBankAccountTitle')}</Text>
                     <SelectionList
                         canSelectMultiple
-                        sections={sections}
-                        textInputValue={searchTerm}
-                        textInputLabel={textInputLabel}
-                        onChangeText={setSearchTerm}
-                        headerMessage={headerMessage}
-                        shouldClearInputOnSelect={false}
+                        textInputOptions={{
+                            headerMessage,
+                            value: searchTerm,
+                            label: textInputLabel,
+                            onChangeText: setSearchTerm,
+                        }}
+                        data={adminsList}
                         onSelectAll={toggleSelectAll}
                         shouldUpdateFocusedIndex
                         listEmptyContent={

--- a/src/pages/settings/Wallet/ShareBankAccount/ShareBankAccount.tsx
+++ b/src/pages/settings/Wallet/ShareBankAccount/ShareBankAccount.tsx
@@ -127,17 +127,19 @@ function ShareBankAccount({route}: ShareBankAccountProps) {
     const adminsList = getAdminList();
 
     const toggleSelectAll = () => {
-        const hasSelectedOptions = selectedOptions.length > 0;
         setIsAlertVisible(false);
 
-        if (hasSelectedOptions) {
-            setSelectedOptions([]);
+        const areAllFilteredOptionsSelected = adminsList.length > 0 && adminsList.every((admin) => selectedOptions.some((selected) => selected.login === admin.login));
+
+        if (areAllFilteredOptionsSelected) {
+            const filteredLogins = new Set(adminsList.map((admin) => admin.login));
+            setSelectedOptions(selectedOptions.filter((option) => !filteredLogins.has(option.login)));
         } else {
-            const selectedAllOptions = adminsList?.map((member) => ({
-                ...member,
-                isSelected: true,
-            }));
-            setSelectedOptions(selectedAllOptions);
+            const existingLogins = new Set(selectedOptions.map((option) => option.login));
+            const newSelections = adminsList
+                .filter((admin) => !existingLogins.has(admin.login))
+                .map((admin) => ({...admin, isSelected: true}));
+            setSelectedOptions([...selectedOptions, ...newSelections]);
         }
     };
 

--- a/src/pages/settings/Wallet/WalletPage/index.tsx
+++ b/src/pages/settings/Wallet/WalletPage/index.tsx
@@ -130,9 +130,7 @@ function WalletPage() {
                     type: CONST.PAYMENT_METHODS.DEBIT_CARD,
                 };
             }
-            if (accountData?.type === CONST.BANK_ACCOUNT.TYPE.BUSINESS) {
-                setShouldShowShareButton(accountData?.state === CONST.BANK_ACCOUNT.STATE.OPEN);
-            }
+            setShouldShowShareButton(accountData?.type === CONST.BANK_ACCOUNT.TYPE.BUSINESS && accountData?.state === CONST.BANK_ACCOUNT.STATE.OPEN);
             setPaymentMethod({
                 isSelectedPaymentMethodDefault: !!isDefault,
                 selectedPaymentMethod: accountData ?? {},


### PR DESCRIPTION
### Explanation of Change

Fixes a couple of bugs 

1. The share option was erroneously showing up for personal bank accounts because we weren't setting it to false 
2. When searching for a user after selecting them, we wouldn't retain the selected status 


### Fixed Issues
$ https://github.com/Expensify/App/issues/78367
$ https://github.com/Expensify/App/issues/78366


### Tests

bug 1: 

Precondition:

- Workspace owner has invited user as workspace admin.
- Workspace is set up with business bank account.
- Workspace owner has personal bank account.
- Perform the steps below as workspace owner.

1. Go to Profile > Wallet.
2. Click on the business bank account.
3. Click Share.
4. Click on the personal bank account.
6. Confirm you don't see the option to share

bug 2: 

Precondition:

- Workspace is set up with bank account.
- Workspace has at least 13 admins.
- Perform the action below as workspace owner:

1. Go to Profile > Wallet.
2. Click 3-dot menu on the bank account > Share.
3. Search for a user and select the user.
5. Search for the same user.
6. Confirm the selected user will be marked as selected in the search result.

- [x] Verify that no errors appear in the JS console

### Offline tests
N/A 


### QA Steps

Same as test steps 

- [x] Verify that no errors appear in the JS console

### PR Author Checklist


- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I verified there are no new alerts related to the `canBeMissing` param for `useOnyx`
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>

https://github.com/user-attachments/assets/867443d1-c3eb-4574-a597-345daeb94553


