### PR TITLE
Update link behaviour for PDF on native devices for trip

### DIFF
--- a/src/ROUTES.ts
+++ b/src/ROUTES.ts
@@ -2591,7 +2591,10 @@ const ROUTES = {
     },
     TRAVEL_DOT_LINK_WEB_VIEW: {
         route: 'travel-dot-link',
-        getRoute: (token: string, isTestAccount?: boolean) => `travel-dot-link?token=${token}&isTestAccount=${isTestAccount}` as const,
+        getRoute: (token: string, isTestAccount?: boolean, postLoginPath?: string) => {
+            const redirectURL = postLoginPath ? `&redirectUrl=${encodeURIComponent(postLoginPath)}` : '';
+            return `travel-dot-link?token=${token}&isTestAccount=${isTestAccount}${redirectURL}` as const;
+        },
     },
     TRAVEL_TCS: {
         route: 'travel/terms/:domain/accept',

--- a/src/components/PDFView/index.native.tsx
+++ b/src/components/PDFView/index.native.tsx
@@ -127,14 +127,17 @@ function PDFView({onToggleKeyboard, onLoadComplete, fileName, onPress, isFocused
     /**
      * Handle press link event on native apps.
      */
-    const handlePressLink = useCallback((url: string) => {
-        if (isTravelLink(url) && activePolicyID) {
-            const postLoginPath = getRelativeUrl(url);
-            openTravelDotLink(activePolicyID, postLoginPath);
-            return;
-        }
-        Linking.openURL(url);
-    }, []);
+    const handlePressLink = useCallback(
+        (url: string) => {
+            if (isTravelLink(url) && activePolicyID) {
+                const postLoginPath = getRelativeUrl(url);
+                openTravelDotLink(activePolicyID, postLoginPath);
+                return;
+            }
+            Linking.openURL(url);
+        },
+        [activePolicyID],
+    );
 
     function renderPDFView() {
         const pdfWidth = isUsedAsChatAttachment ? LOADING_THUMBNAIL_WIDTH : windowWidth;

--- a/src/components/PDFView/index.native.tsx
+++ b/src/components/PDFView/index.native.tsx
@@ -7,11 +7,15 @@ import KeyboardAvoidingView from '@components/KeyboardAvoidingView';
 import PressableWithoutFeedback from '@components/Pressable/PressableWithoutFeedback';
 import useKeyboardState from '@hooks/useKeyboardState';
 import useLocalize from '@hooks/useLocalize';
+import useOnyx from '@hooks/useOnyx';
 import useResponsiveLayout from '@hooks/useResponsiveLayout';
 import useStyleUtils from '@hooks/useStyleUtils';
 import useThemeStyles from '@hooks/useThemeStyles';
 import useWindowDimensions from '@hooks/useWindowDimensions';
+import {openTravelDotLink} from '@libs/openTravelDotLink';
+import {getRelativeUrl, isTravelLink} from '@libs/TravelUtils';
 import CONST from '@src/CONST';
+import ONYXKEYS from '@src/ONYXKEYS';
 import PDFPasswordForm from './PDFPasswordForm';
 import type {PDFViewNativeProps} from './types';
 
@@ -47,6 +51,8 @@ function PDFView({onToggleKeyboard, onLoadComplete, fileName, onPress, isFocused
     const themeStyles = useThemeStyles();
     const {isKeyboardShown} = useKeyboardState();
     const StyleUtils = useStyleUtils();
+
+    const [activePolicyID] = useOnyx(ONYXKEYS.NVP_ACTIVE_POLICY_ID, {canBeMissing: true});
 
     useEffect(() => {
         onToggleKeyboard?.(isKeyboardShown);
@@ -122,6 +128,11 @@ function PDFView({onToggleKeyboard, onLoadComplete, fileName, onPress, isFocused
      * Handle press link event on native apps.
      */
     const handlePressLink = useCallback((url: string) => {
+        if (isTravelLink(url) && activePolicyID) {
+            const postLoginPath = getRelativeUrl(url);
+            openTravelDotLink(activePolicyID, postLoginPath);
+            return;
+        }
         Linking.openURL(url);
     }, []);
 

--- a/src/libs/Navigation/types.ts
+++ b/src/libs/Navigation/types.ts
@@ -2241,6 +2241,7 @@ type TravelNavigatorParamList = {
     [SCREENS.TRAVEL.TRAVEL_DOT_LINK_WEB_VIEW]: {
         token: string;
         isTestAccount?: string;
+        redirectUrl?: string;
     };
     [SCREENS.TRAVEL.TRIP_SUMMARY]: {
         reportID: string;

--- a/src/libs/TravelUtils/index.tsx
+++ b/src/libs/TravelUtils/index.tsx
@@ -19,12 +19,12 @@ function isTravelLink(url: string): boolean {
         const {hostname, pathname} = new URL(url.toLowerCase());
 
         // Any travel subdomain (prod, staging, dev, etc.)
-        if (hostname.includes('travel.expensify.com')) {
+        if (hostname.endsWith('travel.expensify.com')) {
             return true;
         }
 
         // Trip pages hosted on any expensify domain
-        if (hostname.includes('expensify.com') && pathname.includes('/trips/')) {
+        if (hostname.endsWith('expensify.com') && pathname.includes('/trips/')) {
             return true;
         }
 

--- a/src/libs/TravelUtils/index.tsx
+++ b/src/libs/TravelUtils/index.tsx
@@ -1,0 +1,62 @@
+/**
+ * Determines whether the given URL points to an Expensify Travel (Trip) page.
+ *
+ * A link is considered a travel link if:
+ * - it belongs to any `*.travel.expensify.com` domain, or
+ * - it belongs to any `*.expensify.com` domain and contains a `/trips/` path segment
+ *
+ * The check is case-insensitive and safely handles invalid URLs.
+ *
+ * @param url - URL string to evaluate
+ * @returns true if the URL is an Expensify Travel / Trip link, otherwise false
+ */
+function isTravelLink(url: string): boolean {
+    if (!url) {
+        return false;
+    }
+
+    try {
+        const {hostname, pathname} = new URL(url.toLowerCase());
+
+        // Any travel subdomain (prod, staging, dev, etc.)
+        if (hostname.includes('travel.expensify.com')) {
+            return true;
+        }
+
+        // Trip pages hosted on any expensify domain
+        if (hostname.includes('expensify.com') && pathname.includes('/trips/')) {
+            return true;
+        }
+
+        return false;
+    } catch {
+        return false;
+    }
+}
+
+/**
+ * Extracts a relative path from a full URL.
+ *
+ * Example:
+ * https://staging.new.expensify.com/trips/3737539511 -> /trips/3737539511
+ *
+ * Returns an empty string for invalid or empty URLs.
+ *
+ * @param url - Absolute URL string
+ * @returns Relative URL path starting with `/`
+ */
+function getRelativeUrl(url: string): string {
+    if (!url) {
+        return '';
+    }
+
+    try {
+        const {pathname, search, hash} = new URL(url);
+
+        return `${pathname}${search}${hash}`;
+    } catch {
+        return '';
+    }
+}
+
+export {isTravelLink, getRelativeUrl};

--- a/src/libs/actions/Link.ts
+++ b/src/libs/actions/Link.ts
@@ -117,7 +117,7 @@ function buildTravelDotURL(spotnanaToken: string, isTestAccount: boolean, postLo
 
     const authCode = `authCode=${spotnanaToken}`;
     const tmcIDParam = `tmcId=${tmcID}`;
-    const redirectURL = postLoginPath ? `redirectUrl=${Url.addLeadingForwardSlash(postLoginPath)}` : '';
+    const redirectURL = postLoginPath ? `redirectUrl=${encodeURIComponent(Url.addLeadingForwardSlash(postLoginPath))}` : '';
 
     const paramsArray = [authCode, tmcIDParam, redirectURL];
     const params = paramsArray.filter(Boolean).join('&');

--- a/src/libs/openTravelDotLink/index.native.ts
+++ b/src/libs/openTravelDotLink/index.native.ts
@@ -2,11 +2,11 @@ import {getTravelDotLink} from '@libs/actions/Link';
 import Navigation from '@libs/Navigation/Navigation';
 import ROUTES from '@src/ROUTES';
 
-const openTravelDotLink = (activePolicyID?: string) => {
+const openTravelDotLink = (activePolicyID?: string, postLoginPath?: string) => {
     getTravelDotLink(activePolicyID)
         ?.then((response) => {
             if (response.spotnanaToken) {
-                Navigation.navigate(ROUTES.TRAVEL_DOT_LINK_WEB_VIEW.getRoute(response.spotnanaToken, response.isTestAccount));
+                Navigation.navigate(ROUTES.TRAVEL_DOT_LINK_WEB_VIEW.getRoute(response.spotnanaToken, response.isTestAccount, postLoginPath));
                 return;
             }
             Navigation.navigate(ROUTES.TRAVEL_MY_TRIPS.getRoute(activePolicyID));

--- a/src/libs/openTravelDotLink/index.ts
+++ b/src/libs/openTravelDotLink/index.ts
@@ -2,8 +2,8 @@ import {openTravelDotLink as openTravelDotLinkWeb} from '@libs/actions/Link';
 import Navigation from '@libs/Navigation/Navigation';
 import ROUTES from '@src/ROUTES';
 
-const openTravelDotLink = (activePolicyID?: string) => {
-    openTravelDotLinkWeb(activePolicyID)
+const openTravelDotLink = (activePolicyID?: string, postLoginPath?: string) => {
+    openTravelDotLinkWeb(activePolicyID, postLoginPath)
         ?.then(() => {})
         ?.catch(() => {
             Navigation.navigate(ROUTES.TRAVEL_MY_TRIPS.getRoute(activePolicyID));

--- a/src/pages/Travel/TravelDotLinkWebview.tsx
+++ b/src/pages/Travel/TravelDotLinkWebview.tsx
@@ -13,11 +13,11 @@ type TravelDotLinkWebviewProps = StackScreenProps<TravelNavigatorParamList, type
 
 function TravelDotLinkWebview({route}: TravelDotLinkWebviewProps) {
     const {translate} = useLocalize();
-    const {token, isTestAccount} = route.params;
+    const {token, isTestAccount, redirectUrl} = route.params;
     const webViewRef = useRef<WebView>(null);
     const styles = useThemeStyles();
 
-    const url = buildTravelDotURL(token, isTestAccount === 'true');
+    const url = buildTravelDotURL(token, isTestAccount === 'true', redirectUrl);
 
     return (
         <ScreenWrapper

--- a/tests/unit/libs/TravelUtilsTest.ts
+++ b/tests/unit/libs/TravelUtilsTest.ts
@@ -1,0 +1,98 @@
+import {getRelativeUrl, isTravelLink} from '@libs/TravelUtils';
+
+describe('TravelUtils', () => {
+    describe('isTravelLink', () => {
+        it('should return false for empty or undefined values', () => {
+            expect(isTravelLink('')).toBe(false);
+            expect(isTravelLink(undefined as unknown as string)).toBe(false);
+        });
+
+        it('should return true for direct travel domain links', () => {
+            expect(isTravelLink('https://travel.expensify.com')).toBe(true);
+            expect(isTravelLink('https://staging.travel.expensify.com')).toBe(true);
+            expect(isTravelLink('https://dev.travel.expensify.com/some/path')).toBe(true);
+        });
+
+        it('should return true for trip links on expensify domains', () => {
+            expect(isTravelLink('https://www.expensify.com/trips/123')).toBe(true);
+            expect(isTravelLink('https://staging.expensify.com/trips/abc')).toBe(true);
+            expect(isTravelLink('https://dev.expensify.com/trips/123/details')).toBe(true);
+        });
+
+        it('should return false for non-trip expensify links', () => {
+            expect(isTravelLink('https://www.expensify.com')).toBe(false);
+            expect(isTravelLink('https://www.expensify.com/settings')).toBe(false);
+            expect(isTravelLink('https://www.expensify.com/trip/123')).toBe(false);
+        });
+
+        it('should return false for non-expensify domains', () => {
+            expect(isTravelLink('https://example.com/trips/123')).toBe(false);
+            expect(isTravelLink('https://travel.fake-expensify.com')).toBe(false);
+        });
+
+        it('should return false for invalid URLs', () => {
+            expect(isTravelLink('not-a-url')).toBe(false);
+            expect(isTravelLink('expensify.com/trips/123')).toBe(false);
+        });
+
+        it('should be case-insensitive', () => {
+            expect(isTravelLink('HTTPS://TRAVEL.EXPENSIFY.COM')).toBe(true);
+            expect(isTravelLink('https://www.expensify.com/TRIPS/123')).toBe(true);
+        });
+    });
+
+    describe('getRelativeUrl', () => {
+        it('should return the pathname for a valid URL', () => {
+            expect(getRelativeUrl('https://staging.new.expensify.com/trips/3737539511')).toBe('/trips/3737539511');
+        });
+
+        it('should include query parameters if present', () => {
+            expect(getRelativeUrl('https://www.expensify.com/trips/123?from=chat&env=staging')).toBe('/trips/123?from=chat&env=staging');
+        });
+
+        it('should include hash if present', () => {
+            expect(getRelativeUrl('https://www.expensify.com/trips/123#details')).toBe('/trips/123#details');
+        });
+
+        it('should include both query parameters and hash if present', () => {
+            expect(getRelativeUrl('https://www.expensify.com/trips/123?foo=bar#section')).toBe('/trips/123?foo=bar#section');
+        });
+
+        it('should work with different environments and subdomains', () => {
+            expect(getRelativeUrl('https://travel.expensify.com/trips/1')).toBe('/trips/1');
+            expect(getRelativeUrl('https://staging.travel.expensify.com/trips/2')).toBe('/trips/2');
+            expect(getRelativeUrl('https://dev.new.expensify.com/settings/profile')).toBe('/settings/profile');
+        });
+
+        it('should return "/" for root URLs', () => {
+            expect(getRelativeUrl('https://www.expensify.com')).toBe('/');
+            expect(getRelativeUrl('https://www.expensify.com/')).toBe('/');
+        });
+
+        it('should preserve trailing slashes', () => {
+            expect(getRelativeUrl('https://www.expensify.com/trips/123/')).toBe('/trips/123/');
+        });
+
+        it('should return an empty string for empty input', () => {
+            expect(getRelativeUrl('')).toBe('');
+        });
+
+        it('should return an empty string for undefined or null values', () => {
+            expect(getRelativeUrl(undefined as unknown as string)).toBe('');
+            expect(getRelativeUrl(null as unknown as string)).toBe('');
+        });
+
+        it('should return an empty string for invalid URLs', () => {
+            expect(getRelativeUrl('not-a-url')).toBe('');
+            expect(getRelativeUrl('expensify.com/trips/123')).toBe('');
+        });
+
+        it('should handle URLs with encoded characters', () => {
+            expect(getRelativeUrl('https://www.expensify.com/trips/%E2%9C%93')).toBe('/trips/%E2%9C%93');
+        });
+
+        it('should not be affected by protocol case', () => {
+            expect(getRelativeUrl('HTTPS://WWW.EXPENSIFY.COM/TRIPS/123')).toBe('/TRIPS/123');
+        });
+    });
+});


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
<!-- Explain what your change does and how it addresses the linked issue -->
This PR is for native devices to open links to trips natively, rather than following the link to the web.
### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$https://github.com/Expensify/App/issues/77027
PROPOSAL:https://github.com/Expensify/App/issues/77027#issuecomment-3659811208


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

Preconditiom: 

- user has booked trip (e.g. fly) in worksapce
- Only native apps

1. Go to worksapce chat
2. Open trip expense
3. Click the receipt
4. Click "View Trip" in the top right
5. Make sure link is clickable and opens travel page without redirecting to web

- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->
There are no offline tests, as this is related to a request to the backend to obtain a token.
### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->
// TODO: These must be filled out, or the issue title must include "[No QA]."
Same as tests
- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I verified there are no new alerts related to the `canBeMissing` param for `useOnyx`
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

https://github.com/user-attachments/assets/8871a8eb-36c1-44a7-a287-1cf91d9cb46a

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

https://github.com/user-attachments/assets/dbd2ed1f-b2a8-4227-bfbe-0b018f125474


<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>