### PR TITLE
fix: Company card button text should be 'Assign card' not 'Assign'

### DIFF
--- a/src/pages/workspace/companyCards/WorkspaceCompanyCardsTable/WorkspaceCompanyCardsTableItem.tsx
+++ b/src/pages/workspace/companyCards/WorkspaceCompanyCardsTable/WorkspaceCompanyCardsTableItem.tsx
@@ -230,7 +230,7 @@ function WorkspaceCompanyCardTableItem({
                                 <Button
                                     success
                                     small={shouldUseNarrowTableLayout}
-                                    text={translate('workspace.companyCards.assign')}
+                                    text={translate('workspace.companyCards.assignCard')}
                                     onPress={assignCard}
                                     isDisabled={isAssigningCardDisabled}
                                 />


### PR DESCRIPTION
## Description
Fixes #78376

The button for assigning company cards was displaying 'Assign' instead of the expected 'Assign card' text for UI consistency.

## Changes
Changed the translation key from `workspace.companyCards.assign` to `workspace.companyCards.assignCard` in the Button component to display the full 'Assign card' text.

**File changed:** `src/pages/workspace/companyCards/WorkspaceCompanyCardsTable/WorkspaceCompanyCardsTableItem.tsx`

## Testing
- Verified that the translation key `workspace.companyCards.assignCard` exists in all language files (en, fr, ja, nl, zh-hans, es, pl, it, de, pt-BR)
- The same key is already correctly used in other parts of the codebase (ConfirmationStep, BankConnection, etc.)

## Checklist
- [x] I verified the issue exists in the latest version
- [x] I verified the translation key exists
- [x] I verified no other code uses the old key for this specific button