### PR TITLE
Fix: Remove trailing slash from DISTANCE_REQUEST_CREATE route

### DIFF
--- a/src/ROUTES.ts
+++ b/src/ROUTES.ts
@@ -1268,8 +1268,12 @@ const ROUTES = {
     },
     DISTANCE_REQUEST_CREATE: {
         route: ':action/:iouType/start/:transactionID/:reportID/distance-new/:backToReport?',
-        getRoute: (action: IOUAction, iouType: IOUType, transactionID: string, reportID: string, backToReport?: string) =>
-            `${action as string}/${iouType as string}/start/${transactionID}/${reportID}/distance-new/${backToReport ?? ''}` as const,
+        getRoute: (action: IOUAction, iouType: IOUType, transactionID: string, reportID: string, backToReport?: string) => {
+            if (backToReport) {
+                return `${action as string}/${iouType as string}/start/${transactionID}/${reportID}/distance-new/${backToReport}` as const;
+            }
+            return `${action as string}/${iouType as string}/start/${transactionID}/${reportID}/distance-new` as const;
+        },
     },
     DISTANCE_REQUEST_CREATE_TAB_MAP: {
         route: 'distance-map',


### PR DESCRIPTION
## Summary

Fixes #77760

The `DISTANCE_REQUEST_CREATE.getRoute()` function was generating a URL with a trailing slash when `backToReport` parameter is undefined/empty. This caused the route to not match the expected pattern, resulting in a NotFound page when navigating to the "Track distance" screen.

**Before:**
```
create/track-expense/start/123/456/distance-new/
```

**After:**
```
create/track-expense/start/123/456/distance-new
```

## Root Cause

In `src/ROUTES.ts`, the `getRoute` function used template literals that always included the trailing segment:
```typescript
return `${action}/${iouType}/start/${transactionID}/${reportID}/distance-new/${backToReport}` as const;
```

When `backToReport` is undefined, this produced a trailing slash.

## Fix

Added a conditional check to only append `backToReport` when it has a value:
```typescript
if (backToReport) {
    return `${action}/${iouType}/start/${transactionID}/${reportID}/distance-new/${backToReport}` as const;
}
return `${action}/${iouType}/start/${transactionID}/${reportID}/distance-new` as const;
```

## Test Plan

1. Open a chat
2. Click "+" → "Track distance"
3. Verify the screen loads correctly without NotFound error
4. Verify the URL does not have a trailing slash

### Tests
- [ ] Verify that no errors appear in the JS console
- [x] I verified there are no console errors (after closing the498 issue, those are separate)

### QA Steps
- [x] I linked the correct issue in the `Fixes` line above