### PR TITLE
Fix invoice room backward compatibility issue (#78576)

### DIFF
--- a/src/libs/actions/IOU/index.ts
+++ b/src/libs/actions/IOU/index.ts
@@ -3396,7 +3396,7 @@ function getSendInvoiceInformation({
 
     // STEP 1: Get existing chat report OR build a new optimistic one
     let isNewChatReport = false;
-    let chatReport = !isEmptyObject(invoiceChatReport) && invoiceChatReport?.reportID && invoiceChatReportReceiverMatches ? invoiceChatReport : null;
+    let chatReport = !isEmptyObject(invoiceChatReport) && invoiceChatReport?.reportID && invoiceChatReportReceiverMatches && Object.keys(invoiceChatReport?.participants || {}).length === 1 ? invoiceChatReport : null;
 
     if (!chatReport) {
         isNewChatReport = true;

--- a/src/libs/actions/IOU/index.ts
+++ b/src/libs/actions/IOU/index.ts
@@ -3401,7 +3401,7 @@ function getSendInvoiceInformation({
     if (!chatReport) {
         isNewChatReport = true;
         chatReport = buildOptimisticChatReport({
-            participantList: [receiverAccountID, currentUserAccountID],
+            participantList: [receiverAccountID],
             chatType: CONST.REPORT.CHAT_TYPE.INVOICE,
             policyID: senderWorkspaceID,
         });

--- a/tests/actions/IOUTest.ts
+++ b/tests/actions/IOUTest.ts
@@ -10212,12 +10212,6 @@ describe('actions/IOU', () => {
                 type: CONST.REPORT.TYPE.CHAT,
                 participants: {
                     // eslint-disable-next-line @typescript-eslint/naming-convention
-                    '123': {
-                        accountID: 123,
-                        role: CONST.REPORT.ROLE.MEMBER,
-                        notificationPreference: CONST.REPORT.NOTIFICATION_PREFERENCE.ALWAYS,
-                    },
-                    // eslint-disable-next-line @typescript-eslint/naming-convention
                     '456': {
                         accountID: 456,
                         role: CONST.REPORT.ROLE.MEMBER,


### PR DESCRIPTION
### Explanation of Change
This change fixes an invoice compatibility issue between Classic Expensify and NewDot (ND). When invoices were created in Classic and accessed in ND, the invoice room incorrectly included both the sender and receiver as participants, leading to wrong invite messages, inaccurate LHN member counts, and missing expense display.

This fix updates the `getSendInvoiceInformation` flow so ND only treats the invoice recipient as the participant. Additionally, it ensures the invoice expense action displays correctly in the invoice room. This restores behavior parity with invoices created fully in NewDot and fixes backward compatibility issues.

### Fixed Issues
$ https://github.com/Expensify/App/issues/78576
PROPOSAL: https://github.com/Expensify/App/issues/78576#issuecomment-3701670400

### Tests
1. Sign in to ND as User A.
2. Create a workspace and enable Invoices.
3. Switch to Classic using Troubleshoot.
4. Create an Invoice report, add an expense.
5. Send invoice to User B (a contact you have never interacted with before).
6. When redirected back to ND, open the invoice room.
7. Verify:
   - Only "invited @[User B's email]" message is displayed
   - LHN shows "invited 1 member"
   - Expense is displayed in the invoice room
8. Repeat on all platforms to ensure no regressions.
- [x] Verify that no errors appear in the JS console

### Offline tests
Perform the above steps while offline.
Verify that invoice behavior remains stable and errors are handled gracefully for network-dependent actions.

### QA Steps
Same as Tests.
- [x] Verify that no errors appear in the JS console

### PR Author Checklist
- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a High Traffic account against the staging or production API to ensure there are no regressions
- [x] I included screenshots or videos for tests on all platforms
- [x] I ran the tests on all platforms & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors
- [x] I verified there are no new alerts related to the `canBeMissing` param for `useOnyx`
- [x] I followed proper code patterns
- [x] I verified callbacks are properly named
- [x] I verified clear comments exist where needed
- [x] I verified localization requirements
- [x] I verified grammar, capitalization, and text correctness
- [x] I verified file naming conventions
- [x] I verified JSDoc style compliance
- [x] I followed PR review guidelines
- [x] I verified shared components impacted still function
- [x] I verified all code is DRY
- [x] I verified variables use constants where applicable
- [x] I verified all function usage updates
- [x] If new files were added, they include purpose descriptions
- [x] If new styles were added, they are necessary and non-duplicate
- [x] If assets were added or modified, they are optimized and working
- [x] If messaging/editing logic touched, markdown behavior tested
- [x] If Storybook components touched, stories verified
- [x] If deeplink flows touched, verified logged in & logged out
- [x] If UI changed, alignment and layout verified
- [x] Design approval obtained if UI changed
- [x] ScrollView verified for new pages
- [x] Added unit tests if applicable
- [x] If main branch was merged into this PR after review, retested

