### PR TITLE
fix: show (You) suffix in self-DM header title

### DIFF
--- a/src/pages/home/HeaderView.tsx
+++ b/src/pages/home/HeaderView.tsx
@@ -314,7 +314,7 @@ function HeaderView({report, parentReportAction, onNavigationMenuButtonClicked, 
                                                 tooltipEnabled
                                                 numberOfLines={1}
                                                 textStyles={[styles.headerText, styles.pre]}
-                                                shouldUseFullTitle={isChatRoom || isPolicyExpenseChat || isChatThread || isTaskReport || shouldUseGroupTitle || isReportArchived}
+                                                shouldUseFullTitle={isChatRoom || isPolicyExpenseChat || isChatThread || isTaskReport || shouldUseGroupTitle || isReportArchived || isSelfDM}
                                                 renderAdditionalText={renderAdditionalText}
                                                 shouldAddEllipsis={shouldAddEllipsis}
                                             />


### PR DESCRIPTION
## Summary
- Added `isSelfDM` to the `shouldUseFullTitle` condition in the `DisplayNames` component within `HeaderView.tsx`
- This ensures self-DM chat headers display the full title including "(You)" suffix, matching the search list behavior

## Root Cause
The `DisplayNames` component has two modes:
1. **Full Title Mode** (`shouldUseFullTitle = true`): Uses pre-computed title strings that include the "(You)" postfix
2. **Participant List Mode** (`shouldUseFullTitle = false`): Dynamically builds displays from participant names without the postfix

The header was not enabling full title mode for self-DMs, causing it to fall back to participant rendering without the suffix.

## Fix
Added `isSelfDM` to the `shouldUseFullTitle` condition at `src/pages/home/HeaderView.tsx:317`:
```tsx
shouldUseFullTitle={isChatRoom || isPolicyExpenseChat || isChatThread || isTaskReport || shouldUseGroupTitle || isReportArchived || isSelfDM}
```

## Test plan
- [ ] Open self-DM chat
- [ ] Verify header shows "[Name] (You)" instead of just "[Name]"
- [ ] Verify search results still show "[Name] (You)" (no regression)

Fixes #78748

🤖 Generated with [Claude Code](https://claude.com/claude-code)