### PR TITLE
[CP Staging] Revert "Fix : Reports - Create report button does not show upgrade page when account has no workspace"

### DIFF
--- a/src/pages/Search/SearchTransactionsChangeReport.tsx
+++ b/src/pages/Search/SearchTransactionsChangeReport.tsx
@@ -99,23 +99,6 @@ function SearchTransactionsChangeReport() {
     });
 
     const createReport = () => {
-        if (!policyForMovingExpensesID && !shouldSelectPolicy && selectedTransactionsKeys.length > 0) {
-            const firstTransactionID = selectedTransactionsKeys.at(0);
-            if (firstTransactionID) {
-                Navigation.navigate(
-                    ROUTES.MONEY_REQUEST_UPGRADE.getRoute({
-                        action: CONST.IOU.ACTION.EDIT,
-                        iouType: CONST.IOU.TYPE.SUBMIT,
-                        transactionID: firstTransactionID,
-                        reportID: selectedTransactions[firstTransactionID]?.reportID,
-                        upgradePath: CONST.UPGRADE_PATHS.REPORTS,
-                    }),
-                    {forceReplace: true},
-                );
-            }
-            return;
-        }
-
         if (shouldSelectPolicy) {
             Navigation.navigate(ROUTES.NEW_REPORT_WORKSPACE_SELECTION.getRoute(true));
             return;


### PR DESCRIPTION
Reverts Expensify/App#77040

Straight revert

Fixes https://github.com/Expensify/App/issues/78740
Fixes https://github.com/Expensify/App/issues/78742