### PR TITLE
Copilot/align security features access with OldDot

### DIFF
--- a/src/pages/settings/Security/CloseAccountPage.tsx
+++ b/src/pages/settings/Security/CloseAccountPage.tsx
@@ -2,7 +2,6 @@ import {Str} from 'expensify-common';
 import React, {useEffect, useState} from 'react';
 import {View} from 'react-native';
 import ConfirmModal from '@components/ConfirmModal';
-import DelegateNoAccessWrapper from '@components/DelegateNoAccessWrapper';
 import FormProvider from '@components/Form/FormProvider';
 import InputWrapper from '@components/Form/InputWrapper';
 import type {FormInputErrors, FormOnyxValues} from '@components/Form/types';
@@ -97,65 +96,63 @@ function CloseAccountPage() {
             includeSafeAreaPaddingBottom
             testID="CloseAccountPage"
         >
-            <DelegateNoAccessWrapper accessDeniedVariants={[CONST.DELEGATE.DENIED_ACCESS_VARIANTS.SUBMITTER]}>
-                <HeaderWithBackButton
-                    title={translate('closeAccountPage.closeAccount')}
-                    onBackButtonPress={() => Navigation.goBack()}
-                />
-                <FormProvider
-                    formID={ONYXKEYS.FORMS.CLOSE_ACCOUNT_FORM}
-                    validate={validate}
-                    onSubmit={showConfirmModal}
-                    submitButtonText={translate('closeAccountPage.closeAccount')}
-                    style={[styles.flexGrow1, styles.mh5]}
-                    isSubmitActionDangerous
+            <HeaderWithBackButton
+                title={translate('closeAccountPage.closeAccount')}
+                onBackButtonPress={() => Navigation.goBack()}
+            />
+            <FormProvider
+                formID={ONYXKEYS.FORMS.CLOSE_ACCOUNT_FORM}
+                validate={validate}
+                onSubmit={showConfirmModal}
+                submitButtonText={translate('closeAccountPage.closeAccount')}
+                style={[styles.flexGrow1, styles.mh5]}
+                isSubmitActionDangerous
+            >
+                <View
+                    fsClass={CONST.FULLSTORY.CLASS.UNMASK}
+                    style={[styles.flexGrow1]}
                 >
-                    <View
-                        fsClass={CONST.FULLSTORY.CLASS.UNMASK}
-                        style={[styles.flexGrow1]}
-                    >
-                        <Text>{translate('closeAccountPage.reasonForLeavingPrompt')}</Text>
-                        <InputWrapper
-                            InputComponent={TextInput}
-                            inputID={INPUT_IDS.REASON_FOR_LEAVING}
-                            autoGrowHeight
-                            maxAutoGrowHeight={variables.textInputAutoGrowMaxHeight}
-                            label={translate('closeAccountPage.enterMessageHere')}
-                            aria-label={translate('closeAccountPage.enterMessageHere')}
-                            role={CONST.ROLE.PRESENTATION}
-                            containerStyles={[styles.mt5]}
-                            forwardedFSClass={CONST.FULLSTORY.CLASS.UNMASK}
-                        />
-                        <Text style={[styles.mt5]}>
-                            {translate('closeAccountPage.enterDefaultContactToConfirm')} <Text style={[styles.textStrong]}>{userEmailOrPhone}</Text>
-                        </Text>
-                        <InputWrapper
-                            InputComponent={TextInput}
-                            inputID={INPUT_IDS.PHONE_OR_EMAIL}
-                            autoCapitalize="none"
-                            label={translate('closeAccountPage.enterDefaultContact')}
-                            aria-label={translate('closeAccountPage.enterDefaultContact')}
-                            role={CONST.ROLE.PRESENTATION}
-                            containerStyles={[styles.mt5]}
-                            autoCorrect={false}
-                            inputMode={userEmailOrPhone && Str.isValidEmail(userEmailOrPhone) ? CONST.INPUT_MODE.EMAIL : CONST.INPUT_MODE.TEXT}
-                            forwardedFSClass={CONST.FULLSTORY.CLASS.UNMASK}
-                        />
-                        <ConfirmModal
-                            danger
-                            title={translate('closeAccountPage.closeAccountWarning')}
-                            onConfirm={onConfirm}
-                            onCancel={hideConfirmModal}
-                            isVisible={isConfirmModalVisible}
-                            prompt={translate('closeAccountPage.closeAccountPermanentlyDeleteData')}
-                            confirmText={translate('common.yesContinue')}
-                            cancelText={translate('common.cancel')}
-                            shouldDisableConfirmButtonWhenOffline
-                            shouldShowCancelButton
-                        />
-                    </View>
-                </FormProvider>
-            </DelegateNoAccessWrapper>
+                    <Text>{translate('closeAccountPage.reasonForLeavingPrompt')}</Text>
+                    <InputWrapper
+                        InputComponent={TextInput}
+                        inputID={INPUT_IDS.REASON_FOR_LEAVING}
+                        autoGrowHeight
+                        maxAutoGrowHeight={variables.textInputAutoGrowMaxHeight}
+                        label={translate('closeAccountPage.enterMessageHere')}
+                        aria-label={translate('closeAccountPage.enterMessageHere')}
+                        role={CONST.ROLE.PRESENTATION}
+                        containerStyles={[styles.mt5]}
+                        forwardedFSClass={CONST.FULLSTORY.CLASS.UNMASK}
+                    />
+                    <Text style={[styles.mt5]}>
+                        {translate('closeAccountPage.enterDefaultContactToConfirm')} <Text style={[styles.textStrong]}>{userEmailOrPhone}</Text>
+                    </Text>
+                    <InputWrapper
+                        InputComponent={TextInput}
+                        inputID={INPUT_IDS.PHONE_OR_EMAIL}
+                        autoCapitalize="none"
+                        label={translate('closeAccountPage.enterDefaultContact')}
+                        aria-label={translate('closeAccountPage.enterDefaultContact')}
+                        role={CONST.ROLE.PRESENTATION}
+                        containerStyles={[styles.mt5]}
+                        autoCorrect={false}
+                        inputMode={userEmailOrPhone && Str.isValidEmail(userEmailOrPhone) ? CONST.INPUT_MODE.EMAIL : CONST.INPUT_MODE.TEXT}
+                        forwardedFSClass={CONST.FULLSTORY.CLASS.UNMASK}
+                    />
+                    <ConfirmModal
+                        danger
+                        title={translate('closeAccountPage.closeAccountWarning')}
+                        onConfirm={onConfirm}
+                        onCancel={hideConfirmModal}
+                        isVisible={isConfirmModalVisible}
+                        prompt={translate('closeAccountPage.closeAccountPermanentlyDeleteData')}
+                        confirmText={translate('common.yesContinue')}
+                        cancelText={translate('common.cancel')}
+                        shouldDisableConfirmButtonWhenOffline
+                        shouldShowCancelButton
+                    />
+                </View>
+            </FormProvider>
         </ScreenWrapper>
     );
 }

--- a/src/pages/settings/Security/SecuritySettingsPage.tsx
+++ b/src/pages/settings/Security/SecuritySettingsPage.tsx
@@ -394,25 +394,27 @@ function SecuritySettingsPage() {
                                             <MenuItemList menuItems={delegateMenuItems} />
                                         </>
                                     )}
-                                    {!isDelegateAccessRestricted && (
-                                        <MenuItem
-                                            title={translate('delegate.addCopilot')}
-                                            icon={icons.UserPlus}
-                                            onPress={() => {
-                                                if (!isUserValidated) {
-                                                    Navigation.navigate(ROUTES.SETTINGS_DELEGATE_VERIFY_ACCOUNT);
-                                                    return;
-                                                }
-                                                if (isAccountLocked) {
-                                                    showLockedAccountModal();
-                                                    return;
-                                                }
-                                                Navigation.navigate(ROUTES.SETTINGS_ADD_DELEGATE);
-                                            }}
-                                            shouldShowRightIcon
-                                            wrapperStyle={[styles.sectionMenuItemTopDescription, hasDelegators && styles.mb6]}
-                                        />
-                                    )}
+                                    <MenuItem
+                                        title={translate('delegate.addCopilot')}
+                                        icon={icons.UserPlus}
+                                        onPress={() => {
+                                            if (isActingAsDelegate) {
+                                                modalClose(() => showDelegateNoAccessModal());
+                                                return;
+                                            }
+                                            if (!isUserValidated) {
+                                                Navigation.navigate(ROUTES.SETTINGS_DELEGATE_VERIFY_ACCOUNT);
+                                                return;
+                                            }
+                                            if (isAccountLocked) {
+                                                showLockedAccountModal();
+                                                return;
+                                            }
+                                            Navigation.navigate(ROUTES.SETTINGS_ADD_DELEGATE);
+                                        }}
+                                        shouldShowRightIcon
+                                        wrapperStyle={[styles.sectionMenuItemTopDescription, hasDelegators && styles.mb6]}
+                                    />
                                     {hasDelegators && (
                                         <>
                                             <Text style={[styles.textLabelSupporting, styles.pv1]}>{translate('delegate.youCanAccessTheseAccounts')}</Text>

--- a/src/pages/settings/Security/SecuritySettingsPage.tsx
+++ b/src/pages/settings/Security/SecuritySettingsPage.tsx
@@ -311,7 +311,7 @@ function SecuritySettingsPage() {
             text: translate('delegate.removeCopilot'),
             icon: Expensicons.Trashcan,
             onPress: () => {
-                if (selectedDelegate?.email!==account?.delegatedAccess?.delegate && isActingAsDelegate) {
+                if (selectedDelegate?.email !== account?.delegatedAccess?.delegate && isActingAsDelegate) {
                     modalClose(() => showDelegateNoAccessModal());
                     return;
                 }

--- a/src/pages/settings/Security/SecuritySettingsPage.tsx
+++ b/src/pages/settings/Security/SecuritySettingsPage.tsx
@@ -293,7 +293,7 @@ function SecuritySettingsPage() {
             text: translate('delegate.changeAccessLevel'),
             icon: icons.Pencil,
             onPress: () => {
-                if (isDelegateAccessRestricted) {
+                if (isActingAsDelegate) {
                     modalClose(() => showDelegateNoAccessModal());
                     return;
                 }

--- a/src/pages/settings/Security/SecuritySettingsPage.tsx
+++ b/src/pages/settings/Security/SecuritySettingsPage.tsx
@@ -446,11 +446,6 @@ function SecuritySettingsPage() {
                                 prompt={translate('delegate.removeCopilotConfirmation')}
                                 danger
                                 onConfirm={() => {
-                                    if (isActingAsDelegate) {
-                                        setShouldShowRemoveDelegateModal(false);
-                                        showDelegateNoAccessModal();
-                                        return;
-                                    }
                                     removeDelegate({email: selectedDelegate?.email ?? '', delegatedAccess: account?.delegatedAccess});
                                     setShouldShowRemoveDelegateModal(false);
                                     setSelectedDelegate(undefined);

--- a/src/pages/settings/Security/SecuritySettingsPage.tsx
+++ b/src/pages/settings/Security/SecuritySettingsPage.tsx
@@ -185,11 +185,6 @@ function SecuritySettingsPage() {
             translationKey: 'closeAccountPage.closeAccount',
             icon: Expensicons.ClosedSign,
             action: () => {
-                if (isDelegateAccessRestricted) {
-                    showDelegateNoAccessModal();
-                    return;
-                }
-
                 if (isAccountLocked) {
                     showLockedAccountModal();
                     return;

--- a/src/pages/settings/Security/SecuritySettingsPage.tsx
+++ b/src/pages/settings/Security/SecuritySettingsPage.tsx
@@ -151,10 +151,6 @@ function SecuritySettingsPage() {
                 translationKey: 'mergeAccountsPage.mergeAccount',
                 icon: Expensicons.ArrowCollapse,
                 action: () => {
-                    if (isDelegateAccessRestricted) {
-                        showDelegateNoAccessModal();
-                        return;
-                    }
                     if (isAccountLocked) {
                         showLockedAccountModal();
                         return;

--- a/src/pages/settings/Security/SecuritySettingsPage.tsx
+++ b/src/pages/settings/Security/SecuritySettingsPage.tsx
@@ -311,7 +311,7 @@ function SecuritySettingsPage() {
             text: translate('delegate.removeCopilot'),
             icon: Expensicons.Trashcan,
             onPress: () => {
-                if (isActingAsDelegate) {
+                if (selectedDelegate?.email!==account?.delegatedAccess?.delegate && isActingAsDelegate) {
                     modalClose(() => showDelegateNoAccessModal());
                     return;
                 }

--- a/src/pages/settings/Security/SecuritySettingsPage.tsx
+++ b/src/pages/settings/Security/SecuritySettingsPage.tsx
@@ -132,7 +132,7 @@ function SecuritySettingsPage() {
                 translationKey: 'twoFactorAuth.headerTitle',
                 icon: icons.Shield,
                 action: () => {
-                    if (isDelegateAccessRestricted) {
+                    if (isActingAsDelegate) {
                         showDelegateNoAccessModal();
                         return;
                     }

--- a/src/pages/settings/Security/TwoFactorAuth/TwoFactorAuthWrapper.tsx
+++ b/src/pages/settings/Security/TwoFactorAuth/TwoFactorAuthWrapper.tsx
@@ -1,8 +1,7 @@
-import React, {useContext, useMemo} from 'react';
+import React, {useMemo} from 'react';
 import type {ValueOf} from 'type-fest';
 import FullPageNotFoundView from '@components/BlockingViews/FullPageNotFoundView';
 import FullPageOfflineBlockingView from '@components/BlockingViews/FullPageOfflineBlockingView';
-import {DelegateNoAccessContext} from '@components/DelegateNoAccessModalProvider';
 import DelegateNoAccessWrapper from '@components/DelegateNoAccessWrapper';
 import HeaderWithBackButton from '@components/HeaderWithBackButton';
 import ScreenWrapper from '@components/ScreenWrapper';
@@ -45,7 +44,6 @@ function TwoFactorAuthWrapper({
     children,
 }: TwoFactorAuthWrapperProps) {
     const [account] = useOnyx(ONYXKEYS.ACCOUNT, {canBeMissing: false});
-    const {isDelegateAccessRestricted} = useContext(DelegateNoAccessContext);
 
     // eslint-disable-next-line rulesdir/no-negated-variables
     const shouldShowNotFound = useMemo(() => {
@@ -73,18 +71,6 @@ function TwoFactorAuthWrapper({
 
     const viewportOffsetTop = useViewportOffsetTop();
 
-    if (isDelegateAccessRestricted) {
-        return (
-            <ScreenWrapper
-                testID="TwoFactorAuthWrapper"
-                includeSafeAreaPaddingBottom={false}
-                shouldEnablePickerAvoiding={false}
-            >
-                <DelegateNoAccessWrapper accessDeniedVariants={[CONST.DELEGATE.DENIED_ACCESS_VARIANTS.DELEGATE]} />
-            </ScreenWrapper>
-        );
-    }
-
     const defaultGoBack = () => quitAndNavigateBack(ROUTES.SETTINGS_SECURITY);
 
     return (
@@ -95,18 +81,20 @@ function TwoFactorAuthWrapper({
             testID={stepName}
             style={shouldEnableViewportOffsetTop ? {marginTop: viewportOffsetTop} : undefined}
         >
-            <FullPageNotFoundView
-                shouldShow={shouldShowNotFound}
-                linkTranslationKey="securityPage.goToSecurity"
-                onLinkPress={defaultGoBack}
-            >
-                <HeaderWithBackButton
-                    title={title}
-                    stepCounter={stepCounter}
-                    onBackButtonPress={onBackButtonPress ?? defaultGoBack}
-                />
-                <FullPageOfflineBlockingView>{children}</FullPageOfflineBlockingView>
-            </FullPageNotFoundView>
+            <DelegateNoAccessWrapper accessDeniedVariants={[CONST.DELEGATE.DENIED_ACCESS_VARIANTS.DELEGATE]}>
+                <FullPageNotFoundView
+                    shouldShow={shouldShowNotFound}
+                    linkTranslationKey="securityPage.goToSecurity"
+                    onLinkPress={defaultGoBack}
+                >
+                    <HeaderWithBackButton
+                        title={title}
+                        stepCounter={stepCounter}
+                        onBackButtonPress={onBackButtonPress ?? defaultGoBack}
+                    />
+                    <FullPageOfflineBlockingView>{children}</FullPageOfflineBlockingView>
+                </FullPageNotFoundView>
+            </DelegateNoAccessWrapper>
         </ScreenWrapper>
     );
 }


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
<!-- Explain what your change does and how it addresses the linked issue -->

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/78105
PROPOSAL: https://github.com/Expensify/App/issues/78105#issuecomment-3674620076


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->
prerequisite : have an account with copiloted access.

Note: all the following tests are for both limited and full access copilots.

Test 1
1. As a copilot go to settings > security.
2. Verify clicking `Two-factor Authentication` option pops up the `Not So Fast...` modal.
3. Verify `Merge accounts`, `Report suspicious activity` and `Close account` flows are accessible and do not show the `Not So Fast...` modal when clicked.
4. Verify clicking `Add copilot` option pops up the `Not So Fast...` modal.
5. Click three dot options for one of the listed copilots.
6. Verify clicking `Change Access Level` option pops up the `Not So Fast...` modal.

Test 2
1. As a copilot go to settings > security.
2. Click three dot options for one of the listed copilots other than current login.
3. Verify clicking `Remove Copilot` option pops up the `Not So Fast...` modal.
4. Click the three dot option for current login from the copilots list.
5. Verify clicking `Remove Copilot` option pops up the `Remove copilot` modal.
6. Verify clicking `Remove Copilot` button from the modal successfully removes currently logged in user from delegated access and app switches to current user.

- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
7. Upload an image via copy paste
8. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->
// TODO: These must be filled out, or the issue title must include "[No QA]."

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I verified there are no new alerts related to the `canBeMissing` param for `useOnyx`
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>


https://github.com/user-attachments/assets/f3c24291-324b-463b-8b36-435c4663b89e


https://github.com/user-attachments/assets/fda067c2-a0cd-44fb-9995-04247f9afe67



</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/8da5a078-a69a-4a2c-83c6-dcae8c5e2e34

https://github.com/user-attachments/assets/b037c6f1-b2d9-4e78-8f11-63f3935f7e50




</details>

<details>
<summary>iOS: Native</summary>


https://github.com/user-attachments/assets/498b1e15-26fa-413e-ac3f-c399d093dc61



https://github.com/user-attachments/assets/44270495-e99b-4ce1-b7ab-86f0ff829b92




</details>

<details>
<summary>iOS: mWeb Safari</summary>


https://github.com/user-attachments/assets/b59b3c24-a834-47ec-80b3-5bc0921195a5


https://github.com/user-attachments/assets/506831d9-62f2-405e-a8d5-04505171b70a

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->
https://github.com/user-attachments/assets/2f3e2aa2-eab2-4b42-af79-291e00d29430

https://github.com/user-attachments/assets/9b93e48a-5e84-453c-97ee-90326a805073


</details>





