### PR TITLE
Revert "fix: Reports is paid can be moved to another workspace by a member"

### DIFF
--- a/src/pages/ReportChangeWorkspacePage.tsx
+++ b/src/pages/ReportChangeWorkspacePage.tsx
@@ -27,7 +27,6 @@ import {
     isIOUReport,
     isMoneyRequestReport,
     isMoneyRequestReportPendingDeletion,
-    isSettled,
     isWorkspaceEligibleForReportChange,
 } from '@libs/ReportUtils';
 import CONST from '@src/CONST';
@@ -133,14 +132,7 @@ function ReportChangeWorkspacePage({report, route}: ReportChangeWorkspacePagePro
         selectedPolicyIDs: report.policyID ? [report.policyID] : undefined,
         searchTerm: debouncedSearchTerm,
         localeCompare,
-        additionalFilter: (newPolicy) => {
-            const isReportSettled = isSettled(report);
-            const isEligible = isWorkspaceEligibleForReportChange(submitterEmail, newPolicy);
-            if (isReportSettled) {
-                return isEligible && isPolicyAdmin(newPolicy, session?.email);
-            }
-            return isEligible;
-        },
+        additionalFilter: (newPolicy) => isWorkspaceEligibleForReportChange(submitterEmail, newPolicy),
     });
 
     const textInputOptions = useMemo(


### PR DESCRIPTION
Reverts Expensify/App#77900

~Fixes https://github.com/Expensify/App/issues/78931~

Doesn't seem to fix https://github.com/Expensify/App/issues/78931, I still see the menu option to change the workspace and still get the error