### PR TITLE
fix:78958: fix few placew with wrong text display on Android native when text size is small

### DIFF
--- a/src/pages/TeachersUnite/ImTeacherUpdateEmailPage.tsx
+++ b/src/pages/TeachersUnite/ImTeacherUpdateEmailPage.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
+import {View} from 'react-native';
 import BlockingView from '@components/BlockingViews/BlockingView';
 import Button from '@components/Button';
 import FixedFooter from '@components/FixedFooter';
 import HeaderWithBackButton from '@components/HeaderWithBackButton';
 import RenderHTML from '@components/RenderHTML';
 import ScreenWrapper from '@components/ScreenWrapper';
-import Text from '@components/Text';
 import useEnvironment from '@hooks/useEnvironment';
 import {useMemoizedLazyIllustrations} from '@hooks/useLazyAsset';
 import useLocalize from '@hooks/useLocalize';
@@ -33,9 +33,9 @@ function ImTeacherUpdateEmailPage() {
                 icon={illustrations.EmailAddress}
                 title={translate('teachersUnitePage.updateYourEmail')}
                 CustomSubtitle={
-                    <Text style={[styles.textAlignCenter]}>
-                        <RenderHTML html={translate('teachersUnitePage.schoolMailAsDefault', contactMethodsRoute)} />
-                    </Text>
+                    <View style={[styles.textAlignCenter, styles.flexRow, styles.w100]}>
+                        <RenderHTML html={`<centered-text>${translate('teachersUnitePage.schoolMailAsDefault', contactMethodsRoute)}</centered-text>`} />
+                    </View>
                 }
                 iconWidth={variables.signInLogoWidthLargeScreen}
                 iconHeight={variables.signInLogoHeightLargeScreen}

--- a/src/pages/settings/Subscription/CardSection/CardSection.tsx
+++ b/src/pages/settings/Subscription/CardSection/CardSection.tsx
@@ -273,7 +273,11 @@ function CardSection() {
                     isVisible={isRequestRefundModalVisible}
                     onConfirm={requestRefund}
                     onCancel={() => setIsRequestRefundModalVisible(false)}
-                    prompt={<RenderHTML html={translate('subscription.cardSection.requestRefundModal.full')} />}
+                    prompt={
+                        <View style={[styles.flexRow]}>
+                            <RenderHTML html={translate('subscription.cardSection.requestRefundModal.full')} />
+                        </View>
+                    }
                     confirmText={translate('subscription.cardSection.requestRefundModal.confirm')}
                     cancelText={translate('common.cancel')}
                     danger

--- a/src/pages/workspace/accounting/intacct/import/SageIntacctToggleMappingsPage.tsx
+++ b/src/pages/workspace/accounting/intacct/import/SageIntacctToggleMappingsPage.tsx
@@ -1,12 +1,12 @@
 import {Str} from 'expensify-common';
 import React, {useEffect, useState} from 'react';
+import {View} from 'react-native';
 import {useSharedValue} from 'react-native-reanimated';
 import Accordion from '@components/Accordion';
 import ConnectionLayout from '@components/ConnectionLayout';
 import MenuItemWithTopDescription from '@components/MenuItemWithTopDescription';
 import OfflineWithFeedback from '@components/OfflineWithFeedback';
 import RenderHTML from '@components/RenderHTML';
-import Text from '@components/Text';
 import useLocalize from '@hooks/useLocalize';
 import usePolicy from '@hooks/usePolicy';
 import useThemeStyles from '@hooks/useThemeStyles';
@@ -83,13 +83,13 @@ function SageIntacctToggleMappingsPage({route}: SageIntacctToggleMappingsPagePro
             connectionName={CONST.POLICY.CONNECTIONS.NAME.SAGE_INTACCT}
             onBackButtonPress={() => Navigation.goBack(ROUTES.POLICY_ACCOUNTING_SAGE_INTACCT_IMPORT.getRoute(policyID))}
         >
-            <Text style={[styles.flexRow, styles.alignItemsCenter, styles.w100, styles.mb5, styles.ph5]}>
+            <View style={[styles.flexRow, styles.alignItemsCenter, styles.w100, styles.mb5, styles.ph5, styles.flexRow]}>
                 <RenderHTML
                     html={translate('workspace.intacct.toggleImportTitle', {
                         mappingTitle: translate('workspace.intacct.mappingTitle', {mappingName}),
                     })}
                 />
-            </Text>
+            </View>
             <ToggleSettingOptionRow
                 title={translate('workspace.accounting.import')}
                 switchAccessibilityLabel={`${translate('workspace.accounting.import')} ${translate('workspace.intacct.mappingTitle', {mappingName})}`}

--- a/src/pages/workspace/companyCards/WorkspaceCompanyCardsTable/WorkspaceCompanyCardsTableHeaderButtons.tsx
+++ b/src/pages/workspace/companyCards/WorkspaceCompanyCardsTable/WorkspaceCompanyCardsTableHeaderButtons.tsx
@@ -8,7 +8,6 @@ import Icon from '@components/Icon';
 // eslint-disable-next-line no-restricted-imports
 import RenderHTML from '@components/RenderHTML';
 import Table from '@components/Table';
-import Text from '@components/Text';
 import useCardFeeds from '@hooks/useCardFeeds';
 import {useMemoizedLazyExpensifyIcons} from '@hooks/useLazyAsset';
 import useLocalize from '@hooks/useLocalize';
@@ -153,12 +152,12 @@ function WorkspaceCompanyCardsTableHeaderButtons({policyID, feedName, isLoading,
                         fill={theme.danger}
                         additionalStyles={styles.mr1}
                     />
-                    <Text style={[styles.offlineFeedbackText, styles.pr5]}>
+                    <View style={[styles.offlineFeedbackText, styles.pr5, styles.flexRow, styles.w100]}>
                         <RenderHTML
                             html={translate('workspace.companyCards.brokenConnectionError')}
                             onLinkPress={openBankConnection}
                         />
-                    </Text>
+                    </View>
                 </View>
             )}
         </View>

--- a/src/pages/workspace/upgrade/GenericFeaturesView.tsx
+++ b/src/pages/workspace/upgrade/GenericFeaturesView.tsx
@@ -62,9 +62,9 @@ function GenericFeaturesView({onUpgrade, buttonDisabled, loading, formattedPrice
                         <Text style={[styles.textNormal, styles.textSupporting]}>{benefit}</Text>
                     </View>
                 ))}
-                <Text style={[styles.textNormal, styles.textSupporting, styles.mt4]}>
+                <View style={[styles.textNormal, styles.textSupporting, styles.mt4, styles.flexRow]}>
                     <RenderHTML html={translate('workspace.upgrade.commonFeatures.benefits.startsAtFull', {learnMoreMethodsRoute, formattedPrice, hasTeam2025Pricing})} />
-                </Text>
+                </View>
             </View>
             {!policyID && (
                 <Text style={[styles.mb5, styles.textNormal, styles.textSupporting]}>


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
<!-- Explain what your change does and how it addresses the linked issue -->
This PR fixes a bug in several places where text was cut off in the Android app when the text size was small.
### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$https://github.com/Expensify/App/issues/78958
PROPOSAL:https://github.com/Expensify/App/issues/78218#issuecomment-3710752290


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

Precondition for all bugs: have small font-size on device

Bug 1 - Upgrade workspace
Precondition: have collect workspace

1. Go to workspace overview
2. Click Plan type
3. Select Control
4. Click save
5. Make sure text is displayed correctly

Bug 2 - Company card
Precondition: Have a workspace with broken card connection

1. Go to the Company cards page
2. Look at the error
3. Make sure the error message is displayed in full without any text being cut off, and the entire message is visible

Bug 3 - I am a teacher
Precondition: log in with Gmail

1. Go to your account page
2. Go to the “Save the world” section
3. Select “I am a teacher”
4. Make sure text is displayed correctly

Bug 4 - Subscription payments
Precondition: have request refund option in Subscription(For this account must have value `isEligibleForRefund` as true and at least one control workspace)

In dev env you past this code into this component:
https://github.com/Expensify/App/blob/3191e6d34e27d6f4b2e969e38b322441c26207aa/src/pages/settings/Subscription/CardSection/CardSection.tsx#L114

```ts
import Onyx from 'react-native-onyx';

useEffect(() => {
        setTimeout(() => {
            Onyx.merge(ONYXKEYS.ACCOUNT, {isEligibleForRefund: true});
        }, 3000);
    }, []);
```
PS: i got this steps from this PR: https://github.com/Expensify/App/pull/44138


1. Click Request refund
2. Ensure that a description appears when the modal window opens.

Bug 5 - Sage Intacct mapping page
Precondition: have connected Sage Intacct

1. Go to workspace > Accounting > Import
2. Click on import > Classes
3. Verify that the subtitle below the back button is displayed correctly

- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->
Same as tests, except bug 4 - no offline tests
### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->
// TODO: These must be filled out, or the issue title must include "[No QA]."
Same as tests, not sure QA can test Bug 4
- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I verified there are no new alerts related to the `canBeMissing` param for `useOnyx`
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

https://github.com/user-attachments/assets/1ed53e4b-b911-4c91-8342-d600b7c99200


https://github.com/user-attachments/assets/24c580f8-1558-4889-896b-51f02cff3c4d


https://github.com/user-attachments/assets/5e5e7a0f-3851-4423-914a-8df2220c9542


https://github.com/user-attachments/assets/94e7944f-6a36-40af-b17c-7fd3e143e8d1

<img width="507" height="1001" alt="78958-5-android-native" src="https://github.com/user-attachments/assets/6ecebbae-2418-435f-8fc6-8efb6a8b9607" />

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

https://github.com/user-attachments/assets/0e3f3fb1-2b1c-4d0d-92a0-136f6fc2b9f4


https://github.com/user-attachments/assets/a1782fd4-a768-420c-81a3-acc07f716fe0


https://github.com/user-attachments/assets/d43f59c0-a33b-4805-ba94-fac7365ccdd2


https://github.com/user-attachments/assets/219e7f46-3fb3-4278-a985-51ea58862d4c

<img width="507" height="1001" alt="78958-5-android-web" src="https://github.com/user-attachments/assets/22da49a8-0c8b-4a53-b589-f45f6897362c" />

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

https://github.com/user-attachments/assets/812a57a2-df35-4d57-9ba7-faa67b487a47


https://github.com/user-attachments/assets/00c648da-4716-4d9e-8af3-11ea06089ae8


https://github.com/user-attachments/assets/9db32edd-a27f-4c31-996a-409b8ed5666d


https://github.com/user-attachments/assets/fcee0c7d-7b09-46e1-b532-323886a546ad

<img width="507" height="1001" alt="78958-5-ios-native" src="https://github.com/user-attachments/assets/1e9d3717-7e79-4a2d-b4a0-c44b1f557829" />

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

https://github.com/user-attachments/assets/3a6f6be4-e96d-43b6-bcfe-2e5289948873


https://github.com/user-attachments/assets/b43b156e-b540-4f1e-b2b0-358f62012766


https://github.com/user-attachments/assets/dc492130-5ece-45e1-af4d-2833437806d0


https://github.com/user-attachments/assets/983b3690-62e9-422d-829e-b824e952cfbb

<img width="507" height="1001" alt="78958-5-ios-web" src="https://github.com/user-attachments/assets/aedf2408-fe78-4329-b22c-2ce1a9a14a87" />

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

https://github.com/user-attachments/assets/d745165a-2bbb-4254-8e25-9ccf79f3da3b


https://github.com/user-attachments/assets/58786242-6acb-49f7-8cbe-d1591cfa8bc4


https://github.com/user-attachments/assets/41487e55-18de-493b-a649-477f21b71168

https://github.com/user-attachments/assets/98938244-7d37-4758-86e6-ea71e4e1fb02

<img width="1792" height="1076" alt="78958-5-web" src="https://github.com/user-attachments/assets/54abfc5d-1f75-4364-bd95-2487db49e3c1" />

<!-- add screenshots or videos here -->

</details>