### PR TITLE
No animation for Search report when opened as not the first screen in RHP v2

### DIFF
--- a/src/components/MoneyRequestReportView/MoneyRequestReportTransactionsNavigation.tsx
+++ b/src/components/MoneyRequestReportView/MoneyRequestReportTransactionsNavigation.tsx
@@ -12,7 +12,6 @@ import {getOriginalMessage, isMoneyRequestAction} from '@libs/ReportActionsUtils
 import Navigation from '@navigation/Navigation';
 import navigationRef from '@navigation/navigationRef';
 import ONYXKEYS from '@src/ONYXKEYS';
-import ROUTES from '@src/ROUTES';
 import SCREENS from '@src/SCREENS';
 import type * as OnyxTypes from '@src/types/onyx';
 import getEmptyArray from '@src/types/utils/getEmptyArray';
@@ -142,7 +141,7 @@ function MoneyRequestReportTransactionsNavigation({currentTransactionID, isFromR
             navigationParams.reportID = transactionThreadReport?.reportID;
         }
         // Wait for the next frame to ensure Onyx has processed the optimistic data updates from setOptimisticTransactionThread or createTransactionThreadReport before navigating
-        requestAnimationFrame(() => Navigation.navigate(ROUTES.SEARCH_REPORT.getRoute(navigationParams), {forceReplace: true}));
+        requestAnimationFrame(() => Navigation.setParams(navigationParams));
     };
 
     const onPrevious = (e: GestureResponderEvent | KeyboardEvent | undefined) => {
@@ -170,7 +169,7 @@ function MoneyRequestReportTransactionsNavigation({currentTransactionID, isFromR
             navigationParams.reportID = transactionThreadReport?.reportID;
         }
         // Wait for the next frame to ensure Onyx has processed the optimistic data updates from setOptimisticTransactionThread or createTransactionThreadReport before navigating
-        requestAnimationFrame(() => Navigation.navigate(ROUTES.SEARCH_REPORT.getRoute(navigationParams), {forceReplace: true}));
+        requestAnimationFrame(() => Navigation.setParams(navigationParams));
     };
 
     return (

--- a/src/components/WideRHPContextProvider/default.ts
+++ b/src/components/WideRHPContextProvider/default.ts
@@ -13,6 +13,7 @@ const defaultWideRHPContextValue: WideRHPContextType = {
     isReportIDMarkedAsExpense: () => false,
     isReportIDMarkedAsMultiTransactionExpense: () => false,
     isWideRHPFocused: false,
+    isSuperWideRHPFocused: false,
     shouldRenderTertiaryOverlay: false,
     superWideRHPRouteKeys: [],
     showSuperWideRHPVersion: () => {},

--- a/src/components/WideRHPContextProvider/index.tsx
+++ b/src/components/WideRHPContextProvider/index.tsx
@@ -81,6 +81,20 @@ function removeWideRHPRoute(route: NavigationRoute, setAllRHPRouteKeys: React.Di
     setAllRHPRouteKeys((prev) => (prev.includes(keyToRemove) ? prev.filter((key) => key !== keyToRemove) : prev));
 }
 
+// Set the rhp width based on the super wide / wide rhp route keys
+function setExpandedRHPProgress(superWideRHPRouteKeys: string[], wideRHPRouteKeys: string[]) {
+    const numberOfSuperWideRoutes = superWideRHPRouteKeys.length;
+    const numberOfWideRoutes = wideRHPRouteKeys.length;
+
+    if (numberOfSuperWideRoutes > 0) {
+        expandedRHPProgress.setValue(2);
+    } else if (numberOfWideRoutes > 0) {
+        expandedRHPProgress.setValue(1);
+    } else {
+        expandedRHPProgress.setValue(0);
+    }
+}
+
 function WideRHPContextProvider({children}: React.PropsWithChildren) {
     // We have a separate containers for allWideRHPRouteKeys and wideRHPRouteKeys because we may have two or more RHPs on the stack.
     // For convenience and proper overlay logic wideRHPRouteKeys will show only the keys existing in the last RHP.
@@ -112,6 +126,10 @@ function WideRHPContextProvider({children}: React.PropsWithChildren) {
         return !!focusedRoute?.key && allWideRHPRouteKeys.includes(focusedRoute.key);
     }, [focusedRoute?.key, allWideRHPRouteKeys]);
 
+    const isSuperWideRHPFocused = useMemo(() => {
+        return !!focusedRoute?.key && allSuperWideRHPRouteKeys.includes(focusedRoute.key);
+    }, [focusedRoute?.key, allSuperWideRHPRouteKeys]);
+
     const isRHPFocused = focusedNavigator === NAVIGATORS.RIGHT_MODAL_NAVIGATOR;
 
     // Whether Wide RHP is displayed below the currently displayed screen
@@ -122,11 +140,13 @@ function WideRHPContextProvider({children}: React.PropsWithChildren) {
         const {visibleSuperWideRHPRouteKeys, visibleWideRHPRouteKeys} = getVisibleRHPKeys(allSuperWideRHPRouteKeys, allWideRHPRouteKeys);
         setWideRHPRouteKeys(visibleWideRHPRouteKeys);
         setSuperWideRHPRouteKeys(visibleSuperWideRHPRouteKeys);
+        setExpandedRHPProgress(visibleSuperWideRHPRouteKeys, visibleWideRHPRouteKeys);
     }, [allSuperWideRHPRouteKeys, allWideRHPRouteKeys]);
 
     const clearWideRHPKeys = useCallback(() => {
         setWideRHPRouteKeys([]);
         setSuperWideRHPRouteKeys([]);
+        expandedRHPProgress.setValue(0);
     }, []);
 
     // Once we have updated the array of all Super Wide RHP keys, we should sync it with the array of RHP keys visible on the screen
@@ -156,21 +176,6 @@ function WideRHPContextProvider({children}: React.PropsWithChildren) {
      * Effect that manages the tertiary overlay animation and rendering state.
      */
     const shouldRenderTertiaryOverlay = useShouldRenderOverlay(isRHPFocused && isWideRHPBelow && isSuperWideRHPBelow, thirdOverlayProgress);
-
-    /**
-     * Effect that shows/hides the expanded RHP progress based on the number of wide RHP routes.
-     */
-    useEffect(() => {
-        const numberOfSuperWideRoutes = superWideRHPRouteKeys.length;
-        const numberOfWideRoutes = wideRHPRouteKeys.length;
-        if (numberOfSuperWideRoutes > 0) {
-            expandedRHPProgress.setValue(2);
-        } else if (numberOfWideRoutes > 0) {
-            expandedRHPProgress.setValue(1);
-        } else {
-            expandedRHPProgress.setValue(0);
-        }
-    }, [superWideRHPRouteKeys.length, wideRHPRouteKeys.length]);
 
     /**
      * Removes a route from the super wide RHP route keys list, disabling wide RHP display for that route.
@@ -325,6 +330,7 @@ function WideRHPContextProvider({children}: React.PropsWithChildren) {
             isReportIDMarkedAsExpense,
             isReportIDMarkedAsMultiTransactionExpense,
             isWideRHPFocused,
+            isSuperWideRHPFocused,
             syncRHPKeys,
             clearWideRHPKeys,
         }),
@@ -345,6 +351,7 @@ function WideRHPContextProvider({children}: React.PropsWithChildren) {
             isReportIDMarkedAsExpense,
             isReportIDMarkedAsMultiTransactionExpense,
             isWideRHPFocused,
+            isSuperWideRHPFocused,
             syncRHPKeys,
             clearWideRHPKeys,
         ],

--- a/src/components/WideRHPContextProvider/types.ts
+++ b/src/components/WideRHPContextProvider/types.ts
@@ -49,6 +49,9 @@ type WideRHPContextType = {
     // Whether the currently focused route is inside the wide RHP set
     isWideRHPFocused: boolean;
 
+    // Whether the currently focused route is inside the super wide RHP set
+    isSuperWideRHPFocused: boolean;
+
     // Sync super wide and wide RHP keys with the visible RHP screens
     syncRHPKeys: () => void;
 

--- a/src/components/WideRHPContextProvider/useShowSuperWideRHPVersion/index.ts
+++ b/src/components/WideRHPContextProvider/useShowSuperWideRHPVersion/index.ts
@@ -1,8 +1,8 @@
 import {useRoute} from '@react-navigation/native';
 import {useCallback, useContext, useEffect} from 'react';
-import {InteractionManager} from 'react-native';
-import useBeforeRemove from '@hooks/useBeforeRemove';
-import {WideRHPContext} from '..';
+import {navigationRef} from '@libs/Navigation/Navigation';
+import NAVIGATORS from '@src/NAVIGATORS';
+import {expandedRHPProgress, WideRHPContext} from '..';
 
 /**
  * Hook that manages super wide RHP display for a screen based on condition or optimistic state.
@@ -25,14 +25,18 @@ function useShowSuperWideRHPVersion(condition: boolean) {
     } = useContext(WideRHPContext);
 
     const onSuperWideRHPClose = useCallback(() => {
-        // eslint-disable-next-line @typescript-eslint/no-deprecated
-        InteractionManager.runAfterInteractions(() => {
-            removeWideRHPRouteKey(route);
-            removeSuperWideRHPRouteKey(route);
-        });
+        removeWideRHPRouteKey(route);
+        removeSuperWideRHPRouteKey(route);
+        // When the RHP has been closed, expandedRHPProgress should be set to 0.
+        if (navigationRef.getRootState().routes.at(-1)?.name !== NAVIGATORS.RIGHT_MODAL_NAVIGATOR) {
+            expandedRHPProgress.setValue(0);
+        }
     }, [removeSuperWideRHPRouteKey, removeWideRHPRouteKey, route]);
 
-    useBeforeRemove(onSuperWideRHPClose);
+    /**
+     * Effect that sets up cleanup when the screen is unmounted.
+     */
+    useEffect(() => () => onSuperWideRHPClose(), [onSuperWideRHPClose]);
 
     /**
      * Effect that determines whether to show wide RHP based on condition or optimistic state.

--- a/src/components/WideRHPContextProvider/useShowWideRHPVersion/index.ts
+++ b/src/components/WideRHPContextProvider/useShowWideRHPVersion/index.ts
@@ -1,8 +1,8 @@
 import {useRoute} from '@react-navigation/native';
 import {useCallback, useContext, useEffect} from 'react';
-import {InteractionManager} from 'react-native';
-import useBeforeRemove from '@hooks/useBeforeRemove';
-import {WideRHPContext} from '..';
+import {navigationRef} from '@libs/Navigation/Navigation';
+import NAVIGATORS from '@src/NAVIGATORS';
+import {expandedRHPProgress, WideRHPContext} from '..';
 
 /**
  * Hook that manages wide RHP display for a screen based on condition or optimistic state.
@@ -16,22 +16,18 @@ function useShowWideRHPVersion(condition: boolean) {
     const reportID = route.params && 'reportID' in route.params && typeof route.params.reportID === 'string' ? route.params.reportID : '';
     const {showWideRHPVersion, removeWideRHPRouteKey, isReportIDMarkedAsExpense} = useContext(WideRHPContext);
 
-    // beforeRemove event is not called when closing nested Wide RHP using the browser back button.
-    // This hook removes the route key from the array in the following case.
-    useEffect(() => () => removeWideRHPRouteKey(route), [removeWideRHPRouteKey, route]);
-
     const onWideRHPClose = useCallback(() => {
-        // eslint-disable-next-line @typescript-eslint/no-deprecated
-        InteractionManager.runAfterInteractions(() => {
-            removeWideRHPRouteKey(route);
-        });
+        removeWideRHPRouteKey(route);
+        // When the RHP has been closed, expandedRHPProgress should be set to 0.
+        if (navigationRef.getRootState().routes.at(-1)?.name !== NAVIGATORS.RIGHT_MODAL_NAVIGATOR) {
+            expandedRHPProgress.setValue(0);
+        }
     }, [removeWideRHPRouteKey, route]);
 
     /**
-     * Effect that sets up cleanup when the screen is about to be removed.
-     * Uses InteractionManager to ensure cleanup happens after closing animation.
+     * Effect that sets up cleanup when the screen is unmounted.
      */
-    useBeforeRemove(onWideRHPClose);
+    useEffect(() => () => onWideRHPClose(), [onWideRHPClose]);
 
     /**
      * Effect that determines whether to show wide RHP based on condition or optimistic state.

--- a/src/libs/Navigation/AppNavigator/Navigators/RightModalNavigator.tsx
+++ b/src/libs/Navigation/AppNavigator/Navigators/RightModalNavigator.tsx
@@ -83,17 +83,22 @@ function SecondaryOverlay() {
     return null;
 }
 
-const loadReportScreen = () => require<ReactComponentModule>('../../../../pages/home/ReportScreen').default;
+const loadRHPReportScreen = () => require<ReactComponentModule>('../../../../pages/home/RHPReportScreen').default;
 
 function RightModalNavigator({navigation, route}: RightModalNavigatorProps) {
-    const {shouldUseNarrowLayout} = useResponsiveLayout();
+    // eslint-disable-next-line rulesdir/prefer-shouldUseNarrowLayout-instead-of-isSmallScreenWidth
+    const {isSmallScreenWidth, shouldUseNarrowLayout} = useResponsiveLayout();
     const isExecutingRef = useRef<boolean>(false);
     const screenOptions = useRHPScreenOptions();
-    const {shouldRenderTertiaryOverlay, clearWideRHPKeys, syncRHPKeys} = useContext(WideRHPContext);
+    const {superWideRHPRouteKeys, shouldRenderTertiaryOverlay, clearWideRHPKeys, syncRHPKeys} = useContext(WideRHPContext);
     const {windowWidth} = useWindowDimensions();
     const modalStackScreenOptions = useModalStackScreenOptions();
     const styles = useThemeStyles();
     const {sidePanelOffset} = useSidePanel();
+
+    // Animation should be disabled when we open the wide rhp from the narrow one.
+    // When the wide rhp page is opened as first one, it will be animated with the entire RightModalNavigator.
+    const animationEnabledOnSearchReport = superWideRHPRouteKeys.length > 0 || isSmallScreenWidth;
 
     const animatedWidth = expandedRHPProgress.interpolate({
         inputRange: [0, 1, 2],
@@ -340,10 +345,10 @@ function RightModalNavigator({navigation, route}: RightModalNavigatorProps) {
                         />
                         <Stack.Screen
                             name={SCREENS.RIGHT_MODAL.SEARCH_REPORT}
-                            getComponent={loadReportScreen}
+                            getComponent={loadRHPReportScreen}
                             options={(props) => {
                                 const options = modalStackScreenOptions(props);
-                                return {...options, animation: Animations.NONE};
+                                return {...options, animation: animationEnabledOnSearchReport ? Animations.SLIDE_FROM_RIGHT : Animations.NONE};
                             }}
                         />
                         <Stack.Screen

--- a/src/pages/home/RHPReportScreen.tsx
+++ b/src/pages/home/RHPReportScreen.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import type {PlatformStackScreenProps} from '@libs/Navigation/PlatformStackNavigation/types';
+import type {RightModalNavigatorParamList} from '@libs/Navigation/types';
+import type SCREENS from '@src/SCREENS';
+import ReportScreen from './ReportScreen';
+
+type PageProps = PlatformStackScreenProps<RightModalNavigatorParamList, typeof SCREENS.RIGHT_MODAL.SEARCH_REPORT>;
+
+// When switching search reports using arrows SET_PARAMS action is performed, but it's necessary to remount the whole component after changing the reportID due to the hooks dependencies.
+// It's suggested to refactor hooks in ReportScreen to remove this file and perform SET_PARAMS without the report screen remount.
+export default function RHPReportScreen({route, navigation}: PageProps) {
+    return (
+        <ReportScreen
+            key={route.params?.reportID}
+            route={route}
+            navigation={navigation}
+        />
+    );
+}


### PR DESCRIPTION
cc: @mountiny @ZhenjaHorbach 

### Explanation of Change
<!-- Explain what your change does and how it addresses the linked issue -->

This PR fixes the animation issues with `SearchReport` page. Previously this structure was more complex, this page was wrapped by the modal stack that was animated but the page doesn't have animations itself. Now this page is displayed directly in `RightModalNavigator`. We want to animate it when showing and closing but not when switching using arrow buttons. To do that we need to perform `SET_PARAMS` action instead of `REPLACE` to not trigger animation. 

Now it's consistent with expense reports as on these pages `SET_PARAMS` action is triggered when pressing the arrow buttons.

In this PR, the deploy blocker which appeared after merging v1 has been fixed.  https://github.com/Expensify/App/issues/78437

To avoid this animation glitch SearchReport won't be animated when opening from a narrow RHP on a wide layout.



### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/78340
$ https://github.com/Expensify/App/issues/78437
PROPOSAL:


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

- [ ] Verify that no errors appear in the JS console

1. Launch the app
2. Go to workspace chat.
3. Create two expenses with the same amount.
4. Open the expense report.
5. Click Review duplicates.
6. Click on the first expense preview.
7. Verify if the transition between screens is animated on small screen width.

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->

- [ ] Verify that no errors appear in the JS console

1. Launch the app
2. Go to workspace chat.
3. Create two expenses with the same amount.
4. Open the expense report.
5. Click Review duplicates.
6. Click on the first expense preview.
7. Verify if the transition between screens is animated on small screen width.


### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I verified there are no new alerts related to the `canBeMissing` param for `useOnyx`
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/69dd91b7-771a-4e63-8b48-463a2b48bfed


</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/72b5ec17-e33a-4e9d-9f88-276b7c421534


</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/2b1557c2-ac5e-4b16-8141-5e29f2b29251


</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/5a553465-86ca-47bd-b490-aac49e4d72b9


</details>