### PR TITLE
Prevent Excel tag files from being uploaded (PR by ijmalik)

### DIFF
--- a/src/components/ImportSpreadsheet.tsx
+++ b/src/components/ImportSpreadsheet.tsx
@@ -64,39 +64,25 @@ function ImportSpreadsheet({backTo, goTo, isImportingMultiLevelTags}: ImportSpre
     };
 
     const validateFile = (file: FileObject) => {
-        const {fileExtension} = splitExtensionFromFileName(file?.name ?? '');
-        const lowerExt = fileExtension.toLowerCase();
-
-        if (isImportingMultiLevelTags) {
-            if (
-                !CONST.MULTILEVEL_TAG_ALLOWED_SPREADSHEET_EXTENSIONS.includes(
-                    lowerExt as TupleToUnion<typeof CONST.MULTILEVEL_TAG_ALLOWED_SPREADSHEET_EXTENSIONS>,
-                )
-            ) {
-                setUploadFileError(
-                    true,
-                    'attachmentPicker.wrongFileType',
-                    'attachmentPicker.notAllowedExtension',
-                );
-                return false;
-            }
-        } else if (
-            !CONST.ALLOWED_SPREADSHEET_EXTENSIONS.includes(
-                lowerExt as TupleToUnion<typeof CONST.ALLOWED_SPREADSHEET_EXTENSIONS>,
-            )
-        ) {
-            setUploadFileError(true, 'attachmentPicker.wrongFileType', 'attachmentPicker.notAllowedExtension');
+    const {
+        fileExtension
+    } = splitExtensionFromFileName(file?.name ?? '');
+    const lowerExt = fileExtension.toLowerCase();
+    if (isImportingMultiLevelTags) {
+        if (!CONST.MULTILEVEL_TAG_ALLOWED_SPREADSHEET_EXTENSIONS.includes(lowerExt as TupleToUnion < typeof CONST.MULTILEVEL_TAG_ALLOWED_SPREADSHEET_EXTENSIONS > , )) {
+            setUploadFileError(true, 'attachmentPicker.wrongFileType', 'attachmentPicker.notAllowedExtension', );
             return false;
         }
-
-        if ((file?.size ?? 0) <= 0) {
-            setUploadFileError(true, 'attachmentPicker.attachmentTooSmall', 'spreadsheet.sizeNotMet');
-            return false;
-        }
-
-        return true;
-    };
-
+    } else if (!CONST.ALLOWED_SPREADSHEET_EXTENSIONS.includes(lowerExt as TupleToUnion < typeof CONST.ALLOWED_SPREADSHEET_EXTENSIONS > , )) {
+        setUploadFileError(true, 'attachmentPicker.wrongFileType', 'attachmentPicker.notAllowedExtension');
+        return false;
+    }
+    if ((file?.size ?? 0) <= 0) {
+        setUploadFileError(true, 'attachmentPicker.attachmentTooSmall', 'spreadsheet.sizeNotMet');
+        return false;
+    }
+    return true;
+};
     const readFile = (file: File) => {
         if (!validateFile(file)) {
             return;

--- a/src/components/ImportSpreadsheet.tsx
+++ b/src/components/ImportSpreadsheet.tsx
@@ -66,14 +66,10 @@ function ImportSpreadsheet({backTo, goTo, isImportingMultiLevelTags}: ImportSpre
     const validateFile = (file: FileObject) => {
         const {fileExtension} = splitExtensionFromFileName(file?.name ?? '');
         const lowerExt = fileExtension.toLowerCase();
+
         const allowedExtensions: readonly string[] = isImportingMultiLevelTags ? CONST.MULTILEVEL_TAG_ALLOWED_SPREADSHEET_EXTENSIONS : CONST.ALLOWED_SPREADSHEET_EXTENSIONS;
 
-        if (isImportingMultiLevelTags) {
-            if (!CONST.MULTILEVEL_TAG_ALLOWED_SPREADSHEET_EXTENSIONS.includes(lowerExt as TupleToUnion<typeof CONST.MULTILEVEL_TAG_ALLOWED_SPREADSHEET_EXTENSIONS>)) {
-                setUploadFileError(true, 'attachmentPicker.wrongFileType', 'attachmentPicker.notAllowedExtension');
-                return false;
-            }
-        } else if (!allowedExtensions.includes(fileExtension.toLowerCase())) {
+        if (!allowedExtensions.includes(lowerExt)) {
             setUploadFileError(true, 'attachmentPicker.wrongFileType', 'attachmentPicker.notAllowedExtension');
             return false;
         }
@@ -82,6 +78,7 @@ function ImportSpreadsheet({backTo, goTo, isImportingMultiLevelTags}: ImportSpre
             setUploadFileError(true, 'attachmentPicker.attachmentTooSmall', 'spreadsheet.sizeNotMet');
             return false;
         }
+
         return true;
     };
 

--- a/src/components/ImportSpreadsheet.tsx
+++ b/src/components/ImportSpreadsheet.tsx
@@ -65,7 +65,6 @@ function ImportSpreadsheet({backTo, goTo, isImportingMultiLevelTags}: ImportSpre
 
     const validateFile = (file: FileObject) => {
         const {fileExtension} = splitExtensionFromFileName(file?.name ?? '');
-        const lowerExt = fileExtension.toLowerCase();
         const allowedExtensions: readonly string[] = isImportingMultiLevelTags ? CONST.MULTILEVEL_TAG_ALLOWED_SPREADSHEET_EXTENSIONS : CONST.ALLOWED_SPREADSHEET_EXTENSIONS;
 
         if (!allowedExtensions.includes(fileExtension.toLowerCase())) {

--- a/src/components/ImportSpreadsheet.tsx
+++ b/src/components/ImportSpreadsheet.tsx
@@ -27,9 +27,14 @@ import ScreenWrapper from './ScreenWrapper';
 import Text from './Text';
 
 type ImportSpreadsheetProps = {
-    backTo?: Routes; // The route to navigate to when the back button is pressed.
-    goTo: Routes; // The route to navigate to after the file import is completed.
-    isImportingMultiLevelTags?: boolean; // Whether the spreadsheet is importing multi-level tags
+    // The route to navigate to when the back button is pressed.
+    backTo?: Routes;
+
+    // The route to navigate to after the file import is completed.
+    goTo: Routes;
+
+    /** Whether the spreadsheet is importing multi-level tags */
+    isImportingMultiLevelTags?: boolean;
 };
 
 function ImportSpreadsheet({backTo, goTo, isImportingMultiLevelTags}: ImportSpreadsheetProps) {
@@ -41,6 +46,8 @@ function ImportSpreadsheet({backTo, goTo, isImportingMultiLevelTags}: ImportSpre
     const [isAttachmentInvalid, setIsAttachmentInvalid] = useState(false);
     const [attachmentInvalidReasonTitle, setAttachmentInvalidReasonTitle] = useState<TranslationPaths>();
     const [attachmentInvalidReason, setAttachmentValidReason] = useState<TranslationPaths>();
+    // We need to use isSmallScreenWidth instead of shouldUseNarrowLayout to use different copies depending on the screen size
+    // eslint-disable-next-line rulesdir/prefer-shouldUseNarrowLayout-instead-of-isSmallScreenWidth
     const {isSmallScreenWidth} = useResponsiveLayout();
     const [isDraggingOver, setIsDraggingOver] = useState(false);
 
@@ -74,7 +81,6 @@ function ImportSpreadsheet({backTo, goTo, isImportingMultiLevelTags}: ImportSpre
             setUploadFileError(true, 'attachmentPicker.attachmentTooSmall', 'spreadsheet.sizeNotMet');
             return false;
         }
-
         return true;
     };
 
@@ -84,12 +90,12 @@ function ImportSpreadsheet({backTo, goTo, isImportingMultiLevelTags}: ImportSpre
         }
 
         let fileURI = file.uri ?? URL.createObjectURL(file);
-        if (!fileURI) return;
-
+        if (!fileURI) {
+            return;
+        }
         if (Platform.OS === 'ios') {
             fileURI = fileURI.replaceAll(/^.*\/Documents\//g, `${RNFetchBlob.fs.dirs.DocumentDir}/`);
         }
-
         const {fileExtension} = splitExtensionFromFileName(file?.name ?? '');
         const shouldReadAsText = CONST.TEXT_SPREADSHEET_EXTENSIONS.includes(fileExtension as TupleToUnion<typeof CONST.TEXT_SPREADSHEET_EXTENSIONS>);
 
@@ -100,20 +106,22 @@ function ImportSpreadsheet({backTo, goTo, isImportingMultiLevelTags}: ImportSpre
                 const readWorkbook = () => {
                     if (shouldReadAsText) {
                         return fetch(fileURI)
-                            .then((data) => data.text())
+                            .then((data) => {
+                                return data.text();
+                            })
                             .then((text) => XLSX.read(text, {type: 'string'}));
                     }
                     return fetch(fileURI)
-                        .then((data) => data.arrayBuffer())
+                        .then((data) => {
+                            return data.arrayBuffer();
+                        })
                         .then((arrayBuffer) => XLSX.read(new Uint8Array(arrayBuffer), {type: 'buffer'}));
                 };
-
                 readWorkbook()
                     .then((workbook) => {
                         const worksheet = workbook.Sheets[workbook.SheetNames[0]];
                         const data = XLSX.utils.sheet_to_json(worksheet, {header: 1, blankrows: false}) as string[][] | unknown[][];
                         const formattedSpreadsheetData = data.map((row) => row.map((cell) => String(cell)));
-
                         setSpreadsheetData(formattedSpreadsheetData, fileURI, file.type, file.name, isImportingMultiLevelTags ?? false)
                             .then(() => {
                                 Navigation.navigate(goTo);
@@ -122,7 +130,9 @@ function ImportSpreadsheet({backTo, goTo, isImportingMultiLevelTags}: ImportSpre
                                 setUploadFileError(true, 'spreadsheet.importFailedTitle', 'spreadsheet.invalidFileMessage');
                             });
                     })
-                    .finally(() => setIsReadingFile(false));
+                    .finally(() => {
+                        setIsReadingFile(false);
+                    });
             })
             .catch((error) => {
                 console.error('Failed to load XLSX library:', error);
@@ -132,15 +142,18 @@ function ImportSpreadsheet({backTo, goTo, isImportingMultiLevelTags}: ImportSpre
     };
 
     const getTextForImportModal = () => {
+        let text = '';
         if (isImportingMultiLevelTags) {
-            return isSmallScreenWidth ? translate('spreadsheet.chooseSpreadsheetMultiLevelTag') : translate('spreadsheet.dragAndDropMultiLevelTag');
+            text = isSmallScreenWidth ? translate('spreadsheet.chooseSpreadsheetMultiLevelTag') : translate('spreadsheet.dragAndDropMultiLevelTag');
+        } else {
+            text = isSmallScreenWidth ? translate('spreadsheet.chooseSpreadsheet') : translate('spreadsheet.dragAndDrop');
         }
-        return isSmallScreenWidth ? translate('spreadsheet.chooseSpreadsheet') : translate('spreadsheet.dragAndDrop');
+        return text;
     };
 
     const acceptableFileTypes = isImportingMultiLevelTags
-        ? CONST.MULTILEVEL_TAG_ALLOWED_SPREADSHEET_EXTENSIONS.map((ext) => `.${ext}`).join(',')
-        : CONST.ALLOWED_SPREADSHEET_EXTENSIONS.map((ext) => `.${ext}`).join(',');
+        ? CONST.MULTILEVEL_TAG_ALLOWED_SPREADSHEET_EXTENSIONS.map((extension) => `.${extension}`).join(',')
+        : CONST.ALLOWED_SPREADSHEET_EXTENSIONS.map((extension) => `.${extension}`).join(',');
 
     const desktopView = (
         <>
@@ -153,9 +166,9 @@ function ImportSpreadsheet({backTo, goTo, isImportingMultiLevelTags}: ImportSpre
                     height={CONST.IMPORT_SPREADSHEET.ICON_HEIGHT}
                 />
             </View>
-
             <View
                 style={[styles.uploadFileViewTextContainer, styles.userSelectNone]}
+                // eslint-disable-next-line react-compiler/react-compiler, react/jsx-props-no-spreading
                 {...panResponder.panHandlers}
             >
                 <Text style={[styles.textFileUpload, styles.mb1]}>{isImportingMultiLevelTags ? translate('spreadsheet.import') : translate('spreadsheet.upload')}</Text>
@@ -163,7 +176,6 @@ function ImportSpreadsheet({backTo, goTo, isImportingMultiLevelTags}: ImportSpre
                     <RenderHTML html={getTextForImportModal()} />
                 </View>
             </View>
-
             <FilePicker acceptableFileTypes={acceptableFileTypes}>
                 {({openPicker}) => (
                     <Button
@@ -172,13 +184,13 @@ function ImportSpreadsheet({backTo, goTo, isImportingMultiLevelTags}: ImportSpre
                         accessibilityLabel={translate('common.chooseFile')}
                         style={[styles.pt9]}
                         isLoading={isReadingFile}
-                        onPress={() =>
+                        onPress={() => {
                             openPicker({
                                 onPicked: (file) => {
                                     readFile(file as File);
                                 },
-                            })
-                        }
+                            });
+                        }}
                     />
                 )}
             </FilePicker>
@@ -234,7 +246,6 @@ function ImportSpreadsheet({backTo, goTo, isImportingMultiLevelTags}: ImportSpre
                                     </View>
                                 </View>
                             </DragAndDropConsumer>
-
                             <ConfirmModal
                                 title={attachmentInvalidReasonTitle ? translate(attachmentInvalidReasonTitle) : ''}
                                 onConfirm={hideInvalidAttachmentModal}

--- a/src/components/ImportSpreadsheet.tsx
+++ b/src/components/ImportSpreadsheet.tsx
@@ -66,10 +66,9 @@ function ImportSpreadsheet({backTo, goTo, isImportingMultiLevelTags}: ImportSpre
     const validateFile = (file: FileObject) => {
         const {fileExtension} = splitExtensionFromFileName(file?.name ?? '');
         const lowerExt = fileExtension.toLowerCase();
-
         const allowedExtensions: readonly string[] = isImportingMultiLevelTags ? CONST.MULTILEVEL_TAG_ALLOWED_SPREADSHEET_EXTENSIONS : CONST.ALLOWED_SPREADSHEET_EXTENSIONS;
 
-        if (!allowedExtensions.includes(lowerExt)) {
+        if (!allowedExtensions.includes(fileExtension.toLowerCase())) {
             setUploadFileError(true, 'attachmentPicker.wrongFileType', 'attachmentPicker.notAllowedExtension');
             return false;
         }
@@ -78,7 +77,6 @@ function ImportSpreadsheet({backTo, goTo, isImportingMultiLevelTags}: ImportSpre
             setUploadFileError(true, 'attachmentPicker.attachmentTooSmall', 'spreadsheet.sizeNotMet');
             return false;
         }
-
         return true;
     };
 

--- a/src/components/ImportSpreadsheet.tsx
+++ b/src/components/ImportSpreadsheet.tsx
@@ -1,20 +1,46 @@
-import React, {useRef, useState} from 'react';
-import {PanResponder, PixelRatio, Platform, View} from 'react-native';
+import React, {
+    useRef,
+    useState
+} from 'react';
+import {
+    PanResponder,
+    PixelRatio,
+    Platform,
+    View
+} from 'react-native';
 import RNFetchBlob from 'react-native-blob-util';
-import type {TupleToUnion} from 'type-fest';
-import {useMemoizedLazyExpensifyIcons} from '@hooks/useLazyAsset';
+import type {
+    TupleToUnion
+} from 'type-fest';
+import {
+    useMemoizedLazyExpensifyIcons
+} from '@hooks/useLazyAsset';
 import useLocalize from '@hooks/useLocalize';
 import useResponsiveLayout from '@hooks/useResponsiveLayout';
 import useThemeStyles from '@hooks/useThemeStyles';
-import {setSpreadsheetData} from '@libs/actions/ImportSpreadsheet';
-import {setImportedSpreadsheetIsImportingMultiLevelTags} from '@libs/actions/Policy/Tag';
-import {canUseTouchScreen} from '@libs/DeviceCapabilities';
-import {splitExtensionFromFileName} from '@libs/fileDownload/FileUtils';
+import {
+    setSpreadsheetData
+} from '@libs/actions/ImportSpreadsheet';
+import {
+    setImportedSpreadsheetIsImportingMultiLevelTags
+} from '@libs/actions/Policy/Tag';
+import {
+    canUseTouchScreen
+} from '@libs/DeviceCapabilities';
+import {
+    splitExtensionFromFileName
+} from '@libs/fileDownload/FileUtils';
 import Navigation from '@libs/Navigation/Navigation';
 import CONST from '@src/CONST';
-import type {TranslationPaths} from '@src/languages/types';
-import type {Route as Routes} from '@src/ROUTES';
-import type {FileObject} from '@src/types/utils/Attachment';
+import type {
+    TranslationPaths
+} from '@src/languages/types';
+import type {
+    Route as Routes
+} from '@src/ROUTES';
+import type {
+    FileObject
+} from '@src/types/utils/Attachment';
 import Button from './Button';
 import ConfirmModal from './ConfirmModal';
 import DragAndDropConsumer from './DragAndDrop/Consumer';
@@ -25,158 +51,128 @@ import ImageSVG from './ImageSVG';
 import RenderHTML from './RenderHTML';
 import ScreenWrapper from './ScreenWrapper';
 import Text from './Text';
-
 type ImportSpreadsheetProps = {
-    backTo?: Routes; // The route to navigate to when the back button is pressed.
-    goTo: Routes; // The route to navigate to after the file import is completed.
-    isImportingMultiLevelTags?: boolean; // Whether the spreadsheet is importing multi-level tags
+    // The route to navigate to when the back button is pressed.
+    backTo ? : Routes;
+    // The route to navigate to after the file import is completed.
+    goTo: Routes;
+    /** Whether the spreadsheet is importing multi-level tags */
+    isImportingMultiLevelTags ? : boolean;
 };
 
 function ImportSpreadsheet({
     backTo,
     goTo,
-    isImportingMultiLevelTags,
+    isImportingMultiLevelTags
 }: ImportSpreadsheetProps) {
     const icons = useMemoizedLazyExpensifyIcons(['SpreadsheetComputer']);
     const styles = useThemeStyles();
-    const {translate} = useLocalize();
+    const {
+        translate
+    } = useLocalize();
     const [isReadingFile, setIsReadingFile] = useState(false);
     const [fileTopPosition, setFileTopPosition] = useState(0);
     const [isAttachmentInvalid, setIsAttachmentInvalid] = useState(false);
-    const [attachmentInvalidReasonTitle, setAttachmentInvalidReasonTitle] = useState<TranslationPaths>();
-    const [attachmentInvalidReason, setAttachmentValidReason] = useState<TranslationPaths>();
-    const {isSmallScreenWidth} = useResponsiveLayout();
+    const [attachmentInvalidReasonTitle, setAttachmentInvalidReasonTitle] = useState < TranslationPaths > ();
+    const [attachmentInvalidReason, setAttachmentValidReason] = useState < TranslationPaths > ();
+    // We need to use isSmallScreenWidth instead of shouldUseNarrowLayout to use different copies depending on the screen size
+    // eslint-disable-next-line rulesdir/prefer-shouldUseNarrowLayout-instead-of-isSmallScreenWidth
+    const {
+        isSmallScreenWidth
+    } = useResponsiveLayout();
     const [isDraggingOver, setIsDraggingOver] = useState(false);
-
-    const panResponder = useRef(
-        PanResponder.create({
-            onPanResponderTerminationRequest: () => false,
-        }),
-    ).current;
-
+    const panResponder = useRef(PanResponder.create({
+        onPanResponderTerminationRequest: () => false,
+    }), ).current;
     const setUploadFileError = (isInvalid: boolean, title: TranslationPaths, reason: TranslationPaths) => {
         setIsAttachmentInvalid(isInvalid);
         setAttachmentInvalidReasonTitle(title);
         setAttachmentValidReason(reason);
     };
-
     const validateFile = (file: FileObject) => {
-        const {fileExtension} = splitExtensionFromFileName(file?.name ?? '');
+        const {
+            fileExtension
+        } = splitExtensionFromFileName(file?.name ?? '');
         const lowerExt = fileExtension.toLowerCase();
-
         if (isImportingMultiLevelTags) {
-            if (
-                !CONST.MULTILEVEL_TAG_ALLOWED_SPREADSHEET_EXTENSIONS.includes(
-                    lowerExt as TupleToUnion<typeof CONST.MULTILEVEL_TAG_ALLOWED_SPREADSHEET_EXTENSIONS>,
-                )
-            ) {
-                setUploadFileError(
-                    true,
-                    'attachmentPicker.wrongFileType',
-                    'attachmentPicker.notAllowedExtension',
-                );
+            if (!CONST.MULTILEVEL_TAG_ALLOWED_SPREADSHEET_EXTENSIONS.includes(lowerExt as TupleToUnion < typeof CONST.MULTILEVEL_TAG_ALLOWED_SPREADSHEET_EXTENSIONS > , )) {
+                setUploadFileError(true, 'attachmentPicker.wrongFileType', 'attachmentPicker.notAllowedExtension', );
                 return false;
             }
-        } else if (
-            !CONST.ALLOWED_SPREADSHEET_EXTENSIONS.includes(
-                lowerExt as TupleToUnion<typeof CONST.ALLOWED_SPREADSHEET_EXTENSIONS>,
-            )
-        ) {
+        } else if (!CONST.ALLOWED_SPREADSHEET_EXTENSIONS.includes(lowerExt as TupleToUnion < typeof CONST.ALLOWED_SPREADSHEET_EXTENSIONS > , )) {
             setUploadFileError(true, 'attachmentPicker.wrongFileType', 'attachmentPicker.notAllowedExtension');
             return false;
         }
-
         if ((file?.size ?? 0) <= 0) {
             setUploadFileError(true, 'attachmentPicker.attachmentTooSmall', 'spreadsheet.sizeNotMet');
             return false;
         }
-
         return true;
     };
-
     const readFile = (file: File) => {
         if (!validateFile(file)) {
             return;
         }
-
         let fileURI = file.uri ?? URL.createObjectURL(file);
-        if (!fileURI) return;
-
+        if (!fileURI) {
+            return;
+        }
         if (Platform.OS === 'ios') {
             fileURI = fileURI.replaceAll(/^.*\/Documents\//g, `${RNFetchBlob.fs.dirs.DocumentDir}/`);
         }
-
-        const {fileExtension} = splitExtensionFromFileName(file?.name ?? '');
-        const shouldReadAsText = CONST.TEXT_SPREADSHEET_EXTENSIONS.includes(
-            fileExtension as TupleToUnion<typeof CONST.TEXT_SPREADSHEET_EXTENSIONS>,
-        );
-
+        const {
+            fileExtension
+        } = splitExtensionFromFileName(file?.name ?? '');
+        const shouldReadAsText = CONST.TEXT_SPREADSHEET_EXTENSIONS.includes(fileExtension as TupleToUnion < typeof CONST.TEXT_SPREADSHEET_EXTENSIONS > );
         setIsReadingFile(true);
-
-        import('xlsx')
-            .then((XLSX) => {
-                const readWorkbook = () => {
-                    if (shouldReadAsText) {
-                        return fetch(fileURI)
-                            .then((data) => data.text())
-                            .then((text) => XLSX.read(text, {type: 'string'}));
-                    }
-                    return fetch(fileURI)
-                        .then((data) => data.arrayBuffer())
-                        .then((arrayBuffer) => XLSX.read(new Uint8Array(arrayBuffer), {type: 'buffer'}));
-                };
-
-                readWorkbook()
-                    .then((workbook) => {
-                        const worksheet = workbook.Sheets[workbook.SheetNames[0]];
-                        const data = XLSX.utils.sheet_to_json(worksheet, {header: 1, blankrows: false}) as
-                            | string[][]
-                            | unknown[][];
-                        const formattedSpreadsheetData = data.map((row) => row.map((cell) => String(cell)));
-
-                        setSpreadsheetData(
-                            formattedSpreadsheetData,
-                            fileURI,
-                            file.type,
-                            file.name,
-                            isImportingMultiLevelTags ?? false,
-                        )
-                            .then(() => {
-                                Navigation.navigate(goTo);
-                            })
-                            .catch(() => {
-                                setUploadFileError(true, 'spreadsheet.importFailedTitle', 'spreadsheet.invalidFileMessage');
-                            });
-                    })
-                    .finally(() => setIsReadingFile(false));
-            })
-            .catch((error) => {
-                console.error('Failed to load XLSX library:', error);
-                setUploadFileError(true, 'spreadsheet.importFailedTitle', 'spreadsheet.importSpreadsheetLibraryError');
+        import('xlsx').then((XLSX) => {
+            const readWorkbook = () => {
+                if (shouldReadAsText) {
+                    return fetch(fileURI).then((data) => {
+                        return data.text();
+                    }).then((text) => XLSX.read(text, {
+                        type: 'string'
+                    }));
+                }
+                return fetch(fileURI).then((data) => {
+                    return data.arrayBuffer();
+                }).then((arrayBuffer) => XLSX.read(new Uint8Array(arrayBuffer), {
+                    type: 'buffer'
+                }));
+            };
+            readWorkbook().then((workbook) => {
+                const worksheet = workbook.Sheets[workbook.SheetNames[0]];
+                const data = XLSX.utils.sheet_to_json(worksheet, {
+                    header: 1,
+                    blankrows: false
+                }) as string[][] | unknown[][];
+                const formattedSpreadsheetData = data.map((row) => row.map((cell) => String(cell)));
+                setSpreadsheetData(formattedSpreadsheetData, fileURI, file.type, file.name, isImportingMultiLevelTags ?? false).then(() => {
+                    Navigation.navigate(goTo);
+                }).catch(() => {
+                    setUploadFileError(true, 'spreadsheet.importFailedTitle', 'spreadsheet.invalidFileMessage');
+                });
+            }).finally(() => {
                 setIsReadingFile(false);
             });
+        }).catch((error) => {
+            console.error('Failed to load XLSX library:', error);
+            setUploadFileError(true, 'spreadsheet.importFailedTitle', 'spreadsheet.importSpreadsheetLibraryError');
+            setIsReadingFile(false);
+        });
     };
-
     const getTextForImportModal = () => {
+        let text = '';
         if (isImportingMultiLevelTags) {
-            return isSmallScreenWidth
-                ? translate('spreadsheet.chooseSpreadsheetMultiLevelTag')
-                : translate('spreadsheet.dragAndDropMultiLevelTag');
+            text = isSmallScreenWidth ? translate('spreadsheet.chooseSpreadsheetMultiLevelTag') : translate('spreadsheet.dragAndDropMultiLevelTag');
+        } else {
+            text = isSmallScreenWidth ? translate('spreadsheet.chooseSpreadsheet') : translate('spreadsheet.dragAndDrop');
         }
-        return isSmallScreenWidth ? translate('spreadsheet.chooseSpreadsheet') : translate('spreadsheet.dragAndDrop');
+        return text;
     };
-
-    const acceptableFileTypes = isImportingMultiLevelTags
-        ? CONST.MULTILEVEL_TAG_ALLOWED_SPREADSHEET_EXTENSIONS.map((ext) => `.${ext}`).join(',')
-        : CONST.ALLOWED_SPREADSHEET_EXTENSIONS.map((ext) => `.${ext}`).join(',');
-
-    const desktopView = (
-        <>
-            <View
-                onLayout={({nativeEvent}) =>
-                    setFileTopPosition(PixelRatio.roundToNearestPixel((nativeEvent.layout as DOMRect).top))
-                }
-            >
+    const acceptableFileTypes = isImportingMultiLevelTags ? CONST.MULTILEVEL_TAG_ALLOWED_SPREADSHEET_EXTENSIONS.map((extension) => `.${extension}`).join(',') : CONST.ALLOWED_SPREADSHEET_EXTENSIONS.map((extension) => `.${extension}`).join(',');
+    const desktopView = (<>
+            <View onLayout={({nativeEvent}) => setFileTopPosition(PixelRatio.roundToNearestPixel((nativeEvent.layout as DOMRect).top))}>
                 <ImageSVG
                     src={icons.SpreadsheetComputer}
                     contentFit="contain"
@@ -185,16 +181,16 @@ function ImportSpreadsheet({
                     height={CONST.IMPORT_SPREADSHEET.ICON_HEIGHT}
                 />
             </View>
-
-            <View style={[styles.uploadFileViewTextContainer, styles.userSelectNone]} {...panResponder.panHandlers}>
-                <Text style={[styles.textFileUpload, styles.mb1]}>
-                    {isImportingMultiLevelTags ? translate('spreadsheet.import') : translate('spreadsheet.upload')}
-                </Text>
+            <View
+                style={[styles.uploadFileViewTextContainer, styles.userSelectNone]}
+                // eslint-disable-next-line react-compiler/react-compiler, react/jsx-props-no-spreading
+                {...panResponder.panHandlers}
+            >
+                <Text style={[styles.textFileUpload, styles.mb1]}>{isImportingMultiLevelTags ? translate('spreadsheet.import') : translate('spreadsheet.upload')}</Text>
                 <View style={[styles.flexRow]}>
                     <RenderHTML html={getTextForImportModal()} />
                 </View>
             </View>
-
             <FilePicker acceptableFileTypes={acceptableFileTypes}>
                 {({openPicker}) => (
                     <Button
@@ -203,25 +199,21 @@ function ImportSpreadsheet({
                         accessibilityLabel={translate('common.chooseFile')}
                         style={[styles.pt9]}
                         isLoading={isReadingFile}
-                        onPress={() =>
+                        onPress={() => {
                             openPicker({
                                 onPicked: (file) => {
                                     readFile(file as File);
                                 },
-                            })
-                        }
+                            });
+                        }}
                     />
                 )}
             </FilePicker>
-        </>
-    );
-
+        </>);
     const hideInvalidAttachmentModal = () => {
         setIsAttachmentInvalid(false);
     };
-
-    return (
-        <ScreenWrapper
+    return (<ScreenWrapper
             includeSafeAreaPaddingBottom={false}
             shouldEnableKeyboardAvoidingView={false}
             testID="ImportSpreadsheet"
@@ -240,13 +232,7 @@ function ImportSpreadsheet({
                             }}
                         />
 
-                        <View
-                            style={[
-                                styles.flex1,
-                                styles.uploadFileView,
-                                styles.uploadFileViewBorderWidth(isSmallScreenWidth),
-                            ]}
-                        >
+                        <View style={[styles.flex1, styles.uploadFileView, styles.uploadFileViewBorderWidth(isSmallScreenWidth)]}>
                             {!(isDraggingOver ?? isDraggingOver) && desktopView}
 
                             <DragAndDropConsumer
@@ -257,15 +243,7 @@ function ImportSpreadsheet({
                                     }
                                 }}
                             >
-                                <View
-                                    style={[
-                                        styles.fileDropOverlay,
-                                        styles.w100,
-                                        styles.h100,
-                                        styles.justifyContentCenter,
-                                        styles.alignItemsCenter,
-                                    ]}
-                                >
+                                <View style={[styles.fileDropOverlay, styles.w100, styles.h100, styles.justifyContentCenter, styles.alignItemsCenter]}>
                                     <View style={[styles.pAbsolute, styles.fileUploadImageWrapper(fileTopPosition)]}>
                                         <ImageSVG
                                             src={icons.SpreadsheetComputer}
@@ -275,13 +253,10 @@ function ImportSpreadsheet({
                                             height={CONST.IMPORT_SPREADSHEET.ICON_HEIGHT}
                                         />
                                         <Text style={[styles.textFileUpload]}>{translate('common.dropTitle')}</Text>
-                                        <Text style={[styles.subTextFileUpload, styles.themeTextColor]}>
-                                            {translate('common.dropMessage')}
-                                        </Text>
+                                        <Text style={[styles.subTextFileUpload, styles.themeTextColor]}>{translate('common.dropMessage')}</Text>
                                     </View>
                                 </View>
                             </DragAndDropConsumer>
-
                             <ConfirmModal
                                 title={attachmentInvalidReasonTitle ? translate(attachmentInvalidReasonTitle) : ''}
                                 onConfirm={hideInvalidAttachmentModal}
@@ -296,8 +271,6 @@ function ImportSpreadsheet({
                     </View>
                 </DragAndDropProvider>
             )}
-        </ScreenWrapper>
-    );
+        </ScreenWrapper>);
 }
-
 export default ImportSpreadsheet;

--- a/src/components/ImportSpreadsheet.tsx
+++ b/src/components/ImportSpreadsheet.tsx
@@ -68,21 +68,32 @@ function ImportSpreadsheet({backTo, goTo, isImportingMultiLevelTags}: ImportSpre
         const lowerExt = fileExtension.toLowerCase();
 
         if (isImportingMultiLevelTags) {
-            if (!CONST.MULTILEVEL_TAG_ALLOWED_SPREADSHEET_EXTENSIONS.includes(lowerExt as TupleToUnion<typeof CONST.MULTILEVEL_TAG_ALLOWED_SPREADSHEET_EXTENSIONS>)) {
-                setUploadFileError(true, 'attachmentPicker.wrongFileType', 'attachmentPicker.notAllowedExtension');
+            if (
+                !CONST.MULTILEVEL_TAG_ALLOWED_SPREADSHEET_EXTENSIONS.includes(
+                    lowerExt as TupleToUnion<typeof CONST.MULTILEVEL_TAG_ALLOWED_SPREADSHEET_EXTENSIONS>,
+                )
+            ) {
+                setUploadFileError(
+                    true,
+                    'attachmentPicker.wrongFileType',
+                    'attachmentPicker.notAllowedExtension',
+                );
                 return false;
             }
-        } else {
-            if (!CONST.ALLOWED_SPREADSHEET_EXTENSIONS.includes(lowerExt as TupleToUnion<typeof CONST.ALLOWED_SPREADSHEET_EXTENSIONS>)) {
-                setUploadFileError(true, 'attachmentPicker.wrongFileType', 'attachmentPicker.notAllowedExtension');
-                return false;
-            }
-        }    
+        } else if (
+            !CONST.ALLOWED_SPREADSHEET_EXTENSIONS.includes(
+                lowerExt as TupleToUnion<typeof CONST.ALLOWED_SPREADSHEET_EXTENSIONS>,
+            )
+        ) {
+            setUploadFileError(true, 'attachmentPicker.wrongFileType', 'attachmentPicker.notAllowedExtension');
+            return false;
+        }
 
         if ((file?.size ?? 0) <= 0) {
             setUploadFileError(true, 'attachmentPicker.attachmentTooSmall', 'spreadsheet.sizeNotMet');
             return false;
         }
+
         return true;
     };
 

--- a/src/components/ImportSpreadsheet.tsx
+++ b/src/components/ImportSpreadsheet.tsx
@@ -66,13 +66,14 @@ function ImportSpreadsheet({backTo, goTo, isImportingMultiLevelTags}: ImportSpre
     const validateFile = (file: FileObject) => {
         const {fileExtension} = splitExtensionFromFileName(file?.name ?? '');
         const lowerExt = fileExtension.toLowerCase();
+        const allowedExtensions: readonly string[] = isImportingMultiLevelTags ? CONST.MULTILEVEL_TAG_ALLOWED_SPREADSHEET_EXTENSIONS : CONST.ALLOWED_SPREADSHEET_EXTENSIONS;
 
         if (isImportingMultiLevelTags) {
             if (!CONST.MULTILEVEL_TAG_ALLOWED_SPREADSHEET_EXTENSIONS.includes(lowerExt as TupleToUnion<typeof CONST.MULTILEVEL_TAG_ALLOWED_SPREADSHEET_EXTENSIONS>)) {
                 setUploadFileError(true, 'attachmentPicker.wrongFileType', 'attachmentPicker.notAllowedExtension');
                 return false;
             }
-        } else if (!CONST.ALLOWED_SPREADSHEET_EXTENSIONS.includes(lowerExt as TupleToUnion<typeof CONST.ALLOWED_SPREADSHEET_EXTENSIONS>)) {
+        } else if (!allowedExtensions.includes(fileExtension.toLowerCase())) {
             setUploadFileError(true, 'attachmentPicker.wrongFileType', 'attachmentPicker.notAllowedExtension');
             return false;
         }

--- a/src/components/ImportSpreadsheet.tsx
+++ b/src/components/ImportSpreadsheet.tsx
@@ -27,17 +27,16 @@ import ScreenWrapper from './ScreenWrapper';
 import Text from './Text';
 
 type ImportSpreadsheetProps = {
-    // The route to navigate to when the back button is pressed.
-    backTo?: Routes;
-
-    // The route to navigate to after the file import is completed.
-    goTo: Routes;
-
-    /** Whether the spreadsheet is importing multi-level tags */
-    isImportingMultiLevelTags?: boolean;
+    backTo?: Routes; // The route to navigate to when the back button is pressed.
+    goTo: Routes; // The route to navigate to after the file import is completed.
+    isImportingMultiLevelTags?: boolean; // Whether the spreadsheet is importing multi-level tags
 };
 
-function ImportSpreadsheet({backTo, goTo, isImportingMultiLevelTags}: ImportSpreadsheetProps) {
+function ImportSpreadsheet({
+    backTo,
+    goTo,
+    isImportingMultiLevelTags,
+}: ImportSpreadsheetProps) {
     const icons = useMemoizedLazyExpensifyIcons(['SpreadsheetComputer']);
     const styles = useThemeStyles();
     const {translate} = useLocalize();
@@ -46,8 +45,6 @@ function ImportSpreadsheet({backTo, goTo, isImportingMultiLevelTags}: ImportSpre
     const [isAttachmentInvalid, setIsAttachmentInvalid] = useState(false);
     const [attachmentInvalidReasonTitle, setAttachmentInvalidReasonTitle] = useState<TranslationPaths>();
     const [attachmentInvalidReason, setAttachmentValidReason] = useState<TranslationPaths>();
-    // We need to use isSmallScreenWidth instead of shouldUseNarrowLayout to use different copies depending on the screen size
-    // eslint-disable-next-line rulesdir/prefer-shouldUseNarrowLayout-instead-of-isSmallScreenWidth
     const {isSmallScreenWidth} = useResponsiveLayout();
     const [isDraggingOver, setIsDraggingOver] = useState(false);
 
@@ -64,39 +61,55 @@ function ImportSpreadsheet({backTo, goTo, isImportingMultiLevelTags}: ImportSpre
     };
 
     const validateFile = (file: FileObject) => {
-    const {
-        fileExtension
-    } = splitExtensionFromFileName(file?.name ?? '');
-    const lowerExt = fileExtension.toLowerCase();
-    if (isImportingMultiLevelTags) {
-        if (!CONST.MULTILEVEL_TAG_ALLOWED_SPREADSHEET_EXTENSIONS.includes(lowerExt as TupleToUnion < typeof CONST.MULTILEVEL_TAG_ALLOWED_SPREADSHEET_EXTENSIONS > , )) {
-            setUploadFileError(true, 'attachmentPicker.wrongFileType', 'attachmentPicker.notAllowedExtension', );
+        const {fileExtension} = splitExtensionFromFileName(file?.name ?? '');
+        const lowerExt = fileExtension.toLowerCase();
+
+        if (isImportingMultiLevelTags) {
+            if (
+                !CONST.MULTILEVEL_TAG_ALLOWED_SPREADSHEET_EXTENSIONS.includes(
+                    lowerExt as TupleToUnion<typeof CONST.MULTILEVEL_TAG_ALLOWED_SPREADSHEET_EXTENSIONS>,
+                )
+            ) {
+                setUploadFileError(
+                    true,
+                    'attachmentPicker.wrongFileType',
+                    'attachmentPicker.notAllowedExtension',
+                );
+                return false;
+            }
+        } else if (
+            !CONST.ALLOWED_SPREADSHEET_EXTENSIONS.includes(
+                lowerExt as TupleToUnion<typeof CONST.ALLOWED_SPREADSHEET_EXTENSIONS>,
+            )
+        ) {
+            setUploadFileError(true, 'attachmentPicker.wrongFileType', 'attachmentPicker.notAllowedExtension');
             return false;
         }
-    } else if (!CONST.ALLOWED_SPREADSHEET_EXTENSIONS.includes(lowerExt as TupleToUnion < typeof CONST.ALLOWED_SPREADSHEET_EXTENSIONS > , )) {
-        setUploadFileError(true, 'attachmentPicker.wrongFileType', 'attachmentPicker.notAllowedExtension');
-        return false;
-    }
-    if ((file?.size ?? 0) <= 0) {
-        setUploadFileError(true, 'attachmentPicker.attachmentTooSmall', 'spreadsheet.sizeNotMet');
-        return false;
-    }
-    return true;
-};
+
+        if ((file?.size ?? 0) <= 0) {
+            setUploadFileError(true, 'attachmentPicker.attachmentTooSmall', 'spreadsheet.sizeNotMet');
+            return false;
+        }
+
+        return true;
+    };
+
     const readFile = (file: File) => {
         if (!validateFile(file)) {
             return;
         }
 
         let fileURI = file.uri ?? URL.createObjectURL(file);
-        if (!fileURI) {
-            return;
-        }
+        if (!fileURI) return;
+
         if (Platform.OS === 'ios') {
             fileURI = fileURI.replaceAll(/^.*\/Documents\//g, `${RNFetchBlob.fs.dirs.DocumentDir}/`);
         }
+
         const {fileExtension} = splitExtensionFromFileName(file?.name ?? '');
-        const shouldReadAsText = CONST.TEXT_SPREADSHEET_EXTENSIONS.includes(fileExtension as TupleToUnion<typeof CONST.TEXT_SPREADSHEET_EXTENSIONS>);
+        const shouldReadAsText = CONST.TEXT_SPREADSHEET_EXTENSIONS.includes(
+            fileExtension as TupleToUnion<typeof CONST.TEXT_SPREADSHEET_EXTENSIONS>,
+        );
 
         setIsReadingFile(true);
 
@@ -105,23 +118,29 @@ function ImportSpreadsheet({backTo, goTo, isImportingMultiLevelTags}: ImportSpre
                 const readWorkbook = () => {
                     if (shouldReadAsText) {
                         return fetch(fileURI)
-                            .then((data) => {
-                                return data.text();
-                            })
+                            .then((data) => data.text())
                             .then((text) => XLSX.read(text, {type: 'string'}));
                     }
                     return fetch(fileURI)
-                        .then((data) => {
-                            return data.arrayBuffer();
-                        })
+                        .then((data) => data.arrayBuffer())
                         .then((arrayBuffer) => XLSX.read(new Uint8Array(arrayBuffer), {type: 'buffer'}));
                 };
+
                 readWorkbook()
                     .then((workbook) => {
                         const worksheet = workbook.Sheets[workbook.SheetNames[0]];
-                        const data = XLSX.utils.sheet_to_json(worksheet, {header: 1, blankrows: false}) as string[][] | unknown[][];
+                        const data = XLSX.utils.sheet_to_json(worksheet, {header: 1, blankrows: false}) as
+                            | string[][]
+                            | unknown[][];
                         const formattedSpreadsheetData = data.map((row) => row.map((cell) => String(cell)));
-                        setSpreadsheetData(formattedSpreadsheetData, fileURI, file.type, file.name, isImportingMultiLevelTags ?? false)
+
+                        setSpreadsheetData(
+                            formattedSpreadsheetData,
+                            fileURI,
+                            file.type,
+                            file.name,
+                            isImportingMultiLevelTags ?? false,
+                        )
                             .then(() => {
                                 Navigation.navigate(goTo);
                             })
@@ -129,9 +148,7 @@ function ImportSpreadsheet({backTo, goTo, isImportingMultiLevelTags}: ImportSpre
                                 setUploadFileError(true, 'spreadsheet.importFailedTitle', 'spreadsheet.invalidFileMessage');
                             });
                     })
-                    .finally(() => {
-                        setIsReadingFile(false);
-                    });
+                    .finally(() => setIsReadingFile(false));
             })
             .catch((error) => {
                 console.error('Failed to load XLSX library:', error);
@@ -141,22 +158,25 @@ function ImportSpreadsheet({backTo, goTo, isImportingMultiLevelTags}: ImportSpre
     };
 
     const getTextForImportModal = () => {
-        let text = '';
         if (isImportingMultiLevelTags) {
-            text = isSmallScreenWidth ? translate('spreadsheet.chooseSpreadsheetMultiLevelTag') : translate('spreadsheet.dragAndDropMultiLevelTag');
-        } else {
-            text = isSmallScreenWidth ? translate('spreadsheet.chooseSpreadsheet') : translate('spreadsheet.dragAndDrop');
+            return isSmallScreenWidth
+                ? translate('spreadsheet.chooseSpreadsheetMultiLevelTag')
+                : translate('spreadsheet.dragAndDropMultiLevelTag');
         }
-        return text;
+        return isSmallScreenWidth ? translate('spreadsheet.chooseSpreadsheet') : translate('spreadsheet.dragAndDrop');
     };
 
     const acceptableFileTypes = isImportingMultiLevelTags
-        ? CONST.MULTILEVEL_TAG_ALLOWED_SPREADSHEET_EXTENSIONS.map((extension) => `.${extension}`).join(',')
-        : CONST.ALLOWED_SPREADSHEET_EXTENSIONS.map((extension) => `.${extension}`).join(',');
+        ? CONST.MULTILEVEL_TAG_ALLOWED_SPREADSHEET_EXTENSIONS.map((ext) => `.${ext}`).join(',')
+        : CONST.ALLOWED_SPREADSHEET_EXTENSIONS.map((ext) => `.${ext}`).join(',');
 
     const desktopView = (
         <>
-            <View onLayout={({nativeEvent}) => setFileTopPosition(PixelRatio.roundToNearestPixel((nativeEvent.layout as DOMRect).top))}>
+            <View
+                onLayout={({nativeEvent}) =>
+                    setFileTopPosition(PixelRatio.roundToNearestPixel((nativeEvent.layout as DOMRect).top))
+                }
+            >
                 <ImageSVG
                     src={icons.SpreadsheetComputer}
                     contentFit="contain"
@@ -165,16 +185,16 @@ function ImportSpreadsheet({backTo, goTo, isImportingMultiLevelTags}: ImportSpre
                     height={CONST.IMPORT_SPREADSHEET.ICON_HEIGHT}
                 />
             </View>
-            <View
-                style={[styles.uploadFileViewTextContainer, styles.userSelectNone]}
-                // eslint-disable-next-line react-compiler/react-compiler, react/jsx-props-no-spreading
-                {...panResponder.panHandlers}
-            >
-                <Text style={[styles.textFileUpload, styles.mb1]}>{isImportingMultiLevelTags ? translate('spreadsheet.import') : translate('spreadsheet.upload')}</Text>
+
+            <View style={[styles.uploadFileViewTextContainer, styles.userSelectNone]} {...panResponder.panHandlers}>
+                <Text style={[styles.textFileUpload, styles.mb1]}>
+                    {isImportingMultiLevelTags ? translate('spreadsheet.import') : translate('spreadsheet.upload')}
+                </Text>
                 <View style={[styles.flexRow]}>
                     <RenderHTML html={getTextForImportModal()} />
                 </View>
             </View>
+
             <FilePicker acceptableFileTypes={acceptableFileTypes}>
                 {({openPicker}) => (
                     <Button
@@ -183,13 +203,13 @@ function ImportSpreadsheet({backTo, goTo, isImportingMultiLevelTags}: ImportSpre
                         accessibilityLabel={translate('common.chooseFile')}
                         style={[styles.pt9]}
                         isLoading={isReadingFile}
-                        onPress={() => {
+                        onPress={() =>
                             openPicker({
                                 onPicked: (file) => {
                                     readFile(file as File);
                                 },
-                            });
-                        }}
+                            })
+                        }
                     />
                 )}
             </FilePicker>
@@ -220,7 +240,13 @@ function ImportSpreadsheet({backTo, goTo, isImportingMultiLevelTags}: ImportSpre
                             }}
                         />
 
-                        <View style={[styles.flex1, styles.uploadFileView, styles.uploadFileViewBorderWidth(isSmallScreenWidth)]}>
+                        <View
+                            style={[
+                                styles.flex1,
+                                styles.uploadFileView,
+                                styles.uploadFileViewBorderWidth(isSmallScreenWidth),
+                            ]}
+                        >
                             {!(isDraggingOver ?? isDraggingOver) && desktopView}
 
                             <DragAndDropConsumer
@@ -231,7 +257,15 @@ function ImportSpreadsheet({backTo, goTo, isImportingMultiLevelTags}: ImportSpre
                                     }
                                 }}
                             >
-                                <View style={[styles.fileDropOverlay, styles.w100, styles.h100, styles.justifyContentCenter, styles.alignItemsCenter]}>
+                                <View
+                                    style={[
+                                        styles.fileDropOverlay,
+                                        styles.w100,
+                                        styles.h100,
+                                        styles.justifyContentCenter,
+                                        styles.alignItemsCenter,
+                                    ]}
+                                >
                                     <View style={[styles.pAbsolute, styles.fileUploadImageWrapper(fileTopPosition)]}>
                                         <ImageSVG
                                             src={icons.SpreadsheetComputer}
@@ -241,10 +275,13 @@ function ImportSpreadsheet({backTo, goTo, isImportingMultiLevelTags}: ImportSpre
                                             height={CONST.IMPORT_SPREADSHEET.ICON_HEIGHT}
                                         />
                                         <Text style={[styles.textFileUpload]}>{translate('common.dropTitle')}</Text>
-                                        <Text style={[styles.subTextFileUpload, styles.themeTextColor]}>{translate('common.dropMessage')}</Text>
+                                        <Text style={[styles.subTextFileUpload, styles.themeTextColor]}>
+                                            {translate('common.dropMessage')}
+                                        </Text>
                                     </View>
                                 </View>
                             </DragAndDropConsumer>
+
                             <ConfirmModal
                                 title={attachmentInvalidReasonTitle ? translate(attachmentInvalidReasonTitle) : ''}
                                 onConfirm={hideInvalidAttachmentModal}

--- a/src/components/ImportSpreadsheet.tsx
+++ b/src/components/ImportSpreadsheet.tsx
@@ -65,10 +65,19 @@ function ImportSpreadsheet({backTo, goTo, isImportingMultiLevelTags}: ImportSpre
 
     const validateFile = (file: FileObject) => {
         const {fileExtension} = splitExtensionFromFileName(file?.name ?? '');
-        if (!CONST.ALLOWED_SPREADSHEET_EXTENSIONS.includes(fileExtension.toLowerCase() as TupleToUnion<typeof CONST.ALLOWED_SPREADSHEET_EXTENSIONS>)) {
-            setUploadFileError(true, 'attachmentPicker.wrongFileType', 'attachmentPicker.notAllowedExtension');
-            return false;
-        }
+        const lowerExt = fileExtension.toLowerCase();
+
+        if (isImportingMultiLevelTags) {
+            if (!CONST.MULTILEVEL_TAG_ALLOWED_SPREADSHEET_EXTENSIONS.includes(lowerExt as TupleToUnion<typeof CONST.MULTILEVEL_TAG_ALLOWED_SPREADSHEET_EXTENSIONS>)) {
+                setUploadFileError(true, 'attachmentPicker.wrongFileType', 'attachmentPicker.notAllowedExtension');
+                return false;
+            }
+        } else {
+            if (!CONST.ALLOWED_SPREADSHEET_EXTENSIONS.includes(lowerExt as TupleToUnion<typeof CONST.ALLOWED_SPREADSHEET_EXTENSIONS>)) {
+                setUploadFileError(true, 'attachmentPicker.wrongFileType', 'attachmentPicker.notAllowedExtension');
+                return false;
+            }
+        }    
 
         if ((file?.size ?? 0) <= 0) {
             setUploadFileError(true, 'attachmentPicker.attachmentTooSmall', 'spreadsheet.sizeNotMet');


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
<!-- Explain what your change does and how it addresses the linked issue -->
This change prevents Excel-based files (.xls and .xlsx) from being uploaded during tag imports.
Previously, the client allowed these files to be selected and submitted, resulting in an error after upload.
 
The update prevents users from submitting unsupported Excel files.

### Fixed Issues
<!---
1. Please postfix $ with a URL link to the GitHub issue this Pull Request is fixing. For example, $ https://github.com/Expensify/App/issues/<issueID>.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/78415
PROPOSAL: https://github.com/Expensify/App/issues/78415#issuecomment-3689614178


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests

1. Create a policy.
2. Enable Tag import.
3. Go to Tags > Import > Multi-level tags
4. Select an XLSX file
5. Notice how the client will not let you upload XLS/XLSX files

<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

- [X] Verify that no errors appear in the JS console

### Offline tests
Same as tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

### QA Steps
Same as tests
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->
// TODO: These must be filled out, or the issue title must include "[No QA]."

- [X] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [X] I linked the correct issue in the `### Fixed Issues` section above
- [X] I wrote clear testing steps that cover the changes made in this PR
    - [X] I added steps for local testing in the `Tests` section
    - [X] I added steps for the expected offline behavior in the `Offline steps` section
    - [X] I added steps for Staging and/or Production testing in the `QA steps` section
    - [X] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [X] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [X] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [X] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [X] I ran the tests on **all platforms** & verified they passed on:
    - [X] Android: Native
    - [X] Android: mWeb Chrome
    - [X] iOS: Native
    - [X] iOS: mWeb Safari
    - [X] MacOS: Chrome / Safari
- [X] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [X] I verified there are no new alerts related to the `canBeMissing` param for `useOnyx`
- [X] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [X] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [X] I verified that comments were added to code that is not self explanatory
    - [X] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [X] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [X] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [X] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [X] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [X] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [X] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [X] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [X] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [X] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [X] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [X] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [X] I verified that if a function's arguments changed that all usages have also been updated correctly
- [X] If any new file was added I verified that:
    - [X] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [X] If a new CSS style is added I verified that:
    - [X] A similar style doesn't already exist
    - [X] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [X] If new assets were added or existing ones were modified, I verified that:
    - [X] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [X] The assets load correctly across all supported platforms.
- [X] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [X] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [X] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [X] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [X] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [X] I verified that all the inputs inside a form are aligned with each other.
    - [X] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [X] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [X] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [X] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

https://github.com/user-attachments/assets/f6854eb2-723d-4e4e-a705-05438fd593b4


<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>


https://github.com/user-attachments/assets/f1013379-b896-434d-ae79-0968ce62891c




<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

https://github.com/user-attachments/assets/90f485bf-6d0b-405c-a5db-e95a9887335d


<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

https://github.com/user-attachments/assets/862172a0-8ea9-4378-b388-af3f3fcd31a2


<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

https://github.com/user-attachments/assets/e0d223d5-ba88-420a-848d-8e8c7722d7e0


<!-- add screenshots or videos here -->

</details>



