### PR TITLE
fix leave thread and join thread buttons visibility

### DIFF
--- a/src/libs/ContextMenuUtils.ts
+++ b/src/libs/ContextMenuUtils.ts
@@ -1,0 +1,65 @@
+import type {OnyxEntry} from 'react-native-onyx';
+import CONST from '@src/CONST';
+import type {ReportAction} from '@src/types/onyx';
+import {isActionableTrackExpense, isCreatedAction, isCreatedTaskReportAction, isDeletedAction, isMoneyRequestAction, isReportPreviewAction, isWhisperAction} from './ReportActionsUtils';
+import {getChildReportNotificationPreference, shouldDisplayThreadReplies} from './ReportUtils';
+
+type ThreadMenuParams = {
+    reportAction: OnyxEntry<ReportAction>;
+    isArchivedRoom: boolean;
+    isThreadReportParentAction: boolean;
+    isHarvestReport?: boolean;
+};
+
+/**
+ * Determines if the "Join Thread" context menu option should be shown.
+ * Shows when user is not subscribed to the thread and the action is eligible.
+ */
+function shouldShowJoinThread({reportAction, isArchivedRoom, isThreadReportParentAction, isHarvestReport}: ThreadMenuParams): boolean {
+    const childReportNotificationPreference = getChildReportNotificationPreference(reportAction);
+    const isDeletedActionResult = isDeletedAction(reportAction);
+    const shouldDisplayThreadRepliesResult = shouldDisplayThreadReplies(reportAction, isThreadReportParentAction);
+    const subscribed = childReportNotificationPreference !== CONST.REPORT.NOTIFICATION_PREFERENCE.HIDDEN;
+    const isWhisperActionResult = isWhisperAction(reportAction) || isActionableTrackExpense(reportAction);
+    const isExpenseReportAction = isMoneyRequestAction(reportAction) || isReportPreviewAction(reportAction);
+    const isTaskAction = isCreatedTaskReportAction(reportAction);
+    const isHarvestCreatedExpenseReportAction = isHarvestReport && isCreatedAction(reportAction);
+
+    return (
+        !subscribed &&
+        !isWhisperActionResult &&
+        !isTaskAction &&
+        !isExpenseReportAction &&
+        !isThreadReportParentAction &&
+        !isHarvestCreatedExpenseReportAction &&
+        (shouldDisplayThreadRepliesResult || (!isDeletedActionResult && !isArchivedRoom))
+    );
+}
+
+/**
+ * Determines if the "Leave Thread" context menu option should be shown.
+ * Shows when user is subscribed to the thread and the action is eligible.
+ */
+function shouldShowLeaveThread({reportAction, isArchivedRoom, isThreadReportParentAction, isHarvestReport}: ThreadMenuParams & {isHarvestReport?: boolean}): boolean {
+    const childReportNotificationPreference = getChildReportNotificationPreference(reportAction);
+    const isDeletedActionResult = isDeletedAction(reportAction);
+    const shouldDisplayThreadRepliesResult = shouldDisplayThreadReplies(reportAction, isThreadReportParentAction);
+    const subscribed = childReportNotificationPreference !== CONST.REPORT.NOTIFICATION_PREFERENCE.HIDDEN;
+    const isWhisperActionResult = isWhisperAction(reportAction) || isActionableTrackExpense(reportAction);
+    const isExpenseReportAction = isMoneyRequestAction(reportAction) || isReportPreviewAction(reportAction);
+    const isTaskAction = isCreatedTaskReportAction(reportAction);
+    const isHarvestCreatedExpenseReportAction = isHarvestReport && isCreatedAction(reportAction);
+
+    return (
+        subscribed &&
+        !isWhisperActionResult &&
+        !isTaskAction &&
+        !isExpenseReportAction &&
+        !isThreadReportParentAction &&
+        !isHarvestCreatedExpenseReportAction &&
+        (shouldDisplayThreadRepliesResult || (!isDeletedActionResult && !isArchivedRoom))
+    );
+}
+
+export {shouldShowJoinThread, shouldShowLeaveThread};
+export type {ThreadMenuParams};

--- a/src/libs/ContextMenuUtils.ts
+++ b/src/libs/ContextMenuUtils.ts
@@ -2,7 +2,7 @@ import type {OnyxEntry} from 'react-native-onyx';
 import CONST from '@src/CONST';
 import type {ReportAction} from '@src/types/onyx';
 import {isActionableTrackExpense, isCreatedAction, isCreatedTaskReportAction, isDeletedAction, isMoneyRequestAction, isReportPreviewAction, isWhisperAction} from './ReportActionsUtils';
-import {getChildReportNotificationPreference, shouldDisplayThreadReplies} from './ReportUtils';
+import {getChildReportNotificationPreference, shouldDisableThread, shouldDisplayThreadReplies} from './ReportUtils';
 
 type ThreadMenuParams = {
     reportAction: OnyxEntry<ReportAction>;
@@ -24,6 +24,7 @@ function shouldShowJoinThread({reportAction, isArchivedRoom, isThreadReportParen
     const isExpenseReportAction = isMoneyRequestAction(reportAction) || isReportPreviewAction(reportAction);
     const isTaskAction = isCreatedTaskReportAction(reportAction);
     const isHarvestCreatedExpenseReportAction = isHarvestReport && isCreatedAction(reportAction);
+    const isThreadDisabled = shouldDisableThread(reportAction, isThreadReportParentAction, isArchivedRoom);
 
     return (
         !subscribed &&
@@ -32,6 +33,7 @@ function shouldShowJoinThread({reportAction, isArchivedRoom, isThreadReportParen
         !isExpenseReportAction &&
         !isThreadReportParentAction &&
         !isHarvestCreatedExpenseReportAction &&
+        !isThreadDisabled &&
         (shouldDisplayThreadRepliesResult || (!isDeletedActionResult && !isArchivedRoom))
     );
 }
@@ -49,6 +51,7 @@ function shouldShowLeaveThread({reportAction, isArchivedRoom, isThreadReportPare
     const isExpenseReportAction = isMoneyRequestAction(reportAction) || isReportPreviewAction(reportAction);
     const isTaskAction = isCreatedTaskReportAction(reportAction);
     const isHarvestCreatedExpenseReportAction = isHarvestReport && isCreatedAction(reportAction);
+    const isThreadDisabled = shouldDisableThread(reportAction, isThreadReportParentAction, isArchivedRoom);
 
     return (
         subscribed &&
@@ -57,6 +60,7 @@ function shouldShowLeaveThread({reportAction, isArchivedRoom, isThreadReportPare
         !isExpenseReportAction &&
         !isThreadReportParentAction &&
         !isHarvestCreatedExpenseReportAction &&
+        !isThreadDisabled &&
         (shouldDisplayThreadRepliesResult || (!isDeletedActionResult && !isArchivedRoom))
     );
 }

--- a/src/libs/ReportUtils.ts
+++ b/src/libs/ReportUtils.ts
@@ -2750,7 +2750,7 @@ function isActionCreator(reportAction: OnyxInputOrEntry<ReportAction> | Partial<
  * Returns the notification preference of the action's child report if it exists.
  * Otherwise, calculates it based on the action's authorship.
  */
-function getChildReportNotificationPreference(reportAction: OnyxInputOrEntry<ReportAction> | Partial<ReportAction>, isContextMenu: boolean = true): NotificationPreference {
+function getChildReportNotificationPreference(reportAction: OnyxInputOrEntry<ReportAction> | Partial<ReportAction>, isContextMenu = true): NotificationPreference {
     const childReportNotificationPreference = reportAction?.childReportNotificationPreference ?? '';
     if (childReportNotificationPreference) {
         return childReportNotificationPreference;

--- a/src/libs/ReportUtils.ts
+++ b/src/libs/ReportUtils.ts
@@ -2756,7 +2756,7 @@ function getChildReportNotificationPreference(reportAction: OnyxInputOrEntry<Rep
         return childReportNotificationPreference;
     }
 
-    return isActionCreator(reportAction) ? CONST.REPORT.NOTIFICATION_PREFERENCE.ALWAYS : CONST.REPORT.NOTIFICATION_PREFERENCE.HIDDEN;
+    return CONST.REPORT.NOTIFICATION_PREFERENCE.HIDDEN;
 }
 
 function canAddOrDeleteTransactions(moneyRequestReport: OnyxEntry<Report>, isReportArchived = false): boolean {

--- a/src/libs/ReportUtils.ts
+++ b/src/libs/ReportUtils.ts
@@ -2750,13 +2750,13 @@ function isActionCreator(reportAction: OnyxInputOrEntry<ReportAction> | Partial<
  * Returns the notification preference of the action's child report if it exists.
  * Otherwise, calculates it based on the action's authorship.
  */
-function getChildReportNotificationPreference(reportAction: OnyxInputOrEntry<ReportAction> | Partial<ReportAction>): NotificationPreference {
+function getChildReportNotificationPreference(reportAction: OnyxInputOrEntry<ReportAction> | Partial<ReportAction>, isContextMenu: boolean = true): NotificationPreference {
     const childReportNotificationPreference = reportAction?.childReportNotificationPreference ?? '';
     if (childReportNotificationPreference) {
         return childReportNotificationPreference;
     }
 
-    return CONST.REPORT.NOTIFICATION_PREFERENCE.HIDDEN;
+    return isActionCreator(reportAction) && !isContextMenu ? CONST.REPORT.NOTIFICATION_PREFERENCE.ALWAYS : CONST.REPORT.NOTIFICATION_PREFERENCE.HIDDEN;
 }
 
 function canAddOrDeleteTransactions(moneyRequestReport: OnyxEntry<Report>, isReportArchived = false): boolean {

--- a/src/libs/actions/Report.ts
+++ b/src/libs/actions/Report.ts
@@ -1558,7 +1558,7 @@ function navigateToAndOpenChildReport(childReportID: string | undefined, parentR
             policyID: parentReport?.policyID ?? CONST.POLICY.OWNER_EMAIL_FAKE,
             ownerAccountID: CONST.POLICY.OWNER_ACCOUNT_ID_FAKE,
             oldPolicyName: parentReport?.policyName ?? '',
-            notificationPreference: getChildReportNotificationPreference(parentReportAction),
+            notificationPreference: getChildReportNotificationPreference(parentReportAction, false),
             parentReportActionID: parentReportAction.reportActionID,
             parentReportID,
             optimisticReportID: childReportID,

--- a/src/pages/home/report/ContextMenu/ContextMenuActions.tsx
+++ b/src/pages/home/report/ContextMenu/ContextMenuActions.tsx
@@ -13,6 +13,7 @@ import QuickEmojiReactions from '@components/Reactions/QuickEmojiReactions';
 import addEncryptedAuthTokenToURL from '@libs/addEncryptedAuthTokenToURL';
 import {isMobileSafari} from '@libs/Browser';
 import Clipboard from '@libs/Clipboard';
+import {shouldShowJoinThread, shouldShowLeaveThread} from '@libs/ContextMenuUtils';
 import EmailUtils from '@libs/EmailUtils';
 import {getEnvironmentURL} from '@libs/Environment/Environment';
 import fileDownload from '@libs/fileDownload';
@@ -86,9 +87,7 @@ import {
     isActionableTrackExpense,
     isActionOfType,
     isCardIssuedAction,
-    isCreatedAction,
     isCreatedTaskReportAction,
-    isDeletedAction as isDeletedActionReportActionsUtils,
     isMarkAsClosedAction,
     isMemberChangeAction,
     isMessageDeleted,
@@ -105,7 +104,6 @@ import {
     isTaskAction as isTaskActionReportActionsUtils,
     isTripPreview,
     isUnapprovedAction,
-    isWhisperAction as isWhisperActionReportActionsUtils,
 } from '@libs/ReportActionsUtils';
 import {getReportName} from '@libs/ReportNameUtils';
 import {
@@ -133,7 +131,6 @@ import {
     getWorkspaceNameUpdatedMessage,
     isExpenseReport,
     shouldDisableThread,
-    shouldDisplayThreadReplies as shouldDisplayThreadRepliesReportUtils,
 } from '@libs/ReportUtils';
 import {getTaskCreatedMessage, getTaskReportActionMessage} from '@libs/TaskUtils';
 import {setDownload} from '@userActions/Download';
@@ -493,27 +490,8 @@ const ContextMenuActions: ContextMenuAction[] = [
         isAnonymousAction: false,
         textTranslateKey: 'reportActionContextMenu.joinThread',
         icon: 'Bell',
-        shouldShow: ({reportAction, isArchivedRoom, isThreadReportParentAction, isHarvestReport}) => {
-            const childReportNotificationPreference = getChildReportNotificationPreferenceReportUtils(reportAction);
-            const isDeletedAction = isDeletedActionReportActionsUtils(reportAction);
-            const shouldDisplayThreadReplies = shouldDisplayThreadRepliesReportUtils(reportAction, isThreadReportParentAction);
-            const subscribed = childReportNotificationPreference !== 'hidden';
-            const isWhisperAction = isWhisperActionReportActionsUtils(reportAction) || isActionableTrackExpense(reportAction);
-            const isExpenseReportAction = isMoneyRequestAction(reportAction) || isReportPreviewActionReportActionsUtils(reportAction);
-            const isTaskAction = isCreatedTaskReportAction(reportAction);
-            const isHarvestCreatedExpenseReportAction = isHarvestReport && isCreatedAction(reportAction);
-            const shouldDisableJoinThread = shouldDisableThread(reportAction, isThreadReportParentAction, isArchivedRoom);
-            return (
-                !subscribed &&
-                !isWhisperAction &&
-                !isTaskAction &&
-                !isExpenseReportAction &&
-                !isThreadReportParentAction &&
-                !isHarvestCreatedExpenseReportAction &&
-                !shouldDisableJoinThread &&
-                (shouldDisplayThreadReplies || (!isDeletedAction && !isArchivedRoom))
-            );
-        },
+        shouldShow: ({reportAction, isArchivedRoom, isThreadReportParentAction, isHarvestReport}) =>
+            shouldShowJoinThread({reportAction, isArchivedRoom, isThreadReportParentAction, isHarvestReport}),
         onPress: (closePopover, {reportAction, reportID}) => {
             const childReportNotificationPreference = getChildReportNotificationPreferenceReportUtils(reportAction);
             const originalReportID = getOriginalReportID(reportID, reportAction);
@@ -535,25 +513,8 @@ const ContextMenuActions: ContextMenuAction[] = [
         isAnonymousAction: false,
         textTranslateKey: 'reportActionContextMenu.leaveThread',
         icon: Expensicons.Exit,
-        shouldShow: ({reportAction, isArchivedRoom, isThreadReportParentAction, isHarvestReport}) => {
-            const childReportNotificationPreference = getChildReportNotificationPreferenceReportUtils(reportAction);
-            const isDeletedAction = isDeletedActionReportActionsUtils(reportAction);
-            const shouldDisplayThreadReplies = shouldDisplayThreadRepliesReportUtils(reportAction, isThreadReportParentAction);
-            const subscribed = childReportNotificationPreference !== 'hidden';
-            const isWhisperAction = isWhisperActionReportActionsUtils(reportAction) || isActionableTrackExpense(reportAction);
-            const isExpenseReportAction = isMoneyRequestAction(reportAction) || isReportPreviewActionReportActionsUtils(reportAction);
-            const isTaskAction = isCreatedTaskReportAction(reportAction);
-            const isHarvestCreatedExpenseReportAction = isHarvestReport && isCreatedAction(reportAction);
-            return (
-                subscribed &&
-                !isWhisperAction &&
-                !isTaskAction &&
-                !isExpenseReportAction &&
-                !isThreadReportParentAction &&
-                !isHarvestCreatedExpenseReportAction &&
-                (shouldDisplayThreadReplies || (!isDeletedAction && !isArchivedRoom))
-            );
-        },
+        shouldShow: ({reportAction, isArchivedRoom, isThreadReportParentAction, isHarvestReport}) =>
+            shouldShowLeaveThread({reportAction, isArchivedRoom, isThreadReportParentAction, isHarvestReport}),
         onPress: (closePopover, {reportAction, reportID}) => {
             const childReportNotificationPreference = getChildReportNotificationPreferenceReportUtils(reportAction);
             const originalReportID = getOriginalReportID(reportID, reportAction);

--- a/tests/unit/ContextMenuActionsTest.ts
+++ b/tests/unit/ContextMenuActionsTest.ts
@@ -1,0 +1,499 @@
+import CONST from '@src/CONST';
+import {shouldShowJoinThread, shouldShowLeaveThread} from '@src/libs/ContextMenuUtils';
+import type {ReportAction} from '@src/types/onyx';
+
+/**
+ * Creates a base ADD_COMMENT report action for testing.
+ */
+function createBaseReportAction(overrides: Partial<ReportAction> = {}): ReportAction {
+    return {
+        actionName: CONST.REPORT.ACTIONS.TYPE.ADD_COMMENT,
+        reportActionID: '12345',
+        actorAccountID: 1,
+        created: '2024-01-01 12:00:00.000',
+        message: [{type: 'COMMENT', html: 'Test message', text: 'Test message'}],
+        originalMessage: {html: 'Test message', whisperedTo: []},
+        avatar: '',
+        automatic: false,
+        shouldShow: true,
+        ...overrides,
+    } as ReportAction;
+}
+
+describe('ContextMenuActions - Join/Leave Thread', () => {
+    describe('shouldShowJoinThread', () => {
+        it('should show Join Thread for a regular message with thread replies when user is not subscribed', () => {
+            const reportAction = createBaseReportAction({
+                childReportNotificationPreference: CONST.REPORT.NOTIFICATION_PREFERENCE.HIDDEN,
+                childVisibleActionCount: 2,
+                childCommenterCount: 1,
+            });
+
+            const result = shouldShowJoinThread({
+                reportAction,
+                isArchivedRoom: false,
+                isThreadReportParentAction: false,
+            });
+
+            expect(result).toBe(true);
+        });
+
+        it('should show Join Thread for a regular message without thread replies in a non-archived room when user is not subscribed', () => {
+            const reportAction = createBaseReportAction({
+                childReportNotificationPreference: CONST.REPORT.NOTIFICATION_PREFERENCE.HIDDEN,
+                childVisibleActionCount: 0,
+                childCommenterCount: 0,
+            });
+
+            const result = shouldShowJoinThread({
+                reportAction,
+                isArchivedRoom: false,
+                isThreadReportParentAction: false,
+            });
+
+            expect(result).toBe(true);
+        });
+
+        it('should NOT show Join Thread when user is already subscribed', () => {
+            const reportAction = createBaseReportAction({
+                childReportNotificationPreference: CONST.REPORT.NOTIFICATION_PREFERENCE.ALWAYS,
+                childVisibleActionCount: 2,
+                childCommenterCount: 1,
+            });
+
+            const result = shouldShowJoinThread({
+                reportAction,
+                isArchivedRoom: false,
+                isThreadReportParentAction: false,
+            });
+
+            expect(result).toBe(false);
+        });
+
+        it('should NOT show Join Thread for whisper actions', () => {
+            const reportAction = createBaseReportAction({
+                childReportNotificationPreference: CONST.REPORT.NOTIFICATION_PREFERENCE.HIDDEN,
+                originalMessage: {html: 'Whisper', whisperedTo: [1]},
+            });
+
+            const result = shouldShowJoinThread({
+                reportAction,
+                isArchivedRoom: false,
+                isThreadReportParentAction: false,
+            });
+
+            expect(result).toBe(false);
+        });
+
+        it('should NOT show Join Thread for IOU/money request actions', () => {
+            const reportAction = createBaseReportAction({
+                actionName: CONST.REPORT.ACTIONS.TYPE.IOU,
+                childReportNotificationPreference: CONST.REPORT.NOTIFICATION_PREFERENCE.HIDDEN,
+                originalMessage: {
+                    type: CONST.IOU.REPORT_ACTION_TYPE.CREATE,
+                    IOUTransactionID: 'txn123',
+                    IOUReportID: 'report123',
+                    amount: 100,
+                    currency: 'USD',
+                    comment: '',
+                },
+            });
+
+            const result = shouldShowJoinThread({
+                reportAction,
+                isArchivedRoom: false,
+                isThreadReportParentAction: false,
+            });
+
+            expect(result).toBe(false);
+        });
+
+        it('should NOT show Join Thread when viewing the thread report parent action', () => {
+            const reportAction = createBaseReportAction({
+                childReportNotificationPreference: CONST.REPORT.NOTIFICATION_PREFERENCE.HIDDEN,
+                childVisibleActionCount: 2,
+                childCommenterCount: 1,
+            });
+
+            const result = shouldShowJoinThread({
+                reportAction,
+                isArchivedRoom: false,
+                isThreadReportParentAction: true,
+            });
+
+            expect(result).toBe(false);
+        });
+
+        it('should NOT show Join Thread for deleted actions in archived rooms without thread replies', () => {
+            const reportAction = createBaseReportAction({
+                childReportNotificationPreference: CONST.REPORT.NOTIFICATION_PREFERENCE.HIDDEN,
+                childVisibleActionCount: 0,
+                childCommenterCount: 0,
+                message: [{type: 'COMMENT', html: '', text: '', deleted: '2024-01-01 12:00:00.000'}],
+            });
+
+            const result = shouldShowJoinThread({
+                reportAction,
+                isArchivedRoom: true,
+                isThreadReportParentAction: false,
+            });
+
+            expect(result).toBe(false);
+        });
+
+        it('should show Join Thread for deleted actions that have thread replies', () => {
+            const reportAction = createBaseReportAction({
+                childReportNotificationPreference: CONST.REPORT.NOTIFICATION_PREFERENCE.HIDDEN,
+                childVisibleActionCount: 2,
+                childCommenterCount: 1,
+                message: [{type: 'COMMENT', html: '', text: '', deleted: '2024-01-01 12:00:00.000'}],
+            });
+
+            const result = shouldShowJoinThread({
+                reportAction,
+                isArchivedRoom: true,
+                isThreadReportParentAction: false,
+            });
+
+            expect(result).toBe(true);
+        });
+    });
+
+    describe('shouldShowLeaveThread', () => {
+        it('should show Leave Thread for a regular message when user is subscribed', () => {
+            const reportAction = createBaseReportAction({
+                childReportNotificationPreference: CONST.REPORT.NOTIFICATION_PREFERENCE.ALWAYS,
+                childVisibleActionCount: 2,
+                childCommenterCount: 1,
+            });
+
+            const result = shouldShowLeaveThread({
+                reportAction,
+                isArchivedRoom: false,
+                isThreadReportParentAction: false,
+            });
+
+            expect(result).toBe(true);
+        });
+
+        it('should show Leave Thread for a message the user created (subscribed by default)', () => {
+            // When a user creates a message, they are automatically subscribed to it
+            const reportAction = createBaseReportAction({
+                childReportNotificationPreference: CONST.REPORT.NOTIFICATION_PREFERENCE.ALWAYS,
+                actorAccountID: 12345, // Current user
+                childVisibleActionCount: 0,
+                childCommenterCount: 0,
+            });
+
+            const result = shouldShowLeaveThread({
+                reportAction,
+                isArchivedRoom: false,
+                isThreadReportParentAction: false,
+            });
+
+            expect(result).toBe(true);
+        });
+
+        it('should show Leave Thread for a message the user is the only participant in', () => {
+            // User should be able to leave any thread they are subscribed to,
+            // regardless of whether they created it or are the only participant
+            const reportAction = createBaseReportAction({
+                childReportNotificationPreference: CONST.REPORT.NOTIFICATION_PREFERENCE.ALWAYS,
+                actorAccountID: 12345,
+                childVisibleActionCount: 1,
+                childCommenterCount: 1,
+            });
+
+            const result = shouldShowLeaveThread({
+                reportAction,
+                isArchivedRoom: false,
+                isThreadReportParentAction: false,
+            });
+
+            expect(result).toBe(true);
+        });
+
+        it('should NOT show Leave Thread when user is not subscribed', () => {
+            const reportAction = createBaseReportAction({
+                childReportNotificationPreference: CONST.REPORT.NOTIFICATION_PREFERENCE.HIDDEN,
+                childVisibleActionCount: 2,
+                childCommenterCount: 1,
+            });
+
+            const result = shouldShowLeaveThread({
+                reportAction,
+                isArchivedRoom: false,
+                isThreadReportParentAction: false,
+            });
+
+            expect(result).toBe(false);
+        });
+
+        it('should NOT show Leave Thread for whisper actions', () => {
+            const reportAction = createBaseReportAction({
+                childReportNotificationPreference: CONST.REPORT.NOTIFICATION_PREFERENCE.ALWAYS,
+                originalMessage: {html: 'Whisper', whisperedTo: [1]},
+            });
+
+            const result = shouldShowLeaveThread({
+                reportAction,
+                isArchivedRoom: false,
+                isThreadReportParentAction: false,
+            });
+
+            expect(result).toBe(false);
+        });
+
+        it('should NOT show Leave Thread for IOU/money request actions', () => {
+            const reportAction = createBaseReportAction({
+                actionName: CONST.REPORT.ACTIONS.TYPE.IOU,
+                childReportNotificationPreference: CONST.REPORT.NOTIFICATION_PREFERENCE.ALWAYS,
+                originalMessage: {
+                    type: CONST.IOU.REPORT_ACTION_TYPE.CREATE,
+                    IOUTransactionID: 'txn123',
+                    IOUReportID: 'report123',
+                    amount: 100,
+                    currency: 'USD',
+                    comment: '',
+                },
+            });
+
+            const result = shouldShowLeaveThread({
+                reportAction,
+                isArchivedRoom: false,
+                isThreadReportParentAction: false,
+            });
+
+            expect(result).toBe(false);
+        });
+
+        it('should NOT show Leave Thread when viewing the thread report parent action', () => {
+            const reportAction = createBaseReportAction({
+                childReportNotificationPreference: CONST.REPORT.NOTIFICATION_PREFERENCE.ALWAYS,
+                childVisibleActionCount: 2,
+                childCommenterCount: 1,
+            });
+
+            const result = shouldShowLeaveThread({
+                reportAction,
+                isArchivedRoom: false,
+                isThreadReportParentAction: true,
+            });
+
+            expect(result).toBe(false);
+        });
+
+        it('should NOT show Leave Thread for deleted actions in archived rooms without thread replies', () => {
+            const reportAction = createBaseReportAction({
+                childReportNotificationPreference: CONST.REPORT.NOTIFICATION_PREFERENCE.ALWAYS,
+                childVisibleActionCount: 0,
+                childCommenterCount: 0,
+                message: [{type: 'COMMENT', html: '', text: '', deleted: '2024-01-01 12:00:00.000'}],
+            });
+
+            const result = shouldShowLeaveThread({
+                reportAction,
+                isArchivedRoom: true,
+                isThreadReportParentAction: false,
+            });
+
+            expect(result).toBe(false);
+        });
+
+        it('should show Leave Thread for deleted actions that have thread replies when subscribed', () => {
+            const reportAction = createBaseReportAction({
+                childReportNotificationPreference: CONST.REPORT.NOTIFICATION_PREFERENCE.ALWAYS,
+                childVisibleActionCount: 2,
+                childCommenterCount: 1,
+                message: [{type: 'COMMENT', html: '', text: '', deleted: '2024-01-01 12:00:00.000'}],
+            });
+
+            const result = shouldShowLeaveThread({
+                reportAction,
+                isArchivedRoom: true,
+                isThreadReportParentAction: false,
+            });
+
+            expect(result).toBe(true);
+        });
+    });
+
+    describe('User-owned threads', () => {
+        it('should show Leave Thread for threads created by the user when subscribed', () => {
+            // This is the expected behavior: users should be able to leave any thread,
+            // including ones they created
+            const userCreatedAction = createBaseReportAction({
+                actorAccountID: 12345, // Simulating current user
+                childReportNotificationPreference: CONST.REPORT.NOTIFICATION_PREFERENCE.ALWAYS,
+                childVisibleActionCount: 0,
+                childCommenterCount: 0,
+            });
+
+            const result = shouldShowLeaveThread({
+                reportAction: userCreatedAction,
+                isArchivedRoom: false,
+                isThreadReportParentAction: false,
+            });
+
+            // User should be able to leave threads they created
+            expect(result).toBe(true);
+        });
+
+        it('should show Leave Thread for threads where user is the only participant', () => {
+            // Users should be able to leave threads even if they are the only participant
+            const soleParticipantAction = createBaseReportAction({
+                actorAccountID: 12345,
+                childReportNotificationPreference: CONST.REPORT.NOTIFICATION_PREFERENCE.ALWAYS,
+                childVisibleActionCount: 3,
+                childCommenterCount: 1, // Only one commenter (the user)
+            });
+
+            const result = shouldShowLeaveThread({
+                reportAction: soleParticipantAction,
+                isArchivedRoom: false,
+                isThreadReportParentAction: false,
+            });
+
+            expect(result).toBe(true);
+        });
+
+        it('should show Leave Thread for threads with multiple participants when user is subscribed', () => {
+            const multiParticipantAction = createBaseReportAction({
+                actorAccountID: 12345,
+                childReportNotificationPreference: CONST.REPORT.NOTIFICATION_PREFERENCE.ALWAYS,
+                childVisibleActionCount: 10,
+                childCommenterCount: 5,
+            });
+
+            const result = shouldShowLeaveThread({
+                reportAction: multiParticipantAction,
+                isArchivedRoom: false,
+                isThreadReportParentAction: false,
+            });
+
+            expect(result).toBe(true);
+        });
+    });
+
+    describe('Notification preference variations', () => {
+        it('should show Leave Thread when notification preference is DAILY', () => {
+            const reportAction = createBaseReportAction({
+                childReportNotificationPreference: CONST.REPORT.NOTIFICATION_PREFERENCE.DAILY,
+                childVisibleActionCount: 2,
+                childCommenterCount: 1,
+            });
+
+            const result = shouldShowLeaveThread({
+                reportAction,
+                isArchivedRoom: false,
+                isThreadReportParentAction: false,
+            });
+
+            expect(result).toBe(true);
+        });
+
+        it('should show Leave Thread when notification preference is MUTE', () => {
+            const reportAction = createBaseReportAction({
+                childReportNotificationPreference: CONST.REPORT.NOTIFICATION_PREFERENCE.MUTE,
+                childVisibleActionCount: 2,
+                childCommenterCount: 1,
+            });
+
+            const result = shouldShowLeaveThread({
+                reportAction,
+                isArchivedRoom: false,
+                isThreadReportParentAction: false,
+            });
+
+            expect(result).toBe(true);
+        });
+
+        it('should show Join Thread only when notification preference is HIDDEN', () => {
+            const reportAction = createBaseReportAction({
+                childReportNotificationPreference: CONST.REPORT.NOTIFICATION_PREFERENCE.HIDDEN,
+                childVisibleActionCount: 2,
+                childCommenterCount: 1,
+            });
+
+            const result = shouldShowJoinThread({
+                reportAction,
+                isArchivedRoom: false,
+                isThreadReportParentAction: false,
+            });
+
+            expect(result).toBe(true);
+        });
+    });
+
+    describe('Join/Leave Thread mutual exclusivity', () => {
+        it('should show exactly one of Join Thread or Leave Thread for a valid action, never both', () => {
+            const subscribedAction = createBaseReportAction({
+                childReportNotificationPreference: CONST.REPORT.NOTIFICATION_PREFERENCE.ALWAYS,
+                childVisibleActionCount: 2,
+                childCommenterCount: 1,
+            });
+
+            const params = {
+                reportAction: subscribedAction,
+                isArchivedRoom: false,
+                isThreadReportParentAction: false,
+            };
+
+            const showJoin = shouldShowJoinThread(params);
+            const showLeave = shouldShowLeaveThread(params);
+
+            // Should show Leave Thread (subscribed), not Join Thread
+            expect(showJoin).toBe(false);
+            expect(showLeave).toBe(true);
+        });
+
+        it('should show Join Thread and not Leave Thread when not subscribed', () => {
+            const unsubscribedAction = createBaseReportAction({
+                childReportNotificationPreference: CONST.REPORT.NOTIFICATION_PREFERENCE.HIDDEN,
+                childVisibleActionCount: 2,
+                childCommenterCount: 1,
+            });
+
+            const params = {
+                reportAction: unsubscribedAction,
+                isArchivedRoom: false,
+                isThreadReportParentAction: false,
+            };
+
+            const showJoin = shouldShowJoinThread(params);
+            const showLeave = shouldShowLeaveThread(params);
+
+            // Should show Join Thread (not subscribed), not Leave Thread
+            expect(showJoin).toBe(true);
+            expect(showLeave).toBe(false);
+        });
+
+        it('should show neither Join nor Leave Thread for excluded action types', () => {
+            const iouAction = createBaseReportAction({
+                actionName: CONST.REPORT.ACTIONS.TYPE.IOU,
+                childReportNotificationPreference: CONST.REPORT.NOTIFICATION_PREFERENCE.ALWAYS,
+                originalMessage: {
+                    type: CONST.IOU.REPORT_ACTION_TYPE.CREATE,
+                    IOUTransactionID: 'txn123',
+                    IOUReportID: 'report123',
+                    amount: 100,
+                    currency: 'USD',
+                    comment: '',
+                },
+            });
+
+            const params = {
+                reportAction: iouAction,
+                isArchivedRoom: false,
+                isThreadReportParentAction: false,
+            };
+
+            const showJoin = shouldShowJoinThread(params);
+            const showLeave = shouldShowLeaveThread(params);
+
+            // Neither should show for IOU actions
+            expect(showJoin).toBe(false);
+            expect(showLeave).toBe(false);
+        });
+    });
+});


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
<!-- Explain what your change does and how it addresses the linked issue -->

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/76489

PROPOSAL: https://github.com/Expensify/App/issues/76489#issuecomment-3602927089


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->
 The same as QA
- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->

Test 1 for your own message:

1. Send a message in any channel or DM
2. Right click on the message
- Verify you see 'Join thread'
3. Click "Join Thread" option
- Verify you see "Leave Thread" option now

Test 2 for other's message:

Have a separate account send a message in any channel or a DM to you
1. Right click on the message
2. Click Join thread
3. Right click on the message again
- Verify you see 'Leave thread'

Another test case for https://github.com/Expensify/App/issues/78922

- Navigate to 1:1 chat
- Send a message
- Click on "Reply on Thread" in the action menu
- Verify you don't see any "Join thread" button on top header briefly

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I verified there are no new alerts related to the `canBeMissing` param for `useOnyx`
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>


https://github.com/user-attachments/assets/4f72c8d9-0fef-464f-9842-35317ac426f0



<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>


https://github.com/user-attachments/assets/ca2c3229-2980-4fed-a363-dd777939c9a8



<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>


https://github.com/user-attachments/assets/1cfa6b1c-69da-4c67-a12c-e02c4a1e495e



<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>


https://github.com/user-attachments/assets/8f526ad3-04de-4a32-843d-c7fb15b5967e



<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>


https://github.com/user-attachments/assets/c353c81f-6f1b-49f6-9f9e-6fd2b597c8ed



<!-- add screenshots or videos here -->

</details> 