### PR TITLE
fix: update codecov.yml to match test shard count (fixes #79270)

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -13,8 +13,8 @@ coverage:
 
 codecov:
   notify:
-    # We shard our tests into 3 chunks, so we want CodeCov to wait for 3 builds before commenting
-    after_n_builds: 3
+    # We shard our tests into 8 chunks, so we want CodeCov to wait for 8 builds before commenting
+    after_n_builds: 8
 
 comment:
   require_changes: "coverage_drop OR uncovered_patch"


### PR DESCRIPTION
## Details

This PR fixes the mismatch between the test workflow shard count and the Codecov configuration, addressing issue #79270.

## Problem

The `codecov.yml` configuration currently has `after_n_builds: 3`, but the test workflow (`.github/workflows/test.yml`) was updated to shard tests into **8 chunks** instead of 3 (commit [3379941](https://github.com/Expensify/App/commit/3379941844e7ef70a2e8ee49538757e6f609169a)).

This mismatch causes Codecov to:
- Comment on PRs prematurely after only 3 builds complete
- Report incomplete coverage data (missing 5 out of 8 shards)
- Potentially show inaccurate coverage metrics

## Solution

Update `after_n_builds` from `3` to `8` to match the current test shard count.

## Changes

**codecov.yml:**
```diff
  codecov:
    notify:
-     # We shard our tests into 3 chunks, so we want CodeCov to wait for 3 builds before commenting
-     after_n_builds: 3
+     # We shard our tests into 8 chunks, so we want CodeCov to wait for 8 builds before commenting
+     after_n_builds: 8
```

## Verification

### Current Test Workflow Configuration
From `.github/workflows/test.yml`:
```yaml
strategy:
  fail-fast: false
  matrix:
    chunk: [1, 2, 3, 4, 5, 6, 7, 8]  # 8 shards
```

### Test Shard History
- **Before**: 3 shards (original configuration)
- **Nov 19, 2025**: Increased to 8 shards ([commit 3379941](https://github.com/Expensify/App/commit/3379941844e7ef70a2e8ee49538757e6f609169a))
- **Now**: Codecov config updated to match

## Impact

### Before This PR
- ❌ Codecov comments after 3/8 builds (37.5% complete)
- ❌ Coverage reports missing data from 5 shards
- ❌ Potentially misleading coverage metrics

### After This PR
- ✅ Codecov waits for all 8 builds to complete
- ✅ Complete coverage data from all test shards
- ✅ Accurate coverage metrics and reporting

## Testing

- [x] Verified test workflow uses 8 shards
- [x] Updated codecov.yml configuration
- [x] Updated comment to reflect current shard count
- [x] No other changes needed (Codecov will automatically detect the new configuration)

## Related Issues

Fixes #79270

## Additional Context

This is a configuration-only change with no impact on test execution or application code. The test workflow has been running with 8 shards since November 2025, but the Codecov configuration was not updated at that time.

The fix ensures that Codecov waits for all test shards to complete before generating coverage reports and commenting on PRs, providing accurate and complete coverage data.

---

**Note**: This change will take effect on the next PR where tests run. Codecov will automatically pick up the new configuration from the updated `codecov.yml` file.