### PR TITLE
Make checkboxes in TableListItem more easily clickable

### DIFF
--- a/src/components/Checkbox.tsx
+++ b/src/components/Checkbox.tsx
@@ -139,6 +139,7 @@ function Checkbox({
             pressDimmingValue={1}
             wrapperStyle={wrapperStyle}
             sentryLabel={sentryLabel}
+            shouldUseAutoHitSlop
         >
             {children ?? (
                 <View

--- a/src/components/SelectionList/ListItem/TableListItem.tsx
+++ b/src/components/SelectionList/ListItem/TableListItem.tsx
@@ -1,15 +1,12 @@
 import React from 'react';
 import {View} from 'react-native';
-import Icon from '@components/Icon';
-import PressableWithFeedback from '@components/Pressable/PressableWithFeedback';
+import Checkbox from '@components/Checkbox';
 import ReportActionAvatars from '@components/ReportActionAvatars';
 import TextWithTooltip from '@components/TextWithTooltip';
 import useAnimatedHighlightStyle from '@hooks/useAnimatedHighlightStyle';
-import {useMemoizedLazyExpensifyIcons} from '@hooks/useLazyAsset';
 import useStyleUtils from '@hooks/useStyleUtils';
 import useTheme from '@hooks/useTheme';
 import useThemeStyles from '@hooks/useThemeStyles';
-import CONST from '@src/CONST';
 import BaseListItem from './BaseListItem';
 import type {ListItem, TableListItemProps} from './types';
 
@@ -33,7 +30,6 @@ function TableListItem<TItem extends ListItem>({
     const styles = useThemeStyles();
     const theme = useTheme();
     const StyleUtils = useStyleUtils();
-    const icons = useMemoizedLazyExpensifyIcons(['Checkmark']);
 
     const animatedHighlightStyle = useAnimatedHighlightStyle({
         borderRadius: styles.selectionListPressableItemWrapper.borderRadius,
@@ -87,26 +83,17 @@ function TableListItem<TItem extends ListItem>({
             {(hovered) => (
                 <>
                     {!!canSelectMultiple && (
-                        <PressableWithFeedback
+                        <Checkbox
                             accessibilityLabel={item.text ?? ''}
-                            role={CONST.ROLE.BUTTON}
                             // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
                             disabled={isDisabled || item.isDisabledCheckbox}
+                            isChecked={!!item.isSelected}
                             onPress={handleCheckboxPress}
+                            shouldStopMouseDownPropagation
+                            style={[styles.cursorUnset, item.isDisabledCheckbox && styles.cursorDisabled, item.cursorStyle, styles.p6, styles.mn6, styles.mrn2]}
+                            containerStyle={[StyleUtils.getMultiselectListStyles(!!item.isSelected, !!item.isDisabled), item.cursorStyle]}
                             testID={`TableListItemCheckbox-${item.text}`}
-                            style={[styles.cursorUnset, StyleUtils.getCheckboxPressableStyle(), item.isDisabledCheckbox && styles.cursorDisabled, styles.mr3, item.cursorStyle]}
-                        >
-                            <View style={[StyleUtils.getCheckboxContainerStyle(20), StyleUtils.getMultiselectListStyles(!!item.isSelected, !!item.isDisabled), item.cursorStyle]}>
-                                {!!item.isSelected && (
-                                    <Icon
-                                        src={icons.Checkmark}
-                                        fill={theme.textLight}
-                                        height={14}
-                                        width={14}
-                                    />
-                                )}
-                            </View>
-                        </PressableWithFeedback>
+                        />
                     )}
                     {!!item.accountID && (
                         <ReportActionAvatars

--- a/src/components/SelectionList/ListItem/TableListItem.tsx
+++ b/src/components/SelectionList/ListItem/TableListItem.tsx
@@ -90,7 +90,7 @@ function TableListItem<TItem extends ListItem>({
                             isChecked={!!item.isSelected}
                             onPress={handleCheckboxPress}
                             shouldStopMouseDownPropagation
-                            style={[styles.cursorUnset, item.isDisabledCheckbox && styles.cursorDisabled, item.cursorStyle, styles.p6, styles.mn6, styles.mrn3]}
+                            style={[item.cursorStyle, styles.p6, styles.mn6, styles.mrn3]}
                             containerStyle={[StyleUtils.getMultiselectListStyles(!!item.isSelected, !!item.isDisabled), item.cursorStyle]}
                             testID={`TableListItemCheckbox-${item.text}`}
                         />

--- a/src/components/SelectionList/ListItem/TableListItem.tsx
+++ b/src/components/SelectionList/ListItem/TableListItem.tsx
@@ -90,7 +90,7 @@ function TableListItem<TItem extends ListItem>({
                             isChecked={!!item.isSelected}
                             onPress={handleCheckboxPress}
                             shouldStopMouseDownPropagation
-                            style={[item.cursorStyle, styles.p6, styles.mn6, styles.mrn3]}
+                            style={[item.cursorStyle, styles.p5, styles.mln4, styles.mhv5, styles.mrn1]}
                             containerStyle={[StyleUtils.getMultiselectListStyles(!!item.isSelected, !!item.isDisabled), item.cursorStyle]}
                             testID={`TableListItemCheckbox-${item.text}`}
                         />

--- a/src/components/SelectionList/ListItem/TableListItem.tsx
+++ b/src/components/SelectionList/ListItem/TableListItem.tsx
@@ -90,7 +90,7 @@ function TableListItem<TItem extends ListItem>({
                             isChecked={!!item.isSelected}
                             onPress={handleCheckboxPress}
                             shouldStopMouseDownPropagation
-                            style={[styles.cursorUnset, item.isDisabledCheckbox && styles.cursorDisabled, item.cursorStyle, styles.p6, styles.mn6, styles.mrn2]}
+                            style={[styles.cursorUnset, item.isDisabledCheckbox && styles.cursorDisabled, item.cursorStyle, styles.p6, styles.mn6, styles.mrn3]}
                             containerStyle={[StyleUtils.getMultiselectListStyles(!!item.isSelected, !!item.isDisabled), item.cursorStyle]}
                             testID={`TableListItemCheckbox-${item.text}`}
                         />

--- a/src/styles/utils/spacing.ts
+++ b/src/styles/utils/spacing.ts
@@ -31,6 +31,10 @@ export default {
         margin: 20,
     },
 
+    mn6: {
+        margin: -24,
+    },
+
     mhAuto: {
         marginHorizontal: 'auto',
     },

--- a/src/styles/utils/spacing.ts
+++ b/src/styles/utils/spacing.ts
@@ -31,6 +31,10 @@ export default {
         margin: 20,
     },
 
+    mn5: {
+        margin: -20,
+    },
+
     mn6: {
         margin: -24,
     },
@@ -169,6 +173,10 @@ export default {
 
     mr10: {
         marginRight: 40,
+    },
+
+    mrn1: {
+        marginRight: -4,
     },
 
     mrn2: {

--- a/src/styles/utils/spacing.ts
+++ b/src/styles/utils/spacing.ts
@@ -175,6 +175,10 @@ export default {
         marginRight: -8,
     },
 
+    mrn3: {
+        marginRight: -12,
+    },
+
     mrn5: {
         marginRight: -20,
     },


### PR DESCRIPTION
### Explanation of Change
I was finding it much to easy to miss the checkbox in table views, accidentally clicking the surrounding view and opening for example category details.

This PR expands the checkbox's clickable area by adding some padding and negative margins around it so that it fills up the padding of the surrounding view without changing the visual dimensions or layout of anything.

I did enable `shouldUseAutoHitSlop`, because that is an accessibility feature to make sure the hitbox of checkboxes anywhere is at least 44x44px per common accessibility guidelines. But it's not strictly necessary for this change. hitSlop only works on iOS/Android, because on React Native doesn't have tight control to dictate where to dispatch press events in a browser, and as such `hitSlop` is unsupported on web. The padding+negative margin trick works just as well in a more portable fashion.

### Fixed Issues
$ https://github.com/Expensify/App/issues/79289

### Tests
1. Sign into or create an account that's an admin for a workspace with categories enabled.
2. Go to workspace settings -> categories.
3. Make sure you can click on the checkboxes as usual.
4. Try clicking just outside the checkboxes - verify that the checkbox still toggles.
5. (desktop web only) Click on the row closer to the center - verify it opens category details.

- [x] Verify that no errors appear in the JS console

### Offline tests
n/a - no network interaction.

### QA Steps
Same as tests.

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist
- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I verified there are no new alerts related to the `canBeMissing` param for `useOnyx`
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

https://github.com/user-attachments/assets/fdf69aee-265e-487b-b72a-b9edd48eaefc

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

https://github.com/user-attachments/assets/32d4521c-35b6-4b14-b3cb-f034d8e67e53

</details>

<details>
<summary>iOS: mWeb Safari</summary>

https://github.com/user-attachments/assets/a0cd7229-6830-42d0-92f2-cbf98a423d41

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

|This PR|Staging|
|---|---|
|<img width="1109" height="681" alt="image" src="https://github.com/user-attachments/assets/3581a277-c7e0-463e-9b4a-5a90862aead8" />|<img width="751" height="727" alt="image" src="https://github.com/user-attachments/assets/ac0c8b86-816b-46b0-9109-f3b3e9869c09" />|

https://github.com/user-attachments/assets/2da89b2e-3d56-43cf-94f1-30a30b9dd9cb

</details>