### PR TITLE
fix QBD - Application crashes when try to connect QBD

### DIFF
--- a/src/pages/workspace/accounting/qbd/QuickBooksDesktopSetupPage.tsx
+++ b/src/pages/workspace/accounting/qbd/QuickBooksDesktopSetupPage.tsx
@@ -38,10 +38,6 @@ function RequireQuickBooksDesktopModal({route}: RequireQuickBooksDesktopModalPro
     const [codatSetupLink, setCodatSetupLink] = useState<string>('');
     const hasResultOfFetchingSetupLink = !!codatSetupLink || hasError;
 
-    const ContentWrapper = hasResultOfFetchingSetupLink
-        ? ({children}: React.PropsWithChildren) => children
-        : ({children}: React.PropsWithChildren) => <FullPageOfflineBlockingView addBottomSafeAreaPadding>{children}</FullPageOfflineBlockingView>;
-
     const fetchSetupLink = useCallback(() => {
         setHasError(false);
         // eslint-disable-next-line rulesdir/no-thenable-actions-in-views
@@ -79,6 +75,56 @@ function RequireQuickBooksDesktopModal({route}: RequireQuickBooksDesktopModalPro
 
     const shouldShowError = hasError;
 
+    const children = (
+        <>
+            {shouldShowError && (
+                <View style={[styles.flex1, styles.justifyContentCenter, styles.alignItemsCenter, styles.ph5, styles.mb9]}>
+                    <Icon
+                        src={illustrations.BrokenMagnifyingGlass}
+                        width={116}
+                        height={168}
+                    />
+                    <Text style={[styles.textHeadlineLineHeightXXL, styles.mt3]}>{translate('workspace.qbd.setupPage.setupErrorTitle')}</Text>
+                    <View style={[styles.renderHTML, styles.ph5, styles.mv3]}>
+                        <RenderHTML html={translate('workspace.qbd.setupPage.setupErrorBody', {conciergeLink: `${environmentURL}/${ROUTES.CONCIERGE}`})} />
+                    </View>
+                </View>
+            )}
+            {!shouldShowError && (
+                <View style={[styles.flex1, styles.ph5]}>
+                    <View style={[styles.alignSelfCenter, styles.computerIllustrationContainer, styles.pv6]}>
+                        <ImageSVG src={illustrations.LaptopWithSecondScreenSync} />
+                    </View>
+
+                    <Text style={[styles.textHeadlineH1, styles.pt5]}>{translate('workspace.qbd.setupPage.title')}</Text>
+                    <Text style={[styles.textSupporting, styles.textNormal, styles.pt4]}>{translate('workspace.qbd.setupPage.body')}</Text>
+                    <View style={[styles.qbdSetupLinkBox, styles.mt5]}>
+                        {!hasResultOfFetchingSetupLink ? (
+                            <ActivityIndicator />
+                        ) : (
+                            <CopyTextToClipboard
+                                text={codatSetupLink}
+                                textStyles={[styles.textSupporting]}
+                            />
+                        )}
+                    </View>
+                    <FixedFooter
+                        style={[styles.mtAuto, styles.ph0]}
+                        addBottomSafeAreaPadding
+                    >
+                        <Button
+                            success
+                            text={translate('common.done')}
+                            onPress={() => Navigation.navigate(ROUTES.POLICY_ACCOUNTING_QUICKBOOKS_DESKTOP_TRIGGER_FIRST_SYNC.getRoute(policyID))}
+                            pressOnEnter
+                            large
+                        />
+                    </FixedFooter>
+                </View>
+            )}
+        </>
+    );
+
     return (
         <ScreenWrapper
             shouldEnablePickerAvoiding={false}
@@ -90,53 +136,7 @@ function RequireQuickBooksDesktopModal({route}: RequireQuickBooksDesktopModalPro
                 shouldShowBackButton
                 onBackButtonPress={() => Navigation.dismissModal()}
             />
-            <ContentWrapper>
-                {shouldShowError && (
-                    <View style={[styles.flex1, styles.justifyContentCenter, styles.alignItemsCenter, styles.ph5, styles.mb9]}>
-                        <Icon
-                            src={illustrations.BrokenMagnifyingGlass}
-                            width={116}
-                            height={168}
-                        />
-                        <Text style={[styles.textHeadlineLineHeightXXL, styles.mt3]}>{translate('workspace.qbd.setupPage.setupErrorTitle')}</Text>
-                        <View style={[styles.renderHTML, styles.ph5, styles.mv3]}>
-                            <RenderHTML html={translate('workspace.qbd.setupPage.setupErrorBody', {conciergeLink: `${environmentURL}/${ROUTES.CONCIERGE}`})} />
-                        </View>
-                    </View>
-                )}
-                {!shouldShowError && (
-                    <View style={[styles.flex1, styles.ph5]}>
-                        <View style={[styles.alignSelfCenter, styles.computerIllustrationContainer, styles.pv6]}>
-                            <ImageSVG src={illustrations.LaptopWithSecondScreenSync} />
-                        </View>
-
-                        <Text style={[styles.textHeadlineH1, styles.pt5]}>{translate('workspace.qbd.setupPage.title')}</Text>
-                        <Text style={[styles.textSupporting, styles.textNormal, styles.pt4]}>{translate('workspace.qbd.setupPage.body')}</Text>
-                        <View style={[styles.qbdSetupLinkBox, styles.mt5]}>
-                            {!hasResultOfFetchingSetupLink ? (
-                                <ActivityIndicator />
-                            ) : (
-                                <CopyTextToClipboard
-                                    text={codatSetupLink}
-                                    textStyles={[styles.textSupporting]}
-                                />
-                            )}
-                        </View>
-                        <FixedFooter
-                            style={[styles.mtAuto, styles.ph0]}
-                            addBottomSafeAreaPadding
-                        >
-                            <Button
-                                success
-                                text={translate('common.done')}
-                                onPress={() => Navigation.navigate(ROUTES.POLICY_ACCOUNTING_QUICKBOOKS_DESKTOP_TRIGGER_FIRST_SYNC.getRoute(policyID))}
-                                pressOnEnter
-                                large
-                            />
-                        </FixedFooter>
-                    </View>
-                )}
-            </ContentWrapper>
+            {hasResultOfFetchingSetupLink ? children : <FullPageOfflineBlockingView addBottomSafeAreaPadding>{children}</FullPageOfflineBlockingView>}
         </ScreenWrapper>
     );
 }


### PR DESCRIPTION
### Explanation of Change
The offending PR is #79286.
The root cause is related to react compiler.
The culprit is here:
https://github.com/Expensify/App/blob/b0ad823b38412bb143289fd3b574e05b541ee2da/src/pages/workspace/accounting/qbd/QuickBooksDesktopSetupPage.tsx#L41-L43


Crash log:

<img width="590" height="189" alt="Screenshot 2026-01-14 at 3 27 49 AM" src="https://github.com/user-attachments/assets/fc465bbe-1591-4615-a92d-08191ac0a5a6" />


I updated code like this:

Before:
```
ContentWrapper = hasResultOfFetchingSetupLink ? ({children}) => children : ({children}) => <FullPageOfflineBlockingView>{children}</FullPageOfflineBlockingView>

render:
...
<ContentWrapper>{children}</ContentWrapper>
...
```

After:
```
render:
...
{hasResultOfFetchingSetupLink ? children : <FullPageOfflineBlockingView>{children}</FullPageOfflineBlockingView>}
...
```

### Fixed Issues
$ https://github.com/Expensify/App/issues/79454

### Tests
Precondition: Control workspace with enabled Accounting.

1. Go to Accounting
2. Click on Connect nearby QuickBook Desktop
3. Verify that 'QuickBooks Desktop setup' tap opens without crash

- [x] Verify that no errors appear in the JS console

### Offline tests
Same as Tests

### QA Steps
Same as Tests

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I verified there are no new alerts related to the `canBeMissing` param for `useOnyx`
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>



</details>

<details>
<summary>Android: mWeb Chrome</summary>



</details>

<details>
<summary>iOS: Native</summary>



</details>

<details>
<summary>iOS: mWeb Safari</summary>



</details>

<details open>
<summary>MacOS: Chrome / Safari</summary>


https://github.com/user-attachments/assets/e61fd489-4d22-400c-a834-bfa03973674f



</details>
