### PR TITLE
[CP Staging] feat: feature flag for require attendees to disable feature in case of regressions

### DIFF
--- a/src/CONST/index.ts
+++ b/src/CONST/index.ts
@@ -5724,6 +5724,16 @@ const CONST = {
     },
 
     /**
+     * Feature flag to disable the missingAttendees violation feature.
+     * Set to true to disable the feature if regressions are found.
+     * When true:
+     * - Prevents new missingAttendees violations from being created
+     * - Removes existing missingAttendees violations from transaction lists
+     * - Hides "Require attendees" toggle in category settings
+     */
+    IS_ATTENDEES_REQUIRED_FEATURE_DISABLED: false,
+
+    /**
      * Constants for types of violation.
      */
     VIOLATION_TYPES: {

--- a/src/CONST/index.ts
+++ b/src/CONST/index.ts
@@ -5731,7 +5731,7 @@ const CONST = {
      * - Removes existing missingAttendees violations from transaction lists
      * - Hides "Require attendees" toggle in category settings
      */
-    IS_ATTENDEES_REQUIRED_FEATURE_DISABLED: false,
+    IS_ATTENDEES_REQUIRED_FEATURE_DISABLED: true,
 
     /**
      * Constants for types of violation.

--- a/src/components/TransactionItemRow/index.tsx
+++ b/src/components/TransactionItemRow/index.tsx
@@ -199,6 +199,16 @@ function TransactionItemRow({
     const isAmountColumnWide = amountColumnSize === CONST.SEARCH.TABLE_COLUMN_SIZES.WIDE;
     const isTaxAmountColumnWide = taxAmountColumnSize === CONST.SEARCH.TABLE_COLUMN_SIZES.WIDE;
 
+    const filteredViolations = useMemo(() => {
+        if (!violations) {
+            return undefined;
+        }
+        if (CONST.IS_ATTENDEES_REQUIRED_FEATURE_DISABLED) {
+            return violations.filter((violation) => violation.name !== CONST.VIOLATIONS.MISSING_ATTENDEES);
+        }
+        return violations;
+    }, [violations]);
+
     const bgActiveStyles = useMemo(() => {
         if (!isSelected || !shouldHighlightItemWhenSelected) {
             return [];
@@ -703,7 +713,7 @@ function TransactionItemRow({
                             {shouldShowErrors && (
                                 <TransactionItemRowRBR
                                     transaction={transactionItem}
-                                    violations={violations}
+                                    violations={filteredViolations}
                                     report={report}
                                     containerStyles={[styles.mt2, styles.minHeight4]}
                                     missingFieldError={missingFieldError}
@@ -777,7 +787,7 @@ function TransactionItemRow({
                 {shouldShowErrors && (
                     <TransactionItemRowRBR
                         transaction={transactionItem}
-                        violations={violations}
+                        violations={filteredViolations}
                         report={report}
                         missingFieldError={missingFieldError}
                     />

--- a/src/hooks/useTransactionViolations.ts
+++ b/src/hooks/useTransactionViolations.ts
@@ -1,6 +1,7 @@
 import {useMemo} from 'react';
 import getNonEmptyStringOnyxID from '@libs/getNonEmptyStringOnyxID';
 import {isViolationDismissed, mergeProhibitedViolations, shouldShowViolation} from '@libs/TransactionUtils';
+import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
 import type {TransactionViolation, TransactionViolations} from '@src/types/onyx';
 import getEmptyArray from '@src/types/utils/getEmptyArray';
@@ -28,7 +29,8 @@ function useTransactionViolations(transactionID?: string, shouldShowRterForSettl
                 transactionViolations.filter(
                     (violation: TransactionViolation) =>
                         !isViolationDismissed(transaction, violation, currentUserDetails.email ?? '', currentUserDetails.accountID, iouReport, policy) &&
-                        shouldShowViolation(iouReport, policy, violation.name, currentUserDetails.email ?? '', shouldShowRterForSettledReport, transaction),
+                        shouldShowViolation(iouReport, policy, violation.name, currentUserDetails.email ?? '', shouldShowRterForSettledReport, transaction) &&
+                        (!CONST.IS_ATTENDEES_REQUIRED_FEATURE_DISABLED || violation.name !== CONST.VIOLATIONS.MISSING_ATTENDEES),
                 ),
             ),
         [transaction, transactionViolations, iouReport, policy, shouldShowRterForSettledReport, currentUserDetails.email, currentUserDetails.accountID],

--- a/src/libs/TransactionUtils/index.ts
+++ b/src/libs/TransactionUtils/index.ts
@@ -1392,13 +1392,26 @@ function getTransactionViolations(
         return undefined;
     }
 
-    return transactionViolations?.[ONYXKEYS.COLLECTION.TRANSACTION_VIOLATIONS + transaction.transactionID]?.filter(
-        (violation) => !isViolationDismissed(transaction, violation, currentUserEmail, currentUserAccountID, iouReport, policy),
-    );
+    const violations =
+        transactionViolations?.[ONYXKEYS.COLLECTION.TRANSACTION_VIOLATIONS + transaction.transactionID]?.filter(
+            (violation) => !isViolationDismissed(transaction, violation, currentUserEmail, currentUserAccountID, iouReport, policy),
+        ) ?? [];
+
+    if (CONST.IS_ATTENDEES_REQUIRED_FEATURE_DISABLED) {
+        return violations.filter((violation) => violation.name !== CONST.VIOLATIONS.MISSING_ATTENDEES);
+    }
+
+    return violations;
 }
 
 function getTransactionViolationsOfTransaction(transactionID: string) {
-    return deprecatedAllTransactionViolations?.[`${ONYXKEYS.COLLECTION.TRANSACTION_VIOLATIONS}${transactionID}`] ?? [];
+    const violations = deprecatedAllTransactionViolations?.[`${ONYXKEYS.COLLECTION.TRANSACTION_VIOLATIONS}${transactionID}`] ?? [];
+
+    if (CONST.IS_ATTENDEES_REQUIRED_FEATURE_DISABLED) {
+        return violations.filter((violation) => violation.name !== CONST.VIOLATIONS.MISSING_ATTENDEES);
+    }
+
+    return violations;
 }
 
 /**
@@ -1818,7 +1831,8 @@ function hasViolation(
         (violation) =>
             violation.type === CONST.VIOLATION_TYPES.VIOLATION &&
             (showInReview === undefined || showInReview === (violation.showInReview ?? false)) &&
-            !isViolationDismissed(transaction, violation, currentUserEmail, currentUserAccountID, iouReport, policy),
+            !isViolationDismissed(transaction, violation, currentUserEmail, currentUserAccountID, iouReport, policy) &&
+            (!CONST.IS_ATTENDEES_REQUIRED_FEATURE_DISABLED || violation.name !== CONST.VIOLATIONS.MISSING_ATTENDEES),
     );
 }
 

--- a/src/libs/Violations/ViolationsUtils.ts
+++ b/src/libs/Violations/ViolationsUtils.ts
@@ -502,15 +502,22 @@ const ViolationsUtils = {
             newTransactionViolations = reject(newTransactionViolations, {name: CONST.VIOLATIONS.MISSING_COMMENT});
         }
 
-        if (!hasMissingAttendeesViolation && shouldShowMissingAttendees) {
-            newTransactionViolations.push({
-                name: CONST.VIOLATIONS.MISSING_ATTENDEES,
-                type: CONST.VIOLATION_TYPES.VIOLATION,
-                showInReview: true,
-            });
-        }
+        const shouldProcessMissingAttendees = !CONST.IS_ATTENDEES_REQUIRED_FEATURE_DISABLED;
 
-        if (hasMissingAttendeesViolation && !shouldShowMissingAttendees) {
+        if (shouldProcessMissingAttendees) {
+            if (!hasMissingAttendeesViolation && shouldShowMissingAttendees) {
+                newTransactionViolations.push({
+                    name: CONST.VIOLATIONS.MISSING_ATTENDEES,
+                    type: CONST.VIOLATION_TYPES.VIOLATION,
+                    showInReview: true,
+                });
+            }
+
+            if (hasMissingAttendeesViolation && !shouldShowMissingAttendees) {
+                newTransactionViolations = reject(newTransactionViolations, {name: CONST.VIOLATIONS.MISSING_ATTENDEES});
+            }
+        } else if (hasMissingAttendeesViolation) {
+            // Feature flag is disabled - always remove missingAttendees violations
             newTransactionViolations = reject(newTransactionViolations, {name: CONST.VIOLATIONS.MISSING_ATTENDEES});
         }
 
@@ -715,7 +722,8 @@ const ViolationsUtils = {
             return transactionViolations.some((violation: TransactionViolation) => {
                 return (
                     !isViolationDismissed(transaction, violation, currentUserEmail, currentUserAccountID, report, policy) &&
-                    shouldShowViolation(report, policy, violation.name, currentUserEmail, true, transaction)
+                    shouldShowViolation(report, policy, violation.name, currentUserEmail, true, transaction) &&
+                    (!CONST.IS_ATTENDEES_REQUIRED_FEATURE_DISABLED || violation.name !== CONST.VIOLATIONS.MISSING_ATTENDEES)
                 );
             });
         });

--- a/src/pages/workspace/categories/CategoryRequiredFieldsPage.tsx
+++ b/src/pages/workspace/categories/CategoryRequiredFieldsPage.tsx
@@ -76,7 +76,7 @@ function CategoryRequiredFieldsPage({
                             </View>
                         </View>
                     </OfflineWithFeedback>
-                    {isAttendeeTrackingEnabled && (
+                    {isAttendeeTrackingEnabled && !CONST.IS_ATTENDEES_REQUIRED_FEATURE_DISABLED && (
                         <OfflineWithFeedback pendingAction={policyCategory?.pendingFields?.areAttendeesRequired}>
                             <View style={[styles.mh5]}>
                                 <View style={[styles.flexRow, styles.mv5, styles.mr2, styles.alignItemsCenter, styles.justifyContentBetween]}>

--- a/tests/unit/ViolationUtilsTest.ts
+++ b/tests/unit/ViolationUtilsTest.ts
@@ -635,13 +635,13 @@ describe('getViolationsOnyxData', () => {
             } as Report;
         });
 
-        it('should add missingAttendees violation when no attendees are present', () => {
+        (CONST.IS_ATTENDEES_REQUIRED_FEATURE_DISABLED ? it.skip : it)('should add missingAttendees violation when no attendees are present', () => {
             transaction.comment = {attendees: []};
             const result = ViolationsUtils.getViolationsOnyxData(transaction, transactionViolations, policy, policyTags, policyCategories, false, false, false, iouReport);
             expect(result.value).toEqual(expect.arrayContaining([missingAttendeesViolation]));
         });
 
-        it('should add missingAttendees violation when only owner is an attendee', () => {
+        (CONST.IS_ATTENDEES_REQUIRED_FEATURE_DISABLED ? it.skip : it)('should add missingAttendees violation when only owner is an attendee', () => {
             transaction.comment = {
                 attendees: [{email: 'owner@example.com', displayName: 'Owner', avatarUrl: '', accountID: ownerAccountID}],
             };
@@ -689,7 +689,7 @@ describe('getViolationsOnyxData', () => {
         describe('optimistic / offline scenarios (iouReport is undefined)', () => {
             // In offline scenarios, iouReport is undefined so we can't get ownerAccountID.
             // The code falls back to using getCurrentUserEmail() to identify the owner by login/email.
-            it('should correctly calculate violation when iouReport is undefined but attendees have matching email', () => {
+            (CONST.IS_ATTENDEES_REQUIRED_FEATURE_DISABLED ? it.skip : it)('should correctly calculate violation when iouReport is undefined but attendees have matching email', () => {
                 // When iouReport is undefined, we use getCurrentUserEmail() as fallback
                 // If only the current user (matching MOCK_CURRENT_USER_EMAIL) is an attendee, violation should show
                 transactionViolations = [];
@@ -729,7 +729,7 @@ describe('getViolationsOnyxData', () => {
                 expect(result.value).not.toEqual(expect.arrayContaining([missingAttendeesViolation]));
             });
 
-            it('should preserve violation when only owner attendee remains (offline)', () => {
+            (CONST.IS_ATTENDEES_REQUIRED_FEATURE_DISABLED ? it.skip : it)('should preserve violation when only owner attendee remains (offline)', () => {
                 // If violation existed and only owner attendee remains, violation stays
                 transactionViolations = [missingAttendeesViolation];
                 transaction.comment = {
@@ -757,7 +757,7 @@ describe('getViolationsOnyxData', () => {
                 jest.restoreAllMocks();
             });
 
-            it("should add missingAttendees violation when no attendees are present (can't identify owner)", () => {
+            (CONST.IS_ATTENDEES_REQUIRED_FEATURE_DISABLED ? it.skip : it)("should add missingAttendees violation when no attendees are present (can't identify owner)", () => {
                 transactionViolations = [];
                 transaction.comment = {attendees: []};
                 const result = ViolationsUtils.getViolationsOnyxData(transaction, transactionViolations, policy, policyTags, policyCategories, false, false, false, undefined);
@@ -765,7 +765,7 @@ describe('getViolationsOnyxData', () => {
                 expect(result.value).toEqual(expect.arrayContaining([missingAttendeesViolation]));
             });
 
-            it('should add missingAttendees violation when only 1 attendee exists (assumed to be owner)', () => {
+            (CONST.IS_ATTENDEES_REQUIRED_FEATURE_DISABLED ? it.skip : it)('should add missingAttendees violation when only 1 attendee exists (assumed to be owner)', () => {
                 transactionViolations = [];
                 transaction.comment = {
                     attendees: [{email: 'anyone@example.com', displayName: 'Someone', avatarUrl: ''}],


### PR DESCRIPTION
### Explanation of Change
<!-- Explain what your change does and how it addresses the linked issue -->

This PR adds a feature flag that can quickly disable the `missingAttendees` violation functionality added in PR https://github.com/Expensify/App/pull/79050, without requiring a full revert of the attendees required feature.

### Problem

The attendees required feature introduces missingAttendees violations that can appear:

1. During expense creation (MoneyRequestConfirmationList).
2. When viewing expenses (MoneyRequestView).
3. In Search results (TransactionListItem).
4. Via ViolationsUtils.getViolationsOnyxData.

If regressions occur, we need a way to quickly disable this feature without reverting all the code changes.

### How to Disable the Feature

When regressions are found:

1. Change `IS_ATTENDEES_REQUIRED_FEATURE_DISABLED` from `false` to `true` in 
`src/CONST/index.ts`.
2. This will:
- Prevent new `missingAttendees` violations from being created
- Remove existing `missingAttendees` violations from transaction lists
- Hide the "Require attendees" toggle in category settings
- `getIsMissingAttendeesViolation` will always return `false`
- `syncMissingAttendeesViolation` will filter out any existing violations

@JS00001 To merge this one in case https://github.com/Expensify/App/pull/79050 will have any deploy-blocking regressions ✅ 

### Fixed Issues
$ https://github.com/Expensify/App/issues/79707
$ https://github.com/Expensify/App/issues/79710

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

**Test 1**: Verify feature is disabled when flag is `true` (default)

1. Set `IS_ATTENDEES_REQUIRED_FEATURE_DISABLED: true` in CONST.
2. Follow the original test cases from PR https://github.com/Expensify/App/pull/79050.
3. Based on the original test cases verify that the feature is disabled:
- Verify NO `missingAttendees` violation error appears anywhere
- Verify "Require attendees" toggle is hidden in individual category settings on Require fields section

**Test 2**: Verify feature works when flag is `false`

1. Ensure `IS_ATTENDEES_REQUIRED_FEATURE_DISABLED: false` in CONST.
2. Follow the original test cases from PR https://github.com/Expensify/App/pull/79050.
3. Based on the original test cases verify that the feature is enabled.

- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

**N/A**

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->

Same as **Tests**.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I verified there are no new alerts related to the `canBeMissing` param for `useOnyx`
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.