### PR TITLE
Fix value and unit not on the same line for small font size in expense create flow

### DIFF
--- a/src/pages/iou/request/step/IOURequestStepDistanceManual.tsx
+++ b/src/pages/iou/request/step/IOURequestStepDistanceManual.tsx
@@ -348,7 +348,7 @@ function IOURequestStepDistanceManual({
         if (isLoadingSelectedTab) {
             return;
         }
-        // eslint-disable-next-line react-hooks/set-state-in-effect
+        // eslint-disable-next-line react-hooks/set-state-in-effect -- Clear form error when tab changes
         setFormError('');
     }, [selectedTab, isLoadingSelectedTab]);
 

--- a/src/pages/iou/request/step/IOURequestStepDistanceManual.tsx
+++ b/src/pages/iou/request/step/IOURequestStepDistanceManual.tsx
@@ -348,6 +348,7 @@ function IOURequestStepDistanceManual({
         if (isLoadingSelectedTab) {
             return;
         }
+        // eslint-disable-next-line react-hooks/set-state-in-effect
         setFormError('');
     }, [selectedTab, isLoadingSelectedTab]);
 
@@ -378,6 +379,7 @@ function IOURequestStepDistanceManual({
                 style={styles.iouAmountTextInput}
                 containerStyle={styles.iouAmountTextInputContainer}
                 autoGrowExtraSpace={variables.w80}
+                touchableInputWrapperStyle={styles.heightUndefined}
                 errorText={formError}
                 footer={
                     <Button

--- a/src/pages/iou/request/step/IOURequestStepHours.tsx
+++ b/src/pages/iou/request/step/IOURequestStepHours.tsx
@@ -113,6 +113,7 @@ function IOURequestStepHours({
                 style={styles.iouAmountTextInput}
                 containerStyle={styles.iouAmountTextInputContainer}
                 errorText={formError}
+                touchableInputWrapperStyle={styles.heightUndefined}
                 onInputChange={() => {
                     if (!formError) {
                         return;


### PR DESCRIPTION
### Explanation of Change
<!-- Explain what your change does and how it addresses the linked issue -->

Sets NumberWithSymbolForm's input wrapper height to undefined, which makes the unit and value be on the same line even with smallest device font on Android.

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/79528
PROPOSAL: N/A

<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

Precondition:
1. Device font size is set to the smallest.
2. Time tracking feature is enabled on OD.

--

1. Go to workspace chat with time tracking enabled.
2. Tap + > Create expense > Time.
4. Enter any amount.
5. The value and unit symbol should be rendered correctly (on the same line)
6. Go back to the chat.
7. Tap + > Track distance > Manual.
8. Enter any amount. 
9. The value and unit symbol should be rendered correctly (on the same line)

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

N/A

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
4. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->

Same as tests.

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I verified there are no new alerts related to the `canBeMissing` param for `useOnyx`
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<img width="1280" height="2856" alt="Screenshot_20260115_151022" src="https://github.com/user-attachments/assets/3c1747f7-c0af-42d2-b4cb-5c27e0b08372" />

<img width="1280" height="2856" alt="Screenshot_20260115_153040" src="https://github.com/user-attachments/assets/f14bc13b-0f58-4a79-b0a2-88281f267a81" />


</details>

<details>
<summary>Android: mWeb Chrome</summary>

<img width="437" height="786" alt="Zrzut ekranu 2026-01-15 o 15 41 21" src="https://github.com/user-attachments/assets/4c8281f0-b953-4e4b-9414-eef6b47b1291" />

<img width="437" height="786" alt="Zrzut ekranu 2026-01-15 o 15 41 36" src="https://github.com/user-attachments/assets/9e951075-3d7a-4ae9-afea-6a928b69df1f" />

</details>

<details>
<summary>iOS: Native</summary>

<img width="1320" height="2868" alt="Simulator Screenshot - iPhone 16 Pro Max - 2026-01-15 at 15 38 01" src="https://github.com/user-attachments/assets/ed4405db-1235-4d96-aceb-0710b6417fff" />

<img width="1320" height="2868" alt="Simulator Screenshot - iPhone 16 Pro Max - 2026-01-15 at 15 38 28" src="https://github.com/user-attachments/assets/d18f198f-4055-4ea5-af15-925ad0b41191" />

<img width="1320" height="2868" alt="Simulator Screenshot - iPhone 16 Pro Max - 2026-01-15 at 15 35 33" src="https://github.com/user-attachments/assets/2a7bbf54-5487-441d-a4c5-e93114014cf0" />

<img width="1320" height="2868" alt="Simulator Screenshot - iPhone 16 Pro Max - 2026-01-15 at 15 36 01" src="https://github.com/user-attachments/assets/1530cf15-09dc-4add-b28b-3c4fd50ac4d0" />

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<img width="1320" height="2868" alt="Simulator Screenshot - iPhone 16 Pro Max - 2026-01-15 at 15 39 26" src="https://github.com/user-attachments/assets/4cec7827-e77e-4dde-aa0c-0f01d42c0022" />

<img width="1320" height="2868" alt="Simulator Screenshot - iPhone 16 Pro Max - 2026-01-15 at 15 39 46" src="https://github.com/user-attachments/assets/4d99598e-3782-4b44-970f-1055d58e6a94" />

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<img width="1508" height="944" alt="Zrzut ekranu 2026-01-15 o 15 35 04" src="https://github.com/user-attachments/assets/499ec7b6-8dba-4653-a0c6-9d111b627af3" />

<img width="1508" height="944" alt="Zrzut ekranu 2026-01-15 o 15 35 17" src="https://github.com/user-attachments/assets/9a9d3727-8a09-45dd-a254-7d74e58f2858" />

</details>