### PR TITLE
Fix accessibility roles and states for radio buttons and tabs

### DIFF
--- a/src/components/Checkbox.tsx
+++ b/src/components/Checkbox.tsx
@@ -18,7 +18,7 @@ type CheckboxProps = Partial<ChildrenProps> &
         /** Whether checkbox is checked */
         isChecked?: boolean;
 
-        /** Whether checkbox is in the indeterminate (“mixed”) state */
+        /** Whether checkbox is in the indeterminate ("mixed") state */
         isIndeterminate?: boolean;
 
         /** A function that is called when the box/label is pressed */
@@ -51,6 +51,12 @@ type CheckboxProps = Partial<ChildrenProps> &
         /** An accessibility label for the checkbox */
         accessibilityLabel: string;
 
+        /** Accessibility role - defaults to checkbox, can be overridden to radio */
+        accessibilityRole?: 'checkbox' | 'radio';
+
+        /** Accessibility state */
+        accessibilityState?: {selected?: boolean; checked?: boolean};
+
         /** stop propagation of the mouse down event */
         shouldStopMouseDownPropagation?: boolean;
 
@@ -81,6 +87,8 @@ function Checkbox({
     caretSize = 14,
     onPress,
     accessibilityLabel,
+    accessibilityRole = CONST.ROLE.CHECKBOX,
+    accessibilityState,
     shouldStopMouseDownPropagation,
     shouldSelectOnPressEnter,
     wrapperStyle,
@@ -116,6 +124,12 @@ function Checkbox({
         onPress();
     };
 
+    const computedAccessibilityState = accessibilityState ?? (
+        accessibilityRole === CONST.ROLE.RADIO
+            ? {selected: isChecked}
+            : {checked: isIndeterminate ? 'mixed' : isChecked}
+    );
+
     return (
         <PressableWithFeedback
             testID={testID}
@@ -130,7 +144,8 @@ function Checkbox({
             ref={ref as PressableRef}
             style={[StyleUtils.getCheckboxPressableStyle(containerBorderRadius + 2), style]} // to align outline on focus, border-radius of pressable should be 2px more than Checkbox
             onKeyDown={handleSpaceOrEnterKey}
-            role={CONST.ROLE.CHECKBOX}
+            role={accessibilityRole}
+            accessibilityState={computedAccessibilityState}
             /*  true  → checked
                 false → unchecked
                 mixed → indeterminate  */

--- a/src/components/SelectionList/ListItem/SingleSelectListItem.tsx
+++ b/src/components/SelectionList/ListItem/SingleSelectListItem.tsx
@@ -1,6 +1,7 @@
 import React, {useCallback} from 'react';
 import Checkbox from '@components/Checkbox';
 import useThemeStyles from '@hooks/useThemeStyles';
+import CONST from '@src/CONST';
 import RadioListItem from './RadioListItem';
 import type {ListItem, SingleSelectListItemProps} from './types';
 
@@ -33,6 +34,8 @@ function SingleSelectListItem<TItem extends ListItem>({
                 shouldSelectOnPressEnter
                 containerBorderRadius={999}
                 accessibilityLabel="SingleSelectListItem"
+                accessibilityRole={CONST.ROLE.RADIO}
+                accessibilityState={{selected: item.isSelected}}
                 isChecked={item.isSelected}
                 onPress={() => onSelectRow(item)}
             />

--- a/src/components/TabSelector/TabSelectorItem.tsx
+++ b/src/components/TabSelector/TabSelectorItem.tsx
@@ -115,12 +115,14 @@ function TabSelectorItem({
     const children = (
         <AnimatedPressableWithFeedback
             accessibilityLabel={title}
+            accessibilityRole={CONST.ROLE.TAB}
+            accessibilityState={{selected: isActive}}
             style={[styles.tabSelectorButton, styles.tabBackground(isHovered, isActive, backgroundColor), styles.userSelectNone]}
             wrapperStyle={[equalWidth ? styles.flex1 : styles.flexGrow1]}
             onPress={onPress}
             onHoverIn={() => setIsHovered(true)}
             onHoverOut={() => setIsHovered(false)}
-            role={CONST.ROLE.BUTTON}
+            role={CONST.ROLE.TAB}
             dataSet={{[CONST.SELECTION_SCRAPER_HIDDEN_ELEMENT]: true}}
             testID={testID}
             ref={childRef}


### PR DESCRIPTION
### Explanation of Change
This PR fixes accessibility issues where radio buttons, checkboxes, and tabs were not properly announcing their roles and states to screen readers. The changes ensure WCAG 4.1.2 compliance by implementing proper accessibility properties.

**Changes made:**
1. **Radio buttons in Reports filters (SingleSelectListItem)**: Changed from role="checkbox" to role="radio" with proper selected state
2. **Tabs in Track Distance feature (TabSelectorItem)**: Changed from role="button" to role="tab" with proper selected state  
3. **Checkbox component**: Enhanced to support dynamic roles and states

The Checkbox component was refactored to accept optional `accessibilityRole` and `accessibilityState` props, defaulting to correct behavior for both checkbox and radio button use cases.

### Fixed Issues
$ https://github.com/Expensify/App/issues/79240
$ https://github.com/Expensify/App/issues/77540
$ https://github.com/Expensify/App/issues/74848

### Tests
1. Navigate to Reports > Filters > Date dropdown
2. Verify radio buttons are announced correctly with screen reader (VoiceOver/TalkBack)
3. Navigate to Track Distance feature (+ button > Track distance)
4. Verify tabs are announced correctly with screen reader
5. Navigate to Reports > Filters > Status dropdown
6. Verify checkboxes are announced correctly with screen reader
- [x] Verify that no errors appear in the JS console

### Offline tests
N/A - This is a screen reader accessibility fix that works the same offline

### QA Steps
Same as Tests

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)

### Screenshots/Videos
N/A - This is a screen reader accessibility change with no visual differences. Testing requires screen reader software (VoiceOver on iOS/macOS or TalkBack on Android).