### PR TITLE
feat: implement keyboard reordering for DraggableList

### DIFF
--- a/src/components/DraggableList/SortableItem.tsx
+++ b/src/components/DraggableList/SortableItem.tsx
@@ -1,16 +1,49 @@
 import {useSortable} from '@dnd-kit/sortable';
 import {CSS} from '@dnd-kit/utilities';
-import React from 'react';
+import type {KeyboardEvent} from 'react';
+import React, {useCallback, useEffect, useRef} from 'react';
 import type {SortableItemProps} from './types';
 
 function SortableItem({id, children, disabled = false}: SortableItemProps) {
     const {attributes, listeners, setNodeRef, transform, transition} = useSortable({id, disabled});
+    const contentRef = useRef<HTMLDivElement>(null);
 
     const style = {
         touchAction: 'none',
         transform: CSS.Transform.toString(transform),
         transition,
     };
+
+    // Remove inner focusable elements from tab order
+    useEffect(() => {
+        if (contentRef.current) {
+            const focusableElements = contentRef.current.querySelectorAll<HTMLElement>(
+                '[tabindex="0"], [role="button"], [role="menuitem"], button:not([tabindex="-1"]), a:not([tabindex="-1"])',
+            );
+            focusableElements.forEach((el) => {
+                el.tabIndex = -1;
+            });
+        }
+    });
+
+    // Handle keyboard: merge dnd-kit's handler with Enter for activation
+    const handleKeyDown = useCallback(
+        (e: KeyboardEvent<HTMLDivElement>) => {
+            // Let dnd-kit handle Space for drag operations
+            if (listeners?.onKeyDown) {
+                (listeners.onKeyDown as (event: KeyboardEvent<HTMLElement>) => void)(e);
+            }
+
+            // Handle Enter to activate the inner element (e.g., open waypoint editor)
+            if (e.key === 'Enter' && !e.defaultPrevented) {
+                const innerElement = contentRef.current?.querySelector<HTMLElement>('[role="menuitem"]');
+                if (innerElement) {
+                    innerElement.click();
+                }
+            }
+        },
+        [listeners],
+    );
 
     return (
         <div
@@ -19,11 +52,14 @@ function SortableItem({id, children, disabled = false}: SortableItemProps) {
             // eslint-disable-next-line react/jsx-props-no-spreading
             {...attributes}
             // eslint-disable-next-line react/jsx-props-no-spreading
-            {...(disabled ? {} : listeners)}
-            // Override dnd-kit's tabIndex to prevent double focus (outer wrapper + inner MenuItem)
-            tabIndex={-1}
+            {...(disabled ? {} : {...listeners, onKeyDown: handleKeyDown})}
         >
-            {children}
+            <div
+                ref={contentRef}
+                style={{outline: 'none'}}
+            >
+                {children}
+            </div>
         </div>
     );
 }

--- a/src/components/DraggableList/index.tsx
+++ b/src/components/DraggableList/index.tsx
@@ -1,7 +1,7 @@
-import type {DragEndEvent} from '@dnd-kit/core';
-import {closestCenter, DndContext, PointerSensor, useSensor} from '@dnd-kit/core';
+import type {DragEndEvent, KeyboardCoordinateGetter} from '@dnd-kit/core';
+import {closestCenter, DndContext, KeyboardCode, KeyboardSensor, PointerSensor, useSensor, useSensors} from '@dnd-kit/core';
 import {restrictToParentElement, restrictToVerticalAxis} from '@dnd-kit/modifiers';
-import {arrayMove, SortableContext, verticalListSortingStrategy} from '@dnd-kit/sortable';
+import {arrayMove, SortableContext, sortableKeyboardCoordinates, verticalListSortingStrategy} from '@dnd-kit/sortable';
 import React, {Fragment} from 'react';
 // eslint-disable-next-line no-restricted-imports
 import type {ScrollView as RNScrollView} from 'react-native';
@@ -69,13 +69,23 @@ function DraggableList<T>({
         );
     });
 
-    const sensors = [
+    const sensors = useSensors(
         useSensor(PointerSensor, {
             activationConstraint: {
                 distance: minimumActivationDistance,
             },
         }),
-    ];
+        useSensor(KeyboardSensor, {
+            coordinateGetter: sortableKeyboardCoordinates,
+            // Only use Space for drag activation, not Enter
+            // Enter is reserved for activating the item (opening editor)
+            keyboardCodes: {
+                start: [KeyboardCode.Space],
+                cancel: [KeyboardCode.Escape],
+                end: [KeyboardCode.Space, KeyboardCode.Enter],
+            },
+        }),
+    );
 
     const Container = disableScroll ? Fragment : ScrollView;
 


### PR DESCRIPTION
## Summary
- Add `KeyboardSensor` with `sortableKeyboardCoordinates` to enable keyboard-based drag-and-drop
- Configure `keyboardCodes` to use Space for drag activation, reserving Enter for item activation
- Handle Enter key in `SortableItem` to click the inner menuitem (e.g., open waypoint editor)
- Remove inner focusable elements from tab order for single Tab stop per item

$ #79247

## Test plan
1. Go to Track Distance flow and add multiple waypoints
2. Tab to a waypoint (verify single Tab stop per item, not double)
3. Press Space to start dragging
4. Use Arrow Up/Down to move the item
5. Press Space or Enter to drop
6. Tab to a waypoint and press Enter (verify it opens the waypoint editor)
