### PR TITLE
Fix GL code gating in formula fields

### DIFF
--- a/src/libs/Formula.ts
+++ b/src/libs/Formula.ts
@@ -885,11 +885,11 @@ function computePersonalDetailsField(path: string[], personalDetails: PersonalDe
         case 'email':
             return personalDetails.login ?? '';
         // userid/customfield1 returns employeeUserID from policy.employeeList
-        // TODO: Check policy.glCodes once backend adds it (issue #568268)
         case 'userid':
         case 'customfield1': {
             const email = personalDetails.login;
-            if (!email || !policy?.employeeList) {
+            const isGlCodesEnabled = policy?.glCodes === true;
+            if (!isGlCodesEnabled || !email || !policy?.employeeList) {
                 return '';
             }
             // eslint-disable-next-line rulesdir/no-default-id-values
@@ -899,7 +899,8 @@ function computePersonalDetailsField(path: string[], personalDetails: PersonalDe
         case 'payrollid':
         case 'customfield2': {
             const email = personalDetails.login;
-            if (!email || !policy?.employeeList) {
+            const isGlCodesEnabled = policy?.glCodes === true;
+            if (!isGlCodesEnabled || !email || !policy?.employeeList) {
                 return '';
             }
             // eslint-disable-next-line rulesdir/no-default-id-values

--- a/tests/unit/FormulaTest.ts
+++ b/tests/unit/FormulaTest.ts
@@ -1022,6 +1022,7 @@ describe('CustomFormula', () => {
             } as Report,
             policy: {
                 name: 'Test Policy',
+                glCodes: true,
                 employeeList: {
                     // eslint-disable-next-line @typescript-eslint/naming-convention
                     'john.doe@company.com': {
@@ -1139,6 +1140,7 @@ describe('CustomFormula', () => {
                     report: {reportID: '123'} as Report,
                     policy: {
                         name: 'Test Policy',
+                        glCodes: true,
                         employeeList: {
                             // eslint-disable-next-line @typescript-eslint/naming-convention
                             'other.user@company.com': {
@@ -1151,6 +1153,28 @@ describe('CustomFormula', () => {
                 };
 
                 expect(compute('{report:submit:from:customfield1}', contextWithDifferentEmployee)).toBe('');
+            });
+
+            test('customfield1/customfield2 - return empty when glCodes disabled', () => {
+                const contextWithGlCodesDisabled: FormulaContext = {
+                    report: {reportID: '123'} as Report,
+                    policy: {
+                        name: 'Test Policy',
+                        glCodes: false,
+                        employeeList: {
+                            // eslint-disable-next-line @typescript-eslint/naming-convention
+                            'john.doe@company.com': {
+                                email: 'john.doe@company.com',
+                                employeeUserID: 'EMP001',
+                                employeePayrollID: 'PAY123',
+                            },
+                        },
+                    } as unknown as Policy,
+                    submitterPersonalDetails: mockSubmitter,
+                };
+
+                expect(compute('{report:submit:from:customfield1}', contextWithGlCodesDisabled)).toBe('');
+                expect(compute('{report:submit:from:customfield2}', contextWithGlCodesDisabled)).toBe('');
             });
         });
 


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
This PR aligns frontend formula computation with backend behavior. The backend only resolves the accounting-related placeholders userid/customfield1 and payrollid/customfield2 when the workspace has GL codes enabled. The frontend previously returned those values optimistically regardless of the GL codes flag, which could produce a report title that didn’t match the backend’s result. The change adds the same GL codes gate in the frontend formula computation, so the optimistic output matches what the backend will generate.

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/79054
PROPOSAL: https://github.com/Expensify/App/issues/79054#issuecomment-3721576657


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests

Goal: Verify that report-title formulas that reference `{report:submit:from:customfield1}` / `{report:submit:from:customfield2}` use the member’s values only when GL codes are enabled, and return empty when GL codes are disabled.

## 1) Unit test for GL codes disabled (value present but must return empty)
- Command: `npm test -- tests/unit/FormulaTest.ts`
- Why: The UI does not expose custom field inputs when GL codes are disabled, so the disabled path is validated via unit test.
- What it proves: In `tests/unit/FormulaTest.ts`, the test `customfield1/customfield2 - return empty when glCodes disabled` builds a context where `glCodes: false` but `employeeUserID/employeePayrollID` are present; the expected result is empty strings for both formula placeholders.

## 2) Unit tests already present for GL codes enabled (values should resolve)
- What it proves: In `tests/unit/FormulaTest.ts`, `mockContextWithSubmissionInfo` sets `glCodes: true` with `employeeUserID/employeePayrollID`, and the tests `customfield1 - submitter employee user ID from policy` and `customfield2 - submitter employee payroll ID from policy` assert those values are returned.

## 3) UI test for GL codes enabled (values should appear in report title)
- Why: Confirms the real user flow and report title rendering.
- Steps (web):
  1. Open a Control workspace (GL codes enabled).
  2. Go to Workspace → Members → select a member.
  3. Set Custom field 1 and Custom field 2 for that member.
  4. Go to Workspace → Reports → Report title and set a formula like:
     `CF1 {report:submit:from:customfield1} CF2 {report:submit:from:customfield2}`
  5. Create a new expense report as that member (submit an expense in that workspace).
  6. Verify the report title includes the custom field values.

- Evidence: Videos attached (all platforms).

**Following is the member configuration along with the workspace that I am using for testing:**
<img width="359" height="636" alt="Screenshot 2026-01-20 at 10 11 35 PM" src="https://github.com/user-attachments/assets/83d9b374-8267-4e79-bcf7-364654700c50" />


### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

### QA Steps

Same as tests

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I verified there are no new alerts related to the `canBeMissing` param for `useOnyx`
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

https://github.com/user-attachments/assets/3303d0ca-de86-49cf-9276-04533e652068


</details>

<details>
<summary>Android: mWeb Chrome</summary>


https://github.com/user-attachments/assets/ccc0a948-d3ae-4cf5-a0e8-59d9c205a042



</details>

<details>
<summary>iOS: Native</summary>


https://github.com/user-attachments/assets/35e1da06-01b4-4e42-86d1-f14d83fe173b



</details>

<details>
<summary>iOS: mWeb Safari</summary>

https://github.com/user-attachments/assets/98c908b9-a2c1-4f48-b2df-d3fbd86337b5




</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

https://github.com/user-attachments/assets/72bab9bb-50a7-4330-8fec-d3f0df136151




</details>