### PR TITLE
Revert "PreexistingReport: clear stale IOU action on transaction threads"

### DIFF
--- a/src/libs/actions/Report.ts
+++ b/src/libs/actions/Report.ts
@@ -160,7 +160,6 @@ import {
     isGroupChat as isGroupChatReportUtils,
     isHiddenForCurrentUser,
     isIOUReportUsingReport,
-    isMoneyRequest,
     isMoneyRequestReport,
     isOpenExpenseReport,
     isProcessingReport,
@@ -1894,13 +1893,10 @@ function handlePreexistingReport(report: Report) {
     }
 
     // Handle cleanup of stale optimistic IOU report and its report preview separately
-    if ((isMoneyRequestReport(report) || isMoneyRequest(report)) && parentReportID && parentReportActionID) {
-        const parentReportAction = allReportActions?.[parentReportID]?.[parentReportActionID];
-        if (parentReportAction?.childReportID === reportID) {
-            Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${parentReportID}`, {
-                [parentReportActionID]: null,
-            });
-        }
+    if (isMoneyRequestReport(report) && parentReportActionID) {
+        Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${parentReportID}`, {
+            [parentReportActionID]: null,
+        });
         Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT}${reportID}`, null);
         return;
     }


### PR DESCRIPTION
Reverts Expensify/App#79356

In PR  https://github.com/Expensify/App/pull/75101, these tests started failing on the PR branch after PR https://github.com/Expensify/App/pull/79356 was merged.

```
  ● actions/Report › handlePreexistingReport › should handle preexistingReportID for one-transaction report

    expect(received).toBe(expected) // Object.is equality

    Expected: "5555"
    Received: undefined

      3239 |             // Then the childReportID of the IOU action should be updated
      3240 |             const iouReportActions = await getOnyxValue(`${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${iouReportID}`);
    > 3241 |             expect(iouReportActions?.['1']?.childReportID).toBe(preexistingReportID);
           |                                                            ^
      3242 |         });
      3243 |
      3244 |         it('should handle preexistingReportID for multi-transaction report', async () => {

      at Object.toBe (tests/actions/ReportTest.ts:3241:60)
      at asyncGeneratorStep (node_modules/@babel/runtime/helpers/asyncToGenerator.js:3:17)
      at _next (node_modules/@babel/runtime/helpers/asyncToGenerator.js:17:9)

  ● actions/Report › handlePreexistingReport › should handle preexistingReportID for multi-transaction report

    expect(received).toBe(expected) // Object.is equality

    Expected: "5555"
    Received: undefined

      3318 |             // Then the childReportID of the IOU action should be updated
      3319 |             const iouReportActions = await getOnyxValue(`${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${iouReportID}`);
    > 3320 |             expect(iouReportActions?.[iouReportAction1.reportActionID]?.childReportID).toBe(preexistingReportID);
           |                                                                                        ^
      3321 |         });
      3322 |
      3323 |         it('should handle preexistingReportID for thread under comment', async () => {

      at Object.toBe (tests/actions/ReportTest.ts:3320:88)
      at asyncGeneratorStep (node_modules/@babel/runtime/helpers/asyncToGenerator.js:3:17)
      at _next (node_modules/@babel/runtime/helpers/asyncToGenerator.js:17:9)

```

From Abdelhafidh in https://github.com/Expensify/App/pull/75101#issuecomment-3770388309:
> 👋 @rayane-d I just tested on `main` and also on this PR (without the fix) and I'm no longer able to reproduce the original bug of duplicate IOU actions. Thus i think we can go ahead and remove that `Handle cleanup of stale optimistic IOU report and its report preview separately` section.

https://github.com/user-attachments/assets/257ec33c-7ebd-4636-9120-904b1b4b2cdd


https://github.com/user-attachments/assets/9590bca9-648b-4d00-b6cf-7135b0ee82a8



