### PR TITLE
fix: derive currentReceipt from page to fix wrong receipt deletion

### DIFF
--- a/src/pages/iou/request/step/IOURequestStepScan/ReceiptView/index.tsx
+++ b/src/pages/iou/request/step/IOURequestStepScan/ReceiptView/index.tsx
@@ -39,7 +39,6 @@ function ReceiptView({route}: ReceiptViewProps) {
     const {shouldShowArrows, setShouldShowArrows, autoHideArrows, cancelAutoHideArrows} = useCarouselArrows();
     const styles = useThemeStyles();
     const expensifyIcons = useMemoizedLazyExpensifyIcons(['Trashcan'] as const);
-    const [currentReceipt, setCurrentReceipt] = useState<ReceiptWithTransactionIDAndSource | null>();
     const [page, setPage] = useState<number>(-1);
     const {showConfirmModal} = useConfirmModal();
 
@@ -47,17 +46,20 @@ function ReceiptView({route}: ReceiptViewProps) {
         selector: transactionDraftReceiptsViewSelector,
         canBeMissing: true,
     });
+
+    // Derive currentReceipt from page - always in sync with carousel position
+    const currentReceipt = page >= 0 ? receipts.at(page) : undefined;
+
     const secondTransactionID = receipts.at(1)?.transactionID;
     const [secondTransaction] = useOnyx(`${ONYXKEYS.COLLECTION.TRANSACTION_DRAFT}${secondTransactionID}`, {canBeMissing: true});
+
+    // Set initial page based on route transactionID
     useEffect(() => {
         if (!receipts || receipts.length === 0) {
             return;
         }
 
-        const activeReceipt = receipts.find((receipt) => receipt.transactionID === route?.params?.transactionID);
-        const activeReceiptIndex = receipts.findIndex((receipt) => receipt.transactionID === activeReceipt?.transactionID);
-
-        setCurrentReceipt(activeReceipt);
+        const activeReceiptIndex = receipts.findIndex((receipt) => receipt.transactionID === route?.params?.transactionID);
         setPage(activeReceiptIndex);
     }, [receipts, route?.params?.transactionID]);
 


### PR DESCRIPTION
### Explanation of Change

In the Money Requests multi-scan flow, the `ReceiptView` component maintained two pieces of state that should stay in sync but didn't:
- `page` - the current carousel index, updated when user navigates via arrows
- `currentReceipt` - the receipt object used for deletion

The `currentReceipt` was only updated via a `useEffect` that depended on `route.params.transactionID`, which doesn't change during carousel navigation. This caused the delete action to remove the originally opened receipt instead of the currently viewed one.

This fix derives `currentReceipt` directly from the `page` index instead of storing it as separate state, ensuring it always reflects the currently displayed receipt.

### Fixed Issues
$ https://github.com/Expensify/App/issues/79304
PROPOSAL: <!-- add your proposal link here -->

### Tests
1. FAB → Scan → Enable multiple scan
2. Capture 4 receipts
3. Tap on the last receipt preview (4th) to open fullscreen view
4. Click the left navigation arrow to view the 3rd receipt
5. Click delete
6. Verify the 3rd receipt (currently viewed) is deleted, not the 4th

- [x] Verify that no errors appear in the JS console

### Offline tests
N/A - This flow requires camera/receipt capture which doesn't function offline.

### QA Steps
Same as tests.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I verified there are no new alerts related to the `canBeMissing` param for `useOnyx`
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- drag and drop video here -->

https://github.com/user-attachments/assets/c6224f25-144d-408b-ac82-0b4765e1d185


</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- drag and drop video here -->

https://github.com/user-attachments/assets/c076be44-2c75-4193-a957-e5b34c8a8879


</details>

<details>
<summary>iOS: Native</summary>

<!-- drag and drop video here -->

https://github.com/user-attachments/assets/b9acbe0b-959c-484b-99ce-efed32db9fa0


</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- drag and drop video here -->

https://github.com/user-attachments/assets/087b0d5a-fc66-416a-bc7e-d058f93309a3


</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- drag and drop video here -->

https://github.com/user-attachments/assets/8a5e675f-55f2-4b48-864a-1a5ec6e998a9


</details>
