### PR TITLE
Refactor SplashScreenStateContext to improve performance and usability

### DIFF
--- a/src/Expensify.tsx
+++ b/src/Expensify.tsx
@@ -55,7 +55,7 @@ import ONYXKEYS from './ONYXKEYS';
 import PopoverReportActionContextMenu from './pages/home/report/ContextMenu/PopoverReportActionContextMenu';
 import * as ReportActionContextMenu from './pages/home/report/ContextMenu/ReportActionContextMenu';
 import type {Route} from './ROUTES';
-import SplashScreenStateContext from './SplashScreenStateContext';
+import {useSplashScreenActions, useSplashScreenState} from './SplashScreenStateContext';
 import type {ScreenShareRequest} from './types/onyx';
 import isLoadingOnyxValue from './types/utils/isLoadingOnyxValue';
 
@@ -101,7 +101,8 @@ function Expensify() {
     const linkingChangeListener = useRef<NativeEventSubscription | null>(null);
     const [isNavigationReady, setIsNavigationReady] = useState(false);
     const [isOnyxMigrated, setIsOnyxMigrated] = useState(false);
-    const {splashScreenState, setSplashScreenState} = useContext(SplashScreenStateContext);
+    const {splashScreenState} = useSplashScreenState();
+    const {setSplashScreenState} = useSplashScreenActions();
     const [hasAttemptedToOpenPublicRoom, setAttemptedToOpenPublicRoom] = useState(false);
     const {translate, preferredLocale} = useLocalize();
     const [account] = useOnyx(ONYXKEYS.ACCOUNT, {canBeMissing: true});

--- a/src/SplashScreenStateContext.tsx
+++ b/src/SplashScreenStateContext.tsx
@@ -1,34 +1,69 @@
-import React, {useContext, useMemo, useState} from 'react';
+import React, {useContext, useState} from 'react';
 import type {ValueOf} from 'type-fest';
 import CONST from './CONST';
 import type ChildrenProps from './types/utils/ChildrenProps';
 
+type SplashScreenState = ValueOf<typeof CONST.BOOT_SPLASH_STATE>;
+
 type SplashScreenStateContextType = {
-    splashScreenState: ValueOf<typeof CONST.BOOT_SPLASH_STATE>;
-    setSplashScreenState: React.Dispatch<React.SetStateAction<ValueOf<typeof CONST.BOOT_SPLASH_STATE>>>;
+    splashScreenState: SplashScreenState;
+};
+
+type SplashScreenActionsContextType = {
+    setSplashScreenState: React.Dispatch<React.SetStateAction<SplashScreenState>>;
 };
 
 const SplashScreenStateContext = React.createContext<SplashScreenStateContextType>({
     splashScreenState: CONST.BOOT_SPLASH_STATE.VISIBLE,
+});
+
+const SplashScreenActionsContext = React.createContext<SplashScreenActionsContextType>({
     setSplashScreenState: () => {},
 });
 
 function SplashScreenStateContextProvider({children}: ChildrenProps) {
-    const [splashScreenState, setSplashScreenState] = useState<ValueOf<typeof CONST.BOOT_SPLASH_STATE>>(CONST.BOOT_SPLASH_STATE.VISIBLE);
-    const splashScreenStateContext = useMemo(
-        () => ({
-            splashScreenState,
-            setSplashScreenState,
-        }),
-        [splashScreenState],
-    );
+    const [splashScreenState, setSplashScreenState] = useState<SplashScreenState>(CONST.BOOT_SPLASH_STATE.VISIBLE);
 
-    return <SplashScreenStateContext.Provider value={splashScreenStateContext}>{children}</SplashScreenStateContext.Provider>;
+    // Because of the React Compiler we don't need to memoize it manually
+    // eslint-disable-next-line react/jsx-no-constructed-context-values
+    const stateValue = {splashScreenState};
+
+    // Because of the React Compiler we don't need to memoize it manually
+    // eslint-disable-next-line react/jsx-no-constructed-context-values
+    const actionsValue = {setSplashScreenState};
+
+    return (
+        <SplashScreenActionsContext.Provider value={actionsValue}>
+            <SplashScreenStateContext.Provider value={stateValue}>{children}</SplashScreenStateContext.Provider>
+        </SplashScreenActionsContext.Provider>
+    );
 }
 
-function useSplashScreenStateContext() {
+/**
+ * Hook to get the splash screen state.
+ * Use this when you need to read the current splash screen state.
+ */
+function useSplashScreenState() {
     return useContext(SplashScreenStateContext);
 }
 
+/**
+ * Hook to get splash screen actions.
+ * Use this when you only need to update the splash screen state without reading it.
+ */
+function useSplashScreenActions() {
+    return useContext(SplashScreenActionsContext);
+}
+
+/**
+ * @deprecated Use useSplashScreenState() or useSplashScreenActions() instead for better performance.
+ * This hook is kept for backwards compatibility and will cause re-renders on any state change.
+ */
+function useSplashScreenStateContext() {
+    const {splashScreenState} = useSplashScreenState();
+    const {setSplashScreenState} = useSplashScreenActions();
+    return {splashScreenState, setSplashScreenState};
+}
+
 export default SplashScreenStateContext;
-export {SplashScreenStateContextProvider, useSplashScreenStateContext};
+export {SplashScreenStateContextProvider, useSplashScreenStateContext, useSplashScreenState, useSplashScreenActions};

--- a/src/components/ErrorBoundary/BaseErrorBoundary.tsx
+++ b/src/components/ErrorBoundary/BaseErrorBoundary.tsx
@@ -4,7 +4,7 @@ import BootSplash from '@libs/BootSplash';
 import GenericErrorPage from '@pages/ErrorPage/GenericErrorPage';
 import UpdateRequiredView from '@pages/ErrorPage/UpdateRequiredView';
 import CONST from '@src/CONST';
-import {useSplashScreenStateContext} from '@src/SplashScreenStateContext';
+import {useSplashScreenActions} from '@src/SplashScreenStateContext';
 import type {BaseErrorBoundaryProps} from './types';
 
 /**
@@ -15,7 +15,7 @@ import type {BaseErrorBoundaryProps} from './types';
 
 function BaseErrorBoundary({logError = () => {}, errorMessage, children}: BaseErrorBoundaryProps) {
     const [errorContent, setErrorContent] = useState('');
-    const {setSplashScreenState} = useSplashScreenStateContext();
+    const {setSplashScreenState} = useSplashScreenActions();
 
     const catchError = (errorObject: Error, errorInfo: React.ErrorInfo) => {
         logError(errorMessage, errorObject, JSON.stringify(errorInfo));

--- a/src/components/Lottie/index.tsx
+++ b/src/components/Lottie/index.tsx
@@ -11,7 +11,7 @@ import useThemeStyles from '@hooks/useThemeStyles';
 import {getBrowser, isMobile} from '@libs/Browser';
 import isSideModalNavigator from '@libs/Navigation/helpers/isSideModalNavigator';
 import CONST from '@src/CONST';
-import {useSplashScreenStateContext} from '@src/SplashScreenStateContext';
+import {useSplashScreenState} from '@src/SplashScreenStateContext';
 
 type Props = {
     source: DotLottieAnimation;
@@ -22,7 +22,7 @@ type Props = {
 function Lottie({source, webStyle, shouldLoadAfterInteractions, ref, ...props}: Props) {
     const animationRef = useRef<LottieView | null>(null);
     const appState = useAppState();
-    const {splashScreenState} = useSplashScreenStateContext();
+    const {splashScreenState} = useSplashScreenState();
     const styles = useThemeStyles();
     const [isError, setIsError] = React.useState(false);
 

--- a/src/hooks/useAutoFocusInput.ts
+++ b/src/hooks/useAutoFocusInput.ts
@@ -8,7 +8,7 @@ import {moveSelectionToEnd, scrollToBottom} from '@libs/InputUtils';
 import isWindowReadyToFocus from '@libs/isWindowReadyToFocus';
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
-import {useSplashScreenStateContext} from '@src/SplashScreenStateContext';
+import {useSplashScreenState} from '@src/SplashScreenStateContext';
 import useOnyx from './useOnyx';
 import usePrevious from './usePrevious';
 import useSidePanel from './useSidePanel';
@@ -24,7 +24,7 @@ export default function useAutoFocusInput(isMultiline = false): UseAutoFocusInpu
     const [modal] = useOnyx(ONYXKEYS.MODAL, {canBeMissing: true});
     const isPopoverVisible = modal?.willAlertModalBecomeVisible && modal?.isPopover;
 
-    const {splashScreenState} = useSplashScreenStateContext();
+    const {splashScreenState} = useSplashScreenState();
 
     const inputRef = useRef<TextInput | null>(null);
     const focusTimeoutRef = useRef<NodeJS.Timeout | null>(null);

--- a/src/pages/signin/SignInPageLayout/BackgroundImage/index.native.tsx
+++ b/src/pages/signin/SignInPageLayout/BackgroundImage/index.native.tsx
@@ -8,7 +8,7 @@ import useStyleUtils from '@hooks/useStyleUtils';
 import useThemeStyles from '@hooks/useThemeStyles';
 import {isAnonymousUser} from '@libs/actions/Session';
 import CONST from '@src/CONST';
-import {useSplashScreenStateContext} from '@src/SplashScreenStateContext';
+import {useSplashScreenState} from '@src/SplashScreenStateContext';
 import type BackgroundImageProps from './types';
 
 function BackgroundImage({width}: BackgroundImageProps) {
@@ -45,7 +45,7 @@ function BackgroundImage({width}: BackgroundImageProps) {
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
 
-    const {splashScreenState} = useSplashScreenStateContext();
+    const {splashScreenState} = useSplashScreenState();
     // Prevent rendering the background image until the splash screen is hidden.
     // See issue: https://github.com/Expensify/App/issues/34696
     if (splashScreenState !== CONST.BOOT_SPLASH_STATE.HIDDEN || (!isInteractionComplete && isAnonymous)) {


### PR DESCRIPTION

<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

## Details

This PR refactors `SplashScreenStateContext` to separate state and actions into distinct contexts, following the pattern established in #79753.

### Problem
Components that consume only actions from the context provider (like `setSplashScreenState`) are still subject to re-renders on context updates, even when they don't depend on the provider's state. This causes unnecessary re-renders across the app.

### Solution
Separate State and Actions within the context provider by exposing two independent providers:
- `SplashScreenStateContext` - for state (`splashScreenState`)
- `SplashScreenActionsContext` - for actions (`setSplashScreenState`)

This allows components to subscribe only to what they actually need:
- Components that depend on state will re-render only when state changes
- Components that use only actions will remain stable and will not re-render in response to state updates

### New Hooks
- `useSplashScreenState()` - Use when you need to read the splash screen state
- `useSplashScreenActions()` - Use when you only need to update the splash screen state

The deprecated `useSplashScreenStateContext()` is kept for backwards compatibility.

## Fixed Issues
<!-- Link to the GitHub issue this PR addresses -->

## Tests

1. Open the app
2. Verify the splash screen hides correctly
3. Navigate through the app - ensure no regressions in splash screen behavior
4. Sign out and sign in - verify splash screen works on subsequent loads

## Offline tests

N/A - splash screen behavior is not affected by offline state

## QA Steps

Same as Tests section above.

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I verified there are no new alerts related to the `canBeMissing` param for `useOnyx`
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>