### PR TITLE
fix flight number being used as seat number

### DIFF
--- a/src/CONST/index.ts
+++ b/src/CONST/index.ts
@@ -6680,6 +6680,8 @@ const CONST = {
 
     RESERVATION_ADDRESS_TEST_ID: 'ReservationAddress',
 
+    FLIGHT_SEAT_TEST_ID: 'FlightSeat',
+
     CANCELLATION_POLICY: {
         UNKNOWN: 'UNKNOWN',
         NON_REFUNDABLE: 'NON_REFUNDABLE',

--- a/src/libs/TripReservationUtils.ts
+++ b/src/libs/TripReservationUtils.ts
@@ -84,7 +84,7 @@ function parseDurationToSeconds(duration: string): number {
 function getSeatByLegAndFlight(travelerInfo: ArrayValues<AirPnr['travelerInfos']>, legIdx: number, flightIdx: number): string | undefined {
     const seats = travelerInfo.booking?.seats?.filter((seat) => seat.legIdx === legIdx && seat.flightIdx === flightIdx);
     if (seats && seats.length > 0) {
-        return seats.map(SafeString).join(', ');
+        return seats.map((seat) => SafeString(seat.number)).join(', ');
     }
     return '';
 }

--- a/src/pages/Travel/FlightTripDetails.tsx
+++ b/src/pages/Travel/FlightTripDetails.tsx
@@ -108,6 +108,7 @@ function FlightTripDetails({reservation, prevReservation, personalDetails}: Flig
                             interactive={false}
                             copyValue={reservation.seatNumber}
                             copyable={!!reservation.seatNumber?.length}
+                            pressableTestID={CONST.FLIGHT_SEAT_TEST_ID}
                         />
                     </View>
                 )}

--- a/src/pages/Travel/FlightTripDetails.tsx
+++ b/src/pages/Travel/FlightTripDetails.tsx
@@ -100,14 +100,14 @@ function FlightTripDetails({reservation, prevReservation, personalDetails}: Flig
             />
 
             <View style={[styles.flexRow, styles.flexWrap]}>
-                {!!reservation.route?.number && (
+                {!!reservation.seatNumber && (
                     <View style={styles.w50}>
                         <MenuItemWithTopDescription
                             description={translate('travel.flightDetails.seat')}
-                            title={reservation.route?.number}
+                            title={reservation.seatNumber}
                             interactive={false}
-                            copyValue={reservation.route?.number}
-                            copyable={!!reservation.route?.number?.length}
+                            copyValue={reservation.seatNumber}
+                            copyable={!!reservation.seatNumber?.length}
                         />
                     </View>
                 )}

--- a/src/types/onyx/TripData.ts
+++ b/src/types/onyx/TripData.ts
@@ -584,8 +584,8 @@ type AirPnr = {
                 flightIdx: number;
                 /** Amount for the seat. */
                 amount: number;
-                /** Number of the seat. */
-                number: number;
+                /** Number of the seat (e.g., "12A", "7F"). */
+                number: string;
             }>;
         };
         /** Passenger type for the traveler. */

--- a/tests/data/TripAirReservationData.ts
+++ b/tests/data/TripAirReservationData.ts
@@ -167,7 +167,7 @@ const airReservationPnrData: Pnr = {
                             {
                                 legIdx: 0,
                                 flightIdx: 0,
-                                number: 12,
+                                number: '12A',
                                 amount: 0,
                             },
                         ],

--- a/tests/ui/FlightTripDetailsTest.tsx
+++ b/tests/ui/FlightTripDetailsTest.tsx
@@ -1,0 +1,105 @@
+import {render, screen} from '@testing-library/react-native';
+import FlightTripDetails from '@pages/Travel/FlightTripDetails';
+import CONST from '@src/CONST';
+import type {Reservation} from '@src/types/onyx/Transaction';
+
+jest.mock('@hooks/useScreenWrapperTransitionStatus', () => ({
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    __esModule: true,
+    default: () => ({
+        didScreenTransitionEnd: true,
+    }),
+}));
+
+const mockFlightReservation: Reservation = {
+    company: {
+        shortName: 'AS',
+        phone: '',
+        longName: 'Alaska Airlines, Inc.',
+    },
+    start: {
+        date: '2026-01-25T10:08:00Z',
+        shortName: 'DEN',
+        longName: 'Denver Intl',
+        cityName: 'Denver, CO, USA',
+    },
+    end: {
+        date: '2026-01-25T11:58:00Z',
+        shortName: 'SFO',
+        longName: 'San Francisco Intl',
+        cityName: 'San Francisco, CA, USA',
+    },
+    route: {
+        number: '725', // This is the FLIGHT number
+        airlineCode: 'AS725',
+        class: 'ECONOMY',
+    },
+    confirmations: [
+        {
+            name: 'Confirmation Number',
+            value: 'CONF123',
+        },
+    ],
+    seatNumber: '18D', // This is the ACTUAL seat number
+    type: CONST.RESERVATION_TYPE.FLIGHT,
+    duration: 6600, // 1h 50m in seconds
+    travelerPersonalInfo: {
+        name: 'John Doe',
+        email: 'john.doe@example.com',
+    },
+};
+
+describe('FlightTripDetailsTest', () => {
+    it('should display the actual seat number, not the flight number', () => {
+        render(
+            <FlightTripDetails
+                reservation={mockFlightReservation}
+                prevReservation={undefined}
+                personalDetails={undefined}
+            />,
+        );
+
+        // The seat field should display the actual seat number "18D"
+        // and NOT the flight number "725" from route.number
+        const seatElement = screen.getByTestId(CONST.FLIGHT_SEAT_TEST_ID);
+        expect(seatElement).toHaveTextContent('18D');
+        expect(seatElement).not.toHaveTextContent('725');
+    });
+
+    it('should not display seat section when seatNumber is empty', () => {
+        const reservationWithoutSeat: Reservation = {
+            ...mockFlightReservation,
+            seatNumber: undefined,
+        };
+
+        render(
+            <FlightTripDetails
+                reservation={reservationWithoutSeat}
+                prevReservation={undefined}
+                personalDetails={undefined}
+            />,
+        );
+
+        // The seat field should not be rendered when there's no seat number
+        expect(screen.queryByTestId(CONST.FLIGHT_SEAT_TEST_ID)).toBeNull();
+    });
+
+    it('should still not display flight number as seat even when seatNumber is empty', () => {
+        const reservationWithoutSeat: Reservation = {
+            ...mockFlightReservation,
+            seatNumber: undefined,
+        };
+
+        render(
+            <FlightTripDetails
+                reservation={reservationWithoutSeat}
+                prevReservation={undefined}
+                personalDetails={undefined}
+            />,
+        );
+
+        // Even with a route.number present, we should NOT see a seat section
+        // because the actual seatNumber is empty
+        expect(screen.queryByTestId(CONST.FLIGHT_SEAT_TEST_ID)).toBeNull();
+    });
+});

--- a/tests/ui/FlightTripDetailsTest.tsx
+++ b/tests/ui/FlightTripDetailsTest.tsx
@@ -30,7 +30,7 @@ const mockFlightReservation: Reservation = {
         cityName: 'San Francisco, CA, USA',
     },
     route: {
-        number: '725', // This is the FLIGHT number
+        number: '725',
         airlineCode: 'AS725',
         class: 'ECONOMY',
     },
@@ -40,9 +40,9 @@ const mockFlightReservation: Reservation = {
             value: 'CONF123',
         },
     ],
-    seatNumber: '18D', // This is the ACTUAL seat number
+    seatNumber: '18D',
     type: CONST.RESERVATION_TYPE.FLIGHT,
-    duration: 6600, // 1h 50m in seconds
+    duration: 6600,
     travelerPersonalInfo: {
         name: 'John Doe',
         email: 'john.doe@example.com',
@@ -50,7 +50,7 @@ const mockFlightReservation: Reservation = {
 };
 
 describe('FlightTripDetailsTest', () => {
-    it('should display the actual seat number, not the flight number', () => {
+    it('should display the actual seat number correctly', () => {
         render(
             <FlightTripDetails
                 reservation={mockFlightReservation}
@@ -59,8 +59,6 @@ describe('FlightTripDetailsTest', () => {
             />,
         );
 
-        // The seat field should display the actual seat number "18D"
-        // and NOT the flight number "725" from route.number
         const seatElement = screen.getByTestId(CONST.FLIGHT_SEAT_TEST_ID);
         expect(seatElement).toHaveTextContent('18D');
         expect(seatElement).not.toHaveTextContent('725');
@@ -84,7 +82,7 @@ describe('FlightTripDetailsTest', () => {
         expect(screen.queryByTestId(CONST.FLIGHT_SEAT_TEST_ID)).toBeNull();
     });
 
-    it('should still not display flight number as seat even when seatNumber is empty', () => {
+    it('should still not display flight number as seat when seatNumber is empty', () => {
         const reservationWithoutSeat: Reservation = {
             ...mockFlightReservation,
             seatNumber: undefined,
@@ -98,8 +96,6 @@ describe('FlightTripDetailsTest', () => {
             />,
         );
 
-        // Even with a route.number present, we should NOT see a seat section
-        // because the actual seatNumber is empty
         expect(screen.queryByTestId(CONST.FLIGHT_SEAT_TEST_ID)).toBeNull();
     });
 });

--- a/tests/unit/TripReservationUtilsTest.ts
+++ b/tests/unit/TripReservationUtilsTest.ts
@@ -2277,6 +2277,26 @@ describe('TripReservationUtils', () => {
             expect(result.at(0)?.reservation.legId).toBe(0);
             expect(result.at(1)?.reservation.legId).toBe(1);
         });
+
+        it('should correctly extract the seat number from the seats array', () => {
+            const result = getAirReservations(airReservationPnrData, airReservationTravelers);
+
+            // The first leg has a seat assigned ("12A")
+            expect(result.at(0)?.reservation.seatNumber).toBe('12A');
+
+            // The second leg has no seat assigned (empty string)
+            expect(result.at(1)?.reservation.seatNumber).toBe('');
+        });
+
+        it('should not serialize the entire seat object as the seat number', () => {
+            const result = getAirReservations(airReservationPnrData, airReservationTravelers);
+
+            // Verify the seat number is just the value, not a JSON object
+            const seatNumber = result.at(0)?.reservation.seatNumber;
+            expect(seatNumber).not.toContain('{');
+            expect(seatNumber).not.toContain('amount');
+            expect(seatNumber).not.toContain('legIdx');
+        });
     });
     describe('getReservationsFromTripReport', () => {
         it('should return an empty array when there are no transactions and trip payload', () => {

--- a/tests/unit/TripReservationUtilsTest.ts
+++ b/tests/unit/TripReservationUtilsTest.ts
@@ -178,7 +178,7 @@ const airPnrDirect: Pnr = {
                                 legIdx: 0,
                                 flightIdx: 0,
                                 amount: 0,
-                                number: 0,
+                                number: '14C',
                             },
                         ],
                         itinerary: {


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
<!-- Explain what your change does and how it addresses the linked issue -->

We were using the flight number as the seat number for trips. See [this thread](https://expensify.slack.com/archives/C05S5EV2JTX/p1769042200284269) for details.

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/Expensify/issues/591388
PROPOSAL:


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

Prereq: be a member of a travel enabled workspace
1. book a one-way flight
2. In the spotnana UI (staging.travel.expensify.com) go to **Trips > your trip** and note the seat number
3. in the expensify app go to the trip you just booked and open up the trip details
4. confirm that under "Seat Number" you see the seat number that you saw in Spotnana and that it matches up

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->

same as tests

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I verified there are no new alerts related to the `canBeMissing` param for `useOnyx`
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I verified that similar component doesn't exist in the codebase
- [x] I verified that all props are defined accurately and each prop has a `/** comment above it */`
- [x] I verified that each file is named correctly
- [x] I verified that each component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
- [x] I verified that the only data being stored in component state is data necessary for rendering and nothing else
- [x] In component if we are not using the full Onyx data that we loaded, I've added the proper selector in order to ensure the component only re-renders when the data it is using changes
- [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
- [x] I verified that component internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
- [x] I verified that all JSX used for rendering exists in the render method
- [x] I verified that each component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>

## Before my changes

<img width="1920" height="956" alt="Screenshot 2026-01-21 at 5 32 10 PM" src="https://github.com/user-attachments/assets/24240e9b-9008-454c-ba1d-907557e175a3" />

## After my changes
<img width="1920" height="956" alt="Screenshot 2026-01-21 at 5 31 29 PM" src="https://github.com/user-attachments/assets/a1081eee-3c14-4f78-96f7-8eec4a586f53" />