### PR TITLE
Fix group-by autocomplete appearing incorrectly in Chats search

### DIFF
--- a/src/components/Search/SearchAutocompleteList.tsx
+++ b/src/components/Search/SearchAutocompleteList.tsx
@@ -111,6 +111,9 @@ type SearchAutocompleteListProps = {
     /** All cards */
     allCards: CardList;
 
+    /** The current search context type (from queryJSON) */
+    contextType?: SearchDataTypes;
+
     /** Reference to the outer element */
     ref?: ForwardedRef<SelectionListHandle>;
 };
@@ -183,6 +186,7 @@ function SearchAutocompleteList({
     reports,
     allFeeds,
     allCards,
+    contextType,
     ref,
 }: SearchAutocompleteListProps) {
     const styles = useThemeStyles();
@@ -224,7 +228,7 @@ function SearchAutocompleteList({
     const [isInitialRender, setIsInitialRender] = useState(true);
     const parsedQuery = useMemo(() => parseForAutocomplete(autocompleteQueryValue), [autocompleteQueryValue]);
     const typeFilter = parsedQuery?.ranges?.find((range) => range.key === CONST.SEARCH.SYNTAX_ROOT_KEYS.TYPE);
-    const currentType = (typeFilter?.value ?? CONST.SEARCH.DATA_TYPES.EXPENSE) as SearchDataTypes;
+    const currentType = (typeFilter?.value ?? contextType ?? CONST.SEARCH.DATA_TYPES.EXPENSE) as SearchDataTypes;
 
     const groupByAutocompleteList = useMemo(() => {
         switch (currentType) {

--- a/src/components/Search/SearchPageHeader/SearchPageHeaderInput.tsx
+++ b/src/components/Search/SearchPageHeader/SearchPageHeaderInput.tsx
@@ -66,7 +66,7 @@ function SearchPageHeaderInput({queryJSON, searchRouterListVisible, hideSearchRo
     const [workspaceCardFeeds] = useOnyx(ONYXKEYS.COLLECTION.WORKSPACE_CARDS_LIST, {canBeMissing: true});
     const allCards = useMemo(() => mergeCardListWithWorkspaceFeeds(workspaceCardFeeds ?? CONST.EMPTY_OBJECT, userCardList), [userCardList, workspaceCardFeeds]);
     const [allFeeds] = useOnyx(ONYXKEYS.COLLECTION.SHARED_NVP_PRIVATE_DOMAIN_MEMBER, {canBeMissing: true});
-    const {inputQuery: originalInputQuery} = queryJSON;
+    const {inputQuery: originalInputQuery, type: currentSearchType} = queryJSON;
     const [currentUserAccountID = -1] = useOnyx(ONYXKEYS.SESSION, {selector: accountIDSelector, canBeMissing: false});
     const queryText = buildUserReadableQueryString(queryJSON, personalDetails, reports, taxRates, allCards, allFeeds, policies, currentUserAccountID, true);
 
@@ -402,6 +402,7 @@ function SearchPageHeaderInput({queryJSON, searchRouterListVisible, hideSearchRo
                                 reports={reports}
                                 allCards={allCards}
                                 allFeeds={allFeeds}
+                                contextType={currentSearchType}
                             />
                         </View>
                     )}
@@ -476,6 +477,7 @@ function SearchPageHeaderInput({queryJSON, searchRouterListVisible, hideSearchRo
                                 reports={reports}
                                 allCards={allCards}
                                 allFeeds={allFeeds}
+                                contextType={currentSearchType}
                             />
                         </View>
                     )}


### PR DESCRIPTION
### Explanation of Change
When searching in Reports > Chats and typing "group-by:", autocomplete suggestions were incorrectly appearing even though group-by is not a valid filter for chats. This occurred because the SearchAutocompleteList component defaulted to EXPENSE type when no explicit type filter was present in the query, causing it to show group-by suggestions.

The fix adds a contextType prop to SearchAutocompleteList that receives the current search type from queryJSON. This creates a precedence chain: explicit type in query > page context type > default to EXPENSE.

### Fixed Issues
$ https://github.com/Expensify/App/issues/79783
PROPOSAL: https://github.com/Expensify/App/issues/79783#issuecomment-3761108938

### Tests
1. Navigate to Reports > Chats
2. Click in the search input
3. Type "group-by:"
4. Verify no autocomplete suggestions appear
5. Navigate to Reports > Expenses  
6. Click in the search input
7. Type "group-by:"
8. Verify autocomplete suggestions appear (group-by:from, group-by:card, group-by:withdrawal-id)

- [x] Verify that no errors appear in the JS console

### Offline tests
Not applicable - this is a UI autocomplete behavior that doesn't depend on network state.

### QA Steps
Same as Tests

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
- [x] I linked the correct issue in the ### Fixed Issues section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the Tests section
    - [x] I added steps for the expected offline behavior in the Offline steps section
    - [x] I added steps for Staging and/or Production testing in the QA steps section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [ ] I tested this PR with a High Traffic account against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on all platforms
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [ ] Android: Native
    - [ ] Android: mWeb Chrome
    - [ ] iOS: Native
    - [ ] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I verified there are no new alerts related to the canBeMissing param for useOnyx
- [x] I followed proper code patterns (see Reviewing the code)
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. toggleReport and not onIconClick)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to src/languages/* files and using the translation method
      - [x] If any non-english text was added/modified, I used JaimeGPT to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the localization methods
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in STYLE.md) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the Review Guidelines
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like Avatar, I verified the components using Avatar are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing StyleUtils function (i.e. StyleUtils.getBackgroundAndBorderStyle(theme.componentBG))
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run npm run compress-svg)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like Avatar is modified, I verified that Avatar is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [ ] I added Design label and/or tagged @Expensify/design so the design team can review the changes.
- [x] If a new page is added, I verified it's using the ScrollView component to make it scrollable when more elements are added to the page.
- [ ] I added unit tests for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the main branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the Test steps.

### Screenshots/Videos
<details>
<summary>MacOS: Chrome / Safari</summary>

**Before (Bug):**
Typing "group-by:" in Chats shows autocomplete suggestions incorrectly

**After (Fixed):**
Typing "group-by:" in Chats shows no suggestions, but Expenses still shows suggestions correctly

</details>