### PR TITLE
[WIP][POC] Lock users on NewApp on mobile

### DIFF
--- a/src/libs/HybridApp.ts
+++ b/src/libs/HybridApp.ts
@@ -64,7 +64,7 @@ function shouldUseOldApp(tryNewDot: TryNewDot) {
         return true;
     }
 
-    if (tryNewDot.classicRedirect.isLockedToNewApp === true) {
+    if (tryNewDot.isLockedToNewApp) {
         return false;
     }
 

--- a/src/libs/HybridApp.ts
+++ b/src/libs/HybridApp.ts
@@ -63,11 +63,13 @@ function shouldUseOldApp(tryNewDot: TryNewDot) {
     if (isEmptyObject(tryNewDot) || isEmptyObject(tryNewDot.classicRedirect)) {
         return true;
     }
+    
+    console.log('tryNewDot', tryNewDot);
 
-    if (tryNewDot.classicRedirect.isLockedToNewApp) {
+    if (tryNewDot.classicRedirect.isLockedToNewApp === true || tryNewDot.classicRedirect.isLockedToNewApp === 'true') {
         return false;
     }
-    
+
     return tryNewDot.classicRedirect.dismissed;
 }
 

--- a/src/libs/HybridApp.ts
+++ b/src/libs/HybridApp.ts
@@ -63,6 +63,11 @@ function shouldUseOldApp(tryNewDot: TryNewDot) {
     if (isEmptyObject(tryNewDot) || isEmptyObject(tryNewDot.classicRedirect)) {
         return true;
     }
+
+    if (tryNewDot.classicRedirect.isLockedToNewApp) {
+        return false;
+    }
+    
     return tryNewDot.classicRedirect.dismissed;
 }
 

--- a/src/libs/HybridApp.ts
+++ b/src/libs/HybridApp.ts
@@ -63,10 +63,8 @@ function shouldUseOldApp(tryNewDot: TryNewDot) {
     if (isEmptyObject(tryNewDot) || isEmptyObject(tryNewDot.classicRedirect)) {
         return true;
     }
-    
-    console.log('tryNewDot', tryNewDot);
 
-    if (tryNewDot.classicRedirect.isLockedToNewApp === true || tryNewDot.classicRedirect.isLockedToNewApp === 'true') {
+    if (tryNewDot.classicRedirect.isLockedToNewApp === true) {
         return false;
     }
 

--- a/src/pages/settings/Troubleshoot/TroubleshootPage.tsx
+++ b/src/pages/settings/Troubleshoot/TroubleshootPage.tsx
@@ -1,6 +1,7 @@
 import {differenceInDays} from 'date-fns';
 import React, {useCallback, useMemo, useState} from 'react';
 import {View} from 'react-native';
+import getPlatform from '@libs/getPlatform';
 import ConfirmModal from '@components/ConfirmModal';
 import FullScreenLoadingIndicator from '@components/FullscreenLoadingIndicator';
 import HeaderWithBackButton from '@components/HeaderWithBackButton';
@@ -96,6 +97,12 @@ function TroubleshootPage() {
     }, [tryNewDot?.classicRedirect]);
 
     const classicRedirectMenuItem: BaseMenuItem | null = useMemo(() => {
+        const platform = getPlatform();
+        const isMobileApp = [CONST.PLATFORM.IOS, CONST.PLATFORM.ANDROID].includes(platform as 'ios' | 'android');
+        if (tryNewDot?.classicRedirect?.isLockedToNewApp && isMobileApp) {
+            return null;
+        }
+
         if (tryNewDot?.classicRedirect?.isLockedToNewDot) {
             return null;
         }

--- a/src/pages/settings/Troubleshoot/TroubleshootPage.tsx
+++ b/src/pages/settings/Troubleshoot/TroubleshootPage.tsx
@@ -99,6 +99,7 @@ function TroubleshootPage() {
     const classicRedirectMenuItem: BaseMenuItem | null = useMemo(() => {
         const platform = getPlatform();
         const isMobileApp = [CONST.PLATFORM.IOS, CONST.PLATFORM.ANDROID].includes(platform as 'ios' | 'android');
+        
         if (tryNewDot?.classicRedirect?.isLockedToNewApp && isMobileApp) {
             return null;
         }

--- a/src/pages/settings/Troubleshoot/TroubleshootPage.tsx
+++ b/src/pages/settings/Troubleshoot/TroubleshootPage.tsx
@@ -100,7 +100,7 @@ function TroubleshootPage() {
         const platform = getPlatform();
         const isMobileApp = [CONST.PLATFORM.IOS, CONST.PLATFORM.ANDROID].includes(platform as 'ios' | 'android');
 
-        if (tryNewDot?.classicRedirect?.isLockedToNewApp && isMobileApp) {
+        if (tryNewDot?.isLockedToNewApp && isMobileApp) {
             return null;
         }
 

--- a/src/pages/settings/Troubleshoot/TroubleshootPage.tsx
+++ b/src/pages/settings/Troubleshoot/TroubleshootPage.tsx
@@ -99,7 +99,7 @@ function TroubleshootPage() {
     const classicRedirectMenuItem: BaseMenuItem | null = useMemo(() => {
         const platform = getPlatform();
         const isMobileApp = [CONST.PLATFORM.IOS, CONST.PLATFORM.ANDROID].includes(platform as 'ios' | 'android');
-        
+
         if (tryNewDot?.classicRedirect?.isLockedToNewApp && isMobileApp) {
             return null;
         }

--- a/src/pages/settings/Troubleshoot/TroubleshootPage.tsx
+++ b/src/pages/settings/Troubleshoot/TroubleshootPage.tsx
@@ -1,7 +1,6 @@
 import {differenceInDays} from 'date-fns';
 import React, {useCallback, useMemo, useState} from 'react';
 import {View} from 'react-native';
-import getPlatform from '@libs/getPlatform';
 import ConfirmModal from '@components/ConfirmModal';
 import FullScreenLoadingIndicator from '@components/FullscreenLoadingIndicator';
 import HeaderWithBackButton from '@components/HeaderWithBackButton';
@@ -30,6 +29,7 @@ import {closeReactNativeApp} from '@libs/actions/HybridApp';
 import {openOldDotLink} from '@libs/actions/Link';
 import {setShouldMaskOnyxState} from '@libs/actions/MaskOnyx';
 import ExportOnyxState from '@libs/ExportOnyxState';
+import getPlatform from '@libs/getPlatform';
 import Navigation from '@libs/Navigation/Navigation';
 import colors from '@styles/theme/colors';
 import {clearOnyxAndResetApp} from '@userActions/App';

--- a/src/pages/settings/Troubleshoot/TroubleshootPage.tsx
+++ b/src/pages/settings/Troubleshoot/TroubleshootPage.tsx
@@ -29,7 +29,6 @@ import {closeReactNativeApp} from '@libs/actions/HybridApp';
 import {openOldDotLink} from '@libs/actions/Link';
 import {setShouldMaskOnyxState} from '@libs/actions/MaskOnyx';
 import ExportOnyxState from '@libs/ExportOnyxState';
-import getPlatform from '@libs/getPlatform';
 import Navigation from '@libs/Navigation/Navigation';
 import colors from '@styles/theme/colors';
 import {clearOnyxAndResetApp} from '@userActions/App';
@@ -97,10 +96,7 @@ function TroubleshootPage() {
     }, [tryNewDot?.classicRedirect]);
 
     const classicRedirectMenuItem: BaseMenuItem | null = useMemo(() => {
-        const platform = getPlatform();
-        const isMobileApp = [CONST.PLATFORM.IOS, CONST.PLATFORM.ANDROID].includes(platform as 'ios' | 'android');
-
-        if (tryNewDot?.isLockedToNewApp && isMobileApp) {
+        if (tryNewDot?.isLockedToNewApp && CONFIG.IS_HYBRID_APP) {
             return null;
         }
 

--- a/src/types/onyx/TryNewDot.ts
+++ b/src/types/onyx/TryNewDot.ts
@@ -3,6 +3,11 @@
  */
 type TryNewDot = {
     /**
+     * Indicates whether the user is forced to use the NewApp on mobile.
+     */
+    isLockedToNewApp?: boolean;
+
+    /**
      * This key is mostly used on OldDot. In NewDot, we only use `completedHybridAppOnboarding` and `isLockedToNewDot`.
      */
     classicRedirect?: {
@@ -24,11 +29,6 @@ type TryNewDot = {
          * Indicates whether the user has access to the OldDot transition.
          */
         isLockedToNewDot?: boolean;
-
-        /**
-         * Indicates whether the user is forced to use the NewApp on mobile.
-         */
-        isLockedToNewApp?: boolean;
 
         /**
          * Array of dismissed reasons with timestamps.

--- a/src/types/onyx/TryNewDot.ts
+++ b/src/types/onyx/TryNewDot.ts
@@ -26,6 +26,11 @@ type TryNewDot = {
         isLockedToNewDot?: boolean;
 
         /**
+         * Indicates whether the user is forced to use the NewApp on mobile.
+         */
+        isLockedToNewApp?: boolean;
+
+        /**
          * Array of dismissed reasons with timestamps.
          */
         dismissedReasons?: Array<{


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
<!-- Explain what your change does and how it addresses the linked issue -->

When user logs in to mobile app we have to check if they were locked to use New App on mobile


### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ 
PROPOSAL:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/13829

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

1. Sign on Web and go to Expensify Classic.
2. Open JavaScript console and execute this:
```javascript
NVP.set('tryNewDot', {
  "classicRedirect": {
    "completedHybridAppOnboarding": true,
    "dismissed": true,
    "dismissedReasons": [
      {
        "reason": "force mobile",
        "timestamp": "2026-01-27 18:59:37.769"
      },
      {
        "reason": "force mobile",
        "timestamp": "2026-01-27 18:59:37.947"
      }
    ],
    "timestamp": "2026-01-27T23:35:39.962Z"
  },
  "isLockedToNewApp": true,
  "tappedTryNewExpensifyButton": {
    "timestamp": "2026-01-27T23:35:39.962Z"
  }
})
```
3. Open mobile App and sign in.
4. Verify it opens NewApp.
5. Go to TroubleshootPage.
6. Verify that there's no "Switch to Expensify Classic button".
7. Close app and open it once again.
8. Verify that it still opens NewApp
9. [Android only] Open OldApp deeplink (for example: https://staging.expensify.com/report?reportID=<reportID>)
10. [Android only] Verify that deeplink leads to NewApp.


- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

N/A

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
11. Upload an image via copy paste
12. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->

1. Sign on Web and go to Expensify Classic.
2. Open JavaScript console and execute this:
```javascript
NVP.set('tryNewDot', {
  "classicRedirect": {
    "completedHybridAppOnboarding": true,
    "dismissed": true,
    "dismissedReasons": [
      {
        "reason": "force mobile",
        "timestamp": "2026-01-27 18:59:37.769"
      },
      {
        "reason": "force mobile",
        "timestamp": "2026-01-27 18:59:37.947"
      }
    ],
    "timestamp": "2026-01-27T23:35:39.962Z"
  },
  "isLockedToNewApp": true,
  "tappedTryNewExpensifyButton": {
    "timestamp": "2026-01-27T23:35:39.962Z"
  }
})
```
3. Open mobile App and sign in.
4. Verify it opens NewApp.
5. Go to TroubleshootPage.
6. Verify that there's no "Switch to Expensify Classic button".
7. Close app and open it once again.
8. Verify that it still opens NewApp
9. Open OldApp deeplink (for example: https://staging.expensify.com/report?reportID=<reportID>)
10. Verify that deeplink leads to NewApp.


- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I verified there are no new alerts related to the `canBeMissing` param for `useOnyx`
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->
<img width="1460" height="855" alt="image" src="https://github.com/user-attachments/assets/bca5bbb0-c08b-4f56-bdef-4d094818d012" />


https://github.com/user-attachments/assets/b074bea0-8d21-4f77-a6bd-283094b19501



https://github.com/user-attachments/assets/70d0d8dc-6a64-4530-95e8-fc4a17422716


</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->
N/A
</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/76b05a34-55e6-40bc-b22e-e2327096734d


</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->
N/A
</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->
N/A
</details>