### PR TITLE
Fix: Attendees field shows only title to invited user (#80687)

### DIFF
--- a/src/languages/en.ts
+++ b/src/languages/en.ts
@@ -248,6 +248,7 @@ const translations = {
         optional: 'Optional',
         new: 'New',
         newFeature: 'New feature',
+        fallbackAccountName: ({accountID}: {accountID: number}) => `Account ${accountID}`,
         search: 'Search',
         reports: 'Reports',
         find: 'Find',

--- a/src/languages/es.ts
+++ b/src/languages/es.ts
@@ -247,6 +247,7 @@ const translations: TranslationDeepObject<typeof en> = {
         kilometer: 'kilómetro',
         kilometers: 'kilómetros',
         recent: 'Reciente',
+        fallbackAccountName: ({accountID}: {accountID: number}) => `Cuenta ${accountID}`,
         all: 'Todo',
         am: 'AM',
         pm: 'PM',

--- a/src/libs/TransactionUtils/index.ts
+++ b/src/libs/TransactionUtils/index.ts
@@ -1185,20 +1185,18 @@ function getReportOwnerAsAttendee(transaction: OnyxInputOrEntry<Transaction>, cu
     if (creatorAccountID) {
         const [creatorDetails] = getPersonalDetailsByIDs({accountIDs: [creatorAccountID], currentUserAccountID: currentUserPersonalDetails?.accountID});
         const creatorEmail = creatorDetails?.login ?? '';
-        const creatorDisplayName = creatorDetails?.displayName ?? creatorEmail;
+        const creatorDisplayName = (creatorDetails?.displayName ?? creatorEmail) || `Account ${creatorAccountID}`;
 
-        if (creatorEmail) {
-            return {
-                email: creatorEmail,
-                login: creatorEmail,
-                displayName: creatorDisplayName,
-                accountID: creatorAccountID,
-                text: creatorDisplayName,
-                searchText: creatorDisplayName,
-                avatarUrl: creatorDetails?.avatarThumbnail ?? '',
-                selected: true,
-            };
-        }
+        return {
+            email: creatorEmail,
+            login: creatorEmail,
+            displayName: creatorDisplayName,
+            accountID: creatorAccountID,
+            text: creatorDisplayName,
+            searchText: creatorDisplayName,
+            avatarUrl: creatorDetails?.avatarThumbnail ?? '',
+            selected: true,
+        };
     }
 }
 

--- a/src/libs/TransactionUtils/index.ts
+++ b/src/libs/TransactionUtils/index.ts
@@ -1185,7 +1185,7 @@ function getReportOwnerAsAttendee(transaction: OnyxInputOrEntry<Transaction>, cu
     if (creatorAccountID) {
         const [creatorDetails] = getPersonalDetailsByIDs({accountIDs: [creatorAccountID], currentUserAccountID: currentUserPersonalDetails?.accountID});
         const creatorEmail = creatorDetails?.login ?? '';
-        const creatorDisplayName = (creatorDetails?.displayName ?? creatorEmail) || `Account ${creatorAccountID}`;
+        const creatorDisplayName = (creatorDetails?.displayName ?? creatorEmail) || translateLocal('common.fallbackAccountName', {accountID: creatorAccountID});
 
         return {
             email: creatorEmail,

--- a/tests/unit/TransactionUtilsTest.ts
+++ b/tests/unit/TransactionUtilsTest.ts
@@ -1143,6 +1143,27 @@ describe('TransactionUtils', () => {
             expect(result?.displayName).toBe('Current User');
             expect(result?.selected).toBe(true);
         });
+
+        it('should return valid attendee with Account fallback when personal details are missing', () => {
+            const THIRD_USER_ID = 3;
+            const UNCACHED_REPORT_ID = 'UNCACHED_REPORT_ID';
+            return Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT}${UNCACHED_REPORT_ID}`, {
+                reportID: UNCACHED_REPORT_ID,
+                ownerAccountID: THIRD_USER_ID,
+                type: CONST.REPORT.TYPE.EXPENSE,
+            }).then(() => {
+                const transaction = generateTransaction({
+                    reportID: UNCACHED_REPORT_ID,
+                });
+
+                const result = TransactionUtils.getReportOwnerAsAttendee(transaction, currentUserPersonalDetails);
+
+                expect(result).toBeDefined();
+                expect(result?.accountID).toBe(THIRD_USER_ID);
+                expect(result?.email).toBe('');
+                expect(result?.displayName).toBe(`Account ${THIRD_USER_ID}`);
+            });
+        });
     });
 
     describe('getOriginalAttendees', () => {


### PR DESCRIPTION
### Explanation of Change
This PR fixes a bug where the "Attendees" field in an expense report would only show the title "Attendees" but no names for an invited user (User B). The issue occurred because `getReportOwnerAsAttendee` returned `undefined` when the report owner's personal details (email/login) were not cached locally for the invited user.

The fix ensures `getReportOwnerAsAttendee` always returns an attendee object if the `creatorAccountID` exists, using a fallback display name `Account <ID>` when personal details specifically `login` or `displayName` are missing.

### Fixed Issues
$ https://github.com/Expensify/App/issues/80687
PROPOSAL: https://github.com/Expensify/App/issues/80687#issuecomment-2619054707

### Tests

1.  Log in as User A (Admin).
2.  Go to a workspace with Rules enabled.
3.  Create two expenses in the workspace chat.
4.  Open the expense report.
5.  Invite User B to the report (ensure they are "Invited to chat only" or added as a member).
6.  Log in as User B (Invited User) in a different browser or Incognito window.
7.  Open the same report.
8.  Verify the "Attendees" field displays the attendee name (or "Account <ID>" if name is not cached), instead of being empty.
9.  Verify the field is read-only for the invited user.

- [x] Verify that no errors appear in the JS console

### Offline tests
1.  Follow the steps above to load the report as User B.
2.  Turn off the internet connection.
3.  Refresh or reload the report (or navigate away and back).
4.  Verify the "Attendees" information (or fallback) is still displayed/cached correctly.

### QA Steps
1.  Log in as a Workspace Admin.
2.  Enable "Attendee tracking" in Workspace Rules.
3.  Create an expense in the workspace.
4.  Open the expense report and invite a second user (who has not interacted with the admin before, if possible, to simulate uncached details).
5.  Log in as the second (invited) user.
6.  Open the report.
7.  Verify the "Attendees" field lists the attendees correctly.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [ ] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [ ] Android: Native
    - [ ] Android: mWeb Chrome
    - [ ] iOS: Native
    - [ ] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I verified there are no new alerts related to the `canBeMissing` param for `useOnyx`
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [ ] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->
<img width="2560" height="1440" alt="image" src="https://github.com/user-attachments/assets/339e1f72-c432-4961-a2e1-92102ff4b917" />


</details>