### PR TITLE
[Suggested Follow-ups][R1] Update the buttons styling & refactor

### DIFF
--- a/src/components/ReportActionItem/ActionableItemButtons.tsx
+++ b/src/components/ReportActionItem/ActionableItemButtons.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import {View} from 'react-native';
-import type {StyleProp, TextStyle} from 'react-native';
+import type {StyleProp, TextStyle, ViewStyle} from 'react-native';
 import Button from '@components/Button';
 import useLocalize from '@hooks/useLocalize';
 import useThemeStyles from '@hooks/useThemeStyles';
@@ -20,6 +20,8 @@ type ActionableItemButtonsProps = {
     shouldUseLocalization?: boolean;
     primaryTextNumberOfLines?: number;
     textStyles?: StyleProp<TextStyle>;
+    buttonStyles?: StyleProp<ViewStyle>;
+    containerStyles?: StyleProp<ViewStyle>;
 };
 
 function ActionableItemButtons(props: ActionableItemButtonsProps) {
@@ -27,7 +29,7 @@ function ActionableItemButtons(props: ActionableItemButtonsProps) {
     const {translate} = useLocalize();
 
     return (
-        <View style={[props.layout === 'horizontal' ? styles.flexRow : [styles.flexColumn, styles.alignItemsStart], styles.gap2, styles.mt2]}>
+        <View style={[styles.gap2, styles.mt2, props.layout === 'horizontal' ? styles.flexRow : [styles.flexColumn, styles.alignItemsStart, props.containerStyles]]}>
             {props.items?.map((item) => (
                 <Button
                     key={item.key}
@@ -35,6 +37,7 @@ function ActionableItemButtons(props: ActionableItemButtonsProps) {
                     text={props.shouldUseLocalization ? translate(item.text as TranslationPaths) : item.text}
                     medium
                     success={item.isPrimary}
+                    innerStyles={props.buttonStyles}
                     primaryTextNumberOfLines={props.primaryTextNumberOfLines}
                     textStyles={props.textStyles}
                 />

--- a/src/components/ReportActionItem/ActionableItemButtons.tsx
+++ b/src/components/ReportActionItem/ActionableItemButtons.tsx
@@ -19,9 +19,12 @@ type ActionableItemButtonsProps = {
     layout?: 'horizontal' | 'vertical';
     shouldUseLocalization?: boolean;
     primaryTextNumberOfLines?: number;
-    textStyles?: StyleProp<TextStyle>;
-    buttonStyles?: StyleProp<ViewStyle>;
-    containerStyles?: StyleProp<ViewStyle>;
+    styles?: {
+        text?: StyleProp<TextStyle>;
+        button?: StyleProp<ViewStyle>;
+        buttonHover?: StyleProp<ViewStyle>;
+        container?: StyleProp<ViewStyle>;
+    };
 };
 
 function ActionableItemButtons(props: ActionableItemButtonsProps) {
@@ -29,7 +32,7 @@ function ActionableItemButtons(props: ActionableItemButtonsProps) {
     const {translate} = useLocalize();
 
     return (
-        <View style={[styles.gap2, styles.mt2, props.layout === 'horizontal' ? styles.flexRow : [styles.flexColumn, styles.alignItemsStart, props.containerStyles]]}>
+        <View style={[styles.gap2, styles.mt2, props.layout === 'horizontal' ? styles.flexRow : [styles.flexColumn, styles.alignItemsStart, props.styles?.container]]}>
             {props.items?.map((item) => (
                 <Button
                     key={item.key}
@@ -37,9 +40,10 @@ function ActionableItemButtons(props: ActionableItemButtonsProps) {
                     text={props.shouldUseLocalization ? translate(item.text as TranslationPaths) : item.text}
                     medium
                     success={item.isPrimary}
-                    innerStyles={props.buttonStyles}
+                    innerStyles={props.styles?.button}
+                    hoverStyles={props.styles?.buttonHover}
                     primaryTextNumberOfLines={props.primaryTextNumberOfLines}
-                    textStyles={props.textStyles}
+                    textStyles={props.styles?.text}
                 />
             ))}
         </View>

--- a/src/libs/ReportActionFollowupUtils/stripFollowupListFromHtml.ts
+++ b/src/libs/ReportActionFollowupUtils/stripFollowupListFromHtml.ts
@@ -1,0 +1,16 @@
+/**
+ * Used for generating preview text in LHN and other places where followups should not be displayed.
+ * Implemented here instead of ReportActionFollowupUtils due to circular ref
+ * @param html message.html from the report COMMENT actions
+ * @returns html with the <followup-list> element and its contents stripped out or undefined if html is undefined
+ */
+function stripFollowupListFromHtml(html?: string): string | undefined {
+    if (!html) {
+        return;
+    }
+    // Matches a <followup-list> HTML element and its entire contents. (<followup-list><followup><followup-text>Question?</followup-text></followup></followup-list>)
+    const followUpListRegex = /<followup-list(\s[^>]*)?>[\s\S]*?<\/followup-list>/i;
+    return html.replace(followUpListRegex, '').trim();
+}
+
+export default stripFollowupListFromHtml;

--- a/src/libs/ReportActionsUtils.ts
+++ b/src/libs/ReportActionsUtils.ts
@@ -43,6 +43,7 @@ import getReportURLForCurrentContext from './Navigation/helpers/getReportURLForC
 import Parser from './Parser';
 import {arePersonalDetailsMissing, getEffectiveDisplayName, getPersonalDetailByEmail, getPersonalDetailsByIDs} from './PersonalDetailsUtils';
 import {getPolicy, isPolicyAdmin as isPolicyAdminPolicyUtils} from './PolicyUtils';
+import stripFollowupListFromHtml from './ReportActionFollowupUtils/stripFollowupListFromHtml';
 import type {getReportName, OptimisticIOUReportAction, PartialReportAction} from './ReportUtils';
 import StringUtils from './StringUtils';
 import {getReportFieldTypeTranslationKey} from './WorkspaceReportFieldUtils';
@@ -1732,21 +1733,6 @@ function getMemberChangeMessageElements(
         ...formatMessageElementList(mentionElements),
         ...buildRoomElements(),
     ];
-}
-
-/**
- * Used for generating preview text in LHN and other places where followups should not be displayed.
- * Implemented here instead of ReportActionFollowupUtils due to circular ref
- * @param html message.html from the report COMMENT actions
- * @returns html with the <followup-list> element and its contents stripped out or undefined if html is undefined
- */
-function stripFollowupListFromHtml(html?: string): string | undefined {
-    if (!html) {
-        return;
-    }
-    // Matches a <followup-list> HTML element and its entire contents. (<followup-list><followup><followup-text>Question?</followup-text></followup></followup-list>)
-    const followUpListRegex = /<followup-list(\s[^>]*)?>[\s\S]*?<\/followup-list>/i;
-    return html.replace(followUpListRegex, '').trim();
 }
 
 function getReportActionHtml(reportAction: PartialReportAction): string {

--- a/src/libs/actions/Report.ts
+++ b/src/libs/actions/Report.ts
@@ -102,9 +102,8 @@ import {
 import processReportIDDeeplink from '@libs/processReportIDDeeplink';
 import Pusher from '@libs/Pusher';
 import type {UserIsLeavingRoomEvent, UserIsTypingEvent} from '@libs/Pusher/types';
-import * as ReportActionsFollowupUtils from '@libs/ReportActionsFollowupUtils';
+import * as ReportActionsFollowupUtils from '@libs/ReportActionFollowupUtils';
 import * as ReportActionsUtils from '@libs/ReportActionsUtils';
-import {getLastVisibleAction} from '@libs/ReportActionsUtils';
 import {updateTitleFieldToMatchPolicy} from '@libs/ReportTitleUtils';
 import type {Ancestor, OptimisticAddCommentReportAction, OptimisticChatReport, SelfDMParameters} from '@libs/ReportUtils';
 import {
@@ -555,6 +554,7 @@ function buildOptimisticResolvedFollowups(reportAction: OnyxEntry<ReportAction>)
         return null;
     }
 
+    // Mark followup-list as selected after a comment has been posted below the follow up list comment
     const updatedHtml = html.replace(/<followup-list(\s[^>]*)?>/, '<followup-list selected>');
     return {
         ...reportAction,
@@ -644,7 +644,7 @@ function addActions(report: OnyxEntry<Report>, notifyReportID: string, ancestors
 
     // Check if the last visible action is from Concierge with unresolved followups
     // If so, optimistically resolve them by adding the updated action to optimisticReportActions
-    const lastVisibleAction = getLastVisibleAction(reportID);
+    const lastVisibleAction = ReportActionsUtils.getLastVisibleAction(reportID);
     const lastActorAccountID = lastVisibleAction?.actorAccountID;
     const lastActionReportActionID = lastVisibleAction?.reportActionID;
     const resolvedAction = buildOptimisticResolvedFollowups(lastVisibleAction);

--- a/src/libs/actions/Report.ts
+++ b/src/libs/actions/Report.ts
@@ -6550,46 +6550,6 @@ function resolveConciergeDescriptionOptions(
 }
 
 /**
- * Resolves a suggested followup by posting the selected question as a comment
- * and optimistically updating the HTML to mark the followup-list as resolved.
- * @param report - The report where the action exists
- * @param notifyReportID - The report ID to notify for new actions
- * @param reportAction - The report action containing the followup-list
- * @param selectedFollowup - The followup question selected by the user
- * @param timezoneParam - The user's timezone
- * @param ancestors - Array of ancestor reports for proper threading
- */
-function resolveSuggestedFollowup(
-    report: OnyxEntry<Report>,
-    notifyReportID: string | undefined,
-    reportAction: OnyxEntry<ReportAction>,
-    selectedFollowup: string,
-    timezoneParam: Timezone,
-    ancestors: Ancestor[] = [],
-) {
-    const reportID = report?.reportID;
-    const reportActionID = reportAction?.reportActionID;
-
-    if (!reportID || !reportActionID) {
-        return;
-    }
-
-    const resolvedAction = buildOptimisticResolvedFollowups(reportAction);
-
-    if (!resolvedAction) {
-        return;
-    }
-
-    // Optimistically update the HTML to mark followup-list as resolved
-    Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${reportID}`, {
-        [reportActionID]: resolvedAction,
-    });
-
-    // Post the selected followup question as a comment
-    addComment(report, notifyReportID ?? reportID, ancestors, selectedFollowup, timezoneParam);
-}
-
-/**
  * Enhances existing transaction thread reports with additional context for navigation
  *
  * This is NOT the same as createTransactionThreadReport - this function only adds missing
@@ -6689,7 +6649,6 @@ export {
     resolveActionableReportMentionWhisper,
     resolveConciergeCategoryOptions,
     resolveConciergeDescriptionOptions,
-    resolveSuggestedFollowup,
     savePrivateNotesDraft,
     saveReportActionDraft,
     saveReportDraftComment,

--- a/src/libs/actions/Report/SuggestedFollowup.ts
+++ b/src/libs/actions/Report/SuggestedFollowup.ts
@@ -1,12 +1,10 @@
 import type {OnyxEntry} from 'react-native-onyx';
 import Onyx from 'react-native-onyx';
 import type {Ancestor} from '@libs/ReportUtils';
-// We have directory and file with the same name, so below is needed
-// eslint-disable-next-line @dword-design/import-alias/prefer-alias
-import {addComment, buildOptimisticResolvedFollowups} from '@userActions/Report';
 import ONYXKEYS from '@src/ONYXKEYS';
 import type {Report, ReportAction} from '@src/types/onyx';
 import type {Timezone} from '@src/types/onyx/PersonalDetails';
+import {addComment, buildOptimisticResolvedFollowups} from '.';
 
 /**
  * Resolves a suggested followup by posting the selected question as a comment

--- a/src/libs/actions/Report/SuggestedFollowup.ts
+++ b/src/libs/actions/Report/SuggestedFollowup.ts
@@ -1,0 +1,50 @@
+import type {OnyxEntry} from 'react-native-onyx';
+import Onyx from 'react-native-onyx';
+import type {Ancestor} from '@libs/ReportUtils';
+// eslint-disable-next-line @dword-design/import-alias/prefer-alias
+import {addComment, buildOptimisticResolvedFollowups} from '@userActions/Report';
+import ONYXKEYS from '@src/ONYXKEYS';
+import type {Report, ReportAction} from '@src/types/onyx';
+import type {Timezone} from '@src/types/onyx/PersonalDetails';
+
+/**
+ * Resolves a suggested followup by posting the selected question as a comment
+ * and optimistically updating the HTML to mark the followup-list as resolved.
+ * @param report - The report where the action exists
+ * @param notifyReportID - The report ID to notify for new actions
+ * @param reportAction - The report action containing the followup-list
+ * @param selectedFollowup - The followup question selected by the user
+ * @param timezoneParam - The user's timezone
+ * @param ancestors - Array of ancestor reports for proper threading
+ */
+function resolveSuggestedFollowup(
+    report: OnyxEntry<Report>,
+    notifyReportID: string | undefined,
+    reportAction: OnyxEntry<ReportAction>,
+    selectedFollowup: string,
+    timezoneParam: Timezone,
+    ancestors: Ancestor[] = [],
+) {
+    const reportID = report?.reportID;
+    const reportActionID = reportAction?.reportActionID;
+
+    if (!reportID || !reportActionID) {
+        return;
+    }
+
+    const resolvedAction = buildOptimisticResolvedFollowups(reportAction);
+
+    if (!resolvedAction) {
+        return;
+    }
+
+    // Optimistically update the HTML to mark followup-list as resolved
+    Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${reportID}`, {
+        [reportActionID]: resolvedAction,
+    });
+
+    // Post the selected followup question as a comment
+    addComment(report, notifyReportID ?? reportID, ancestors, selectedFollowup, timezoneParam);
+}
+
+export default resolveSuggestedFollowup;

--- a/src/libs/actions/Report/SuggestedFollowup.ts
+++ b/src/libs/actions/Report/SuggestedFollowup.ts
@@ -1,6 +1,7 @@
 import type {OnyxEntry} from 'react-native-onyx';
 import Onyx from 'react-native-onyx';
 import type {Ancestor} from '@libs/ReportUtils';
+// We have directory and file with the same name, so below is needed
 // eslint-disable-next-line @dword-design/import-alias/prefer-alias
 import {addComment, buildOptimisticResolvedFollowups} from '@userActions/Report';
 import ONYXKEYS from '@src/ONYXKEYS';

--- a/src/libs/actions/Report/index.ts
+++ b/src/libs/actions/Report/index.ts
@@ -176,6 +176,24 @@ import playSound, {SOUNDS} from '@libs/Sound';
 import {getAmount, getCurrency, hasValidModifiedAmount, isOnHold, shouldClearConvertedAmount} from '@libs/TransactionUtils';
 import addTrailingForwardSlash from '@libs/UrlUtils';
 import Visibility from '@libs/Visibility';
+import {clearByKey} from '@userActions/CachedPDFPaths';
+import {setDownload} from '@userActions/Download';
+import {close} from '@userActions/Modal';
+import navigateFromNotification from '@userActions/navigateFromNotification';
+import {getAll} from '@userActions/PersistedRequests';
+import {buildAddMembersToWorkspaceOnyxData, buildRoomMembersOnyxData} from '@userActions/Policy/Member';
+import {createPolicyExpenseChats} from '@userActions/Policy/Policy';
+import {
+    createUpdateCommentMatcher,
+    resolveCommentDeletionConflicts,
+    resolveDuplicationConflictAction,
+    resolveEditCommentWithNewAddCommentRequest,
+    resolveOpenReportDuplicationConflictAction,
+} from '@userActions/RequestConflictUtils';
+import {isAnonymousUser} from '@userActions/Session';
+import {onServerDataReady} from '@userActions/Welcome';
+import {getOnboardingMessages} from '@userActions/Welcome/OnboardingFlow';
+import type {OnboardingCompanySize, OnboardingMessage} from '@userActions/Welcome/OnboardingFlow';
 import CONFIG from '@src/CONFIG';
 import type {OnboardingAccounting} from '@src/CONST';
 import CONST from '@src/CONST';
@@ -211,24 +229,6 @@ import type {Message, ReportActions} from '@src/types/onyx/ReportAction';
 import type {FileObject} from '@src/types/utils/Attachment';
 import {isEmptyObject} from '@src/types/utils/EmptyObject';
 import type {Dimensions} from '@src/types/utils/Layout';
-import {clearByKey} from './CachedPDFPaths';
-import {setDownload} from './Download';
-import {close} from './Modal';
-import navigateFromNotification from './navigateFromNotification';
-import {getAll} from './PersistedRequests';
-import {buildAddMembersToWorkspaceOnyxData, buildRoomMembersOnyxData} from './Policy/Member';
-import {createPolicyExpenseChats} from './Policy/Policy';
-import {
-    createUpdateCommentMatcher,
-    resolveCommentDeletionConflicts,
-    resolveDuplicationConflictAction,
-    resolveEditCommentWithNewAddCommentRequest,
-    resolveOpenReportDuplicationConflictAction,
-} from './RequestConflictUtils';
-import {isAnonymousUser} from './Session';
-import {onServerDataReady} from './Welcome';
-import {getOnboardingMessages} from './Welcome/OnboardingFlow';
-import type {OnboardingCompanySize, OnboardingMessage} from './Welcome/OnboardingFlow';
 
 type SubscriberCallback = (isFromCurrentUser: boolean, reportAction: ReportAction | undefined) => void;
 

--- a/src/pages/inbox/report/PureReportActionItem.tsx
+++ b/src/pages/inbox/report/PureReportActionItem.tsx
@@ -51,6 +51,7 @@ import useResponsiveLayout from '@hooks/useResponsiveLayout';
 import useStyleUtils from '@hooks/useStyleUtils';
 import useTheme from '@hooks/useTheme';
 import useThemeStyles from '@hooks/useThemeStyles';
+import resolveSuggestedFollowup from '@libs/actions/Report/SuggestedFollowup';
 import ControlSelection from '@libs/ControlSelection';
 import {convertToDisplayString} from '@libs/CurrencyUtils';
 import {canUseTouchScreen} from '@libs/DeviceCapabilities';
@@ -204,7 +205,6 @@ import {
     resolveActionableMentionConfirmWhisper,
     resolveConciergeCategoryOptions,
     resolveConciergeDescriptionOptions,
-    resolveSuggestedFollowup,
 } from '@userActions/Report';
 import type {IgnoreDirection} from '@userActions/ReportActions';
 import {isAnonymousUser, signOutAndRedirectToSignIn} from '@userActions/Session';

--- a/src/pages/inbox/report/PureReportActionItem.tsx
+++ b/src/pages/inbox/report/PureReportActionItem.tsx
@@ -63,7 +63,7 @@ import Parser from '@libs/Parser';
 import Permissions from '@libs/Permissions';
 import {getDisplayNameOrDefault} from '@libs/PersonalDetailsUtils';
 import {getCleanedTagName, hasDynamicExternalWorkflow, isPolicyAdmin, isPolicyMember, isPolicyOwner} from '@libs/PolicyUtils';
-import {containsActionableFollowUps, parseFollowupsFromHtml} from '@libs/ReportActionsFollowupUtils';
+import {containsActionableFollowUps, parseFollowupsFromHtml} from '@libs/ReportActionFollowupUtils';
 import {
     extractLinksFromMessageHtml,
     getActionableCardFraudAlertMessage,
@@ -1723,6 +1723,7 @@ function PureReportActionItem({
                                             shouldUseLocalization={!isConciergeOptions && !actionContainsFollowUps}
                                             primaryTextNumberOfLines={actionableButtonsNoLines}
                                             textStyles={isConciergeOptions || actionContainsFollowUps ? styles.textAlignLeft : undefined}
+                                            buttonStyles={styles.actionableItemButton}
                                         />
                                     )}
                                 </View>

--- a/src/pages/inbox/report/PureReportActionItem.tsx
+++ b/src/pages/inbox/report/PureReportActionItem.tsx
@@ -1723,10 +1723,10 @@ function PureReportActionItem({
                                             shouldUseLocalization={!isConciergeOptions && !actionContainsFollowUps}
                                             primaryTextNumberOfLines={actionableButtonsNoLines}
                                             styles={{
-                                                text: isConciergeOptions || actionContainsFollowUps ? styles.textAlignLeft : undefined,
+                                                text: [isConciergeOptions || actionContainsFollowUps ? styles.textAlignLeft : undefined, actionContainsFollowUps && styles.fontWeightNormal],
                                                 button: actionContainsFollowUps ? [styles.actionableItemButton, hovered && styles.actionableItemButtonBackgroundHovered] : undefined,
                                                 buttonHover: actionContainsFollowUps ? styles.actionableItemButtonHovered : undefined,
-                                                container: actionContainsFollowUps && shouldUseNarrowLayout ? styles.alignItemsStretch : undefined,
+                                                container: actionContainsFollowUps && shouldUseNarrowLayout ? [styles.alignItemsStretch] : undefined,
                                             }}
                                         />
                                     )}

--- a/src/pages/inbox/report/PureReportActionItem.tsx
+++ b/src/pages/inbox/report/PureReportActionItem.tsx
@@ -1722,9 +1722,12 @@ function PureReportActionItem({
                                             }
                                             shouldUseLocalization={!isConciergeOptions && !actionContainsFollowUps}
                                             primaryTextNumberOfLines={actionableButtonsNoLines}
-                                            textStyles={isConciergeOptions || actionContainsFollowUps ? styles.textAlignLeft : undefined}
-                                            buttonStyles={actionContainsFollowUps && [styles.actionableItemButton, hovered && styles.actionableItemButtonHovered]}
-                                            containerStyles={actionContainsFollowUps && shouldUseNarrowLayout && styles.alignItemsStretch}
+                                            styles={{
+                                                text: isConciergeOptions || actionContainsFollowUps ? styles.textAlignLeft : undefined,
+                                                button: actionContainsFollowUps ? [styles.actionableItemButton, hovered && styles.actionableItemButtonBackgroundHovered] : undefined,
+                                                buttonHover: actionContainsFollowUps ? styles.actionableItemButtonHovered : undefined,
+                                                container: actionContainsFollowUps && shouldUseNarrowLayout ? styles.alignItemsStretch : undefined,
+                                            }}
                                         />
                                     )}
                                 </View>

--- a/src/pages/inbox/report/PureReportActionItem.tsx
+++ b/src/pages/inbox/report/PureReportActionItem.tsx
@@ -1723,7 +1723,7 @@ function PureReportActionItem({
                                             shouldUseLocalization={!isConciergeOptions && !actionContainsFollowUps}
                                             primaryTextNumberOfLines={actionableButtonsNoLines}
                                             textStyles={isConciergeOptions || actionContainsFollowUps ? styles.textAlignLeft : undefined}
-                                            buttonStyles={actionContainsFollowUps && styles.actionableItemButton}
+                                            buttonStyles={actionContainsFollowUps && [styles.actionableItemButton, hovered && styles.actionableItemButtonHovered]}
                                             containerStyles={actionContainsFollowUps && shouldUseNarrowLayout && styles.alignItemsStretch}
                                         />
                                     )}

--- a/src/pages/inbox/report/PureReportActionItem.tsx
+++ b/src/pages/inbox/report/PureReportActionItem.tsx
@@ -1723,7 +1723,8 @@ function PureReportActionItem({
                                             shouldUseLocalization={!isConciergeOptions && !actionContainsFollowUps}
                                             primaryTextNumberOfLines={actionableButtonsNoLines}
                                             textStyles={isConciergeOptions || actionContainsFollowUps ? styles.textAlignLeft : undefined}
-                                            buttonStyles={styles.actionableItemButton}
+                                            buttonStyles={actionContainsFollowUps && styles.actionableItemButton}
+                                            containerStyles={actionContainsFollowUps && shouldUseNarrowLayout && styles.alignItemsStretch}
                                         />
                                     )}
                                 </View>

--- a/src/styles/index.ts
+++ b/src/styles/index.ts
@@ -937,8 +937,12 @@ const staticStyles = (theme: ThemeColors) =>
             borderRadius: variables.componentBorderRadiusMedium,
         },
 
-        actionableItemButtonHovered: {
+        actionableItemButtonBackgroundHovered: {
             borderColor: theme.buttonPressedBG,
+        },
+
+        actionableItemButtonHovered: {
+            borderWidth: 1,
         },
 
         hoveredComponentBG: {

--- a/src/styles/index.ts
+++ b/src/styles/index.ts
@@ -934,6 +934,7 @@ const staticStyles = (theme: ThemeColors) =>
             backgroundColor: 'transparent',
             borderWidth: 1,
             borderColor: theme.border,
+            alignItems: 'flex-start',
             borderRadius: variables.componentBorderRadiusMedium,
         },
 

--- a/src/styles/index.ts
+++ b/src/styles/index.ts
@@ -928,6 +928,15 @@ const staticStyles = (theme: ThemeColors) =>
             overflow: 'hidden',
         },
 
+        actionableItemButton: {
+            paddingTop: 8,
+            paddingBottom: 8,
+            backgroundColor: 'transparent',
+            borderWidth: 1,
+            borderColor: theme.border,
+            borderRadius: variables.componentBorderRadiusMedium,
+        },
+
         hoveredComponentBG: {
             backgroundColor: theme.hoverComponentBG,
         },

--- a/src/styles/index.ts
+++ b/src/styles/index.ts
@@ -937,6 +937,10 @@ const staticStyles = (theme: ThemeColors) =>
             borderRadius: variables.componentBorderRadiusMedium,
         },
 
+        actionableItemButtonHovered: {
+            borderColor: theme.buttonPressedBG,
+        },
+
         hoveredComponentBG: {
             backgroundColor: theme.hoverComponentBG,
         },

--- a/tests/actions/ReportTest.ts
+++ b/tests/actions/ReportTest.ts
@@ -9,6 +9,7 @@ import type {OnyxCollection, OnyxEntry, OnyxUpdate} from 'react-native-onyx';
 import OnyxUtils from 'react-native-onyx/dist/OnyxUtils';
 import type {SearchQueryJSON} from '@components/Search/types';
 import useAncestors from '@hooks/useAncestors';
+import resolveSuggestedFollowup from '@libs/actions/Report/SuggestedFollowup';
 import {getOnboardingMessages} from '@libs/actions/Welcome/OnboardingFlow';
 import {WRITE_COMMANDS} from '@libs/API/types';
 import HttpUtils from '@libs/HttpUtils';
@@ -3697,7 +3698,7 @@ describe('actions/Report', () => {
             });
             await waitForBatchedUpdates();
 
-            Report.resolveSuggestedFollowup(report, undefined, reportAction, 'test question', CONST.DEFAULT_TIME_ZONE);
+            resolveSuggestedFollowup(report, undefined, reportAction, 'test question', CONST.DEFAULT_TIME_ZONE);
             await waitForBatchedUpdates();
 
             // The report action should remain unchanged (no followup-list to resolve)
@@ -3725,7 +3726,7 @@ describe('actions/Report', () => {
             });
             await waitForBatchedUpdates();
 
-            Report.resolveSuggestedFollowup(report, undefined, reportAction, 'How do I set up QuickBooks?', CONST.DEFAULT_TIME_ZONE);
+            resolveSuggestedFollowup(report, undefined, reportAction, 'How do I set up QuickBooks?', CONST.DEFAULT_TIME_ZONE);
             await waitForBatchedUpdates();
 
             // Verify the followup-list was marked as selected

--- a/tests/unit/ReportActionsFollowupUtilsTest.ts
+++ b/tests/unit/ReportActionsFollowupUtilsTest.ts
@@ -1,9 +1,9 @@
 import CONST from '../../src/CONST';
-import {containsActionableFollowUps, parseFollowupsFromHtml} from '../../src/libs/ReportActionsFollowupUtils';
+import {containsActionableFollowUps, parseFollowupsFromHtml} from '../../src/libs/ReportActionFollowupUtils';
 import {stripFollowupListFromHtml} from '../../src/libs/ReportActionsUtils';
 import type {ReportAction} from '../../src/types/onyx';
 
-describe('FollowupUtils', () => {
+describe('ReportActionsFollowupUtils', () => {
     describe('parseFollowupsFromHtml', () => {
         it('should return null when no followup-list exists', () => {
             const html = '<p>Hello world</p>';


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
<!-- Explain what your change does and how it addresses the linked issue -->

This is a follow up to https://github.com/Expensify/App/pull/80539. 
The PR includes refactor and follow up button styling changes.

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/80686

PROPOSAL:


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->
Pre requisites:
- Have expensifail or swmansion account
- Use staging server


1. Open the app
2. Go to concierge chat and prompt him to give actionable follow ups 
3. The follow ups should be generated and shown with new styles. 
4. The other actionable buttons from concierge should remain the same for now

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

N/A

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
5. Upload an image via copy paste
6. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->
Same as tests

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I verified there are no new alerts related to the `canBeMissing` param for `useOnyx`
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>
<img width="352" height="775" alt="image" src="https://github.com/user-attachments/assets/88059ae3-ec43-4291-bfeb-bda04383214b" />

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>
<img width="350" height="745" alt="image" src="https://github.com/user-attachments/assets/54981593-6b33-4f6d-9231-e5f1e0cdc7ee" />


<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>
<img width="402" height="854" alt="image" src="https://github.com/user-attachments/assets/0911cf17-2d0c-4922-b94d-eeff01d89104" />

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>
<img width="406" height="857" alt="image" src="https://github.com/user-attachments/assets/5b17413b-1c3a-4551-b1c7-116120a73966" />

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

https://github.com/user-attachments/assets/d206eeff-ed96-47ff-8e99-19fdb404e3b1


<!-- add screenshots or videos here -->

</details>