### PR TITLE
Allow admins to apply rule changes to existing unsubmitted expenses

### DIFF
--- a/src/languages/de.ts
+++ b/src/languages/de.ts
@@ -6409,6 +6409,7 @@ Fordere Spesendetails wie Belege und Beschreibungen an, lege Limits und Standard
                 matchTypeContains: 'Enthält',
                 matchTypeExact: 'Exakte Übereinstimmung',
                 expensesExactlyMatching: 'Für Ausgaben mit genau folgender Übereinstimmung:',
+                applyToExistingUnsubmittedExpenses: 'Auf bestehende nicht eingereichte Ausgaben anwenden',
             },
         },
         planTypePage: {

--- a/src/languages/de.ts
+++ b/src/languages/de.ts
@@ -6409,7 +6409,7 @@ Fordere Spesendetails wie Belege und Beschreibungen an, lege Limits und Standard
                 matchTypeContains: 'Enthält',
                 matchTypeExact: 'Exakte Übereinstimmung',
                 expensesExactlyMatching: 'Für Ausgaben mit genau folgender Übereinstimmung:',
-                applyToExistingUnsubmittedExpenses: 'Auf bestehende nicht eingereichte Ausgaben anwenden',
+                applyToExistingUnsubmittedExpenses: 'Auf bereits vorhandene, noch nicht eingereichte Ausgaben anwenden',
             },
         },
         planTypePage: {

--- a/src/languages/en.ts
+++ b/src/languages/en.ts
@@ -6265,6 +6265,7 @@ const translations = {
                 matchType: 'Match type',
                 matchTypeContains: 'Contains',
                 matchTypeExact: 'Exactly matches',
+                applyToExistingUnsubmittedExpenses: 'Apply to existing unsubmitted expenses',
             },
             categoryRules: {
                 title: 'Category rules',

--- a/src/languages/es.ts
+++ b/src/languages/es.ts
@@ -6044,6 +6044,7 @@ ${amount} para ${merchant} - ${date}`,
                 matchType: 'Tipo de coincidencia',
                 matchTypeContains: 'Contiene',
                 matchTypeExact: 'Coincide exactamente',
+                applyToExistingUnsubmittedExpenses: 'Aplicar a gastos existentes no enviados',
             },
             categoryRules: {
                 title: 'Reglas de categoría',

--- a/src/languages/fr.ts
+++ b/src/languages/fr.ts
@@ -6420,7 +6420,7 @@ Exigez des informations de dépense comme les reçus et les descriptions, défin
                 matchTypeContains: 'Contient',
                 matchTypeExact: 'Correspond exactement',
                 expensesExactlyMatching: 'Pour les dépenses correspondant exactement :',
-                applyToExistingUnsubmittedExpenses: 'Appliquer aux dépenses existantes non soumises',
+                applyToExistingUnsubmittedExpenses: 'Appliquer aux dépenses non soumises existantes',
             },
         },
         planTypePage: {

--- a/src/languages/fr.ts
+++ b/src/languages/fr.ts
@@ -6420,6 +6420,7 @@ Exigez des informations de dépense comme les reçus et les descriptions, défin
                 matchTypeContains: 'Contient',
                 matchTypeExact: 'Correspond exactement',
                 expensesExactlyMatching: 'Pour les dépenses correspondant exactement :',
+                applyToExistingUnsubmittedExpenses: 'Appliquer aux dépenses existantes non soumises',
             },
         },
         planTypePage: {

--- a/src/languages/it.ts
+++ b/src/languages/it.ts
@@ -6391,6 +6391,7 @@ Richiedi dettagli di spesa come ricevute e descrizioni, imposta limiti e valori 
                 matchTypeContains: 'Contiene',
                 matchTypeExact: 'Corrisponde esattamente',
                 expensesExactlyMatching: 'Per le spese che corrispondono esattamente:',
+                applyToExistingUnsubmittedExpenses: 'Applica alle spese esistenti non inviate',
             },
         },
         planTypePage: {

--- a/src/languages/ja.ts
+++ b/src/languages/ja.ts
@@ -6346,7 +6346,7 @@ ${reportName}
                 matchTypeContains: '含む',
                 matchTypeExact: '完全一致',
                 expensesExactlyMatching: '以下と完全一致する経費について:',
-                applyToExistingUnsubmittedExpenses: '既存の未提出経費に適用する',
+                applyToExistingUnsubmittedExpenses: '既存の未提出経費に適用',
             },
         },
         planTypePage: {

--- a/src/languages/ja.ts
+++ b/src/languages/ja.ts
@@ -6346,6 +6346,7 @@ ${reportName}
                 matchTypeContains: '含む',
                 matchTypeExact: '完全一致',
                 expensesExactlyMatching: '以下と完全一致する経費について:',
+                applyToExistingUnsubmittedExpenses: '既存の未提出経費に適用する',
             },
         },
         planTypePage: {

--- a/src/languages/nl.ts
+++ b/src/languages/nl.ts
@@ -6379,7 +6379,7 @@ Vraag verplichte uitgavedetails zoals bonnetjes en beschrijvingen, stel limieten
                 matchTypeContains: 'Bevat',
                 matchTypeExact: 'Komt exact overeen',
                 expensesExactlyMatching: 'Voor uitgaven die exact overeenkomen met:',
-                applyToExistingUnsubmittedExpenses: 'Toepassen op bestaande niet-ingediende uitgaven',
+                applyToExistingUnsubmittedExpenses: 'Toepassen op bestaande niet-ingediende onkosten',
             },
         },
         planTypePage: {

--- a/src/languages/nl.ts
+++ b/src/languages/nl.ts
@@ -6379,6 +6379,7 @@ Vraag verplichte uitgavedetails zoals bonnetjes en beschrijvingen, stel limieten
                 matchTypeContains: 'Bevat',
                 matchTypeExact: 'Komt exact overeen',
                 expensesExactlyMatching: 'Voor uitgaven die exact overeenkomen met:',
+                applyToExistingUnsubmittedExpenses: 'Toepassen op bestaande niet-ingediende uitgaven',
             },
         },
         planTypePage: {

--- a/src/languages/pl.ts
+++ b/src/languages/pl.ts
@@ -6371,7 +6371,7 @@ Wymagaj szczegółów wydatków, takich jak paragony i opisy, ustawiaj limity i 
                 matchTypeContains: 'Zawiera',
                 matchTypeExact: 'Dokładne dopasowanie',
                 expensesExactlyMatching: 'Dla wydatków dokładnie pasujących:',
-                applyToExistingUnsubmittedExpenses: 'Zastosuj do istniejących niezgłoszonych wydatków',
+                applyToExistingUnsubmittedExpenses: 'Zastosuj do istniejących niewysłanych wydatków',
             },
         },
         planTypePage: {

--- a/src/languages/pl.ts
+++ b/src/languages/pl.ts
@@ -6371,6 +6371,7 @@ Wymagaj szczegółów wydatków, takich jak paragony i opisy, ustawiaj limity i 
                 matchTypeContains: 'Zawiera',
                 matchTypeExact: 'Dokładne dopasowanie',
                 expensesExactlyMatching: 'Dla wydatków dokładnie pasujących:',
+                applyToExistingUnsubmittedExpenses: 'Zastosuj do istniejących niezgłoszonych wydatków',
             },
         },
         planTypePage: {

--- a/src/languages/pt-BR.ts
+++ b/src/languages/pt-BR.ts
@@ -6371,7 +6371,7 @@ Exija detalhes de despesas como recibos e descrições, defina limites e padrõe
                 matchTypeContains: 'Contém',
                 matchTypeExact: 'Corresponde exatamente',
                 expensesExactlyMatching: 'Para despesas que correspondem exatamente:',
-                applyToExistingUnsubmittedExpenses: 'Aplicar a despesas existentes não enviadas',
+                applyToExistingUnsubmittedExpenses: 'Aplicar às despesas não enviadas existentes',
             },
         },
         planTypePage: {

--- a/src/languages/pt-BR.ts
+++ b/src/languages/pt-BR.ts
@@ -6371,6 +6371,7 @@ Exija detalhes de despesas como recibos e descrições, defina limites e padrõe
                 matchTypeContains: 'Contém',
                 matchTypeExact: 'Corresponde exatamente',
                 expensesExactlyMatching: 'Para despesas que correspondem exatamente:',
+                applyToExistingUnsubmittedExpenses: 'Aplicar a despesas existentes não enviadas',
             },
         },
         planTypePage: {

--- a/src/languages/zh-hans.ts
+++ b/src/languages/zh-hans.ts
@@ -6236,6 +6236,7 @@ ${reportName}
                 matchTypeContains: '包含',
                 matchTypeExact: '完全匹配',
                 expensesExactlyMatching: '对于完全匹配以下条件的报销：',
+                applyToExistingUnsubmittedExpenses: '应用于现有未提交的费用',
             },
         },
         planTypePage: {

--- a/src/languages/zh-hans.ts
+++ b/src/languages/zh-hans.ts
@@ -6236,7 +6236,7 @@ ${reportName}
                 matchTypeContains: '包含',
                 matchTypeExact: '完全匹配',
                 expensesExactlyMatching: '对于完全匹配以下条件的报销：',
-                applyToExistingUnsubmittedExpenses: '应用于现有未提交的费用',
+                applyToExistingUnsubmittedExpenses: '应用到现有的未提交报销费用',
             },
         },
         planTypePage: {

--- a/src/pages/workspace/rules/MerchantRules/MerchantRulePageBase.tsx
+++ b/src/pages/workspace/rules/MerchantRules/MerchantRulePageBase.tsx
@@ -287,9 +287,7 @@ function MerchantRulePageBase({policyID, ruleID, titleKey, testID}: MerchantRule
                     footerContent={
                         <>
                             <View style={[styles.flexRow, styles.alignItemsCenter, styles.justifyContentBetween, styles.mb4]}>
-                                <Text style={[styles.textNormal]}>
-                                    {translate('workspace.rules.merchantRules.applyToExistingUnsubmittedExpenses')}
-                                </Text>
+                                <Text style={[styles.textNormal]}>{translate('workspace.rules.merchantRules.applyToExistingUnsubmittedExpenses')}</Text>
                                 <Switch
                                     accessibilityLabel={translate('workspace.rules.merchantRules.applyToExistingUnsubmittedExpenses')}
                                     isOn={shouldUpdateMatchingTransactions}

--- a/src/pages/workspace/rules/MerchantRules/MerchantRulePageBase.tsx
+++ b/src/pages/workspace/rules/MerchantRules/MerchantRulePageBase.tsx
@@ -8,6 +8,7 @@ import type {LocalizedTranslate} from '@components/LocaleContextProvider';
 import MenuItemWithTopDescription from '@components/MenuItemWithTopDescription';
 import ScreenWrapper from '@components/ScreenWrapper';
 import ScrollView from '@components/ScrollView';
+import Switch from '@components/Switch';
 import Text from '@components/Text';
 import useLocalize from '@hooks/useLocalize';
 import useOnyx from '@hooks/useOnyx';
@@ -87,6 +88,7 @@ function MerchantRulePageBase({policyID, ruleID, titleKey, testID}: MerchantRule
     const [policyTags] = useOnyx(`${ONYXKEYS.COLLECTION.POLICY_TAGS}${policyID}`, {canBeMissing: true});
     const [shouldShowError, setShouldShowError] = useState(false);
     const [isDeleteModalVisible, setIsDeleteModalVisible] = useState(false);
+    const [shouldUpdateMatchingTransactions, setShouldUpdateMatchingTransactions] = useState(false);
 
     // Get the existing rule from the policy (for edit mode)
     const existingRule = ruleID ? policy?.rules?.codingRules?.[ruleID] : undefined;
@@ -160,7 +162,7 @@ function MerchantRulePageBase({policyID, ruleID, titleKey, testID}: MerchantRule
             return;
         }
 
-        setPolicyCodingRule(policyID, form, policy, ruleID, false);
+        setPolicyCodingRule(policyID, form, policy, ruleID, shouldUpdateMatchingTransactions);
         Navigation.goBack();
     };
 
@@ -283,14 +285,26 @@ function MerchantRulePageBase({policyID, ruleID, titleKey, testID}: MerchantRule
                     enabledWhenOffline
                     shouldRenderFooterAboveSubmit
                     footerContent={
-                        isEditing ? (
-                            <Button
-                                text={translate('workspace.rules.merchantRules.deleteRule')}
-                                onPress={() => setIsDeleteModalVisible(true)}
-                                style={[styles.mb4]}
-                                large
-                            />
-                        ) : null
+                        <>
+                            <View style={[styles.flexRow, styles.alignItemsCenter, styles.justifyContentBetween, styles.mb4]}>
+                                <Text style={[styles.textNormal]}>
+                                    {translate('workspace.rules.merchantRules.applyToExistingUnsubmittedExpenses')}
+                                </Text>
+                                <Switch
+                                    accessibilityLabel={translate('workspace.rules.merchantRules.applyToExistingUnsubmittedExpenses')}
+                                    isOn={shouldUpdateMatchingTransactions}
+                                    onToggle={setShouldUpdateMatchingTransactions}
+                                />
+                            </View>
+                            {isEditing && (
+                                <Button
+                                    text={translate('workspace.rules.merchantRules.deleteRule')}
+                                    onPress={() => setIsDeleteModalVisible(true)}
+                                    style={[styles.mb4]}
+                                    large
+                                />
+                            )}
+                        </>
                     }
                 />
                 {isEditing && (


### PR DESCRIPTION
### Explanation of Change
Add a new "Apply to existing unsubmitted expenses" toggle to the merchant rule form footer.

### Fixed Issues
$ https://github.com/Expensify/App/issues/80525

### Tests
Pre-condition: rules are enabled in the workspace

1. Navigate to `Workspace > Rules > Merchant`
2. Press `Add merchant rule`
3. Verify that you see the `Apply to existing unsubmitted expenses` toggle
4. Verify that toggled it on calls the `SetPolicyCodingRule` API command with `shouldUpdateMatchingTransactions` as `true`
5. After saving the rule, reopen the created rule
6. Verify that the toggle is off (this is intended because editing the rule shouldn't necessarily apply it to existing unsubmitted expenses)

- [x] Verify that no errors appear in the JS console

### Offline tests
N/A

### QA Steps
Same as tests

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I verified there are no new alerts related to the `canBeMissing` param for `useOnyx`
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos

https://github.com/user-attachments/assets/27b6eace-baa1-4545-b2cf-f02cf21b39a9


<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>