### PR TITLE
fix: add bottom margin to error row in TableListItem

### DIFF
--- a/src/components/SelectionList/ListItem/BaseListItem.tsx
+++ b/src/components/SelectionList/ListItem/BaseListItem.tsx
@@ -47,6 +47,7 @@ function BaseListItem<TItem extends ListItem>({
     shouldDisableHoverStyle,
     shouldStopMouseLeavePropagation = true,
     shouldShowRightCaret = false,
+    shouldAddErrorRowBottomMargin = false,
 }: BaseListItemProps<TItem>) {
     const theme = useTheme();
     const styles = useThemeStyles();
@@ -90,7 +91,7 @@ function BaseListItem<TItem extends ListItem>({
             onClose={() => onDismissError(item)}
             pendingAction={pendingAction}
             errors={errors}
-            errorRowStyles={styles.ph5}
+            errorRowStyles={shouldAddErrorRowBottomMargin ? [styles.ph5, styles.mb2] : styles.ph5}
             contentContainerStyle={containerStyle}
         >
             <PressableWithFeedback

--- a/src/components/SelectionList/ListItem/TableListItem.tsx
+++ b/src/components/SelectionList/ListItem/TableListItem.tsx
@@ -79,6 +79,7 @@ function TableListItem<TItem extends ListItem>({
             hoverStyle={item.isSelected && styles.activeComponentBG}
             shouldUseDefaultRightHandSideCheckmark={shouldUseDefaultRightHandSideCheckmark}
             shouldShowRightCaret={shouldShowRightCaret}
+            shouldAddErrorRowBottomMargin
         >
             {(hovered) => (
                 <>

--- a/src/components/SelectionList/ListItem/types.ts
+++ b/src/components/SelectionList/ListItem/types.ts
@@ -314,6 +314,9 @@ type BaseListItemProps<TItem extends ListItem> = CommonListItemProps<TItem> & {
 
     /** Whether to call stopPropagation on the mouseleave event in BaseListItem */
     shouldStopMouseLeavePropagation?: boolean;
+
+    /** Whether to add bottom margin to error row styles */
+    shouldAddErrorRowBottomMargin?: boolean;
 };
 
 type SplitListItemType = ListItem &


### PR DESCRIPTION
## Summary

Add `shouldAddErrorRowBottomMargin` prop to `BaseListItem` to conditionally apply bottom margin to error row styles. Enable this prop in `TableListItem` to fix uneven padding when error messages are displayed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Release Notes
- Fixed uneven top/bottom padding on error messages in TableListItem (e.g., when updating tags)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Fixed Issues

$ #80869

## Tests

- [x] Verify error messages in TableListItem now have consistent top/bottom padding
- [x] Verify other BaseListItem usages are unaffected (default is false)

## Offline Tests

N/A - UI styling change only

## QA Steps

1. Navigate to a screen using TableListItem (e.g., Tags)
2. Trigger an error (e.g., network error while updating)
3. Verify error message has equal top and bottom padding

## Screenshots/Demo Video

_Demo video will be added in follow-up comment_

/claim #80869

🤖 Generated with [Claude Code](https://claude.ai/code)