### PR TITLE
feat: patch Victory Native to fix X axis label rendering issues

### DIFF
--- a/patches/victory-native/details.md
+++ b/patches/victory-native/details.md
@@ -2,6 +2,10 @@
 
 ## 001+fix-rotated-label-bounds-check
 
+- **Patch:** [victory-native+41.20.2+001+fix-rotated-label-bounds-check.patch](victory-native+41.20.2+001+fix-rotated-label-bounds-check.patch)
+- **Issue:** https://github.com/Expensify/App/issues/80970
+- **PR:** https://github.com/Expensify/App/pull/80967
+
 **Problem:** Victory Native's XAxis component calculates label bounds using the unrotated text width, even when `labelRotate` is specified. This causes labels near the chart edges to be incorrectly hidden when rotated.
 
 For example, at 90° rotation:
@@ -18,6 +22,8 @@ rotatedWidth = textWidth * |cos(angle)| + fontSize * |sin(angle)|
 Use this `rotatedLabelWidth` for the bounds check (`canFitLabelContent`) while preserving the original `labelWidth` for positioning and rotation origin calculations.
 
 ## 002+add-label-overflow-prop
+
+- **Patch:** [victory-native+41.20.2+002+add-label-overflow-prop.patch](victory-native+41.20.2+002+add-label-overflow-prop.patch)
 
 **Problem:** Victory Native's XAxis component applies a `canFitLabelContent` bounds check that hides labels near chart edges. When consumers already control label visibility via `formatXLabel` (returning `''` for skipped labels), this creates double-filtering — labels are hidden both by the consumer's skip logic and by Victory's bounds check. This causes non-uniform gaps and missing end labels.
 

--- a/patches/victory-native/details.md
+++ b/patches/victory-native/details.md
@@ -1,0 +1,37 @@
+# victory-native patches
+
+## 001+fix-rotated-label-bounds-check
+
+**Problem:** Victory Native's XAxis component calculates label bounds using the unrotated text width, even when `labelRotate` is specified. This causes labels near the chart edges to be incorrectly hidden when rotated.
+
+For example, at 90° rotation:
+- Actual horizontal extent = font height (~14px)
+- Victory's bounds check uses = text width (could be 50-100px+)
+
+This results in labels being hidden even though they would visually fit.
+
+**Fix:** Calculate the actual horizontal extent of rotated labels using the formula:
+```
+rotatedWidth = textWidth * |cos(angle)| + fontSize * |sin(angle)|
+```
+
+Use this `rotatedLabelWidth` for the bounds check (`canFitLabelContent`) while preserving the original `labelWidth` for positioning and rotation origin calculations.
+
+## 002+add-label-overflow-prop
+
+**Problem:** Victory Native's XAxis component applies a `canFitLabelContent` bounds check that hides labels near chart edges. When consumers already control label visibility via `formatXLabel` (returning `''` for skipped labels), this creates double-filtering — labels are hidden both by the consumer's skip logic and by Victory's bounds check. This causes non-uniform gaps and missing end labels.
+
+**Fix:** Add a `labelOverflow` prop to `XAxisInputProps`:
+- `"hidden"` (default) — current behavior, bounds check active
+- `"visible"` — skip the `canFitLabelContent` check, render all labels with non-empty text
+
+When `labelOverflow` is `"visible"`, the rendering condition changes from:
+```typescript
+font && labelWidth && canFitLabelContent
+```
+to:
+```typescript
+font && labelWidth && (labelOverflow === "visible" || canFitLabelContent)
+```
+
+Labels with empty text (`formatXLabel` returning `''`) still get hidden naturally because `labelWidth` evaluates to `0` (falsy). This means the consumer's skip logic remains the sole visibility filter, eliminating double-filtering.

--- a/patches/victory-native/victory-native+41.20.2+001+fix-rotated-label-bounds-check.patch
+++ b/patches/victory-native/victory-native+41.20.2+001+fix-rotated-label-bounds-check.patch
@@ -1,16 +1,11 @@
 diff --git a/node_modules/victory-native/src/cartesian/components/XAxis.tsx b/node_modules/victory-native/src/cartesian/components/XAxis.tsx
-index 1234567..abcdefg 100644
+index 6d83472..a6e2ed0 100644
 --- a/node_modules/victory-native/src/cartesian/components/XAxis.tsx
 +++ b/node_modules/victory-native/src/cartesian/components/XAxis.tsx
-@@ -59,13 +59,21 @@ export const XAxis = <
-     const val = isNumericalData ? tick : ix[tick];
-
-     const contentX = formatXLabel(val as never);
-     const labelWidth =
+@@ -63,13 +63,22 @@ export const XAxis = <
        font
          ?.getGlyphWidths?.(font.getGlyphIDs(contentX))
          .reduce((sum, value) => sum + value, 0) ?? 0;
--    const labelX = xScale(tick) - (labelWidth ?? 0) / 2;
 +
 +    // Calculate actual horizontal extent accounting for rotation for bounds checking
 +    // For a rotated rectangle: width * |cos(angle)| + height * |sin(angle)|
@@ -19,7 +14,7 @@ index 1234567..abcdefg 100644
 +    const sinAngle = Math.abs(Math.sin(rotateRad));
 +    const rotatedLabelWidth = labelWidth * cosAngle + fontSize * sinAngle;
 +
-+    const labelX = xScale(tick) - (labelWidth ?? 0) / 2;
+     const labelX = xScale(tick) - (labelWidth ?? 0) / 2;
 +    const rotatedLabelX = xScale(tick) - rotatedLabelWidth / 2;
      const canFitLabelContent =
        xScale(tick) >= chartBounds.left &&
@@ -29,5 +24,6 @@ index 1234567..abcdefg 100644
 -        : chartBounds.left < labelX);
 +        ? rotatedLabelX + rotatedLabelWidth < chartBounds.right
 +        : chartBounds.left < rotatedLabelX);
-
+ 
      const labelY = (() => {
+       // bottom, outset

--- a/patches/victory-native/victory-native+41.20.2+001+fix-rotated-label-bounds-check.patch
+++ b/patches/victory-native/victory-native+41.20.2+001+fix-rotated-label-bounds-check.patch
@@ -1,0 +1,33 @@
+diff --git a/node_modules/victory-native/src/cartesian/components/XAxis.tsx b/node_modules/victory-native/src/cartesian/components/XAxis.tsx
+index 1234567..abcdefg 100644
+--- a/node_modules/victory-native/src/cartesian/components/XAxis.tsx
++++ b/node_modules/victory-native/src/cartesian/components/XAxis.tsx
+@@ -59,13 +59,21 @@ export const XAxis = <
+     const val = isNumericalData ? tick : ix[tick];
+
+     const contentX = formatXLabel(val as never);
+     const labelWidth =
+       font
+         ?.getGlyphWidths?.(font.getGlyphIDs(contentX))
+         .reduce((sum, value) => sum + value, 0) ?? 0;
+-    const labelX = xScale(tick) - (labelWidth ?? 0) / 2;
++
++    // Calculate actual horizontal extent accounting for rotation for bounds checking
++    // For a rotated rectangle: width * |cos(angle)| + height * |sin(angle)|
++    const rotateRad = (Math.PI / 180) * (labelRotate ?? 0);
++    const cosAngle = Math.abs(Math.cos(rotateRad));
++    const sinAngle = Math.abs(Math.sin(rotateRad));
++    const rotatedLabelWidth = labelWidth * cosAngle + fontSize * sinAngle;
++
++    const labelX = xScale(tick) - (labelWidth ?? 0) / 2;
++    const rotatedLabelX = xScale(tick) - rotatedLabelWidth / 2;
+     const canFitLabelContent =
+       xScale(tick) >= chartBounds.left &&
+       xScale(tick) <= chartBounds.right &&
+       (yAxisSide === "left"
+-        ? labelX + labelWidth < chartBounds.right
+-        : chartBounds.left < labelX);
++        ? rotatedLabelX + rotatedLabelWidth < chartBounds.right
++        : chartBounds.left < rotatedLabelX);
+
+     const labelY = (() => {

--- a/patches/victory-native/victory-native+41.20.2+002+add-label-overflow-prop.patch
+++ b/patches/victory-native/victory-native+41.20.2+002+add-label-overflow-prop.patch
@@ -1,0 +1,46 @@
+diff --git a/node_modules/victory-native/src/cartesian/components/XAxis.tsx b/node_modules/victory-native/src/cartesian/components/XAxis.tsx
+--- a/node_modules/victory-native/src/cartesian/components/XAxis.tsx
++++ b/node_modules/victory-native/src/cartesian/components/XAxis.tsx
+@@ -41,6 +41,7 @@ export const XAxis = <
+   chartBounds,
+   enableRescaling,
++  labelOverflow,
+   zoom,
+ }: XAxisProps<RawData, XK>) => {
+   const xScale = zoom ? zoom.rescaleX(xScaleProp) : xScaleProp;
+@@ -137,7 +138,7 @@ export const XAxis = <
+         ) : null}
+-        {font && labelWidth && canFitLabelContent ? (
++        {font && labelWidth && (labelOverflow === "visible" || canFitLabelContent) ? (
+           <Group transform={[{ translateY: rotateOffset }]}>
+             <Text
+               transform={[
+diff --git a/node_modules/victory-native/src/types.ts b/node_modules/victory-native/src/types.ts
+--- a/node_modules/victory-native/src/types.ts
++++ b/node_modules/victory-native/src/types.ts
+@@ -201,6 +201,7 @@ export type XAxisInputProps<
+   linePathEffect?: DashPathEffectComponent;
+   enableRescaling?: boolean;
++  labelOverflow?: "hidden" | "visible";
+ };
+
+ export type XAxisPropsWithDefaults<
+@@ -209,17 +210,19 @@ export type XAxisPropsWithDefaults<
+ > = Required<
+   Omit<
+     XAxisInputProps<RawData, XK>,
+-    "font" | "tickValues" | "linePathEffect" | "enableRescaling" | "labelRotate"
++    "font" | "tickValues" | "linePathEffect" | "enableRescaling" | "labelRotate" | "labelOverflow"
+   >
+ > &
+   Partial<
+     Pick<
+       XAxisInputProps<RawData, XK>,
+       | "font"
+       | "tickValues"
+       | "linePathEffect"
+       | "enableRescaling"
+       | "labelRotate"
++      | "labelOverflow"
+     >
+   >;

--- a/patches/victory-native/victory-native+41.20.2+002+add-label-overflow-prop.patch
+++ b/patches/victory-native/victory-native+41.20.2+002+add-label-overflow-prop.patch
@@ -1,14 +1,18 @@
 diff --git a/node_modules/victory-native/src/cartesian/components/XAxis.tsx b/node_modules/victory-native/src/cartesian/components/XAxis.tsx
+index a6e2ed0..628abab 100644
 --- a/node_modules/victory-native/src/cartesian/components/XAxis.tsx
 +++ b/node_modules/victory-native/src/cartesian/components/XAxis.tsx
 @@ -41,6 +41,7 @@ export const XAxis = <
+   linePathEffect,
    chartBounds,
    enableRescaling,
 +  labelOverflow,
    zoom,
  }: XAxisProps<RawData, XK>) => {
    const xScale = zoom ? zoom.rescaleX(xScaleProp) : xScaleProp;
-@@ -137,7 +138,7 @@ export const XAxis = <
+@@ -146,7 +147,7 @@ export const XAxis = <
+             </Line>
+           </Group>
          ) : null}
 -        {font && labelWidth && canFitLabelContent ? (
 +        {font && labelWidth && (labelOverflow === "visible" || canFitLabelContent) ? (
@@ -16,16 +20,18 @@ diff --git a/node_modules/victory-native/src/cartesian/components/XAxis.tsx b/no
              <Text
                transform={[
 diff --git a/node_modules/victory-native/src/types.ts b/node_modules/victory-native/src/types.ts
+index a3a4c81..73f5f48 100644
 --- a/node_modules/victory-native/src/types.ts
 +++ b/node_modules/victory-native/src/types.ts
 @@ -201,6 +201,7 @@ export type XAxisInputProps<
+   yAxisSide?: YAxisSide;
    linePathEffect?: DashPathEffectComponent;
    enableRescaling?: boolean;
 +  labelOverflow?: "hidden" | "visible";
  };
-
+ 
  export type XAxisPropsWithDefaults<
-@@ -209,17 +210,19 @@ export type XAxisPropsWithDefaults<
+@@ -209,7 +210,7 @@ export type XAxisPropsWithDefaults<
  > = Required<
    Omit<
      XAxisInputProps<RawData, XK>,
@@ -34,13 +40,11 @@ diff --git a/node_modules/victory-native/src/types.ts b/node_modules/victory-nat
    >
  > &
    Partial<
-     Pick<
-       XAxisInputProps<RawData, XK>,
-       | "font"
-       | "tickValues"
+@@ -220,6 +221,7 @@ export type XAxisPropsWithDefaults<
        | "linePathEffect"
        | "enableRescaling"
        | "labelRotate"
 +      | "labelOverflow"
      >
    >;
+ 

--- a/patches/victory-native/victory-native+41.20.2+002+add-label-overflow-prop.patch
+++ b/patches/victory-native/victory-native+41.20.2+002+add-label-overflow-prop.patch
@@ -1,3 +1,18 @@
+diff --git a/node_modules/victory-native/dist/types.d.ts b/node_modules/victory-native/dist/types.d.ts
+index efb5207..df7bbba 100644
+--- a/node_modules/victory-native/dist/types.d.ts
++++ b/node_modules/victory-native/dist/types.d.ts
+@@ -177,8 +177,9 @@ export type XAxisInputProps<RawData extends Record<string, unknown>, XK extends
+     yAxisSide?: YAxisSide;
+     linePathEffect?: DashPathEffectComponent;
+     enableRescaling?: boolean;
++    labelOverflow?: "hidden" | "visible";
+ };
+-export type XAxisPropsWithDefaults<RawData extends Record<string, unknown>, XK extends keyof InputFields<RawData>> = Required<Omit<XAxisInputProps<RawData, XK>, "font" | "tickValues" | "linePathEffect" | "enableRescaling" | "labelRotate">> & Partial<Pick<XAxisInputProps<RawData, XK>, "font" | "tickValues" | "linePathEffect" | "enableRescaling" | "labelRotate">>;
++export type XAxisPropsWithDefaults<RawData extends Record<string, unknown>, XK extends keyof InputFields<RawData>> = Required<Omit<XAxisInputProps<RawData, XK>, "font" | "tickValues" | "linePathEffect" | "enableRescaling" | "labelRotate" | "labelOverflow">> & Partial<Pick<XAxisInputProps<RawData, XK>, "font" | "tickValues" | "linePathEffect" | "enableRescaling" | "labelRotate" | "labelOverflow">>;
+ export type XAxisProps<RawData extends Record<string, unknown>, XK extends keyof InputFields<RawData>> = XAxisPropsWithDefaults<RawData, XK> & {
+     xScale: Scale;
+     yScale: Scale;
 diff --git a/node_modules/victory-native/src/cartesian/components/XAxis.tsx b/node_modules/victory-native/src/cartesian/components/XAxis.tsx
 index a6e2ed0..628abab 100644
 --- a/node_modules/victory-native/src/cartesian/components/XAxis.tsx

--- a/src/components/Charts/BarChart/BarChartContent.tsx
+++ b/src/components/Charts/BarChart/BarChartContent.tsx
@@ -54,6 +54,7 @@ function BarChartContent({data, title, titleIcon, isLoading, yAxisUnit, yAxisUni
     const {shouldUseNarrowLayout} = useResponsiveLayout();
     const font = useFont(fontSource, variables.iconSizeExtraSmall);
     const [chartWidth, setChartWidth] = useState(0);
+    const [barAreaWidth, setBarAreaWidth] = useState(0);
     const [containerHeight, setContainerHeight] = useState(0);
 
     const defaultBarColor = CHART_COLORS.at(DEFAULT_SINGLE_BAR_COLOR_INDEX);
@@ -94,6 +95,7 @@ function BarChartContent({data, title, titleIcon, isLoading, yAxisUnit, yAxisUni
         data,
         font,
         chartWidth,
+        barAreaWidth,
         containerHeight,
     });
 
@@ -126,6 +128,7 @@ function BarChartContent({data, title, titleIcon, isLoading, yAxisUnit, yAxisUni
                 barWidth: calculatedBarWidth,
                 chartBottom: bounds.bottom,
             });
+            setBarAreaWidth(domainWidth);
         },
         [data.length, barGeometry],
     );

--- a/src/components/Charts/BarChart/BarChartContent.tsx
+++ b/src/components/Charts/BarChart/BarChartContent.tsx
@@ -259,6 +259,7 @@ function BarChartContent({data, title, titleIcon, isLoading, yAxisUnit, yAxisUni
                             lineWidth: X_AXIS_LINE_WIDTH,
                             formatXLabel: formatXAxisLabel,
                             labelRotate: labelRotation,
+                            labelOverflow: 'visible',
                         }}
                         yAxis={[
                             {


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
This is a follow up PR to https://github.com/Expensify/Mobile-Expensify/pull/13830. It patches Victory XL to improve X axis labels rendering.

Problems fixed:
- Random non-uniform gaps in the middle
- Missing labels at the end
- Rendering issues on narrow screens or with many bars

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/80970 https://github.com/Expensify/App/issues/80971
PROPOSAL: 


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

Check all those steps against "Problems fixed" section:

- [ ] Test charts with many bars
- [ ] Test charts on screens with small width
- [ ] Open dev tools on web and press `Toggle device toolbar` to test different widths of screen.

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->
-

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->
Same as tests

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I verified there are no new alerts related to the `canBeMissing` param for `useOnyx`
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>