### PR TITLE
Add the ability to create a workspace for a client

### DIFF
--- a/src/components/PlanTypeSelector.tsx
+++ b/src/components/PlanTypeSelector.tsx
@@ -1,0 +1,130 @@
+import React, {useRef, useState} from 'react';
+import type {View} from 'react-native';
+import type {ValueOf} from 'type-fest';
+import useLocalize from '@hooks/useLocalize';
+import useThemeStyles from '@hooks/useThemeStyles';
+import {getUserFriendlyWorkspaceType} from '@libs/PolicyUtils';
+import CONST from '@src/CONST';
+import HeaderWithBackButton from './HeaderWithBackButton';
+import MenuItemWithTopDescription from './MenuItemWithTopDescription';
+import Modal from './Modal';
+import ScreenWrapper from './ScreenWrapper';
+import SelectionList from './SelectionList';
+import RadioListItem from './SelectionList/ListItem/RadioListItem';
+import Text from './Text';
+
+type PlanTypeItem = {
+    value: ValueOf<typeof CONST.POLICY.TYPE>;
+    text: string;
+    alternateText: string;
+    keyForList: ValueOf<typeof CONST.POLICY.TYPE>;
+    isSelected: boolean;
+};
+
+type PlanTypeSelectorProps = {
+    /** Form error text. e.g when no plan type is selected */
+    errorText?: string;
+
+    /** Callback called when the plan type changes. */
+    onInputChange?: (value?: string, key?: string) => void;
+
+    /** Current selected plan type */
+    value?: string;
+
+    /** inputID used by the Form component */
+    // eslint-disable-next-line react/no-unused-prop-types
+    inputID: string;
+
+    /** Callback to call when the picker modal is dismissed */
+    onBlur?: () => void;
+
+    /** Label for the input */
+    label?: string;
+};
+
+function PlanTypeSelector({errorText = '', value: planType, onInputChange = () => {}, onBlur, label}: PlanTypeSelectorProps) {
+    const styles = useThemeStyles();
+    const {translate} = useLocalize();
+    const inputRef = useRef<View>(null);
+    const [isPickerVisible, setIsPickerVisible] = useState(false);
+
+    const showPickerModal = () => {
+        setIsPickerVisible(true);
+    };
+
+    const hidePickerModal = () => {
+        setIsPickerVisible(false);
+    };
+
+    const handlePlanTypeSelect = (option: PlanTypeItem) => {
+        onInputChange?.(option.value);
+        hidePickerModal();
+    };
+
+    const getPlanTypeDisplayText = () => {
+        if (!planType) {
+            return '';
+        }
+        return getUserFriendlyWorkspaceType(planType as ValueOf<typeof CONST.POLICY.TYPE>, translate);
+    };
+
+    // Create plan type options
+    const planTypeOptions: PlanTypeItem[] = Object.values(CONST.POLICY.TYPE)
+        .filter((type) => type !== CONST.POLICY.TYPE.PERSONAL)
+        .map((policyType) => ({
+            value: policyType,
+            text: translate(`workspace.planTypePage.planTypes.${policyType}.label`),
+            alternateText: translate(`workspace.planTypePage.planTypes.${policyType}.description`),
+            keyForList: policyType,
+            isSelected: policyType === planType,
+        }));
+
+    return (
+        <>
+            <MenuItemWithTopDescription
+                ref={inputRef}
+                shouldShowRightIcon
+                title={getPlanTypeDisplayText()}
+                description={label ?? translate('workspace.common.planType')}
+                descriptionTextStyle={styles.textNormalThemeText}
+                onPress={showPickerModal}
+                brickRoadIndicator={errorText ? CONST.BRICK_ROAD_INDICATOR_STATUS.ERROR : undefined}
+                errorText={errorText}
+                onBlur={onBlur}
+            />
+            <Modal
+                type={CONST.MODAL.MODAL_TYPE.RIGHT_DOCKED}
+                isVisible={isPickerVisible}
+                onClose={hidePickerModal}
+                onModalHide={hidePickerModal}
+                enableEdgeToEdgeBottomSafeAreaPadding
+            >
+                <ScreenWrapper
+                    style={styles.pb0}
+                    includePaddingTop={false}
+                    enableEdgeToEdgeBottomSafeAreaPadding
+                    testID="PlanTypeSelectorModal"
+                >
+                    <HeaderWithBackButton
+                        title={label ?? translate('workspace.common.planType')}
+                        shouldShowBackButton
+                        onBackButtonPress={hidePickerModal}
+                    />
+                    <Text style={[styles.ph5, styles.pb4, styles.sidebarLinkText, styles.optionAlternateText]}>{translate('workspace.planTypePage.description')}</Text>
+                    <SelectionList
+                        data={planTypeOptions}
+                        ListItem={RadioListItem}
+                        onSelectRow={handlePlanTypeSelect}
+                        shouldSingleExecuteRowSelect
+                        initiallyFocusedItemKey={planTypeOptions.find((option) => option.isSelected)?.keyForList}
+                        addBottomSafeAreaPadding
+                    />
+                </ScreenWrapper>
+            </Modal>
+        </>
+    );
+}
+
+PlanTypeSelector.displayName = 'PlanTypeSelector';
+
+export default PlanTypeSelector;

--- a/src/components/WorkspaceConfirmationForm.tsx
+++ b/src/components/WorkspaceConfirmationForm.tsx
@@ -26,6 +26,7 @@ import FormProvider from './Form/FormProvider';
 import InputWrapper from './Form/InputWrapper';
 import type {FormInputErrors, FormOnyxValues} from './Form/types';
 import HeaderWithBackButton from './HeaderWithBackButton';
+import PlanTypeSelector from './PlanTypeSelector';
 import ScrollView from './ScrollView';
 import Text from './Text';
 import TextInput from './TextInput';
@@ -33,6 +34,7 @@ import TextInput from './TextInput';
 type WorkspaceConfirmationSubmitFunctionParams = {
     name: string;
     currency: string;
+    planType: string;
     avatarFile: File | CustomRNImageManipulatorResult | undefined;
     policyID: string;
 };
@@ -77,6 +79,10 @@ function WorkspaceConfirmationForm({onSubmit, policyOwnerEmail = '', onBackButto
                 errors[INPUT_IDS.CURRENCY] = translate('common.error.fieldRequired');
             }
 
+            if (!isRequiredFulfilled(values[INPUT_IDS.PLAN_TYPE])) {
+                errors[INPUT_IDS.PLAN_TYPE] = translate('common.error.fieldRequired');
+            }
+
             return errors;
         },
         [translate],
@@ -92,6 +98,7 @@ function WorkspaceConfirmationForm({onSubmit, policyOwnerEmail = '', onBackButto
     const [workspaceNameFirstCharacter, setWorkspaceNameFirstCharacter] = useState(defaultWorkspaceName ?? '');
 
     const userCurrency = draftValues?.currency ?? currentUserPersonalDetails?.localCurrencyCode ?? CONST.CURRENCY.USD;
+    const userPlanType = draftValues?.planType ?? CONST.POLICY.TYPE.TEAM;
 
     useEffect(() => {
         return () => {
@@ -159,6 +166,7 @@ function WorkspaceConfirmationForm({onSubmit, policyOwnerEmail = '', onBackButto
                         onSubmit({
                             name: val[INPUT_IDS.NAME],
                             currency: val[INPUT_IDS.CURRENCY],
+                            planType: val[INPUT_IDS.PLAN_TYPE],
                             avatarFile,
                             policyID,
                         })
@@ -194,6 +202,14 @@ function WorkspaceConfirmationForm({onSubmit, policyOwnerEmail = '', onBackButto
                                 value={userCurrency}
                                 shouldShowCurrencySymbol
                                 currencySelectorRoute={ROUTES.CURRENCY_SELECTION}
+                            />
+                        </View>
+                        <View style={[styles.mhn5]}>
+                            <InputWrapper
+                                InputComponent={PlanTypeSelector}
+                                inputID={INPUT_IDS.PLAN_TYPE}
+                                label={translate('workspace.common.planType')}
+                                value={userPlanType}
                             />
                         </View>
                     </View>

--- a/src/types/form/WorkspaceConfirmationForm.tsx
+++ b/src/types/form/WorkspaceConfirmationForm.tsx
@@ -4,6 +4,7 @@ import type Form from './Form';
 const INPUT_IDS = {
     NAME: 'name',
     CURRENCY: 'currency',
+    PLAN_TYPE: 'planType',
 } as const;
 
 type InputID = ValueOf<typeof INPUT_IDS>;
@@ -13,6 +14,7 @@ type WorkspaceConfirmationForm = Form<
     {
         [INPUT_IDS.NAME]: string;
         [INPUT_IDS.CURRENCY]: string;
+        [INPUT_IDS.PLAN_TYPE]: string;
     }
 >;
 


### PR DESCRIPTION
### Explanation of Change


### Fixed Issues

$ https://github.com/Expensify/App/issues/80057
PROPOSAL: https://github.com/Expensify/App/issues/80057#issuecomment-3779019708

### Tests

Same QA step

- [ ] Verify that no errors appear in the JS console

### Offline tests

### QA Steps

1. Open the Expensify app.

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [ ] I linked the correct issue in the `### Fixed Issues` section above
- [ ] I wrote clear testing steps that cover the changes made in this PR
    - [ ] I added steps for local testing in the `Tests` section
    - [ ] I added steps for the expected offline behavior in the `Offline steps` section
    - [ ] I added steps for Staging and/or Production testing in the `QA steps` section
    - [ ] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [ ] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [ ] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [ ] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [ ] I ran the tests on **all platforms** & verified they passed on:
    - [ ] Android: Native
    - [ ] Android: mWeb Chrome
    - [ ] iOS: Native
    - [ ] iOS: mWeb Safari
    - [ ] MacOS: Chrome / Safari
- [ ] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [ ] I verified there are no new alerts related to the `canBeMissing` param for `useOnyx`
- [ ] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [ ] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [ ] I verified that comments were added to code that is not self explanatory
    - [ ] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [ ] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [ ] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [ ] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [ ] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [ ] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [ ] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [ ] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [ ] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [ ] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [ ] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [ ] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [ ] I verified that if a function's arguments changed that all usages have also been updated correctly
- [ ] If any new file was added I verified that:
    - [ ] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [ ] If a new CSS style is added I verified that:
    - [ ] A similar style doesn't already exist
    - [ ] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [ ] If new assets were added or existing ones were modified, I verified that:
    - [ ] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [ ] The assets load correctly across all supported platforms.
- [ ] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [ ] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [ ] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [ ] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [ ] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [ ] I verified that all the inputs inside a form are aligned with each other.
    - [ ] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [ ] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [ ] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [ ] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.


### Screenshots/Videos
<details>
<summary>Android: Native</summary>







</details>

<details>
<summary>Android: mWeb Chrome</summary>




</details>

<details>
<summary>iOS: Native</summary>





</details>

<details>
<summary>iOS: mWeb Safari</summary>





</details>

<details>
<summary>MacOS: Chrome / Safari</summary>




</details>