### PR TITLE
fix: hide tax columns for time expenses in TransactionItemRow

### DIFF
--- a/src/components/TransactionItemRow/index.tsx
+++ b/src/components/TransactionItemRow/index.tsx
@@ -41,6 +41,7 @@ import {
     isAmountMissing,
     isMerchantMissing,
     isScanning,
+    isTimeRequest,
     isUnreportedAndHasInvalidDistanceRateTransaction,
 } from '@libs/TransactionUtils';
 import CONST from '@src/CONST';
@@ -528,7 +529,7 @@ function TransactionItemRow({
                     key={CONST.SEARCH.TABLE_COLUMNS.TAX_RATE}
                     style={[StyleUtils.getReportTableColumnStyles(CONST.SEARCH.TABLE_COLUMNS.TAX_RATE)]}
                 >
-                    <TextCell text={getTaxName(transactionItem.policy, transactionItem) ?? transactionItem.taxValue ?? ''} />
+                    <TextCell text={isTimeRequest(transactionItem) ? '' : (getTaxName(transactionItem.policy, transactionItem) ?? transactionItem.taxValue ?? '')} />
                 </View>
             ),
             [CONST.SEARCH.TABLE_COLUMNS.TAX_AMOUNT]: (
@@ -536,10 +537,12 @@ function TransactionItemRow({
                     key={CONST.SEARCH.TABLE_COLUMNS.TAX_AMOUNT}
                     style={[StyleUtils.getReportTableColumnStyles(CONST.SEARCH.TABLE_COLUMNS.TAX_AMOUNT, undefined, undefined, isTaxAmountColumnWide)]}
                 >
-                    <TaxCell
-                        transactionItem={transactionItem}
-                        shouldShowTooltip={shouldShowTooltip}
-                    />
+                    {isTimeRequest(transactionItem) ? null : (
+                        <TaxCell
+                            transactionItem={transactionItem}
+                            shouldShowTooltip={shouldShowTooltip}
+                        />
+                    )}
                 </View>
             ),
             [CONST.SEARCH.TABLE_COLUMNS.POLICY_NAME]: (

--- a/tests/ui/TransactionItemRowRBRTest.tsx
+++ b/tests/ui/TransactionItemRowRBRTest.tsx
@@ -283,6 +283,32 @@ describe('TransactionItemRowRBR', () => {
         expect(screen.getByText('Unexpected error posting the comment. Please try again later. Missing category.')).toBeOnTheScreen();
     });
 
+    it('should not display tax columns for time expense transactions', async () => {
+        const mockTimeTransaction = createBaseTransaction({
+            iouRequestType: CONST.IOU.REQUEST_TYPE.TIME,
+            taxAmount: 1000,
+            taxCode: 'TAX_CODE_1',
+            taxValue: '10%',
+        });
+        await Onyx.merge(`${ONYXKEYS.COLLECTION.TRANSACTION}${MOCK_TRANSACTION_ID}`, mockTimeTransaction);
+
+        render(
+            <ComposeProviders components={[OnyxListItemProvider, LocaleContextProvider, HTMLEngineProvider]}>
+                <TransactionItemRow
+                    transactionItem={mockTimeTransaction}
+                    violations={undefined}
+                    // eslint-disable-next-line react/jsx-props-no-spreading
+                    {...defaultProps}
+                    columns={[CONST.SEARCH.TABLE_COLUMNS.TAX_RATE, CONST.SEARCH.TABLE_COLUMNS.TAX_AMOUNT]}
+                />
+            </ComposeProviders>,
+        );
+        await waitForBatchedUpdates();
+
+        expect(screen.queryByText('10%')).not.toBeOnTheScreen();
+        expect(screen.queryByText('$10.00')).not.toBeOnTheScreen();
+    });
+
     it('should display RBR message for transaction with violations, errors, and missing merchant error', async () => {
         // Given a transaction with violations, errors, and missing merchant error
         const mockViolations: TransactionViolations = [


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change

This PR fixes an issue where Tax Rate and Tax Amount columns in the Reports > Expenses view were displaying tax data for time expenses. According to PR #77748, time expenses should not display tax information since they don't support taxes.

The fix adds a check using the existing `isTimeRequest()` function from `TransactionUtils` in the `TransactionItemRow` component to conditionally hide tax data for time expenses:
- For the `TAX_RATE` column: returns an empty string when the transaction is a time expense
- For the `TAX_AMOUNT` column: returns `null` (renders nothing) when the transaction is a time expense

This aligns the Search/Reports view behavior with the `MoneyRequestView` behavior established in PR #77748.

### Fixed Issues

$ https://github.com/Expensify/App/issues/80208
PROPOSAL: https://github.com/Expensify/App/issues/80208#issuecomment-3784000146

### Tests

1. Log in with an Expensifail account that has Time tracking enabled and Taxes feature enabled
2. Go to workspace chat
3. Click + > Create expense > Time
4. Create a time expense
5. Go to Reports > Expenses
6. Click Columns
7. Select Tax and Tax rate and click Save
8. Scroll the table to Tax and Tax rate columns
9. Verify that Tax and Tax rate columns are empty for the time expense

- [x] Verify that no errors appear in the JS console

### Offline tests

1. Create a time expense while online
2. Go offline
3. Navigate to Reports > Expenses
4. Verify that Tax and Tax rate columns are still empty for time expenses
5. Verify no errors appear in the console

### QA Steps

1. Log in with an Expensifail account that has Time tracking enabled and Taxes feature enabled
2. Go to workspace chat
3. Click + > Create expense > Time
4. Create a time expense
5. Go to Reports > Expenses
6. Click Columns
7. Select Tax and Tax rate and click Save
8. Scroll the table to Tax and Tax rate columns
9. Verify that Tax and Tax rate columns are empty for the time expense
10. Create a regular expense (not time) with tax
11. Verify that Tax and Tax rate columns show the tax data for the regular expense

- [x] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I verified there are no new alerts related to the `canBeMissing` param for `useOnyx`
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

NA as column selection is disabled on narrow screens.

</details>

<details>
<summary>Android: mWeb Chrome</summary>

NA as column selection is disabled on narrow screens.


</details>

<details>
<summary>iOS: Native</summary>

NA as column selection is disabled on narrow screens.

</details>

<details>
<summary>iOS: mWeb Safari</summary>

NA as column selection is disabled on narrow screens.

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

https://github.com/user-attachments/assets/1f3658fc-b375-4d61-8a5f-efe38c925423


</details>

