### PR TITLE
Chat- Thread message is not shown in the detail page adding  conditional parsing logic to ReportDetailsPage.tsx 

### DIFF
--- a/src/pages/ReportDetailsPage.tsx
+++ b/src/pages/ReportDetailsPage.tsx
@@ -352,9 +352,9 @@ function ReportDetailsPage({policy, report, route, reportMetadata}: ReportDetail
     const shouldShowGoToWorkspace = shouldShowPolicy(policy, false, currentUserPersonalDetails?.email) && !policy?.isJoinRequestPending;
 
     const reportForHeader = useMemo(() => getReportForHeader(report), [report]);
-    const shouldParseFullTitle = parentReportAction?.actionName !==
-         CONST.REPORT.ACTIONS.TYPE.ADD_COMMENT && !isGroupChat;
-    const reportName = shouldParseFullTitle ? Parser.htmlToText(getReportNameFromReportNameUtils(report, reportAttributes)) : getReportNameFromReportNameUtils(report, reportAttributes);
+    const shouldParseFullTitle = parentReportAction?.actionName !== CONST.REPORT.ACTIONS.TYPE.ADD_COMMENT && !isGroupChat;
+    const rawReportName = getReportNameFromReportNameUtils(reportForHeader, reportAttributes);
+    const reportName = shouldParseFullTitle ? Parser.htmlToText(rawReportName) : rawReportName;
     const additionalRoomDetails =
         (isPolicyExpenseChat && !!report?.isOwnPolicyExpenseChat) || isExpenseReportUtil(report) || isPolicyExpenseChat || isInvoiceRoom
             ? chatRoomSubtitle
@@ -746,6 +746,7 @@ function ReportDetailsPage({policy, report, route, reportMetadata}: ReportDetail
                     </View>
                     {isPolicyAdmin ? (
                         <PressableWithoutFeedback
+                            sentryLabel="nameSectionExpenseIOU"
                             style={[styles.w100]}
                             disabled={policy?.pendingAction === CONST.RED_BRICK_ROAD_PENDING_ACTION.DELETE}
                             role={CONST.ROLE.BUTTON}

--- a/src/pages/ReportDetailsPage.tsx
+++ b/src/pages/ReportDetailsPage.tsx
@@ -350,10 +350,11 @@ function ReportDetailsPage({policy, report, route, reportMetadata}: ReportDetail
 
     const shouldShowLeaveButton = canLeaveChat(report, policy, !!reportNameValuePairs?.private_isArchived);
     const shouldShowGoToWorkspace = shouldShowPolicy(policy, false, currentUserPersonalDetails?.email) && !policy?.isJoinRequestPending;
+
     const reportForHeader = useMemo(() => getReportForHeader(report), [report]);
-    const reportName = isGroupChat
-        ? getReportNameFromReportNameUtils(reportForHeader, reportAttributes)
-        : Parser.htmlToText(getReportNameFromReportNameUtils(reportForHeader, reportAttributes));
+    const shouldParseFullTitle = parentReportAction?.actionName !==
+         CONST.REPORT.ACTIONS.TYPE.ADD_COMMENT && !isGroupChat;
+    const reportName = shouldParseFullTitle ? Parser.htmlToText(getReportNameFromReportNameUtils(report, reportAttributes)) : getReportNameFromReportNameUtils(report, reportAttributes);
     const additionalRoomDetails =
         (isPolicyExpenseChat && !!report?.isOwnPolicyExpenseChat) || isExpenseReportUtil(report) || isPolicyExpenseChat || isInvoiceRoom
             ? chatRoomSubtitle

--- a/src/pages/ReportDetailsPage.tsx
+++ b/src/pages/ReportDetailsPage.tsx
@@ -746,7 +746,6 @@ function ReportDetailsPage({policy, report, route, reportMetadata}: ReportDetail
                     </View>
                     {isPolicyAdmin ? (
                         <PressableWithoutFeedback
-                            sentryLabel={CONST.SENTRY_LABEL.REPORT.SEND_BUTTON}
                             style={[styles.w100]}
                             disabled={policy?.pendingAction === CONST.RED_BRICK_ROAD_PENDING_ACTION.DELETE}
                             role={CONST.ROLE.BUTTON}

--- a/src/pages/ReportDetailsPage.tsx
+++ b/src/pages/ReportDetailsPage.tsx
@@ -746,7 +746,7 @@ function ReportDetailsPage({policy, report, route, reportMetadata}: ReportDetail
                     </View>
                     {isPolicyAdmin ? (
                         <PressableWithoutFeedback
-                            sentryLabel="nameSectionExpenseIOU"
+                            sentryLabel={CONST.SENTRY_LABEL.REPORT.SEND_BUTTON}
                             style={[styles.w100]}
                             disabled={policy?.pendingAction === CONST.RED_BRICK_ROAD_PENDING_ACTION.DELETE}
                             role={CONST.ROLE.BUTTON}

--- a/tests/ui/GroupChatNameTests.tsx
+++ b/tests/ui/GroupChatNameTests.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable testing-library/no-node-access */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
-import {act, render, screen, waitFor} from '@testing-library/react-native';
+import {act, cleanup, render, screen, waitFor} from '@testing-library/react-native';
 import React from 'react';
 import Onyx from 'react-native-onyx';
 import {setSidebarLoaded} from '@userActions/App';
@@ -239,6 +239,10 @@ describe('Tests for group chat name', () => {
         PusherHelper.teardown();
 
         return Onyx.clear().then(waitForBatchedUpdates);
+    });
+
+    afterEach(() => {
+        cleanup();
     });
 
     const participantAccountIDs4 = [USER_A_ACCOUNT_ID, USER_B_ACCOUNT_ID, USER_C_ACCOUNT_ID, USER_D_ACCOUNT_ID];

--- a/tests/ui/GroupChatNameTests.tsx
+++ b/tests/ui/GroupChatNameTests.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable testing-library/no-node-access */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
-import {act, cleanup, render, screen, waitFor} from '@testing-library/react-native';
+import {act, render, screen, waitFor} from '@testing-library/react-native';
 import React from 'react';
 import Onyx from 'react-native-onyx';
 import {setSidebarLoaded} from '@userActions/App';
@@ -239,10 +239,6 @@ describe('Tests for group chat name', () => {
         PusherHelper.teardown();
 
         return Onyx.clear().then(waitForBatchedUpdates);
-    });
-
-    afterEach(() => {
-        cleanup();
     });
 
     const participantAccountIDs4 = [USER_A_ACCOUNT_ID, USER_B_ACCOUNT_ID, USER_C_ACCOUNT_ID, USER_D_ACCOUNT_ID];

--- a/tests/unit/components/reportDetails/ReportDetailsPageTest.tsx
+++ b/tests/unit/components/reportDetails/ReportDetailsPageTest.tsx
@@ -1,0 +1,94 @@
+import {act, render} from '@testing-library/react-native';
+import React from 'react';
+import Onyx from 'react-native-onyx';
+import {LocaleContextProvider} from '@components/LocaleContextProvider';
+import OnyxListItemProvider from '@components/OnyxListItemProvider';
+import type Navigation from '@libs/Navigation/Navigation';
+import type {PlatformStackScreenProps} from '@libs/Navigation/PlatformStackNavigation/types';
+import type {ReportDetailsNavigatorParamList} from '@libs/Navigation/types';
+import Parser from '@libs/Parser';
+import ReportDetailsPage from '@pages/ReportDetailsPage';
+import CONST from '@src/CONST';
+import ONYXKEYS from '@src/ONYXKEYS';
+import type SCREENS from '@src/SCREENS';
+import type {Report, ReportAction} from '@src/types/onyx';
+import createRandomReportAction from '../../../utils/collections/reportActions';
+import {createRandomReport} from '../../../utils/collections/reports';
+import waitForBatchedUpdatesWithAct from '../../../utils/waitForBatchedUpdatesWithAct';
+
+jest.mock('@src/components/ConfirmedRoute.tsx');
+
+jest.mock('@react-navigation/native', () => {
+    const actualNav = jest.requireActual<typeof Navigation>('@react-navigation/native');
+    return {
+        ...actualNav,
+        useIsFocused: jest.fn(),
+        useRoute: jest.fn(),
+        usePreventRemove: jest.fn(),
+    };
+});
+
+const mockHtmlToText = jest.spyOn(Parser, 'htmlToText');
+
+describe('ReportDetailsPage', () => {
+    beforeAll(() => {
+        Onyx.init({
+            keys: ONYXKEYS,
+            evictableKeys: [ONYXKEYS.COLLECTION.REPORT_ACTIONS],
+        });
+    });
+
+    beforeEach(() => {
+        mockHtmlToText.mockClear();
+    });
+
+    afterEach(async () => {
+        await act(async () => {
+            await Onyx.clear();
+        });
+    });
+
+    it('should not call Parser.htmlToText when parentReportAction is ADD_COMMENT', async () => {
+        const reportID = '10';
+        const parentReportID = '20';
+        const parentActionID = '100';
+
+        const parentReportAction = {
+            ...createRandomReportAction(Number(parentActionID)),
+            actionName: CONST.REPORT.ACTIONS.TYPE.ADD_COMMENT,
+        } as ReportAction;
+
+        const report: Report = {
+            ...createRandomReport(Number(reportID), undefined),
+            parentReportID,
+            parentReportActionID: parentActionID,
+        };
+
+        await act(async () => {
+            await Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT}${parentReportID}`, createRandomReport(Number(parentReportID), undefined));
+            await Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${parentReportID}`, {
+                [parentActionID]: parentReportAction,
+            });
+        });
+
+        render(
+            <OnyxListItemProvider>
+                <LocaleContextProvider>
+                    <ReportDetailsPage
+                        betas={[]}
+                        isLoadingReportData={false}
+                        navigation={{} as PlatformStackScreenProps<ReportDetailsNavigatorParamList, typeof SCREENS.REPORT_DETAILS.ROOT>['navigation']}
+                        policy={undefined}
+                        report={report}
+                        reportMetadata={undefined}
+                        route={{params: {reportID}} as PlatformStackScreenProps<ReportDetailsNavigatorParamList, typeof SCREENS.REPORT_DETAILS.ROOT>['route']}
+                    />
+                </LocaleContextProvider>
+            </OnyxListItemProvider>,
+        );
+
+        await waitForBatchedUpdatesWithAct();
+
+        expect(mockHtmlToText).not.toHaveBeenCalled();
+    });
+});


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
<!-- Explain what your change does and how it addresses the linked issue -->
Modify ReportDetailsPage.tsx to match the conditional parsing logic
ADD_COMMENT threads: Don't parse preserves text exactly as
entered)
Group chats: Don't parse (preserves exact text)
Other cases: Parse with htmlToText() as before
### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/75979#
PROPOSAL: https://github.com/Expensify/App/issues/75979#issuecomment-3770858742


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->
## Testing Steps

### Priority 1: Critical Tests

#### Test 1: Original Issue
**Scenario:** Thread detail page shows HTML as user typed it

**Steps:**
1. Open any chat
2. Send message: `<div>test</div>`
3. Long press message → "Reply in thread"
4. Click thread header → Detail page opens
5. Verify detail page shows `<div>test</div>` (not "test")

---

#### Test 2: Header and Detail Page Parity
**Scenario:** Thread header and detail page show identical text

**Steps:**
1. Use same thread from Test 1
2. Note thread header text
3. Click thread header → Open detail page
4. Verify header text === detail page text (exact match)

---

#### Test 3: System Messages
**Scenario:** System-generated HTML still parses correctly

**Steps:**
1. Find thread with system-generated message
2. Open detail page
3. Verify system HTML parses correctly (not shown as raw tags)

---

#### Test 4: Regular (Non-Thread) Chat Detail Pages
**Scenario:** Backward compatibility for normal chats

**Steps:**
1. Open any regular chat (not a thread)
2. Click chat header/avatar → Detail page opens
3. Verify detail page works normally
4. Verify chat name displays correctly

---

#### Test 5: Group Chat Thread
**Scenario:** Group chat threads handle HTML correctly

**Steps:**
1. Open a group chat (3+ people)
2. Send message: `<b>Bold Test</b>`
3. Long press → "Reply in thread"
4. Click thread header → Detail page opens
5. Verify detail page shows `<b>Bold Test</b>` correctly
6. Verify header matches detail page

---

### Priority 2: Important Tests

#### Test 6: LHN (Left-Hand Navigation) Consistency
**Scenario:** Thread name in sidebar matches detail page

**Steps:**
1. Use thread from Test 1 (`<div>test</div>`)
2. Return to main view
3. Check thread in left-hand navigation list
4. Verify LHN shows same text as header/detail page

---

#### Test 7: @Mention in Thread Detail
**Scenario:** Backend HTML (mentions) display correctly

**Steps:**
1. Send message with @mention: "Hey @[User] check this"
2. Create thread from that message
3. Click thread header → Detail page
4. Verify mention displays as `@Username` (not raw HTML tags)

---

#### Test 8: Non-ADD_COMMENT Thread
**Scenario:** System message threads parse HTML correctly

**Steps:**
1. Find system-generated message (expense notification, workspace change, etc.)
2. Create thread from it (if possible)
3. Click thread header → Detail page
4. Verify system message HTML parses correctly
5. Verify header matches detail page

---

#### Test 9: Workspace Report Detail Page
**Scenario:** Workspace contexts unaffected

**Steps:**
1. Open a workspace (not thread, not chat)
2. Click workspace name/avatar → Detail page
3. Verify workspace detail page still works
4. Verify workspace name displays correctly

---

### Priority 3: Edge Cases

#### Test 10: Complex Nested HTML
**Scenario:** Complex HTML edge cases

**Steps:**
1. Send message: `<div><b>nested</b> tags</div>`
2. Create thread
3. Open detail page
4. Verify shows exactly as typed

---

#### Test 11: Empty/Null Thread Name
**Scenario:** Edge case handling

**Steps:**
1. Create thread with minimal/empty text
2. Open detail page
3. Verify handles gracefully (no crash, no errors)

---

#### Test 12: Search Results Consistency
**Scenario:** Search results match detail page

**Steps:**
1. Use thread from Test 1
2. Search for "test" or "div"
3. Verify search result matches detail page text
- [ ] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->
disconnected network while in production build
Navigate to staging.new.expensify.com
Open a chat
Send a message - <div>test<div>
Long press and open reply thread
Go to thread header and open header page


### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->
"Same as tests"
// TODO: These must be filled out, or the issue title must include "[No QA]."

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I verified there are no new alerts related to the `canBeMissing` param for `useOnyx`
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->
<img width="864" height="1939" alt="android standalone" src="https://github.com/user-attachments/assets/9b290e63-3787-4c12-98a4-69487fe67441" />
</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->
<img width="864" height="1939" alt="prodmobileweb" src="https://github.com/user-attachments/assets/ebbbb01e-1504-433b-9155-4faaf93365da" />

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->
<img width="1206" height="2622" alt="ios" src="https://github.com/user-attachments/assets/446c085e-04ca-452f-920b-ac8facca6f04" />

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->
<img width="1206" height="2622" alt="safarimobile" src="https://github.com/user-attachments/assets/e485defd-47ba-4dfb-bce6-80556b0d90e9" />

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->
<img width="1507" height="824" alt="macprodweb" src="https://github.com/user-attachments/assets/ce34f611-7c49-4096-bca1-cda0063624a5" />
<img width="1319" height="945" alt="safariweb" src="https://github.com/user-attachments/assets/32ce9e3a-d4ad-427c-9234-2127d375e25e" />

</details>

