### PR TITLE
Treat simulated failing network requests as offline

### DIFF
--- a/src/hooks/useNetwork.ts
+++ b/src/hooks/useNetwork.ts
@@ -21,25 +21,29 @@ export default function useNetwork({onReconnect = () => {}}: UseNetworkProps = {
 
     // Extract values with proper defaults
     const isOffline = network?.isOffline ?? false;
+    const shouldForceOffline = network?.shouldForceOffline ?? false;
+    const shouldFailAllRequests = network?.shouldFailAllRequests ?? false;
     const networkStatus = network?.networkStatus;
     const lastOfflineAt = network?.lastOfflineAt;
 
-    const prevOfflineStatusRef = useRef(isOffline);
+    const isOfflineEffective = isOffline || shouldForceOffline || shouldFailAllRequests;
+
+    const prevOfflineStatusRef = useRef(isOfflineEffective);
     useEffect(() => {
         // If we were offline before and now we are not offline then we just reconnected
-        const didReconnect = prevOfflineStatusRef.current && !isOffline;
+        const didReconnect = prevOfflineStatusRef.current && !isOfflineEffective;
         if (!didReconnect) {
             return;
         }
 
         callback.current();
-    }, [isOffline]);
+    }, [isOfflineEffective]);
 
     useEffect(() => {
         // Used to store previous prop values to compare on next render
-        prevOfflineStatusRef.current = isOffline;
-    }, [isOffline]);
+        prevOfflineStatusRef.current = isOfflineEffective;
+    }, [isOfflineEffective]);
 
     // If the network status is undefined, we don't treat it as offline. Otherwise, we utilize the isOffline prop.
-    return {isOffline: networkStatus === CONST.NETWORK.NETWORK_STATUS.UNKNOWN ? false : isOffline, lastOfflineAt};
+    return {isOffline: networkStatus === CONST.NETWORK.NETWORK_STATUS.UNKNOWN ? false : isOfflineEffective, lastOfflineAt};
 }

--- a/src/selectors/Network.ts
+++ b/src/selectors/Network.ts
@@ -11,6 +11,9 @@ const networkStatusSelector = (networkData: OnyxEntry<Network>) => {
         isOffline: networkData.isOffline,
         networkStatus: networkData.networkStatus,
         lastOfflineAt: networkData.lastOfflineAt,
+        // test tools / overrides
+        shouldForceOffline: networkData.shouldForceOffline,
+        shouldFailAllRequests: networkData.shouldFailAllRequests,
     };
 };
 


### PR DESCRIPTION
## Problem
When the Troubleshoot toggle "Simulate failing network requests" is enabled, navigating to the Reports page can show blank filters / loading skeletons.

## Solution
Treat the test-tool state "fail all requests" as effectively offline at the UI layer:
- Extend the network selector to include shouldFailAllRequests / shouldForceOffline.
- In useNetwork(), compute an effective offline state that includes these overrides.

This prevents Search/Reports flows from acting like they are online while all requests are forced to fail, and avoids wiping cached data unnecessarily.

## Test plan
- Enable Troubleshoot -> Simulate failing network requests
- Navigate to Reports
- Confirm filters + page render without getting stuck in loading skeleton state

## Link
- Fix for issue https://github.com/Expensify/App/issues/79874