### PR TITLE
Add markdown to rule description

### DIFF
--- a/src/components/Rule/RuleTextBase.tsx
+++ b/src/components/Rule/RuleTextBase.tsx
@@ -42,9 +42,25 @@ type RuleTextBaseProps<TFormID extends OnyxFormKey> = {
 
     /** Optional hash for rule not found validation */
     hash?: string;
+
+    /** Whether to use markdown input type */
+    isMarkdownEnabled?: boolean;
 };
 
-function RuleTextBase<TFormID extends OnyxFormKey>({fieldID, hintKey, isRequired, titleKey, labelKey, testID, characterLimit, formID, onSave, onBack, hash}: RuleTextBaseProps<TFormID>) {
+function RuleTextBase<TFormID extends OnyxFormKey>({
+    fieldID,
+    hintKey,
+    isRequired,
+    titleKey,
+    labelKey,
+    testID,
+    characterLimit,
+    formID,
+    onSave,
+    onBack,
+    hash,
+    isMarkdownEnabled,
+}: RuleTextBaseProps<TFormID>) {
     const {translate} = useLocalize();
     const styles = useThemeStyles();
 
@@ -69,6 +85,7 @@ function RuleTextBase<TFormID extends OnyxFormKey>({fieldID, hintKey, isRequired
                     onSubmit={onSave}
                     title={translate(titleKey)}
                     characterLimit={characterLimit}
+                    isMarkdownEnabled={isMarkdownEnabled}
                 />
             </ScreenWrapper>
         </RuleNotFoundPageWrapper>

--- a/src/components/Rule/TextBase.tsx
+++ b/src/components/Rule/TextBase.tsx
@@ -9,6 +9,7 @@ import useLocalize from '@hooks/useLocalize';
 import useOnyx from '@hooks/useOnyx';
 import useThemeStyles from '@hooks/useThemeStyles';
 import {isRequiredFulfilled, isValidInputLength} from '@libs/ValidationUtils';
+import variables from '@styles/variables';
 import CONST from '@src/CONST';
 import type {OnyxFormKey} from '@src/ONYXKEYS';
 
@@ -21,9 +22,22 @@ type TextBaseProps<TFormID extends OnyxFormKey> = {
     characterLimit?: number;
     formID: TFormID;
     onSubmit: (values: FormOnyxValues<TFormID>) => void;
+
+    /** Whether to use markdown input type */
+    isMarkdownEnabled?: boolean;
 };
 
-function TextBase<TFormID extends OnyxFormKey>({fieldID, hint, isRequired, title, label, onSubmit, formID, characterLimit = CONST.MERCHANT_NAME_MAX_BYTES}: TextBaseProps<TFormID>) {
+function TextBase<TFormID extends OnyxFormKey>({
+    fieldID,
+    hint,
+    isRequired,
+    title,
+    label,
+    onSubmit,
+    formID,
+    characterLimit = CONST.MERCHANT_NAME_MAX_BYTES,
+    isMarkdownEnabled = false,
+}: TextBaseProps<TFormID>) {
     const {translate} = useLocalize();
     const [form] = useOnyx(formID, {canBeMissing: true});
     const styles = useThemeStyles();
@@ -74,6 +88,9 @@ function TextBase<TFormID extends OnyxFormKey>({fieldID, hint, isRequired, title
                     accessibilityLabel={title}
                     role={CONST.ROLE.PRESENTATION}
                     ref={inputCallbackRef}
+                    type={isMarkdownEnabled ? 'markdown' : undefined}
+                    autoGrowHeight={isMarkdownEnabled}
+                    maxAutoGrowHeight={isMarkdownEnabled ? variables.textInputAutoGrowMaxHeight : undefined}
                 />
             </View>
         </FormProvider>

--- a/src/libs/ExpenseRuleUtils.ts
+++ b/src/libs/ExpenseRuleUtils.ts
@@ -44,7 +44,6 @@ function formatExpenseRuleChanges(rule: ExpenseRule, translate: LocaleContextPro
         addChange('category', getDecodedCategoryName(rule.category));
     }
     if (rule.comment) {
-        // Convert HTML comment to markdown for display
         const commentMarkdown = Parser.htmlToMarkdown(rule.comment);
         addChange('comment', commentMarkdown);
     }

--- a/src/libs/ExpenseRuleUtils.ts
+++ b/src/libs/ExpenseRuleUtils.ts
@@ -3,6 +3,7 @@ import type {TranslationParameters, TranslationPaths} from '@src/languages/types
 import type {ExpenseRuleForm} from '@src/types/form';
 import type {ExpenseRule, TaxRate} from '@src/types/onyx';
 import {getDecodedCategoryName} from './CategoryUtils';
+import Parser from './Parser';
 import {getCleanedTagName} from './PolicyUtils';
 import StringUtils from './StringUtils';
 
@@ -43,7 +44,9 @@ function formatExpenseRuleChanges(rule: ExpenseRule, translate: LocaleContextPro
         addChange('category', getDecodedCategoryName(rule.category));
     }
     if (rule.comment) {
-        addChange('comment', rule.comment);
+        // Convert HTML comment to markdown for display
+        const commentMarkdown = Parser.htmlToMarkdown(rule.comment);
+        addChange('comment', commentMarkdown);
     }
     if (rule.merchant) {
         addChange('merchant', rule.merchant);
@@ -67,10 +70,13 @@ function formatExpenseRuleChanges(rule: ExpenseRule, translate: LocaleContextPro
 }
 
 function extractRuleFromForm(form: ExpenseRuleForm, taxRate?: TaxRate) {
+    // Convert markdown comment to HTML for storage
+    const commentHTML = form.comment ? Parser.replace(form.comment) : undefined;
+
     const rule: ExpenseRule = {
         billable: form.billable,
         category: form.category,
-        comment: form.comment,
+        comment: commentHTML,
         createReport: form.createReport,
         merchant: form.merchant,
         merchantToMatch: form.merchantToMatch,

--- a/src/libs/actions/Policy/Rules.ts
+++ b/src/libs/actions/Policy/Rules.ts
@@ -7,6 +7,7 @@ import {READ_COMMANDS, WRITE_COMMANDS} from '@libs/API/types';
 import * as ErrorUtils from '@libs/ErrorUtils';
 import Log from '@libs/Log';
 import * as NumberUtils from '@libs/NumberUtils';
+import Parser from '@libs/Parser';
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
 import type {MerchantRuleForm} from '@src/types/form';
@@ -37,6 +38,17 @@ function buildTaxObject(taxKey: string | undefined, policy: Policy | undefined):
 }
 
 /**
+ * Converts a markdown comment to HTML using Parser.replace().
+ * Returns null if the comment is empty or undefined.
+ */
+function convertCommentToHTML(comment: string | undefined): string | null {
+    if (!comment) {
+        return null;
+    }
+    return Parser.replace(comment);
+}
+
+/**
  * Maps form fields to rule properties with null for empty values.
  * Used for Onyx to properly remove cleared fields during merge.
  */
@@ -46,7 +58,7 @@ function mapFormFieldsToRuleForOnyx(form: MerchantRuleForm, policy: Policy | und
         category: form.category || null,
         tag: form.tag || null,
         tax: buildTaxObject(form.tax, policy) ?? null,
-        comment: form.comment || null,
+        comment: convertCommentToHTML(form.comment),
         reimbursable: form.reimbursable ?? null,
         billable: form.billable ?? null,
     };
@@ -72,8 +84,9 @@ function mapFormFieldsToRuleForAPI(form: MerchantRuleForm, policy: Policy | unde
     if (tax) {
         rule.tax = tax;
     }
-    if (form.comment) {
-        rule.comment = form.comment;
+    const commentHTML = convertCommentToHTML(form.comment);
+    if (commentHTML) {
+        rule.comment = commentHTML;
     }
     if (form.reimbursable !== undefined) {
         rule.reimbursable = form.reimbursable;

--- a/src/pages/settings/Rules/ExpenseRulesPage.tsx
+++ b/src/pages/settings/Rules/ExpenseRulesPage.tsx
@@ -30,6 +30,7 @@ import {clearDraftRule, setDraftRule, setNameValuePair} from '@libs/actions/User
 import {canUseTouchScreen} from '@libs/DeviceCapabilities';
 import {formatExpenseRuleChanges, getKeyForRule} from '@libs/ExpenseRuleUtils';
 import Navigation from '@libs/Navigation/Navigation';
+import Parser from '@libs/Parser';
 import tokenizedSearch from '@libs/tokenizedSearch';
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
@@ -125,8 +126,11 @@ function ExpenseRulesPage() {
         if (!expenseRule) {
             return;
         }
+        // Convert HTML comment back to markdown for editing
+        const commentMarkdown = expenseRule.comment ? Parser.htmlToMarkdown(expenseRule.comment) : undefined;
         setDraftRule({
             ...expenseRule,
+            comment: commentMarkdown,
             tax: expenseRule.tax?.field_id_TAX ? expenseRule.tax.field_id_TAX.externalID : undefined,
         });
         Navigation.navigate(ROUTES.SETTINGS_RULES_EDIT.getRoute(hash));

--- a/src/pages/settings/Rules/ExpenseRulesPage.tsx
+++ b/src/pages/settings/Rules/ExpenseRulesPage.tsx
@@ -126,7 +126,7 @@ function ExpenseRulesPage() {
         if (!expenseRule) {
             return;
         }
-        // Convert HTML comment back to markdown for editing
+
         const commentMarkdown = expenseRule.comment ? Parser.htmlToMarkdown(expenseRule.comment) : undefined;
         setDraftRule({
             ...expenseRule,

--- a/src/pages/settings/Rules/Fields/AddDescriptionPage.tsx
+++ b/src/pages/settings/Rules/Fields/AddDescriptionPage.tsx
@@ -34,6 +34,7 @@ function AddDescriptionPage({route}: AddDescriptionPageProps) {
             onSave={onSave}
             onBack={goBack}
             hash={hash}
+            isMarkdownEnabled
         />
     );
 }

--- a/src/pages/settings/Rules/RulePageBase.tsx
+++ b/src/pages/settings/Rules/RulePageBase.tsx
@@ -184,7 +184,6 @@ function RulePageBase({titleKey, testID, hash}: RulePageBaseProps) {
                     : undefined,
                 {
                     descriptionTranslationKey: 'common.description',
-                    // Convert markdown to HTML for display
                     title: form?.comment ? Parser.replace(form.comment) : undefined,
                     onPress: () => navigateTo(CONST.EXPENSE_RULES.FIELDS.DESCRIPTION, hash),
                     shouldRenderAsHTML: true,

--- a/src/pages/settings/Rules/RulePageBase.tsx
+++ b/src/pages/settings/Rules/RulePageBase.tsx
@@ -17,6 +17,7 @@ import {clearDraftRule, setNameValuePair, updateDraftRule} from '@libs/actions/U
 import {getAvailableNonPersonalPolicyCategories, getDecodedCategoryName} from '@libs/CategoryUtils';
 import {extractRuleFromForm, getKeyForRule} from '@libs/ExpenseRuleUtils';
 import Navigation from '@libs/Navigation/Navigation';
+import Parser from '@libs/Parser';
 import {getAllTaxRatesNamesAndValues, getCleanedTagName, getTagNamesFromTagsLists} from '@libs/PolicyUtils';
 import ToggleSettingOptionRow from '@pages/workspace/workflows/ToggleSettingsOptionRow';
 import CONST from '@src/CONST';
@@ -33,17 +34,17 @@ type RulePageBaseProps = {
     hash?: string;
 };
 
+type SectionItemType = {
+    descriptionTranslationKey: TranslationPaths;
+    required?: boolean;
+    title?: string;
+    onPress: () => void;
+    shouldRenderAsHTML?: boolean;
+};
+
 type SectionType = {
     titleTranslationKey: TranslationPaths;
-    items: Array<
-        | {
-              descriptionTranslationKey: TranslationPaths;
-              required?: boolean;
-              title?: string;
-              onPress: () => void;
-          }
-        | undefined
-    >;
+    items: Array<SectionItemType | undefined>;
 };
 
 const navigateTo = (field: ValueOf<typeof CONST.EXPENSE_RULES.FIELDS>, hash?: string) => {
@@ -183,8 +184,10 @@ function RulePageBase({titleKey, testID, hash}: RulePageBaseProps) {
                     : undefined,
                 {
                     descriptionTranslationKey: 'common.description',
-                    title: form?.comment,
+                    // Convert markdown to HTML for display
+                    title: form?.comment ? Parser.replace(form.comment) : undefined,
                     onPress: () => navigateTo(CONST.EXPENSE_RULES.FIELDS.DESCRIPTION, hash),
+                    shouldRenderAsHTML: true,
                 },
                 {
                     descriptionTranslationKey: 'common.reimbursable',
@@ -235,6 +238,7 @@ function RulePageBase({titleKey, testID, hash}: RulePageBaseProps) {
                                         shouldShowRightIcon
                                         title={item.title}
                                         titleStyle={styles.flex1}
+                                        shouldRenderAsHTML={item.shouldRenderAsHTML}
                                     />
                                 );
                             })}

--- a/src/pages/workspace/rules/MerchantRules/AddDescriptionPage.tsx
+++ b/src/pages/workspace/rules/MerchantRules/AddDescriptionPage.tsx
@@ -35,6 +35,7 @@ function AddDescriptionPage({route}: AddDescriptionPageProps) {
             characterLimit={CONST.DESCRIPTION_LIMIT}
             onSave={onSave}
             onBack={goBack}
+            isMarkdownEnabled
         />
     );
 }

--- a/src/pages/workspace/rules/MerchantRules/MerchantRulePageBase.tsx
+++ b/src/pages/workspace/rules/MerchantRules/MerchantRulePageBase.tsx
@@ -294,7 +294,6 @@ function MerchantRulePageBase({policyID, ruleID, titleKey, testID}: MerchantRule
                     : undefined,
                 {
                     descriptionTranslationKey: 'common.description',
-                    // Convert markdown to HTML for display
                     title: form?.comment ? Parser.replace(form.comment) : undefined,
                     onPress: () => Navigation.navigate(ROUTES.RULES_MERCHANT_DESCRIPTION.getRoute(policyID, ruleID)),
                     shouldRenderAsHTML: true,

--- a/src/pages/workspace/rules/MerchantRules/MerchantRulePageBase.tsx
+++ b/src/pages/workspace/rules/MerchantRules/MerchantRulePageBase.tsx
@@ -19,6 +19,7 @@ import {deletePolicyCodingRule, setPolicyCodingRule} from '@libs/actions/Policy/
 import {clearDraftMerchantRule, setDraftMerchantRule} from '@libs/actions/User';
 import {getDecodedCategoryName} from '@libs/CategoryUtils';
 import Navigation from '@libs/Navigation/Navigation';
+import Parser from '@libs/Parser';
 import {getCleanedTagName, getTagNamesFromTagsLists} from '@libs/PolicyUtils';
 import NotFoundPage from '@pages/ErrorPage/NotFoundPage';
 import AccessOrNotFoundWrapper from '@pages/workspace/AccessOrNotFoundWrapper';
@@ -41,6 +42,7 @@ type SectionItemType = {
     required?: boolean;
     title?: string;
     onPress: () => void;
+    shouldRenderAsHTML?: boolean;
 };
 
 type SectionType = {
@@ -103,6 +105,8 @@ function MerchantRulePageBase({policyID, ruleID, titleKey, testID}: MerchantRule
         // Convert the operator to matchType for the form
         // 'eq' = exact match, 'contains' = contains match
         const matchType = existingRule.filters?.operator;
+        // Convert HTML comment back to markdown for editing
+        const commentMarkdown = existingRule.comment ? Parser.htmlToMarkdown(existingRule.comment) : undefined;
         setDraftMerchantRule({
             merchantToMatch: existingRule.filters?.right,
             matchType,
@@ -110,7 +114,7 @@ function MerchantRulePageBase({policyID, ruleID, titleKey, testID}: MerchantRule
             category: existingRule.category,
             tag: existingRule.tag,
             tax: existingRule.tax?.field_id_TAX?.externalID,
-            comment: existingRule.comment,
+            comment: commentMarkdown,
             reimbursable: existingRule.reimbursable,
             billable: existingRule.billable,
         });
@@ -290,8 +294,10 @@ function MerchantRulePageBase({policyID, ruleID, titleKey, testID}: MerchantRule
                     : undefined,
                 {
                     descriptionTranslationKey: 'common.description',
-                    title: form?.comment,
+                    // Convert markdown to HTML for display
+                    title: form?.comment ? Parser.replace(form.comment) : undefined,
                     onPress: () => Navigation.navigate(ROUTES.RULES_MERCHANT_DESCRIPTION.getRoute(policyID, ruleID)),
+                    shouldRenderAsHTML: true,
                 },
                 {
                     descriptionTranslationKey: 'common.reimbursable',
@@ -350,6 +356,7 @@ function MerchantRulePageBase({policyID, ruleID, titleKey, testID}: MerchantRule
                                         shouldShowRightIcon
                                         title={item.title}
                                         titleStyle={styles.flex1}
+                                        shouldRenderAsHTML={item.shouldRenderAsHTML}
                                     />
                                 ))}
                         </View>

--- a/src/pages/workspace/rules/MerchantRulesSection.tsx
+++ b/src/pages/workspace/rules/MerchantRulesSection.tsx
@@ -47,7 +47,6 @@ function getRuleDescription(rule: CodingRule, translate: ReturnType<typeof useLo
         actions.push(translate('workspace.rules.merchantRules.ruleSummarySubtitleUpdateField', labels.tag, getCleanedTagName(rule.tag)));
     }
     if (rule.comment) {
-        // Convert HTML comment to markdown for display
         const commentMarkdown = Parser.htmlToMarkdown(rule.comment);
         actions.push(translate('workspace.rules.merchantRules.ruleSummarySubtitleUpdateField', labels.description, commentMarkdown));
     }

--- a/src/pages/workspace/rules/MerchantRulesSection.tsx
+++ b/src/pages/workspace/rules/MerchantRulesSection.tsx
@@ -13,6 +13,7 @@ import useTheme from '@hooks/useTheme';
 import useThemeStyles from '@hooks/useThemeStyles';
 import {getDecodedCategoryName} from '@libs/CategoryUtils';
 import Navigation from '@libs/Navigation/Navigation';
+import Parser from '@libs/Parser';
 import {getCleanedTagName} from '@libs/PolicyUtils';
 import CONST from '@src/CONST';
 import ROUTES from '@src/ROUTES';
@@ -46,7 +47,9 @@ function getRuleDescription(rule: CodingRule, translate: ReturnType<typeof useLo
         actions.push(translate('workspace.rules.merchantRules.ruleSummarySubtitleUpdateField', labels.tag, getCleanedTagName(rule.tag)));
     }
     if (rule.comment) {
-        actions.push(translate('workspace.rules.merchantRules.ruleSummarySubtitleUpdateField', labels.description, rule.comment));
+        // Convert HTML comment to markdown for display
+        const commentMarkdown = Parser.htmlToMarkdown(rule.comment);
+        actions.push(translate('workspace.rules.merchantRules.ruleSummarySubtitleUpdateField', labels.description, commentMarkdown));
     }
     if (rule.tax?.field_id_TAX?.value) {
         actions.push(translate('workspace.rules.merchantRules.ruleSummarySubtitleUpdateField', labels.tax, `${rule.tax.field_id_TAX.name} (${rule.tax.field_id_TAX.value})`));


### PR DESCRIPTION
### Explanation of Change
Adds support for markdown in personal and merchant rule description field.

### Fixed Issues
$ https://github.com/Expensify/App/issues/81145


### Tests
Pre-condition: Rules are enabled in the policy

1. Navigate to `Account > Expense Rules`
2. Create a Rule as follows
- If expense contains -> Merchant: Google
- Set description to : `# google.com`
3. Verify that the description field is displayed as markdown (bold with link)
4. Save
5. Verify that the menu item is displayed in markdown (bold with link)
6. Verify that the rule description shows the rule as `Update description to "# [google.com](https://google.com)"`
7. Create a new expense with merchant as Google
8. Verify that the description is updated and it's shown as markdown (bold with link)

1. Navigate to `Workspace > Rules > Merchant Rules`
2. Create a Rule as follows
- If expense contains -> Merchant: Apple
- Set description to : `# apple.com`
3. Verify that the description field is displayed as markdown (bold with link)
4. Save
5. Verify that the menu item is displayed in markdown (bold with link)
6. Verify that the rule description shows the rule as `Update description to "# [apple.com](https://apple.com)"`
7. Create a new expense with merchant as Apple
8. Verify that the description is updated and it's shown as markdown (bold with link)

- [x] Verify that no errors appear in the JS console

### Offline tests
N/A

### QA Steps
Same as tests

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I verified there are no new alerts related to the `canBeMissing` param for `useOnyx`
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos

https://github.com/user-attachments/assets/0a26609c-a290-4d8a-ab2b-232319b5c10f


<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>