### PR TITLE
Fix test drive modal appearing twice on Android

### DIFF
--- a/src/hooks/useOnboardingFlow.ts
+++ b/src/hooks/useOnboardingFlow.ts
@@ -80,7 +80,6 @@ function useOnboardingFlowRouter() {
             if (hasCompletedGuidedSetupFlowSelector(onboardingValues) && onboardingValues?.testDriveModalDismissed === false) {
                 const navigationState = navigationRef.getRootState();
                 const lastRoute = navigationState.routes.at(-1);
-                // Prevent duplicate navigation if the test drive modal is already shown
                 if (lastRoute?.name !== NAVIGATORS.TEST_DRIVE_MODAL_NAVIGATOR) {
                     Navigation.setNavigationActionToMicrotaskQueue(() => {
                         Log.info('[Onboarding] User has not completed the guided setup flow, starting onboarding flow from test drive modal');

--- a/src/hooks/useOnboardingFlow.ts
+++ b/src/hooks/useOnboardingFlow.ts
@@ -78,17 +78,22 @@ function useOnboardingFlowRouter() {
             // Should be removed once Test Drive modal route has its own navigation guard
             // Details: https://github.com/Expensify/App/pull/79898
             if (hasCompletedGuidedSetupFlowSelector(onboardingValues) && onboardingValues?.testDriveModalDismissed === false) {
-                Navigation.setNavigationActionToMicrotaskQueue(() => {
-                    Log.info('[Onboarding] User has not completed the guided setup flow, starting onboarding flow from test drive modal');
-                    startOnboardingFlow({
-                        onboardingInitialPath: ROUTES.TEST_DRIVE_MODAL_ROOT.route,
-                        isUserFromPublicDomain: false,
-                        hasAccessiblePolicies: false,
-                        currentOnboardingCompanySize: undefined,
-                        currentOnboardingPurposeSelected: undefined,
-                        onboardingValues,
+                const navigationState = navigationRef.getRootState();
+                const lastRoute = navigationState.routes.at(-1);
+                // Prevent duplicate navigation if the test drive modal is already shown
+                if (lastRoute?.name !== NAVIGATORS.TEST_DRIVE_MODAL_NAVIGATOR) {
+                    Navigation.setNavigationActionToMicrotaskQueue(() => {
+                        Log.info('[Onboarding] User has not completed the guided setup flow, starting onboarding flow from test drive modal');
+                        startOnboardingFlow({
+                            onboardingInitialPath: ROUTES.TEST_DRIVE_MODAL_ROOT.route,
+                            isUserFromPublicDomain: false,
+                            hasAccessiblePolicies: false,
+                            currentOnboardingCompanySize: undefined,
+                            currentOnboardingPurposeSelected: undefined,
+                            onboardingValues,
+                        });
                     });
-                });
+                }
             }
             if (hasBeenAddedToNudgeMigration && !isProductTrainingElementDismissed('migratedUserWelcomeModal', dismissedProductTraining)) {
                 const navigationState = navigationRef.getRootState();

--- a/src/libs/Navigation/AppNavigator/AuthScreens.tsx
+++ b/src/libs/Navigation/AppNavigator/AuthScreens.tsx
@@ -668,6 +668,7 @@ function AuthScreens() {
                     name={NAVIGATORS.TEST_DRIVE_MODAL_NAVIGATOR}
                     options={rootNavigatorScreenOptions.basicModalNavigator}
                     component={TestDriveModalNavigator}
+                    listeners={modalScreenListeners}
                 />
                 <RootStack.Screen
                     name={NAVIGATORS.TEST_DRIVE_DEMO_NAVIGATOR}


### PR DESCRIPTION
### Explanation of Change

Fixes the test drive modal appearing twice during onboarding on Android, which was causing tabs to become unresponsive. The issue was caused by two independent navigation triggers racing to show the modal when onboarding completes.

I think it's okay to implement this as the fix, we should be refactoring this logic away as a follow-up to the original PR, as indicated [here](https://github.com/Expensify/App/pull/81465/changes#diff-17ecf321592267f5245bca94189c5b1604f17936a5a53942226767478d47aa8bR78): 
```
// Should be removed once Test Drive modal route has its own navigation guard
 // Details: https://github.com/Expensify/App/pull/79898
```

Two fixes:
1. Added navigation guard in `useOnboardingFlow.ts` to prevent duplicate navigation if the modal is already shown (similar to the migrated user modal pattern)
2. Added `modalScreenListeners` to `TestDriveModalNavigator` in `AuthScreens.tsx` to properly manage modal visibility state on Android

### Fixed Issues
$ https://github.com/Expensify/App/issues/81453

### Tests
1. Fresh install the app
2. Create a new account
3. Tap Skip on work email step
4. Select Track and budget expenses
5. Complete the onboarding
6. Tap Skip on test drive modal
7. Verify the modal appears only once (not twice)
8. Go to Workspaces > Account > Workspaces > Inbox
9. Switch between different tabs
10. Verify tabs are responsive

### QA Steps

Same as tests

### PR Author Checklist
- [ ] I linked the correct issue in the \`### Fixed Issues\` section above
- [ ] I wrote clear testing steps that cover the changes made in this PR
    - [ ] I added steps for local testing in the \`Tests\` section
    - [ ] I added steps for the expected offline behavior in the \`Offline steps\` section
    - [ ] I added steps for Staging and/or Production testing in the \`QA steps\` section
    - [ ] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [ ] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [ ] I tested this PR with a High Traffic account against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [ ] I included screenshots or videos for tests on all platforms
- [ ] I ran the tests on **all platforms** & verified they passed on:
    - [ ] Android: Native
    - [ ] Android: mWeb Chrome
    - [ ] iOS: Native
    - [ ] iOS: mWeb Safari
    - [ ] MacOS: Chrome / Safari
- [ ] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [ ] I verified there are no new alerts related to the \`canBeMissing\` param for \`useOnyx\`
- [ ] I followed proper code patterns (see Reviewing the code)
    - [ ] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. \`toggleReport\` and not \`onIconClick\`)
    - [ ] I verified that comments were added to code that is not self explanatory
    - [ ] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [ ] I verified any copy / text shown in the product is localized by adding it to \`src/languages/*\` files and using the translation method
    - [ ] I verified all numbers, amounts, dates and phone numbers shown in the product are using the localization methods
    - [ ] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [ ] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [ ] I verified the JSDocs style guidelines (in \`STYLE.md\`) were followed
- [ ] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [ ] I followed the guidelines as stated in the Review Guidelines
- [ ] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like \`Avatar\`, I verified the components using \`Avatar\` are working as expected)
- [ ] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [ ] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [ ] I verified that if a function's arguments changed that all usages have also been updated correctly
- [ ] If any new file was added I verified that:
    - [ ] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [ ] If a new CSS style is added I verified that:
    - [ ] A similar style doesn't already exist
    - [ ] The style can't be created with an existing StyleUtils function (i.e. \`StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)\`)
- [ ] If new assets were added or existing ones were modified, I verified that:
    - [ ] The assets are optimized and compressed (for SVG files, run \`npm run compress-svg\`)
    - [ ] The assets load correctly across all supported platforms.
- [ ] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [ ] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like \`Avatar\` is modified, I verified that \`Avatar\` is working as expected in all cases)
- [ ] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [ ] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [ ] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [ ] I verified that all the inputs inside a form are aligned with each other.
    - [ ] I added \`Design\` label and/or tagged \`@Expensify/design\` so the design team can review the changes.
- [ ] If a new page is added, I verified it's using the \`ScrollView\` component to make it scrollable when more elements are added to the page.
- [ ] I added unit tests for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [ ] If the \`main\` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the \`Test\` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- Will add after testing -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- Will add after testing -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- Will add after testing -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- Will add after testing -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- Will add after testing -->

</details>