### PR TITLE
Consistent back navigation from workspace pages

### DIFF
--- a/src/libs/Navigation/Navigation.ts
+++ b/src/libs/Navigation/Navigation.ts
@@ -458,6 +458,11 @@ function goBack(backToRoute?: Route, options?: GoBackOptions) {
         return;
     }
 
+    if (shouldPopToSidebar) {
+        popToSidebar();
+        return;
+    }
+
     if (!navigationRef.current?.canGoBack()) {
         Log.hmmm('[Navigation] Unable to go back');
         return;
@@ -751,19 +756,6 @@ const dismissModalWithReport = ({reportID, reportActionID, referrer, backTo}: Re
     });
 };
 
-/**
- * Returns to the first screen in the stack, dismissing all the others, only if the global variable shouldPopToSidebar is set to true.
- */
-function popToTop() {
-    if (!shouldPopToSidebar) {
-        goBack();
-        return;
-    }
-
-    shouldPopToSidebar = false;
-    navigationRef.current?.dispatch(StackActions.popToTop());
-}
-
 function popRootToTop() {
     const rootState = navigationRef.getRootState();
     navigationRef.current?.dispatch({...StackActions.popToTop(), target: rootState.key});
@@ -932,7 +924,6 @@ export default {
     goBackToHome,
     closeRHPFlow,
     setNavigationActionToMicrotaskQueue,
-    popToTop,
     popRootToTop,
     pop,
     removeScreenFromNavigationState,

--- a/src/libs/Navigation/NavigationRoot.tsx
+++ b/src/libs/Navigation/NavigationRoot.tsx
@@ -29,7 +29,7 @@ import ROUTES from '@src/ROUTES';
 import AppNavigator from './AppNavigator';
 import {cleanPreservedNavigatorStates} from './AppNavigator/createSplitNavigator/usePreserveNavigatorState';
 import getAdaptedStateFromPath from './helpers/getAdaptedStateFromPath';
-import {isWorkspacesTabScreenName} from './helpers/isNavigatorName';
+import {isSplitNavigatorName, isWorkspacesTabScreenName} from './helpers/isNavigatorName';
 import {saveSettingsTabPathToSessionStorage, saveWorkspacesTabPathToSessionStorage} from './helpers/lastVisitedTabPathUtils';
 import {linkingConfig} from './linkingConfig';
 import Navigation, {navigationRef} from './Navigation';
@@ -212,6 +212,13 @@ function NavigationRoot({authenticated, lastVisitedPath, initialUrl, onReady}: N
         // Now when this value is true, Navigation.goBack with the option {shouldPopToTop: true} will remove all visited central screens in the given tab from the navigation stack and go back to the LHN.
         // More context here: https://github.com/Expensify/App/pull/59300
         if (!shouldUseNarrowLayout) {
+            return;
+        }
+
+        const lastRoute = navigationRef?.getRootState()?.routes?.at(-1);
+
+        // Sidebar is a separate screen only in SplitNavigators, so shouldPopToSidebar should only be set when the last route is a SplitNavigator.
+        if (!isSplitNavigatorName(lastRoute?.name)) {
             return;
         }
 

--- a/src/libs/navigateAfterJoinRequest.ts
+++ b/src/libs/navigateAfterJoinRequest.ts
@@ -2,11 +2,7 @@ import ROUTES from '@src/ROUTES';
 import Navigation from './Navigation/Navigation';
 
 const navigateAfterJoinRequest = () => {
-    if (Navigation.getShouldPopToSidebar()) {
-        Navigation.popToSidebar();
-    } else {
-        Navigation.goBack();
-    }
+    Navigation.goBack();
     Navigation.setNavigationActionToMicrotaskQueue(() => {
         Navigation.navigate(ROUTES.WORKSPACES_LIST.route);
     });

--- a/src/pages/TeachersUnite/SaveTheWorldPage.tsx
+++ b/src/pages/TeachersUnite/SaveTheWorldPage.tsx
@@ -58,7 +58,7 @@ function SaveTheWorldPage() {
                 title={translate('sidebarScreen.saveTheWorld')}
                 shouldShowBackButton={shouldUseNarrowLayout}
                 shouldDisplaySearchRouter
-                onBackButtonPress={Navigation.popToSidebar}
+                onBackButtonPress={Navigation.goBack}
                 icon={illustrations.TeachersUnite}
                 shouldUseHeadlineHeader
             />

--- a/src/pages/domain/BaseDomainMembersPage.tsx
+++ b/src/pages/domain/BaseDomainMembersPage.tsx
@@ -151,7 +151,7 @@ function BaseDomainMembersPage({
             >
                 <HeaderWithBackButton
                     title={headerTitle}
-                    onBackButtonPress={Navigation.popToSidebar}
+                    onBackButtonPress={Navigation.goBack}
                     icon={headerIcon}
                     shouldShowBackButton={shouldUseNarrowLayout}
                 >

--- a/src/pages/domain/DomainSamlPage.tsx
+++ b/src/pages/domain/DomainSamlPage.tsx
@@ -85,7 +85,7 @@ function DomainSamlPage({route}: DomainSamlPageProps) {
             >
                 <HeaderWithBackButton
                     title={translate('domain.saml')}
-                    onBackButtonPress={Navigation.popToSidebar}
+                    onBackButtonPress={Navigation.goBack}
                     icon={illustrations.LockClosed}
                     shouldShowBackButton={shouldUseNarrowLayout}
                 />

--- a/src/pages/inbox/ReportScreen.tsx
+++ b/src/pages/inbox/ReportScreen.tsx
@@ -413,10 +413,6 @@ function ReportScreen({route, navigation, isInSidePanel = false}: ReportScreenPr
                 Navigation.goBack(backTo as Route);
                 return;
             }
-            if (Navigation.getShouldPopToSidebar()) {
-                Navigation.popToSidebar();
-                return;
-            }
             Navigation.goBack();
         },
         [isInSidePanel, backTo, isInNarrowPaneModal, closeSidePanel],

--- a/src/pages/settings/AboutPage/AboutPage.tsx
+++ b/src/pages/settings/AboutPage/AboutPage.tsx
@@ -148,7 +148,7 @@ function AboutPage() {
                 title={translate('initialSettingsPage.about')}
                 shouldShowBackButton={shouldUseNarrowLayout}
                 shouldDisplaySearchRouter
-                onBackButtonPress={Navigation.popToSidebar}
+                onBackButtonPress={Navigation.goBack}
                 icon={illustrations.PalmTree}
                 shouldUseHeadlineHeader
             />

--- a/src/pages/settings/Preferences/PreferencesPage.tsx
+++ b/src/pages/settings/Preferences/PreferencesPage.tsx
@@ -61,7 +61,7 @@ function PreferencesPage() {
                 shouldUseHeadlineHeader
                 shouldShowBackButton={shouldUseNarrowLayout}
                 shouldDisplaySearchRouter
-                onBackButtonPress={Navigation.popToSidebar}
+                onBackButtonPress={Navigation.goBack}
             />
             <ScrollView contentContainerStyle={styles.pt3}>
                 <View style={[styles.flex1, shouldUseNarrowLayout ? styles.workspaceSectionMobile : styles.workspaceSection]}>

--- a/src/pages/settings/Profile/ProfilePage.tsx
+++ b/src/pages/settings/Profile/ProfilePage.tsx
@@ -7,7 +7,6 @@ import AvatarSkeleton from '@components/AvatarSkeleton';
 import Button from '@components/Button';
 import {DelegateNoAccessContext} from '@components/DelegateNoAccessModalProvider';
 import HeaderWithBackButton from '@components/HeaderWithBackButton';
-import * as Expensicons from '@components/Icon/Expensicons';
 import {loadIllustration} from '@components/Icon/IllustrationLoader';
 import type {IllustrationName} from '@components/Icon/IllustrationLoader';
 import MenuItemGroup from '@components/MenuItemGroup';
@@ -16,7 +15,7 @@ import ScreenWrapper from '@components/ScreenWrapper';
 import ScrollView from '@components/ScrollView';
 import Section from '@components/Section';
 import useCurrentUserPersonalDetails from '@hooks/useCurrentUserPersonalDetails';
-import {useMemoizedLazyAsset} from '@hooks/useLazyAsset';
+import {useMemoizedLazyAsset, useMemoizedLazyExpensifyIcons} from '@hooks/useLazyAsset';
 import useLocalize from '@hooks/useLocalize';
 import useOnyx from '@hooks/useOnyx';
 import useResponsiveLayout from '@hooks/useResponsiveLayout';
@@ -61,6 +60,7 @@ function ProfilePage() {
     const accountID = currentUserPersonalDetails?.accountID ?? CONST.DEFAULT_NUMBER_ID;
     const avatarStyle = [styles.avatarXLarge, styles.alignSelfStart];
     const {asset: Profile} = useMemoizedLazyAsset(() => loadIllustration('Profile' as IllustrationName));
+    const icons = useMemoizedLazyExpensifyIcons(['QrCode']);
 
     const contactMethodBrickRoadIndicator = getLoginListBrickRoadIndicator(loginList, currentUserPersonalDetails?.email);
     const emojiCode = currentUserPersonalDetails?.status?.emojiCode ?? '';
@@ -160,11 +160,11 @@ function ProfilePage() {
             <HeaderWithBackButton
                 title={translate('common.profile')}
                 onBackButtonPress={() => {
-                    if (Navigation.getShouldPopToSidebar()) {
-                        Navigation.popToSidebar();
+                    if (route.params?.backTo) {
+                        Navigation.goBack(route.params?.backTo);
                         return;
                     }
-                    Navigation.goBack(route.params?.backTo);
+                    Navigation.goBack();
                 }}
                 shouldShowBackButton={shouldUseNarrowLayout}
                 shouldDisplaySearchRouter
@@ -222,7 +222,7 @@ function ProfilePage() {
                                 accessibilityLabel={translate('common.shareCode')}
                                 text={translate('common.share')}
                                 onPress={() => Navigation.navigate(ROUTES.SETTINGS_SHARE_CODE)}
-                                icon={Expensicons.QrCode}
+                                icon={icons.QrCode}
                                 style={[styles.alignSelfStart, styles.mt6]}
                             />
                         </Section>

--- a/src/pages/settings/Rules/ExpenseRulesPage.tsx
+++ b/src/pages/settings/Rules/ExpenseRulesPage.tsx
@@ -244,7 +244,7 @@ function ExpenseRulesPage() {
                         return;
                     }
 
-                    Navigation.popToSidebar();
+                    Navigation.goBack();
                 }}
                 shouldShowBackButton={shouldUseNarrowLayout}
                 shouldUseHeadlineHeader={!selectionModeHeader}

--- a/src/pages/settings/Security/SecuritySettingsPage.tsx
+++ b/src/pages/settings/Security/SecuritySettingsPage.tsx
@@ -372,7 +372,7 @@ function SecuritySettingsPage() {
                     <HeaderWithBackButton
                         title={translate('initialSettingsPage.security')}
                         shouldShowBackButton={shouldUseNarrowLayout}
-                        onBackButtonPress={Navigation.popToSidebar}
+                        onBackButtonPress={Navigation.goBack}
                         icon={illustrations.LockClosed}
                         shouldUseHeadlineHeader
                         shouldDisplaySearchRouter

--- a/src/pages/settings/Subscription/SubscriptionSettingsPage.tsx
+++ b/src/pages/settings/Subscription/SubscriptionSettingsPage.tsx
@@ -56,11 +56,11 @@ function SubscriptionSettingsPage({route}: SubscriptionSettingsPageProps) {
             <HeaderWithBackButton
                 title={translate('workspace.common.subscription')}
                 onBackButtonPress={() => {
-                    if (Navigation.getShouldPopToSidebar()) {
-                        Navigation.popToSidebar();
+                    if (backTo) {
+                        Navigation.goBack(backTo);
                         return;
                     }
-                    Navigation.goBack(backTo);
+                    Navigation.goBack();
                 }}
                 shouldShowBackButton={shouldUseNarrowLayout}
                 shouldDisplaySearchRouter

--- a/src/pages/settings/Troubleshoot/TroubleshootPage.tsx
+++ b/src/pages/settings/Troubleshoot/TroubleshootPage.tsx
@@ -180,7 +180,7 @@ function TroubleshootPage() {
                 title={translate('initialSettingsPage.aboutPage.troubleshoot')}
                 shouldShowBackButton={shouldUseNarrowLayout}
                 shouldDisplaySearchRouter
-                onBackButtonPress={Navigation.popToSidebar}
+                onBackButtonPress={Navigation.goBack}
                 icon={illustrations.Lightbulb}
                 shouldUseHeadlineHeader
             />

--- a/src/pages/settings/Wallet/WalletPage/index.tsx
+++ b/src/pages/settings/Wallet/WalletPage/index.tsx
@@ -320,6 +320,15 @@ function WalletPage() {
     // Determines whether or not the modal popup is mounted from the bottom of the screen instead of the side mount on Web screen
     const alertTextStyle = [styles.inlineSystemMessage, styles.flexShrink1];
     const alertViewStyle = [styles.flexRow, styles.alignItemsCenter, styles.w100];
+
+    const onBackButtonPress = () => {
+        if (Navigation.getShouldPopToSidebar()) {
+            Navigation.popToSidebar();
+            return;
+        }
+        Navigation.goBack();
+    };
+
     const headerWithBackButton = (
         <HeaderWithBackButton
             title={translate('common.wallet')}
@@ -327,7 +336,7 @@ function WalletPage() {
             shouldUseHeadlineHeader
             shouldShowBackButton={shouldUseNarrowLayout}
             shouldDisplaySearchRouter
-            onBackButtonPress={Navigation.popToSidebar}
+            onBackButtonPress={onBackButtonPress}
         />
     );
 

--- a/src/pages/settings/Wallet/WalletPage/index.tsx
+++ b/src/pages/settings/Wallet/WalletPage/index.tsx
@@ -320,15 +320,6 @@ function WalletPage() {
     // Determines whether or not the modal popup is mounted from the bottom of the screen instead of the side mount on Web screen
     const alertTextStyle = [styles.inlineSystemMessage, styles.flexShrink1];
     const alertViewStyle = [styles.flexRow, styles.alignItemsCenter, styles.w100];
-
-    const onBackButtonPress = () => {
-        if (Navigation.getShouldPopToSidebar()) {
-            Navigation.popToSidebar();
-            return;
-        }
-        Navigation.goBack();
-    };
-
     const headerWithBackButton = (
         <HeaderWithBackButton
             title={translate('common.wallet')}
@@ -336,7 +327,6 @@ function WalletPage() {
             shouldUseHeadlineHeader
             shouldShowBackButton={shouldUseNarrowLayout}
             shouldDisplaySearchRouter
-            onBackButtonPress={onBackButtonPress}
         />
     );
 

--- a/src/pages/workspace/WorkspaceJoinUserPage.tsx
+++ b/src/pages/workspace/WorkspaceJoinUserPage.tsx
@@ -32,11 +32,7 @@ function WorkspaceJoinUserPage({route}: WorkspaceJoinUserPageProps) {
         }
         if (!isEmptyObject(policy) && !policy?.isJoinRequestPending && !isPendingDeletePolicy(policy)) {
             Navigation.isNavigationReady().then(() => {
-                if (Navigation.getShouldPopToSidebar()) {
-                    Navigation.popToSidebar();
-                } else {
-                    Navigation.goBack();
-                }
+                Navigation.goBack();
                 Navigation.navigate(ROUTES.WORKSPACE_INITIAL.getRoute(policyID));
             });
             return;

--- a/src/pages/workspace/WorkspaceMembersPage.tsx
+++ b/src/pages/workspace/WorkspaceMembersPage.tsx
@@ -558,15 +558,7 @@ function WorkspaceMembersPage({personalDetails, route, policy}: WorkspaceMembers
             return;
         }
 
-        setSelectedEmployees([]);        
-        return () => {
-            if (!isMobileSelectionModeEnabled) {
-                return;
-            }
-
-            setSelectedEmployees([]);
-            turnOffMobileSelectionMode();
-        };
+        setSelectedEmployees([]);
     }, [setSelectedEmployees, isMobileSelectionModeEnabled]);
 
     useSearchBackPress({
@@ -825,6 +817,14 @@ function WorkspaceMembersPage({personalDetails, route, policy}: WorkspaceMembers
             shouldUseHeadlineHeader={!selectionModeHeader}
             shouldShowOfflineIndicatorInWideScreen
             shouldShowNonAdmin
+            onBackButtonPress={() => {
+                if (isMobileSelectionModeEnabled) {
+                    setSelectedEmployees([]);
+                    turnOffMobileSelectionMode();
+                    return;
+                }
+                Navigation.goBack();
+            }}
         >
             {() => (
                 <>

--- a/src/pages/workspace/WorkspaceMembersPage.tsx
+++ b/src/pages/workspace/WorkspaceMembersPage.tsx
@@ -554,11 +554,14 @@ function WorkspaceMembersPage({personalDetails, route, policy}: WorkspaceMembers
     );
 
     useEffect(() => {
-        if (isMobileSelectionModeEnabled) {
-            return;
-        }
+        return () => {
+            if (!isMobileSelectionModeEnabled) {
+                return;
+            }
 
-        setSelectedEmployees([]);
+            setSelectedEmployees([]);
+            turnOffMobileSelectionMode();
+        };
     }, [setSelectedEmployees, isMobileSelectionModeEnabled]);
 
     useSearchBackPress({
@@ -817,14 +820,6 @@ function WorkspaceMembersPage({personalDetails, route, policy}: WorkspaceMembers
             shouldUseHeadlineHeader={!selectionModeHeader}
             shouldShowOfflineIndicatorInWideScreen
             shouldShowNonAdmin
-            onBackButtonPress={() => {
-                if (isMobileSelectionModeEnabled) {
-                    setSelectedEmployees([]);
-                    turnOffMobileSelectionMode();
-                    return;
-                }
-                Navigation.popToSidebar();
-            }}
         >
             {() => (
                 <>

--- a/src/pages/workspace/WorkspaceMembersPage.tsx
+++ b/src/pages/workspace/WorkspaceMembersPage.tsx
@@ -554,6 +554,11 @@ function WorkspaceMembersPage({personalDetails, route, policy}: WorkspaceMembers
     );
 
     useEffect(() => {
+        if (isMobileSelectionModeEnabled) {
+            return;
+        }
+
+        setSelectedEmployees([]);        
         return () => {
             if (!isMobileSelectionModeEnabled) {
                 return;

--- a/src/pages/workspace/WorkspaceMoreFeaturesPage.tsx
+++ b/src/pages/workspace/WorkspaceMoreFeaturesPage.tsx
@@ -1,10 +1,7 @@
 import React, {useCallback, useEffect, useState} from 'react';
 import {View} from 'react-native';
 import ConfirmModal from '@components/ConfirmModal';
-import HeaderWithBackButton from '@components/HeaderWithBackButton';
 import Hoverable from '@components/Hoverable';
-import ScreenWrapper from '@components/ScreenWrapper';
-import ScrollView from '@components/ScrollView';
 import Section from '@components/Section';
 import Text from '@components/Text';
 import useCardFeeds from '@hooks/useCardFeeds';
@@ -56,6 +53,7 @@ import AccessOrNotFoundWrapper from './AccessOrNotFoundWrapper';
 import type {WithPolicyAndFullscreenLoadingProps} from './withPolicyAndFullscreenLoading';
 import withPolicyAndFullscreenLoading from './withPolicyAndFullscreenLoading';
 import ToggleSettingOptionRow from './workflows/ToggleSettingsOptionRow';
+import WorkspacePageWithSections from './WorkspacePageWithSections';
 
 type WorkspaceMoreFeaturesPageProps = WithPolicyAndFullscreenLoadingProps & PlatformStackScreenProps<WorkspaceSplitNavigatorParamList, typeof SCREENS.WORKSPACE.MORE_FEATURES>;
 
@@ -612,114 +610,112 @@ function WorkspaceMoreFeaturesPage({policy, route}: WorkspaceMoreFeaturesPagePro
 
     useNetwork({onReconnect: fetchFeatures});
 
+    const modals = (
+        <>
+            <ConfirmModal
+                title={translate('workspace.moreFeatures.connectionsWarningModal.featureEnabledTitle')}
+                onConfirm={() => {
+                    if (!policyID) {
+                        return;
+                    }
+                    setIsOrganizeWarningModalOpen(false);
+                    Navigation.navigate(ROUTES.POLICY_ACCOUNTING.getRoute(policyID));
+                }}
+                onCancel={() => setIsOrganizeWarningModalOpen(false)}
+                isVisible={isOrganizeWarningModalOpen}
+                prompt={translate('workspace.moreFeatures.connectionsWarningModal.featureEnabledText')}
+                confirmText={translate('workspace.moreFeatures.connectionsWarningModal.manageSettings')}
+                cancelText={translate('common.cancel')}
+            />
+            <ConfirmModal
+                title={translate('workspace.moreFeatures.connectionsWarningModal.featureEnabledTitle')}
+                onConfirm={() => {
+                    if (!policyID) {
+                        return;
+                    }
+                    setIsIntegrateWarningModalOpen(false);
+                    Navigation.navigate(ROUTES.POLICY_ACCOUNTING.getRoute(policyID));
+                }}
+                onCancel={() => setIsIntegrateWarningModalOpen(false)}
+                isVisible={isIntegrateWarningModalOpen}
+                prompt={translate('workspace.moreFeatures.connectionsWarningModal.disconnectText')}
+                confirmText={translate('workspace.moreFeatures.connectionsWarningModal.manageSettings')}
+                cancelText={translate('common.cancel')}
+            />
+            {isBetaEnabled(CONST.BETAS.UBER_FOR_BUSINESS) && (
+                <ConfirmModal
+                    title={translate('workspace.moreFeatures.receiptPartnersWarningModal.featureEnabledTitle')}
+                    onConfirm={() => {
+                        if (!policyID) {
+                            return;
+                        }
+                        setIsReceiptPartnersWarningModalOpen(false);
+                        // TODO: Navigate to Receipt Partners settings page when it exists
+                        // Navigation.navigate(ROUTES.POLICY_RECEIPT_PARTNERS.getRoute(policyID));
+                    }}
+                    isVisible={isReceiptPartnersWarningModalOpen}
+                    prompt={translate('workspace.moreFeatures.receiptPartnersWarningModal.disconnectText')}
+                    confirmText={translate('workspace.moreFeatures.receiptPartnersWarningModal.confirmText')}
+                    shouldShowCancelButton={false}
+                />
+            )}
+            <ConfirmModal
+                title={translate('workspace.moreFeatures.expensifyCard.disableCardTitle')}
+                isVisible={isDisableExpensifyCardWarningModalOpen}
+                onConfirm={() => {
+                    setIsDisableExpensifyCardWarningModalOpen(false);
+                    navigateToConciergeChat(conciergeReportID, false);
+                }}
+                onCancel={() => setIsDisableExpensifyCardWarningModalOpen(false)}
+                prompt={translate('workspace.moreFeatures.expensifyCard.disableCardPrompt')}
+                confirmText={translate('workspace.moreFeatures.expensifyCard.disableCardButton')}
+                cancelText={translate('common.cancel')}
+            />
+            <ConfirmModal
+                title={translate('workspace.moreFeatures.companyCards.disableCardTitle')}
+                isVisible={isDisableCompanyCardsWarningModalOpen}
+                onConfirm={() => {
+                    setIsDisableCompanyCardsWarningModalOpen(false);
+                    navigateToConciergeChat(conciergeReportID, false);
+                }}
+                onCancel={() => setIsDisableCompanyCardsWarningModalOpen(false)}
+                prompt={translate('workspace.moreFeatures.companyCards.disableCardPrompt')}
+                confirmText={translate('workspace.moreFeatures.companyCards.disableCardButton')}
+                cancelText={translate('common.cancel')}
+            />
+            <ConfirmModal
+                title={translate('workspace.moreFeatures.workflowWarningModal.featureEnabledTitle')}
+                isVisible={isDisableWorkflowWarningModalOpen}
+                onConfirm={() => {
+                    setIsDisableWorkflowWarningModalOpen(false);
+                    Navigation.navigate(ROUTES.WORKSPACE_EXPENSIFY_CARD.getRoute(policyID));
+                }}
+                onCancel={() => setIsDisableWorkflowWarningModalOpen(false)}
+                prompt={translate('workspace.moreFeatures.workflowWarningModal.featureEnabledText')}
+                confirmText={translate('workspace.moreFeatures.workflowWarningModal.confirmText')}
+                cancelText={translate('common.cancel')}
+            />
+        </>
+    );
+
     return (
         <AccessOrNotFoundWrapper
             accessVariants={[CONST.POLICY.ACCESS_VARIANTS.ADMIN, CONST.POLICY.ACCESS_VARIANTS.PAID]}
             policyID={route.params.policyID}
         >
-            <ScreenWrapper
-                enableEdgeToEdgeBottomSafeAreaPadding
-                style={[styles.defaultModalContainer]}
+            <WorkspacePageWithSections
+                headerText={translate('workspace.common.moreFeatures')}
+                route={route}
+                icon={illustrations.Gears}
                 testID="WorkspaceMoreFeaturesPage"
                 shouldShowOfflineIndicatorInWideScreen
+                shouldUseScrollView
+                addBottomSafeAreaPadding
+                modals={modals}
             >
-                <HeaderWithBackButton
-                    icon={illustrations.Gears}
-                    shouldUseHeadlineHeader
-                    title={translate('workspace.common.moreFeatures')}
-                    shouldShowBackButton={shouldUseNarrowLayout}
-                    onBackButtonPress={() => Navigation.goBack()}
-                />
-
-                <ScrollView addBottomSafeAreaPadding>
-                    <Text style={[styles.ph5, styles.mb5, styles.mt3, styles.textSupporting, styles.workspaceSectionMobile]}>{translate('workspace.moreFeatures.subtitle')}</Text>
-                    {sections.map(renderSection)}
-                </ScrollView>
-
-                <ConfirmModal
-                    title={translate('workspace.moreFeatures.connectionsWarningModal.featureEnabledTitle')}
-                    onConfirm={() => {
-                        if (!policyID) {
-                            return;
-                        }
-                        setIsOrganizeWarningModalOpen(false);
-                        Navigation.navigate(ROUTES.POLICY_ACCOUNTING.getRoute(policyID));
-                    }}
-                    onCancel={() => setIsOrganizeWarningModalOpen(false)}
-                    isVisible={isOrganizeWarningModalOpen}
-                    prompt={translate('workspace.moreFeatures.connectionsWarningModal.featureEnabledText')}
-                    confirmText={translate('workspace.moreFeatures.connectionsWarningModal.manageSettings')}
-                    cancelText={translate('common.cancel')}
-                />
-                <ConfirmModal
-                    title={translate('workspace.moreFeatures.connectionsWarningModal.featureEnabledTitle')}
-                    onConfirm={() => {
-                        if (!policyID) {
-                            return;
-                        }
-                        setIsIntegrateWarningModalOpen(false);
-                        Navigation.navigate(ROUTES.POLICY_ACCOUNTING.getRoute(policyID));
-                    }}
-                    onCancel={() => setIsIntegrateWarningModalOpen(false)}
-                    isVisible={isIntegrateWarningModalOpen}
-                    prompt={translate('workspace.moreFeatures.connectionsWarningModal.disconnectText')}
-                    confirmText={translate('workspace.moreFeatures.connectionsWarningModal.manageSettings')}
-                    cancelText={translate('common.cancel')}
-                />
-                {isBetaEnabled(CONST.BETAS.UBER_FOR_BUSINESS) && (
-                    <ConfirmModal
-                        title={translate('workspace.moreFeatures.receiptPartnersWarningModal.featureEnabledTitle')}
-                        onConfirm={() => {
-                            if (!policyID) {
-                                return;
-                            }
-                            setIsReceiptPartnersWarningModalOpen(false);
-                            // TODO: Navigate to Receipt Partners settings page when it exists
-                            // Navigation.navigate(ROUTES.POLICY_RECEIPT_PARTNERS.getRoute(policyID));
-                        }}
-                        isVisible={isReceiptPartnersWarningModalOpen}
-                        prompt={translate('workspace.moreFeatures.receiptPartnersWarningModal.disconnectText')}
-                        confirmText={translate('workspace.moreFeatures.receiptPartnersWarningModal.confirmText')}
-                        shouldShowCancelButton={false}
-                    />
-                )}
-                <ConfirmModal
-                    title={translate('workspace.moreFeatures.expensifyCard.disableCardTitle')}
-                    isVisible={isDisableExpensifyCardWarningModalOpen}
-                    onConfirm={() => {
-                        setIsDisableExpensifyCardWarningModalOpen(false);
-                        navigateToConciergeChat(conciergeReportID, false);
-                    }}
-                    onCancel={() => setIsDisableExpensifyCardWarningModalOpen(false)}
-                    prompt={translate('workspace.moreFeatures.expensifyCard.disableCardPrompt')}
-                    confirmText={translate('workspace.moreFeatures.expensifyCard.disableCardButton')}
-                    cancelText={translate('common.cancel')}
-                />
-                <ConfirmModal
-                    title={translate('workspace.moreFeatures.companyCards.disableCardTitle')}
-                    isVisible={isDisableCompanyCardsWarningModalOpen}
-                    onConfirm={() => {
-                        setIsDisableCompanyCardsWarningModalOpen(false);
-                        navigateToConciergeChat(conciergeReportID, false);
-                    }}
-                    onCancel={() => setIsDisableCompanyCardsWarningModalOpen(false)}
-                    prompt={translate('workspace.moreFeatures.companyCards.disableCardPrompt')}
-                    confirmText={translate('workspace.moreFeatures.companyCards.disableCardButton')}
-                    cancelText={translate('common.cancel')}
-                />
-                <ConfirmModal
-                    title={translate('workspace.moreFeatures.workflowWarningModal.featureEnabledTitle')}
-                    isVisible={isDisableWorkflowWarningModalOpen}
-                    onConfirm={() => {
-                        setIsDisableWorkflowWarningModalOpen(false);
-                        Navigation.navigate(ROUTES.WORKSPACE_EXPENSIFY_CARD.getRoute(policyID));
-                    }}
-                    onCancel={() => setIsDisableWorkflowWarningModalOpen(false)}
-                    prompt={translate('workspace.moreFeatures.workflowWarningModal.featureEnabledText')}
-                    confirmText={translate('workspace.moreFeatures.workflowWarningModal.confirmText')}
-                    cancelText={translate('common.cancel')}
-                />
-            </ScreenWrapper>
+                <Text style={[styles.ph5, styles.mb5, styles.mt3, styles.textSupporting, styles.workspaceSectionMobile]}>{translate('workspace.moreFeatures.subtitle')}</Text>
+                {sections.map(renderSection)}
+            </WorkspacePageWithSections>
         </AccessOrNotFoundWrapper>
     );
 }

--- a/src/pages/workspace/WorkspaceMoreFeaturesPage.tsx
+++ b/src/pages/workspace/WorkspaceMoreFeaturesPage.tsx
@@ -1,7 +1,10 @@
 import React, {useCallback, useEffect, useState} from 'react';
 import {View} from 'react-native';
 import ConfirmModal from '@components/ConfirmModal';
+import HeaderWithBackButton from '@components/HeaderWithBackButton';
 import Hoverable from '@components/Hoverable';
+import ScreenWrapper from '@components/ScreenWrapper';
+import ScrollView from '@components/ScrollView';
 import Section from '@components/Section';
 import Text from '@components/Text';
 import useCardFeeds from '@hooks/useCardFeeds';
@@ -53,7 +56,6 @@ import AccessOrNotFoundWrapper from './AccessOrNotFoundWrapper';
 import type {WithPolicyAndFullscreenLoadingProps} from './withPolicyAndFullscreenLoading';
 import withPolicyAndFullscreenLoading from './withPolicyAndFullscreenLoading';
 import ToggleSettingOptionRow from './workflows/ToggleSettingsOptionRow';
-import WorkspacePageWithSections from './WorkspacePageWithSections';
 
 type WorkspaceMoreFeaturesPageProps = WithPolicyAndFullscreenLoadingProps & PlatformStackScreenProps<WorkspaceSplitNavigatorParamList, typeof SCREENS.WORKSPACE.MORE_FEATURES>;
 
@@ -610,112 +612,114 @@ function WorkspaceMoreFeaturesPage({policy, route}: WorkspaceMoreFeaturesPagePro
 
     useNetwork({onReconnect: fetchFeatures});
 
-    const modals = (
-        <>
-            <ConfirmModal
-                title={translate('workspace.moreFeatures.connectionsWarningModal.featureEnabledTitle')}
-                onConfirm={() => {
-                    if (!policyID) {
-                        return;
-                    }
-                    setIsOrganizeWarningModalOpen(false);
-                    Navigation.navigate(ROUTES.POLICY_ACCOUNTING.getRoute(policyID));
-                }}
-                onCancel={() => setIsOrganizeWarningModalOpen(false)}
-                isVisible={isOrganizeWarningModalOpen}
-                prompt={translate('workspace.moreFeatures.connectionsWarningModal.featureEnabledText')}
-                confirmText={translate('workspace.moreFeatures.connectionsWarningModal.manageSettings')}
-                cancelText={translate('common.cancel')}
-            />
-            <ConfirmModal
-                title={translate('workspace.moreFeatures.connectionsWarningModal.featureEnabledTitle')}
-                onConfirm={() => {
-                    if (!policyID) {
-                        return;
-                    }
-                    setIsIntegrateWarningModalOpen(false);
-                    Navigation.navigate(ROUTES.POLICY_ACCOUNTING.getRoute(policyID));
-                }}
-                onCancel={() => setIsIntegrateWarningModalOpen(false)}
-                isVisible={isIntegrateWarningModalOpen}
-                prompt={translate('workspace.moreFeatures.connectionsWarningModal.disconnectText')}
-                confirmText={translate('workspace.moreFeatures.connectionsWarningModal.manageSettings')}
-                cancelText={translate('common.cancel')}
-            />
-            {isBetaEnabled(CONST.BETAS.UBER_FOR_BUSINESS) && (
-                <ConfirmModal
-                    title={translate('workspace.moreFeatures.receiptPartnersWarningModal.featureEnabledTitle')}
-                    onConfirm={() => {
-                        if (!policyID) {
-                            return;
-                        }
-                        setIsReceiptPartnersWarningModalOpen(false);
-                        // TODO: Navigate to Receipt Partners settings page when it exists
-                        // Navigation.navigate(ROUTES.POLICY_RECEIPT_PARTNERS.getRoute(policyID));
-                    }}
-                    isVisible={isReceiptPartnersWarningModalOpen}
-                    prompt={translate('workspace.moreFeatures.receiptPartnersWarningModal.disconnectText')}
-                    confirmText={translate('workspace.moreFeatures.receiptPartnersWarningModal.confirmText')}
-                    shouldShowCancelButton={false}
-                />
-            )}
-            <ConfirmModal
-                title={translate('workspace.moreFeatures.expensifyCard.disableCardTitle')}
-                isVisible={isDisableExpensifyCardWarningModalOpen}
-                onConfirm={() => {
-                    setIsDisableExpensifyCardWarningModalOpen(false);
-                    navigateToConciergeChat(conciergeReportID, false);
-                }}
-                onCancel={() => setIsDisableExpensifyCardWarningModalOpen(false)}
-                prompt={translate('workspace.moreFeatures.expensifyCard.disableCardPrompt')}
-                confirmText={translate('workspace.moreFeatures.expensifyCard.disableCardButton')}
-                cancelText={translate('common.cancel')}
-            />
-            <ConfirmModal
-                title={translate('workspace.moreFeatures.companyCards.disableCardTitle')}
-                isVisible={isDisableCompanyCardsWarningModalOpen}
-                onConfirm={() => {
-                    setIsDisableCompanyCardsWarningModalOpen(false);
-                    navigateToConciergeChat(conciergeReportID, false);
-                }}
-                onCancel={() => setIsDisableCompanyCardsWarningModalOpen(false)}
-                prompt={translate('workspace.moreFeatures.companyCards.disableCardPrompt')}
-                confirmText={translate('workspace.moreFeatures.companyCards.disableCardButton')}
-                cancelText={translate('common.cancel')}
-            />
-            <ConfirmModal
-                title={translate('workspace.moreFeatures.workflowWarningModal.featureEnabledTitle')}
-                isVisible={isDisableWorkflowWarningModalOpen}
-                onConfirm={() => {
-                    setIsDisableWorkflowWarningModalOpen(false);
-                    Navigation.navigate(ROUTES.WORKSPACE_EXPENSIFY_CARD.getRoute(policyID));
-                }}
-                onCancel={() => setIsDisableWorkflowWarningModalOpen(false)}
-                prompt={translate('workspace.moreFeatures.workflowWarningModal.featureEnabledText')}
-                confirmText={translate('workspace.moreFeatures.workflowWarningModal.confirmText')}
-                cancelText={translate('common.cancel')}
-            />
-        </>
-    );
-
     return (
         <AccessOrNotFoundWrapper
             accessVariants={[CONST.POLICY.ACCESS_VARIANTS.ADMIN, CONST.POLICY.ACCESS_VARIANTS.PAID]}
             policyID={route.params.policyID}
         >
-            <WorkspacePageWithSections
-                headerText={translate('workspace.common.moreFeatures')}
-                route={route}
-                icon={illustrations.Gears}
+            <ScreenWrapper
+                enableEdgeToEdgeBottomSafeAreaPadding
+                style={[styles.defaultModalContainer]}
                 testID="WorkspaceMoreFeaturesPage"
                 shouldShowOfflineIndicatorInWideScreen
-                shouldUseScrollView
-                addBottomSafeAreaPadding
-                modals={modals}
             >
-                <Text style={[styles.ph5, styles.mb5, styles.mt3, styles.textSupporting, styles.workspaceSectionMobile]}>{translate('workspace.moreFeatures.subtitle')}</Text>
-                {sections.map(renderSection)}
-            </WorkspacePageWithSections>
+                <HeaderWithBackButton
+                    icon={illustrations.Gears}
+                    shouldUseHeadlineHeader
+                    title={translate('workspace.common.moreFeatures')}
+                    shouldShowBackButton={shouldUseNarrowLayout}
+                    onBackButtonPress={() => Navigation.goBack()}
+                />
+
+                <ScrollView addBottomSafeAreaPadding>
+                    <Text style={[styles.ph5, styles.mb5, styles.mt3, styles.textSupporting, styles.workspaceSectionMobile]}>{translate('workspace.moreFeatures.subtitle')}</Text>
+                    {sections.map(renderSection)}
+                </ScrollView>
+
+                <ConfirmModal
+                    title={translate('workspace.moreFeatures.connectionsWarningModal.featureEnabledTitle')}
+                    onConfirm={() => {
+                        if (!policyID) {
+                            return;
+                        }
+                        setIsOrganizeWarningModalOpen(false);
+                        Navigation.navigate(ROUTES.POLICY_ACCOUNTING.getRoute(policyID));
+                    }}
+                    onCancel={() => setIsOrganizeWarningModalOpen(false)}
+                    isVisible={isOrganizeWarningModalOpen}
+                    prompt={translate('workspace.moreFeatures.connectionsWarningModal.featureEnabledText')}
+                    confirmText={translate('workspace.moreFeatures.connectionsWarningModal.manageSettings')}
+                    cancelText={translate('common.cancel')}
+                />
+                <ConfirmModal
+                    title={translate('workspace.moreFeatures.connectionsWarningModal.featureEnabledTitle')}
+                    onConfirm={() => {
+                        if (!policyID) {
+                            return;
+                        }
+                        setIsIntegrateWarningModalOpen(false);
+                        Navigation.navigate(ROUTES.POLICY_ACCOUNTING.getRoute(policyID));
+                    }}
+                    onCancel={() => setIsIntegrateWarningModalOpen(false)}
+                    isVisible={isIntegrateWarningModalOpen}
+                    prompt={translate('workspace.moreFeatures.connectionsWarningModal.disconnectText')}
+                    confirmText={translate('workspace.moreFeatures.connectionsWarningModal.manageSettings')}
+                    cancelText={translate('common.cancel')}
+                />
+                {isBetaEnabled(CONST.BETAS.UBER_FOR_BUSINESS) && (
+                    <ConfirmModal
+                        title={translate('workspace.moreFeatures.receiptPartnersWarningModal.featureEnabledTitle')}
+                        onConfirm={() => {
+                            if (!policyID) {
+                                return;
+                            }
+                            setIsReceiptPartnersWarningModalOpen(false);
+                            // TODO: Navigate to Receipt Partners settings page when it exists
+                            // Navigation.navigate(ROUTES.POLICY_RECEIPT_PARTNERS.getRoute(policyID));
+                        }}
+                        isVisible={isReceiptPartnersWarningModalOpen}
+                        prompt={translate('workspace.moreFeatures.receiptPartnersWarningModal.disconnectText')}
+                        confirmText={translate('workspace.moreFeatures.receiptPartnersWarningModal.confirmText')}
+                        shouldShowCancelButton={false}
+                    />
+                )}
+                <ConfirmModal
+                    title={translate('workspace.moreFeatures.expensifyCard.disableCardTitle')}
+                    isVisible={isDisableExpensifyCardWarningModalOpen}
+                    onConfirm={() => {
+                        setIsDisableExpensifyCardWarningModalOpen(false);
+                        navigateToConciergeChat(conciergeReportID, false);
+                    }}
+                    onCancel={() => setIsDisableExpensifyCardWarningModalOpen(false)}
+                    prompt={translate('workspace.moreFeatures.expensifyCard.disableCardPrompt')}
+                    confirmText={translate('workspace.moreFeatures.expensifyCard.disableCardButton')}
+                    cancelText={translate('common.cancel')}
+                />
+                <ConfirmModal
+                    title={translate('workspace.moreFeatures.companyCards.disableCardTitle')}
+                    isVisible={isDisableCompanyCardsWarningModalOpen}
+                    onConfirm={() => {
+                        setIsDisableCompanyCardsWarningModalOpen(false);
+                        navigateToConciergeChat(conciergeReportID, false);
+                    }}
+                    onCancel={() => setIsDisableCompanyCardsWarningModalOpen(false)}
+                    prompt={translate('workspace.moreFeatures.companyCards.disableCardPrompt')}
+                    confirmText={translate('workspace.moreFeatures.companyCards.disableCardButton')}
+                    cancelText={translate('common.cancel')}
+                />
+                <ConfirmModal
+                    title={translate('workspace.moreFeatures.workflowWarningModal.featureEnabledTitle')}
+                    isVisible={isDisableWorkflowWarningModalOpen}
+                    onConfirm={() => {
+                        setIsDisableWorkflowWarningModalOpen(false);
+                        Navigation.navigate(ROUTES.WORKSPACE_EXPENSIFY_CARD.getRoute(policyID));
+                    }}
+                    onCancel={() => setIsDisableWorkflowWarningModalOpen(false)}
+                    prompt={translate('workspace.moreFeatures.workflowWarningModal.featureEnabledText')}
+                    confirmText={translate('workspace.moreFeatures.workflowWarningModal.confirmText')}
+                    cancelText={translate('common.cancel')}
+                />
+            </ScreenWrapper>
         </AccessOrNotFoundWrapper>
     );
 }

--- a/src/pages/workspace/WorkspaceOverviewPage.tsx
+++ b/src/pages/workspace/WorkspaceOverviewPage.tsx
@@ -341,7 +341,7 @@ function WorkspaceOverviewPage({policyDraft, policy: policyProp, route}: Workspa
             return;
         }
 
-        Navigation.popToSidebar();
+        Navigation.goBack();
     };
 
     const startChangeOwnershipFlow = useCallback(() => {

--- a/src/pages/workspace/WorkspacePageWithSections.tsx
+++ b/src/pages/workspace/WorkspacePageWithSections.tsx
@@ -194,7 +194,12 @@ function WorkspacePageWithSections({
             return true;
         }
 
-        Navigation.popToSidebar();
+        if (Navigation.getShouldPopToSidebar()) {
+            Navigation.popToSidebar();
+            return true;
+        }
+
+        Navigation.goBack();
         return true;
     };
 
@@ -210,7 +215,7 @@ function WorkspacePageWithSections({
             shouldShowOfflineIndicatorInWideScreen={shouldShowOfflineIndicatorInWideScreen && !shouldShow}
         >
             <FullPageNotFoundView
-                onBackButtonPress={goBackFromWorkspaceSettingPages}
+                onBackButtonPress={handleOnBackButtonPress}
                 onLinkPress={() => Navigation.goBackToHome()}
                 shouldShow={shouldShow}
                 subtitleKey={shouldShowPolicy ? 'workspace.common.notAuthorized' : undefined}

--- a/src/pages/workspace/WorkspacePageWithSections.tsx
+++ b/src/pages/workspace/WorkspacePageWithSections.tsx
@@ -194,11 +194,6 @@ function WorkspacePageWithSections({
             return true;
         }
 
-        if (Navigation.getShouldPopToSidebar()) {
-            Navigation.popToSidebar();
-            return true;
-        }
-
         Navigation.goBack();
         return true;
     };

--- a/src/pages/workspace/accounting/PolicyAccountingPage.tsx
+++ b/src/pages/workspace/accounting/PolicyAccountingPage.tsx
@@ -557,7 +557,7 @@ function PolicyAccountingPage({policy}: PolicyAccountingPageProps) {
                     shouldShowBackButton={shouldUseNarrowLayout}
                     icon={illustrations.Accounting}
                     shouldUseHeadlineHeader
-                    onBackButtonPress={Navigation.popToSidebar}
+                    onBackButtonPress={Navigation.goBack}
                 />
                 <ScrollView
                     contentContainerStyle={styles.pt3}

--- a/src/pages/workspace/categories/WorkspaceCategoriesPage.tsx
+++ b/src/pages/workspace/categories/WorkspaceCategoriesPage.tsx
@@ -655,7 +655,7 @@ function WorkspaceCategoriesPage({route}: WorkspaceCategoriesPageProps) {
                             return;
                         }
 
-                        Navigation.popToSidebar();
+                        Navigation.goBack();
                     }}
                 >
                     {!shouldUseNarrowLayout && getHeaderButtons()}

--- a/src/pages/workspace/distanceRates/PolicyDistanceRatesPage.tsx
+++ b/src/pages/workspace/distanceRates/PolicyDistanceRatesPage.tsx
@@ -482,7 +482,7 @@ function PolicyDistanceRatesPage({
                             turnOffMobileSelectionMode();
                             return;
                         }
-                        Navigation.popToSidebar();
+                        Navigation.goBack();
                     }}
                 >
                     {!shouldUseNarrowLayout && headerButtons}

--- a/src/pages/workspace/expensifyCard/WorkspaceExpensifyCardListPage.tsx
+++ b/src/pages/workspace/expensifyCard/WorkspaceExpensifyCardListPage.tsx
@@ -209,7 +209,7 @@ function WorkspaceExpensifyCardListPage({route, cardsList, fundID}: WorkspaceExp
     );
 
     const handleBackButtonPress = () => {
-        Navigation.popToSidebar();
+        Navigation.goBack();
         return true;
     };
 

--- a/src/pages/workspace/perDiem/WorkspacePerDiemPage.tsx
+++ b/src/pages/workspace/perDiem/WorkspacePerDiemPage.tsx
@@ -435,7 +435,7 @@ function WorkspacePerDiemPage({route}: WorkspacePerDiemPageProps) {
                             return;
                         }
 
-                        Navigation.popToSidebar();
+                        Navigation.goBack();
                     }}
                 >
                     {!shouldUseNarrowLayout && getHeaderButtons()}

--- a/src/pages/workspace/receiptPartners/WorkspaceReceiptPartnersPage.tsx
+++ b/src/pages/workspace/receiptPartners/WorkspaceReceiptPartnersPage.tsx
@@ -271,7 +271,7 @@ function WorkspaceReceiptPartnersPage({route}: WorkspaceReceiptPartnersPageProps
                         shouldShowBackButton={shouldUseNarrowLayout}
                         icon={ReceiptPartners}
                         shouldUseHeadlineHeader
-                        onBackButtonPress={Navigation.popToSidebar}
+                        onBackButtonPress={Navigation.goBack}
                     />
                     <ScrollView
                         contentContainerStyle={styles.pt3}

--- a/src/pages/workspace/reports/WorkspaceReportsPage.tsx
+++ b/src/pages/workspace/reports/WorkspaceReportsPage.tsx
@@ -6,7 +6,6 @@ import {View} from 'react-native';
 import ActivityIndicator from '@components/ActivityIndicator';
 import ConfirmModal from '@components/ConfirmModal';
 import HeaderWithBackButton from '@components/HeaderWithBackButton';
-import {Plus} from '@components/Icon/Expensicons';
 import ImportedFromAccountingSoftware from '@components/ImportedFromAccountingSoftware';
 import MenuItem from '@components/MenuItem';
 import MenuItemWithTopDescription from '@components/MenuItemWithTopDescription';
@@ -17,7 +16,7 @@ import ScrollView from '@components/ScrollView';
 import Section from '@components/Section';
 import type {ListItem} from '@components/SelectionListWithSections/types';
 import Text from '@components/Text';
-import {useMemoizedLazyIllustrations} from '@hooks/useLazyAsset';
+import {useMemoizedLazyExpensifyIcons, useMemoizedLazyIllustrations} from '@hooks/useLazyAsset';
 import useLocalize from '@hooks/useLocalize';
 import useNetwork from '@hooks/useNetwork';
 import useOnyx from '@hooks/useOnyx';
@@ -74,6 +73,7 @@ function WorkspaceReportFieldsPage({
     const [isOrganizeWarningModalOpen, setIsOrganizeWarningModalOpen] = useState(false);
 
     const illustrations = useMemoizedLazyIllustrations(['ReportReceipt']);
+    const icons = useMemoizedLazyExpensifyIcons(['Plus']);
 
     const onDisabledOrganizeSwitchPress = () => {
         if (!hasAccountingConnections) {
@@ -186,7 +186,7 @@ function WorkspaceReportFieldsPage({
                     title={translate('common.reports')}
                     shouldUseHeadlineHeader
                     shouldShowBackButton={shouldUseNarrowLayout}
-                    onBackButtonPress={Navigation.popToSidebar}
+                    onBackButtonPress={Navigation.goBack}
                 />
                 {isLoading && (
                     <ActivityIndicator
@@ -282,7 +282,7 @@ function WorkspaceReportFieldsPage({
                                                 <MenuItem
                                                     onPress={() => Navigation.navigate(ROUTES.WORKSPACE_CREATE_REPORT_FIELD.getRoute(policyID))}
                                                     title={translate('workspace.reportFields.addField')}
-                                                    icon={Plus}
+                                                    icon={icons.Plus}
                                                     style={[styles.sectionMenuItemTopDescription]}
                                                 />
                                             )}

--- a/src/pages/workspace/tags/WorkspaceTagsPage.tsx
+++ b/src/pages/workspace/tags/WorkspaceTagsPage.tsx
@@ -762,7 +762,7 @@ function WorkspaceTagsPage({route}: WorkspaceTagsPageProps) {
                                 return;
                             }
 
-                            Navigation.popToSidebar();
+                            Navigation.goBack();
                         }}
                     >
                         {!shouldUseNarrowLayout && getHeaderButtons()}

--- a/src/pages/workspace/taxes/WorkspaceTaxesPage.tsx
+++ b/src/pages/workspace/taxes/WorkspaceTaxesPage.tsx
@@ -406,7 +406,7 @@ function WorkspaceTaxesPage({
                             turnOffMobileSelectionMode();
                             return;
                         }
-                        Navigation.popToSidebar();
+                        Navigation.goBack();
                     }}
                 >
                     {!shouldUseNarrowLayout && headerButtons}

--- a/src/pages/workspace/travel/PolicyTravelPage.tsx
+++ b/src/pages/workspace/travel/PolicyTravelPage.tsx
@@ -104,7 +104,7 @@ function WorkspaceTravelPage({
                     title={translate('workspace.moreFeatures.travel.title')}
                     shouldUseHeadlineHeader
                     shouldShowBackButton={shouldUseNarrowLayout}
-                    onBackButtonPress={Navigation.popToSidebar}
+                    onBackButtonPress={Navigation.goBack}
                 />
                 <ScrollViewWithContext addBottomSafeAreaPadding>
                     <View style={[styles.pt3, shouldUseNarrowLayout ? styles.workspaceSectionMobile : styles.workspaceSection]}>{mainContent}</View>

--- a/tests/ui/ProfilePageTest.tsx
+++ b/tests/ui/ProfilePageTest.tsx
@@ -26,15 +26,13 @@ jest.mock('@libs/Navigation/Navigation', () => ({
     navigate: jest.fn(),
     goBack: jest.fn(),
     getActiveRoute: jest.fn(() => ''),
-    getShouldPopToSidebar: jest.fn(() => false),
-    popToSidebar: jest.fn(),
 }));
 
 jest.mock('@react-navigation/native', () => {
     const actualNav = jest.requireActual<typeof ReactNavigation>('@react-navigation/native');
     return {
         ...actualNav,
-        useRoute: jest.fn(),
+        useRoute: jest.fn(() => ({params: {}})),
         createNavigationContainerRef: () => ({
             getState: () => jest.fn(),
         }),


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change

With changes introduced in this PR, `popToSidebar` is called from `Navigation.goBack` function only if `shouldPopToSidebar` is `true`. Thanks to that, `goBack` behaviour is consistent across all screens from `Account` and `Workspaces` tabs.

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/72081
$ https://github.com/Expensify/App/issues/73091
$ https://github.com/Expensify/App/issues/72559
PROPOSAL:


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

- [ ] Verify that no errors appear in the JS console

##### Android - Expense - Tapping device back button from workflow directs to workspace page

1. Launch app in both mweb and android
2. Create a expense in workspace chat
3. Tap submit
4. Open the expense details - more - change approver
5. Tap workflow settings link
6. Tap device back button
7. Verify if the change approver page has been displayed.

##### User not navigated to workspace settings on tapping back button in More features page

1. Launch Hybrid app or navigate to staging.new.expensify.com
2. Create new user
3. Select Skip on work email page
4. Select the option "Manage my team's expenses" >> "1-10 employees" >> Quickbooks Desktop accounting software >>Continue >>Skip on take a test drive modal
5. Go to Concierge chat
6. Select “Invite your team” task >> Take me to workspace members link >> click back button
7. Verify if you have been redirected to the previous page.
8. Go back to Concierge chat >> Select "Add expense approvals"" task
9. Click on "Take me to more features" link
10. User redirected to More features page>> observe workflows option is enabled
11. Tap on back button
12. Verify if you have been redirected to the previous page.

##### Chat - Tapping tapping app's top left arrow navigates to workspace settings

1. Launch app
2. Go to workspace settings
3. Tap company card
4. Use region bank and assign a direct feed card
5. Open workspace chat
6. Tap company card link
7. Tap device back button
8. Note user directed to same company card link page
9. Again tap on company card link
10. Tap app's top left arrow
11. Verify if you have been redirected to the Company Card Link page

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->
// TODO: These must be filled out, or the issue title must include "[No QA]."

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I verified there are no new alerts related to the `canBeMissing` param for `useOnyx`
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/3e2face7-d112-40a8-a526-56ec1ddf2815


</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/fbb5aa2d-d4d3-439b-82e5-f1560ff28d6c


</details>