### PR TITLE
[No QA][ECUK] MFA re-register flow when server returns "registration required"

### DIFF
--- a/src/components/MultifactorAuthentication/Context/Main.tsx
+++ b/src/components/MultifactorAuthentication/Context/Main.tsx
@@ -24,7 +24,7 @@ let deviceBiometricsState: OnyxEntry<DeviceBiometrics>;
 
 // Use Onyx.connectWithoutView instead of useOnyx hook to access the device biometrics state.
 // This is a non-reactive read that allows us to check the current value (hasAcceptedSoftPrompt)
-// from within the process() callback without triggering calling it too many times during the 
+// from within the process() callback without triggering calling it too many times during the
 // fresh registration flow
 Onyx.connectWithoutView({
     key: ONYXKEYS.DEVICE_BIOMETRICS,

--- a/src/components/MultifactorAuthentication/Context/State.tsx
+++ b/src/components/MultifactorAuthentication/Context/State.tsx
@@ -93,6 +93,7 @@ type Action =
     | {type: 'SET_FLOW_COMPLETE'; payload: boolean}
     | {type: 'SET_AUTHENTICATION_METHOD'; payload: AuthTypeInfo | undefined}
     | {type: 'INIT'; payload: InitPayload}
+    | {type: 'REREGISTER'}
     | {type: 'RESET'};
 
 /**
@@ -153,6 +154,13 @@ function stateReducer(state: MultifactorAuthenticationState, action: Action): Mu
             };
         case 'RESET':
             return DEFAULT_STATE;
+        case 'REREGISTER':
+            return {
+                ...DEFAULT_STATE,
+                scenario: state.scenario,
+                payload: state.payload,
+                outcomePaths: state.outcomePaths,
+            };
         default:
             return state;
     }

--- a/src/components/MultifactorAuthentication/Context/usePromptContent.ts
+++ b/src/components/MultifactorAuthentication/Context/usePromptContent.ts
@@ -48,9 +48,9 @@ function usePromptContent(promptType: MultifactorAuthenticationPromptType): Prom
     // restart the whole flow. The registration flow clears a relevant state, which causes the prompt page to
     // change from the authentication version to the registration version briefly before we navigate away from the
     // page. Since there is no legitimate case for the prompt page to transition from authentication =>
-    // registration, only the other way around, this ref prevents that from happening.
-    // Functionally, it acts as a latch for isReturningUser, so that once it becomes true, it'll never become
-    // false until this screen unmounts
+    // registration, only the other way around, this ref prevents that from happening. Functionally, it acts as a
+    // latch for isReturningUser, so that once it becomes true, it'll never become false until this screen
+    // unmounts.
     const wasPreviouslyRegisteredRef = useRef(false);
 
     const contentData = MULTIFACTOR_AUTHENTICATION_PROMPT_UI[promptType];

--- a/src/components/MultifactorAuthentication/Context/usePromptContent.ts
+++ b/src/components/MultifactorAuthentication/Context/usePromptContent.ts
@@ -50,7 +50,7 @@ function usePromptContent(promptType: MultifactorAuthenticationPromptType): Prom
     // page. Since there is no legitimate case for the prompt page to transition from authentication =>
     // registration during a single flow, only the other way around, this ref prevents that from happening.
     // Functionally, it acts as a latch for isReturningUser, so that once it becomes true, it'll never become
-    // false for the duration of the flow.
+    // false until we navigate to a different page
     const wasPreviouslyRegisteredRef = useRef(false);
 
     const contentData = MULTIFACTOR_AUTHENTICATION_PROMPT_UI[promptType];

--- a/src/components/MultifactorAuthentication/Context/usePromptContent.ts
+++ b/src/components/MultifactorAuthentication/Context/usePromptContent.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react';
+import {useEffect, useRef} from 'react';
 import type {OnyxEntry} from 'react-native-onyx';
 import type DotLottieAnimation from '@components/LottieAnimations/types';
 import {MULTIFACTOR_AUTHENTICATION_PROMPT_UI} from '@components/MultifactorAuthentication/config';
@@ -40,7 +40,7 @@ function usePromptContent(promptType: MultifactorAuthenticationPromptType): Prom
     const [serverHasCredentials = false] = useOnyx(ONYXKEYS.ACCOUNT, {canBeMissing: true, selector: serverHasRegisteredCredentials});
     const [deviceBiometricsState] = useOnyx(ONYXKEYS.DEVICE_BIOMETRICS, {canBeMissing: true});
     const hasEverAcceptedSoftPrompt = deviceBiometricsState?.hasAcceptedSoftPrompt ?? false;
-    
+
     // This one's a real doozy. There's an edge case with the MFA flows where the user's keys were revoked
     // server-side, but the client missed the onyx update clearing them, so the client launches into the authenticate
     // flow, shows the user this screen with the "Let's authenticate you" message,
@@ -81,7 +81,8 @@ function usePromptContent(promptType: MultifactorAuthenticationPromptType): Prom
     // Display confirm button only for new users during their first biometric registration.
     // Hide it for: users who already approved the soft prompt, users who finished registration,
     // or returning users with existing server credentials. The button prompts users to enable biometrics.
-    const shouldDisplayConfirmButton = !hasEverAcceptedSoftPrompt || (!state.softPromptApproved && !state.isRegistrationComplete && !serverHasCredentials && !wasPreviouslyRegisteredRef.current);
+    const shouldDisplayConfirmButton =
+        !hasEverAcceptedSoftPrompt || (!state.softPromptApproved && !state.isRegistrationComplete && !serverHasCredentials && !wasPreviouslyRegisteredRef.current);
 
     return {
         animation: contentData.animation,

--- a/src/components/MultifactorAuthentication/Context/usePromptContent.ts
+++ b/src/components/MultifactorAuthentication/Context/usePromptContent.ts
@@ -1,3 +1,4 @@
+import { useEffect, useRef } from 'react';
 import type {OnyxEntry} from 'react-native-onyx';
 import type DotLottieAnimation from '@components/LottieAnimations/types';
 import {MULTIFACTOR_AUTHENTICATION_PROMPT_UI} from '@components/MultifactorAuthentication/config';
@@ -39,11 +40,27 @@ function usePromptContent(promptType: MultifactorAuthenticationPromptType): Prom
     const [serverHasCredentials = false] = useOnyx(ONYXKEYS.ACCOUNT, {canBeMissing: true, selector: serverHasRegisteredCredentials});
     const [deviceBiometricsState] = useOnyx(ONYXKEYS.DEVICE_BIOMETRICS, {canBeMissing: true});
     const hasEverAcceptedSoftPrompt = deviceBiometricsState?.hasAcceptedSoftPrompt ?? false;
+    
+    // This one's a real doozy. There's an edge case with the MFA flows where the user's keys were revoked
+    // server-side, but the client missed the onyx update clearing them, so the client launches into the authenticate
+    // flow, shows the user this screen with the "Let's authenticate you" message,
+    //  then finds out mid-flow (after requesting the authentication challenge) that we actually need to restart
+    // the whole flow and re-register. This ref is used to prevent UI jank after we clear the relevant state
+    // but haven't yet navigated to the beginning of the registration flow (magic code input)
+    // Functionally, it acts as a latch for isReturningUser, so that once it becomes true, it'll never become false
+    const wasPreviouslyRegisteredRef = useRef(false);
 
     const contentData = MULTIFACTOR_AUTHENTICATION_PROMPT_UI[promptType];
 
     // Returning user: server has credentials, but user hasn't approved soft prompt yet
-    const isReturningUser = hasEverAcceptedSoftPrompt && serverHasCredentials && !state.softPromptApproved;
+    const isReturningUser = wasPreviouslyRegisteredRef.current || (hasEverAcceptedSoftPrompt && serverHasCredentials && !state.softPromptApproved);
+
+    useEffect(() => {
+        if (!isReturningUser) {
+            return;
+        }
+        wasPreviouslyRegisteredRef.current = isReturningUser;
+    }, [isReturningUser]);
 
     let title: TranslationPaths = contentData.title;
     let subtitle: TranslationPaths | undefined = contentData.subtitle;
@@ -64,7 +81,7 @@ function usePromptContent(promptType: MultifactorAuthenticationPromptType): Prom
     // Display confirm button only for new users during their first biometric registration.
     // Hide it for: users who already approved the soft prompt, users who finished registration,
     // or returning users with existing server credentials. The button prompts users to enable biometrics.
-    const shouldDisplayConfirmButton = !hasEverAcceptedSoftPrompt || (!state.softPromptApproved && !state.isRegistrationComplete && !serverHasCredentials);
+    const shouldDisplayConfirmButton = !hasEverAcceptedSoftPrompt || (!state.softPromptApproved && !state.isRegistrationComplete && !serverHasCredentials && !wasPreviouslyRegisteredRef.current);
 
     return {
         animation: contentData.animation,

--- a/src/components/MultifactorAuthentication/Context/usePromptContent.ts
+++ b/src/components/MultifactorAuthentication/Context/usePromptContent.ts
@@ -48,9 +48,9 @@ function usePromptContent(promptType: MultifactorAuthenticationPromptType): Prom
     // restart the whole flow. The registration flow clears a relevant state, which causes the prompt page to
     // change from the authentication version to the registration version briefly before we navigate away from the
     // page. Since there is no legitimate case for the prompt page to transition from authentication =>
-    // registration during a single flow, only the other way around, this ref prevents that from happening.
+    // registration, only the other way around, this ref prevents that from happening.
     // Functionally, it acts as a latch for isReturningUser, so that once it becomes true, it'll never become
-    // false until we navigate to a different page
+    // false until this screen unmounts
     const wasPreviouslyRegisteredRef = useRef(false);
 
     const contentData = MULTIFACTOR_AUTHENTICATION_PROMPT_UI[promptType];

--- a/src/libs/MultifactorAuthentication/Biometrics/VALUES.ts
+++ b/src/libs/MultifactorAuthentication/Biometrics/VALUES.ts
@@ -212,7 +212,7 @@ const MULTIFACTOR_AUTHENTICATION_VALUES = {
      * but isn't allowed to be assigned to a `string[]` field
      */
     PUBLIC_KEYS_PREVIOUSLY_BUT_NOT_CURRENTLY_REGISTERED: [] as string[],
-    PUBLIC_KEYS_AUTHENTICATION_NEVER_REGISTERED: undefined
+    PUBLIC_KEYS_AUTHENTICATION_NEVER_REGISTERED: undefined,
 } as const;
 
 export {MultifactorAuthenticationCallbacks};

--- a/src/libs/MultifactorAuthentication/Biometrics/VALUES.ts
+++ b/src/libs/MultifactorAuthentication/Biometrics/VALUES.ts
@@ -206,10 +206,10 @@ const MULTIFACTOR_AUTHENTICATION_VALUES = {
     API_RESPONSE_MAP,
     REASON,
     /**
-     * Specifically meaningful values for `multifactorAuthenticationPublicKeyIDs` in the `account` Onyx key
-     * casting `[] as string[]` is necessary to allow us to actually store the value in Onyx. Otherwise the
+     * Specifically meaningful values for `multifactorAuthenticationPublicKeyIDs` in the `account` Onyx key.
+     * Casting `[] as string[]` is necessary to allow us to actually store the value in Onyx. Otherwise the
      * `as const` would mean `[]` becomes `readonly []` (readonly empty array), which is more precise,
-     * but isn't allowed to be assigned to a `string[]` field
+     * but isn't allowed to be assigned to a `string[]` field.
      */
     PUBLIC_KEYS_PREVIOUSLY_BUT_NOT_CURRENTLY_REGISTERED: [] as string[],
     PUBLIC_KEYS_AUTHENTICATION_NEVER_REGISTERED: undefined,

--- a/src/libs/MultifactorAuthentication/Biometrics/VALUES.ts
+++ b/src/libs/MultifactorAuthentication/Biometrics/VALUES.ts
@@ -205,6 +205,14 @@ const MULTIFACTOR_AUTHENTICATION_VALUES = {
     },
     API_RESPONSE_MAP,
     REASON,
+    /**
+     * Specifically meaningful values for `multifactorAuthenticationPublicKeyIDs` in the `account` Onyx key
+     * casting `[] as string[]` is necessary to allow us to actually store the value in Onyx. Otherwise the
+     * `as const` would mean `[]` becomes `readonly []` (readonly empty array), which is more precise,
+     * but isn't allowed to be assigned to a `string[]` field
+     */
+    PUBLIC_KEYS_PREVIOUSLY_BUT_NOT_CURRENTLY_REGISTERED: [] as string[],
+    PUBLIC_KEYS_AUTHENTICATION_NEVER_REGISTERED: undefined
 } as const;
 
 export {MultifactorAuthenticationCallbacks};

--- a/src/libs/actions/MultifactorAuthentication/index.ts
+++ b/src/libs/actions/MultifactorAuthentication/index.ts
@@ -195,7 +195,7 @@ function markHasAcceptedSoftPrompt() {
 
 function clearLocalMFAPublicKeyList() {
     Onyx.merge(ONYXKEYS.ACCOUNT, {
-        multifactorAuthenticationPublicKeyIDs: [],
+        multifactorAuthenticationPublicKeyIDs: CONST.MULTIFACTOR_AUTHENTICATION.PUBLIC_KEYS_PREVIOUSLY_BUT_NOT_CURRENTLY_REGISTERED
     });
 }
 

--- a/src/libs/actions/MultifactorAuthentication/index.ts
+++ b/src/libs/actions/MultifactorAuthentication/index.ts
@@ -193,6 +193,12 @@ function markHasAcceptedSoftPrompt() {
     });
 }
 
+function clearLocalMFAPublicKeyList() {
+    Onyx.merge(ONYXKEYS.ACCOUNT, {
+        multifactorAuthenticationPublicKeyIDs: null,
+    });
+}
+
 export {
     registerAuthenticationKey,
     requestRegistrationChallenge,
@@ -200,4 +206,5 @@ export {
     troubleshootMultifactorAuthentication,
     revokeMultifactorAuthenticationCredentials,
     markHasAcceptedSoftPrompt,
+    clearLocalMFAPublicKeyList,
 };

--- a/src/libs/actions/MultifactorAuthentication/index.ts
+++ b/src/libs/actions/MultifactorAuthentication/index.ts
@@ -195,7 +195,7 @@ function markHasAcceptedSoftPrompt() {
 
 function clearLocalMFAPublicKeyList() {
     Onyx.merge(ONYXKEYS.ACCOUNT, {
-        multifactorAuthenticationPublicKeyIDs: null,
+        multifactorAuthenticationPublicKeyIDs: [],
     });
 }
 

--- a/src/libs/actions/MultifactorAuthentication/index.ts
+++ b/src/libs/actions/MultifactorAuthentication/index.ts
@@ -195,7 +195,7 @@ function markHasAcceptedSoftPrompt() {
 
 function clearLocalMFAPublicKeyList() {
     Onyx.merge(ONYXKEYS.ACCOUNT, {
-        multifactorAuthenticationPublicKeyIDs: CONST.MULTIFACTOR_AUTHENTICATION.PUBLIC_KEYS_PREVIOUSLY_BUT_NOT_CURRENTLY_REGISTERED
+        multifactorAuthenticationPublicKeyIDs: CONST.MULTIFACTOR_AUTHENTICATION.PUBLIC_KEYS_PREVIOUSLY_BUT_NOT_CURRENTLY_REGISTERED,
     });
 }
 

--- a/src/pages/settings/Security/SecuritySettingsPage.tsx
+++ b/src/pages/settings/Security/SecuritySettingsPage.tsx
@@ -91,7 +91,7 @@ function SecuritySettingsPage() {
     const hasDelegates = delegates.length > 0;
     const hasDelegators = delegators.length > 0;
 
-    const hasEverRegisteredForMultifactorAuthentication = account?.multifactorAuthenticationPublicKeyIDs !== undefined;
+    const hasEverRegisteredForMultifactorAuthentication = account?.multifactorAuthenticationPublicKeyIDs !== CONST.MULTIFACTOR_AUTHENTICATION.PUBLIC_KEYS_AUTHENTICATION_NEVER_REGISTERED;
 
     const setMenuPosition = useCallback(() => {
         if (!delegateButtonRef.current) {


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
When `process` is called with the `BACKEND.REGISTRATION_REQUIRED` error, we need to delete the `multifactorAuthenticationPublicKeyIDs` from onyx and start the flow over.

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/81745
PROPOSAL:


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

This one isn't testable under normal circumstances because the commands we use to revoke a user's keys should also clear this state for us in an onyx update, so you have to manipulate the onyx state locally (or somehow force your client to miss the onyx update). Also, this flow is only available on native.

1. Go to account > troubleshoot
2. press biometrics > test to kick off the registration flow
3. Register successfully
4. run `Onyx.get("account").then(console.log)` in your console to print the account onyx key
5. store the value of `multifactorAuthenticationPublicKeyIDs` to a variable, you'll need it later
6. press biometrics > remove to revoke your keys on the server
7. run `Onyx.merge("account", { multifactorAuthenticationPublicKeyIDs: [<value you stored earlier>] })` in your console to make the client think you're still registered
8. Press biometrics > test
9. Verify that after a brief moment on the fingerprint screen, you're redirected to the magic code input, and the rest of the flow works normally



- [x] Verify that no errors appear in the JS console

### Offline tests
N/A

### QA Steps
N/A - not possible to test without a devtools connection

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I verified there are no new alerts related to the `canBeMissing` param for `useOnyx`
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos


<details>
<summary>Android: Native</summary>

https://github.com/user-attachments/assets/3f3e4fb1-8843-4b37-a766-0ef135514338

</details>

<details>
<summary>iOS: Native</summary>

https://github.com/user-attachments/assets/dd815310-cf93-4c13-af1a-13d2c8e57b27


</details>