### PR TITLE
Fix disabled Next button not announced as disabled by screen readers

### DIFF
--- a/src/components/Pressable/GenericPressable/implementation/index.tsx
+++ b/src/components/Pressable/GenericPressable/implementation/index.tsx
@@ -10,6 +10,7 @@ function WebGenericPressable({focusable = true, ref, sentryLabel, ...props}: Pre
         <GenericPressable
             // eslint-disable-next-line react/jsx-props-no-spreading
             {...props}
+            fullDisabled={!!props.fullDisabled || !!props.disabled}
             ref={ref}
             // change native accessibility props to web accessibility props
             focusable={focusable}


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
<!-- Explain what your change does and how it addresses the linked issue -->
- This PR fixes the Web-only issue where the disabled "Next" button in the Workspace Workflows approval flow is not announced as disabled by screen readers (JAWS, NVDA, VoiceOver).

**Root Cause:**

- In `WebGenericPressable`, the `disabled` prop was only used for "soft-disable" (JS-level handler removal and visual styling) but was never propagated to `fullDisabled`, which controls the native HTML `disabled` attribute on the underlying `<Pressable>`.
- As a result, the rendered `<button>` element had no `disabled` attribute and no `aria-disabled` attribute, so screen readers announced it as an active button: "Next, button".

**Solution:**
- Map the `disabled` prop to `fullDisabled` in `WebGenericPressable` via `fullDisabled={!!props.fullDisabled || !!props.disabled}`.
- This ensures that when `disabled={true}` is passed, the underlying `<button>` receives the native `disabled` attribute and `aria-disabled="true"`, allowing screen readers to correctly announce: "Next, disabled, button".
- The fix is web-only (`index.tsx`). The native implementation (`index.native.tsx`) and `BaseGenericPressable.tsx` are unchanged.

### Fixed Issues
<!---
1. Please postfix with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal.

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
PROPOSAL: https://github.com/Expensify/App/issues/76908#issuecomment-3621568960

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/76908
PROPOSAL: https://github.com/Expensify/App/issues/76908#issuecomment-3621568960

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
--->

**Prerequisites:**
- User is logged in
- User has created at least one workspace
- Using Chrome on Windows (with JAWS/NVDA) or Safari on macOS (with VoiceOver)

**Primary Tests:**

1. Navigate to Workspaces -> select any workspace -> Workflows
2. Click "Add approval workflow"
3. On the "Expenses from" page, do NOT select any members
4. Tab to the disabled "Next" button
5. Verify the screen reader announces: **"Next, disabled, button"** (or equivalent: "unavailable"/"dimmed")
6. Inspect the DOM and confirm the `<button>` has `disabled` and `aria-disabled="true"` attributes

**Disabled to Enabled Transition Tests:**

7. Select a member (e.g., click on a name in the list)
8. Verify the "Next" button becomes enabled (full opacity, clickable)
9. Tab to the "Next" button  ,verify the screen reader announces: **"Next, button"** (no disabled state)
10. Inspect DOM nconfirm `disabled` and `aria-disabled` attributes are removed

**Keyboard / Focus Tests:**

11. With no members selected (disabled state), press Tab through all controls & verify the disabled "Next" button is **skipped** in tab order
12. Open browser console and run `document.querySelector('button[disabled]').focus()` & verify focus does NOT move to the disabled button
13. Select a member (enabled state), Tab to "Next" nverify it receives focus

**Regression Tests:**

14. Navigate to Workflows page , verify the disabled Approvals toggle (lock icon) and Auto-pay toggle still display correctly as disabled
15. Navigate to any chat , verify the Send button works normally (type a message, click Send)
16. Verify no other buttons on the page became unexpectedly disabled

- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add a numbered list of manual tests that validate your changes work as expected in a variety of network states.
--->
N/A , This fix only affects HTML attribute rendering on the web platform. Disabled state is determined by local component state (member selection), not network state.

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment.
--->
Same as Primary Tests (steps 1–6) and Disabled , Enabled Transition Tests (steps 7–10).

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] Windows: Chrome
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I verified there are no new alerts related to the `canBeMissing` param for `useOnyx`
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.


### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->


https://github.com/user-attachments/assets/540958d2-ebe9-4f87-81c4-2356c5180e3e



</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->


https://github.com/user-attachments/assets/8f0c817f-3f01-498d-872b-1084f03bba8d



</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->




https://github.com/user-attachments/assets/862f8146-9e4f-4cd4-93b2-315eed1d1923



</details>

<details>
<summary>iOS: mWeb Safari</summary>



https://github.com/user-attachments/assets/81b2c566-ef64-4ff3-922b-c48bd1d5bb0f



</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

https://github.com/user-attachments/assets/9a3c9af5-fc90-4155-bf25-4df474b707f4

</details>