### PR TITLE
fix: use parseISO to prevent date shift in resetSplitExpensesByDateRange

### DIFF
--- a/src/libs/actions/IOU/index.ts
+++ b/src/libs/actions/IOU/index.ts
@@ -1,5 +1,5 @@
 /* eslint-disable max-lines */
-import {eachDayOfInterval, format} from 'date-fns';
+import {eachDayOfInterval, format, parseISO} from 'date-fns';
 import {fastMerge} from 'expensify-common';
 import cloneDeep from 'lodash/cloneDeep';
 // eslint-disable-next-line you-dont-need-lodash-underscore/union-by
@@ -13251,8 +13251,8 @@ function resetSplitExpensesByDateRange(transaction: OnyxEntry<OnyxTypes.Transact
 
     // Generate all dates in the range
     const dates = eachDayOfInterval({
-        start: new Date(startDate),
-        end: new Date(endDate),
+        start: parseISO(startDate),
+        end: parseISO(endDate),
     });
 
     const transactionDetails = getTransactionDetails(transaction);


### PR DESCRIPTION
Using `new Date(string)` to parse `yyyy-MM-dd` strings can cause local timezone shifts (e.g., `2026-02-16` becoming `2026-02-15 22:00` in GMT+2). This PR switches to `parseISO` from `date-fns` to ensure dates are parsed consistently as local dates. \n\nFixes #80530