### PR TITLE
Fix: Allow opening tasks from Reports > Task search results

### DIFF
--- a/src/components/Search/index.tsx
+++ b/src/components/Search/index.tsx
@@ -883,6 +883,15 @@ function Search({
         [selectedTransactions, setSelectedTransactions, filteredData, updateSelectAllMatchingItemsState, transactions, email, accountID, outstandingReportsByPolicyID, searchResults?.data],
     );
 
+    const startReportOpenTelemetry = useCallback((reportID: string) => {
+        Performance.markStart(CONST.TIMING.OPEN_REPORT_SEARCH);
+        Timing.start(CONST.TIMING.OPEN_REPORT_SEARCH);
+        startSpan(`${CONST.TELEMETRY.SPAN_OPEN_REPORT}_${reportID}`, {
+            name: 'Search',
+            op: CONST.TELEMETRY.SPAN_OPEN_REPORT,
+        });
+    }, []);
+
     const onSelectRow = useCallback(
         (item: SearchListItem, transactionPreviewData?: TransactionPreviewData) => {
             if (isMobileSelectionModeEnabled) {
@@ -1076,6 +1085,18 @@ function Search({
                 return;
             }
 
+            // Handle task items - navigate to the task report
+            if (isTaskListItemType(item)) {
+                const reportID = item.reportID;
+                if (!reportID) {
+                    return;
+                }
+
+                startReportOpenTelemetry(reportID);
+                requestAnimationFrame(() => Navigation.navigate(ROUTES.SEARCH_REPORT.getRoute({reportID, backTo})));
+                return;
+            }
+
             // After handling all group types, item should be TransactionListItemType, ReportActionListItemType, or TransactionGroupListItemType
             if (!isTransactionItem && !isReportActionListItemType(item) && !isTransactionGroupListItemType(item)) {
                 return;
@@ -1098,12 +1119,7 @@ function Search({
                 return;
             }
 
-            Performance.markStart(CONST.TIMING.OPEN_REPORT_SEARCH);
-            Timing.start(CONST.TIMING.OPEN_REPORT_SEARCH);
-            startSpan(`${CONST.TELEMETRY.SPAN_OPEN_REPORT}_${reportID}`, {
-                name: 'Search',
-                op: CONST.TELEMETRY.SPAN_OPEN_REPORT,
-            });
+            startReportOpenTelemetry(reportID);
 
             if (isTransactionGroupListItemType(item)) {
                 const groupItem = item as TransactionGroupListItemType;
@@ -1149,6 +1165,7 @@ function Search({
             searchKey,
             markReportIDAsMultiTransactionExpense,
             unmarkReportIDAsMultiTransactionExpense,
+            startReportOpenTelemetry,
         ],
     );
 


### PR DESCRIPTION
### Explanation of Change
The `onSelectRow` handler in the Search component had no logic to handle `TaskListItemType` items. When a task item was clicked in Reports > Task, it would fall through to the guard clause that only allows `TransactionListItemType`, `ReportActionListItemType`, or `TransactionGroupListItemType`. Since a task item is none of these, the function would early-return without navigating anywhere.

This PR adds explicit handling for `TaskListItemType` items before the guard clause. When a task item is clicked, it extracts the `reportID` from the task item and navigates to `ROUTES.SEARCH_REPORT` with that `reportID` and the current route as `backTo`, following the same pattern used for other item types (telemetry marks, `requestAnimationFrame` for navigation).

### Fixed Issues
$ https://github.com/Expensify/App/issues/81789

### Tests
1. Go to the app
2. Create a task (or have one already)
3. Navigate to Reports > Expenses
4. Click Type > Task > Apply
5. Click on any task in the list
6. Verify the task opens correctly and navigation works as expected
7. Verify the back button returns you to the search results

- [x] Verify that no errors appear in the JS console

### Offline tests
1. Go to Reports > Task while online
2. Turn off network
3. Click on a task
4. Verify the task still opens from cached data (offline-first behavior)

### QA Steps
1. Go to staging.new.expensify.com
2. Create a task or ensure one exists
3. Navigate to Reports > Expenses
4. Click Type > Task > Apply
5. Click on any task in the search results
6. Verify the task opens correctly
7. Verify you can navigate back to the search results

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I verified there are no new alerts related to the `canBeMissing` param for `useOnyx`
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>