### PR TITLE
Fix expense discarded when location permission modal dismissed via backdrop

### DIFF
--- a/src/components/LocationPermissionModal/index.android.tsx
+++ b/src/components/LocationPermissionModal/index.android.tsx
@@ -74,7 +74,9 @@ function LocationPermissionModal({startPermissionFlow, resetPermissionFlow, onDe
     };
 
     const closeModal = () => {
+        onDeny();
         setShowModal(false);
+        setHasError(false);
         resetPermissionFlow();
     };
 

--- a/src/components/LocationPermissionModal/index.tsx
+++ b/src/components/LocationPermissionModal/index.tsx
@@ -125,7 +125,9 @@ function LocationPermissionModal({startPermissionFlow, resetPermissionFlow, onDe
     };
 
     const closeModal = () => {
+        onDeny();
         setShowModal(false);
+        setHasError(false);
         resetPermissionFlow();
     };
 


### PR DESCRIPTION
$ https://github.com/Expensify/App/issues/81804

## Root Cause

`LocationPermissionModal` passes `onBackdropPress={closeModal}` to `ConfirmModal`. When the user dismisses the location permission modal by tapping outside it (backdrop press), `closeModal()` only hides the modal and resets the permission flow — it does **not** call `onDeny()`. This means the parent component never receives the "continue without location" signal, so the expense creation flow is abandoned.

In contrast, clicking the "Not Now" cancel button calls `skipLocationPermission()`, which correctly calls `onDeny()` before cleanup.

## Fix

Call `onDeny()` inside `closeModal()` (and also reset `hasError` for consistency with `skipLocationPermission`), so that dismissing the modal via backdrop press is treated identically to tapping "Not Now". The expense creation flow continues without location data.

Applied to both platform implementations:
- `src/components/LocationPermissionModal/index.tsx` (Web)
- `src/components/LocationPermissionModal/index.android.tsx` (Android)

## Test Plan

- [ ] Start creating a new expense that triggers the location permission modal
- [ ] Dismiss the modal by tapping/clicking outside of it (backdrop press)
- [ ] Verify the expense creation flow continues without location data (not abandoned)
- [ ] Verify tapping "Not Now" still works as before
- [ ] Verify tapping "Continue" and granting/denying via the system prompt still works as before