### PR TITLE
Fix expense highlight replaying on reopen

### DIFF
--- a/src/hooks/useSearchHighlightAndScroll.ts
+++ b/src/hooks/useSearchHighlightAndScroll.ts
@@ -209,7 +209,7 @@ function useSearchHighlightAndScroll({
             // Find new transaction IDs that are not in the previousTransactionIDs and not already highlighted
             const newTransactionIDs = currentTransactionIDs.filter((id) => {
                 if (manualHighlightTransactionIDs.has(id)) {
-                    return true;
+                    return !highlightedIDs.current.has(`${ONYXKEYS.COLLECTION.TRANSACTION}${id}`);
                 }
                 if (!triggeredByHookRef.current || !hasNewItemsRef.current) {
                     return false;


### PR DESCRIPTION
$ https://github.com/Expensify/App/issues/81474

## Root Cause

In `useSearchHighlightAndScroll`, when filtering for transactions to highlight, the manual highlight path (`manualHighlightTransactionIDs.has(id)`) returns `true` unconditionally -- it never checks if the ID was already highlighted via `highlightedIDs.current`.

There's a race condition between the two cleanup effects: `newSearchResultKeys` gets reset to `null` (plain `setTimeout`) before `transactionIDsToHighlight` gets reset to `false` (`requestAnimationFrame` + `setTimeout`). When `newSearchResultKeys` becomes `null` first, the cleanup effect for `transactionIDsToHighlight` short-circuits, leaving the highlight flag permanently set. So opening/closing the expense triggers re-highlight.

## Fix

Check `highlightedIDs.current` for the manual highlight path too, consistent with how the automatic highlight path already works. Once a transaction has been highlighted once, it's tracked in `highlightedIDs.current` and won't be highlighted again regardless of the `transactionIDsToHighlight` state.

## Tests

- Create expense on Reports > Expenses -> highlights once
- Open and close the expense -> no re-highlight
- Multiple expenses -> each highlights exactly once