### PR TITLE
Fix Reports counters not showing 0

### DIFF
--- a/src/libs/SearchUIUtils.ts
+++ b/src/libs/SearchUIUtils.ts
@@ -346,9 +346,6 @@ function isValidExpenseStatus(status: unknown): status is ValueOf<typeof CONST.S
 }
 
 function formatBadgeText(count: number): string {
-    if (count === 0) {
-        return '';
-    }
     return count > CONST.SEARCH.TODO_BADGE_MAX_COUNT ? `${CONST.SEARCH.TODO_BADGE_MAX_COUNT}+` : count.toString();
 }
 


### PR DESCRIPTION
### Fixed Issues

$ https://github.com/Expensify/App/issues/81613

### Explanation of Change

The `formatBadgeText` function in `SearchUIUtils.ts` was returning an empty string when count was 0, which caused the badge to not render at all (since `!!''` is false in `MenuItem`). Removed that early return so `count.toString()` handles 0 like any other number and the badge displays "0".

### Tests

1. Go to the Reports page
2. Verify counters show "0" when there are no pending expenses in a category (e.g. Submit: 1, Approve: 0, Pay: 0)
3. Verify counters still show correct numbers for non-zero counts
4. Verify large counts still show "99+" (or whatever TODO_BADGE_MAX_COUNT is)

- [x] Verify that no errors appear in the JS console

### Offline tests

N/A

### QA Steps

Same as tests

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
- [x] I verified there are no console errors
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))