### PR TITLE
Fix webinar button showing in thread headers in #admins room

### DIFF
--- a/src/libs/ReportUtils.ts
+++ b/src/libs/ReportUtils.ts
@@ -12006,7 +12006,9 @@ function isChatUsedForOnboarding(optionOrReport: OnyxEntry<Report> | OptionData,
         return (optionOrReport as OptionData)?.isConciergeChat ?? isConciergeChatReport(optionOrReport);
     }
 
-    return isPostingTasksInAdminsRoom(onboardingPurposeSelected) ? isAdminRoom(optionOrReport) : ((optionOrReport as OptionData)?.isConciergeChat ?? isConciergeChatReport(optionOrReport));
+    return isPostingTasksInAdminsRoom(onboardingPurposeSelected)
+        ? isAdminRoom(optionOrReport) && !isChatThread(optionOrReport)
+        : ((optionOrReport as OptionData)?.isConciergeChat ?? isConciergeChatReport(optionOrReport));
 }
 
 /**

--- a/src/libs/ReportUtils.ts
+++ b/src/libs/ReportUtils.ts
@@ -12006,8 +12006,12 @@ function isChatUsedForOnboarding(optionOrReport: OnyxEntry<Report> | OptionData,
         return (optionOrReport as OptionData)?.isConciergeChat ?? isConciergeChatReport(optionOrReport);
     }
 
+    if (isChatThread(optionOrReport)) {
+        return false;
+    }
+
     return isPostingTasksInAdminsRoom(onboardingPurposeSelected)
-        ? isAdminRoom(optionOrReport) && !isChatThread(optionOrReport)
+        ? isAdminRoom(optionOrReport)
         : ((optionOrReport as OptionData)?.isConciergeChat ?? isConciergeChatReport(optionOrReport));
 }
 


### PR DESCRIPTION
$ https://github.com/Expensify/App/issues/81069

## Summary
- Thread reports in #admins room inherit `chatType: POLICY_ADMINS` from their parent, causing `isChatUsedForOnboarding()` to return true for threads via the fallback `isAdminRoom` check
- Added `!isChatThread` guard in the fallback path of `isChatUsedForOnboarding()` so thread reports are never considered the onboarding chat
- This fixes the root cause at the utility function level rather than adding another condition in `HeaderView.tsx`

## Test plan
- [ ] Sign in with a new account (no `+` in email), choose "Manage my team expenses" > 1-10 employees > "Other" accounting
- [ ] Navigate to #admins room, verify "Register for webinar" button is displayed in the header
- [ ] Send a message in the #admins room and click "Reply in thread"
- [ ] Verify "Register for webinar" is **not** displayed in the thread header
- [ ] Go back to #admins room, verify button still shows correctly there