### PR TITLE
Fix label gaps in `LineChart` and `BarChart` components

### DIFF
--- a/src/components/Charts/BarChart/BarChartContent.tsx
+++ b/src/components/Charts/BarChart/BarChartContent.tsx
@@ -8,7 +8,7 @@ import {Bar, CartesianChart} from 'victory-native';
 import ActivityIndicator from '@components/ActivityIndicator';
 import ChartHeader from '@components/Charts/components/ChartHeader';
 import ChartTooltip from '@components/Charts/components/ChartTooltip';
-import {CHART_CONTENT_MIN_HEIGHT, CHART_PADDING, X_AXIS_LABEL_OFFSET, X_AXIS_LINE_WIDTH, Y_AXIS_LABEL_OFFSET, Y_AXIS_LINE_WIDTH, Y_AXIS_TICK_COUNT} from '@components/Charts/constants';
+import {AXIS_LABEL_GAP, CHART_CONTENT_MIN_HEIGHT, CHART_PADDING, X_AXIS_LINE_WIDTH, Y_AXIS_LINE_WIDTH, Y_AXIS_TICK_COUNT} from '@components/Charts/constants';
 import fontSource from '@components/Charts/font';
 import type {HitTestArgs} from '@components/Charts/hooks';
 import {useChartInteractions, useChartLabelFormats, useChartLabelLayout, useDynamicYDomain, useTooltipData} from '@components/Charts/hooks';
@@ -216,7 +216,9 @@ function BarChartContent({data, title, titleIcon, isLoading, yAxisUnit, yAxisUni
                             tickCount: data.length,
                             labelColor: theme.textSupporting,
                             lineWidth: X_AXIS_LINE_WIDTH,
-                            labelOffset: X_AXIS_LABEL_OFFSET,
+                            // Victory-native positions x-axis labels at: chartBounds.bottom + labelOffset + fontSize.
+                            // We subtract descent (fontSize - ascent) so the gap from chart to the ascent line equals AXIS_LABEL_GAP.
+                            labelOffset: AXIS_LABEL_GAP - Math.abs(font?.getMetrics().descent ?? 0),
                             formatXLabel: formatXAxisLabel,
                             labelRotate: labelRotation,
                             labelOverflow: 'visible',
@@ -229,7 +231,7 @@ function BarChartContent({data, title, titleIcon, isLoading, yAxisUnit, yAxisUni
                                 tickCount: Y_AXIS_TICK_COUNT,
                                 lineWidth: Y_AXIS_LINE_WIDTH,
                                 lineColor: theme.border,
-                                labelOffset: Y_AXIS_LABEL_OFFSET,
+                                labelOffset: AXIS_LABEL_GAP,
                                 domain: yAxisDomain,
                             },
                         ]}

--- a/src/components/Charts/BarChart/BarChartContent.tsx
+++ b/src/components/Charts/BarChart/BarChartContent.tsx
@@ -8,7 +8,7 @@ import {Bar, CartesianChart} from 'victory-native';
 import ActivityIndicator from '@components/ActivityIndicator';
 import ChartHeader from '@components/Charts/components/ChartHeader';
 import ChartTooltip from '@components/Charts/components/ChartTooltip';
-import {CHART_CONTENT_MIN_HEIGHT, CHART_PADDING, X_AXIS_LINE_WIDTH, Y_AXIS_LABEL_OFFSET, Y_AXIS_LINE_WIDTH, Y_AXIS_TICK_COUNT} from '@components/Charts/constants';
+import {CHART_CONTENT_MIN_HEIGHT, CHART_PADDING, X_AXIS_LABEL_OFFSET, X_AXIS_LINE_WIDTH, Y_AXIS_LABEL_OFFSET, Y_AXIS_LINE_WIDTH, Y_AXIS_TICK_COUNT} from '@components/Charts/constants';
 import fontSource from '@components/Charts/font';
 import type {HitTestArgs} from '@components/Charts/hooks';
 import {useChartInteractions, useChartLabelFormats, useChartLabelLayout, useDynamicYDomain, useTooltipData} from '@components/Charts/hooks';
@@ -216,6 +216,7 @@ function BarChartContent({data, title, titleIcon, isLoading, yAxisUnit, yAxisUni
                             tickCount: data.length,
                             labelColor: theme.textSupporting,
                             lineWidth: X_AXIS_LINE_WIDTH,
+                            labelOffset: X_AXIS_LABEL_OFFSET,
                             formatXLabel: formatXAxisLabel,
                             labelRotate: labelRotation,
                             labelOverflow: 'visible',

--- a/src/components/Charts/LineChart/LineChartContent.tsx
+++ b/src/components/Charts/LineChart/LineChartContent.tsx
@@ -8,7 +8,7 @@ import {CartesianChart, Line, Scatter} from 'victory-native';
 import ActivityIndicator from '@components/ActivityIndicator';
 import ChartHeader from '@components/Charts/components/ChartHeader';
 import ChartTooltip from '@components/Charts/components/ChartTooltip';
-import {CHART_CONTENT_MIN_HEIGHT, CHART_PADDING, X_AXIS_LINE_WIDTH, Y_AXIS_LABEL_OFFSET, Y_AXIS_LINE_WIDTH, Y_AXIS_TICK_COUNT} from '@components/Charts/constants';
+import {CHART_CONTENT_MIN_HEIGHT, CHART_PADDING, X_AXIS_LABEL_OFFSET, X_AXIS_LINE_WIDTH, Y_AXIS_LABEL_OFFSET, Y_AXIS_LINE_WIDTH, Y_AXIS_TICK_COUNT} from '@components/Charts/constants';
 import fontSource from '@components/Charts/font';
 import type {HitTestArgs} from '@components/Charts/hooks';
 import {useChartInteractions, useChartLabelFormats, useChartLabelLayout, useDynamicYDomain, useTooltipData} from '@components/Charts/hooks';
@@ -27,9 +27,6 @@ const DOT_HOVER_EXTRA_RADIUS = 2;
 
 /** Base domain padding applied to all sides */
 const BASE_DOMAIN_PADDING = {top: 16, bottom: 16, left: 0, right: 0};
-
-/** Consistent gap between x-axis and closest point of label (regardless of rotation) */
-const LABEL_GAP = 8;
 
 type LineChartProps = CartesianChartProps & {
     /** Callback when a data point is pressed */
@@ -163,7 +160,7 @@ function LineChartContent({data, title, titleIcon, isLoading, yAxisUnit, yAxisUn
             const fontMetrics = font.getMetrics();
             const ascent = Math.abs(fontMetrics.ascent);
             const descent = Math.abs(fontMetrics.descent);
-            const labelY = args.chartBounds.bottom + LABEL_GAP + rotatedLabelYOffset(ascent, descent, angleRad);
+            const labelY = args.chartBounds.bottom + X_AXIS_LABEL_OFFSET + rotatedLabelYOffset(ascent, descent, angleRad);
 
             return truncatedLabels.map((label, i) => {
                 if (i % labelSkipInterval !== 0) {

--- a/src/components/Charts/LineChart/LineChartContent.tsx
+++ b/src/components/Charts/LineChart/LineChartContent.tsx
@@ -8,7 +8,7 @@ import {CartesianChart, Line, Scatter} from 'victory-native';
 import ActivityIndicator from '@components/ActivityIndicator';
 import ChartHeader from '@components/Charts/components/ChartHeader';
 import ChartTooltip from '@components/Charts/components/ChartTooltip';
-import {CHART_CONTENT_MIN_HEIGHT, CHART_PADDING, X_AXIS_LABEL_OFFSET, X_AXIS_LINE_WIDTH, Y_AXIS_LABEL_OFFSET, Y_AXIS_LINE_WIDTH, Y_AXIS_TICK_COUNT} from '@components/Charts/constants';
+import {AXIS_LABEL_GAP, CHART_CONTENT_MIN_HEIGHT, CHART_PADDING, X_AXIS_LINE_WIDTH, Y_AXIS_LINE_WIDTH, Y_AXIS_TICK_COUNT} from '@components/Charts/constants';
 import fontSource from '@components/Charts/font';
 import type {HitTestArgs} from '@components/Charts/hooks';
 import {useChartInteractions, useChartLabelFormats, useChartLabelLayout, useDynamicYDomain, useTooltipData} from '@components/Charts/hooks';
@@ -160,7 +160,7 @@ function LineChartContent({data, title, titleIcon, isLoading, yAxisUnit, yAxisUn
             const fontMetrics = font.getMetrics();
             const ascent = Math.abs(fontMetrics.ascent);
             const descent = Math.abs(fontMetrics.descent);
-            const labelY = args.chartBounds.bottom + X_AXIS_LABEL_OFFSET + rotatedLabelYOffset(ascent, descent, angleRad);
+            const labelY = args.chartBounds.bottom + AXIS_LABEL_GAP + rotatedLabelYOffset(ascent, descent, angleRad);
 
             return truncatedLabels.map((label, i) => {
                 if (i % labelSkipInterval !== 0) {
@@ -263,7 +263,7 @@ function LineChartContent({data, title, titleIcon, isLoading, yAxisUnit, yAxisUn
                                 tickCount: Y_AXIS_TICK_COUNT,
                                 lineWidth: Y_AXIS_LINE_WIDTH,
                                 lineColor: theme.border,
-                                labelOffset: Y_AXIS_LABEL_OFFSET,
+                                labelOffset: AXIS_LABEL_GAP,
                                 domain: yAxisDomain,
                             },
                         ]}

--- a/src/components/Charts/constants.ts
+++ b/src/components/Charts/constants.ts
@@ -1,8 +1,8 @@
 /** Number of Y-axis ticks (including zero) */
 const Y_AXIS_TICK_COUNT = 5;
 
-/** Distance between Y-axis labels and the chart */
-const Y_AXIS_LABEL_OFFSET = 16;
+/** Desired visual gap (px) between axis labels and the chart edge, used for both axes */
+const AXIS_LABEL_GAP = 8;
 
 /** Chart padding */
 const CHART_PADDING = 5;
@@ -13,10 +13,7 @@ const CHART_CONTENT_MIN_HEIGHT = 250;
 /** Line width for X-axis (hidden) */
 const X_AXIS_LINE_WIDTH = 0;
 
-/** Distance between X-axis labels and the chart */
-const X_AXIS_LABEL_OFFSET = 8;
-
 /** Line width for Y-axis grid lines */
 const Y_AXIS_LINE_WIDTH = 1;
 
-export {Y_AXIS_TICK_COUNT, Y_AXIS_LABEL_OFFSET, X_AXIS_LABEL_OFFSET, CHART_PADDING, CHART_CONTENT_MIN_HEIGHT, X_AXIS_LINE_WIDTH, Y_AXIS_LINE_WIDTH};
+export {Y_AXIS_TICK_COUNT, AXIS_LABEL_GAP, CHART_PADDING, CHART_CONTENT_MIN_HEIGHT, X_AXIS_LINE_WIDTH, Y_AXIS_LINE_WIDTH};

--- a/src/components/Charts/constants.ts
+++ b/src/components/Charts/constants.ts
@@ -13,7 +13,10 @@ const CHART_CONTENT_MIN_HEIGHT = 250;
 /** Line width for X-axis (hidden) */
 const X_AXIS_LINE_WIDTH = 0;
 
+/** Distance between X-axis labels and the chart */
+const X_AXIS_LABEL_OFFSET = 8;
+
 /** Line width for Y-axis grid lines */
 const Y_AXIS_LINE_WIDTH = 1;
 
-export {Y_AXIS_TICK_COUNT, Y_AXIS_LABEL_OFFSET, CHART_PADDING, CHART_CONTENT_MIN_HEIGHT, X_AXIS_LINE_WIDTH, Y_AXIS_LINE_WIDTH};
+export {Y_AXIS_TICK_COUNT, Y_AXIS_LABEL_OFFSET, X_AXIS_LABEL_OFFSET, CHART_PADDING, CHART_CONTENT_MIN_HEIGHT, X_AXIS_LINE_WIDTH, Y_AXIS_LINE_WIDTH};

--- a/src/components/Charts/constants.ts
+++ b/src/components/Charts/constants.ts
@@ -2,7 +2,7 @@
 const Y_AXIS_TICK_COUNT = 5;
 
 /** Desired visual gap (px) between axis labels and the chart edge, used for both axes */
-const AXIS_LABEL_GAP = 8;
+const AXIS_LABEL_GAP = 12;
 
 /** Chart padding */
 const CHART_PADDING = 5;


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
This is a follow up PR that fixes spacing between labels and plot axes in both `LineChart` and `BarChart`

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/81834
PROPOSAL:


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->
-


#### BarChart:
- [ ] Verify that X-axis labels have 12px spacing
- [ ] Verify that Y-axis labels have 12px spacing

#### LineChart:
- [ ] Verify that X-axis labels have 12px spacing
- [ ] Verify that Y-axis labels have 12px spacing

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->
1. Have a workspace with some expenses
2. Go to Reports
3. Enter Type: expense view: bar into the search bar
4. Verify that X-axis labels have 8px spacing
5. Verify that Y-axis labels have 8px spacing
6. Enter Type: expense view: line into the search bar
7. Verify that X-axis labels have 8px spacing
8. Verify that Y-axis labels have 8px spacing

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I verified there are no new alerts related to the `canBeMissing` param for `useOnyx`
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<img width="411" height="866" alt="Screenshot 2026-02-09 at 10 30 39" src="https://github.com/user-attachments/assets/11581618-9ac8-42a3-b7c8-6e4f07cd6adc" />

<img width="406" height="860" alt="Screenshot 2026-02-09 at 10 30 54" src="https://github.com/user-attachments/assets/5a1f2635-7fd3-4982-85b0-207e94b10ba2" />


</details>

<details>
<summary>Android: mWeb Chrome</summary>

<img width="402" height="837" alt="Screenshot 2026-02-09 at 11 02 37" src="https://github.com/user-attachments/assets/27105a83-b3a6-4234-a9d4-34ca77181e48" />

<img width="407" height="862" alt="Screenshot 2026-02-09 at 11 02 46" src="https://github.com/user-attachments/assets/033843ef-d771-4326-9b1b-ac532979906d" />


</details>

<details>
<summary>iOS: Native</summary>

<img width="309" height="647" alt="Screenshot 2026-02-09 at 10 47 34" src="https://github.com/user-attachments/assets/6fd3ad72-8a4f-4a83-861f-b969d2e31482" />

<img width="314" height="637" alt="Screenshot 2026-02-09 at 10 47 49" src="https://github.com/user-attachments/assets/31e4a765-9c31-4443-a4b6-4ce4d6f95c48" />


</details>

<details>
<summary>iOS: mWeb Safari</summary>

<img width="312" height="641" alt="Screenshot 2026-02-09 at 10 57 15" src="https://github.com/user-attachments/assets/4170d6a9-4a39-4b3f-8db1-c8a369882448" />

<img width="309" height="636" alt="Screenshot 2026-02-09 at 10 57 32" src="https://github.com/user-attachments/assets/e271e360-6dca-482a-ac0b-913a215b0163" />


</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<img width="1115" height="392" alt="Screenshot 2026-02-09 at 10 11 55" src="https://github.com/user-attachments/assets/0b16ab3a-fa0f-48c4-8c2f-0b55b4102dfc" />


<img width="1116" height="387" alt="Screenshot 2026-02-09 at 10 11 49" src="https://github.com/user-attachments/assets/42cdccc7-4b4c-4ed3-bb2f-c93c31d13713" />

</details>