### PR TITLE
[CP Staging] Revert "Resolve brief display of bottom comments when switching between chats"

### DIFF
--- a/src/hooks/useFlatListScrollKey.ts
+++ b/src/hooks/useFlatListScrollKey.ts
@@ -113,9 +113,7 @@ export default function useFlatListScrollKey<T>({
     const [shouldPreserveVisibleContentPosition, setShouldPreserveVisibleContentPosition] = useState(true);
     const maintainVisibleContentPosition = useMemo(() => {
         if ((!initialScrollKey && (!isInitialData || !isQueueRendering)) || !shouldPreserveVisibleContentPosition) {
-            return {
-                minIndexForVisible: null as unknown as number,
-            };
+            return undefined;
         }
 
         const config: ScrollViewProps['maintainVisibleContentPosition'] = {

--- a/src/pages/inbox/report/ReportActionsList.tsx
+++ b/src/pages/inbox/report/ReportActionsList.tsx
@@ -639,10 +639,6 @@ function ReportActionsList({
      * the height of the smallest report action possible.
      */
     const initialNumToRender = useMemo((): number | undefined => {
-        if (shouldScrollToEndAfterLayout && (!hasCreatedActionAdded || isOffline)) {
-            return sortedVisibleReportActions.length;
-        }
-
         const minimumReportActionHeight = styles.chatItem.paddingTop + styles.chatItem.paddingBottom + variables.fontSizeNormalHeight;
         const availableHeight = windowHeight - (CONST.CHAT_FOOTER_MIN_HEIGHT + variables.contentHeaderHeight);
         const numToRender = Math.ceil(availableHeight / minimumReportActionHeight);
@@ -650,16 +646,7 @@ function ReportActionsList({
             return getInitialNumToRender(numToRender);
         }
         return numToRender || undefined;
-    }, [
-        styles.chatItem.paddingBottom,
-        styles.chatItem.paddingTop,
-        windowHeight,
-        linkedReportActionID,
-        sortedVisibleReportActions.length,
-        shouldScrollToEndAfterLayout,
-        hasCreatedActionAdded,
-        isOffline,
-    ]);
+    }, [styles.chatItem.paddingBottom, styles.chatItem.paddingTop, windowHeight, linkedReportActionID]);
 
     /**
      * Thread's divider line should hide when the first chat in the thread is marked as unread.


### PR DESCRIPTION
Reverts Expensify/App#76554

$ https://github.com/Expensify/App/issues/81953
$ https://github.com/Expensify/App/issues/81976