### PR TITLE
Respect mute preference for iOS foreground notification sounds

### DIFF
--- a/src/libs/Notification/PushNotification/ForegroundNotifications/index.ios.ts
+++ b/src/libs/Notification/PushNotification/ForegroundNotifications/index.ios.ts
@@ -1,5 +1,6 @@
 import Airship, {iOS} from '@ua/react-native-airship';
 import shouldShowPushNotification from '@libs/Notification/PushNotification/shouldShowPushNotification';
+import {getIsMuted} from '@libs/Sound/BaseSound';
 import type ForegroundNotificationsModule from './types';
 
 function configureForegroundNotifications() {
@@ -14,7 +15,15 @@ function configureForegroundNotifications() {
 
     // Set a callback to override our foreground presentation per notification depending on the app's current state.
     // Returning null keeps the default presentation. Returning [] uses no presentation (hides the notification).
-    Airship.push.iOS.setForegroundPresentationOptionsCallback((pushPayload) => Promise.resolve(shouldShowPushNotification(pushPayload) ? null : []));
+    Airship.push.iOS.setForegroundPresentationOptionsCallback((pushPayload) => {
+        if (!shouldShowPushNotification(pushPayload)) {
+            return Promise.resolve([]);
+        }
+        if (getIsMuted()) {
+            return Promise.resolve([iOS.ForegroundPresentationOption.List, iOS.ForegroundPresentationOption.Banner, iOS.ForegroundPresentationOption.Badge]);
+        }
+        return Promise.resolve(null);
+    });
 }
 
 function disableForegroundNotifications() {

--- a/tests/unit/ForegroundNotificationsTest.ts
+++ b/tests/unit/ForegroundNotificationsTest.ts
@@ -1,0 +1,84 @@
+import type {PushPayload} from '@ua/react-native-airship';
+import {iOS} from '@ua/react-native-airship';
+
+const mockShouldShowPushNotification = jest.fn<boolean, [PushPayload]>();
+jest.mock('@libs/Notification/PushNotification/shouldShowPushNotification', () => mockShouldShowPushNotification);
+
+const mockGetIsMuted = jest.fn<boolean, []>();
+jest.mock('@libs/Sound/BaseSound', () => ({
+    getIsMuted: mockGetIsMuted,
+}));
+
+const fakePushPayload: PushPayload = {
+    alert: 'test notification',
+    extras: {payload: '{}'},
+    notificationId: 'test-id',
+    title: 'Test',
+    subtitle: '',
+};
+
+type ForegroundCallback = (push: PushPayload) => Promise<iOS.ForegroundPresentationOption[] | null>;
+
+function setupAndGetCallback(method: 'configureForegroundNotifications' | 'disableForegroundNotifications'): ForegroundCallback {
+    let callback: ForegroundCallback | undefined;
+
+    jest.isolateModules(() => {
+        // eslint-disable-next-line @typescript-eslint/no-var-requires, @typescript-eslint/no-require-imports
+        const AirshipModule = require('@ua/react-native-airship') as {default: {push: {iOS: {setForegroundPresentationOptionsCallback: jest.Mock}}}};
+        const {setForegroundPresentationOptionsCallback} = AirshipModule.default.push.iOS;
+        setForegroundPresentationOptionsCallback.mockClear();
+
+        // eslint-disable-next-line @typescript-eslint/no-var-requires, @typescript-eslint/no-require-imports
+        const ForegroundNotifications = require('@libs/Notification/PushNotification/ForegroundNotifications/index.ios') as {
+            default: {configureForegroundNotifications: () => void; disableForegroundNotifications: () => void};
+        };
+        ForegroundNotifications.default[method]();
+
+        const lastCall = setForegroundPresentationOptionsCallback.mock.calls.at(-1) as ForegroundCallback[] | undefined;
+        callback = lastCall?.[0];
+    });
+
+    if (!callback) {
+        throw new Error('Failed to capture foreground presentation options callback');
+    }
+    return callback;
+}
+
+describe('ForegroundNotifications iOS', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('returns empty array when notification should not be shown', async () => {
+        mockShouldShowPushNotification.mockReturnValue(false);
+        const callback = setupAndGetCallback('configureForegroundNotifications');
+
+        const result = await callback(fakePushPayload);
+        expect(result).toEqual([]);
+    });
+
+    it('returns null (default presentation with sound) when not muted', async () => {
+        mockShouldShowPushNotification.mockReturnValue(true);
+        mockGetIsMuted.mockReturnValue(false);
+        const callback = setupAndGetCallback('configureForegroundNotifications');
+
+        const result = await callback(fakePushPayload);
+        expect(result).toBeNull();
+    });
+
+    it('returns List, Banner, Badge without Sound when muted', async () => {
+        mockShouldShowPushNotification.mockReturnValue(true);
+        mockGetIsMuted.mockReturnValue(true);
+        const callback = setupAndGetCallback('configureForegroundNotifications');
+
+        const result = await callback(fakePushPayload);
+        expect(result).toEqual([iOS.ForegroundPresentationOption.List, iOS.ForegroundPresentationOption.Banner, iOS.ForegroundPresentationOption.Badge]);
+    });
+
+    it('disableForegroundNotifications sets callback that returns empty array', async () => {
+        const callback = setupAndGetCallback('disableForegroundNotifications');
+
+        const result = await callback(fakePushPayload);
+        expect(result).toEqual([]);
+    });
+});


### PR DESCRIPTION
### Explanation of Change
When the "Mute all sounds from Expensify" preference is enabled, iOS foreground push notifications still play a sound. This fix checks the mute preference in the `setForegroundPresentationOptionsCallback` and, when muted, explicitly returns only `List`, `Banner`, and `Badge` presentation options (omitting `Sound`), instead of returning `null` which uses the default presentation (which includes sound).

### Fixed Issues
$ https://github.com/Expensify/App/issues/81282
PROPOSAL: https://github.com/Expensify/App/issues/81282#issuecomment-3840239313

### Tests
1. Log into the app on a physical iOS device
2. Go to Settings > Troubleshoot > toggle on "Mute all sounds from Expensify"
3. Have another user send you a message while the app is in the foreground
4. Verify the notification banner appears but no sound plays
5. Toggle off "Mute all sounds from Expensify"
6. Have another user send you a message again
7. Verify the notification banner appears with sound

- [x] Verify that no errors appear in the JS console

### Offline tests
N/A - This change only affects iOS foreground push notification presentation options, which require an active network connection to receive.

### QA Steps
1. Log into the app on a physical iOS device
2. Go to Settings > Troubleshoot > toggle on "Mute all sounds from Expensify"
3. Have another user send you a message while the app is in the foreground
4. Verify the notification banner appears but no sound plays
5. Toggle off "Mute all sounds from Expensify"
6. Have another user send you a message again
7. Verify the notification banner appears with sound

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I verified there are no new alerts related to the `canBeMissing` param for `useOnyx`
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>