### PR TITLE
Avoid using selector returning Sets

### DIFF
--- a/src/hooks/useArchivedReportsIdSet.ts
+++ b/src/hooks/useArchivedReportsIdSet.ts
@@ -1,18 +1,37 @@
-import {archivedReportsIdSetSelector} from '@selectors/ReportNameValuePairs';
+import type {OnyxCollection} from 'react-native-onyx';
+import {isArchivedReport} from '@libs/ReportUtils';
 import type {ArchivedReportsIDSet} from '@libs/SearchUIUtils';
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
+import type {ReportNameValuePairs} from '@src/types/onyx';
 import useDeepCompareRef from './useDeepCompareRef';
 import useOnyx from './useOnyx';
+
+/**
+ * Function that creates a Set of archived report IDs from report name value pairs
+ */
+const getArchivedReportsIdSet = (reportNameValuePairs: OnyxCollection<ReportNameValuePairs>): ArchivedReportsIDSet | undefined => {
+    if (!reportNameValuePairs) {
+        return undefined;
+    }
+    const ids = new Set<string>();
+
+    for (const [key, value] of Object.entries(reportNameValuePairs)) {
+        if (isArchivedReport(value)) {
+            ids.add(key);
+        }
+    }
+    return ids;
+};
 
 /**
  * Hook that returns a Set of archived report IDs
  */
 function useArchivedReportsIdSet(): ArchivedReportsIDSet {
-    const [archivedReportsIdSet = CONST.EMPTY_SET] = useOnyx(ONYXKEYS.COLLECTION.REPORT_NAME_VALUE_PAIRS, {
+    const [reportNameValuePairs] = useOnyx(ONYXKEYS.COLLECTION.REPORT_NAME_VALUE_PAIRS, {
         canBeMissing: true,
-        selector: archivedReportsIdSetSelector,
     });
+    const archivedReportsIdSet = getArchivedReportsIdSet(reportNameValuePairs) ?? CONST.EMPTY_SET;
 
     // useDeepCompareRef is used here to prevent unnecessary re-renders by maintaining referential equality
     // when the Set contents are the same, even if it's a new Set instance. This is important for performance

--- a/src/hooks/useArchivedReportsIdSet.ts
+++ b/src/hooks/useArchivedReportsIdSet.ts
@@ -1,4 +1,3 @@
-import {useMemo} from 'react';
 import type {OnyxCollection} from 'react-native-onyx';
 import {isArchivedReport} from '@libs/ReportUtils';
 import type {ArchivedReportsIDSet} from '@libs/SearchUIUtils';
@@ -32,7 +31,7 @@ function useArchivedReportsIdSet(): ArchivedReportsIDSet {
     const [reportNameValuePairs] = useOnyx(ONYXKEYS.COLLECTION.REPORT_NAME_VALUE_PAIRS, {
         canBeMissing: true,
     });
-    const archivedReportsIdSet = useMemo(() => getArchivedReportsIdSet(reportNameValuePairs) ?? CONST.EMPTY_SET, [reportNameValuePairs]);
+    const archivedReportsIdSet = getArchivedReportsIdSet(reportNameValuePairs) ?? CONST.EMPTY_SET;
 
     // useDeepCompareRef is used here to prevent unnecessary re-renders by maintaining referential equality
     // when the Set contents are the same, even if it's a new Set instance. This is important for performance

--- a/src/hooks/useArchivedReportsIdSet.ts
+++ b/src/hooks/useArchivedReportsIdSet.ts
@@ -1,3 +1,4 @@
+import {useMemo} from 'react';
 import type {OnyxCollection} from 'react-native-onyx';
 import {isArchivedReport} from '@libs/ReportUtils';
 import type {ArchivedReportsIDSet} from '@libs/SearchUIUtils';
@@ -31,7 +32,7 @@ function useArchivedReportsIdSet(): ArchivedReportsIDSet {
     const [reportNameValuePairs] = useOnyx(ONYXKEYS.COLLECTION.REPORT_NAME_VALUE_PAIRS, {
         canBeMissing: true,
     });
-    const archivedReportsIdSet = getArchivedReportsIdSet(reportNameValuePairs) ?? CONST.EMPTY_SET;
+    const archivedReportsIdSet = useMemo(() => getArchivedReportsIdSet(reportNameValuePairs) ?? CONST.EMPTY_SET, [reportNameValuePairs]);
 
     // useDeepCompareRef is used here to prevent unnecessary re-renders by maintaining referential equality
     // when the Set contents are the same, even if it's a new Set instance. This is important for performance

--- a/src/hooks/useCardFeedsForDisplay.ts
+++ b/src/hooks/useCardFeedsForDisplay.ts
@@ -1,3 +1,4 @@
+import {useMemo} from 'react';
 import type {OnyxCollection} from 'react-native-onyx';
 import {getCardFeedsForDisplayPerPolicy} from '@libs/CardFeedUtils';
 import {isCustomFeed} from '@libs/CardUtils';
@@ -8,23 +9,26 @@ import type {CardFeedWithNumber} from '@src/types/onyx/CardFeeds';
 import useLocalize from './useLocalize';
 import useOnyx from './useOnyx';
 
-function getEligiblePolicyIDs(policies: OnyxCollection<Policy>): Set<string> {
+const eligiblePoliciesSelector = (policies: OnyxCollection<Policy>): string[] => {
     return Object.values(policies ?? {}).reduce((policiesIDs, policy) => {
         if (isPaidGroupPolicy(policy) && policy?.areCompanyCardsEnabled) {
-            policiesIDs.add(policy.id);
+            policiesIDs.push(policy.id);
         }
         return policiesIDs;
-    }, new Set<string>());
-}
+    }, [] as string[]);
+};
 
 const useCardFeedsForDisplay = () => {
     const {localeCompare, translate} = useLocalize();
     const [allFeeds] = useOnyx(ONYXKEYS.COLLECTION.SHARED_NVP_PRIVATE_DOMAIN_MEMBER, {canBeMissing: true});
     const [activePolicyID] = useOnyx(ONYXKEYS.NVP_ACTIVE_POLICY_ID, {canBeMissing: true});
-    const [policies] = useOnyx(ONYXKEYS.COLLECTION.POLICY, {canBeMissing: true});
+    const [eligiblePoliciesIDsArray] = useOnyx(ONYXKEYS.COLLECTION.POLICY, {
+        selector: eligiblePoliciesSelector,
+        canBeMissing: true,
+    });
 
     const cardFeedsByPolicy = getCardFeedsForDisplayPerPolicy(allFeeds, translate);
-    const eligiblePoliciesIDs = getEligiblePolicyIDs(policies);
+    const eligiblePoliciesIDs = useMemo(() => new Set(eligiblePoliciesIDsArray), [eligiblePoliciesIDsArray]);
 
     let defaultCardFeed;
     if (eligiblePoliciesIDs) {

--- a/src/hooks/useCardFeedsForDisplay.ts
+++ b/src/hooks/useCardFeedsForDisplay.ts
@@ -1,32 +1,31 @@
-import type {OnyxCollection} from 'react-native-onyx';
 import {getCardFeedsForDisplayPerPolicy} from '@libs/CardFeedUtils';
 import {isCustomFeed} from '@libs/CardUtils';
 import {isPaidGroupPolicy} from '@libs/PolicyUtils';
 import ONYXKEYS from '@src/ONYXKEYS';
 import type {Policy} from '@src/types/onyx';
 import type {CardFeedWithNumber} from '@src/types/onyx/CardFeeds';
+import type { OnyxCollection } from 'react-native-onyx';
 import useLocalize from './useLocalize';
 import useOnyx from './useOnyx';
 
-const eligiblePoliciesSelector = (policies: OnyxCollection<Policy>) => {
+function getEligiblePolicyIDs(policies: OnyxCollection<Policy>): Set<string> {
     return Object.values(policies ?? {}).reduce((policiesIDs, policy) => {
         if (isPaidGroupPolicy(policy) && policy?.areCompanyCardsEnabled) {
             policiesIDs.add(policy.id);
         }
         return policiesIDs;
     }, new Set<string>());
-};
+}
+
 
 const useCardFeedsForDisplay = () => {
     const {localeCompare, translate} = useLocalize();
     const [allFeeds] = useOnyx(ONYXKEYS.COLLECTION.SHARED_NVP_PRIVATE_DOMAIN_MEMBER, {canBeMissing: true});
     const [activePolicyID] = useOnyx(ONYXKEYS.NVP_ACTIVE_POLICY_ID, {canBeMissing: true});
-    const [eligiblePoliciesIDs] = useOnyx(ONYXKEYS.COLLECTION.POLICY, {
-        selector: eligiblePoliciesSelector,
-        canBeMissing: true,
-    });
+    const [policies] = useOnyx(ONYXKEYS.COLLECTION.POLICY, {canBeMissing: true});
 
     const cardFeedsByPolicy = getCardFeedsForDisplayPerPolicy(allFeeds, translate);
+    const eligiblePoliciesIDs = getEligiblePolicyIDs(policies);
 
     let defaultCardFeed;
     if (eligiblePoliciesIDs) {

--- a/src/hooks/useCardFeedsForDisplay.ts
+++ b/src/hooks/useCardFeedsForDisplay.ts
@@ -1,4 +1,3 @@
-import {useMemo} from 'react';
 import type {OnyxCollection} from 'react-native-onyx';
 import {getCardFeedsForDisplayPerPolicy} from '@libs/CardFeedUtils';
 import {isCustomFeed} from '@libs/CardUtils';
@@ -28,7 +27,7 @@ const useCardFeedsForDisplay = () => {
     });
 
     const cardFeedsByPolicy = getCardFeedsForDisplayPerPolicy(allFeeds, translate);
-    const eligiblePoliciesIDs = useMemo(() => new Set(eligiblePoliciesIDsArray), [eligiblePoliciesIDsArray]);
+    const eligiblePoliciesIDs = new Set(eligiblePoliciesIDsArray);
 
     let defaultCardFeed;
     if (eligiblePoliciesIDs) {

--- a/src/hooks/useCardFeedsForDisplay.ts
+++ b/src/hooks/useCardFeedsForDisplay.ts
@@ -1,10 +1,10 @@
+import type {OnyxCollection} from 'react-native-onyx';
 import {getCardFeedsForDisplayPerPolicy} from '@libs/CardFeedUtils';
 import {isCustomFeed} from '@libs/CardUtils';
 import {isPaidGroupPolicy} from '@libs/PolicyUtils';
 import ONYXKEYS from '@src/ONYXKEYS';
 import type {Policy} from '@src/types/onyx';
 import type {CardFeedWithNumber} from '@src/types/onyx/CardFeeds';
-import type { OnyxCollection } from 'react-native-onyx';
 import useLocalize from './useLocalize';
 import useOnyx from './useOnyx';
 
@@ -16,7 +16,6 @@ function getEligiblePolicyIDs(policies: OnyxCollection<Policy>): Set<string> {
         return policiesIDs;
     }, new Set<string>());
 }
-
 
 const useCardFeedsForDisplay = () => {
     const {localeCompare, translate} = useLocalize();

--- a/src/selectors/ReportNameValuePairs.ts
+++ b/src/selectors/ReportNameValuePairs.ts
@@ -1,6 +1,4 @@
 import type {OnyxCollection, OnyxEntry} from 'react-native-onyx';
-import {isArchivedReport} from '@libs/ReportUtils';
-import type {ArchivedReportsIDSet} from '@libs/SearchUIUtils';
 import type {ReportNameValuePairs} from '@src/types/onyx';
 import mapOnyxCollectionItems from '@src/utils/mapOnyxCollectionItems';
 
@@ -8,23 +6,6 @@ type ReportNameValuePairsSelector<T> = (reportNameValuePairs: OnyxEntry<ReportNa
 
 const createReportNameValuePairsSelector = <T>(reportNameValuePairs: OnyxCollection<ReportNameValuePairs>, reportNameValuePairsSelector: ReportNameValuePairsSelector<T>) =>
     mapOnyxCollectionItems(reportNameValuePairs, reportNameValuePairsSelector);
-
-/**
- * Selector that creates a Set of archived report IDs from report name value pairs
- */
-const archivedReportsIdSetSelector = (all: OnyxCollection<ReportNameValuePairs>): ArchivedReportsIDSet => {
-    const ids = new Set<string>();
-    if (!all) {
-        return ids;
-    }
-
-    for (const [key, value] of Object.entries(all)) {
-        if (isArchivedReport(value)) {
-            ids.add(key);
-        }
-    }
-    return ids;
-};
 
 type PrivateIsArchivedMap = Record<string, string | undefined>;
 
@@ -43,5 +24,5 @@ const privateIsArchivedMapSelector = (all: OnyxCollection<ReportNameValuePairs>)
     return map;
 };
 
-export {createReportNameValuePairsSelector, archivedReportsIdSetSelector, privateIsArchivedMapSelector};
+export {createReportNameValuePairsSelector, privateIsArchivedMapSelector};
 export type {PrivateIsArchivedMap};


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
<!-- Explain what your change does and how it addresses the linked issue -->
The `eligiblePoliciesSelector` was being called repeatedly, iterating over all policies to create a Set on each call. The `useOnyx` hook uses `deepEqual` to compare the old and new `Set` values, and this comparison is extremely slow for large `Set` structures. Since this selector was invoked frequently, it caused significant performance degradation.

A quick fix for this is to avoid using selector and filter the policies in place.

The same above fix applied also in `useArchivedReportsIdSet` by avoiding selector returning `Set` type data

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$[77176](https://github.com/Expensify/App/issues/77176)
PROPOSAL:


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->
1. Open Reports
- Open the app
- Open any chat or expense report and navigate through them
- Expected: Report opens normally
2. Use Search
- Go to Search screen
- Perform a search or view existing results (also check for "archived" keyword)
Expected: Search works, results display

- [ ] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->
// TODO: These must be filled out, or the issue title must include "[No QA]."

Same as tests.

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I verified there are no new alerts related to the `canBeMissing` param for `useOnyx`
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>