### PR TITLE
[HomePage] Adjust paddings on HomePage and TimeSensitive button texts

### DIFF
--- a/src/languages/de.ts
+++ b/src/languages/de.ts
@@ -1000,7 +1000,11 @@ const translations: TranslationDeepObject<typeof en> = {
                 title: ({feedName}: {feedName: string}) => (feedName ? `${feedName}-Firmenkartenverbindung reparieren` : 'Firmenkarte reparieren Verbindung der Firmenkarte reparieren'),
                 subtitle: 'Workspace > Unternehmenskarten',
             },
-            fixAccountingConnection: {title: ({integrationName}: {integrationName: string}) => `${integrationName}-Verbindung reparieren`, subtitle: 'Arbeitsbereich > Buchhaltung'},
+            fixAccountingConnection: {
+                title: ({integrationName}: {integrationName: string}) => `${integrationName}-Verbindung reparieren`,
+                defaultSubtitle: 'Arbeitsbereich > Buchhaltung',
+                subtitle: ({policyName}: {policyName: string}) => `${policyName} > Buchhaltung`,
+            },
         },
         announcements: 'Ankündigungen',
         discoverSection: {

--- a/src/languages/en.ts
+++ b/src/languages/en.ts
@@ -999,7 +999,8 @@ const translations = {
             },
             fixAccountingConnection: {
                 title: ({integrationName}: {integrationName: string}) => `Fix ${integrationName} connection`,
-                subtitle: 'Workspace > Accounting',
+                defaultSubtitle: 'Workspace > Accounting',
+                subtitle: ({policyName}: {policyName: string}) => `${policyName} > Accounting`,
             },
             addShippingAddress: {
                 title: 'We need your shipping address',

--- a/src/languages/es.ts
+++ b/src/languages/es.ts
@@ -769,7 +769,8 @@ const translations: TranslationDeepObject<typeof en> = {
             },
             fixAccountingConnection: {
                 title: ({integrationName}: {integrationName: string}) => `Reconectar con ${integrationName}`,
-                subtitle: 'Espacio de trabajo > Contabilidad',
+                defaultSubtitle: 'Espacio de trabajo > Contabilidad',
+                subtitle: ({policyName}: {policyName: string}) => `${policyName} > Contabilidad`,
             },
             addShippingAddress: {
                 title: 'Necesitamos tu dirección de envío',

--- a/src/languages/fr.ts
+++ b/src/languages/fr.ts
@@ -1004,7 +1004,11 @@ const translations: TranslationDeepObject<typeof en> = {
                 title: ({feedName}: {feedName: string}) => (feedName ? `Corriger la connexion de la carte d'entreprise ${feedName}` : 'Corriger la connexion de la carte entreprise'),
                 subtitle: 'Espace de travail > Cartes d’entreprise',
             },
-            fixAccountingConnection: {title: ({integrationName}: {integrationName: string}) => `Corriger la connexion ${integrationName}`, subtitle: 'Espace de travail > Comptabilité'},
+            fixAccountingConnection: {
+                title: ({integrationName}: {integrationName: string}) => `Corriger la connexion ${integrationName}`,
+                defaultSubtitle: 'Espace de travail > Comptabilité',
+                subtitle: ({policyName}: {policyName: string}) => `${policyName} > Comptabilité`,
+            },
         },
         announcements: 'Annonces',
         discoverSection: {

--- a/src/languages/it.ts
+++ b/src/languages/it.ts
@@ -999,7 +999,11 @@ const translations: TranslationDeepObject<typeof en> = {
                 title: ({feedName}: {feedName: string}) => (feedName ? `Correggi la connessione della carta aziendale ${feedName}` : 'Correggi connessione carta aziendale'),
                 subtitle: 'Spazio di lavoro > Carte aziendali',
             },
-            fixAccountingConnection: {title: ({integrationName}: {integrationName: string}) => `Correggi connessione ${integrationName}`, subtitle: 'Spazio di lavoro > Contabilità'},
+            fixAccountingConnection: {
+                title: ({integrationName}: {integrationName: string}) => `Correggi connessione ${integrationName}`,
+                defaultSubtitle: 'Spazio di lavoro > Contabilità',
+                subtitle: ({policyName}: {policyName: string}) => `${policyName} > Contabilità`,
+            },
         },
         announcements: 'Annunci',
         discoverSection: {

--- a/src/languages/ja.ts
+++ b/src/languages/ja.ts
@@ -995,7 +995,11 @@ const translations: TranslationDeepObject<typeof en> = {
                 title: ({feedName}: {feedName: string}) => (feedName ? `${feedName} 会社カード接続を修正` : '法人クレジットカードの接続を修正'),
                 subtitle: 'ワークスペース > 会社カード',
             },
-            fixAccountingConnection: {title: ({integrationName}: {integrationName: string}) => `${integrationName} 接続を修正`, subtitle: 'ワークスペース > 会計'},
+            fixAccountingConnection: {
+                title: ({integrationName}: {integrationName: string}) => `${integrationName} 接続を修正`,
+                defaultSubtitle: 'ワークスペース > 会計',
+                subtitle: ({policyName}: {policyName: string}) => `${policyName} > 会計`,
+            },
         },
         announcements: 'お知らせ',
         discoverSection: {

--- a/src/languages/nl.ts
+++ b/src/languages/nl.ts
@@ -999,7 +999,11 @@ const translations: TranslationDeepObject<typeof en> = {
                 title: ({feedName}: {feedName: string}) => (feedName ? `Verbinding bedrijfskaart ${feedName} herstellen` : 'Verbinding van bedrijfskaart repareren'),
                 subtitle: 'Werkruimte > Bedrijfspassen',
             },
-            fixAccountingConnection: {title: ({integrationName}: {integrationName: string}) => `Verbinding met ${integrationName} repareren`, subtitle: 'Werkruimte > Boekhouding'},
+            fixAccountingConnection: {
+                title: ({integrationName}: {integrationName: string}) => `Verbinding met ${integrationName} repareren`,
+                defaultSubtitle: 'Werkruimte > Boekhouding',
+                subtitle: ({policyName}: {policyName: string}) => `${policyName} > Boekhouding`,
+            },
         },
         announcements: 'Aankondigingen',
         discoverSection: {

--- a/src/languages/pl.ts
+++ b/src/languages/pl.ts
@@ -1000,7 +1000,11 @@ const translations: TranslationDeepObject<typeof en> = {
                 title: ({feedName}: {feedName: string}) => (feedName ? `Napraw połączenie karty firmowej ${feedName}` : 'Napraw połączenie karty firmowej'),
                 subtitle: 'Workspace > Karty firmowe',
             },
-            fixAccountingConnection: {title: ({integrationName}: {integrationName: string}) => `Napraw połączenie ${integrationName}`, subtitle: 'Przestrzeń robocza > Księgowość'},
+            fixAccountingConnection: {
+                title: ({integrationName}: {integrationName: string}) => `Napraw połączenie ${integrationName}`,
+                defaultSubtitle: 'Przestrzeń robocza > Księgowość',
+                subtitle: ({policyName}: {policyName: string}) => `${policyName} > Księgowość`,
+            },
         },
         announcements: 'Ogłoszenia',
         discoverSection: {

--- a/src/languages/pt-BR.ts
+++ b/src/languages/pt-BR.ts
@@ -998,7 +998,11 @@ const translations: TranslationDeepObject<typeof en> = {
                 title: ({feedName}: {feedName: string}) => (feedName ? `Corrigir conexão do cartão corporativo ${feedName}` : 'Corrigir conexão do cartão corporativo'),
                 subtitle: 'Área de trabalho > Cartões corporativos',
             },
-            fixAccountingConnection: {title: ({integrationName}: {integrationName: string}) => `Corrigir conexão com ${integrationName}`, subtitle: 'Espaço de trabalho > Contabilidade'},
+            fixAccountingConnection: {
+                title: ({integrationName}: {integrationName: string}) => `Corrigir conexão com ${integrationName}`,
+                defaultSubtitle: 'Espaço de trabalho > Contabilidade',
+                subtitle: ({policyName}: {policyName: string}) => `${policyName} > Contabilidade`,
+            },
         },
         announcements: 'Comunicados',
         discoverSection: {

--- a/src/languages/zh-hans.ts
+++ b/src/languages/zh-hans.ts
@@ -981,8 +981,15 @@ const translations: TranslationDeepObject<typeof en> = {
                 cta: '审核',
             },
             ctaFix: '修复',
-            fixCompanyCardConnection: {title: ({feedName}: {feedName: string}) => (feedName ? `修复 ${feedName} 公司卡连接` : '修复公司卡连接'), subtitle: '工作区 > 公司卡片'},
-            fixAccountingConnection: {title: ({integrationName}: {integrationName: string}) => `修复 ${integrationName} 连接`, subtitle: '工作区 > 会计'},
+            fixCompanyCardConnection: {
+                title: ({feedName}: {feedName: string}) => (feedName ? `修复 ${feedName} 公司卡连接` : '修复公司卡连接'),
+                subtitle: '工作区 > 公司卡片',
+            },
+            fixAccountingConnection: {
+                title: ({integrationName}: {integrationName: string}) => `修复 ${integrationName} 连接`,
+                defaultSubtitle: '工作区 > 会计',
+                subtitle: ({policyName}: {policyName: string}) => `${policyName} > 会计`,
+            },
         },
         announcements: '公告',
         discoverSection: {

--- a/src/pages/home/ForYouSection/index.tsx
+++ b/src/pages/home/ForYouSection/index.tsx
@@ -80,7 +80,7 @@ function ForYouSection() {
     ].filter((item) => item.count > 0);
 
     const renderTodoItems = () => (
-        <View style={shouldUseNarrowLayout ? styles.mb2 : styles.mb5}>
+        <View style={styles.getForYouSectionContainerStyle(shouldUseNarrowLayout)}>
             {todoItems.map(({key, count, icon, translationKey, handler}) => (
                 <BaseWidgetItem
                     key={key}

--- a/src/pages/home/ForYouSection/index.tsx
+++ b/src/pages/home/ForYouSection/index.tsx
@@ -80,7 +80,7 @@ function ForYouSection() {
     ].filter((item) => item.count > 0);
 
     const renderTodoItems = () => (
-        <View style={styles.getForYouSectionContainerStyle(shouldUseNarrowLayout)}>
+        <View style={shouldUseNarrowLayout ? styles.mb2 : styles.mb5}>
             {todoItems.map(({key, count, icon, translationKey, handler}) => (
                 <BaseWidgetItem
                     key={key}

--- a/src/pages/home/TimeSensitiveSection/index.tsx
+++ b/src/pages/home/TimeSensitiveSection/index.tsx
@@ -125,7 +125,7 @@ function TimeSensitiveSection() {
     // 6. Expensify card activation
     return (
         <WidgetContainer title={translate('homePage.timeSensitiveSection.title')}>
-            <View style={shouldUseNarrowLayout ? styles.mb2 : styles.mb5}>
+            <View style={styles.getForYouSectionContainerStyle(shouldUseNarrowLayout)}>
                 {/* Priority 1: Card fraud alerts */}
                 {shouldShowReviewCardFraud &&
                     cardsWithFraud.map((card) => {

--- a/src/pages/home/TimeSensitiveSection/index.tsx
+++ b/src/pages/home/TimeSensitiveSection/index.tsx
@@ -121,7 +121,7 @@ function TimeSensitiveSection() {
     // 6. Expensify card activation
     return (
         <WidgetContainer title={translate('homePage.timeSensitiveSection.title')}>
-            <View style={styles.getForYouSectionContainerStyle(shouldUseNarrowLayout)}>
+            <View style={shouldUseNarrowLayout ? styles.mb2 : styles.mb5}>
                 {/* Priority 1: Card fraud alerts */}
                 {shouldShowReviewCardFraud &&
                     cardsWithFraud.map((card) => {

--- a/src/pages/home/TimeSensitiveSection/index.tsx
+++ b/src/pages/home/TimeSensitiveSection/index.tsx
@@ -27,6 +27,9 @@ type BrokenAccountingConnection = {
     /** The policy ID associated with this connection */
     policyID: string;
 
+    /** The policy name associated with this connection */
+    policyName: string;
+
     /** The connection name that has an error */
     connectionName: PolicyConnectionName;
 };
@@ -73,6 +76,7 @@ function TimeSensitiveSection() {
             if (hasSynchronizationErrorMessage(policy, connectionName, isSyncInProgress)) {
                 brokenAccountingConnections.push({
                     policyID: policy.id,
+                    policyName: policy.name,
                     connectionName,
                 });
             }
@@ -157,6 +161,7 @@ function TimeSensitiveSection() {
                         key={`accounting-${connection.policyID}-${connection.connectionName}`}
                         connectionName={connection.connectionName}
                         policyID={connection.policyID}
+                        policyName={connection.policyName}
                     />
                 ))}
 

--- a/src/pages/home/TimeSensitiveSection/items/FixAccountingConnection.tsx
+++ b/src/pages/home/TimeSensitiveSection/items/FixAccountingConnection.tsx
@@ -14,13 +14,19 @@ type FixAccountingConnectionProps = {
 
     /** The policy ID associated with this connection */
     policyID: string;
+
+    /** The policy name associated with this connection */
+    policyName: string;
 };
 
-function FixAccountingConnection({connectionName, policyID}: FixAccountingConnectionProps) {
+function FixAccountingConnection({connectionName, policyID, policyName}: FixAccountingConnectionProps) {
     const {translate} = useLocalize();
     const icons = useMemoizedLazyExpensifyIcons(['Connect']);
 
     const integrationName = CONST.POLICY.CONNECTIONS.NAME_USER_FRIENDLY[connectionName];
+    const subtitle = policyName
+        ? translate('homePage.timeSensitiveSection.fixAccountingConnection.subtitle', {policyName})
+        : translate('homePage.timeSensitiveSection.fixAccountingConnection.defaultSubtitle');
 
     return (
         <BaseWidgetItem
@@ -28,7 +34,7 @@ function FixAccountingConnection({connectionName, policyID}: FixAccountingConnec
             iconBackgroundColor={colors.tangerine100}
             iconFill={colors.tangerine500}
             title={translate('homePage.timeSensitiveSection.fixAccountingConnection.title', {integrationName})}
-            subtitle={translate('homePage.timeSensitiveSection.fixAccountingConnection.subtitle')}
+            subtitle={subtitle}
             ctaText={translate('homePage.timeSensitiveSection.ctaFix')}
             onCtaPress={() => Navigation.navigate(ROUTES.WORKSPACE_ACCOUNTING.getRoute(policyID))}
             buttonProps={{danger: true}}

--- a/src/styles/index.ts
+++ b/src/styles/index.ts
@@ -6099,6 +6099,11 @@ const dynamicStyles = (theme: ThemeColors) =>
             maxWidth: shouldUseNarrowLayout ? '100%' : 300,
         }),
 
+        getForYouSectionContainerStyle: (shouldUseNarrowLayout: boolean): ViewStyle => ({
+            flexDirection: 'column',
+            marginBottom: shouldUseNarrowLayout ? 8 : 20,
+        }),
+
         getSelectionListPopoverHeight: (itemCount: number, windowHeight: number, isSearchable: boolean) => {
             const SEARCHBAR_HEIGHT = isSearchable ? 52 : 0;
             const SEARCHBAR_PADDING = isSearchable ? 12 : 0;

--- a/src/styles/index.ts
+++ b/src/styles/index.ts
@@ -6099,12 +6099,6 @@ const dynamicStyles = (theme: ThemeColors) =>
             maxWidth: shouldUseNarrowLayout ? '100%' : 300,
         }),
 
-        getForYouSectionContainerStyle: (shouldUseNarrowLayout: boolean): ViewStyle => ({
-            flexDirection: 'column',
-            marginBottom: shouldUseNarrowLayout ? 8 : 12,
-            paddingVertical: 12,
-        }),
-
         getSelectionListPopoverHeight: (itemCount: number, windowHeight: number, isSearchable: boolean) => {
             const SEARCHBAR_HEIGHT = isSearchable ? 52 : 0;
             const SEARCHBAR_PADDING = isSearchable ? 12 : 0;


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
<!-- Explain what your change does and how it addresses the linked issue -->

This PR:
- adjusts paddings in "For You" and "Time Sensitive" sections

https://github.com/user-attachments/assets/86b14522-8cd6-493c-81a4-c61723246d26

- refactors  `Workspace > Accounting` to `{Workspace Name} > Accounting` in Time Sensitive section rows
<img width="1305" height="1002" alt="image" src="https://github.com/user-attachments/assets/4322fb70-7316-4c5c-8150-b3348e61c59c" />



### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/81160
$ https://github.com/Expensify/App/issues/81508
PROPOSAL:


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

- [ ] Verify that no errors appear in the JS console

1. Verify that the paddings are the same for all sections on the home page.
2. Verify that the Workspace name is displayed in the accounting error in the Time sensitive section.

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->
// TODO: These must be filled out, or the issue title must include "[No QA]."

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I verified there are no new alerts related to the `canBeMissing` param for `useOnyx`
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>