### PR TITLE
Update create transaction Manual flow to ask for merchant after asking for amount v3

### DIFF
--- a/src/ROUTES.ts
+++ b/src/ROUTES.ts
@@ -1312,13 +1312,22 @@ const ROUTES = {
     },
     MONEY_REQUEST_STEP_MERCHANT: {
         route: ':action/:iouType/merchant/:transactionID/:reportID/:reportActionID?',
-        getRoute: (action: IOUAction, iouType: IOUType, transactionID: string | undefined, reportID: string | undefined, backTo = '', reportActionID?: string) => {
+        getRoute: (action: IOUAction, iouType: IOUType, transactionID: string | undefined, reportID: string | undefined, backTo = '', reportActionID?: string, backToReport?: string) => {
             if (!transactionID || !reportID) {
                 Log.warn('Invalid transactionID or reportID is used to build the MONEY_REQUEST_STEP_MERCHANT route');
             }
 
+            let optionalRoutePart = '';
+
+            if (reportActionID) {
+                optionalRoutePart += `/${reportActionID}`;
+            }
+            if (backToReport) {
+                optionalRoutePart += `?backToReport=${backToReport}`;
+            }
+
             // eslint-disable-next-line no-restricted-syntax -- Legacy route generation
-            return getUrlWithBackToParam(`${action as string}/${iouType as string}/merchant/${transactionID}/${reportID}${reportActionID ? `/${reportActionID}` : ''}`, backTo);
+            return getUrlWithBackToParam(`${action as string}/${iouType as string}/merchant/${transactionID}/${reportID}${optionalRoutePart}`, backTo);
         },
     },
     MONEY_REQUEST_STEP_PARTICIPANTS: {

--- a/src/libs/IOUUtils.ts
+++ b/src/libs/IOUUtils.ts
@@ -5,14 +5,15 @@ import CONST from '@src/CONST';
 import ROUTES from '@src/ROUTES';
 import type {OnyxInputOrEntry, PersonalDetails, Policy, Report} from '@src/types/onyx';
 import type {Attendee, Participant} from '@src/types/onyx/IOU';
+import type Transaction from '@src/types/onyx/Transaction';
 import SafeString from '@src/utils/SafeString';
 import type {IOURequestType} from './actions/IOU';
 import {getCurrencyUnit} from './CurrencyUtils';
 import Navigation from './Navigation/Navigation';
 import Performance from './Performance';
 import {isPaidGroupPolicy} from './PolicyUtils';
-import {getReportTransactions} from './ReportUtils';
-import {getCurrency, getTagArrayFromName} from './TransactionUtils';
+import {getReportTransactions, isExpenseReport, isPolicyExpenseChat as isPolicyExpenseChatUtils} from './ReportUtils';
+import {getCurrency, getTagArrayFromName, isMerchantMissing, isScanRequest} from './TransactionUtils';
 
 function navigateToStartMoneyRequestStep(requestType: IOURequestType, iouType: IOUType, transactionID: string, reportID: string, iouAction?: IOUAction): void {
     if (iouAction === CONST.IOU.ACTION.CATEGORIZE || iouAction === CONST.IOU.ACTION.SUBMIT || iouAction === CONST.IOU.ACTION.SHARE) {
@@ -324,6 +325,34 @@ function formatCurrentUserToAttendee(currentUser?: PersonalDetails, reportID?: s
     return [initialAttendee];
 }
 
+/**
+ * Checks if merchant is required and missing for a transaction.
+ * Merchant is required for policy expense chats, expense requests, or when any participant is a policy expense chat.
+ * For scan requests, merchant is not required unless it's a split bill being edited.
+ *
+ * @param transaction - The transaction to check
+ * @param report - The report associated with the transaction
+ * @param isEditingSplitBill - Whether this is editing a split bill
+ * @returns true if merchant is required and missing, false otherwise
+ */
+function shouldRequireMerchant(transaction: OnyxInputOrEntry<Transaction> | undefined, report: OnyxInputOrEntry<Report> | undefined, isEditingSplitBill = false): boolean {
+    if (!transaction) {
+        return false;
+    }
+
+    if (!isMerchantMissing(transaction)) {
+        return false;
+    }
+
+    // For scan requests, merchant is not required unless it's a split bill being edited
+    if (isScanRequest(transaction) && !isEditingSplitBill) {
+        return false;
+    }
+
+    // Check if merchant is required based on report type and participants
+    return !!(isPolicyExpenseChatUtils(report) || isExpenseReport(report) || transaction?.participants?.some((participant) => !!participant.isPolicyExpenseChat));
+}
+
 function navigateToConfirmationPage(
     iouType: IOUType,
     transactionID: string,
@@ -392,6 +421,7 @@ export {
     formatCurrentUserToAttendee,
     navigateToParticipantPage,
     shouldShowReceiptEmptyState,
+    shouldRequireMerchant,
     navigateToConfirmationPage,
     calculateDefaultReimbursable,
 };

--- a/src/libs/Navigation/types.ts
+++ b/src/libs/Navigation/types.ts
@@ -1846,6 +1846,7 @@ type MoneyRequestNavigatorParamList = {
         // eslint-disable-next-line no-restricted-syntax -- `backTo` usages in this file are legacy. Do not add new `backTo` params to screens. See contributingGuides/NAVIGATION.md
         backTo: Routes;
         reportActionID?: string;
+        backToReport?: string;
     };
     [SCREENS.IOU_SEND.ENABLE_PAYMENTS]: undefined;
     [SCREENS.IOU_SEND.ADD_BANK_ACCOUNT]: undefined;

--- a/src/pages/iou/request/step/IOURequestStepAmount.tsx
+++ b/src/pages/iou/request/step/IOURequestStepAmount.tsx
@@ -21,7 +21,7 @@ import useShowNotFoundPageInIOUStep from '@hooks/useShowNotFoundPageInIOUStep';
 import {setTransactionReport} from '@libs/actions/Transaction';
 import {convertToBackendAmount} from '@libs/CurrencyUtils';
 import getNonEmptyStringOnyxID from '@libs/getNonEmptyStringOnyxID';
-import {calculateDefaultReimbursable, isMovingTransactionFromTrackExpense, navigateToConfirmationPage, navigateToParticipantPage} from '@libs/IOUUtils';
+import {calculateDefaultReimbursable, isMovingTransactionFromTrackExpense, navigateToConfirmationPage, navigateToParticipantPage, shouldRequireMerchant} from '@libs/IOUUtils';
 import Navigation from '@libs/Navigation/Navigation';
 import {getParticipantsOption, getReportOption} from '@libs/OptionsListUtils';
 import {getPolicyExpenseChat, getReportOrDraftReport, getTransactionDetails, isMoneyRequestReport, isPolicyExpenseChat, isSelfDM, shouldEnableNegative} from '@libs/ReportUtils';
@@ -307,8 +307,14 @@ function IOURequestStepAmount({
                 setSplitShares(transaction, amountInSmallestCurrencyUnits, selectedCurrency || CONST.CURRENCY.USD, participantAccountIDs);
             }
             setMoneyRequestParticipantsFromReport(transactionID, report, currentUserPersonalDetails.accountID).then(() => {
+                // If merchant is required and missing, navigate to merchant step first
+                if (shouldRequireMerchant(transaction, report, isEditingSplitBill)) {
+                    Navigation.navigate(ROUTES.MONEY_REQUEST_STEP_MERCHANT.getRoute(action, CONST.IOU.TYPE.SUBMIT, transactionID, reportID, undefined, reportActionID));
+                    return;
+                }
                 navigateToConfirmationPage(iouType, transactionID, reportID, backToReport);
             });
+
             return;
         }
 
@@ -324,7 +330,11 @@ function IOURequestStepAmount({
             const resetToDefaultWorkspace = () => {
                 setTransactionReport(transactionID, {reportID: transactionReportID}, true);
                 setMoneyRequestParticipantsFromReport(transactionID, targetReport, currentUserPersonalDetails.accountID).then(() => {
-                    Navigation.navigate(ROUTES.MONEY_REQUEST_STEP_CONFIRMATION.getRoute(CONST.IOU.ACTION.CREATE, iouTypeTrackOrSubmit, transactionID, targetReport?.reportID));
+                    if (transactionReportID === CONST.REPORT.UNREPORTED_REPORT_ID) {
+                        Navigation.navigate(ROUTES.MONEY_REQUEST_STEP_CONFIRMATION.getRoute(CONST.IOU.ACTION.CREATE, iouTypeTrackOrSubmit, transactionID, targetReport?.reportID));
+                        return;
+                    }
+                    Navigation.navigate(ROUTES.MONEY_REQUEST_STEP_MERCHANT.getRoute(action, CONST.IOU.TYPE.SUBMIT, transactionID, targetReport?.reportID, undefined, reportActionID));
                 });
             };
 
@@ -346,6 +356,10 @@ function IOURequestStepAmount({
                 const chatReportID = selectedReport?.chatReportID ?? selectedReport?.reportID;
 
                 Navigation.setNavigationActionToMicrotaskQueue(() => {
+                    if (shouldRequireMerchant(transaction, selectedReport, isEditingSplitBill)) {
+                        Navigation.navigate(ROUTES.MONEY_REQUEST_STEP_MERCHANT.getRoute(CONST.IOU.ACTION.CREATE, navigationIOUType, transactionID, chatReportID, undefined, reportActionID));
+                        return;
+                    }
                     Navigation.navigate(ROUTES.MONEY_REQUEST_STEP_CONFIRMATION.getRoute(CONST.IOU.ACTION.CREATE, navigationIOUType, transactionID, chatReportID));
                 });
             } else {

--- a/src/pages/iou/request/step/IOURequestStepAmount.tsx
+++ b/src/pages/iou/request/step/IOURequestStepAmount.tsx
@@ -309,7 +309,7 @@ function IOURequestStepAmount({
             setMoneyRequestParticipantsFromReport(transactionID, report, currentUserPersonalDetails.accountID).then(() => {
                 // If merchant is required and missing, navigate to merchant step first
                 if (shouldRequireMerchant(transaction, report, isEditingSplitBill)) {
-                    Navigation.navigate(ROUTES.MONEY_REQUEST_STEP_MERCHANT.getRoute(action, CONST.IOU.TYPE.SUBMIT, transactionID, reportID, undefined, reportActionID));
+                    Navigation.navigate(ROUTES.MONEY_REQUEST_STEP_MERCHANT.getRoute(action, CONST.IOU.TYPE.SUBMIT, transactionID, reportID, undefined, reportActionID, backToReport));
                     return;
                 }
                 navigateToConfirmationPage(iouType, transactionID, reportID, backToReport);

--- a/src/pages/iou/request/step/IOURequestStepMerchant.tsx
+++ b/src/pages/iou/request/step/IOURequestStepMerchant.tsx
@@ -1,4 +1,5 @@
-import React, {useCallback, useEffect, useRef, useState} from 'react';
+import {useFocusEffect} from '@react-navigation/native';
+import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import {InteractionManager, View} from 'react-native';
 import FormProvider from '@components/Form/FormProvider';
 import InputWrapper from '@components/Form/InputWrapper';
@@ -21,6 +22,7 @@ import {setMoneyRequestMerchant, updateMoneyRequestMerchant} from '@userActions/
 import {setDraftSplitTransaction} from '@userActions/IOU/Split';
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
+import ROUTES from '@src/ROUTES';
 import type SCREENS from '@src/SCREENS';
 import INPUT_IDS from '@src/types/form/MoneyRequestMerchantForm';
 import {isEmptyObject} from '@src/types/utils/EmptyObject';
@@ -69,19 +71,35 @@ function IOURequestStepMerchant({
     const {isBetaEnabled} = usePermissions();
     const isASAPSubmitBetaEnabled = isBetaEnabled(CONST.BETAS.ASAP_SUBMIT);
 
-    const isMerchantRequired = isPolicyExpenseChat(report) || isExpenseRequest(report) || transaction?.participants?.some((participant) => !!participant.isPolicyExpenseChat);
+    const isMerchantRequired = useMemo(() => {
+        if (isEditing) {
+            return isPolicyExpenseChat(report) || isExpenseRequest(report);
+        }
+        return transaction?.participants?.some((participant) => !!participant.isPolicyExpenseChat);
+    }, [isEditing, report, transaction?.participants]);
 
     const navigateBack = useCallback(() => {
         Navigation.goBack(backTo);
     }, [backTo]);
+
+    useFocusEffect(
+        useCallback(() => {
+            setIsSaved(false);
+            setCurrentMerchant(initialMerchant);
+        }, [initialMerchant]),
+    );
 
     useEffect(() => {
         if (!isSaved || !shouldNavigateAfterSaveRef.current) {
             return;
         }
         shouldNavigateAfterSaveRef.current = false;
+        if (!isEditing && !backTo) {
+            Navigation.navigate(ROUTES.MONEY_REQUEST_STEP_CONFIRMATION.getRoute(action, iouType, transactionID, reportID, undefined, undefined, Navigation.getActiveRoute()));
+            return;
+        }
         navigateBack();
-    }, [isSaved, navigateBack]);
+    }, [isSaved, navigateBack, action, iouType, transactionID, reportID, backTo, isEditing]);
 
     const validate = useCallback(
         (value: FormOnyxValues<typeof ONYXKEYS.FORMS.MONEY_REQUEST_MERCHANT_FORM>) => {
@@ -165,6 +183,7 @@ function IOURequestStepMerchant({
                         inputID={INPUT_IDS.MONEY_REQUEST_MERCHANT}
                         name={INPUT_IDS.MONEY_REQUEST_MERCHANT}
                         defaultValue={initialMerchant}
+                        value={currentMerchant}
                         onValueChange={updateMerchantRef}
                         label={translate('common.merchant')}
                         accessibilityLabel={translate('common.merchant')}

--- a/src/pages/iou/request/step/IOURequestStepMerchant.tsx
+++ b/src/pages/iou/request/step/IOURequestStepMerchant.tsx
@@ -38,7 +38,7 @@ type IOURequestStepMerchantProps = WithWritableReportOrNotFoundProps<typeof SCRE
 
 function IOURequestStepMerchant({
     route: {
-        params: {transactionID, reportID, backTo, action, iouType, reportActionID},
+        params: {transactionID, reportID, backTo, action, iouType, reportActionID, backToReport},
     },
     transaction,
     report,
@@ -95,11 +95,11 @@ function IOURequestStepMerchant({
         }
         shouldNavigateAfterSaveRef.current = false;
         if (!isEditing && !backTo) {
-            Navigation.navigate(ROUTES.MONEY_REQUEST_STEP_CONFIRMATION.getRoute(action, iouType, transactionID, reportID, undefined, undefined, Navigation.getActiveRoute()));
+            Navigation.navigate(ROUTES.MONEY_REQUEST_STEP_CONFIRMATION.getRoute(action, iouType, transactionID, reportID, backToReport, undefined, Navigation.getActiveRoute()));
             return;
         }
         navigateBack();
-    }, [isSaved, navigateBack, action, iouType, transactionID, reportID, backTo, isEditing]);
+    }, [isSaved, navigateBack, action, iouType, transactionID, reportID, backTo, isEditing, backToReport]);
 
     const validate = useCallback(
         (value: FormOnyxValues<typeof ONYXKEYS.FORMS.MONEY_REQUEST_MERCHANT_FORM>) => {

--- a/src/pages/iou/request/step/IOURequestStepParticipants.tsx
+++ b/src/pages/iou/request/step/IOURequestStepParticipants.tsx
@@ -339,7 +339,10 @@ function IOURequestStepParticipants({
             }
 
             const firstParticipant = selectedParticipants.current?.at(0);
-            const isMerchantRequired = !!firstParticipant?.isPolicyExpenseChat && isMerchantMissing(initialTransaction) && iouRequestType === CONST.IOU.REQUEST_TYPE.MANUAL;
+            const isMerchantRequired =
+                !!firstParticipant?.isPolicyExpenseChat &&
+                isMerchantMissing(initialTransaction) &&
+                (iouRequestType === CONST.IOU.REQUEST_TYPE.MANUAL || (isMovingTransactionFromTrackExpense && iouRequestType === CONST.IOU.REQUEST_TYPE.TIME));
 
             const iouConfirmationPageRoute = ROUTES.MONEY_REQUEST_STEP_CONFIRMATION.getRoute(
                 action,

--- a/src/pages/iou/request/step/IOURequestStepParticipants.tsx
+++ b/src/pages/iou/request/step/IOURequestStepParticipants.tsx
@@ -22,7 +22,7 @@ import {isPaidGroupPolicy} from '@libs/PolicyUtils';
 import {findSelfDMReportID, generateReportID, isInvoiceRoomWithID} from '@libs/ReportUtils';
 import {shouldRestrictUserBillableActions} from '@libs/SubscriptionUtils';
 import {endSpan} from '@libs/telemetry/activeSpans';
-import {getRequestType, hasRoute, isCorporateCardTransaction, isDistanceRequest, isPerDiemRequest} from '@libs/TransactionUtils';
+import {getRequestType, hasRoute, isCorporateCardTransaction, isDistanceRequest, isMerchantMissing, isPerDiemRequest} from '@libs/TransactionUtils';
 import MoneyRequestParticipantsSelector from '@pages/iou/request/MoneyRequestParticipantsSelector';
 import {
     navigateToStartStepIfScanFileCannotBeRead,
@@ -38,6 +38,7 @@ import {createDraftWorkspace} from '@userActions/Policy/Policy';
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
 import ROUTES from '@src/ROUTES';
+import type {Route} from '@src/ROUTES';
 import type SCREENS from '@src/SCREENS';
 import type {Policy} from '@src/types/onyx';
 import type {Participant} from '@src/types/onyx/IOU';
@@ -88,6 +89,7 @@ function IOURequestStepParticipants({
 
     // We need to set selectedReportID if user has navigated back from confirmation page and navigates to confirmation page with already selected participant
     const selectedReportID = useRef<string>(participants?.length === 1 ? (participants.at(0)?.reportID ?? reportID) : reportID);
+    const selectedParticipants = useRef<Participant[]>(participants);
     const numberOfParticipants = useRef(participants?.length ?? 0);
     const iouRequestType = getRequestType(initialTransaction);
     const isSplitRequest = iouType === CONST.IOU.TYPE.SPLIT;
@@ -221,6 +223,7 @@ function IOURequestStepParticipants({
         (val: Participant[]) => {
             HttpUtils.cancelPendingRequests(READ_COMMANDS.SEARCH_FOR_REPORTS);
 
+            selectedParticipants.current = val;
             const firstParticipant = val.at(0);
 
             if (firstParticipant?.isSelfDM && !isSplitRequest) {
@@ -335,6 +338,9 @@ function IOURequestStepParticipants({
                 return;
             }
 
+            const firstParticipant = selectedParticipants.current?.at(0);
+            const isMerchantRequired = !!firstParticipant?.isPolicyExpenseChat && isMerchantMissing(initialTransaction) && iouRequestType === CONST.IOU.REQUEST_TYPE.MANUAL;
+
             const iouConfirmationPageRoute = ROUTES.MONEY_REQUEST_STEP_CONFIRMATION.getRoute(
                 action,
                 iouType === CONST.IOU.TYPE.CREATE || iouType === CONST.IOU.TYPE.TRACK ? CONST.IOU.TYPE.SUBMIT : iouType,
@@ -345,9 +351,18 @@ function IOURequestStepParticipants({
                 action === CONST.IOU.ACTION.SHARE ? Navigation.getActiveRoute() : undefined,
             );
 
-            const route = isCategorizing
-                ? ROUTES.MONEY_REQUEST_STEP_CATEGORY.getRoute(action, iouType, initialTransactionID, selectedReportID.current || reportID, iouConfirmationPageRoute)
-                : iouConfirmationPageRoute;
+            let route: Route = iouConfirmationPageRoute;
+
+            if (isCategorizing) {
+                route = ROUTES.MONEY_REQUEST_STEP_CATEGORY.getRoute(action, iouType, initialTransactionID, selectedReportID.current || reportID, iouConfirmationPageRoute);
+            } else if (isMerchantRequired) {
+                route = ROUTES.MONEY_REQUEST_STEP_MERCHANT.getRoute(
+                    action,
+                    iouType === CONST.IOU.TYPE.CREATE || iouType === CONST.IOU.TYPE.TRACK ? CONST.IOU.TYPE.SUBMIT : iouType,
+                    initialTransactionID,
+                    newReportID,
+                );
+            }
 
             Performance.markStart(CONST.TIMING.OPEN_CREATE_EXPENSE_APPROVE);
             waitForKeyboardDismiss(() => {
@@ -355,11 +370,15 @@ function IOURequestStepParticipants({
                 // We wrap navigation in setNavigationActionToMicrotaskQueue so that data loading in Onyx and navigation do not occur simultaneously, which resets the amount to 0.
                 // More information can be found here: https://github.com/Expensify/App/issues/73728
                 Navigation.setNavigationActionToMicrotaskQueue(() => {
-                    if (backTo) {
+                    if (backTo && !isMerchantRequired) {
                         // We don't want to compare params because we just changed the participants.
                         Navigation.goBack(route, {compareParams: false});
                     } else {
-                        Navigation.navigate(route);
+                        // If the merchant step is required and the backTo parameter is set, we need to go back the the confirmation screen first and then navigate to the merchant page with forceReplace to remove this screen from the stack
+                        if (isMerchantRequired && backTo) {
+                            Navigation.goBack();
+                        }
+                        Navigation.navigate(route, {forceReplace: isMerchantRequired && !!backTo});
                     }
                 });
             });
@@ -369,14 +388,15 @@ function IOURequestStepParticipants({
             participants,
             iouType,
             initialTransaction,
+            iouRequestType,
             initialTransactionID,
-            reportID,
             waitForKeyboardDismiss,
             transactions,
             isMovingTransactionFromTrackExpense,
             allPolicies,
             policyForMovingExpenses,
             introSelected,
+            reportID,
             backTo,
             selfDMReportID,
         ],


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
<!-- Explain what your change does and how it addresses the linked issue -->
Update create transaction Manual flow to ask for merchant after asking for amount
### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/76050
PROPOSAL: https://github.com/Expensify/App/issues/76050#issuecomment-3576983184


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

 ## Pre-requisites
 * Have at least one workspace with a policy expense chat
 * Have access to a personal (P2P) chat
 * Set up a default workspace in settings
 
 ## Test Case 1: Manual Expense from Workspace Chat (Primary Flow)
 **Steps:**
 
 1. Open a workspace expense chat
 2. Tap the **+** button in the composer
 3. Select **Create expense** → **Manual** tab
 4. Enter an amount (e.g., $50) and tap **Next**
 5. **Expected:** You should be navigated to the **Merchant** step
 6. Enter a merchant name and tap **Save**
 7. **Expected:** You should be navigated to the **Confirmation** page
 8. Tap the back button on the Confirmation page
 9. **Expected:** You should go back to the **Merchant** page (not Amount)
 10. Tap the back button on the Merchant page
 11. **Expected:** You should go back to the **Amount** page
 12. Enter an amount (e.g., $50) and tap **Next**
 13. **Expected:** You should be navigated to the **Confirmation** page
 
 ## Test Case 2: Global Create with Default Workspace
 **Steps:**
 
 1. Set a workspace as your default (Settings → Workspaces → select one as default)
 2. Tap the global **+** button
 3. Select **Create expense** → **Manual** tab
 4. Enter an amount and tap **Next**
 5. **Expected:** You should be navigated to the **Merchant** step
 6. Enter a merchant and tap **Save**
 7. **Expected:** You should be navigated to the **Confirmation** page
 8. Tap the back button on the Confirmation page
 9. **Expected:** You should go back to the **Merchant** page (not Amount)
 10. Tap the back button on the Merchant page
 11. **Expected:** You should go back to the **Amount** page
 12. Enter an amount (e.g., $50) and tap **Next**
 13. **Expected:** You should be navigated to the **Confirmation** page
 
 ## Test Case 3: Global Create without Default Workspace (Participants Flow)
 **Steps:**
 
 1. Remove any default workspace or use an account with a personal policy only
 2. From any screen, tap the global **+** button
 3. Select **Create expense** → **Manual** tab
 4. Enter an amount and tap **Next**
 5. **Expected:** You should be navigated to the **Participants** step
 6. Select a **workspace expense chat** as the participant
 7. Tap **Next**
 8. **Expected:** You should be navigated to the **Merchant** step
 9. Enter a merchant and tap **Save**
 10. **Expected:** You should be navigated to the **Confirmation** page
 11. Verify back navigation (**Confirmation → Merchant → Participants**)
 
 ## Test Case 4: P2P (Personal) Transaction – No Merchant Step
 **Steps:**
 
 1. Open a personal 1:1 chat (not a workspace chat)
 2. Tap the **+** button
 3. Select **Create expense** → **Manual** tab
 4. Enter an amount and tap **Next**
 5. **Expected:** You should be navigated directly to the **Confirmation** page (no Merchant step)
 
 ## Test Case 5: Scan Request – No Merchant Step
 **Steps:**
 
 1. Open a workspace expense chat
 2. Tap the **+** button
 3. Select **Create expense** → **Scan** tab
 4. Add a receipt
 5. **Expected:** You should be navigated to the **Confirmation** page (no Merchant step before confirmation)
 6. Repeat using the global **+** button → Participants → select a workspace
 7. **Expected:** There should still be no Merchant step for scan requests
 
 ## Test Case 6: Participants – Select Personal Chat (No Merchant Step)
 **Steps:**
 
 1. From global **+** → **Create expense** → **Manual** tab
 2. Enter an amount and tap **Next**
 3. On the Participants step, select a **user** (not a workspace)
 4. Tap **Next**
 5. **Expected:** You should be navigated directly to the **Confirmation** page (no Merchant step)
 
 ## Test Case 7: Self DM Expense – Move to Workspace (Without Merchant)
 **Steps:**
 
 1. Go to your Self DM (personal chat with yourself)
 2. Tap **+** → **Create expense** → **Manual** tab
 3. Enter an amount and complete the expense (without merchant)
 4. Tap it and choose **Submit** or **Categorize** to move it to a workspace
 5. Select a workspace
 6. **Expected:** You should be navigated to the **Merchant** step
 7. Tap the back button on the merchant page
 8. **Expected:** You should go back to the ** Participants** page
 9. Select a P2P chat
 10. **Expected:** You should be navigated to the **Confirmation** page
 11. Tap the back button on the Confirmation page
 12. **Expected:** You should go back to the **Participants** page (not Merchant)
 13. Select a workspace
 14. **Expected:** You should be navigated to the **Merchant** step
 
 ## Test Case 8: Self DM Expense – Move to Workspace (With Merchant)
 **Steps:**
 
 1. Go to your Self DM (personal chat with yourself)
 2. Tap **+** → **Create expense** → **Manual** tab
 3. Enter an amount and complete the expense (with merchant)
 4. Tap it and choose **Submit** or **Categorize** to move it to a workspace
 5. Select a workspace
 6. **Expected:** You should be navigated to the **Confirmation** page
 7. Tap the back button on the Confirmation page
 8. **Expected:** You should go back to the **Participants** page
 9. Select a P2P chat
 10. **Expected:** You should be navigated to the **Confirmation** page
 11. Clear the merchant and tap **Save**
 12. Tap the back button on the Confirmation page
 13. **Expected:** You should go back to the **Participants** page
 14. Select a workspace
 15. **Expected:** You should be navigated to the **Merchant** step
 
 ## Test Case 9: Track Expense from Workspace Chat and FAB (Both)
 **Steps:**
 
 1. Open a workspace expense chat
 2. Tap the **+** button in the composer
 3. Select **Track expense** → **Map** tab
 4. Select waypoints and tap **Next**
 5. **Expected:** You should be navigated to the **Confirmation** page
 
 ## Test Case 10: Track Expense (Manual) from Workspace Chat and FAB (Both)
 **Steps:**
 
 1. Open a workspace expense chat
 2. Tap the **+** button in the composer
 3. Select **Track expense** → **Manual** tab
 4. Enter distance and tap **Next**
 5. **Expected:** You should be navigated to the **Confirmation** page



- https://github.com/Expensify/App/issues/80291

Precondition:

- Workspace has per diem rates.

1. Go to workspace chat.
2. Create a per diem expense.
3. Open the per diem expense.
4. Go to self DM.
5. Open the unreported per diem expense.
6. Click Report > Remove from report/
7. Click on the report header > Submit it to someone.
8. Select any participant
9. Verify that the merchant step isn't displayed

- https://github.com/Expensify/App/issues/80283

1. Go to workspace chat.
2. Create an empty report.
3. Open the empty report.
4. Click Add expense > Create expense > Manual.
5. Enter amount > Next.
6. Verify that the merchant page is displayed

- https://github.com/Expensify/App/issues/80284

Precondition:

- User has received an invoice.

1. Open FAB > Send invoice.
2. Enter amount > Next.
3. Enter merchant > Next.
4. Select user.
5. On confirm page, click Send invoice.
6. On invoice room, click + > Send invoice.
7. Enter amount > Next.
8. Verify that the merchant step isn't displayed in both cases

- https://github.com/Expensify/App/issues/80280

1. Go to self DM.
2. Create a manual or map distance expense.
3. Click Submit it to someone.
4. Select workspace chat.
5. Verify that the merchant step isn't displayed

- https://github.com/Expensify/App/issues/80279

1. Go to self DM.
2. Create a manual expense with merchant.
3. Click Submit it to someone.
4. Select workspace chat.
5. Verify that the merchant step isn't displayed.

- https://github.com/Expensify/App/issues/80282

Precondition:

- User has a workspace.

1. Open FAB > Create expense > Manual.
2. Enter amount > Next.
3. Enter merchant > Next.
4. On confirm page, click To field.
5. Select a user (not self DM).
6. Verify that the merchant step isn't displayed

- https://github.com/Expensify/App/issues/82131

1. Go to workspace chat.
2. Create an empty report.
3. On the report preview, click Add expense > Create expense.
4. Create a manual expense.
5. Verify that the user stays on the workspace chat

- https://github.com/Expensify/App/issues/82107

Precondition:

- Time tracking is enabled in the workspace.

1. Go to workspace chat.
2. Create a time expense.
3. Open the time expense.
4. Click Report > Remove from report.
5. Go to self DM.
6. Open the time expense.
7. Click on the header > Submit it to someone.
8. Enter email and select user.
9. On confirm page, click Merchant.
10. Clear the merchant and save it.
11. Click RHP back button.
12. Select workspace chat
13. Verify that the merchant step is opened

- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->
Same
### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
7. Upload an image via copy paste
10. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->

Same as test

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I verified there are no new alerts related to the `canBeMissing` param for `useOnyx`
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>


https://github.com/user-attachments/assets/dc917217-489c-4228-8169-ad805eeb2842


<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>


https://github.com/user-attachments/assets/9c53bb5f-8792-4875-a884-8f75aecba672


<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

https://github.com/user-attachments/assets/d0f6d2fe-475d-49c9-8f18-a7b58f9b79f8

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>


https://github.com/user-attachments/assets/22e279b7-a71c-45d7-ae58-0ac14e970da0


<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

https://github.com/user-attachments/assets/e4a2c0bb-281a-4a33-9f68-4e540c6ac766


https://github.com/user-attachments/assets/d9f0fcfa-f287-4b7e-be59-d31576ec0c5f



https://github.com/user-attachments/assets/312fb3bb-8568-4027-93e4-262944da4fd4


https://github.com/user-attachments/assets/92a42697-d6b8-4ee9-8a7a-adf8d0e16da6


https://github.com/user-attachments/assets/065478e5-4965-4b4a-8273-71b462d0e5ff


https://github.com/user-attachments/assets/5f23f66e-6718-423f-a61a-b7e30e74fd4c


https://github.com/user-attachments/assets/4c89ec39-1a34-4536-a1e2-36cde75fd751


https://github.com/user-attachments/assets/f4f3eb23-30ee-4b37-a343-eb2afed6f897



https://github.com/user-attachments/assets/a8af94f0-97cd-4e9b-9e14-807627f6684b


https://github.com/user-attachments/assets/42ddf7e1-ce97-4a90-b862-eb2fa5392bb5


<!-- add screenshots or videos here -->

</details>




