### PR TITLE
Limit fallback image rendering and add priority to reduce carousel lo…

### DIFF
--- a/src/CONST/index.ts
+++ b/src/CONST/index.ts
@@ -2201,6 +2201,12 @@ const CONST = {
         INITIAL: 'initial',
     },
 
+    IMAGE_LOADING_PRIORITY: {
+        LOW: 'low',
+        NORMAL: 'normal',
+        HIGH: 'high',
+    },
+
     FILE_TYPE_REGEX: {
         // Image MimeTypes allowed by iOS photos app.
         IMAGE: /\.(jpg|jpeg|png|webp|gif|tiff|bmp|heic|heif)$/,

--- a/src/components/Image/types.ts
+++ b/src/components/Image/types.ts
@@ -31,7 +31,7 @@ type BaseImageProps = {
     /** Priorities for completing loads. If more than one load is queued at a time,
      *  the load with the higher priority will be started first.
      *  Maps to SDWebImageHighPriority (iOS) and Glide.Priority.IMMEDIATE (Android). */
-    priority?: 'low' | 'normal' | 'high' | null;
+    priority?: ValueOf<typeof CONST.IMAGE_LOADING_PRIORITY> | null;
 };
 
 type ImageOwnProps = BaseImageProps & {

--- a/src/components/Image/types.ts
+++ b/src/components/Image/types.ts
@@ -27,6 +27,11 @@ type BaseImageProps = {
 
     /** The image cache policy */
     cachePolicy?: ImagePrefetchOptions['cachePolicy'];
+
+    /** Priorities for completing loads. If more than one load is queued at a time,
+     *  the load with the higher priority will be started first.
+     *  Maps to SDWebImageHighPriority (iOS) and Glide.Priority.IMMEDIATE (Android). */
+    priority?: 'low' | 'normal' | 'high' | null;
 };
 
 type ImageOwnProps = BaseImageProps & {

--- a/src/components/Lightbox/index.tsx
+++ b/src/components/Lightbox/index.tsx
@@ -20,6 +20,8 @@ import CONST from '@src/CONST';
 import type {Dimensions} from '@src/types/utils/Layout';
 import NUMBER_OF_CONCURRENT_LIGHTBOXES from './numberOfConcurrentLightboxes';
 
+const FALLBACK_OFFSET = 2;
+
 const cachedImageDimensions = new Map<string, Dimensions | undefined>();
 
 type LightboxProps = Pick<Attachment, 'attachmentID'> & {
@@ -144,10 +146,21 @@ function Lightbox({attachmentID, isAuthTokenRequired = false, uri, onScaleChange
         const indexOutOfRange = page > activePage + indexCanvasOffset || page < activePage - indexCanvasOffset;
         return !indexOutOfRange;
     }, [activePage, hasSiblingCarouselItems, page]);
+
+    // Limits fallback image rendering to only a few pages around the active page.
+    // This prevents distant carousel items from queuing unnecessary image downloads,
+    // which would starve the active image of network bandwidth.
+    const isFallbackInRange = useMemo(() => {
+        if (!hasSiblingCarouselItems) {
+            return true;
+        }
+        return Math.abs(page - activePage) <= FALLBACK_OFFSET;
+    }, [activePage, hasSiblingCarouselItems, page]);
+
     const [isLightboxImageLoaded, setLightboxImageLoaded] = useState(false);
     const [isLoading, setIsLoading] = useState(true);
 
-    const [isFallbackVisible, setFallbackVisible] = useState(!isLightboxVisible);
+    const [isFallbackVisible, setFallbackVisible] = useState(!isLightboxVisible && isFallbackInRange);
     const [isFallbackImageLoaded, setFallbackImageLoaded] = useState(false);
     const previousUri = usePrevious(uri);
 
@@ -214,10 +227,11 @@ function Lightbox({attachmentID, isAuthTokenRequired = false, uri, onScaleChange
         }
 
         // If the carousel item has become inactive and the lightbox is not continued to be rendered, we want to show the fallback image
+        // but only if the page is within the fallback range to avoid unnecessary image downloads
         if (!isActive && !isLightboxVisible) {
-            setFallbackVisible(true);
+            setFallbackVisible(isFallbackInRange);
         }
-    }, [hasSiblingCarouselItems, isActive, isFallbackVisible, isLightboxImageLoaded, isLightboxVisible]);
+    }, [hasSiblingCarouselItems, isActive, isFallbackInRange, isFallbackVisible, isLightboxImageLoaded, isLightboxVisible]);
 
     const scaleChange = useCallback(
         (scale: number) => {
@@ -226,6 +240,16 @@ function Lightbox({attachmentID, isAuthTokenRequired = false, uri, onScaleChange
         },
         [onScaleChangedContext, onScaleChangedProp],
     );
+
+    const imagePriority = useMemo(() => {
+        if (isActive) {
+            return 'high' as const;
+        }
+        if (isLightboxVisible) {
+            return 'normal' as const;
+        }
+        return 'low' as const;
+    }, [isActive, isLightboxVisible]);
 
     const isALocalFile = isLocalFile(uri);
     const shouldShowOfflineIndicator = isOffline && !isLoading && !isALocalFile;
@@ -257,6 +281,7 @@ function Lightbox({attachmentID, isAuthTokenRequired = false, uri, onScaleChange
                                     source={{uri}}
                                     style={[contentSize ?? styles.invisibleImage]}
                                     isAuthTokenRequired={isAuthTokenRequired}
+                                    priority={imagePriority}
                                     onError={onError}
                                     onLoad={(e) => {
                                         updateContentSize(e);
@@ -279,13 +304,14 @@ function Lightbox({attachmentID, isAuthTokenRequired = false, uri, onScaleChange
                     )}
 
                     {/* Keep rendering the image without gestures as fallback if the carousel item is not active and while the lightbox is loading the image */}
-                    {isFallbackVisible && (
+                    {isFallbackVisible && isFallbackInRange && (
                         <View style={StyleUtils.getFullscreenCenteredContentStyles()}>
                             <Image
                                 source={{uri}}
                                 resizeMode="contain"
                                 style={[fallbackSize ?? styles.invisibleImage]}
                                 isAuthTokenRequired={isAuthTokenRequired}
+                                priority={imagePriority}
                                 onLoad={(e) => {
                                     updateContentSize(e);
                                     setFallbackImageLoaded(true);

--- a/src/components/Lightbox/index.tsx
+++ b/src/components/Lightbox/index.tsx
@@ -243,12 +243,12 @@ function Lightbox({attachmentID, isAuthTokenRequired = false, uri, onScaleChange
 
     const imagePriority = useMemo(() => {
         if (isActive) {
-            return 'high' as const;
+            return CONST.IMAGE_LOADING_PRIORITY.HIGH;
         }
         if (isLightboxVisible) {
-            return 'normal' as const;
+            return CONST.IMAGE_LOADING_PRIORITY.NORMAL;
         }
-        return 'low' as const;
+        return CONST.IMAGE_LOADING_PRIORITY.LOW;
     }, [isActive, isLightboxVisible]);
 
     const isALocalFile = isLocalFile(uri);

--- a/tests/unit/LightboxTest.tsx
+++ b/tests/unit/LightboxTest.tsx
@@ -21,7 +21,7 @@ jest.mock('@components/Image', () => {
         });
     }
     return {
-        // eslint-disable-next-line @typescript-eslint/naming-convention
+        // eslint-disable-next-line @typescript-eslint/naming-convention -- __esModule is required by Jest to properly mock ES modules with default exports
         __esModule: true,
         default: MockReact.memo(MockImage),
     };
@@ -31,7 +31,7 @@ jest.mock('@components/MultiGestureCanvas', () => {
     const MockReact = require('react') as typeof React;
     const {View} = require('react-native') as {View: typeof RNView};
     return {
-        // eslint-disable-next-line @typescript-eslint/naming-convention
+        // eslint-disable-next-line @typescript-eslint/naming-convention -- __esModule is required by Jest to properly mock ES modules with default exports
         __esModule: true,
         default: ({children}: {children: React.ReactNode}) => MockReact.createElement(View, {testID: 'multi-gesture-canvas'}, children),
         DEFAULT_ZOOM_RANGE: {min: 1, max: 5},

--- a/tests/unit/LightboxTest.tsx
+++ b/tests/unit/LightboxTest.tsx
@@ -27,6 +27,12 @@ jest.mock('@components/Image', () => {
     };
 });
 
+jest.mock('@components/Lightbox/numberOfConcurrentLightboxes', () => ({
+    // eslint-disable-next-line @typescript-eslint/naming-convention -- __esModule is required by Jest to properly mock ES modules with default exports
+    __esModule: true,
+    default: 3,
+}));
+
 jest.mock('@components/MultiGestureCanvas', () => {
     const MockReact = require('react') as typeof React;
     const {View} = require('react-native') as {View: typeof RNView};
@@ -129,6 +135,18 @@ describe('Lightbox', () => {
             expect(images.length).toBeGreaterThan(0);
             for (const image of images) {
                 expect(image.props.accessibilityHint).toBe(CONST.IMAGE_LOADING_PRIORITY.HIGH);
+            }
+        });
+
+        it('should assign NORMAL priority to non-active pages within the lightbox visible range', async () => {
+            const contextValue = createContextValue(5, 30);
+
+            await renderLightboxInCarousel('attachment-4', TEST_URI, contextValue);
+
+            const images = screen.getAllByTestId('image');
+            expect(images.length).toBeGreaterThan(0);
+            for (const image of images) {
+                expect(image.props.accessibilityHint).toBe(CONST.IMAGE_LOADING_PRIORITY.NORMAL);
             }
         });
 

--- a/tests/unit/LightboxTest.tsx
+++ b/tests/unit/LightboxTest.tsx
@@ -1,0 +1,144 @@
+import {fireEvent, render, screen} from '@testing-library/react-native';
+import React from 'react';
+import type {SharedValue} from 'react-native-reanimated';
+import AttachmentCarouselPagerContext from '@components/Attachments/AttachmentCarousel/Pager/AttachmentCarouselPagerContext';
+import type {AttachmentCarouselPagerContextValue} from '@components/Attachments/AttachmentCarousel/Pager/AttachmentCarouselPagerContext';
+import Lightbox from '@components/Lightbox';
+import CONST from '@src/CONST';
+import waitForBatchedUpdatesWithAct from '../utils/waitForBatchedUpdatesWithAct';
+
+const TEST_URI = 'https://example.com/image.png';
+
+jest.mock('@components/Image', () => {
+    const MockReact = require('react');
+    const {View} = require('react-native');
+    function MockImage({priority, testID, ...props}: {priority?: string; testID?: string}) {
+        return MockReact.createElement(View, {
+            testID: testID ?? 'image',
+            accessibilityHint: priority ?? 'none',
+            ...props,
+        });
+    }
+    return {
+        __esModule: true,
+        default: MockReact.memo(MockImage),
+    };
+});
+
+jest.mock('@components/MultiGestureCanvas', () => {
+    const MockReact = require('react');
+    const {View} = require('react-native');
+    return {
+        __esModule: true,
+        default: ({children}: {children: unknown}) => MockReact.createElement(View, {testID: 'multi-gesture-canvas'}, children),
+        DEFAULT_ZOOM_RANGE: {min: 1, max: 5},
+    };
+});
+
+function createSharedValue<T>(value: T): SharedValue<T> {
+    return {
+        value,
+        get: jest.fn(() => value),
+        set: jest.fn(),
+        addListener: jest.fn(),
+        removeListener: jest.fn(),
+        modify: jest.fn(),
+    } as unknown as SharedValue<T>;
+}
+
+function createPagerItems(count: number) {
+    return Array.from({length: count}, (_, i) => ({
+        source: `https://example.com/image-${i}.png`,
+        previewSource: `https://example.com/image-${i}-preview.png`,
+        index: i,
+        isActive: false,
+        attachmentID: `attachment-${i}`,
+    }));
+}
+
+function createContextValue(activePage: number, itemCount: number): AttachmentCarouselPagerContextValue {
+    return {
+        pagerItems: createPagerItems(itemCount),
+        activePage,
+        isPagerScrolling: createSharedValue(false),
+        isScrollEnabled: createSharedValue(true),
+        pagerRef: {current: null},
+        onTap: jest.fn(),
+        onScaleChanged: jest.fn(),
+        onSwipeDown: jest.fn(),
+    };
+}
+
+async function renderLightboxInCarousel(attachmentID: string, uri: string, contextValue: AttachmentCarouselPagerContextValue) {
+    render(
+        <AttachmentCarouselPagerContext.Provider value={contextValue}>
+            <Lightbox
+                attachmentID={attachmentID}
+                uri={uri}
+            />
+        </AttachmentCarouselPagerContext.Provider>,
+    );
+
+    await waitForBatchedUpdatesWithAct();
+
+    fireEvent(screen.getByTestId('lightbox-wrapper'), 'onLayout', {
+        nativeEvent: {layout: {width: 400, height: 800}},
+    });
+
+    await waitForBatchedUpdatesWithAct();
+}
+
+describe('Lightbox', () => {
+    describe('fallback rendering range', () => {
+        it('should not render any image for distant pages outside FALLBACK_OFFSET range', async () => {
+            const contextValue = createContextValue(15, 30);
+
+            await renderLightboxInCarousel('attachment-0', TEST_URI, contextValue);
+
+            expect(screen.queryAllByTestId('image')).toHaveLength(0);
+        });
+
+        it('should render fallback image for pages within FALLBACK_OFFSET range', async () => {
+            const contextValue = createContextValue(15, 30);
+
+            await renderLightboxInCarousel('attachment-13', TEST_URI, contextValue);
+
+            expect(screen.queryAllByTestId('image').length).toBeGreaterThan(0);
+        });
+
+        it('should render lightbox image for the active page', async () => {
+            const contextValue = createContextValue(15, 30);
+
+            await renderLightboxInCarousel('attachment-15', TEST_URI, contextValue);
+
+            expect(screen.queryByTestId('multi-gesture-canvas')).not.toBeNull();
+            expect(screen.queryAllByTestId('image').length).toBeGreaterThan(0);
+        });
+    });
+
+    describe('image priority', () => {
+        it('should assign HIGH priority to the active page image', async () => {
+            const contextValue = createContextValue(5, 30);
+
+            await renderLightboxInCarousel('attachment-5', TEST_URI, contextValue);
+
+            const images = screen.queryAllByTestId('image');
+            expect(images.length).toBeGreaterThan(0);
+            images.forEach((image) => {
+                expect(image.props.accessibilityHint).toBe(CONST.IMAGE_LOADING_PRIORITY.HIGH);
+            });
+        });
+
+        it('should assign LOW priority to fallback images outside the lightbox window', async () => {
+            const contextValue = createContextValue(15, 30);
+
+            await renderLightboxInCarousel('attachment-13', TEST_URI, contextValue);
+
+            const images = screen.queryAllByTestId('image');
+            expect(images.length).toBeGreaterThan(0);
+            images.forEach((image) => {
+                expect(image.props.accessibilityHint).toBe(CONST.IMAGE_LOADING_PRIORITY.LOW);
+            });
+        });
+    });
+});

--- a/tests/unit/LightboxTest.tsx
+++ b/tests/unit/LightboxTest.tsx
@@ -1,5 +1,6 @@
 import {fireEvent, render, screen} from '@testing-library/react-native';
 import React from 'react';
+import type {View as RNView} from 'react-native';
 import type {SharedValue} from 'react-native-reanimated';
 import AttachmentCarouselPagerContext from '@components/Attachments/AttachmentCarousel/Pager/AttachmentCarouselPagerContext';
 import type {AttachmentCarouselPagerContextValue} from '@components/Attachments/AttachmentCarousel/Pager/AttachmentCarouselPagerContext';
@@ -10,8 +11,8 @@ import waitForBatchedUpdatesWithAct from '../utils/waitForBatchedUpdatesWithAct'
 const TEST_URI = 'https://example.com/image.png';
 
 jest.mock('@components/Image', () => {
-    const MockReact = require('react');
-    const {View} = require('react-native');
+    const MockReact = require('react') as typeof React;
+    const {View} = require('react-native') as {View: typeof RNView};
     function MockImage({priority, testID, ...props}: {priority?: string; testID?: string}) {
         return MockReact.createElement(View, {
             testID: testID ?? 'image',
@@ -20,17 +21,19 @@ jest.mock('@components/Image', () => {
         });
     }
     return {
+        // eslint-disable-next-line @typescript-eslint/naming-convention
         __esModule: true,
         default: MockReact.memo(MockImage),
     };
 });
 
 jest.mock('@components/MultiGestureCanvas', () => {
-    const MockReact = require('react');
-    const {View} = require('react-native');
+    const MockReact = require('react') as typeof React;
+    const {View} = require('react-native') as {View: typeof RNView};
     return {
+        // eslint-disable-next-line @typescript-eslint/naming-convention
         __esModule: true,
-        default: ({children}: {children: unknown}) => MockReact.createElement(View, {testID: 'multi-gesture-canvas'}, children),
+        default: ({children}: {children: React.ReactNode}) => MockReact.createElement(View, {testID: 'multi-gesture-canvas'}, children),
         DEFAULT_ZOOM_RANGE: {min: 1, max: 5},
     };
 });
@@ -103,7 +106,7 @@ describe('Lightbox', () => {
 
             await renderLightboxInCarousel('attachment-13', TEST_URI, contextValue);
 
-            expect(screen.queryAllByTestId('image').length).toBeGreaterThan(0);
+            expect(screen.getAllByTestId('image').length).toBeGreaterThan(0);
         });
 
         it('should render lightbox image for the active page', async () => {
@@ -111,8 +114,8 @@ describe('Lightbox', () => {
 
             await renderLightboxInCarousel('attachment-15', TEST_URI, contextValue);
 
-            expect(screen.queryByTestId('multi-gesture-canvas')).not.toBeNull();
-            expect(screen.queryAllByTestId('image').length).toBeGreaterThan(0);
+            expect(screen.getByTestId('multi-gesture-canvas')).toBeTruthy();
+            expect(screen.getAllByTestId('image').length).toBeGreaterThan(0);
         });
     });
 
@@ -122,11 +125,11 @@ describe('Lightbox', () => {
 
             await renderLightboxInCarousel('attachment-5', TEST_URI, contextValue);
 
-            const images = screen.queryAllByTestId('image');
+            const images = screen.getAllByTestId('image');
             expect(images.length).toBeGreaterThan(0);
-            images.forEach((image) => {
+            for (const image of images) {
                 expect(image.props.accessibilityHint).toBe(CONST.IMAGE_LOADING_PRIORITY.HIGH);
-            });
+            }
         });
 
         it('should assign LOW priority to fallback images outside the lightbox window', async () => {
@@ -134,11 +137,11 @@ describe('Lightbox', () => {
 
             await renderLightboxInCarousel('attachment-13', TEST_URI, contextValue);
 
-            const images = screen.queryAllByTestId('image');
+            const images = screen.getAllByTestId('image');
             expect(images.length).toBeGreaterThan(0);
-            images.forEach((image) => {
+            for (const image of images) {
                 expect(image.props.accessibilityHint).toBe(CONST.IMAGE_LOADING_PRIORITY.LOW);
-            });
+            }
         });
     });
 });


### PR DESCRIPTION

<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
<!-- Explain what your change does and how it addresses the linked issue -->

Previously, Lightbox rendered a fallback <Image> for every carousel page outside the lightbox window. In a 50-image carousel, this meant ~47 unnecessary image downloads queued simultaneously, starving the active image of network bandwidth (SDWebImage processes downloads FIFO with 3 concurrent slots).

This PR adds two fixes:

Bounded fallback window — limits fallback image rendering to ±2 pages around the active page (FALLBACK_OFFSET), reducing total mounted <Image> components from ~50 to ~5.
Image loading priority — passes expo-image priority prop so the active image downloads first (high), adjacent lightbox pages next (normal), and fallback images last (low).

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ #81250
PROPOSAL:

Proposal: Eliminate Bandwidth Starvation in Attachment Carousel Loading

Background
The Expensify mobile application uses a Lightbox component to display full-screen expense receipts and attachments in a horizontally swipeable carousel. To enable smooth swiping between images, the carousel renders the current attachment as well as several adjacent pages.

Problem
When a user opens an attachment carousel in a chat page, if the application simultaneously initiates multiple attachments downloads for all adjacent carousel items, then the active attachment's download speed is throttled by network contention, resulting in a several-second delay before the user can read the attachment.

Solution
We will implement intelligent image loading prioritization and bandwidth management to ensure the active attachment always has the highest throughput.

Introduce Image Priority: Add a priority prop to the base Image component that accepts 'low', 'normal', or 'high'.Limit Fallback Render Range: Introduce a range constraint (FALLBACK_OFFSET = 2) that prevents Lightbox from rendering its fallback <Image> component for pages more than two positions away from the user's current view. The Lightbox component itself remains mounted on all pages, but distant ones simply do not render an Image — and therefore do not initiate any network requests.Dynamic Priority Assignment:Assign High priority to the active page.Assign Normal priority to pages within the lightbox window (±1 on iOS, ±0 on Android).Assign Low priority to pages within the fallback range (±2) but outside the lightbox window.Pages outside the fallback range render no Image component at all.Conditional Rendering: Update the Lightbox logic to strictly enforce that distant carousel items do not mount their Image components until they move within the permitted look-ahead range, using both a synchronous useMemo guard and an asynchronous state flag for defense-in-depth during fast swipe sequences.


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

- [x] Open a chat room that has many image attachments (30+)
- [x] Tap on the first image in the conversation to open the attachment carousel — verify the image loads within 1-2 seconds
- [x] Close the carousel and navigate away from the chat, hard refresh the app, then re-enter it
- [x] Tap on an image in the middle of the conversation — verify the image loads within 1-2 seconds
- [x] Close the carousel and navigate away from the chat, hard refresh the app, then re-enter it
- [x] Tap on the last image in the conversation — verify the image loads within 1-2 seconds (previously took 4-5+ seconds for distant images)
- [x] In each case, swipe left/right — adjacent images should appear immediately or with minimal delay
- [x] Verify zoom/pan gestures work correctly on the active image
- [x] Verify no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->

Same as tests

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data xis not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I verified there are no new alerts related to the `canBeMissing` param for `useOnyx`
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->


https://github.com/user-attachments/assets/2fcbb193-1671-445f-a922-001ac04b88f9




</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

https://github.com/user-attachments/assets/e43bacae-4801-4a10-a662-9c261372a464


<!-- add screenshots or videos here -->

</details>