### PR TITLE
Fix: Make Add expense button width more appropriate in empty state

### DIFF
--- a/src/components/EmptyStateComponent/index.tsx
+++ b/src/components/EmptyStateComponent/index.tsx
@@ -122,7 +122,7 @@ function EmptyStateComponent({
                                             customText={buttonText}
                                             options={dropDownOptions}
                                             isSplitButton={false}
-                                            style={[styles.flex1, style]}
+                                            style={[shouldUseNarrowLayout ? styles.flex1 : styles.alignSelfCenter, style]}
                                         />
                                     ) : (
                                         <Button


### PR DESCRIPTION
## Summary
Fixes issue #82108 where the Add expense button in the empty state feels unnecessarily wide on desktop/tablet screens.

## Changes
- Modified EmptyStateComponent to use responsive button styling
- Wide screens: Uses alignSelfCenter for natural button width
- Narrow screens: Keeps flex1 for better mobile touch targets

## Technical Details
Changed line 125 in src/components/EmptyStateComponent/index.tsx:


## Testing
- Button now has appropriate width on desktop/tablet
- Mobile experience unchanged
- No side effects on other components

## Screenshots
Before: Button stretched across full width
After: Button has natural width fitting content

$ #82108