### PR TITLE
Fix empty Time Sensitive section showing on Home page

### DIFF
--- a/src/pages/home/TimeSensitiveSection/index.tsx
+++ b/src/pages/home/TimeSensitiveSection/index.tsx
@@ -109,8 +109,17 @@ function TimeSensitiveSection() {
 
     const hasBrokenCompanyCards = brokenCompanyCardConnections.length > 0;
     const hasBrokenAccountingConnections = brokenAccountingConnections.length > 0;
+    // This guard must exactly match the conditions used to render each widget below.
+    // If a widget has additional conditions in the render (e.g. && !!discountInfo), those
+    // must be reflected here to avoid showing an empty "Time sensitive" section.
     const hasAnyTimeSensitiveContent =
-        shouldShowReviewCardFraud || shouldShow50off || shouldShow25off || hasBrokenCompanyCards || hasBrokenAccountingConnections || shouldShowAddShippingAddress || shouldShowActivateCard;
+        shouldShowReviewCardFraud ||
+        shouldShow50off ||
+        (shouldShow25off && !!discountInfo) ||
+        hasBrokenCompanyCards ||
+        hasBrokenAccountingConnections ||
+        shouldShowAddShippingAddress ||
+        shouldShowActivateCard;
 
     if (!hasAnyTimeSensitiveContent) {
         return null;

--- a/src/selectors/Card.ts
+++ b/src/selectors/Card.ts
@@ -103,8 +103,10 @@ const timeSensitiveCardsSelector = (cards: OnyxEntry<CardList>): TimeSensitiveCa
             continue;
         }
 
-        // Check for fraud on any Expensify card (physical or virtual)
-        if (isCardWithPotentialFraud(card)) {
+        // Check for fraud on any Expensify card (physical or virtual).
+        // Only include cards that have complete possibleFraud data with a valid fraudAlertReportID,
+        // since without these the ReviewCardFraud widget cannot render anything meaningful.
+        if (isCardWithPotentialFraud(card) && card.nameValuePairs?.possibleFraud?.fraudAlertReportID) {
             result.cardsWithFraud.push(card);
         }
 


### PR DESCRIPTION
### Explanation of Change

The Time Sensitive section on the Home page could render as an empty block (title with no widgets) when the visibility guard `hasAnyTimeSensitiveContent` evaluated to `true` but all child widgets returned `null`.

**Root cause:** `timeSensitiveCardsSelector` included fraud cards that had the `card.fraud` flag set (e.g. `'domain'`) but lacked the `possibleFraud` data or a valid `fraudAlertReportID` that the `ReviewCardFraud` widget needs to actually render. The guard said "show the section" while every child returned null.

**Fix (3 changes):**
1. **Tighten `timeSensitiveCardsSelector`** — only include fraud cards that have complete `possibleFraud` data with a valid `fraudAlertReportID`
2. **Align `hasAnyTimeSensitiveContent` guard** — make every condition in the guard match the exact render conditions (e.g. `shouldShow25off && !!discountInfo` instead of just `shouldShow25off`)
3. **Add 6 unit tests** covering the exact edge cases: fraud flag without possibleFraud data, missing fraudAlertReportID, zero fraudAlertReportID, mixed complete/incomplete cards

### Fixed Issues

$ https://github.com/Expensify/App/issues/82401

### Tests

1. Have an Expensify card with `fraud` flag set to `'domain'` or `'individual'` but without `possibleFraud` NVP data
2. Navigate to Home page
3. Verify the Time Sensitive section does NOT appear (previously it showed an empty block)
4. Have a card with complete fraud data (possibleFraud + valid fraudAlertReportID)
5. Verify the Time Sensitive section appears with the ReviewCardFraud widget

- [x] Verify that no errors appear in the JS console
- [x] Unit tests pass: `npx jest tests/unit/selectors/CardTest.ts` (47 tests, all passing)

### Offline tests

N/A — this is a display-only fix for guard/render condition alignment.

### QA Steps

1. Log in with an account that has an Expensify card flagged for fraud
2. Navigate to Home page  
3. Verify the Time Sensitive section only appears if there is a valid fraud alert widget to show
4. If no time-sensitive items exist, verify the section is completely hidden (no empty block)

____

Overall, verify all the time-sensitive actions work as expected

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I verified there are no new alerts related to the `canBeMissing` param for `useOnyx`
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>