### PR TITLE
Fix: Make Add expense button width more appropriate in empty state

### DIFF
--- a/fix.patch
+++ b/fix.patch
@@ -1,0 +1,13 @@
+diff --git a/src/components/EmptyStateComponent/index.tsx b/src/components/EmptyStateComponent/index.tsx
+index ced3a20..2e6158e 100644
+--- a/src/components/EmptyStateComponent/index.tsx
++++ b/src/components/EmptyStateComponent/index.tsx
+@@ -122,7 +122,7 @@ function EmptyStateComponent({
+                                             customText={buttonText}
+                                             options={dropDownOptions}
+                                             isSplitButton={false}
+-                                            style={[styles.flex1, style]}
++                                            style={[shouldUseNarrowLayout ? styles.flex1 : styles.alignSelfCenter, style]}
+                                         />
+                                     ) : (
+                                         <Button

--- a/src/components/EmptyStateComponent/index.tsx
+++ b/src/components/EmptyStateComponent/index.tsx
@@ -122,7 +122,7 @@ function EmptyStateComponent({
                                             customText={buttonText}
                                             options={dropDownOptions}
                                             isSplitButton={false}
-                                            style={[styles.flex1, style]}
+                                            style={[shouldUseNarrowLayout ? styles.flex1 : styles.alignSelfCenter, style]}
                                         />
                                     ) : (
                                         <Button


### PR DESCRIPTION
## Summary
This PR fixes the issue where the "Add expense" button in empty state components was too wide on desktop/tablet views.

## Changes
- Use `alignSelfCenter` for wide layouts instead of `flex1`
- Maintains `flex1` for narrow layouts to preserve existing mobile behavior
- Improves visual consistency across different screen sizes

## Testing
- Tested on desktop view - button now has appropriate width
- Verified mobile layout remains unchanged
- No breaking changes to existing functionality

$ #82269