### PR TITLE
Change 'comment' to 'description' in report modified action

### DIFF
--- a/src/languages/de.ts
+++ b/src/languages/de.ts
@@ -1527,6 +1527,7 @@ const translations: TranslationDeepObject<typeof en> = {
                 return isFirst ? `setze ${field} auf „${value}“` : `${field} zu „${value}“`;
             },
             format: (fragments: string, route: string) => `${fragments} über <a href="${route}">Workspace-Regeln</a>`,
+            description: (value: string, isFirst: boolean) => (isFirst ? `Beschreibung auf „${value}“ festlegen` : `Beschreibung zu „${value}“`),
         },
         duplicateNonDefaultWorkspacePerDiemError:
             'Sie können Per-Diem-Ausgaben nicht über mehrere Workspaces hinweg duplizieren, da sich die Sätze zwischen den Workspaces unterscheiden können.',

--- a/src/languages/en.ts
+++ b/src/languages/en.ts
@@ -1529,6 +1529,7 @@ const translations = {
             reimbursable: (value: boolean) => (value ? 'marked the expense as "reimbursable"' : 'marked the expense as "non-reimbursable"'),
             billable: (value: boolean) => (value ? 'marked the expense as "billable"' : 'marked the expense as "non-billable"'),
             tax: (value: string, isFirst: boolean) => (isFirst ? `set the tax rate to "${value}"` : `tax rate to "${value}"`),
+            description: (value: string, isFirst: boolean) => (isFirst ? `set the description to "${value}"` : `description to "${value}"`),
             common: (key: keyof PolicyRulesModifiedFields, value: string, isFirst: boolean) => {
                 const field = translations.common[key].toLowerCase();
                 return isFirst ? `set the ${field} to "${value}"` : `${field} to "${value}"`;

--- a/src/languages/es.ts
+++ b/src/languages/es.ts
@@ -1322,6 +1322,7 @@ const translations: TranslationDeepObject<typeof en> = {
             reimbursable: (value: boolean) => (value ? 'marcó el gasto como "reembolsable"' : 'marcó el gasto como "no reembolsable"'),
             billable: (value: boolean) => (value ? 'marcó el gasto como "facturable"' : 'marcó el gasto como "no facturable"'),
             tax: (value: string, isFirst: boolean) => (isFirst ? `estableció la tasa de impuesto a "${value}"` : `tasa de impuesto a "${value}"`),
+            description: (value: string, isFirst: boolean) => (isFirst ? `establecer la descripción en "${value}"` : `la descripción en "${value}"`),
             common: (key: keyof PolicyRulesModifiedFields, value: string, isFirst: boolean) => {
                 const field = translations.common[key].toLowerCase();
                 return isFirst ? `estableció el ${field} a "${value}"` : `${field} a "${value}"`;

--- a/src/languages/fr.ts
+++ b/src/languages/fr.ts
@@ -1533,6 +1533,7 @@ const translations: TranslationDeepObject<typeof en> = {
                 return isFirst ? `définir ${field} sur « ${value} »` : `${field} à « ${value} »`;
             },
             format: (fragments: string, route: string) => `${fragments} via les <a href="${route}">règles de l’espace de travail</a>`,
+            description: (value: string, isFirst: boolean) => (isFirst ? `définir la description sur « ${value} »` : `description à « ${value} »`),
         },
         duplicateNonDefaultWorkspacePerDiemError:
             'Vous ne pouvez pas dupliquer les indemnités journalières entre plusieurs espaces de travail, car les taux peuvent différer d’un espace de travail à l’autre.',

--- a/src/languages/it.ts
+++ b/src/languages/it.ts
@@ -1524,6 +1524,7 @@ const translations: TranslationDeepObject<typeof en> = {
                 return isFirst ? `imposta ${field} su "${value}"` : `${field} a "${value}"`;
             },
             format: (fragments: string, route: string) => `${fragments} tramite le <a href="${route}">regole dello spazio di lavoro</a>`,
+            description: (value: string, isFirst: boolean) => (isFirst ? `imposta la descrizione su "${value}"` : `descrizione in “${value}”`),
         },
         duplicateNonDefaultWorkspacePerDiemError: 'Non puoi duplicare le spese di diaria tra diversi spazi di lavoro perché le tariffe potrebbero essere diverse tra gli spazi di lavoro.',
     },

--- a/src/languages/ja.ts
+++ b/src/languages/ja.ts
@@ -1518,6 +1518,7 @@ const translations: TranslationDeepObject<typeof en> = {
                 return isFirst ? `${field} を「${value}」に設定する` : `${field} から「${value}」へ`;
             },
             format: (fragments: string, route: string) => `${fragments}（<a href="${route}">ワークスペースルール</a>経由）`,
+            description: (value: string, isFirst: boolean) => (isFirst ? `説明を「${value}」に設定` : `説明を「${value}」に設定`),
         },
         duplicateNonDefaultWorkspacePerDiemError: 'ワークスペースごとに日当レートが異なる場合があるため、日当経費をワークスペース間で複製することはできません。',
     },

--- a/src/languages/nl.ts
+++ b/src/languages/nl.ts
@@ -1523,6 +1523,7 @@ const translations: TranslationDeepObject<typeof en> = {
                 return isFirst ? `stel de ${field} in op "${value}"` : `${field} naar "${value}"`;
             },
             format: (fragments: string, route: string) => `${fragments} via <a href="${route}">werkruimte­regels</a>`,
+            description: (value: string, isFirst: boolean) => (isFirst ? `stel de beschrijving in op ‘${value}’` : `beschrijving naar "${value}"`),
         },
         duplicateNonDefaultWorkspacePerDiemError: 'Je kunt dagvergoedingen niet dupliceren tussen werkruimtes, omdat de tarieven per werkruimte kunnen verschillen.',
     },

--- a/src/languages/pl.ts
+++ b/src/languages/pl.ts
@@ -1522,6 +1522,7 @@ const translations: TranslationDeepObject<typeof en> = {
                 return isFirst ? `ustaw ${field} na „${value}”` : `${field} na „${value}”`;
             },
             format: (fragments: string, route: string) => `${fragments} przez <a href="${route}">zasady przestrzeni roboczej</a>`,
+            description: (value: string, isFirst: boolean) => (isFirst ? `ustaw opis na „${value}”` : `opis na „${value}”`),
         },
         duplicateNonDefaultWorkspacePerDiemError:
             'Nie możesz duplikować wydatków z tytułu diet między przestrzeniami roboczymi, ponieważ stawki mogą się różnić między poszczególnymi przestrzeniami.',

--- a/src/languages/pt-BR.ts
+++ b/src/languages/pt-BR.ts
@@ -1520,6 +1520,7 @@ const translations: TranslationDeepObject<typeof en> = {
                 return isFirst ? `defina ${field} como "${value}"` : `${field} para "${value}"`;
             },
             format: (fragments: string, route: string) => `${fragments} via <a href="${route}">regras do espaço de trabalho</a>`,
+            description: (value: string, isFirst: boolean) => (isFirst ? `definir a descrição como "${value}"` : `descrição para "${value}"`),
         },
         duplicateNonDefaultWorkspacePerDiemError: 'Você não pode duplicar despesas de diárias entre espaços de trabalho porque as tarifas podem variar entre eles.',
     },

--- a/src/languages/zh-hans.ts
+++ b/src/languages/zh-hans.ts
@@ -1498,6 +1498,7 @@ const translations: TranslationDeepObject<typeof en> = {
                 return isFirst ? `将 ${field} 设置为“${value}”` : `${field} 至 “${value}”`;
             },
             format: (fragments: string, route: string) => `${fragments} 通过 <a href="${route}">工作区规则</a>`,
+            description: (value: string, isFirst: boolean) => (isFirst ? `将描述设置为“${value}”` : `描述为“${value}”`),
         },
         duplicateNonDefaultWorkspacePerDiemError: '您无法在不同工作区之间复制每日津贴报销，因为各工作区的补贴标准可能不同。',
     },

--- a/src/libs/ModifiedExpenseMessage.ts
+++ b/src/libs/ModifiedExpenseMessage.ts
@@ -223,11 +223,17 @@ function getPolicyRulesModifiedMessage(translate: LocalizedTranslate, fields: Po
         }
 
         const updatedValue = value as string;
+
         if (key === 'category') {
             return translate('iou.policyRulesModifiedFields.common', key, getDecodedCategoryName(updatedValue), isFirst);
         }
+
         if (key === 'tag') {
             return translate('iou.policyRulesModifiedFields.common', key, getCommaSeparatedTagNameWithSanitizedColons(updatedValue), isFirst);
+        }
+
+        if (key === 'comment') {
+            return translate('iou.policyRulesModifiedFields.common', translate('common.description'), updatedValue, isFirst);
         }
 
         return translate('iou.policyRulesModifiedFields.common', key, updatedValue, isFirst);

--- a/src/libs/ModifiedExpenseMessage.ts
+++ b/src/libs/ModifiedExpenseMessage.ts
@@ -233,7 +233,7 @@ function getPolicyRulesModifiedMessage(translate: LocalizedTranslate, fields: Po
         }
 
         if (key === 'comment') {
-            return translate('iou.policyRulesModifiedFields.common', translate('common.description'), updatedValue, isFirst);
+            return translate('iou.policyRulesModifiedFields.description', updatedValue, isFirst);
         }
 
         return translate('iou.policyRulesModifiedFields.common', key, updatedValue, isFirst);

--- a/src/types/onyx/OriginalMessage.ts
+++ b/src/types/onyx/OriginalMessage.ts
@@ -845,6 +845,9 @@ type PolicyRulesModifiedFields = {
     /** The value that the tag was changed to */
     tag?: string;
 
+    /** The value that the comment was changed to */
+    comment?: string;
+
     /** The value that the description was changed to */
     description?: string;
 


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
We dont want to render 'comment', but instead, 'description'

### Fixed Issues
$ https://github.com/Expensify/App/issues/82241

### Tests
Create a new merchant rule that matches "Merchant" and updates description to "Hello"
Create a new expense
Ensure the system messages says "set the description", rather than "set the comment"

- [x] Verify that no errors appear in the JS console

### Offline tests
N/A

### QA Steps
Same as tests

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I verified there are no new alerts related to the `canBeMissing` param for `useOnyx`
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<img width="870" height="917" alt="image" src="https://github.com/user-attachments/assets/d56e8b20-00d3-4976-8d02-b5ed16d8392d" />
