### PR TITLE
Fix: Remove unnecessary scroll bar from selection list popover

### DIFF
--- a/src/styles/index.ts
+++ b/src/styles/index.ts
@@ -6117,10 +6117,11 @@ const dynamicStyles = (theme: ThemeColors) =>
         getSelectionListPopoverHeight: (itemCount: number, windowHeight: number, isSearchable: boolean) => {
             const SEARCHBAR_HEIGHT = isSearchable ? 52 : 0;
             const SEARCHBAR_PADDING = isSearchable ? 12 : 0;
+            const LIST_BOTTOM_PADDING = 12;
             const PADDING = 32;
             const GAP = 8;
             const BUTTON_HEIGHT = 40;
-            const ESTIMATED_LIST_HEIGHT = itemCount * variables.optionRowHeightCompact + SEARCHBAR_HEIGHT + SEARCHBAR_PADDING;
+            const ESTIMATED_LIST_HEIGHT = itemCount * variables.optionRowHeightCompact + SEARCHBAR_HEIGHT + SEARCHBAR_PADDING + LIST_BOTTOM_PADDING;
             const MAX_HEIGHT = CONST.POPOVER_DROPDOWN_MAX_HEIGHT - (PADDING + GAP + BUTTON_HEIGHT);
 
             // Native platforms don't support maxHeight in the way thats expected, so lets manually set the height to either


### PR DESCRIPTION
## Summary
This PR fixes the issue where selection list popovers (View, Status, Type filters) show unnecessary scroll bars when the content exactly fits the container.

## Root Cause
The `getSelectionListPopoverHeight` function calculates the estimated list height without accounting for the bottom padding (`pb3` = 12px) that is applied to the SelectionList's content container in `BaseSelectionList.tsx`.

When the container height exactly matches the estimated height (e.g., 3 items × 52px = 156px for View filter), the actual content height exceeds the container due to the missing 12px padding, causing the scroll indicator to appear.

## Solution
Added `LIST_BOTTOM_PADDING` (12px) to the estimated list height calculation in `getSelectionListPopoverHeight` to account for the `pb3` padding applied to the SelectionList's content container.

## Testing
- Verified that View, Status, and Type filter popovers no longer show unnecessary scroll bars
- Confirmed that the fix doesn't affect other popover behaviors
- Tested on multiple screen sizes to ensure consistent behavior

$ #82415