### PR TITLE
[No QA] fix: improve CLEAN-REACT-PATTERNS-* rules detection

### DIFF
--- a/.claude/skills/coding-standards/rules/clean-react-1-composition-over-config.md
+++ b/.claude/skills/coding-standards/rules/clean-react-1-composition-over-config.md
@@ -255,7 +255,7 @@ In all cases, the rule applies to: **new components**, **new features added to e
 **DO NOT flag if:**
 - Props are domain identifiers used for data fetching (e.g., `reportID`, `policyID`, `transactionID`)
 - Props are event handlers for abstract actions (e.g., `onPress`, `onChange`, `onSelectRow`)
-- Props are structural/presentational (e.g., `style`, `testID`)
+- Props are structural/presentational (e.g., `style`, `testID`) — this includes booleans that select between layout or styling strategies on a focused component (e.g., `shouldUseAspectRatio` toggling between fixed-height and aspect-ratio styles)
 - The component already uses composition and child components for features
 - The optional prop is used for logic beyond just conditional rendering (e.g., computing derived values, passed to callbacks, used in multiple places within the component)
 - The component is a thin wrapper around a platform primitive (e.g., wrapping `TextInput`, `ScrollView`, `Pressable`) — these naturally pass through configuration props

--- a/.claude/skills/coding-standards/rules/clean-react-1-composition-over-config.md
+++ b/.claude/skills/coding-standards/rules/clean-react-1-composition-over-config.md
@@ -450,12 +450,14 @@ Flag when ANY of these are true:
 - Each render function corresponds to an area that could be a compound component child instead
 - The component manages fallback logic between the render function and a default prop (e.g., `renderTitle ? renderTitle() : <Text>{title}</Text>`)
 
-In all cases, the rule applies to: **new components**, **new features added to existing components**, and **refactorings that create new components still following configuration patterns**
+In all cases, the rule applies to: **new components**, **new features added to existing components**, **refactorings that create new components still following configuration patterns**, and **new consumers of existing config-heavy components**.
+
+**Consumer vs. Creator:** New code that consumes a component with a known configuration-heavy API (many props controlling what/how to render) SHOULD be flagged. Each new consumer cements the config pattern and makes future refactoring harder. The fix is to advocate for a compositional wrapper or refactor — not to silently adopt the old pattern. Flag new consumers at the same severity as the component creator.
 
 **DO NOT flag if:**
 - Props are domain identifiers used for data fetching (e.g., `reportID`, `policyID`, `transactionID`)
 - Props are event handlers for abstract actions (e.g., `onPress`, `onChange`, `onSelectRow`)
-- Props are structural/presentational (e.g., `style`, `testID`) — this includes booleans that select between layout or styling strategies on a focused component (e.g., `shouldUseAspectRatio` toggling between fixed-height and aspect-ratio styles)
+- Props are **purely presentational** (e.g., `style`, `testID`, `numberOfLines`, `fill`, `iconFill`). A prop is presentational ONLY if removing it would change appearance but NOT structure, content, or layout strategy. Props that select between rendering strategies (e.g., `shouldUseAspectRatio` toggling layout modes, `shouldShowX` toggling element visibility) or control which content appears are NOT presentational — they are behavioral flags (Case 1).
 - The component already uses composition and child components for features
 - The optional prop is used for logic beyond just conditional rendering (e.g., computing derived values, passed to callbacks, used in multiple places within the component)
 - The component is a thin wrapper around a platform primitive (e.g., wrapping `TextInput`, `ScrollView`, `Pressable`) — these naturally pass through configuration props

--- a/.claude/skills/coding-standards/rules/clean-react-1-composition-over-config.md
+++ b/.claude/skills/coding-standards/rules/clean-react-1-composition-over-config.md
@@ -74,6 +74,41 @@ function BaseWidgetItem({icon, iconBackgroundColor, title, subtitle, ctaText, on
 }
 ```
 
+#### Incorrect (configuration — ReactNode slot props)
+
+- Passing JSX via named props is still configuration — the component must know about each slot
+- Adding a new slot (e.g., `badgeComponent`) requires modifying the component's props AND internals
+- Each slot prop often drags along associated style/behavior props (`leftComponentStyle`, `shouldShowRightComponent`)
+- The consumer can't reorder, wrap, or compose slots — the component controls layout
+
+```tsx
+<MenuItem
+    title="Settings"
+    leftComponent={<Avatar source={avatarURL} />}
+    rightComponent={<Badge count={unreadCount} />}
+    furtherDetailsComponent={<CustomDetails />}
+/>
+
+type MenuItemProps = {
+    title: string;
+    leftComponent?: ReactNode;            // Positional slot configured via prop
+    rightComponent?: ReactNode;           // Another positional slot
+    furtherDetailsComponent?: ReactElement; // Yet another slot
+};
+
+// Inside the component — each slot is a conditional render:
+function MenuItem({title, leftComponent, rightComponent, furtherDetailsComponent}: MenuItemProps) {
+    return (
+        <View style={styles.row}>
+            {!!leftComponent && <View style={styles.left}>{leftComponent}</View>}
+            <Text>{title}</Text>
+            {!!rightComponent && rightComponent}
+            {!!furtherDetailsComponent && <View style={styles.details}>{furtherDetailsComponent}</View>}
+        </View>
+    );
+}
+```
+
 #### Incorrect (configuration — monolithic prop interface)
 
 - All features threaded through props
@@ -135,6 +170,38 @@ const todoItems = [
 {todoItems.map(({key, icon, ...rest}) => (
     <BaseWidgetItem key={key} icon={icon} {...rest} />
 ))}
+```
+
+#### Incorrect (configuration — render function props)
+
+- Render functions are configuration disguised as flexibility — the component still owns each slot
+- Each `render*` prop is an alternative to a composable child component
+- The component must call each function and manage the fallback logic
+- Adding a new renderable area means adding a new `render*` prop to the interface
+
+```tsx
+<Section
+    title="Features"
+    renderSubtitle={() => (
+        <View>
+            <Text style={styles.subtitle}>Advanced features for your workspace</Text>
+            <Badge type="new" />
+        </View>
+    )}
+    overlayContent={() => isLoading && <LoadingOverlay />}
+/>
+
+// Inside the component — render functions called inline:
+function Section({title, renderSubtitle, renderTitle, overlayContent}: SectionProps) {
+    return (
+        <View>
+            {renderTitle ? renderTitle() : <Text>{title}</Text>}
+            {renderSubtitle ? renderSubtitle() : null}
+            {children}
+            {overlayContent?.()}
+        </View>
+    );
+}
 ```
 
 ### Correct
@@ -291,6 +358,53 @@ export default WidgetItem;
 </ForYouSection.Container>
 ```
 
+#### Correct (composition — compound component slots over ReactNode props)
+
+- Each slot is a composable child — visible in the JSX tree, independently testable
+- Adding a new slot (e.g., `<MenuItem.Badge>`) never changes existing sub-components
+- No associated style props needed — each sub-component owns its own styling
+- The consumer has full control over composition, ordering, and conditional rendering
+
+```tsx
+// Consumer controls what appears and where — each slot is explicit JSX
+<MenuItem.Container onPress={onNavigate}>
+    <MenuItem.Left>
+        <Avatar source={avatarURL} />
+    </MenuItem.Left>
+    <MenuItem.Content>
+        <MenuItem.Title>Settings</MenuItem.Title>
+        <MenuItem.Description>Manage your preferences</MenuItem.Description>
+    </MenuItem.Content>
+    <MenuItem.Right>
+        <Badge count={unreadCount} />
+    </MenuItem.Right>
+</MenuItem.Container>
+```
+
+#### Correct (composition — children slots over render functions)
+
+- Each area declared as JSX — the consumer decides what renders, not the component
+- Conditional rendering is standard JSX, not function call fallback chains
+- Adding a new area means creating a new sub-component, not expanding the parent's prop interface
+- Each sub-component is an independent render unit — better for React Compiler memoization
+
+```tsx
+// Each area is a composable child — no render functions needed
+<Section>
+    <Section.Title>Features</Section.Title>
+    <Section.Subtitle>
+        <Text style={styles.subtitle}>Advanced features for your workspace</Text>
+        <Badge type="new" />
+    </Section.Subtitle>
+    <Section.Content>
+        {children}
+    </Section.Content>
+    <Suspense fallback={<Section.Skeleton />}>
+        <Section.Overlay />
+    </Suspense>
+</Section>
+```
+
 ---
 
 ### Review Metadata
@@ -308,12 +422,14 @@ Flag when ANY of these are true:
 - An optional content prop's **sole purpose** is to conditionally render a UI element
 - The test: if removing the prop would only remove a `{!!prop && <Element />}` or `{prop ? <Element /> : null}` block and nothing else, the element should be a composable child instead
 - This applies when **adding new optional content props** to new or existing components — not when modifying existing conditional rendering during a bug fix
+- A named `ReactNode` or `ReactElement` prop whose purpose is to render UI in a specific position within the component (e.g., `leftComponent?: ReactNode`, `footerContent?: ReactNode`, `titleComponent?: ReactElement`)
+- The test: the component wraps the prop in a conditional render (`{!!prop && <Wrapper>{prop}</Wrapper>}`) or renders it directly — the slot could instead be a compound component child
 
 **Detection steps for Case 2:**
 1. In the diff, search for conditional rendering patterns: `{!!prop &&`, `{prop &&`, `{prop ? <...> : null}`
 2. For each match, identify the variable used in the condition (e.g., `subtitle` in `{!!subtitle && <Text>...`)
 3. Check the component's type definition — is this prop optional (`subtitle?: string`)?
-4. Search the entire component body for other uses of this prop — is the conditional render the ONLY place it appears?
+4. Search the entire component body for other uses of this prop — is the prop used **only for conditional rendering**? (Note: a prop may appear in multiple conditional render blocks and still be a violation — the test is whether ALL uses are solely `{!!prop && <Element />}` or `{prop ? <Element /> : null}` patterns, not whether it appears in only one place.)
 5. If yes to both (optional + sole purpose is conditional render) → flag as Case 2 violation
 
 **Case 3 — Monolithic prop interface:**
@@ -326,6 +442,13 @@ Flag when ANY of these are true:
 - The array is `.map()`'d through a generic component to produce JSX
 - Each item has distinct behavior or props that could be expressed as individual JSX elements or dedicated components
 - Business logic is mixed into the array (conditional entries via `&&`, `.filter()`)
+- **Important**: Using compound components inside `.map()` over a static array does not resolve the violation — the fix is to inline each item as distinct JSX, not to improve the mapped component's API. The anti-pattern is the static config array itself, not the component being mapped.
+
+**Case 5 — Render function props:**
+- A component accepts `render*` function props (e.g., `renderTitle`, `renderSubtitle`, `renderFooter`) that return JSX
+- The component calls these functions to fill specific areas of its layout
+- Each render function corresponds to an area that could be a compound component child instead
+- The component manages fallback logic between the render function and a default prop (e.g., `renderTitle ? renderTitle() : <Text>{title}</Text>`)
 
 In all cases, the rule applies to: **new components**, **new features added to existing components**, and **refactorings that create new components still following configuration patterns**
 
@@ -340,9 +463,13 @@ In all cases, the rule applies to: **new components**, **new features added to e
 - The array is used with **list components** (e.g., `FlatList`, `SectionList`, or custom wrappers) — these require data arrays by design
 - Items are truly **homogeneous** (same shape, same behavior, only values differ) and the count is **unbounded** (e.g., list of chat messages, search results)
 - The array is a **framework requirement** (e.g., React Navigation screen config, form validation rules)
+- The `ReactNode` prop is `children` itself — `children` is the foundation of composition, not configuration
+- The render function is a **list component callback** (`renderItem` on `FlatList`, `SectionList`, `DraggableList`) — these are framework requirements
+- The render function receives **per-item runtime data** from a dynamic collection (e.g., `renderSuggestionMenuItem(item, index)`) — this is list-style rendering, not slot configuration
 
 **Search Patterns** (hints for reviewers):
 - **Case 1**: `should\w+`, `can\w+`, `enable`, `disable` (boolean flag prefixes in prop types)
-- **Case 2**: `{!!`, `&&\s*<`, `?\s*<`, `: null`, combined with optional prop markers (`?:` in type definitions)
-- **Case 3**: Components with 8+ props in their type definition, especially mixing state/handler/content props
+- **Case 2**: `{!!`, `&&\s*<`, `?\s*<`, `: null`, combined with optional prop markers (`?:` in type definitions); named `ReactNode` or `ReactElement` optional props (`\w+\?:\s*(React\.)?React(Node|Element)`)
+- **Case 3**: Components where props collectively configure appearance AND behavior — look for a mix of state props, handler props, and content/slot props in the same type definition
 - **Case 4**: `\.map\(` combined with array literal `= \[` in the same component; `actions={[`, `items={[`, `options={[` (config arrays passed as props); `.filter(` on array literals (conditional items)
+- **Case 5**: `render\w+\??\s*:` in type definitions (render function props); `render\w+\s*\??\s*\(` in component bodies (render function calls)

--- a/.claude/skills/coding-standards/rules/clean-react-1-composition-over-config.md
+++ b/.claude/skills/coding-standards/rules/clean-react-1-composition-over-config.md
@@ -7,14 +7,16 @@ title: Favor composition over configuration
 
 ### Reasoning
 
-When new features are implemented by adding configuration (props, flags, conditional logic) to existing components, if requirements change, then those components must be repeatedly modified, increasing coupling, surface area, and regression risk. Composition ensures features scale horizontally, limits the scope of changes, and prevents components from becoming configuration-driven "mega components".
+When features are implemented by adding configuration to components — whether boolean flags, optional content props, or large prop interfaces — the component must be modified every time a consumer needs different behavior. This increases coupling, surface area, and regression risk at scale. Composition treats features as independent building blocks: a Provider manages shared state, sub-components (blocks) render independently via context or direct props, and consumers add/remove features by including or excluding blocks. The component never changes. This applies equally to simple widgets and complex multi-feature UIs.
+
+Reference: [Composition Pattern Guide](https://composition-pattern-starter.vercel.app/comparison)
 
 ### Incorrect
 
-#### Incorrect (configuration)
+#### Incorrect (configuration — boolean flags)
 
 - Features controlled by boolean flags
-- Adding a new feature requires modifying the Table component's API
+- Adding a new feature requires modifying the component's API and internals
 
 ```tsx
 <Table
@@ -38,62 +40,66 @@ type TableProps = {
 };
 ```
 
+#### Incorrect (configuration — content props)
+
+- Optional content props control which UI elements appear
+- Each optional prop maps 1:1 to a conditional render block inside the component
+- Adding a new element (e.g., badge) requires modifying the component's props AND internals
+
 ```tsx
-<SelectionList
-  data={items}
-  shouldShowTextInput
-  shouldShowTooltips
-  shouldScrollToFocusedIndex
-  shouldDebounceScrolling
-  shouldUpdateFocusedIndex
-  canSelectMultiple
-  disableKeyboardShortcuts
+<BaseWidgetItem
+    icon={icon}
+    iconBackgroundColor={theme.widgetIconBG}
+    iconFill={theme.widgetIconFill}
+    title={translate(translationKey, {count})}
+    subtitle={subtitle}
+    ctaText={translate('homePage.forYouSection.begin')}
+    onCtaPress={handler}
 />
 
-type SelectionListProps = {
-  shouldShowTextInput?: boolean;      // Could be <SelectionList.TextInput />
-  shouldShowConfirmButton?: boolean;  // Could be <SelectionList.ConfirmButton />
-  textInputOptions?: {...};           // Configuration object for the above
-};
+// Inside the component — conditional rendering controlled by props:
+function BaseWidgetItem({icon, iconBackgroundColor, title, subtitle, ctaText, onCtaPress, iconFill}: BaseWidgetItemProps) {
+    return (
+        <View>
+            <View style={styles.getWidgetItemIconContainerStyle(iconBackgroundColor)}>
+                <Icon src={icon} fill={iconFill ?? theme.white} />
+            </View>
+            <View>
+                {!!subtitle && <Text style={styles.widgetItemSubtitle}>{subtitle}</Text>}  // ❌ Prop exists solely for this conditional
+                <Text style={styles.widgetItemTitle}>{title}</Text>
+            </View>
+            <Button text={ctaText} onPress={onCtaPress} />
+        </View>
+    );
+}
 ```
 
-#### Incorrect (parent manages child state)
+#### Incorrect (configuration — monolithic prop interface)
+
+- All features threaded through props
+- Every piece of state and behavior configured from outside
+- Adding a new feature (e.g., a new tab, a new button) requires expanding the prop interface
 
 ```tsx
-// Parent fetches and manages state for its children
-// Parent has to know child implementation details
-function ReportScreen({ params: { reportID }}) {
-  const [reportOnyx] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT}${reportID}`, {allowStaleData: true, canBeMissing: true});
-  const reportActions = useMemo(() => getFilteredReportActionsForReportView(unfilteredReportActions), [unfilteredReportActions]);
-  const [reportMetadata = defaultReportMetadata] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT_METADATA}${reportIDFromRoute}`, {canBeMissing: true, allowStaleData: true});
-  const {reportActions: unfilteredReportActions, linkedAction, sortedAllReportActions, hasNewerActions, hasOlderActions} = usePaginatedReportActions(reportID, reportActionIDFromRoute);
-  const parentReportAction = useParentReportAction(reportOnyx);
-  const transactionThreadReportID = getOneTransactionThreadReportID(report, chatReport, reportActions ?? [], isOffline, reportTransactionIDs);
-  const isTransactionThreadView = isReportTransactionThread(report);
-  // other onyx connections etc
-
-  return (
-    <>
-      <ReportActionsView
-        report={report}
-        reportActions={reportActions}
-        isLoadingInitialReportActions={reportMetadata?.isLoadingInitialReportActions}
-        hasNewerActions={hasNewerActions}
-        hasOlderActions={hasOlderActions}
-        parentReportAction={parentReportAction}
-        transactionThreadReportID={transactionThreadReportID}
-        isReportTransactionThread={isTransactionThreadView}
-      />
-      // other features
-      <Composer />
-    </>
-  );
-}
+<SettingsDialog
+    isOpen={isOpen}
+    onClose={onClose}
+    title="Settings"
+    description="Manage your preferences"
+    tabs={tabs}
+    activeTab={activeTab}
+    onTabChange={handleTabChange}
+    onSave={handleSave}
+    onReset={handleReset}
+    values={formValues}
+    onChange={handleChange}
+    // ... props grow with every feature
+/>
 ```
 
 ### Correct
 
-#### Correct (composition)
+#### Correct (composition — boolean features)
 
 - Features expressed as composable children
 - Parent stays stable; add features by adding children
@@ -106,36 +112,112 @@ function ReportScreen({ params: { reportID }}) {
 </Table>
 ```
 
+#### Correct (composition — compound component)
+
+- UI elements are composable children the consumer includes or omits
+- Adding a new element (e.g., Subtitle, Badge) never changes existing sub-components
+- Each sub-component is a small, focused function with its own styles
+
 ```tsx
-<SelectionList data={items}>
-  <SelectionList.TextInput />
-  <SelectionList.Body />
-</SelectionList>
+// Implementation — each sub-component owns its behavior:
+
+function Container({children, onPress, accessibilityLabel}: {children: React.ReactNode; onPress?: () => void; accessibilityLabel?: string}) {
+    const styles = useThemeStyles();
+    const content = <View style={[styles.flexRow, styles.alignItemsCenter, styles.gap3]}>{children}</View>;
+
+    if (onPress) {
+        return (
+            <PressableWithFeedback onPress={onPress} accessibilityLabel={accessibilityLabel} accessibilityRole="button">
+                {content}
+            </PressableWithFeedback>
+        );
+    }
+    return content;
+}
+
+function WidgetIcon({src, backgroundColor, fill}: {src: IconAsset; backgroundColor: string; fill?: string}) {
+    const styles = useThemeStyles();
+    const theme = useTheme();
+    return (
+        <View style={styles.getWidgetItemIconContainerStyle(backgroundColor)}>
+            <Icon src={src} width={variables.iconSizeNormal} height={variables.iconSizeNormal} fill={fill ?? theme.white} />
+        </View>
+    );
+}
+
+function Content({children}: {children: React.ReactNode}) {
+    const styles = useThemeStyles();
+    return <View style={[styles.flex1, styles.flexColumn, styles.justifyContentCenter]}>{children}</View>;
+}
+
+function Title({children, numberOfLines}: {children: React.ReactNode; numberOfLines?: number}) {
+    const styles = useThemeStyles();
+    return <Text style={styles.widgetItemTitle} numberOfLines={numberOfLines}>{children}</Text>;
+}
+
+function Subtitle({children}: {children: React.ReactNode}) {
+    const styles = useThemeStyles();
+    return <Text style={styles.widgetItemSubtitle}>{children}</Text>;
+}
+
+function Action({onPress, isLoading, children}: {onPress: () => void; isLoading?: boolean; children: string}) {
+    const styles = useThemeStyles();
+    return <Button text={children} onPress={onPress} success small isLoading={isLoading} style={styles.widgetItemButton} />;
+}
+
+const WidgetItem = {Container, Icon: WidgetIcon, Content, Title, Subtitle, Action};
+export default WidgetItem;
 ```
 
-#### Correct (children manage their own state)
+```tsx
+// Usage — consumer decides what to render:
+<WidgetItem.Container>
+    <WidgetItem.Icon src={icon} backgroundColor={theme.widgetIconBG} fill={theme.widgetIconFill} />
+    <WidgetItem.Content>
+        <WidgetItem.Title>{translate(translationKey, {count})}</WidgetItem.Title>
+    </WidgetItem.Content>
+    <WidgetItem.Action onPress={handler}>{beginText}</WidgetItem.Action>
+</WidgetItem.Container>
+
+// Need a subtitle? Add it — no changes to any existing sub-component:
+<WidgetItem.Container>
+    <WidgetItem.Icon src={icon} backgroundColor={theme.widgetIconBG} fill={theme.widgetIconFill} />
+    <WidgetItem.Content>
+        <WidgetItem.Subtitle>{subtitle}</WidgetItem.Subtitle>
+        <WidgetItem.Title>{title}</WidgetItem.Title>
+    </WidgetItem.Content>
+    <WidgetItem.Action onPress={handler}>{beginText}</WidgetItem.Action>
+</WidgetItem.Container>
+```
+
+#### Correct (composition — Provider + Blocks)
+
+- Provider manages shared state, sub-components render independently
+- Each block connects to state through context — no props between blocks
+- Features are optional building blocks: add by including, remove by excluding
 
 ```tsx
-// Children are self-contained and manage their own state
-// Parent only passes minimal data (IDs)
-// Adding new features doesn't require changing the parent
-function ReportScreen({ params: { reportID }}) {
-  return (
-    <>
-      <ReportActionsView reportID={reportID} />
-      // other features
-      <Composer />
-    </>
-  );
-}
+<Settings.Provider>
+    <Settings.Trigger>
+        <Button>Open Settings</Button>
+    </Settings.Trigger>
 
-// Component accesses stores and calculates its own state
-// Parent doesn't know the internals
-function ReportActionsView({ reportID }) {
-  const [reportOnyx] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT}${reportID}`);
-  const reportActions = getFilteredReportActionsForReportView(unfilteredReportActions);
-  // ...
-}
+    <Settings.Dialog>
+        <Settings.Header title="Settings" description="Manage your preferences" />
+
+        <Settings.Content>
+            {/* Form content */}
+        </Settings.Content>
+
+        <Settings.Footer>
+            <Settings.ResetButton />
+            <Settings.SaveButton />
+        </Settings.Footer>
+    </Settings.Dialog>
+</Settings.Provider>
+
+// No props between blocks — context manages everything
+// Adding a new section doesn't change the Provider or other blocks
 ```
 
 ---
@@ -144,28 +226,41 @@ function ReportActionsView({ reportID }) {
 
 #### Condition
 
-Flag ONLY when ALL of these are true:
+Flag when ANY of these are true:
 
-- Any of these scenarios apply:
-  - A **new feature** is being introduced
-  - An **existing component's API** is being expanded with new props
-  - A **refactoring** creates a new component that still has boolean configuration props matching the search patterns controlling branching logic — refactoring is an opportunity to eliminate configuration flags, not preserve them
-- The component contains boolean props matching the search patterns that cause `if/else` or ternary branching inside the component body
-- These configuration options control feature presence, layout strategy, or behavior within the component
+**Case 1 — Boolean flag configuration:**
+- A component uses boolean/flag props (matching the Case 1 search patterns) that cause `if/else` or ternary branching inside the component body
+- These flags control feature presence, layout strategy, or behavior within the component
+- These features could instead be expressed as composable child components
 
-**Features that should NOT be controlled by boolean flags:**
-- Optional UI elements that could be composed in
-- New behavior that could be introduced as new children
-- Features that currently require parent component code changes
-- Layout strategy variants
+**Case 2 — Content prop configuration:**
+- An optional content prop's **sole purpose** is to conditionally render a UI element
+- The test: if removing the prop would only remove a `{!!prop && <Element />}` or `{prop ? <Element /> : null}` block and nothing else, the element should be a composable child instead
+- This applies when **adding new optional content props** to new or existing components — not when modifying existing conditional rendering during a bug fix
+
+**Detection steps for Case 2:**
+1. In the diff, search for conditional rendering patterns: `{!!prop &&`, `{prop &&`, `{prop ? <...> : null}`
+2. For each match, identify the variable used in the condition (e.g., `subtitle` in `{!!subtitle && <Text>...`)
+3. Check the component's type definition — is this prop optional (`subtitle?: string`)?
+4. Search the entire component body for other uses of this prop — is the conditional render the ONLY place it appears?
+5. If yes to both (optional + sole purpose is conditional render) → flag as Case 2 violation
+
+**Case 3 — Monolithic prop interface:**
+- A component receives a large set of props that collectively configure its appearance and behavior (e.g., dialog with `isOpen`, `title`, `tabs`, `activeTab`, `onTabChange`, `onSave`, `onReset`, `values`)
+- These props could be broken into independent composable blocks: Provider manages state, sub-components render independently
+- The component becomes a "configuration object consumer" rather than a composition of building blocks
+
+In all cases, the rule applies to: **new components**, **new features added to existing components**, and **refactorings that create new components still following configuration patterns**
 
 **DO NOT flag if:**
-- Props are non-boolean data values needed for coordination between composed parts (e.g., `reportID`, `data`, `columns`).
-- The component uses composition and child components for features
-- Parent components stay stable as features are added
+- Props are domain identifiers used for data fetching (e.g., `reportID`, `policyID`, `transactionID`)
+- Props are event handlers for abstract actions (e.g., `onPress`, `onChange`, `onSelectRow`)
+- Props are structural/presentational (e.g., `style`, `testID`)
+- The component already uses composition and child components for features
+- The optional prop is used for logic beyond just conditional rendering (e.g., computing derived values, passed to callbacks, used in multiple places within the component)
+- The component is a thin wrapper around a platform primitive (e.g., wrapping `TextInput`, `ScrollView`, `Pressable`) — these naturally pass through configuration props
 
 **Search Patterns** (hints for reviewers):
-- `should\w+` (any prop starting with `should`)
-- `canSelect`
-- `enable`
-- `disable`
+- **Case 1**: `should\w+`, `can\w+`, `enable`, `disable` (boolean flag prefixes in prop types)
+- **Case 2**: `{!!`, `&&\s*<`, `?\s*<`, `: null`, combined with optional prop markers (`?:` in type definitions)
+- **Case 3**: Components with 8+ props in their type definition, especially mixing state/handler/content props


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
<!-- Explain what your change does and how it addresses the linked issue -->
- `CLEAN-REACT-PATTERNS-1` (Composition over Configuration): Restructured search patterns to be per-case, broadened boolean prop detection (should\w+, can\w+), added new cases for config-array driven rendering (Case 4), render function props (Case 5), and ReactNode slot props (Case 6). Also closes loopholes, clarifies the presentational prop exception, and adds DO NOT flag exceptions for thin platform wrappers, children, list callbacks, and runtime data.
- `CLEAN-REACT-PATTERNS-4` (No Side-Effect Spaghetti): Added detection for internal render helpers (renderContent, renderTodoItems, etc.) as single-responsibility violations that hide the render tree and prevent React Compiler memoization.

Tested against:
https://github.com/Expensify/App/pull/82229
https://github.com/Expensify/App/pull/80829
https://github.com/Expensify/App/pull/81058
https://github.com/Expensify/App/pull/80974
https://github.com/Expensify/App/pull/80931
https://github.com/Expensify/App/pull/80951

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/74367
PROPOSAL:


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

1. Ask Claude Code to dry-run the `code-inline-reviewer (agent)` against any PR and report you back violations.

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->

Same as tests.

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I verified there are no new alerts related to the `canBeMissing` param for `useOnyx`
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>