### PR TITLE
Add messageKey handling as fallback

### DIFF
--- a/src/components/MoneyReportHeader.tsx
+++ b/src/components/MoneyReportHeader.tsx
@@ -1757,7 +1757,7 @@ function MoneyReportHeader({
             betas,
         });
 
-    const showNextStepBar = shouldShowNextStep && !!optimisticNextStep?.message?.length;
+    const showNextStepBar = shouldShowNextStep && !!(optimisticNextStep?.message?.length ?? (optimisticNextStep && 'messageKey' in optimisticNextStep));
     const showNextStepSkeleton = shouldShowNextStep && !optimisticNextStep && !!isLoadingInitialReportActions && !isOffline;
     const shouldShowMoreContent = showNextStepBar || showNextStepSkeleton || !!statusBarProps || isReportInSearch;
 

--- a/src/components/MoneyReportHeaderStatusBar.tsx
+++ b/src/components/MoneyReportHeaderStatusBar.tsx
@@ -3,27 +3,41 @@ import {View} from 'react-native';
 import type {ValueOf} from 'type-fest';
 import useCurrentUserPersonalDetails from '@hooks/useCurrentUserPersonalDetails';
 import {useMemoizedLazyExpensifyIcons} from '@hooks/useLazyAsset';
+import useLocalize from '@hooks/useLocalize';
 import useTheme from '@hooks/useTheme';
 import useThemeStyles from '@hooks/useThemeStyles';
-import {parseMessage} from '@libs/NextStepUtils';
+import {buildNextStepMessage, parseMessage} from '@libs/NextStepUtils';
 import variables from '@styles/variables';
 import CONST from '@src/CONST';
+import type {ReportNextStep} from '@src/types/onyx/Report';
 import type ReportNextStepDeprecated from '@src/types/onyx/ReportNextStepDeprecated';
 import type IconAsset from '@src/types/utils/IconAsset';
 import Icon from './Icon';
 import RenderHTML from './RenderHTML';
 
+/** Combined type that accepts either the new format or the deprecated format */
+type NextStepData = ReportNextStep | ReportNextStepDeprecated;
+
 type MoneyReportHeaderStatusBarProps = {
-    /** The next step for the report (deprecated old format) */
-    nextStep: ReportNextStepDeprecated | undefined;
+    /** The next step for the report (supports both new and deprecated formats) */
+    nextStep: NextStepData | undefined;
 };
 
 type IconName = ValueOf<typeof CONST.NEXT_STEP.ICONS>;
 type IconMap = Record<IconName, IconAsset>;
 
+/**
+ * Type guard to check if the next step is in the deprecated format (has message array).
+ * We prioritize the old format first for backwards compatibility during migration.
+ */
+function isDeprecatedFormatNextStep(step: NextStepData): step is ReportNextStepDeprecated {
+    return 'message' in step && Array.isArray(step.message) && step.message.length > 0;
+}
+
 function MoneyReportHeaderStatusBar({nextStep}: MoneyReportHeaderStatusBarProps) {
     const styles = useThemeStyles();
     const theme = useTheme();
+    const {translate} = useLocalize();
     const icons = useMemoizedLazyExpensifyIcons(['Hourglass', 'Checkmark', 'Stopwatch', 'DotIndicator']);
     const iconMap: IconMap = useMemo(
         () => ({
@@ -35,11 +49,29 @@ function MoneyReportHeaderStatusBar({nextStep}: MoneyReportHeaderStatusBarProps)
         [icons],
     );
     const currentUserPersonalDetails = useCurrentUserPersonalDetails();
+    const currentUserAccountID = currentUserPersonalDetails.accountID;
     const currentUserEmail = currentUserPersonalDetails.login ?? '';
+
     const messageContent = useMemo(() => {
-        const messageArray = nextStep?.message;
-        return parseMessage(messageArray, currentUserEmail);
-    }, [nextStep?.message, currentUserEmail]);
+        if (!nextStep) {
+            return '';
+        }
+
+        // Handle old/deprecated format first (with message array) for backwards compatibility
+        if (isDeprecatedFormatNextStep(nextStep)) {
+            return parseMessage(nextStep.message, currentUserEmail);
+        }
+
+        // Fall back to new format (with messageKey)
+        if ('messageKey' in nextStep && nextStep.messageKey) {
+            return buildNextStepMessage(nextStep, translate, currentUserAccountID);
+        }
+
+        return '';
+    }, [nextStep, translate, currentUserAccountID, currentUserEmail]);
+
+    // iconFill can be set by frontend optimistic updates (deprecated format) but backend never sends it in new format
+    const iconFill = (nextStep && 'iconFill' in nextStep ? (nextStep as {iconFill?: string}).iconFill : undefined) ?? theme.icon;
 
     return (
         <View style={[styles.dFlex, styles.flexRow, styles.alignItemsCenter, styles.overflowHidden, styles.w100, styles.headerStatusBarContainer]}>
@@ -48,7 +80,7 @@ function MoneyReportHeaderStatusBar({nextStep}: MoneyReportHeaderStatusBarProps)
                     src={(nextStep?.icon && iconMap?.[nextStep.icon]) ?? icons.Hourglass}
                     height={variables.iconSizeSmall}
                     width={variables.iconSizeSmall}
-                    fill={nextStep?.iconFill ?? theme.icon}
+                    fill={iconFill}
                 />
             </View>
             <View style={[styles.dFlex, styles.flexRow, styles.flexShrink1]}>

--- a/src/libs/DebugUtils.ts
+++ b/src/libs/DebugUtils.ts
@@ -544,6 +544,7 @@ function validateReportDraftProperty(key: keyof Report | keyof ReportNameValuePa
                 icon: 'string',
                 actorAccountID: 'number',
                 eta: 'object',
+                iconFill: 'string',
             });
         case 'tripData':
             return validateObject<ObjectElement<Report, 'tripData'>>(value, {

--- a/src/libs/NextStepUtils.ts
+++ b/src/libs/NextStepUtils.ts
@@ -42,7 +42,8 @@ type BuildNextStepNewParams = {
 };
 
 function buildNextStepMessage(nextStep: ReportNextStep, translate: LocaleContextProps['translate'], currentUserAccountID: number): string {
-    const actor = getDisplayNameForParticipant({accountID: nextStep.actorAccountID, formatPhoneNumber: formatPhoneNumberPhoneUtils});
+    // Escape actor name to prevent HTML injection since this will be rendered as HTML
+    const actor = Str.safeEscape(getDisplayNameForParticipant({accountID: nextStep.actorAccountID, formatPhoneNumber: formatPhoneNumberPhoneUtils}) ?? '');
     let actorType: ValueOf<typeof CONST.NEXT_STEP.ACTOR_TYPE>;
     if (nextStep.actorAccountID === currentUserAccountID) {
         actorType = CONST.NEXT_STEP.ACTOR_TYPE.CURRENT_USER;

--- a/src/types/onyx/Report.ts
+++ b/src/types/onyx/Report.ts
@@ -78,6 +78,9 @@ type ReportNextStep = {
         /** The ETA date time */
         dateTime?: string;
     };
+
+    /** The fill color of the icon */
+    iconFill?: string;
 };
 
 /** Model of report data */


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->


### Explanation of Change
redo of https://github.com/Expensify/App/pull/81223

regressions https://github.com/Expensify/App/issues/82000 and https://github.com/Expensify/App/issues/82015  were not from https://github.com/Expensify/App/pull/81223 but from https://github.com/Expensify/App/pull/80715

This PR adds support for the `messageKey` format for ReportNextStep updates while maintaining backward compatibility with the deprecated `message` array format.

**Why this is needed:**
- Auth commands send NextStep updates using the new `messageKey` format
- PHP still sends the old `message` array format
- The frontend needs to support both formats during the transition period
- This ensures a smooth migration without breaking existing functionality

_Note: these changes have no impact until we actually remove queueing next step updates in old format from Web-E_

### Fixed Issues
$ https://github.com/Expensify/Expensify/issues/595924
PROPOSAL:

### Tests
1. Create a WS as User A, invite userB, and user C
2. set User B as approver of expensed from C
3. As user C submit a expense, as user B approve it and as user A pay expense elsewhere
4. As user A cancel payment, verify user B and C expense report updated with "Wating for UserA to pay expense" next step

### Offline tests


### QA Steps

1. Create a WS as User A, invite userB, and user C
2. set User B as approver of expensed from C
3. As user C submit a expense, as user B approve it and as user A pay expense elsewhere
4. As user A cancel payment, verify user B and C expense report updated with "Wating for UserA to pay expense" next step

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the \`### Fixed Issues\` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the \`Tests\` section
    - [x] I added steps for the expected offline behavior in the \`Offline steps\` section
    - [x] I added steps for Staging and/or Production testing in the \`QA steps\` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I verified there are no new alerts related to the \`canBeMissing\` param for \`useOnyx\`
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. \`toggleReport\` and not \`onIconClick\`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained \"why\" the code was doing something instead of only explaining \"what\" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to \`src/languages/*\` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named \"index.js\". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [\`STYLE.md\`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like \`Avatar\`, I verified the components using \`Avatar\` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. \`StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)\`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run \`npm run compress-svg\`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like \`Avatar\` is modified, I verified that \`Avatar\` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added \`Design\` label and/or tagged \`@Expensify/design\` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the \`ScrollView\` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the \`main\` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the \`Test\` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</su


<img width="1840" height="1196" alt="Screenshot 2026-02-14 at 2 08 02 AM" src="https://github.com/user-attachments/assets/49a468ae-ada3-4a96-8283-e522d9245751" />





https://github.com/user-attachments/assets/421d0c6e-428e-41f1-a6a1-3f707d9a706e






</details>
