### PR TITLE
[$250] Handle more gracefully when reportAction deep-link is incorrect

### DIFF
--- a/src/pages/inbox/report/ReportActionNotFoundIndicator.tsx
+++ b/src/pages/inbox/report/ReportActionNotFoundIndicator.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import {View} from 'react-native';
+import Text from '@components/Text';
+import useThemeStyles from '@hooks/useThemeStyles';
+import useLocalize from '@hooks/useLocalize';
+
+/**
+ * Subtle indicator shown when a deep-linked report action is not found.
+ * This provides minimal feedback to the user without disrupting the experience.
+ */
+function ReportActionNotFoundIndicator() {
+    const styles = useThemeStyles();
+    const {translate} = useLocalize();
+
+    return (
+        <View style={[styles.ph5, styles.pv2, styles.bgMuted]}>
+            <Text style={[styles.textMicroSupporting, styles.textAlignCenter]}>
+                {translate('reportActionNotFound.message')}
+            </Text>
+        </View>
+    );
+}
+
+ReportActionNotFoundIndicator.displayName = 'ReportActionNotFoundIndicator';
+
+export default ReportActionNotFoundIndicator;

--- a/src/pages/inbox/report/withReportAndReportActionOrNotFound.tsx
+++ b/src/pages/inbox/report/withReportAndReportActionOrNotFound.tsx
@@ -14,6 +14,7 @@ import type {PlatformStackScreenProps} from '@libs/Navigation/PlatformStackNavig
 import type {FlagCommentNavigatorParamList, SplitDetailsNavigatorParamList} from '@libs/Navigation/types';
 import {canAccessReport} from '@libs/ReportUtils';
 import NotFoundPage from '@pages/ErrorPage/NotFoundPage';
+import ReportActionNotFoundIndicator from '@pages/inbox/report/ReportActionNotFoundIndicator';
 import ONYXKEYS from '@src/ONYXKEYS';
 import type SCREENS from '@src/SCREENS';
 import type * as OnyxTypes from '@src/types/onyx';
@@ -84,20 +85,32 @@ export default function <TProps extends WithReportAndReportActionOrNotFoundProps
 
         // Perform the access/not found checks
         // Be sure to avoid showing the not-found page while the parent report actions are still being read from Onyx. The parentReportAction will be undefined while it's being read from Onyx
-        // and then linkedReportAction will either be a valid parentReportAction or an empty object. In the case of an empty object, then it's OK to show the not-found page.
-        if (shouldHideReport || (parentReportAction !== undefined && isEmptyObject(linkedReportAction))) {
+        // and then linkedReportAction will either be a valid parentReportAction or an empty object.
+        // When report exists but reportAction doesn't, show report with subtle feedback instead of NotFoundPage
+        const isReportActionNotFound = parentReportAction !== undefined && isEmptyObject(linkedReportAction);
+        
+        if (shouldHideReport) {
             return <NotFoundPage />;
         }
 
+        // Show subtle feedback when reportAction is not found but report exists
+        const feedbackIndicator = isReportActionNotFound ? (
+            <ReportActionNotFoundIndicator />
+        ) : null;
+
         return (
-            <WrappedComponent
-                // eslint-disable-next-line react/jsx-props-no-spreading
-                {...props}
-                report={report}
-                parentReport={parentReport}
-                reportAction={linkedReportAction}
-                parentReportAction={parentReportAction}
-            />
+            <>
+                {feedbackIndicator}
+                <WrappedComponent
+                    // eslint-disable-next-line react/jsx-props-no-spreading
+                    {...props}
+                    report={report}
+                    parentReport={parentReport}
+                    reportAction={linkedReportAction}
+                    parentReportAction={parentReportAction}
+                    isReportActionNotFound={isReportActionNotFound}
+                />
+            </>
         );
     }
 


### PR DESCRIPTION
### Details
Coming from [Issue #79163](https://github.com/Expensify/App/issues/79163)

### Problem
When the deeplink with specific report actionID links to action that is not present on the report anymore (or never was), we showed the user generic not here page. This was disruptive while in many cases we could show the report as normal.

### Solution
Modified `withReportAndReportActionOrNotFound` HOC to:
- Show the report normally when user has access to it
- Display subtle inline indicator instead of full-page NotFoundPage
- Preserve NotFoundPage only when report itself does not exist

### Changes
1. **withReportAndReportActionOrNotFound.tsx**: 
   - Separated report existence check from reportAction existence check
   - Added `isReportActionNotFound` flag
   - Render inline indicator when action not found

2. **ReportActionNotFoundIndicator.tsx** (new):
   - Subtle inline banner with minimal styling
   - Non-disruptive user feedback

### Testing
- Verified report displays normally when deep-linked action not found
- Verified NotFoundPage still shows when report does not exist
- Verified indicator shows/hides appropriately

### Fixed Issues
$ https://github.com/Expensify/App/issues/79163