### PR TITLE
Fix/72129b-follow-up: No checkmark displayed for selected recipient in choose recipient page

### DIFF
--- a/src/libs/ReportUtils.ts
+++ b/src/libs/ReportUtils.ts
@@ -11110,6 +11110,7 @@ function createDraftTransactionAndNavigateToParticipantSelector(
         modifiedMerchant: '',
         modifiedAttendees: undefined,
         mccGroup,
+        participants: undefined
     } as Transaction);
 
     let firstPolicy: Policy | undefined;

--- a/src/libs/ReportUtils.ts
+++ b/src/libs/ReportUtils.ts
@@ -11110,7 +11110,7 @@ function createDraftTransactionAndNavigateToParticipantSelector(
         modifiedMerchant: '',
         modifiedAttendees: undefined,
         mccGroup,
-        participants: undefined
+        participants: undefined,
     } as Transaction);
 
     let firstPolicy: Policy | undefined;

--- a/src/libs/actions/IOU/index.ts
+++ b/src/libs/actions/IOU/index.ts
@@ -12301,8 +12301,17 @@ function getMoneyRequestParticipantsFromReport(report: OnyxEntry<OnyxTypes.Repor
         ];
     } else if (isInvoiceRoom(chatReport)) {
         participants = [
-            {reportID: chatReport?.reportID, selected: true},
             {
+                iouType: CONST.IOU.TYPE.INVOICE,
+                accountID: 0,
+                reportID: chatReport?.reportID,
+                isPolicyExpenseChat: false,
+                selected: true,
+                policyID: chatReport?.policyID,
+                isSelfDM: false,
+            },
+            {
+                iouType: CONST.IOU.TYPE.INVOICE,
                 policyID: chatReport?.policyID,
                 isSender: true,
                 selected: false,

--- a/src/pages/iou/request/MoneyRequestParticipantsSelector.tsx
+++ b/src/pages/iou/request/MoneyRequestParticipantsSelector.tsx
@@ -218,27 +218,26 @@ function MoneyRequestParticipantsSelector({
         [isIOUSplit, iouType, onParticipantsAdded],
     );
 
-    const {searchTerm, debouncedSearchTerm, setSearchTerm, availableOptions, selectedOptions, setSelectedOptions, toggleSelection, areOptionsInitialized, onListEndReached, contactState} =
-        useSearchSelector({
-            selectionMode: isIOUSplit ? CONST.SEARCH_SELECTOR.SELECTION_MODE_MULTI : CONST.SEARCH_SELECTOR.SELECTION_MODE_SINGLE,
-            searchContext: CONST.SEARCH_SELECTOR.SEARCH_CONTEXT_GENERAL,
-            includeUserToInvite: !isCategorizeOrShareAction && !isPerDiemRequest,
-            excludeLogins: CONST.EXPENSIFY_EMAILS_OBJECT,
-            includeRecentReports: true,
-            maxRecentReportsToShow: CONST.IOU.MAX_RECENT_REPORTS_TO_SHOW,
-            getValidOptionsConfig,
-            shouldInitialize: didScreenTransitionEnd,
-            enablePhoneContacts: isNative,
-            contactOptions: contacts,
-            initialSelected: participants as OptionData[],
-            onSelectionChange: handleSelectionChange,
-            onSingleSelect: (option: OptionData) => {
-                if (isIOUSplit) {
-                    return;
-                }
-                addSingleParticipant(option);
-            },
-        });
+    const {searchTerm, debouncedSearchTerm, setSearchTerm, availableOptions, selectedOptions, toggleSelection, areOptionsInitialized, onListEndReached, contactState} = useSearchSelector({
+        selectionMode: isIOUSplit ? CONST.SEARCH_SELECTOR.SELECTION_MODE_MULTI : CONST.SEARCH_SELECTOR.SELECTION_MODE_SINGLE,
+        searchContext: CONST.SEARCH_SELECTOR.SEARCH_CONTEXT_GENERAL,
+        includeUserToInvite: !isCategorizeOrShareAction && !isPerDiemRequest,
+        excludeLogins: CONST.EXPENSIFY_EMAILS_OBJECT,
+        includeRecentReports: true,
+        maxRecentReportsToShow: CONST.IOU.MAX_RECENT_REPORTS_TO_SHOW,
+        getValidOptionsConfig,
+        shouldInitialize: didScreenTransitionEnd,
+        enablePhoneContacts: isNative,
+        contactOptions: contacts,
+        initialSelected: isIOUSplit ? (participants as OptionData[]) : undefined,
+        onSelectionChange: handleSelectionChange,
+        onSingleSelect: (option: OptionData) => {
+            if (isIOUSplit) {
+                return;
+            }
+            addSingleParticipant(option);
+        },
+    });
 
     const cleanSearchTerm = useMemo(() => debouncedSearchTerm.trim().toLowerCase(), [debouncedSearchTerm]);
 
@@ -519,11 +518,9 @@ function MoneyRequestParticipantsSelector({
                 return;
             }
 
-            const reportID = option.reportID ?? CONST.REPORT.UNREPORTED_REPORT_ID;
-            setSelectedOptions([{...option, isSelected: true, reportID, keyForList: reportID}]);
             addSingleParticipant(option);
         },
-        [isIOUSplit, addParticipantToSelection, addSingleParticipant, setSelectedOptions],
+        [isIOUSplit, addParticipantToSelection, addSingleParticipant],
     );
 
     const importContactsButtonComponent = useMemo(() => {


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
The follow-up PR #78354


- **#82515:** Because when creating a transaction draft using `createDraftTransaction`, we don’t reset the `participants` property [here](https://github.com/Expensify/App/blob/a93a3165a599fbd8f21989c6e288372df9a5f1dc/src/libs/ReportUtils.ts#L11097-L11113).

- **#82459:** We are missing information for the invoice room when restarting the invoice creation flow [here](https://github.com/Expensify/App/blob/a93a3165a599fbd8f21989c6e288372df9a5f1dc/src/libs/actions/IOU/index.ts#L12304-L12309).

- **#82468:** Because [`selectedOptions`](https://github.com/Expensify/App/blob/a93a3165a599fbd8f21989c6e288372df9a5f1dc/src/hooks/useSearchSelector.base.ts#L168) holds stale data from the previously selected option, the invoice room option gets excluded [here](https://github.com/Expensify/App/blob/a93a3165a599fbd8f21989c6e288372df9a5f1dc/src/hooks/useSearchSelector.base.ts#L415-L419).  
  To fix this issue: since `selectedOptions` is not used in `CONST.SEARCH_SELECTOR.SELECTION_MODE_SINGLE` mode (specifically outside IOU split), we will remove the `setSelectedOptions` logic in `MoneyRequestParticipantsSelector` that was added in PR #78354, and pass `initialSelected` as `undefined` in this case.


### Fixed Issues
$ https://github.com/Expensify/App/issues/82459
$ https://github.com/Expensify/App/issues/82468
$ https://github.com/Expensify/App/issues/82515
PROPOSAL: 

### Tests
Same as QA Steps

- [x] Verify that no errors appear in the JS console

### Offline tests
Same as QA Steps

### QA Steps
**Test 1:**

_Precondition:_

- Invoice is enabled.
- User has sent an invoice.

1. Go to staging.new.expensify.com
2. Open FAB > Send invoice.
3. Enter amount > Next.
4. Select invoice chat.
5. On confirm page, click To field.
6. Click RHP back button until you reach amount input page.
7. Click Next.
8. On confirm page, click To field.
9. Note that the Invoice chat will be selected.


**Test 2:**
1. Go to staging.new.expensify.com
2. Go to self DM.
3. Track a distance expense in self DM.
4. Click Submit it to someone.
5. Note that the Self DM will not be marked as selected in recipient list.

**Test 3:**
_Precondition:_

- Invoice is enabled.
- Send invoice to two different users to create two invoice chats.

1. Go to staging.new.expensify.com
2. Open FAB > Send invoice.
3. Enter amount > Next.
4. Select an invoice chat.
5. On confirm page, click To field.
6. Select another invoice chat.
7. Click RHP back button.
8. Note that the previous invoice chat in Step 4 will appear in recipient list.

**Test 4:**
_Precondition:_ Log in with new account and do not create workspace.

1. Go to staging.new.expensify.com
2. Open FAB > Create expense > Manual.
3. Enter amount > Next.
4. Select Manager McTest.
5. On confirm page, click RHP back button.
6. Click RHP back button again.
7. On amount page, click Next.
8. Enter email of any user and select it.
9. On confirm page, click RHP back button.
10. Clear the search field.
11. Verify that the Manager McTest will appear in the recipient list.



- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I verified there are no new alerts related to the `canBeMissing` param for `useOnyx`
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
**Test 1:**


https://github.com/user-attachments/assets/1b89cc58-da75-49a4-81df-04259f9133a3



**Test 2:**



https://github.com/user-attachments/assets/92d3b2eb-fdad-46dd-bb67-5d54d8f19b76



**Test 3:**


https://github.com/user-attachments/assets/b3216e07-dd63-4271-bba2-8256a21824f9





**Test 4:**


https://github.com/user-attachments/assets/ef43317f-84d3-4d92-b196-fbcd067f6771



