### PR TITLE
Fix: Join button missing in thread when parent report is loading

### DIFF
--- a/src/pages/inbox/HeaderView.tsx
+++ b/src/pages/inbox/HeaderView.tsx
@@ -389,7 +389,7 @@ function HeaderView({report, parentReportAction, onNavigationMenuButtonClicked, 
                                         />
                                     )}
                                     {!shouldUseNarrowLayout && isOpenTaskReport(report, parentReportAction) && <TaskHeaderActionButton report={report} />}
-                                    {!isParentReportLoading && canJoin && !shouldUseNarrowLayout && joinButton}
+                                    {canJoin && !shouldUseNarrowLayout && joinButton}
                                 </View>
                                 {!isInSidePanel && <SidePanelButton style={styles.ml2} />}
                                 {shouldDisplaySearchRouter && <SearchButton />}
@@ -397,7 +397,7 @@ function HeaderView({report, parentReportAction, onNavigationMenuButtonClicked, 
                         </View>
                     )}
                 </View>
-                {!isParentReportLoading && !isLoading && canJoin && shouldUseNarrowLayout && <View style={[styles.ph5, styles.pb2]}>{joinButton}</View>}
+                {!isLoading && canJoin && shouldUseNarrowLayout && <View style={[styles.ph5, styles.pb2]}>{joinButton}</View>}
                 <View style={shouldShowOnBoardingHelpDropdownButton && [styles.flexRow, styles.alignItemsCenter, styles.gap1, styles.ph5]}>
                     {!shouldShowEarlyDiscountBanner && shouldShowOnBoardingHelpDropdownButton && shouldUseNarrowLayout && (
                         <View style={[styles.flex1, styles.pb3]}>{onboardingHelpDropdownButton}</View>


### PR DESCRIPTION
### Problem
When User B opens a thread created by User A, the Join button doesn't appear if the parent report is still loading from Onyx.

### Root Cause
The Join button display condition included \!isParentReportLoading\ which blocked the button when parentReport was loading. However, the \canJoin\ check already contains all necessary logic to determine if the button should be shown.

### Solution
Removed the unnecessary \!isParentReportLoading