### PR TITLE
[No QA] Add unit tests for ImageSVG cache policy behavior 

### DIFF
--- a/tests/unit/ImageSVGCachePolicyTest.tsx
+++ b/tests/unit/ImageSVGCachePolicyTest.tsx
@@ -1,0 +1,114 @@
+import {render} from '@testing-library/react-native';
+import React from 'react';
+import ImageSVGAndroid from '../../src/components/ImageSVG/index.android';
+import ImageSVGiOS from '../../src/components/ImageSVG/index.ios';
+
+type MockImageType = jest.Mock & {clearMemoryCache: jest.Mock};
+
+const mockClearMemoryCache = jest.fn(() => Promise.resolve(true));
+
+const mockImageComponent: MockImageType = Object.assign(
+    jest.fn(() => null),
+    {
+        clearMemoryCache: mockClearMemoryCache,
+    },
+) as MockImageType;
+
+jest.mock('expo-image', () => ({
+    get Image() {
+        return mockImageComponent;
+    },
+}));
+
+jest.mock('@libs/getImageRecyclingKey', () => ({
+    __esModule: true,
+    default: jest.fn((source: unknown) => {
+        if (typeof source === 'number') {
+            return String(source);
+        }
+        if (typeof source === 'object' && source !== null && 'uri' in source) {
+            return (source as {uri: string}).uri;
+        }
+        return undefined;
+    }),
+}));
+
+const MOCK_STATIC_SOURCE = 42;
+
+describe('ImageSVG cache policy', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    describe('iOS implementation', () => {
+        it('should use memory-disk cache policy for static image sources', () => {
+            render(<ImageSVGiOS src={MOCK_STATIC_SOURCE} />);
+
+            expect(mockImageComponent).toHaveBeenCalled();
+            const props = mockImageComponent.mock.calls[0][0] as Record<string, unknown>;
+            expect(props.cachePolicy).toBe('memory-disk');
+        });
+
+        it('should set recyclingKey for static image sources', () => {
+            render(<ImageSVGiOS src={MOCK_STATIC_SOURCE} />);
+
+            const props = mockImageComponent.mock.calls[0][0] as Record<string, unknown>;
+            expect(props.recyclingKey).toBe(String(MOCK_STATIC_SOURCE));
+        });
+
+        it('should render React component sources directly without expo-image Image', () => {
+            const MockSvgComponent = jest.fn(() => null);
+            render(<ImageSVGiOS src={MockSvgComponent} />);
+
+            expect(mockImageComponent).not.toHaveBeenCalled();
+            expect(MockSvgComponent).toHaveBeenCalled();
+        });
+
+        it('should return null when src is undefined', () => {
+            const {toJSON} = render(<ImageSVGiOS src={undefined} />);
+
+            expect(toJSON()).toBeNull();
+            expect(mockImageComponent).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('Android implementation', () => {
+        it('should use memory cache policy for static image sources', () => {
+            render(<ImageSVGAndroid src={MOCK_STATIC_SOURCE} />);
+
+            expect(mockImageComponent).toHaveBeenCalled();
+            const props = mockImageComponent.mock.calls[0][0] as Record<string, unknown>;
+            expect(props.cachePolicy).toBe('memory');
+        });
+
+        it('should set recyclingKey for static image sources', () => {
+            render(<ImageSVGAndroid src={MOCK_STATIC_SOURCE} />);
+
+            const props = mockImageComponent.mock.calls[0][0] as Record<string, unknown>;
+            expect(props.recyclingKey).toBe(String(MOCK_STATIC_SOURCE));
+        });
+
+        it('should clear memory cache on unmount to prevent memory leaks', () => {
+            const {unmount} = render(<ImageSVGAndroid src={MOCK_STATIC_SOURCE} />);
+
+            expect(mockClearMemoryCache).not.toHaveBeenCalled();
+            unmount();
+            expect(mockClearMemoryCache).toHaveBeenCalled();
+        });
+
+        it('should render React component sources directly without expo-image Image', () => {
+            const MockSvgComponent = jest.fn(() => null);
+            render(<ImageSVGAndroid src={MockSvgComponent} />);
+
+            expect(mockImageComponent).not.toHaveBeenCalled();
+            expect(MockSvgComponent).toHaveBeenCalled();
+        });
+
+        it('should return null when src is undefined', () => {
+            const {toJSON} = render(<ImageSVGAndroid src={undefined} />);
+
+            expect(toJSON()).toBeNull();
+            expect(mockImageComponent).not.toHaveBeenCalled();
+        });
+    });
+});

--- a/tests/unit/ImageSVGCachePolicyTest.tsx
+++ b/tests/unit/ImageSVGCachePolicyTest.tsx
@@ -20,9 +20,8 @@ jest.mock('expo-image', () => ({
     },
 }));
 
-jest.mock('@libs/getImageRecyclingKey', () => ({
-    __esModule: true,
-    default: jest.fn((source: unknown) => {
+jest.mock('@libs/getImageRecyclingKey', () =>
+    jest.fn((source: unknown) => {
         if (typeof source === 'number') {
             return String(source);
         }
@@ -31,9 +30,13 @@ jest.mock('@libs/getImageRecyclingKey', () => ({
         }
         return undefined;
     }),
-}));
+);
 
 const MOCK_STATIC_SOURCE = 42;
+
+function getFirstCallProps(): Record<string, unknown> {
+    return mockImageComponent.mock.calls.at(0)?.at(0) as Record<string, unknown>;
+}
 
 describe('ImageSVG cache policy', () => {
     beforeEach(() => {
@@ -45,14 +48,14 @@ describe('ImageSVG cache policy', () => {
             render(<ImageSVGiOS src={MOCK_STATIC_SOURCE} />);
 
             expect(mockImageComponent).toHaveBeenCalled();
-            const props = mockImageComponent.mock.calls[0][0] as Record<string, unknown>;
+            const props = getFirstCallProps();
             expect(props.cachePolicy).toBe('memory-disk');
         });
 
         it('should set recyclingKey for static image sources', () => {
             render(<ImageSVGiOS src={MOCK_STATIC_SOURCE} />);
 
-            const props = mockImageComponent.mock.calls[0][0] as Record<string, unknown>;
+            const props = getFirstCallProps();
             expect(props.recyclingKey).toBe(String(MOCK_STATIC_SOURCE));
         });
 
@@ -77,14 +80,14 @@ describe('ImageSVG cache policy', () => {
             render(<ImageSVGAndroid src={MOCK_STATIC_SOURCE} />);
 
             expect(mockImageComponent).toHaveBeenCalled();
-            const props = mockImageComponent.mock.calls[0][0] as Record<string, unknown>;
+            const props = getFirstCallProps();
             expect(props.cachePolicy).toBe('memory');
         });
 
         it('should set recyclingKey for static image sources', () => {
             render(<ImageSVGAndroid src={MOCK_STATIC_SOURCE} />);
 
-            const props = mockImageComponent.mock.calls[0][0] as Record<string, unknown>;
+            const props = getFirstCallProps();
             expect(props.recyclingKey).toBe(String(MOCK_STATIC_SOURCE));
         });
 

--- a/tests/unit/ImageSVGCachePolicyTest.tsx
+++ b/tests/unit/ImageSVGCachePolicyTest.tsx
@@ -35,7 +35,8 @@ jest.mock('@libs/getImageRecyclingKey', () =>
 const MOCK_STATIC_SOURCE = 42;
 
 function getFirstCallProps(): Record<string, unknown> {
-    return mockImageComponent.mock.calls.at(0)?.at(0) as Record<string, unknown>;
+    const firstCall = mockImageComponent.mock.calls.at(0) as unknown[] | undefined;
+    return firstCall?.at(0) as Record<string, unknown>;
 }
 
 describe('ImageSVG cache policy', () => {


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
<!-- Explain what your change does and how it addresses the linked issue -->

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/80422
PROPOSAL:


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

NA 

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->

NA 
### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [X] I linked the correct issue in the `### Fixed Issues` section above
- [X] I wrote clear testing steps that cover the changes made in this PR
    - [X] I added steps for local testing in the `Tests` section
    - [X] I added steps for the expected offline behavior in the `Offline steps` section
    - [X] I added steps for Staging and/or Production testing in the `QA steps` section
    - [X] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [X] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [X] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [X] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [X] I ran the tests on **all platforms** & verified they passed on:
    - [X] Android: Native
    - [X] Android: mWeb Chrome
    - [X] iOS: Native
    - [X] iOS: mWeb Safari
    - [X] MacOS: Chrome / Safari
- [X] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [X] I verified there are no new alerts related to the `canBeMissing` param for `useOnyx`
- [X] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [X] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [X] I verified that comments were added to code that is not self explanatory
    - [X] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [X] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [X] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [X] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [X] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [X] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [X] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [X] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [X] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [X] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [X] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [X] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [X] I verified that if a function's arguments changed that all usages have also been updated correctly
- [X] If any new file was added I verified that:
    - [X] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [X] If a new CSS style is added I verified that:
    - [X] A similar style doesn't already exist
    - [X] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [X] If new assets were added or existing ones were modified, I verified that:
    - [X] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [X] The assets load correctly across all supported platforms.
- [X] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [X] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [X] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [X] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [X] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [X] I verified that all the inputs inside a form are aligned with each other.
    - [X] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [X] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [X] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [X] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>