### PR TITLE
[CP Staging] fix/82727-82739-revert-workspace-list-accessibility

### DIFF
--- a/src/CONST/index.ts
+++ b/src/CONST/index.ts
@@ -8576,6 +8576,8 @@ const CONST = {
         WORKSPACE: {
             TOGGLE_SETTINGS_ROW: 'Workspace-ToggleSettingsRow',
             WORKSPACE_MENU_ITEM: 'Workspace-WorkspaceMenuItem',
+            WORKSPACE_LIST_ROW: 'Workspace-WorkspacesListRow',
+            WORKSPACE_LIST_ROW_ARROW: 'Workspace-WorkspacesListRow-Arrow',
             COMPANY_CARDS: {
                 TABLE_ITEM: 'Workspace-CompanyCards-TableItem',
             },

--- a/src/CONST/index.ts
+++ b/src/CONST/index.ts
@@ -8576,8 +8576,6 @@ const CONST = {
         WORKSPACE: {
             TOGGLE_SETTINGS_ROW: 'Workspace-ToggleSettingsRow',
             WORKSPACE_MENU_ITEM: 'Workspace-WorkspaceMenuItem',
-            WORKSPACE_LIST_ROW: 'Workspace-WorkspacesListRow',
-            WORKSPACE_LIST_ROW_ARROW: 'Workspace-WorkspacesListRow-Arrow',
             COMPANY_CARDS: {
                 TABLE_ITEM: 'Workspace-CompanyCards-TableItem',
             },

--- a/src/pages/workspace/WorkspacesListPage.tsx
+++ b/src/pages/workspace/WorkspacesListPage.tsx
@@ -467,6 +467,7 @@ function WorkspacesListPage() {
                         style={[styles.mh5]}
                         disabled={item.disabled}
                         onPress={item.action}
+                        sentryLabel={CONST.SENTRY_LABEL.WORKSPACE.WORKSPACE_MENU_ITEM}
                     >
                         {({hovered}) => (
                             <WorkspacesListRow

--- a/src/pages/workspace/WorkspacesListPage.tsx
+++ b/src/pages/workspace/WorkspacesListPage.tsx
@@ -55,6 +55,7 @@ import {
     getConnectionExporters,
     getPolicyBrickRoadIndicatorStatus,
     getUberConnectionErrorDirectlyFromPolicy,
+    getUserFriendlyWorkspaceType,
     isPendingDeletePolicy,
     isPolicyAdmin,
     isPolicyAuditor,
@@ -438,6 +439,17 @@ function WorkspacesListPage() {
                 });
             }
 
+            const ownerDisplayName = personalDetails?.[item.ownerAccountID ?? CONST.DEFAULT_NUMBER_ID]?.displayName ?? '';
+            const workspaceType = item.type ? getUserFriendlyWorkspaceType(item.type, translate) : '';
+            const accessibilityLabel = [
+                `${translate('workspace.common.workspace')}: ${item.title}`,
+                isDefault ? translate('common.default') : '',
+                `${translate('workspace.common.workspaceOwner')}: ${ownerDisplayName}`,
+                `${translate('workspace.common.workspaceType')}: ${workspaceType}`,
+            ]
+                .filter(Boolean)
+                .join(', ');
+
             return (
                 <OfflineWithFeedback
                     key={`${item.title}_${index}`}
@@ -449,13 +461,12 @@ function WorkspacesListPage() {
                     shouldShowErrorMessages={item.policyID !== policyIDToDelete}
                     shouldHideOnDelete={false}
                 >
-                    {/* accessible={false} allows child elements (workspace row and 3-dot menu) to be individually focusable.
-                        onPress is handled by WorkspacesListRow to prevent double-firing on web due to event bubbling. */}
                     <PressableWithoutFeedback
-                        accessible={false}
+                        role={CONST.ROLE.BUTTON}
+                        accessibilityLabel={accessibilityLabel}
                         style={[styles.mh5]}
                         disabled={item.disabled}
-                        sentryLabel={CONST.SENTRY_LABEL.WORKSPACE.WORKSPACE_MENU_ITEM}
+                        onPress={item.action}
                     >
                         {({hovered}) => (
                             <WorkspacesListRow
@@ -476,7 +487,6 @@ function WorkspacesListPage() {
                                 isLoadingBill={isLoadingBill}
                                 resetLoadingSpinnerIconIndex={resetLoadingSpinnerIconIndex}
                                 isHovered={hovered}
-                                onPress={item.action}
                             />
                         )}
                     </PressableWithoutFeedback>

--- a/src/pages/workspace/WorkspacesListRow.tsx
+++ b/src/pages/workspace/WorkspacesListRow.tsx
@@ -10,7 +10,6 @@ import Badge from '@components/Badge';
 import Icon from '@components/Icon';
 import * as Expensicons from '@components/Icon/Expensicons';
 import type {PopoverMenuItem} from '@components/PopoverMenu';
-import PressableWithoutFeedback from '@components/Pressable/PressableWithoutFeedback';
 import Text from '@components/Text';
 import TextWithTooltip from '@components/TextWithTooltip';
 import ThreeDotsMenu from '@components/ThreeDotsMenu';
@@ -21,6 +20,7 @@ import WorkspacesListRowDisplayName from '@components/WorkspacesListRowDisplayNa
 import useAnimatedHighlightStyle from '@hooks/useAnimatedHighlightStyle';
 import {useMemoizedLazyExpensifyIcons, useMemoizedLazyIllustrations} from '@hooks/useLazyAsset';
 import useLocalize from '@hooks/useLocalize';
+import useResponsiveLayout from '@hooks/useResponsiveLayout';
 import useTheme from '@hooks/useTheme';
 import useThemeStyles from '@hooks/useThemeStyles';
 import {getDisplayNameOrDefault, getPersonalDetailsByIDs} from '@libs/PersonalDetailsUtils';
@@ -85,9 +85,6 @@ type WorkspacesListRowProps = WithCurrentUserPersonalDetailsProps & {
 
     /** Whether the list item is hovered */
     isHovered?: boolean;
-
-    /** Callback when the row is pressed */
-    onPress?: () => void;
 };
 
 type BrickRoadIndicatorIconProps = {
@@ -125,10 +122,10 @@ function WorkspacesListRow({
     isLoadingBill,
     resetLoadingSpinnerIconIndex,
     isHovered,
-    onPress,
 }: WorkspacesListRowProps) {
     const styles = useThemeStyles();
     const {translate} = useLocalize();
+    const {shouldUseNarrowLayout} = useResponsiveLayout();
     const theme = useTheme();
     const isFocused = useIsFocused();
     const isNarrow = layoutWidth === CONST.LAYOUT_WIDTH.NARROW;
@@ -181,7 +178,7 @@ function WorkspacesListRow({
     const isDeleted = style && Array.isArray(style) ? style.includes(styles.offlineFeedbackDeleted) : false;
 
     const ThreeDotMenuOrPendingIcon = (
-        <View style={[styles.flexRow, !isNarrow && styles.workspaceThreeDotMenu]}>
+        <View style={[styles.flexRow, !shouldUseNarrowLayout && styles.workspaceThreeDotMenu]}>
             {!!isJoinRequestPending && (
                 <View style={[styles.flexRow, styles.gap2, styles.alignItemsCenter, styles.justifyContentEnd]}>
                     <Badge
@@ -227,29 +224,10 @@ function WorkspacesListRow({
         </View>
     );
 
-    const ownerName = ownerDetails ? getDisplayNameOrDefault(ownerDetails) : '';
-    const workspaceTypeName = workspaceType ? getUserFriendlyWorkspaceType(workspaceType, translate) : '';
-    const accessibilityLabel = [
-        `${translate('workspace.common.workspaceName')}: ${title}`,
-        isDefault ? translate('common.default') : '',
-        isJoinRequestPending ? translate('workspace.common.requested') : '',
-        ownerName ? `${translate('workspace.common.workspaceOwner')}: ${ownerName}` : '',
-        workspaceTypeName ? `${translate('workspace.common.workspaceType')}: ${workspaceTypeName}` : '',
-    ]
-        .filter(Boolean)
-        .join(', ');
-
     return (
         <View style={[styles.flexRow, styles.highlightBG, rowStyles, style, styles.br3]}>
             <Animated.View style={[styles.flex1, styles.flexRow, styles.bgTransparent, isWide && styles.gap5, styles.p5, styles.pr3, animatedHighlightStyle]}>
-                <PressableWithoutFeedback
-                    accessible
-                    accessibilityLabel={accessibilityLabel}
-                    role={CONST.ROLE.BUTTON}
-                    onPress={onPress}
-                    style={[isWide ? styles.flexRow : styles.flexColumn, styles.flex1, isWide && styles.gap5]}
-                    sentryLabel={CONST.SENTRY_LABEL.WORKSPACE.WORKSPACE_LIST_ROW}
-                >
+                <View style={[isWide ? styles.flexRow : styles.flexColumn, styles.flex1, isWide && styles.gap5]}>
                     <View style={[styles.flexRow, styles.justifyContentBetween, styles.flex2, isNarrow && styles.mb3, styles.alignItemsCenter]}>
                         <View style={[styles.flexRow, styles.gap3, styles.flex1, styles.alignItemsCenter]}>
                             <Avatar
@@ -282,7 +260,7 @@ function WorkspacesListRow({
                                 <View style={styles.flex1}>
                                     <WorkspacesListRowDisplayName
                                         isDeleted={isDeleted}
-                                        ownerName={ownerName}
+                                        ownerName={getDisplayNameOrDefault(ownerDetails)}
                                     />
                                     <Text
                                         numberOfLines={1}
@@ -307,7 +285,7 @@ function WorkspacesListRow({
                                     numberOfLines={1}
                                     style={[styles.labelStrong, isDeleted ? styles.offlineFeedbackDeleted : {}]}
                                 >
-                                    {workspaceTypeName}
+                                    {getUserFriendlyWorkspaceType(workspaceType, translate)}
                                 </Text>
                             )}
                             <Text
@@ -318,17 +296,12 @@ function WorkspacesListRow({
                             </Text>
                         </View>
                     </View>
-                </PressableWithoutFeedback>
+                </View>
 
                 <View style={[styles.flexRow, styles.alignItemsCenter]}>
                     {!isNarrow && ThreeDotMenuOrPendingIcon}
                     {!isNarrow && (
-                        <PressableWithoutFeedback
-                            onPress={onPress}
-                            style={[styles.justifyContentCenter, styles.alignItemsCenter, styles.touchableButtonImage]}
-                            accessible={false}
-                            sentryLabel={CONST.SENTRY_LABEL.WORKSPACE.WORKSPACE_LIST_ROW_ARROW}
-                        >
+                        <View style={[styles.justifyContentCenter, styles.alignItemsCenter, styles.touchableButtonImage]}>
                             <Icon
                                 src={icons.ArrowRight}
                                 fill={theme.icon}
@@ -336,7 +309,7 @@ function WorkspacesListRow({
                                 isButtonIcon
                                 medium
                             />
-                        </PressableWithoutFeedback>
+                        </View>
                     )}
                 </View>
             </Animated.View>

--- a/src/pages/workspace/WorkspacesListRow.tsx
+++ b/src/pages/workspace/WorkspacesListRow.tsx
@@ -180,15 +180,17 @@ function WorkspacesListRow({
 
     const isDeleted = style && Array.isArray(style) ? style.includes(styles.offlineFeedbackDeleted) : false;
 
-    const WorkspaceBadges = (
-        <View style={[styles.flexRow, styles.gap1, styles.alignItemsCenter]}>
+    const ThreeDotMenuOrPendingIcon = (
+        <View style={[styles.flexRow, !isNarrow && styles.workspaceThreeDotMenu]}>
             {!!isJoinRequestPending && (
-                <Badge
-                    text={translate('workspace.common.requested')}
-                    textStyles={styles.textStrong}
-                    badgeStyles={[styles.alignSelfCenter, styles.badgeBordered]}
-                    icon={icons.Hourglass}
-                />
+                <View style={[styles.flexRow, styles.gap2, styles.alignItemsCenter, styles.justifyContentEnd]}>
+                    <Badge
+                        text={translate('workspace.common.requested')}
+                        textStyles={styles.textStrong}
+                        badgeStyles={[styles.alignSelfCenter, styles.badgeBordered]}
+                        icon={icons.Hourglass}
+                    />
+                </View>
             )}
             {!!isDefault && (
                 <Tooltip
@@ -196,7 +198,7 @@ function WorkspacesListRow({
                     text={translate('workspace.common.defaultNote')}
                     numberOfLines={4}
                 >
-                    <View>
+                    <View style={[styles.flexRow, styles.gap2, styles.alignItemsCenter, styles.justifyContentEnd]}>
                         <Badge
                             text={translate('common.default')}
                             textStyles={styles.textStrong}
@@ -206,8 +208,20 @@ function WorkspacesListRow({
                 </Tooltip>
             )}
             {!isJoinRequestPending && (
-                <View style={[styles.flexRow, styles.gap2, styles.alignItemsCenter, isNarrow && styles.workspaceListRBR]}>
-                    <BrickRoadIndicatorIcon brickRoadIndicator={brickRoadIndicator} />
+                <View style={[styles.flexRow, styles.ml2, styles.gap1]}>
+                    <View style={[styles.flexRow, styles.gap2, styles.alignItemsCenter, isNarrow && styles.workspaceListRBR]}>
+                        <BrickRoadIndicatorIcon brickRoadIndicator={brickRoadIndicator} />
+                    </View>
+                    <ThreeDotsMenu
+                        isContainerFocused={isFocused}
+                        shouldSelfPosition
+                        menuItems={menuItems}
+                        anchorAlignment={{horizontal: CONST.MODAL.ANCHOR_ORIGIN_HORIZONTAL.RIGHT, vertical: CONST.MODAL.ANCHOR_ORIGIN_VERTICAL.TOP}}
+                        shouldOverlay
+                        disabled={shouldDisableThreeDotsMenu}
+                        isNested
+                        threeDotsMenuRef={threeDotsMenuRef}
+                    />
                 </View>
             )}
         </View>
@@ -215,9 +229,15 @@ function WorkspacesListRow({
 
     const ownerName = ownerDetails ? getDisplayNameOrDefault(ownerDetails) : '';
     const workspaceTypeName = workspaceType ? getUserFriendlyWorkspaceType(workspaceType, translate) : '';
-    const defaultLabel = isDefault ? `, ${translate('common.default')}` : '';
-    const pendingLabel = isJoinRequestPending ? `, ${translate('workspace.common.requested')}` : '';
-    const accessibilityLabel = `${title}${ownerName ? `, ${ownerName}` : ''}${workspaceTypeName ? `, ${workspaceTypeName}` : ''}${defaultLabel}${pendingLabel}`;
+    const accessibilityLabel = [
+        `${translate('workspace.common.workspaceName')}: ${title}`,
+        isDefault ? translate('common.default') : '',
+        isJoinRequestPending ? translate('workspace.common.requested') : '',
+        ownerName ? `${translate('workspace.common.workspaceOwner')}: ${ownerName}` : '',
+        workspaceTypeName ? `${translate('workspace.common.workspaceType')}: ${workspaceTypeName}` : '',
+    ]
+        .filter(Boolean)
+        .join(', ');
 
     return (
         <View style={[styles.flexRow, styles.highlightBG, rowStyles, style, styles.br3]}>
@@ -228,7 +248,7 @@ function WorkspacesListRow({
                     role={CONST.ROLE.BUTTON}
                     onPress={onPress}
                     style={[isWide ? styles.flexRow : styles.flexColumn, styles.flex1, isWide && styles.gap5]}
-                    sentryLabel="WorkspacesListRow"
+                    sentryLabel={CONST.SENTRY_LABEL.WORKSPACE.WORKSPACE_LIST_ROW}
                 >
                     <View style={[styles.flexRow, styles.justifyContentBetween, styles.flex2, isNarrow && styles.mb3, styles.alignItemsCenter]}>
                         <View style={[styles.flexRow, styles.gap3, styles.flex1, styles.alignItemsCenter]}>
@@ -247,7 +267,7 @@ function WorkspacesListRow({
                                 style={[styles.flex1, styles.flexGrow1, styles.textStrong, isDeleted ? styles.offlineFeedbackDeleted : {}]}
                             />
                         </View>
-                        {isNarrow && WorkspaceBadges}
+                        {isNarrow && ThreeDotMenuOrPendingIcon}
                     </View>
                     <View style={[styles.flexRow, isWide && styles.flex1, isWide && styles.workspaceOwnerSectionMinWidth, styles.gap2, styles.alignItemsCenter]}>
                         {!!ownerDetails && (
@@ -298,24 +318,17 @@ function WorkspacesListRow({
                             </Text>
                         </View>
                     </View>
-                    {!isNarrow && WorkspaceBadges}
                 </PressableWithoutFeedback>
 
-                <View style={[styles.flexRow, styles.alignItemsCenter, isNarrow && styles.alignSelfStart]}>
-                    {!isJoinRequestPending && (
-                        <ThreeDotsMenu
-                            isContainerFocused={isFocused}
-                            shouldSelfPosition
-                            menuItems={menuItems}
-                            anchorAlignment={{horizontal: CONST.MODAL.ANCHOR_ORIGIN_HORIZONTAL.RIGHT, vertical: CONST.MODAL.ANCHOR_ORIGIN_VERTICAL.TOP}}
-                            shouldOverlay
-                            disabled={shouldDisableThreeDotsMenu}
-                            isNested
-                            threeDotsMenuRef={threeDotsMenuRef}
-                        />
-                    )}
+                <View style={[styles.flexRow, styles.alignItemsCenter]}>
+                    {!isNarrow && ThreeDotMenuOrPendingIcon}
                     {!isNarrow && (
-                        <View style={[styles.justifyContentCenter, styles.alignItemsCenter, styles.touchableButtonImage]}>
+                        <PressableWithoutFeedback
+                            onPress={onPress}
+                            style={[styles.justifyContentCenter, styles.alignItemsCenter, styles.touchableButtonImage]}
+                            accessible={false}
+                            sentryLabel={CONST.SENTRY_LABEL.WORKSPACE.WORKSPACE_LIST_ROW_ARROW}
+                        >
                             <Icon
                                 src={icons.ArrowRight}
                                 fill={theme.icon}
@@ -323,7 +336,7 @@ function WorkspacesListRow({
                                 isButtonIcon
                                 medium
                             />
-                        </View>
+                        </PressableWithoutFeedback>
                     )}
                 </View>
             </Animated.View>


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
<!-- Explain what your change does and how it addresses the linked issue -->
This PR fully reverts the accessibility changes to `WorkspacesListRow.tsx` and `WorkspacesListPage.tsx` introduced in PR #80450

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/82727
$ https://github.com/Expensify/App/issues/82739
$ https://github.com/Expensify/App/issues/82721
PROPOSAL:


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

#### Deploy Blocker #82727 — Column Alignment
  1. Go to the Workspaces tab (must have 2+ workspaces)
  2. Verify owner name and workspace type columns are properly aligned across all rows on wide layout
  3. Resize the browser to narrow layout and verify the rows still display correctly

  #### Deploy Blocker #82739 — Arrow Click
  1. Go to the Workspaces tab on wide layout
  2. Click the right arrow icon on any workspace row
  3. Verify it navigates to the workspace settings/overview page
 
- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->
Same as tests

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->
// TODO: These must be filled out, or the issue title must include "[No QA]."
Same as tests

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I verified there are no new alerts related to the `canBeMissing` param for `useOnyx`
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/e9299cb6-6cc3-4799-af65-2ee8ffd2fdfc

</details>