### PR TITLE
feat: [CFI] Allow Multi-Line Row Wrapping in Expense Previews (Classic Parity)

### DIFF
--- a/src/components/ReportActionItem/TransactionPreview/TransactionPreviewContent.tsx
+++ b/src/components/ReportActionItem/TransactionPreview/TransactionPreviewContent.tsx
@@ -323,8 +323,8 @@ function TransactionPreviewContent({
                                                 {shouldShowMerchantOrDescription && (
                                                     <Text
                                                         fontSize={variables.fontSizeNormal}
-                                                        style={[isDeleted && styles.lineThrough, styles.flexShrink1]}
-                                                        numberOfLines={1}
+                                                        style={[isDeleted && styles.lineThrough, styles.flexShrink1, styles.preWrap]}
+                                                        numberOfLines={2}
                                                     >
                                                         {merchantOrDescription}
                                                     </Text>
@@ -368,8 +368,8 @@ function TransactionPreviewContent({
                                                         fill={theme.icon}
                                                     />
                                                     <Text
-                                                        numberOfLines={1}
-                                                        style={[isDeleted && styles.lineThrough, styles.textMicroSupporting, styles.pre, styles.flexShrink1]}
+                                                        numberOfLines={2}
+                                                        style={[isDeleted && styles.lineThrough, styles.textMicroSupporting, styles.preWrap, styles.flexShrink1]}
                                                     >
                                                         {getDecodedCategoryName(category ?? '')}
                                                     </Text>
@@ -384,8 +384,8 @@ function TransactionPreviewContent({
                                                         fill={theme.icon}
                                                     />
                                                     <Text
-                                                        numberOfLines={1}
-                                                        style={[isDeleted && styles.lineThrough, styles.textMicroSupporting, styles.pre, styles.flexShrink1]}
+                                                        numberOfLines={2}
+                                                        style={[isDeleted && styles.lineThrough, styles.textMicroSupporting, styles.preWrap, styles.flexShrink1]}
                                                     >
                                                         {getCommaSeparatedTagNameWithSanitizedColons(tag)}
                                                     </Text>

--- a/src/components/SelectionListWithSections/Search/CardListItemHeader.tsx
+++ b/src/components/SelectionListWithSections/Search/CardListItemHeader.tsx
@@ -78,7 +78,11 @@ function CardListItemHeader<TItem extends ListItem>({
                 style={StyleUtils.getReportTableColumnStyles(CONST.SEARCH.TABLE_COLUMNS.CARD)}
             >
                 <View style={[styles.gapHalf, styles.flexShrink1]}>
-                    <TextWithTooltip text={cardItem.formattedCardName ?? ''} />
+                    <TextWithTooltip
+                        text={cardItem.formattedCardName ?? ''}
+                        numberOfLines={2}
+                        style={[styles.preWrap]}
+                    />
                 </View>
             </View>
         ),
@@ -89,7 +93,8 @@ function CardListItemHeader<TItem extends ListItem>({
             >
                 <TextWithTooltip
                     text={cardItem.formattedFeedName ?? ''}
-                    style={[styles.optionDisplayName, styles.lineHeightLarge, styles.pre]}
+                    numberOfLines={2}
+                    style={[styles.lineHeightLarge, styles.preWrap]}
                 />
             </View>
         ),
@@ -143,7 +148,8 @@ function CardListItemHeader<TItem extends ListItem>({
                                 />
                                 <TextWithTooltip
                                     text={cardItem.formattedCardName ?? ''}
-                                    style={[styles.textLabelSupporting, styles.lh16, styles.pre]}
+                                    numberOfLines={2}
+                                    style={[styles.textLabelSupporting, styles.lh16, styles.preWrap]}
                                 />
                             </View>
                         </View>

--- a/src/components/SelectionListWithSections/Search/TaskListItemRow.tsx
+++ b/src/components/SelectionListWithSections/Search/TaskListItemRow.tsx
@@ -50,7 +50,8 @@ function TitleCell({taskItem, showTooltip, isLargeScreenWidth}: TaskCellProps) {
         <TextWithTooltip
             text={taskItem.reportName}
             shouldShowTooltip={showTooltip}
-            style={[isLargeScreenWidth ? styles.lineHeightLarge : styles.lh20, styles.pre, styles.justifyContentCenter]}
+            numberOfLines={2}
+            style={[isLargeScreenWidth ? styles.lineHeightLarge : styles.lh20, styles.preWrap, styles.justifyContentCenter]}
         />
     );
 }
@@ -62,7 +63,8 @@ function DescriptionCell({taskItem, showTooltip, isLargeScreenWidth}: TaskCellPr
         <TextWithTooltip
             shouldShowTooltip={showTooltip}
             text={taskItem.description}
-            style={[styles.lineHeightLarge, styles.pre, styles.justifyContentCenter, isLargeScreenWidth ? undefined : [styles.textMicro, styles.textSupporting]]}
+            numberOfLines={2}
+            style={[styles.lineHeightLarge, styles.preWrap, styles.justifyContentCenter, isLargeScreenWidth ? undefined : [styles.textMicro, styles.textSupporting]]}
         />
     );
 }

--- a/src/components/SelectionListWithSections/Search/TextCell.tsx
+++ b/src/components/SelectionListWithSections/Search/TextCell.tsx
@@ -14,7 +14,8 @@ function TextCell({text = '', isLargeScreenWidth = true}: TextCellProps) {
         <TextWithTooltip
             text={text}
             shouldShowTooltip
-            style={[isLargeScreenWidth ? styles.lineHeightLarge : styles.lh20, styles.pre, styles.justifyContentCenter]}
+            numberOfLines={2}
+            style={[isLargeScreenWidth ? styles.lineHeightLarge : styles.lh20, styles.preWrap, styles.justifyContentCenter]}
         />
     );
 }

--- a/src/components/SelectionListWithSections/Search/TextWithIconCell.tsx
+++ b/src/components/SelectionListWithSections/Search/TextWithIconCell.tsx
@@ -12,9 +12,10 @@ type TextWithIconCellProps = {
     text?: string;
     showTooltip: boolean;
     textStyle?: StyleProp<TextStyle>;
+    numberOfLines?: number;
 };
 
-export default function TextWithIconCell({icon, text, showTooltip, textStyle}: TextWithIconCellProps) {
+export default function TextWithIconCell({icon, text, showTooltip, textStyle, numberOfLines = 1}: TextWithIconCellProps) {
     const styles = useThemeStyles();
     const theme = useTheme();
 
@@ -33,7 +34,8 @@ export default function TextWithIconCell({icon, text, showTooltip, textStyle}: T
             <TextWithTooltip
                 text={text}
                 shouldShowTooltip={showTooltip}
-                style={[styles.optionDisplayName, styles.label, styles.pre, styles.justifyContentCenter, styles.textMicro, styles.textSupporting, styles.flexShrink1, textStyle]}
+                numberOfLines={numberOfLines}
+                style={[styles.label, numberOfLines > 1 ? styles.preWrap : styles.pre, styles.justifyContentCenter, styles.textMicro, styles.textSupporting, styles.flexShrink1, textStyle]}
             />
         </View>
     );

--- a/src/components/TextWithTooltip/index.tsx
+++ b/src/components/TextWithTooltip/index.tsx
@@ -24,7 +24,7 @@ function TextWithTooltip({testID, text, shouldShowTooltip, style, numberOfLines 
                     if (!shouldShowTooltip) {
                         return;
                     }
-                    if (target.scrollWidth > target.offsetWidth) {
+                    if (target.scrollWidth > target.offsetWidth || target.scrollHeight > target.offsetHeight) {
                         setShowTooltip(true);
                         return;
                     }

--- a/src/components/TransactionItemRow/DataCells/CategoryCell.tsx
+++ b/src/components/TransactionItemRow/DataCells/CategoryCell.tsx
@@ -18,12 +18,14 @@ function CategoryCell({shouldUseNarrowLayout, shouldShowTooltip, transactionItem
             showTooltip={shouldShowTooltip}
             text={categoryForDisplay}
             textStyle={[styles.textMicro, styles.mnh0]}
+            numberOfLines={2}
         />
     ) : (
         <TextWithTooltip
             shouldShowTooltip={shouldShowTooltip}
             text={categoryForDisplay}
-            style={[styles.optionDisplayName, styles.lineHeightLarge, styles.pre, styles.justifyContentCenter]}
+            numberOfLines={2}
+            style={[styles.lineHeightLarge, styles.preWrap, styles.justifyContentCenter]}
         />
     );
 }

--- a/src/components/TransactionItemRow/DataCells/MerchantCell.tsx
+++ b/src/components/TransactionItemRow/DataCells/MerchantCell.tsx
@@ -27,7 +27,8 @@ function MerchantOrDescriptionCell({
         <TextWithTooltip
             shouldShowTooltip={shouldShowTooltip}
             text={text}
-            style={[!shouldUseNarrowLayout ? styles.lineHeightLarge : styles.lh20, styles.pre, styles.justifyContentCenter, styles.flex1]}
+            numberOfLines={2}
+            style={[!shouldUseNarrowLayout ? styles.lineHeightLarge : styles.lh20, styles.preWrap, styles.justifyContentCenter, styles.flex1]}
         />
     );
 }

--- a/src/components/TransactionItemRow/DataCells/TagCell.tsx
+++ b/src/components/TransactionItemRow/DataCells/TagCell.tsx
@@ -15,12 +15,14 @@ function TagCell({shouldUseNarrowLayout, shouldShowTooltip, transactionItem}: Tr
             showTooltip={shouldShowTooltip}
             text={getTagForDisplay(transactionItem)}
             textStyle={[styles.textMicro, styles.mnh0]}
+            numberOfLines={2}
         />
     ) : (
         <TextWithTooltip
             shouldShowTooltip={shouldShowTooltip}
             text={getTagForDisplay(transactionItem)}
-            style={[styles.optionDisplayName, styles.lineHeightLarge, styles.pre, styles.justifyContentCenter]}
+            numberOfLines={2}
+            style={[styles.lineHeightLarge, styles.preWrap, styles.justifyContentCenter]}
         />
     );
 }

--- a/src/components/TransactionItemRow/index.tsx
+++ b/src/components/TransactionItemRow/index.tsx
@@ -667,7 +667,7 @@ function TransactionItemRow({
                             style={styles.mr3}
                         />
                         <View style={[styles.flex2, styles.flexColumn, styles.justifyContentEvenly]}>
-                            <View style={[styles.flexRow, styles.alignItemsCenter, styles.minHeight5, styles.maxHeight5]}>
+                            <View style={[styles.flexRow, styles.alignItemsCenter, styles.minHeight5]}>
                                 <DateCell
                                     date={createdAt}
                                     showTooltip={shouldShowTooltip}
@@ -730,7 +730,7 @@ function TransactionItemRow({
                     <View style={[styles.flexRow, styles.justifyContentBetween, styles.alignItemsStart]}>
                         <View style={[styles.flexColumn, styles.flex1]}>
                             {hasCategoryOrTag && !isIOUReport(report) && (
-                                <View style={[styles.flexRow, styles.alignItemsCenter, styles.gap2, styles.mt2, styles.minHeight4]}>
+                                <View style={[styles.flexRow, styles.alignItemsCenter, styles.gap2, styles.mt2, styles.minHeight6]}>
                                     <CategoryCell
                                         transactionItem={transactionItem}
                                         shouldShowTooltip={shouldShowTooltip}


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
<!-- Explain what your change does and how it addresses the linked issue -->
Expense preview rows in New Expensify truncate merchant, description, category, and tag text after a single line with ellipsis. In Expensify Classic, these fields wrap across multiple lines. This PR adds Classic Parity by allowing up to 2 lines of text before truncating.

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/81419
PROPOSAL: https://github.com/Expensify/App/issues/81419#issuecomment-3849284059


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

**Prerequisites:**
  - Have a workspace with categories and tags enabled
  - Create several expenses with long merchant names, long descriptions, long category names, and long tag names (text should be long enough to exceed one line in the table)
  - Submit these expenses in a report containing multiple expenses

  **Expenses page (wide layout):**
  1. Navigate to the Reports -> Expenses page
  2. Verify that merchant, description, category, and tag columns wrap up to **2 lines** before showing "..." at the end
  3. Hover over text that is cut off and verify a **tooltip** appears showing the full text
  4. Hover over text that is NOT cut off and verify no tooltip appears
  5. Verify that **From/To** columns still show names on a single line (no wrapping)

  **Expenses page (narrow layout):**
  6. Resize the browser window to a narrow width
  7. Verify that merchant/description, category, and tag text also wraps up to 2 lines before truncating

  **Report detail view:**
  8. Navigate to Reports -> Reports and open the report containing the expenses created above
  9. Verify that merchant/description, category, and tag text in the expense rows wraps up to 2 lines before truncating
  10. Verify that short text that fits on one line displays normally with no extra spacing
 
- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->
Same as tests

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->
// TODO: These must be filled out, or the issue title must include "[No QA]."
Same as tests

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I verified there are no new alerts related to the `canBeMissing` param for `useOnyx`
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->
<img width="528" height="1054" alt="Screenshot 2026-02-22 at 5 12 02 in the afternoon" src="https://github.com/user-attachments/assets/51ffd387-712a-4d9f-9775-971b29f8bbc9" />


</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->
<img width="528" height="1054" alt="Screenshot 2026-02-22 at 5 17 59 in the afternoon" src="https://github.com/user-attachments/assets/e93d98bb-d9b4-4bf5-a1a2-d263359629b7" />


</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->
<img width="568" height="1084" alt="Screenshot 2026-02-22 at 5 10 15 in the afternoon" src="https://github.com/user-attachments/assets/974a2426-295e-4dcd-a752-84b6e6c8c271" />


</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->
<img width="568" height="1084" alt="Screenshot 2026-02-22 at 5 10 51 in the afternoon" src="https://github.com/user-attachments/assets/08c429fe-8dd5-4368-853d-6bc9d0555fb6" />

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->
<img width="1912" height="1242" alt="Screenshot 2026-02-22 at 5 08 03 in the afternoon" src="https://github.com/user-attachments/assets/8953d4d9-556f-4886-963d-a31d17870a07" />


</details>