### PR TITLE
[No QA] Fix failureNotifier creating issues for non-main branch failures

### DIFF
--- a/.github/actions/javascript/failureNotifier/failureNotifier.ts
+++ b/.github/actions/javascript/failureNotifier/failureNotifier.ts
@@ -17,7 +17,7 @@ type PullRequest = RestEndpointMethodTypes['repos']['listPullRequestsAssociatedW
  * targeting the correct base branch to avoid blaming the wrong PR.
  */
 function getMergedPR(associatedPRs: PullRequest[], targetBranch = 'main'): PullRequest | undefined {
-    return associatedPRs.find((pr) => pr.merged_at !== null && pr.base.ref === targetBranch) ?? associatedPRs.at(0);
+    return associatedPRs.find((pr) => pr.merged_at !== null && pr.base.ref === targetBranch);
 }
 
 async function run() {

--- a/.github/actions/javascript/failureNotifier/index.js
+++ b/.github/actions/javascript/failureNotifier/index.js
@@ -9559,7 +9559,7 @@ const github = __importStar(__nccwpck_require__(5438));
  * targeting the correct base branch to avoid blaming the wrong PR.
  */
 function getMergedPR(associatedPRs, targetBranch = 'main') {
-    return associatedPRs.find((pr) => pr.merged_at !== null && pr.base.ref === targetBranch) ?? associatedPRs.at(0);
+    return associatedPRs.find((pr) => pr.merged_at !== null && pr.base.ref === targetBranch);
 }
 async function run() {
     const token = core.getInput('GITHUB_TOKEN', { required: true });

--- a/.github/workflows/failureNotifier.yml
+++ b/.github/workflows/failureNotifier.yml
@@ -3,6 +3,7 @@ name: Notify on Workflow Failure
 on:
   workflow_run:
     workflows: ["Process new code merged to main", "Remote Build iOS", "Remote Build Android"]
+    branches: [main]
     types:
       - completed
 

--- a/tests/unit/FailureNotifierTest.ts
+++ b/tests/unit/FailureNotifierTest.ts
@@ -65,13 +65,12 @@ describe('getMergedPR', () => {
         expect(result?.number).toBe(82016);
     });
 
-    it('should fall back to first PR if no merged PR is found', () => {
+    it('should return undefined when no merged PR is found instead of blaming an unmerged PR', () => {
         const associatedPRs = [openPRWithMainMerged, openPRDifferentBase];
 
         const result = getMergedPR(associatedPRs);
 
-        // Falls back to first element when no merged PR matches
-        expect(result?.number).toBe(80254);
+        expect(result).toBeUndefined();
     });
 
     it('should return undefined for empty array', () => {


### PR DESCRIPTION
### Explanation of Change
(Neil's AI agent)
Fixes two bugs that caused [#83001](https://github.com/Expensify/App/issues/83001) — a workflow failure issue incorrectly blaming an unmerged PR ([#82370](https://github.com/Expensify/App/pull/82370)) for a build failure on a feature branch.

**Bug 1 — No branch filter:** The `failureNotifier` workflow triggers on `workflow_run` completions from "Remote Build iOS/Android" workflows, but these run on feature branches too. The trigger had no branch filter, so it created "failing on main" issues for feature branch failures. **Fix:** Added `branches: [main]` to the `workflow_run` trigger in `failureNotifier.yml`.

**Bug 2 — Fallback blames unmerged PRs:** `getMergedPR()` fell back to `associatedPRs.at(0)` when no merged PR was found. The GitHub API returns ALL PRs containing a commit (including open PRs that have merged main into their branch), so this fallback could pick an unmerged PR. **Fix:** Removed the fallback so it returns `undefined`, which renders as "N/A" in the issue body.

**Root cause:** Bug 1 was introduced in [#78369](https://github.com/Expensify/App/pull/78369) (Dec 2025), which added "Remote Build iOS" and "Remote Build Android" to the `failureNotifier` trigger list. Before that PR, the trigger only listened to "Process new code merged to main" — which exclusively runs on main, so no branch filter was needed. When the remote build workflows were added (they run on pushes to all branches), the missing `branches: [main]` filter meant the notifier started firing for feature branch failures too.

Neil
---
I have manually reviewed the above and it makes sense to me.

### Fixed Issues

$ https://github.com/Expensify/App/issues/83001

### Tests

(Neil's AI agent)
**Automated (Bug 2):**
- Updated `FailureNotifierTest.ts` — the test "should return undefined when no merged PR is found instead of blaming an unmerged PR" **fails on main** (proving the bug) and **passes with the fix**.

**Bug 1 — branch filter (cannot be tested pre-merge):**
The `branches: [main]` filter on the `workflow_run` trigger cannot be tested until this PR is merged. GitHub always evaluates `workflow_run` trigger conditions from the default branch (main), so our updated `failureNotifier.yml` won't take effect until it's on main. After merging, we can verify by pushing a failing commit to a feature branch and confirming the failureNotifier workflow does NOT run.

Neil
---
I have manually reviewed the above and it makes sense to me.

### Offline tests

N/A — GitHub Actions workflow, no offline behavior.

### QA Steps

N/A — [No QA]. This only affects the automated issue creation workflow.

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I verified there are no new alerts related to the `canBeMissing` param for `useOnyx`
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos


N/A — no UI changes, GitHub Actions workflow fix only.