### PR TITLE
[50] Eliminate redundant sorting in LHN renderItem

### DIFF
--- a/src/components/LHNOptionsList/LHNOptionsList.tsx
+++ b/src/components/LHNOptionsList/LHNOptionsList.tsx
@@ -29,7 +29,6 @@ import Log from '@libs/Log';
 import {getMovedReportID} from '@libs/ModifiedExpenseMessage';
 import {getIOUReportIDOfLastAction, getLastMessageTextForReport} from '@libs/OptionsListUtils';
 import {
-    getOneTransactionThreadReportID,
     getOriginalMessage,
     getSortedReportActions,
     getSortedReportActionsForDisplay,
@@ -179,10 +178,11 @@ function LHNOptionsList({style, contentContainerStyles, data, onSelectRow, optio
             const itemReportNameValuePairs = reportNameValuePairs?.[`${ONYXKEYS.COLLECTION.REPORT_NAME_VALUE_PAIRS}${reportID}`];
             const chatReport = reports?.[`${ONYXKEYS.COLLECTION.REPORT}${item.chatReportID}`];
             const itemReportActions = reportActions?.[`${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${reportID}`];
-            const itemOneTransactionThreadReport = reports?.[`${ONYXKEYS.COLLECTION.REPORT}${getOneTransactionThreadReportID(item, chatReport, itemReportActions, isOffline)}`];
+            const itemReportAttributes = reportAttributes?.[reportID];
+            // Use pre-computed oneTransactionThreadReportID from reportAttributes to avoid redundant computation
+            const itemOneTransactionThreadReport = reports?.[`${ONYXKEYS.COLLECTION.REPORT}${itemReportAttributes?.oneTransactionThreadReportID}`];
             const itemParentReportActions = reportActions?.[`${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${item?.parentReportID}`];
             const itemParentReportAction = item?.parentReportActionID ? itemParentReportActions?.[item?.parentReportActionID] : undefined;
-            const itemReportAttributes = reportAttributes?.[reportID];
 
             let invoiceReceiverPolicyID = '-1';
             if (item?.invoiceReceiver && 'policyID' in item.invoiceReceiver) {

--- a/src/libs/actions/OnyxDerived/configs/reportAttributes.ts
+++ b/src/libs/actions/OnyxDerived/configs/reportAttributes.ts
@@ -1,5 +1,6 @@
 import type {OnyxEntry} from 'react-native-onyx';
 import {computeReportName} from '@libs/ReportNameUtils';
+import {getOneTransactionThreadReportID} from '@libs/ReportActionsUtils';
 import {generateIsEmptyReport, generateReportAttributes, isArchivedReport, isValidReport} from '@libs/ReportUtils';
 import SidebarUtils from '@libs/SidebarUtils';
 import createOnyxDerivedValueConfig from '@userActions/OnyxDerived/createOnyxDerivedValueConfig';
@@ -219,6 +220,9 @@ export default createOnyxDerivedValueConfig({
                 brickRoadStatus = CONST.BRICK_ROAD_INDICATOR_STATUS.INFO;
             }
 
+            // Compute oneTransactionThreadReportID to avoid redundant sorting in LHN renderItem
+            const oneTransactionThreadReportID = getOneTransactionThreadReportID(report, chatReport, reportActionsList, false);
+
             acc[report.reportID] = {
                 reportName: report
                     ? computeReportName(report, reports, policies, transactions, reportNameValuePairs, personalDetails, reportActions, session?.accountID ?? CONST.DEFAULT_NUMBER_ID)
@@ -227,6 +231,7 @@ export default createOnyxDerivedValueConfig({
                 brickRoadStatus,
                 requiresAttention,
                 reportErrors,
+                oneTransactionThreadReportID,
             };
 
             return acc;

--- a/src/types/onyx/DerivedValues.ts
+++ b/src/types/onyx/DerivedValues.ts
@@ -33,6 +33,10 @@ type ReportAttributes = {
      * The errors of the report.
      */
     reportErrors: Errors;
+    /**
+     * The reportID of the one-transaction thread if this report has exactly one transaction.
+     */
+    oneTransactionThreadReportID?: string;
 };
 
 /**


### PR DESCRIPTION
### Details

**Issue:** $ https://github.com/Expensify/App/issues/83025
**Bounty:** $250

### Problem
When the LHN re-renders on a heavy account, each renderItem call independently performs two sort operations, a filter pass, and a find scan over that report's actions, which slows down initial navigation to the inbox and degrades scroll frame rates as the number of reports grows.

### Solution
This PR optimizes the LHN renderItem by:

1. **Adding `oneTransactionThreadReportID` to the `ReportAttributes` type** - This field stores the pre-computed reportID of the one-transaction thread if the report has exactly one transaction.

2. **Computing the value in the `reportAttributes` OnyxDerived config** - The value is now computed once in the derived config along with other report attributes, rather than on every LHN renderItem call.

3. **Using the pre-computed value in LHNOptionsList** - The renderItem now reads `oneTransactionThreadReportID` from the cached `reportAttributes` instead of calling `getOneTransactionThreadReportID()` directly.

### Changes
- `src/types/onyx/DerivedValues.ts` - Added `oneTransactionThreadReportID` field to `ReportAttributes` type
- `src/libs/actions/OnyxDerived/configs/reportAttributes.ts` - Added computation of `oneTransactionThreadReportID`
- `src/components/LHNOptionsList/LHNOptionsList.tsx` - Use pre-computed value from reportAttributes

### Performance Impact
This eliminates redundant sorting and filtering operations on every LHN re-render, improving performance for users with heavy accounts. The derived value is cached and only recomputed when its dependencies change.

### Testing
- [ ] Verify LHN renders correctly with various report types
- [ ] Verify one-transaction reports display correctly
- [ ] Verify no regression in LHN scroll performance

### PR Checklist
- [x] I have read the contribution guidelines
- [x] The PR follows the style guidelines
- [x] I have performed a self-review of my code
