### PR TITLE
Fix: Screen reader does not announce or move focus after emoji category selection

### DIFF
--- a/src/components/EmojiPicker/CategoryShortcutBar.tsx
+++ b/src/components/EmojiPicker/CategoryShortcutBar.tsx
@@ -10,9 +10,12 @@ type CategoryShortcutBarProps = {
 
     /** The emojis consisting emoji code and indices that the icons should link to */
     headerEmojis: HeaderIndices[];
+
+    /** Selected header index */
+    selectedIndex?: number | null;
 };
 
-function CategoryShortcutBar({onPress, headerEmojis}: CategoryShortcutBarProps) {
+function CategoryShortcutBar({onPress, headerEmojis, selectedIndex = null}: CategoryShortcutBarProps) {
     const styles = useThemeStyles();
     return (
         <View style={[styles.ph4, styles.flexRow]}>
@@ -22,6 +25,7 @@ function CategoryShortcutBar({onPress, headerEmojis}: CategoryShortcutBarProps) 
                     onPress={() => onPress(headerEmoji.index)}
                     key={`categoryShortcut${headerEmoji.index}`}
                     code={headerEmoji.code}
+                    isSelected={headerEmoji.index === selectedIndex}
                 />
             ))}
         </View>

--- a/src/components/EmojiPicker/CategoryShortcutButton.tsx
+++ b/src/components/EmojiPicker/CategoryShortcutButton.tsx
@@ -21,9 +21,12 @@ type CategoryShortcutButtonProps = {
 
     /** The function to call when an emoji is selected */
     onPress: () => void;
+
+    /** Indicates if this category is selected */
+    isSelected?: boolean;
 };
 
-function CategoryShortcutButton({code, icon, onPress}: CategoryShortcutButtonProps) {
+function CategoryShortcutButton({code, icon, onPress, isSelected = false}: CategoryShortcutButtonProps) {
     const theme = useTheme();
     const styles = useThemeStyles();
     const StyleUtils = useStyleUtils();
@@ -42,6 +45,7 @@ function CategoryShortcutButton({code, icon, onPress}: CategoryShortcutButtonPro
                 onHoverOut={() => setIsHighlighted(false)}
                 style={({pressed}) => [StyleUtils.getButtonBackgroundColorStyle(getButtonState(false, pressed)), styles.categoryShortcutButton, isHighlighted && styles.emojiItemHighlighted]}
                 accessibilityLabel={translate(`emojiPicker.headers.${code}` as TranslationPaths)}
+                accessibilityState={isSelected ? {selected: true} : undefined}
                 role={CONST.ROLE.BUTTON}
                 sentryLabel={CONST.SENTRY_LABEL.EMOJI_PICKER.CATEGORY_SHORTCUT}
             >

--- a/src/components/EmojiPicker/EmojiPickerMenu/BaseEmojiPickerMenu.tsx
+++ b/src/components/EmojiPicker/EmojiPickerMenu/BaseEmojiPickerMenu.tsx
@@ -20,6 +20,9 @@ type BaseEmojiPickerMenuProps = {
     /** Array of header emojis */
     headerEmojis: HeaderIndices[];
 
+    /** Selected header index */
+    selectedHeaderIndex?: number | null;
+
     /** Function to scroll to a specific header in the emoji list */
     scrollToHeader: (headerIndex: number) => void;
 
@@ -40,6 +43,9 @@ type BaseEmojiPickerMenuProps = {
 
     /** Whether the list should always bounce vertically */
     alwaysBounceVertical?: boolean;
+
+    /** Callback for momentum scroll end */
+    onMomentumScrollEnd?: () => void;
 
     /** Reference to the outer element */
     ref?: ForwardedRef<FlashListRef<EmojiPickerListItem>>;
@@ -82,6 +88,7 @@ function ListEmptyComponent() {
 
 function BaseEmojiPickerMenu({
     headerEmojis,
+    selectedHeaderIndex = null,
     scrollToHeader,
     isFiltered,
     listWrapperStyle = [],
@@ -90,6 +97,7 @@ function BaseEmojiPickerMenu({
     stickyHeaderIndices = [],
     extraData = [],
     alwaysBounceVertical = false,
+    onMomentumScrollEnd,
     ref,
 }: BaseEmojiPickerMenuProps) {
     const styles = useThemeStyles();
@@ -98,6 +106,7 @@ function BaseEmojiPickerMenu({
             {!isFiltered && (
                 <CategoryShortcutBar
                     headerEmojis={headerEmojis}
+                    selectedIndex={selectedHeaderIndex}
                     onPress={scrollToHeader}
                 />
             )}
@@ -113,6 +122,7 @@ function BaseEmojiPickerMenu({
                     stickyHeaderIndices={stickyHeaderIndices}
                     ListEmptyComponent={ListEmptyComponent}
                     alwaysBounceVertical={alwaysBounceVertical}
+                    onMomentumScrollEnd={onMomentumScrollEnd}
                     contentContainerStyle={styles.ph4}
                     extraData={extraData}
                     getItemType={getItemType}

--- a/src/components/EmojiPicker/EmojiPickerMenu/index.native.tsx
+++ b/src/components/EmojiPicker/EmojiPickerMenu/index.native.tsx
@@ -1,6 +1,6 @@
 import type {ListRenderItem} from '@shopify/flash-list';
 import lodashDebounce from 'lodash/debounce';
-import React, {useCallback} from 'react';
+import React, {useCallback, useRef, useState} from 'react';
 import {InteractionManager, View} from 'react-native';
 import type {Emoji} from '@assets/emojis/types';
 import EmojiPickerMenuItem from '@components/EmojiPicker/EmojiPickerMenuItem';
@@ -42,6 +42,52 @@ function EmojiPickerMenu({onEmojiSelected, activeEmoji, ref}: EmojiPickerMenuPro
         emojiListRef,
     } = useEmojiPickerMenu();
     const StyleUtils = useStyleUtils();
+    const headerRefs = useRef<Record<number, React.RefObject<View | null>>>({});
+    const pendingHeaderFocusIndexRef = useRef<number | null>(null);
+    const [selectedHeaderIndex, setSelectedHeaderIndex] = useState<number | null>(null);
+
+    const getHeaderRef = useCallback((index: number) => {
+        if (!headerRefs.current[index]) {
+            headerRefs.current[index] = React.createRef<View>();
+        }
+        return headerRefs.current[index];
+    }, []);
+
+    const focusHeaderAtIndex = useCallback((headerIndex: number) => {
+        const headerRef = headerRefs.current[headerIndex];
+        if (!headerRef?.current) {
+            return false;
+        }
+
+        pendingHeaderFocusIndexRef.current = null;
+        headerRef.current.focus?.();
+        return true;
+    }, []);
+
+    const scheduleHeaderFocus = useCallback(
+        function schedule(headerIndex: number, attempt = 0) {
+            if (focusHeaderAtIndex(headerIndex)) {
+                return;
+            }
+
+            if (attempt >= 2) {
+                return;
+            }
+
+            setTimeout(() => schedule(headerIndex, attempt + 1), CONST.ANIMATED_TRANSITION);
+        },
+        [focusHeaderAtIndex],
+    );
+
+    const handleHeaderLayout = useCallback(
+        (index: number) => {
+            if (pendingHeaderFocusIndexRef.current !== index) {
+                return;
+            }
+            focusHeaderAtIndex(index);
+        },
+        [focusHeaderAtIndex],
+    );
 
     const updateEmojiList = (emojiData: EmojiPickerList | Emoji[], headerData: number[] = []) => {
         setFilteredEmojis(emojiData);
@@ -71,9 +117,12 @@ function EmojiPickerMenu({onEmojiSelected, activeEmoji, ref}: EmojiPickerMenuPro
     const scrollToHeader = useCallback(
         (headerIndex: number) => {
             const calculatedOffset = Math.floor(headerIndex / CONST.EMOJI_NUM_PER_ROW) * CONST.EMOJI_PICKER_HEADER_HEIGHT;
+            setSelectedHeaderIndex(headerIndex);
+            pendingHeaderFocusIndexRef.current = headerIndex;
             emojiListRef.current?.scrollToOffset({offset: calculatedOffset, animated: true});
+            scheduleHeaderFocus(headerIndex);
         },
-        [emojiListRef],
+        [emojiListRef, scheduleHeaderFocus],
     );
 
     /**
@@ -82,7 +131,7 @@ function EmojiPickerMenu({onEmojiSelected, activeEmoji, ref}: EmojiPickerMenuPro
      * so that the sticky headers function properly.
      */
     const renderItem: ListRenderItem<EmojiPickerListItem> = useCallback(
-        ({item, target}) => {
+        ({item, target, index}) => {
             const code = item.code;
             const types = 'types' in item ? item.types : undefined;
 
@@ -92,7 +141,14 @@ function EmojiPickerMenu({onEmojiSelected, activeEmoji, ref}: EmojiPickerMenuPro
 
             if ('header' in item && item.header) {
                 return (
-                    <View style={[styles.emojiHeaderContainer, target === 'StickyHeader' ? styles.mh4 : {width: windowWidth}]}>
+                    <View
+                        ref={getHeaderRef(index)}
+                        accessible
+                        accessibilityRole="header"
+                        accessibilityLabel={translate(`emojiPicker.headers.${code}` as TranslationPaths)}
+                        style={[styles.emojiHeaderContainer, target === 'StickyHeader' ? styles.mh4 : {width: windowWidth}]}
+                        onLayout={() => handleHeaderLayout(index)}
+                    >
                         <Text style={styles.textLabelSupporting}>{translate(`emojiPicker.headers.${code}` as TranslationPaths)}</Text>
                     </View>
                 );
@@ -114,7 +170,7 @@ function EmojiPickerMenu({onEmojiSelected, activeEmoji, ref}: EmojiPickerMenuPro
                 />
             );
         },
-        [styles, windowWidth, preferredSkinTone, singleExecution, onEmojiSelected, translate, activeEmoji],
+        [styles, windowWidth, preferredSkinTone, singleExecution, onEmojiSelected, translate, activeEmoji, getHeaderRef, handleHeaderLayout],
     );
 
     return (
@@ -132,6 +188,7 @@ function EmojiPickerMenu({onEmojiSelected, activeEmoji, ref}: EmojiPickerMenuPro
             <BaseEmojiPickerMenu
                 isFiltered={isListFiltered}
                 headerEmojis={headerEmojis}
+                selectedHeaderIndex={selectedHeaderIndex}
                 scrollToHeader={scrollToHeader}
                 listWrapperStyle={[
                     listStyle,
@@ -145,6 +202,12 @@ function EmojiPickerMenu({onEmojiSelected, activeEmoji, ref}: EmojiPickerMenuPro
                 extraData={[filteredEmojis, preferredSkinTone]}
                 stickyHeaderIndices={headerIndices}
                 alwaysBounceVertical={filteredEmojis.length !== 0}
+                onMomentumScrollEnd={() => {
+                    if (pendingHeaderFocusIndexRef.current == null) {
+                        return;
+                    }
+                    scheduleHeaderFocus(pendingHeaderFocusIndexRef.current);
+                }}
             />
         </View>
     );

--- a/src/components/EmojiPicker/EmojiPickerMenu/index.tsx
+++ b/src/components/EmojiPicker/EmojiPickerMenu/index.tsx
@@ -64,6 +64,52 @@ function EmojiPickerMenu({onEmojiSelected, activeEmoji, ref}: EmojiPickerMenuPro
     const [isUsingKeyboardMovement, setIsUsingKeyboardMovement] = useState(false);
     const [highlightEmoji, setHighlightEmoji] = useState(false);
     const [highlightFirstEmoji, setHighlightFirstEmoji] = useState(false);
+    const headerRefs = useRef<Record<number, React.RefObject<View | null>>>({});
+    const pendingHeaderFocusIndexRef = useRef<number | null>(null);
+    const [selectedHeaderIndex, setSelectedHeaderIndex] = useState<number | null>(null);
+
+    const getHeaderRef = useCallback((index: number) => {
+        if (!headerRefs.current[index]) {
+            headerRefs.current[index] = React.createRef<View>();
+        }
+        return headerRefs.current[index];
+    }, []);
+
+    const focusHeaderAtIndex = useCallback((headerIndex: number) => {
+        const headerRef = headerRefs.current[headerIndex];
+        if (!headerRef?.current) {
+            return false;
+        }
+
+        pendingHeaderFocusIndexRef.current = null;
+        headerRef.current.focus?.();
+        return true;
+    }, []);
+
+    const scheduleHeaderFocus = useCallback(
+        function schedule(headerIndex: number, attempt = 0) {
+            if (focusHeaderAtIndex(headerIndex)) {
+                return;
+            }
+
+            if (attempt >= 2) {
+                return;
+            }
+
+            setTimeout(() => schedule(headerIndex, attempt + 1), CONST.ANIMATED_TRANSITION);
+        },
+        [focusHeaderAtIndex],
+    );
+
+    const handleHeaderLayout = useCallback(
+        (index: number) => {
+            if (pendingHeaderFocusIndexRef.current !== index) {
+                return;
+            }
+            focusHeaderAtIndex(index);
+        },
+        [focusHeaderAtIndex],
+    );
 
     const mouseMoveHandler = useCallback(() => {
         if (!arePointerEventsDisabled) {
@@ -235,10 +281,15 @@ function EmojiPickerMenu({onEmojiSelected, activeEmoji, ref}: EmojiPickerMenuPro
             }
 
             const calculatedOffset = Math.floor(headerIndex / CONST.EMOJI_NUM_PER_ROW) * CONST.EMOJI_PICKER_HEADER_HEIGHT;
+            setSelectedHeaderIndex(headerIndex);
+            pendingHeaderFocusIndexRef.current = headerIndex;
             emojiListRef.current?.scrollToOffset({offset: calculatedOffset, animated: true});
             setFocusedIndex(headerIndex);
+            setTimeout(() => {
+                scheduleHeaderFocus(headerIndex);
+            }, CONST.ANIMATED_TRANSITION);
         },
-        [emojiListRef, setFocusedIndex],
+        [emojiListRef, scheduleHeaderFocus, setFocusedIndex],
     );
 
     /**
@@ -259,6 +310,10 @@ function EmojiPickerMenu({onEmojiSelected, activeEmoji, ref}: EmojiPickerMenuPro
             if ('header' in item && item.header) {
                 return (
                     <View
+                        ref={getHeaderRef(index)}
+                        tabIndex={-1}
+                        role={CONST.ROLE.HEADING}
+                        onLayout={() => handleHeaderLayout(index)}
                         style={[
                             styles.emojiHeaderContainer,
                             styles.emojiHeaderContainerWidth(shouldUseNarrowLayout, windowWidth),
@@ -313,6 +368,8 @@ function EmojiPickerMenu({onEmojiSelected, activeEmoji, ref}: EmojiPickerMenuPro
             onEmojiSelected,
             setFocusedIndex,
             activeEmoji,
+            getHeaderRef,
+            handleHeaderLayout,
         ],
     );
 
@@ -348,6 +405,7 @@ function EmojiPickerMenu({onEmojiSelected, activeEmoji, ref}: EmojiPickerMenuPro
             <BaseEmojiPickerMenu
                 isFiltered={isListFiltered}
                 headerEmojis={headerEmojis}
+                selectedHeaderIndex={selectedHeaderIndex}
                 scrollToHeader={scrollToHeader}
                 listWrapperStyle={[listStyle, styles.flexShrink1]}
                 ref={emojiListRef}


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
<!-- Explain what your change does and how it addresses the linked issue -->
Users can now see which emoji category shortcut is currently selected, and assistive technologies also get that selected state. When someone chooses a category, the picker not only scrolls to the right section but also moves focus to the corresponding category header, making orientation clearer for keyboard and screen-reader users.

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ #77490
PROPOSAL: [#77490 (comment)](https://github.com/Expensify/App/issues/77490#issuecomment-3834841423)


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

1. Using VoiceOver on iOS or TalkBack on Android, open the app
2. Swipe right to focus the Account tab and double-tap to activate it
3. Swipe right to focus the Profile button and double-tap to activate it
4. Swipe right to focus the Status menu item and double-tap to activate it
5. Swipe right to focus the Status Emoji button and double-tap to activate it
6. Swipe right to focus the emoji category emojis and double-tap to activate it
7. Selects an emoji category button (e.g., "Frequently used", "Smileys", "Animals"), verifies that the screen reader focus moves to the corresponding category heading at the top of the emoji list, and announces it.

- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

Same as Tests.

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->
Same as Tests.

// TODO: These must be filled out, or the issue title must include "[No QA]."

- [X] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [X] I linked the correct issue in the `### Fixed Issues` section above
- [X] I wrote clear testing steps that cover the changes made in this PR
    - [X] I added steps for local testing in the `Tests` section
    - [X] I added steps for the expected offline behavior in the `Offline steps` section
    - [X] I added steps for Staging and/or Production testing in the `QA steps` section
    - [X] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [X] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [X] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [X] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [X] I ran the tests on **all platforms** & verified they passed on:
    - [X] Android: Native
    - [X] Android: mWeb Chrome
    - [X] iOS: Native
    - [X] iOS: mWeb Safari
    - [X] MacOS: Chrome / Safari
- [X] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [X] I verified there are no new alerts related to the `canBeMissing` param for `useOnyx`
- [X] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [X] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [X] I verified that comments were added to code that is not self explanatory
    - [X] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [X] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [X] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [X] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [X] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [X] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [X] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [X] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [X] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [X] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [X] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [X] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [X] I verified that if a function's arguments changed that all usages have also been updated correctly
- [X] If any new file was added I verified that:
    - [X] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [X] If a new CSS style is added I verified that:
    - [X] A similar style doesn't already exist
    - [X] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [X] If new assets were added or existing ones were modified, I verified that:
    - [X] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [X] The assets load correctly across all supported platforms.
- [X] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [X] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [X] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [X] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [X] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [X] I verified that all the inputs inside a form are aligned with each other.
    - [X] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [X] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [X] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [X] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->



https://github.com/user-attachments/assets/8686d857-b9e9-4dd9-83a0-dc3fbfa4872f





</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->





https://github.com/user-attachments/assets/04b51892-41a4-42ef-8f97-06bd4b5369b0







</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->









</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->









</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->



https://github.com/user-attachments/assets/6553411e-4621-4c98-b76d-c6846432da82




</details>