### PR TITLE
[FAKE/TEST] Hide FAB tooltip when actions menu is open

### DIFF
--- a/src/components/FloatingActionButton.tsx
+++ b/src/components/FloatingActionButton.tsx
@@ -90,7 +90,10 @@ function FloatingActionButton({onPress, onLongPress, isActive, accessibilityLabe
     };
 
     return (
-        <Tooltip text={translate('common.create')}>
+        <Tooltip
+            text={translate('common.create')}
+            shouldRender={!isActive}
+        >
             <PressableWithoutFeedback
                 ref={(el) => {
                     fabPressable.current = el ?? null;


### PR DESCRIPTION
> **This is a FAKE PR created solely for testing MelvinBot screenshot uploads. See [Expensify/Expensify#601726](https://github.com/Expensify/Expensify/pull/601726).**
> **Do NOT merge. Close after testing.**

### Explanation of Change

Hide the "Create" tooltip on the floating action button while the actions menu is already open. This avoids a redundant tooltip overlapping the open menu.

### Fixed Issues

$ https://github.com/Expensify/App/issues/83167

### Tests

1. Open the app
2. Tap the + (FAB) button to open the actions menu
3. Verify the "Create" tooltip does NOT appear while the menu is open
4. Close the menu and hover the FAB again
5. Verify the tooltip appears normally when the menu is closed

### QA Steps

Same as tests above.

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
