### PR TITLE
Fix: Update predictedNextStatus to account for auto-pay

### DIFF
--- a/src/libs/actions/IOU/index.ts
+++ b/src/libs/actions/IOU/index.ts
@@ -10550,7 +10550,8 @@ function approveMoneyRequest(
     const shouldAddOptimisticApproveAction = !isDEWPolicy || isOffline();
 
     const nextApproverAccountID = getNextApproverAccountID(expenseReport);
-    const predictedNextStatus = !nextApproverAccountID ? CONST.REPORT.STATUS_NUM.APPROVED : CONST.REPORT.STATUS_NUM.SUBMITTED;
+    const isAutoReimbursable = !nextApproverAccountID && canBeAutoReimbursed(expenseReport, policy);
+    const predictedNextStatus = isAutoReimbursable ? CONST.REPORT.STATUS_NUM.REIMBURSED : (!nextApproverAccountID ? CONST.REPORT.STATUS_NUM.APPROVED : CONST.REPORT.STATUS_NUM.SUBMITTED);
     const predictedNextState = !nextApproverAccountID ? CONST.REPORT.STATE_NUM.APPROVED : CONST.REPORT.STATE_NUM.SUBMITTED;
     const managerID = !nextApproverAccountID ? expenseReport.managerID : nextApproverAccountID;
 


### PR DESCRIPTION
### Description
This PR fixes a bug where approved reports were not automatically transitioning to the REIMBURSED status even when the 'Auto-pay approved reports' rule was enabled and the report met the criteria.

### Problem
In pproveMoneyRequest, the predictedNextStatus was hardcoded to APPROVED when no further approvers were needed, ignoring the auto-pay logic.

### Solution
Updated the logic to check canBeAutoReimbursed and set the predictedNextStatus to REIMBURSED if applicable.

$ https://github.com/Expensify/App/issues/82995