### PR TITLE
[WIP][No QA] Add per-migration Sentry spans to Onyx migration runner

### DIFF
--- a/src/libs/migrateOnyx.ts
+++ b/src/libs/migrateOnyx.ts
@@ -1,3 +1,4 @@
+import * as Sentry from '@sentry/react-native';
 import CONST from '@src/CONST';
 import Log from './Log';
 import ConvertPolicyChatReportIDsToString from './migrations/ConvertPolicyChatReportIDsToString';
@@ -15,16 +16,24 @@ export default function () {
             parentSpan: getSpan(CONST.TELEMETRY.SPAN_BOOTSPLASH.ONYX),
         });
 
-        // Add all migrations to an array so they are executed in order
-        const migrationPromises = [RenameEmojiSkinTone, ConvertPolicyChatReportIDsToString];
+        const migrations = [
+            {name: 'RenameEmojiSkinTone', migration: RenameEmojiSkinTone},
+            {name: 'ConvertPolicyChatReportIDsToString', migration: ConvertPolicyChatReportIDsToString},
+        ];
 
-        // Reduce all promises down to a single promise. All promises run in a linear fashion, waiting for the
-        // previous promise to finish before moving onto the next one.
         /* eslint-disable arrow-body-style */
-        migrationPromises
-            .reduce<Promise<void | void[]>>((previousPromise, migrationPromise) => {
+        migrations
+            .reduce<Promise<void | void[]>>((previousPromise, {name, migration}) => {
                 return previousPromise.then(() => {
-                    return migrationPromise();
+                    const span = Sentry.startInactiveSpan({
+                        name,
+                        op: 'migration',
+                        parentSpan: getSpan(CONST.TELEMETRY.SPAN_BOOTSPLASH.ONYX_MIGRATIONS),
+                    });
+                    return migration().finally(() => {
+                        span?.setStatus({code: 1});
+                        span?.end();
+                    });
                 });
             }, Promise.resolve())
 


### PR DESCRIPTION
### Explanation of Change
The Onyx migration runner already creates a single Sentry span wrapping all migrations, but we have no visibility into how long each individual migration takes. This PR instruments the migration runner so that each migration gets its own child Sentry span nested under the existing `ONYX_MIGRATIONS` parent span.

Changes are confined to `migrateOnyx.ts`:
- Added `Sentry.startInactiveSpan()` around each migration invocation
- Changed the migrations array to named objects so each span has a descriptive label
- Each span is a child of the `ONYX_MIGRATIONS` bootsplash span

### Fixed Issues
N/A - internal improvement for Sentry performance visibility

### Tests
- [ ] Verify that no errors appear in the JS console
- [ ] Verify that Sentry traces show individual migration spans nested under the `BootsplashVisibleOnyxMigrations` span

### Offline tests
N/A - Sentry telemetry is best-effort and does not affect offline behavior.

### QA Steps
// TODO: These must be filled out, or the issue title must include "[No QA]."
N/A - title includes [No QA]

### PR Author Checklist
- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [ ] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [ ] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [ ] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [ ] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [ ] I ran the tests on **all platforms** & verified they passed on:
    - [ ] Android: Native
    - [ ] Android: mWeb Chrome
    - [ ] iOS: Native
    - [ ] iOS: mWeb Safari
    - [ ] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [ ] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [ ] If any new file was added I verified that:
    - [ ] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [ ] If a new CSS style is added I verified that:
    - [ ] A similar style doesn't already exist
    - [ ] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [ ] If new assets were added or existing ones were modified, I verified that:
    - [ ] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [ ] The assets load correctly across all supported platforms.
- [ ] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [ ] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [ ] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [ ] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [ ] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [ ] I verified that all the inputs inside a form are aligned with each other.
    - [ ] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [ ] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [ ] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [ ] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

N/A - no UI changes

</details>

<details>
<summary>Android: mWeb Chrome</summary>

N/A - no UI changes

</details>

<details>
<summary>iOS: Native</summary>

N/A - no UI changes

</details>

<details>
<summary>iOS: mWeb Safari</summary>

N/A - no UI changes

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

N/A - no UI changes

</details>

Made with [Cursor](https://cursor.com)