### PR TITLE
fix: exclude thread reports from isChatUsedForOnboarding admin room fallback

### DIFF
--- a/src/libs/ReportUtils.ts
+++ b/src/libs/ReportUtils.ts
@@ -12047,7 +12047,9 @@ function isChatUsedForOnboarding(
         return (optionOrReport as OptionData)?.isConciergeChat ?? isConciergeChatReport(optionOrReport, conciergeReportID);
     }
 
-    return isPostingTasksInAdminsRoom(onboardingPurposeSelected) ? isAdminRoom(optionOrReport) : ((optionOrReport as OptionData)?.isConciergeChat ?? isConciergeChatReport(optionOrReport));
+    return isPostingTasksInAdminsRoom(onboardingPurposeSelected)
+        ? isAdminRoom(optionOrReport) && !isChatThread(optionOrReport)
+        : ((optionOrReport as OptionData)?.isConciergeChat ?? isConciergeChatReport(optionOrReport));
 }
 
 /**

--- a/tests/unit/ReportUtilsTest.ts
+++ b/tests/unit/ReportUtilsTest.ts
@@ -4078,6 +4078,23 @@ describe('ReportUtils', () => {
             expect(isChatUsedForOnboarding(report, onboardingValue, undefined, CONST.ONBOARDING_CHOICES.MANAGE_TEAM)).toBeTruthy();
         });
 
+        it('should return false for admins rooms thread when posting tasks in admins room', async () => {
+            const onboardingValue = {hasCompletedGuidedSetupFlow: true} as Onboarding;
+
+            await Onyx.multiSet({
+                [ONYXKEYS.NVP_ONBOARDING]: onboardingValue,
+            });
+
+            const report = {
+                ...LHNTestUtils.getFakeReport(),
+                chatType: CONST.REPORT.CHAT_TYPE.POLICY_ADMINS,
+                parentReportID: '1',
+                parentReportActionID: '2',
+                type: CONST.REPORT.TYPE.CHAT,
+            };
+            expect(isChatUsedForOnboarding(report, onboardingValue, undefined, CONST.ONBOARDING_CHOICES.MANAGE_TEAM)).toBeFalsy();
+        });
+
         it('should return false for admins room when engagement choice is TRACK_WORKSPACE (Concierge is used for onboarding)', async () => {
             const onboardingValue = {hasCompletedGuidedSetupFlow: true} as Onboarding;
 


### PR DESCRIPTION
### Explanation of Change
When the onboarding NVP exists but lacks a `chatReportID` (transient state during guided setup), `isChatUsedForOnboarding` falls back to `isAdminRoom()`. Thread reports created in the #admins room inherit `chatType: POLICY_ADMINS` from their parent, so `isAdminRoom()` returns `true` for those threads too. This causes the "Register for webinar" button (and other onboarding UI like the LHN tooltip and FreeTrial badge) to incorrectly appear in thread headers.

This PR adds a `!isChatThread(optionOrReport)` guard to the `isAdminRoom` fallback path inside `isChatUsedForOnboarding()`. A thread is never the onboarding chat itself — it is always a child of one — so this change is semantically correct and fixes the root cause at the utility function level rather than patching individual call sites.

A companion unit test is also added to verify that a report with both `chatType: POLICY_ADMINS` and `parentReportID`/`parentReportActionID` set correctly returns `false`.

### Fixed Issues
$ https://github.com/Expensify/App/issues/81069
PROPOSAL: https://github.com/Expensify/App/issues/81069#issuecomment-3826324854

### Tests
1. Log in to the app in your local environment with a new account (or an account that has completed guided setup with the MANAGE_TEAM onboarding choice)
2. Navigate to the #admins room
3. Create a new thread by replying to any message in the #admins room
4. Open the thread
5. Verify that the "Register for webinar" button does **NOT** appear in the thread header
6. Go back to the main #admins room
7. Verify that the "Register for webinar" button still appears correctly in the main #admins room header
- [x] Verify that no errors appear in the JS console

### Offline tests
1. Disconnect from the network
2. Navigate to a thread in the #admins room
3. Verify the "Register for webinar" button does not appear in the thread header
4. Reconnect to the network
5. Verify the behavior remains consistent

### QA Steps
1. Log in on staging with an account that completed onboarding with the MANAGE_TEAM choice
2. Navigate to the #admins room
3. Open any thread in the #admins room
4. Verify the "Register for webinar" button does **NOT** appear in the thread header
5. Go back to the #admins room
6. Verify the "Register for webinar" button still appears in the main room header
- [x] Verify that no errors appear in the JS console

### PR Author Checklist
- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>
<img width="540" height="1128" alt="admins_room_header_no_webinar_button" src="https://github.com/user-attachments/assets/780cdef4-5b34-4007-845a-be2533b0e17b" />
<img width="540" height="1133" alt="thread_header_no_webinar_button" src="https://github.com/user-attachments/assets/532b7345-d809-4ef1-9880-09159ab2f270" />



</details>

<details>
<summary>Android: mWeb Chrome</summary>
<img width="749" height="1600" alt="admins_room_header_no_webinar_button_3" src="https://github.com/user-attachments/assets/37b89680-febd-4e3b-9933-5adb58e879a3" />
<img width="755" height="1600" alt="thread_header_no_webinar_button_3" src="https://github.com/user-attachments/assets/0e45b139-4348-4924-b0e8-4d106a5fbc79" />



</details>

<details>
<summary>iOS: Native</summary>
<img width="1170" height="2532" alt="admins_room_header_no_webinar_button" src="https://github.com/user-attachments/assets/5f71c21f-9770-41d1-a9e7-4b8aaa9d1ac5" />
<img width="1170" height="2532" alt="thread_header_no_webinar_button" src="https://github.com/user-attachments/assets/d3b36ae1-aa6e-4e4b-909b-9af745305e8c" />



</details>

<details>
<summary>iOS mWeb Safari </summary>
<img width="738" height="1600" alt="admins_room_header_no_webinar_button_2" src="https://github.com/user-attachments/assets/7ad6eceb-667d-444b-9962-ab8a56a705ee" />
<img width="738" height="1600" alt="thread_header_no_webinar_button_2" src="https://github.com/user-attachments/assets/e6ea4005-e97a-44f4-a06d-1e9974c35086" />




</details>

<details>
<summary>macOS Chrome & macOS Safari</summary>
<img width="1470" height="878" alt="admins_room_header_no_webinar_button" src="https://github.com/user-attachments/assets/9fad5278-4ae5-4642-82ba-840e4826c04d" />
<img width="1470" height="881" alt="thread_header_no_webinar_button" src="https://github.com/user-attachments/assets/2388d63a-e7c7-4f3b-b31a-0997bffebfe4" />
<img width="1470" height="916" alt="admins_room_header_no_webinar_button" src="https://github.com/user-attachments/assets/b1aa04c9-7387-4c26-97d3-87748580ac80" />
<img width="1470" height="917" alt="thread_header_no_webinar_button" src="https://github.com/user-attachments/assets/dbd66724-8d82-4ea7-882d-ac02848b1b11" />




</details>
