### PR TITLE
[CP Staging] Dedupe approval workflow members

### DIFF
--- a/src/libs/WorkflowUtils.ts
+++ b/src/libs/WorkflowUtils.ts
@@ -575,9 +575,7 @@ function getOpenConnectedToPolicyBusinessBankAccounts(bankAccountList: BankAccou
 }
 
 /**
- * Merge workflow members with all available members, deduplicating by email.
- * Used when setting up the Edit page's availableMembers to prevent duplicate keyForList
- * in the Expenses From list (which causes a blank row when deselecting - see #83251).
+ * Combine workflow members with available members, deduplicating by email.
  */
 function mergeWorkflowMembersWithAvailableMembers(workflowMembers: Member[], allAvailableMembers: Member[]): Member[] {
     const memberEmails = new Set(workflowMembers.map((m) => m.email));

--- a/src/libs/WorkflowUtils.ts
+++ b/src/libs/WorkflowUtils.ts
@@ -574,6 +574,17 @@ function getOpenConnectedToPolicyBusinessBankAccounts(bankAccountList: BankAccou
     });
 }
 
+/**
+ * Merge workflow members with all available members, deduplicating by email.
+ * Used when setting up the Edit page's availableMembers to prevent duplicate keyForList
+ * in the Expenses From list (which causes a blank row when deselecting - see #83251).
+ */
+function mergeWorkflowMembersWithAvailableMembers(workflowMembers: Member[], allAvailableMembers: Member[]): Member[] {
+    const memberEmails = new Set(workflowMembers.map((m) => m.email));
+    const additionalMembers = allAvailableMembers.filter((m) => !memberEmails.has(m.email));
+    return [...workflowMembers, ...additionalMembers];
+}
+
 export {
     calculateApprovers,
     convertPolicyEmployeesToApprovalWorkflows,
@@ -582,5 +593,6 @@ export {
     getEligibleExistingBusinessBankAccounts,
     getOpenConnectedToPolicyBusinessBankAccounts,
     INITIAL_APPROVAL_WORKFLOW,
+    mergeWorkflowMembersWithAvailableMembers,
     updateWorkflowDataOnApproverRemoval,
 };

--- a/src/pages/workspace/workflows/approvals/WorkspaceWorkflowsApprovalsEditPage.tsx
+++ b/src/pages/workspace/workflows/approvals/WorkspaceWorkflowsApprovalsEditPage.tsx
@@ -17,7 +17,7 @@ import Navigation from '@libs/Navigation/Navigation';
 import type {PlatformStackScreenProps} from '@libs/Navigation/PlatformStackNavigation/types';
 import type {WorkspaceSplitNavigatorParamList} from '@libs/Navigation/types';
 import {goBackFromInvalidPolicy, isPendingDeletePolicy, isPolicyAdmin} from '@libs/PolicyUtils';
-import {convertPolicyEmployeesToApprovalWorkflows} from '@libs/WorkflowUtils';
+import {convertPolicyEmployeesToApprovalWorkflows, mergeWorkflowMembersWithAvailableMembers} from '@libs/WorkflowUtils';
 import AccessOrNotFoundWrapper from '@pages/workspace/AccessOrNotFoundWrapper';
 import withPolicyAndFullscreenLoading from '@pages/workspace/withPolicyAndFullscreenLoading';
 import type {WithPolicyAndFullscreenLoadingProps} from '@pages/workspace/withPolicyAndFullscreenLoading';
@@ -115,13 +115,9 @@ function WorkspaceWorkflowsApprovalsEditPage({policy, isLoadingReportData = true
             return clearApprovalWorkflow();
         }
 
-        // Deduplicate by email: current workflow members first, then defaultWorkflowMembers not already in workflow.
-        // Prevents duplicate keyForList (email) in Expenses From list which causes blank row when deselecting (#83251).
-        const memberEmails = new Set(currentApprovalWorkflow.members.map((m) => m.email));
-        const additionalMembers = defaultWorkflowMembers.filter((m) => !memberEmails.has(m.email));
         setApprovalWorkflow({
             ...currentApprovalWorkflow,
-            availableMembers: [...currentApprovalWorkflow.members, ...additionalMembers],
+            availableMembers: mergeWorkflowMembersWithAvailableMembers(currentApprovalWorkflow.members, defaultWorkflowMembers),
             usedApproverEmails,
             action: CONST.APPROVAL_WORKFLOW.ACTION.EDIT,
             errors: null,

--- a/src/pages/workspace/workflows/approvals/WorkspaceWorkflowsApprovalsEditPage.tsx
+++ b/src/pages/workspace/workflows/approvals/WorkspaceWorkflowsApprovalsEditPage.tsx
@@ -115,9 +115,13 @@ function WorkspaceWorkflowsApprovalsEditPage({policy, isLoadingReportData = true
             return clearApprovalWorkflow();
         }
 
+        // Deduplicate by email: current workflow members first, then defaultWorkflowMembers not already in workflow.
+        // Prevents duplicate keyForList (email) in Expenses From list which causes blank row when deselecting (#83251).
+        const memberEmails = new Set(currentApprovalWorkflow.members.map((m) => m.email));
+        const additionalMembers = defaultWorkflowMembers.filter((m) => !memberEmails.has(m.email));
         setApprovalWorkflow({
             ...currentApprovalWorkflow,
-            availableMembers: [...currentApprovalWorkflow.members, ...defaultWorkflowMembers],
+            availableMembers: [...currentApprovalWorkflow.members, ...additionalMembers],
             usedApproverEmails,
             action: CONST.APPROVAL_WORKFLOW.ACTION.EDIT,
             errors: null,

--- a/src/pages/workspace/workflows/approvals/WorkspaceWorkflowsApprovalsEditPage.tsx
+++ b/src/pages/workspace/workflows/approvals/WorkspaceWorkflowsApprovalsEditPage.tsx
@@ -118,7 +118,6 @@ function WorkspaceWorkflowsApprovalsEditPage({policy, isLoadingReportData = true
         setApprovalWorkflow({
             ...currentApprovalWorkflow,
             availableMembers: mergeWorkflowMembersWithAvailableMembers(currentApprovalWorkflow.members, defaultWorkflowMembers),
-            // availableMembers: [...currentApprovalWorkflow.members, ...defaultWorkflowMembers],
             usedApproverEmails,
             action: CONST.APPROVAL_WORKFLOW.ACTION.EDIT,
             errors: null,

--- a/src/pages/workspace/workflows/approvals/WorkspaceWorkflowsApprovalsEditPage.tsx
+++ b/src/pages/workspace/workflows/approvals/WorkspaceWorkflowsApprovalsEditPage.tsx
@@ -118,6 +118,7 @@ function WorkspaceWorkflowsApprovalsEditPage({policy, isLoadingReportData = true
         setApprovalWorkflow({
             ...currentApprovalWorkflow,
             availableMembers: mergeWorkflowMembersWithAvailableMembers(currentApprovalWorkflow.members, defaultWorkflowMembers),
+            // availableMembers: [...currentApprovalWorkflow.members, ...defaultWorkflowMembers],
             usedApproverEmails,
             action: CONST.APPROVAL_WORKFLOW.ACTION.EDIT,
             errors: null,

--- a/tests/ui/WorkspaceWorkflowsApprovalsEditPageTest.tsx
+++ b/tests/ui/WorkspaceWorkflowsApprovalsEditPageTest.tsx
@@ -121,9 +121,9 @@ describe('WorkspaceWorkflowsApprovalsEditPage', () => {
         await waitForBatchedUpdatesWithAct();
 
         expect(setApprovalWorkflow).toHaveBeenCalled();
-        const mockCalls = (setApprovalWorkflow as jest.Mock).mock.calls;
+        const mockCalls = (setApprovalWorkflow as jest.Mock<unknown[], [{availableMembers: Member[]}]>).mock.calls;
         const firstCall = mockCalls.at(0);
-        const callArg = firstCall?.at(0) as {availableMembers?: Member[]} | undefined;
+        const callArg = firstCall?.at(0);
         const availableMembers: Member[] = callArg?.availableMembers ?? [];
         const emails = availableMembers.map((m) => m.email);
         const uniqueEmails = [...new Set(emails)];

--- a/tests/ui/WorkspaceWorkflowsApprovalsEditPageTest.tsx
+++ b/tests/ui/WorkspaceWorkflowsApprovalsEditPageTest.tsx
@@ -1,12 +1,3 @@
-/**
- * Component test for WorkspaceWorkflowsApprovalsEditPage.
- *
- * Regresses on issue #83251: when editing a self-approval workflow (user A submits to user A),
- * availableMembers must not contain duplicate entries. Raw concatenation
- * [...members, ...defaultWorkflowMembers] produces duplicates because defaultWorkflowMembers
- * (from convertPolicyEmployeesToApprovalWorkflows) now includes all workspace members.
- * This test verifies the page uses mergeWorkflowMembersWithAvailableMembers.
- */
 import {act, render} from '@testing-library/react-native';
 import React from 'react';
 import Onyx from 'react-native-onyx';
@@ -14,7 +5,7 @@ import ComposeProviders from '@components/ComposeProviders';
 import {LocaleContextProvider} from '@components/LocaleContextProvider';
 import OnyxListItemProvider from '@components/OnyxListItemProvider';
 import WorkspaceWorkflowsApprovalsEditPage from '@pages/workspace/workflows/approvals/WorkspaceWorkflowsApprovalsEditPage';
-import * as Workflow from '@userActions/Workflow';
+import {setApprovalWorkflow} from '@userActions/Workflow';
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
 import type {Policy} from '@src/types/onyx';
@@ -99,7 +90,7 @@ describe('WorkspaceWorkflowsApprovalsEditPage', () => {
     });
 
     beforeEach(async () => {
-        jest.spyOn(Workflow, 'setApprovalWorkflow');
+        jest.spyOn(require('@userActions/Workflow'), 'setApprovalWorkflow');
         await act(async () => {
             await Onyx.clear();
             await Onyx.set(ONYXKEYS.HAS_LOADED_APP, true);
@@ -127,8 +118,8 @@ describe('WorkspaceWorkflowsApprovalsEditPage', () => {
         renderEditPage();
         await waitForBatchedUpdatesWithAct();
 
-        expect(Workflow.setApprovalWorkflow).toHaveBeenCalled();
-        const callArg = (Workflow.setApprovalWorkflow as jest.Mock).mock.calls[0][0];
+        expect(setApprovalWorkflow).toHaveBeenCalled();
+        const callArg = (setApprovalWorkflow as jest.Mock).mock.calls[0][0];
         const availableMembers = callArg.availableMembers ?? [];
         const emails = availableMembers.map((m: {email: string}) => m.email);
         const uniqueEmails = [...new Set(emails)];

--- a/tests/ui/WorkspaceWorkflowsApprovalsEditPageTest.tsx
+++ b/tests/ui/WorkspaceWorkflowsApprovalsEditPageTest.tsx
@@ -43,7 +43,14 @@ jest.mock('@libs/Navigation/Navigation', () => ({
     dismissModal: jest.fn(),
 }));
 
-function buildPolicy(employeeList: PolicyEmployeeList): Policy {
+function buildPolicy(): Policy {
+    const employeeList: PolicyEmployeeList = {
+        [ALICE_EMAIL]: {
+            email: ALICE_EMAIL,
+            submitsTo: ALICE_EMAIL,
+            forwardsTo: undefined,
+        },
+    };
     return {
         id: POLICY_ID,
         name: 'Test Workspace',
@@ -99,14 +106,7 @@ describe('WorkspaceWorkflowsApprovalsEditPage', () => {
             await Onyx.set(ONYXKEYS.HAS_LOADED_APP, true);
             await Onyx.set(ONYXKEYS.IS_LOADING_REPORT_DATA, false);
 
-            const employeeList: PolicyEmployeeList = {
-                [ALICE_EMAIL]: {
-                    email: ALICE_EMAIL,
-                    submitsTo: ALICE_EMAIL,
-                    forwardsTo: undefined,
-                },
-            };
-            const policy = buildPolicy(employeeList);
+            const policy = buildPolicy();
             const personalDetails = buildPersonalDetailsList();
 
             await Onyx.set(`${ONYXKEYS.COLLECTION.POLICY}${POLICY_ID}`, policy);

--- a/tests/ui/WorkspaceWorkflowsApprovalsEditPageTest.tsx
+++ b/tests/ui/WorkspaceWorkflowsApprovalsEditPageTest.tsx
@@ -7,15 +7,14 @@
  * (from convertPolicyEmployeesToApprovalWorkflows) now includes all workspace members.
  * This test verifies the page uses mergeWorkflowMembersWithAvailableMembers.
  */
-
 import {act, render} from '@testing-library/react-native';
 import React from 'react';
 import Onyx from 'react-native-onyx';
 import ComposeProviders from '@components/ComposeProviders';
 import {LocaleContextProvider} from '@components/LocaleContextProvider';
 import OnyxListItemProvider from '@components/OnyxListItemProvider';
-import * as Workflow from '@userActions/Workflow';
 import WorkspaceWorkflowsApprovalsEditPage from '@pages/workspace/workflows/approvals/WorkspaceWorkflowsApprovalsEditPage';
+import * as Workflow from '@userActions/Workflow';
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
 import type {Policy} from '@src/types/onyx';

--- a/tests/ui/WorkspaceWorkflowsApprovalsEditPageTest.tsx
+++ b/tests/ui/WorkspaceWorkflowsApprovalsEditPageTest.tsx
@@ -1,0 +1,140 @@
+/**
+ * Component test for WorkspaceWorkflowsApprovalsEditPage.
+ *
+ * Regresses on issue #83251: when editing a self-approval workflow (user A submits to user A),
+ * availableMembers must not contain duplicate entries. Raw concatenation
+ * [...members, ...defaultWorkflowMembers] produces duplicates because defaultWorkflowMembers
+ * (from convertPolicyEmployeesToApprovalWorkflows) now includes all workspace members.
+ * This test verifies the page uses mergeWorkflowMembersWithAvailableMembers.
+ */
+
+import {act, render} from '@testing-library/react-native';
+import React from 'react';
+import Onyx from 'react-native-onyx';
+import ComposeProviders from '@components/ComposeProviders';
+import {LocaleContextProvider} from '@components/LocaleContextProvider';
+import OnyxListItemProvider from '@components/OnyxListItemProvider';
+import * as Workflow from '@userActions/Workflow';
+import WorkspaceWorkflowsApprovalsEditPage from '@pages/workspace/workflows/approvals/WorkspaceWorkflowsApprovalsEditPage';
+import CONST from '@src/CONST';
+import ONYXKEYS from '@src/ONYXKEYS';
+import type {Policy} from '@src/types/onyx';
+import type {PersonalDetailsList} from '@src/types/onyx/PersonalDetails';
+import type {PolicyEmployeeList} from '@src/types/onyx/PolicyEmployee';
+import {buildPersonalDetails} from '../utils/TestHelper';
+import waitForBatchedUpdatesWithAct from '../utils/waitForBatchedUpdatesWithAct';
+
+const POLICY_ID = 'workflow-approvals-edit-test-policy';
+const ALICE_EMAIL = 'alice@example.com';
+
+jest.mock('@react-navigation/native', () => {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-unsafe-assignment
+    const actualNav = jest.requireActual('@react-navigation/native');
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+    return {
+        ...actualNav,
+        useIsFocused: () => true,
+        usePreventRemove: jest.fn(),
+    };
+});
+
+jest.mock('@libs/Navigation/Navigation', () => ({
+    goBack: jest.fn(),
+    dismissModal: jest.fn(),
+}));
+
+function buildPolicy(employeeList: PolicyEmployeeList): Policy {
+    return {
+        id: POLICY_ID,
+        name: 'Test Workspace',
+        type: CONST.POLICY.TYPE.CORPORATE,
+        role: CONST.POLICY.ROLE.ADMIN,
+        owner: ALICE_EMAIL,
+        employeeList,
+        approver: ALICE_EMAIL,
+        areWorkflowsEnabled: true,
+        isPolicyExpenseChatEnabled: true,
+        outputCurrency: 'USD',
+        avatarURL: '',
+        lastModified: new Date().toISOString(),
+        pendingAction: null,
+        errors: {},
+    } as Policy;
+}
+
+function buildPersonalDetailsList(): PersonalDetailsList {
+    return {
+        1: buildPersonalDetails(ALICE_EMAIL, 1, 'alice'),
+    };
+}
+
+const mockRoute = {
+    key: 'test-route',
+    name: 'Workspace_Approvals_Edit',
+    params: {
+        policyID: POLICY_ID,
+        firstApproverEmail: ALICE_EMAIL,
+    },
+};
+
+const renderEditPage = () =>
+    render(
+        <ComposeProviders components={[OnyxListItemProvider, LocaleContextProvider]}>
+            <WorkspaceWorkflowsApprovalsEditPage
+                // @ts-expect-error - route type from navigator
+                route={mockRoute}
+            />
+        </ComposeProviders>,
+    );
+
+describe('WorkspaceWorkflowsApprovalsEditPage', () => {
+    beforeAll(async () => {
+        Onyx.init({keys: ONYXKEYS});
+    });
+
+    beforeEach(async () => {
+        jest.spyOn(Workflow, 'setApprovalWorkflow');
+        await act(async () => {
+            await Onyx.clear();
+            await Onyx.set(ONYXKEYS.HAS_LOADED_APP, true);
+            await Onyx.set(ONYXKEYS.IS_LOADING_REPORT_DATA, false);
+
+            const employeeList: PolicyEmployeeList = {
+                [ALICE_EMAIL]: {
+                    email: ALICE_EMAIL,
+                    submitsTo: ALICE_EMAIL,
+                    forwardsTo: undefined,
+                },
+            };
+            const policy = buildPolicy(employeeList);
+            const personalDetails = buildPersonalDetailsList();
+
+            await Onyx.set(`${ONYXKEYS.COLLECTION.POLICY}${POLICY_ID}`, policy);
+            await Onyx.set(ONYXKEYS.PERSONAL_DETAILS_LIST, personalDetails);
+            await Onyx.merge(ONYXKEYS.SESSION, {email: ALICE_EMAIL, accountID: 1});
+            await waitForBatchedUpdatesWithAct();
+        });
+    });
+
+    afterEach(async () => {
+        jest.restoreAllMocks();
+        await act(async () => {
+            await Onyx.clear();
+            await waitForBatchedUpdatesWithAct();
+        });
+    });
+
+    it('should pass deduplicated availableMembers to setApprovalWorkflow for self-approval workflow', async () => {
+        renderEditPage();
+        await waitForBatchedUpdatesWithAct();
+
+        expect(Workflow.setApprovalWorkflow).toHaveBeenCalled();
+        const callArg = (Workflow.setApprovalWorkflow as jest.Mock).mock.calls[0][0];
+        const availableMembers = callArg.availableMembers ?? [];
+        const emails = availableMembers.map((m: {email: string}) => m.email);
+        const uniqueEmails = [...new Set(emails)];
+
+        expect(emails.length).toBe(uniqueEmails.length);
+        expect(emails).toContain(ALICE_EMAIL);
+    });
+});

--- a/tests/unit/WorkflowUtilsTest.ts
+++ b/tests/unit/WorkflowUtilsTest.ts
@@ -6,6 +6,7 @@ import {
     convertPolicyEmployeesToApprovalWorkflows,
     getApprovalLimitDescription,
     getOpenConnectedToPolicyBusinessBankAccounts,
+    mergeWorkflowMembersWithAvailableMembers,
     updateWorkflowDataOnApproverRemoval,
 } from '@src/libs/WorkflowUtils';
 import type {Policy} from '@src/types/onyx';
@@ -540,6 +541,44 @@ describe('WorkflowUtils', () => {
             expect(approvalWorkflows.at(0)?.members).toHaveLength(1);
             const memberEmails = availableMembers.map((m) => m.email).sort();
             expect(memberEmails).toEqual(['alice@example.com', 'bob@example.com']);
+        });
+    });
+
+    describe('mergeWorkflowMembersWithAvailableMembers', () => {
+        it('Should deduplicate members when workflow members overlap with available members', () => {
+            const workflowMembers = [buildMember(1)];
+            const allAvailableMembers = [buildMember(1), buildMember(2), buildMember(3)];
+            const result = mergeWorkflowMembersWithAvailableMembers(workflowMembers, allAvailableMembers);
+
+            expect(result).toHaveLength(3);
+            expect(result.map((m) => m.email)).toEqual(['1@example.com', '2@example.com', '3@example.com']);
+        });
+
+        it('Should not duplicate when editing self-approval workflow (user A submits to user A)', () => {
+            const userA = buildMember(1);
+            const workflowMembers = [userA];
+            const allAvailableMembers = [userA];
+            const result = mergeWorkflowMembersWithAvailableMembers(workflowMembers, allAvailableMembers);
+
+            expect(result).toHaveLength(1);
+            expect(result[0].email).toBe('1@example.com');
+        });
+
+        it('Should preserve workflow member order and append additional members', () => {
+            const workflowMembers = [buildMember(2), buildMember(3)];
+            const allAvailableMembers = [buildMember(1), buildMember(2), buildMember(3), buildMember(4)];
+            const result = mergeWorkflowMembersWithAvailableMembers(workflowMembers, allAvailableMembers);
+
+            expect(result.map((m) => m.email)).toEqual(['2@example.com', '3@example.com', '1@example.com', '4@example.com']);
+        });
+
+        it('Should return workflow members only when all available are already in workflow', () => {
+            const workflowMembers = [buildMember(1), buildMember(2)];
+            const allAvailableMembers = [buildMember(1), buildMember(2)];
+            const result = mergeWorkflowMembersWithAvailableMembers(workflowMembers, allAvailableMembers);
+
+            expect(result).toHaveLength(2);
+            expect(result.map((m) => m.email)).toEqual(['1@example.com', '2@example.com']);
         });
     });
 

--- a/tests/unit/WorkflowUtilsTest.ts
+++ b/tests/unit/WorkflowUtilsTest.ts
@@ -561,7 +561,7 @@ describe('WorkflowUtils', () => {
             const result = mergeWorkflowMembersWithAvailableMembers(workflowMembers, allAvailableMembers);
 
             expect(result).toHaveLength(1);
-            expect(result[0].email).toBe('1@example.com');
+            expect(result.at(0)?.email).toBe('1@example.com');
         });
 
         it('Should preserve workflow member order and append additional members', () => {


### PR DESCRIPTION
### Explanation of Change

PR #82841 changed `convertPolicyEmployeesToApprovalWorkflows` to build `availableMembers` from **all** workspace employees instead of only workflow members. That correctly fixed members in custom workflows not appearing in the "Expenses from" picker.

However, `WorkspaceWorkflowsApprovalsEditPage` builds the approval workflow's `availableMembers` by concatenating:

```ts
availableMembers: [...currentApprovalWorkflow.members, ...defaultWorkflowMembers]
```

Since `defaultWorkflowMembers` (now all employees) includes every workflow member, this produced **duplicates**. For a self-approval workflow (e.g. user A submits to user A), user A appeared twice. Both entries share the same `keyForList` (email) in the selection list. When the user deselected a member, duplicate keys caused React/FlashList reconciliation issues, resulting in a blank row.

This change deduplicates by filtering `defaultWorkflowMembers` to exclude members already in the workflow before concatenating, fixing the blank row while keeping the PR #82841 behavior.

### Fixed Issues

$ https://github.com/Expensify/App/issues/83251

PROPOSAL: https://github.com/Expensify/App/issues/83251#issuecomment-3947686454

### Tests

1. Run `npm test -- tests/unit/WorkflowUtilsTest.ts` — verify `mergeWorkflowMembersWithAvailableMembers` and `convertPolicyEmployeesToApprovalWorkflows` tests pass
2. Manual regression test:
   - Create a workspace with at least one member (user A)
   - Create a workflow where user A submits to user A
   - Go to Workflows → click the workflow → Expenses from
   - Deselect user A
   - **Expected**: No blank row appears; user A appears once in the unselected list

- [x] Verify that no errors appear in the JS console

### Offline tests

N/A — member list is derived from cached policy data.

### QA Steps

1. Go to staging.new.expensify.com
2. Create or use a workspace with at least one member besides the owner
3. Go to workspace settings → Workflows
4. Create a custom workflow where a member submits to themselves (e.g. "Alex submits to Alex")
5. Click on that workflow, then "Expenses from"
6. Deselect the member (uncheck them)
7. **Expected**: No blank row appears in the list
8. Re-select the member — verify the list behaves normally

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I verified there are no new alerts related to the `canBeMissing` param for `useOnyx`
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I verified that similar component doesn't exist in the codebase
- [x] I verified that all props are defined accurately and each prop has a `/** comment above it */`
- [x] I verified that each file is named correctly
- [x] I verified that each component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
- [x] I verified that the only data being stored in component state is data necessary for rendering and nothing else
- [x] In component if we are not using the full Onyx data that we loaded, I've added the proper selector in order to ensure the component only re-renders when the data it is using changes
- [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
- [x] I verified that component internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
- [x] I verified that all JSX used for rendering exists in the render method
- [x] I verified that each component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions

### Screenshots/Videos

<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>



https://github.com/user-attachments/assets/191db96d-6cb5-4c71-8b77-6c2cf734d914


</details>