### PR TITLE
[No QA] fix: iOS deploy uploading wrong IPA to TestFlight

### DIFF
--- a/.github/workflows/buildAdHoc.yml
+++ b/.github/workflows/buildAdHoc.yml
@@ -120,7 +120,7 @@ jobs:
           path: ./
 
       - name: Extract web build
-        run: tar -xzvf webBuild.tar.gz
+        run: tar -xzvf "${{ needs.buildWeb.outputs.TAR_FILENAME }}"
 
       - name: Configure AWS Credentials
         # v6

--- a/.github/workflows/buildAndroid.yml
+++ b/.github/workflows/buildAndroid.yml
@@ -35,6 +35,12 @@ on:
       ROCK_ARTIFACT_URL:
         description: URL to download the ad-hoc build artifact (adhoc only)
         value: ${{ jobs.build.outputs.ROCK_ARTIFACT_URL }}
+      AAB_FILENAME:
+        description: Filename of the AAB artifact (empty if no AAB was produced)
+        value: ${{ jobs.build.outputs.AAB_FILENAME }}
+      APK_FILENAME:
+        description: Filename of the APK artifact (always Expensify.apk)
+        value: ${{ jobs.build.outputs.APK_FILENAME }}
 
 jobs:
   build:
@@ -45,6 +51,8 @@ jobs:
     outputs:
       VERSION_CODE: ${{ steps.getAndroidVersion.outputs.VERSION_CODE }}
       ROCK_ARTIFACT_URL: ${{ steps.set-artifact-url.outputs.ARTIFACT_URL }}
+      AAB_FILENAME: ${{ steps.collectArtifacts.outputs.AAB_FILENAME }}
+      APK_FILENAME: ${{ steps.collectArtifacts.outputs.APK_FILENAME }}
     steps:
       - name: Checkout
         # v6
@@ -193,6 +201,8 @@ jobs:
             echo "Found AAB: $AAB_FILE"
             cp "$AAB_FILE" /tmp/android-artifacts/
             echo "HAS_AAB=true" >> "$GITHUB_OUTPUT"
+            echo "AAB_FILENAME=$(basename "$AAB_FILE")" >> "$GITHUB_OUTPUT"
+            echo "APK_FILENAME=Expensify.apk" >> "$GITHUB_OUTPUT"
           else
             echo "::warning::No AAB file found (expected for remote-cache hits on Adhoc builds)"
             echo "HAS_AAB=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/buildAndroid.yml
+++ b/.github/workflows/buildAndroid.yml
@@ -208,9 +208,11 @@ jobs:
           if [ -n "$AAB_FILE" ]; then
             echo "Found AAB: $AAB_FILE"
             cp "$AAB_FILE" /tmp/android-artifacts/
-            echo "HAS_AAB=true" >> "$GITHUB_OUTPUT"
-            echo "AAB_FILENAME=$(basename "$AAB_FILE")" >> "$GITHUB_OUTPUT"
-            echo "APK_FILENAME=Expensify.apk" >> "$GITHUB_OUTPUT"
+            {
+              echo "HAS_AAB=true"
+              echo "AAB_FILENAME=$(basename "$AAB_FILE")"
+              echo "APK_FILENAME=Expensify.apk"
+            } >> "$GITHUB_OUTPUT"
           else
             echo "::warning::No AAB file found (expected for remote-cache hits on Adhoc builds)"
             echo "HAS_AAB=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/buildAndroid.yml
+++ b/.github/workflows/buildAndroid.yml
@@ -41,6 +41,12 @@ on:
       APK_FILENAME:
         description: Filename of the APK artifact (always Expensify.apk)
         value: ${{ jobs.build.outputs.APK_FILENAME }}
+      SOURCEMAP_FILENAME:
+        description: Filename of the JS sourcemap artifact
+        value: ${{ jobs.build.outputs.SOURCEMAP_FILENAME }}
+      PROGUARD_MAPPING_FILENAME:
+        description: Filename of the proguard mapping artifact
+        value: ${{ jobs.build.outputs.PROGUARD_MAPPING_FILENAME }}
 
 jobs:
   build:
@@ -53,6 +59,8 @@ jobs:
       ROCK_ARTIFACT_URL: ${{ steps.set-artifact-url.outputs.ARTIFACT_URL }}
       AAB_FILENAME: ${{ steps.collectArtifacts.outputs.AAB_FILENAME }}
       APK_FILENAME: ${{ steps.collectArtifacts.outputs.APK_FILENAME }}
+      SOURCEMAP_FILENAME: index.android.bundle.map
+      PROGUARD_MAPPING_FILENAME: mapping.txt
     steps:
       - name: Checkout
         # v6

--- a/.github/workflows/buildIOS.yml
+++ b/.github/workflows/buildIOS.yml
@@ -243,13 +243,15 @@ jobs:
       - name: Set artifact filenames
         id: set-ipa-filename
         run: |
-          IPA_FILE=$(ls .rock/cache/ios/export/*.ipa 2>/dev/null | head -1)
+          IPA_FILE=$(find .rock/cache/ios/export/ -maxdepth 1 -name '*.ipa' -print -quit 2>/dev/null)
           if [ -z "$IPA_FILE" ]; then
             echo "::error::No .ipa found in .rock/cache/ios/export/"
             exit 1
           fi
-          echo "IPA_FILENAME=$(basename "$IPA_FILE")" >> "$GITHUB_OUTPUT"
-          echo "DSYM_FILENAME=Expensify.app.dSYM.zip" >> "$GITHUB_OUTPUT"
+          {
+            echo "IPA_FILENAME=$(basename "$IPA_FILE")"
+            echo "DSYM_FILENAME=Expensify.app.dSYM.zip"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Find and upload IPA artifact
         # v6

--- a/.github/workflows/buildIOS.yml
+++ b/.github/workflows/buildIOS.yml
@@ -41,6 +41,9 @@ on:
       DSYM_FILENAME:
         description: Filename of the app dSYM zip (Expensify.app.dSYM.zip)
         value: ${{ jobs.build.outputs.DSYM_FILENAME }}
+      SOURCEMAP_FILENAME:
+        description: Filename of the JS sourcemap artifact
+        value: ${{ jobs.build.outputs.SOURCEMAP_FILENAME }}
 
 jobs:
   build:
@@ -54,6 +57,7 @@ jobs:
       ROCK_ARTIFACT_URL: ${{ steps.set-artifact-url.outputs.ARTIFACT_URL }}
       IPA_FILENAME: ${{ steps.set-ipa-filename.outputs.IPA_FILENAME }}
       DSYM_FILENAME: ${{ steps.set-ipa-filename.outputs.DSYM_FILENAME }}
+      SOURCEMAP_FILENAME: main.jsbundle.map
     steps:
       - name: Checkout
         # v6

--- a/.github/workflows/buildIOS.yml
+++ b/.github/workflows/buildIOS.yml
@@ -35,6 +35,12 @@ on:
       ROCK_ARTIFACT_URL:
         description: URL to download the ad-hoc build artifact (adhoc only)
         value: ${{ jobs.build.outputs.ROCK_ARTIFACT_URL }}
+      IPA_FILENAME:
+        description: Filename of the IPA artifact produced by the build
+        value: ${{ jobs.build.outputs.IPA_FILENAME }}
+      DSYM_FILENAME:
+        description: Filename of the app dSYM zip (Expensify.app.dSYM.zip)
+        value: ${{ jobs.build.outputs.DSYM_FILENAME }}
 
 jobs:
   build:
@@ -46,6 +52,8 @@ jobs:
     outputs:
       IOS_VERSION: ${{ steps.getIOSVersion.outputs.IOS_VERSION }}
       ROCK_ARTIFACT_URL: ${{ steps.set-artifact-url.outputs.ARTIFACT_URL }}
+      IPA_FILENAME: ${{ steps.set-ipa-filename.outputs.IPA_FILENAME }}
+      DSYM_FILENAME: ${{ steps.set-ipa-filename.outputs.DSYM_FILENAME }}
     steps:
       - name: Checkout
         # v6
@@ -227,6 +235,17 @@ jobs:
         id: set-artifact-url
         if: ${{ inputs.variant == 'Adhoc' }}
         run: echo "ARTIFACT_URL=$ARTIFACT_URL" >> "$GITHUB_OUTPUT"
+
+      - name: Set artifact filenames
+        id: set-ipa-filename
+        run: |
+          IPA_FILE=$(ls .rock/cache/ios/export/*.ipa 2>/dev/null | head -1)
+          if [ -z "$IPA_FILE" ]; then
+            echo "::error::No .ipa found in .rock/cache/ios/export/"
+            exit 1
+          fi
+          echo "IPA_FILENAME=$(basename "$IPA_FILE")" >> "$GITHUB_OUTPUT"
+          echo "DSYM_FILENAME=Expensify.app.dSYM.zip" >> "$GITHUB_OUTPUT"
 
       - name: Find and upload IPA artifact
         # v6

--- a/.github/workflows/buildIOS.yml
+++ b/.github/workflows/buildIOS.yml
@@ -243,7 +243,7 @@ jobs:
       - name: Set artifact filenames
         id: set-ipa-filename
         run: |
-          IPA_FILE=$(find .rock/cache/ios/export/ -maxdepth 1 -name '*.ipa' -print -quit 2>/dev/null)
+          IPA_FILE=$(find .rock/cache/ios/export/ -maxdepth 1 -name '*.ipa' -print -quit 2>/dev/null || true)
           if [ -z "$IPA_FILE" ]; then
             if [ "${{ inputs.variant }}" = "Adhoc" ]; then
               echo "::warning::No .ipa found locally (expected for remote-cache hits on Adhoc builds)"

--- a/.github/workflows/buildIOS.yml
+++ b/.github/workflows/buildIOS.yml
@@ -245,13 +245,18 @@ jobs:
         run: |
           IPA_FILE=$(find .rock/cache/ios/export/ -maxdepth 1 -name '*.ipa' -print -quit 2>/dev/null)
           if [ -z "$IPA_FILE" ]; then
-            echo "::error::No .ipa found in .rock/cache/ios/export/"
-            exit 1
+            if [ "${{ inputs.variant }}" = "Adhoc" ]; then
+              echo "::warning::No .ipa found locally (expected for remote-cache hits on Adhoc builds)"
+            else
+              echo "::error::No .ipa found in .rock/cache/ios/export/"
+              exit 1
+            fi
+          else
+            {
+              echo "IPA_FILENAME=$(basename "$IPA_FILE")"
+              echo "DSYM_FILENAME=Expensify.app.dSYM.zip"
+            } >> "$GITHUB_OUTPUT"
           fi
-          {
-            echo "IPA_FILENAME=$(basename "$IPA_FILE")"
-            echo "DSYM_FILENAME=Expensify.app.dSYM.zip"
-          } >> "$GITHUB_OUTPUT"
 
       - name: Find and upload IPA artifact
         # v6

--- a/.github/workflows/buildWeb.yml
+++ b/.github/workflows/buildWeb.yml
@@ -16,10 +16,25 @@ on:
         type: string
         default: ''
 
+    outputs:
+      TAR_FILENAME:
+        description: Filename of the .tar.gz web build artifact
+        value: ${{ jobs.build.outputs.TAR_FILENAME }}
+      ZIP_FILENAME:
+        description: Filename of the .zip web build artifact
+        value: ${{ jobs.build.outputs.ZIP_FILENAME }}
+      SOURCEMAP_FILENAME:
+        description: Filename of the web sourcemap artifact
+        value: ${{ jobs.build.outputs.SOURCEMAP_FILENAME }}
+
 jobs:
   build:
     name: Build Web
     runs-on: blacksmith-32vcpu-ubuntu-2404
+    outputs:
+      TAR_FILENAME: webBuild.tar.gz
+      ZIP_FILENAME: webBuild.zip
+      SOURCEMAP_FILENAME: merged-source-map.js.map
     env:
       PULL_REQUEST_NUMBER: ${{ inputs.pull-request-number }}
     steps:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -561,7 +561,7 @@ jobs:
           path: ./
 
       - name: Extract web build
-        run: tar -xzvf webBuild.tar.gz
+        run: tar -xzvf "${{ needs.webBuild.outputs.TAR_FILENAME }}"
 
       - name: Download storybook docs artifact
         continue-on-error: true

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -122,14 +122,11 @@ jobs:
 
       - name: Set aabPath for Fastlane
         run: |
-          echo "All .aab files in working directory:"
-          ls -la *.aab 2>/dev/null || echo "(none)"
-          AAB_PATH="$(realpath *.aab 2>/dev/null | head -1)"
-          if [ -z "$AAB_PATH" ]; then
-            echo "::error::No .aab file found in working directory"
+          AAB_PATH="$(pwd)/${{ needs.androidBuild.outputs.AAB_FILENAME }}"
+          if [ ! -f "$AAB_PATH" ]; then
+            echo "::error::Expected AAB not found at $AAB_PATH"
             exit 1
           fi
-          echo "Selected: $AAB_PATH"
           echo "aabPath=$AAB_PATH" >> "$GITHUB_ENV"
 
       - name: Setup Ruby
@@ -244,9 +241,9 @@ jobs:
       - name: Find APK path
         id: find-apk
         run: |
-          APK_PATH="$(pwd)/Expensify.apk"
+          APK_PATH="$(pwd)/${{ needs.androidBuild.outputs.APK_FILENAME }}"
           if [ ! -f "$APK_PATH" ]; then
-            echo "::error::Expected Expensify.apk not found at $APK_PATH"
+            echo "::error::Expected APK not found at $APK_PATH"
             exit 1
           fi
           echo "APK_PATH=$APK_PATH" >> "$GITHUB_OUTPUT"
@@ -290,9 +287,9 @@ jobs:
       - name: Find APK path
         id: find-apk
         run: |
-          APK_PATH="$(pwd)/Expensify.apk"
+          APK_PATH="$(pwd)/${{ needs.androidBuild.outputs.APK_FILENAME }}"
           if [ ! -f "$APK_PATH" ]; then
-            echo "::error::Expected Expensify.apk not found at $APK_PATH"
+            echo "::error::Expected APK not found at $APK_PATH"
             exit 1
           fi
           echo "APK_PATH=$APK_PATH" >> "$GITHUB_OUTPUT"
@@ -352,24 +349,17 @@ jobs:
 
       - name: Set artifact paths for Fastlane
         run: |
-          echo "All .ipa files in working directory:"
-          ls -la *.ipa 2>/dev/null || echo "(none)"
-          IPA_PATH="$(realpath *.ipa 2>/dev/null | head -1)"
-          if [ -z "$IPA_PATH" ]; then
-            echo "::error::No .ipa file found in working directory"
+          IPA_PATH="$(pwd)/${{ needs.iosBuild.outputs.IPA_FILENAME }}"
+          if [ ! -f "$IPA_PATH" ]; then
+            echo "::error::Expected IPA not found at $IPA_PATH"
             exit 1
           fi
-          echo "Selected IPA: $IPA_PATH"
           echo "ipaPath=$IPA_PATH" >> "$GITHUB_ENV"
 
-          echo "All .dSYM.zip files in working directory:"
-          ls -la *.dSYM.zip 2>/dev/null || echo "(none)"
-          DSYM_PATH="$(pwd)/Expensify.app.dSYM.zip"
+          DSYM_PATH="$(pwd)/${{ needs.iosBuild.outputs.DSYM_FILENAME }}"
           if [ ! -f "$DSYM_PATH" ]; then
-            echo "::warning::Expensify.app.dSYM.zip not found, falling back to first .dSYM.zip"
-            DSYM_PATH="$(realpath *.dSYM.zip 2>/dev/null | head -1)"
+            echo "::warning::Expected dSYM not found at $DSYM_PATH"
           fi
-          echo "Selected dSYM: $DSYM_PATH"
           echo "dsymPath=$DSYM_PATH" >> "$GITHUB_ENV"
 
       - name: Setup Ruby
@@ -481,9 +471,9 @@ jobs:
       - name: Find IPA path
         id: find-ipa
         run: |
-          IPA_PATH="$(realpath *.ipa 2>/dev/null | head -1)"
-          if [ -z "$IPA_PATH" ]; then
-            echo "::error::No .ipa file found in working directory"
+          IPA_PATH="$(pwd)/${{ needs.iosBuild.outputs.IPA_FILENAME }}"
+          if [ ! -f "$IPA_PATH" ]; then
+            echo "::error::Expected IPA not found at $IPA_PATH"
             exit 1
           fi
           echo "IPA_PATH=$IPA_PATH" >> "$GITHUB_OUTPUT"
@@ -527,9 +517,9 @@ jobs:
       - name: Find IPA path
         id: find-ipa
         run: |
-          IPA_PATH="$(realpath *.ipa 2>/dev/null | head -1)"
-          if [ -z "$IPA_PATH" ]; then
-            echo "::error::No .ipa file found in working directory"
+          IPA_PATH="$(pwd)/${{ needs.iosBuild.outputs.IPA_FILENAME }}"
+          if [ ! -f "$IPA_PATH" ]; then
+            echo "::error::Expected IPA not found at $IPA_PATH"
             exit 1
           fi
           echo "IPA_PATH=$IPA_PATH" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -121,7 +121,16 @@ jobs:
           path: ./
 
       - name: Set aabPath for Fastlane
-        run: echo "aabPath=$(find "$(pwd)" -name '*.aab' | head -1)" >> "$GITHUB_ENV"
+        run: |
+          echo "All .aab files in working directory:"
+          ls -la *.aab 2>/dev/null || echo "(none)"
+          AAB_PATH="$(realpath *.aab 2>/dev/null | head -1)"
+          if [ -z "$AAB_PATH" ]; then
+            echo "::error::No .aab file found in working directory"
+            exit 1
+          fi
+          echo "Selected: $AAB_PATH"
+          echo "aabPath=$AAB_PATH" >> "$GITHUB_ENV"
 
       - name: Setup Ruby
         # v1.229.0
@@ -234,7 +243,13 @@ jobs:
 
       - name: Find APK path
         id: find-apk
-        run: echo "APK_PATH=$(find "$(pwd)" -name '*.apk' | head -1)" >> "$GITHUB_OUTPUT"
+        run: |
+          APK_PATH="$(pwd)/Expensify.apk"
+          if [ ! -f "$APK_PATH" ]; then
+            echo "::error::Expected Expensify.apk not found at $APK_PATH"
+            exit 1
+          fi
+          echo "APK_PATH=$APK_PATH" >> "$GITHUB_OUTPUT"
 
       - name: Upload Android build to BrowserStack
         if: ${{ fromJSON(env.IS_APP_REPO) }}
@@ -274,7 +289,13 @@ jobs:
 
       - name: Find APK path
         id: find-apk
-        run: echo "APK_PATH=$(find "$(pwd)" -name '*.apk' | head -1)" >> "$GITHUB_OUTPUT"
+        run: |
+          APK_PATH="$(pwd)/Expensify.apk"
+          if [ ! -f "$APK_PATH" ]; then
+            echo "::error::Expected Expensify.apk not found at $APK_PATH"
+            exit 1
+          fi
+          echo "APK_PATH=$APK_PATH" >> "$GITHUB_OUTPUT"
 
       - name: Upload Android build to Applause
         if: ${{ fromJSON(env.IS_APP_REPO) }}
@@ -331,8 +352,25 @@ jobs:
 
       - name: Set artifact paths for Fastlane
         run: |
-          echo "ipaPath=$(find "$(pwd)" -maxdepth 1 -name '*.ipa' | head -1)" >> "$GITHUB_ENV"
-          echo "dsymPath=$(find "$(pwd)" -maxdepth 1 -name '*.dSYM.zip' | head -1)" >> "$GITHUB_ENV"
+          echo "All .ipa files in working directory:"
+          ls -la *.ipa 2>/dev/null || echo "(none)"
+          IPA_PATH="$(realpath *.ipa 2>/dev/null | head -1)"
+          if [ -z "$IPA_PATH" ]; then
+            echo "::error::No .ipa file found in working directory"
+            exit 1
+          fi
+          echo "Selected IPA: $IPA_PATH"
+          echo "ipaPath=$IPA_PATH" >> "$GITHUB_ENV"
+
+          echo "All .dSYM.zip files in working directory:"
+          ls -la *.dSYM.zip 2>/dev/null || echo "(none)"
+          DSYM_PATH="$(pwd)/Expensify.app.dSYM.zip"
+          if [ ! -f "$DSYM_PATH" ]; then
+            echo "::warning::Expensify.app.dSYM.zip not found, falling back to first .dSYM.zip"
+            DSYM_PATH="$(realpath *.dSYM.zip 2>/dev/null | head -1)"
+          fi
+          echo "Selected dSYM: $DSYM_PATH"
+          echo "dsymPath=$DSYM_PATH" >> "$GITHUB_ENV"
 
       - name: Setup Ruby
         # v1.229.0
@@ -442,7 +480,13 @@ jobs:
 
       - name: Find IPA path
         id: find-ipa
-        run: echo "IPA_PATH=$(find "$(pwd)" -maxdepth 1 -name '*.ipa' | head -1)" >> "$GITHUB_OUTPUT"
+        run: |
+          IPA_PATH="$(realpath *.ipa 2>/dev/null | head -1)"
+          if [ -z "$IPA_PATH" ]; then
+            echo "::error::No .ipa file found in working directory"
+            exit 1
+          fi
+          echo "IPA_PATH=$IPA_PATH" >> "$GITHUB_OUTPUT"
 
       - name: Upload iOS build to BrowserStack
         if: ${{ fromJSON(env.IS_APP_REPO) }}
@@ -482,7 +526,13 @@ jobs:
 
       - name: Find IPA path
         id: find-ipa
-        run: echo "IPA_PATH=$(find "$(pwd)" -maxdepth 1 -name '*.ipa' | head -1)" >> "$GITHUB_OUTPUT"
+        run: |
+          IPA_PATH="$(realpath *.ipa 2>/dev/null | head -1)"
+          if [ -z "$IPA_PATH" ]; then
+            echo "::error::No .ipa file found in working directory"
+            exit 1
+          fi
+          echo "IPA_PATH=$IPA_PATH" >> "$GITHUB_OUTPUT"
 
       - name: Upload iOS build to Applause
         if: ${{ fromJSON(env.IS_APP_REPO) }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -331,8 +331,8 @@ jobs:
 
       - name: Set artifact paths for Fastlane
         run: |
-          echo "ipaPath=$(find "$(pwd)" -name '*.ipa' | head -1)" >> "$GITHUB_ENV"
-          echo "dsymPath=$(find "$(pwd)" -name '*.dSYM.zip' | head -1)" >> "$GITHUB_ENV"
+          echo "ipaPath=$(find "$(pwd)" -maxdepth 1 -name '*.ipa' | head -1)" >> "$GITHUB_ENV"
+          echo "dsymPath=$(find "$(pwd)" -maxdepth 1 -name '*.dSYM.zip' | head -1)" >> "$GITHUB_ENV"
 
       - name: Setup Ruby
         # v1.229.0
@@ -442,7 +442,7 @@ jobs:
 
       - name: Find IPA path
         id: find-ipa
-        run: echo "IPA_PATH=$(find "$(pwd)" -name '*.ipa' | head -1)" >> "$GITHUB_OUTPUT"
+        run: echo "IPA_PATH=$(find "$(pwd)" -maxdepth 1 -name '*.ipa' | head -1)" >> "$GITHUB_OUTPUT"
 
       - name: Upload iOS build to BrowserStack
         if: ${{ fromJSON(env.IS_APP_REPO) }}
@@ -482,7 +482,7 @@ jobs:
 
       - name: Find IPA path
         id: find-ipa
-        run: echo "IPA_PATH=$(find "$(pwd)" -name '*.ipa' | head -1)" >> "$GITHUB_OUTPUT"
+        run: echo "IPA_PATH=$(find "$(pwd)" -maxdepth 1 -name '*.ipa' | head -1)" >> "$GITHUB_OUTPUT"
 
       - name: Upload iOS build to Applause
         if: ${{ fromJSON(env.IS_APP_REPO) }}


### PR DESCRIPTION
### Explanation of Change

The `find` commands in `deploy.yml` that locate `.ipa` and `.dSYM.zip` artifacts were recursing into the `Mobile-Expensify` submodule directory. This caused them to pick up a test fixture at `Mobile-Expensify/tests/iOS/Payload.ipa` instead of the actual build artifact downloaded to the repo root.

The test fixture IPA has metadata like `app_version: 1.0, build_version: 1`, so when uploaded to App Store Connect, it would never process into a real build – causing Fastlane to hang at "Waiting for the build to show up in the build list" for hours until timeout.

The fix adds `-maxdepth 1` to all `find` commands that locate `.ipa` and `.dSYM.zip` files, restricting the search to the directory where artifacts are downloaded.

### Fixed Issues

N/A – fix for broken staging deploys

### Tests

None - CP to test.

- [x] Verify that no errors appear in the JS console

### Offline tests

N/A – CI/CD workflow change only.

### QA Steps

[No QA]

### PR Author Checklist
- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I verified there are no new alerts related to the `canBeMissing` param for `useOnyx`
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.


### Screenshots/Videos
<details>
<summary>Android: Native</summary>

N/A – CI/CD change only

</details>

<details>
<summary>Android: mWeb Chrome</summary>

N/A – CI/CD change only

</details>

<details>
<summary>iOS: Native</summary>

N/A – CI/CD change only

</details>

<details>
<summary>iOS: mWeb Safari</summary>

N/A – CI/CD change only

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

N/A – CI/CD change only

</details>

Made with [Cursor](https://cursor.com)