### PR TITLE
[No QA] Fix return behavior of OnyxUpdates apply() for side effect requests

### DIFF
--- a/src/libs/actions/OnyxUpdates.ts
+++ b/src/libs/actions/OnyxUpdates.ts
@@ -200,7 +200,7 @@ function apply<TKey extends OnyxKey>({lastUpdateID, type, request, response, upd
             return applyHTTPSOnyxUpdates(request, responseWithoutOnyxData, Number(lastUpdateID));
         }
 
-        return Promise.resolve();
+        return Promise.resolve(response);
     }
     if (lastUpdateID && (lastUpdateIDAppliedToClient === undefined || Number(lastUpdateID) > lastUpdateIDAppliedToClient)) {
         Onyx.merge(ONYXKEYS.ONYX_UPDATES_LAST_UPDATE_ID_APPLIED_TO_CLIENT, Number(lastUpdateID));

--- a/tests/unit/MiddlewareTest.ts
+++ b/tests/unit/MiddlewareTest.ts
@@ -65,7 +65,7 @@ describe('Middleware', () => {
 
             // Then the response should not be undefined — the caller may need the raw response for side effects
             expect(result).toBeDefined();
-            expect(result?.transactionsPending3DSReview).toBeDefined();
+            expect(result?.jsonCode).toBe(200);
         });
     });
 

--- a/tests/unit/MiddlewareTest.ts
+++ b/tests/unit/MiddlewareTest.ts
@@ -39,6 +39,36 @@ beforeEach(async () => {
 });
 
 describe('Middleware', () => {
+    describe('SaveResponseInOnyx', () => {
+        test('preserves the response for side-effect requests when the update is already applied', async () => {
+            // Given the client already has a lastUpdateID applied
+            await Onyx.merge(ONYXKEYS.ONYX_UPDATES_LAST_UPDATE_ID_APPLIED_TO_CLIENT, 100);
+            await waitForBatchedUpdates();
+
+            Request.addMiddleware(SaveResponseInOnyx, 'SaveResponseInOnyx');
+
+            const mockResponse = {
+                jsonCode: 200,
+                lastUpdateID: 100,
+                previousUpdateID: 99,
+                transactionsPending3DSReview: {
+                    txn123: {amount: 500, currency: 'USD', created: '2026-02-23', expires: '2026-02-24', lastFourPAN: 1234, merchant: 'TestMerchant'},
+                },
+            };
+            jest.spyOn(HttpUtils, 'xhr').mockResolvedValueOnce(mockResponse);
+
+            // When we process a side-effect request with no successData/failureData/finallyData
+            const result = await Request.processWithMiddleware({
+                command: 'GetTransactionsPending3DSReview',
+                data: {apiRequestType: 'makeRequestWithSideEffects'},
+            });
+
+            // Then the response should not be undefined — the caller may need the raw response for side effects
+            expect(result).toBeDefined();
+            expect(result?.transactionsPending3DSReview).toBeDefined();
+        });
+    });
+
     describe('HandleUnusedOptimisticID', () => {
         test('Normal request', async () => {
             Request.addMiddleware(handleUnusedOptimisticID, CONST.TELEMETRY.MIDDLEWARE_HANDLE_UNUSED_OPTIMISTIC_ID);

--- a/tests/unit/OnyxUpdatesTest.ts
+++ b/tests/unit/OnyxUpdatesTest.ts
@@ -95,7 +95,7 @@ describe('OnyxUpdatesTest', () => {
 
         // Then the response should still be returned to the caller, not undefined
         expect(result).toBeDefined();
-        expect(result?.transactionsPending3DSReview).toBeDefined();
+        expect(result?.jsonCode).toBe(200);
     });
 
     it('applies full ReconnectApp Onyx updates even if they appear old', async () => {

--- a/tests/unit/OnyxUpdatesTest.ts
+++ b/tests/unit/OnyxUpdatesTest.ts
@@ -66,6 +66,38 @@ describe('OnyxUpdatesTest', () => {
             });
     });
 
+    it('preserves the response object when HTTPS update is old and request has no successData/failureData/finallyData', async () => {
+        // Given the client already has a lastUpdateID applied
+        const currentUpdateID = 100;
+        await Onyx.merge(ONYXKEYS.ONYX_UPDATES_LAST_UPDATE_ID_APPLIED_TO_CLIENT, currentUpdateID);
+        await waitForBatchedUpdates();
+
+        const mockResponse = {
+            jsonCode: 200,
+            transactionsPending3DSReview: {
+                txn123: {amount: 1000, currency: 'USD', created: '2026-02-23', expires: '2026-02-24', lastFourPAN: 1234, merchant: 'TestMerchant'},
+            },
+            onyxData: [],
+        };
+
+        // When we apply an HTTPS update where lastUpdateID is already applied (i.e. "old"),
+        // and the request has no successData/failureData/finallyData
+        const result = await OnyxUpdates.apply({
+            type: CONST.ONYX_UPDATE_TYPES.HTTPS,
+            lastUpdateID: currentUpdateID,
+            previousUpdateID: currentUpdateID - 1,
+            request: {
+                command: 'GetTransactionsPending3DSReview',
+                data: {},
+            },
+            response: mockResponse,
+        });
+
+        // Then the response should still be returned to the caller, not undefined
+        expect(result).toBeDefined();
+        expect(result?.transactionsPending3DSReview).toBeDefined();
+    });
+
     it('applies full ReconnectApp Onyx updates even if they appear old', async () => {
         // Given the current lastUpdateIDAppliedToClient is merged
         const currentUpdateID = 100;


### PR DESCRIPTION
### Explanation of Change
`OnyxUpdates.apply()` has a code path for when a response's `lastUpdateID` has already been applied to the client (`isUpdateOld`). When the request includes `successData`/`failureData`/`finallyData`, it correctly strips the server's onyxData and applies the request's onyx updates, returning the response. But when the request has none of those, which is a common case for `makeRequestWithSideEffects` as many callers only need the raw response, it was returning `Promise.resolve()`, which resolves to `undefined`.

https://github.com/Expensify/App/blob/436534cf23b9a0a6b0289516db7d268a8074a192/src/libs/actions/OnyxUpdates.ts#L203

This is becomes a problem under a race condition: if a Pusher update or a concurrent HTTP request advances `lastUpdateIDAppliedToClient` while a side-effect request is in flight, the response may hit this codepath and the caller receives `undefined` instead of the response it needs. Several existing callers are affected:
- `AUTHENTICATE_PUSHER` (Session/index.ts): No onyx data. An undefined response causes `response?.jsonCode !== SUCCESS` to be true, and the Pusher callback receives an error ("code: undefined message: undefined"). This could cause intermittent real-time update failures. Notably, the very mechanism that triggers Pusher re-auth (receiving Pusher updates) also advances `lastUpdateIDAppliedToClient`, creating the conditions for the race.
- `GET_SCIM_TOKEN` (Domain.ts): No onyx data. Returns a generic error to the user instead of the `SCIM` token.
- `CREATE_DIGITAL_WALLET` (Wallet.ts): No onyx data. Apple Pay / Google Pay card provisioning would fail silently.
- `GENERATE_SPOTNANA_TOKEN` (Link.ts): Passes `{}`. Travel link opening throws because `undefined?.spotnanaToken `is falsey.
- `CONNECT_POLICY_TO_QUICKBOOKS_DESKTOP` (QuickbooksDesktop.ts): No onyx data. Caller gets `undefined` instead of the Codat setup link.
- `VERIFY_TEST_DRIVE_RECIPIENT` (Onboarding.ts): No onyx data. Throws instead of checking account existence.
- `MultifactorAuthentication` (registerAuthenticationKey, requestAuthorizationChallenge, troubleshootMultifactorAuthentication): MFA operations fail with error status.

This fix changes `Promise.resolve()` to `Promise.resolve(response)` so the response is always propagated back to the caller, even when the Onyx update portion is correctly skipped as redundant.

### Fixed Issues
Relates to https://github.com/Expensify/App/issues/79379 

This change was cherry-picked from https://github.com/Expensify/App/pull/82704, and is necessary for it to work reliably

### Tests
1. Run `npm run test -- OnyxUpdatesTest.ts` and verify the new test 'preserves the response object when HTTPS update is old and request has no successData/failureData/finallyData' passes
2. Run `npm run test -- MiddlewareTest.ts` and verify the new test 'preserves the response for side-effect requests when the update is already applied' passes

- [x] Verify that no errors appear in the JS console

### Offline tests
N/A

### QA Steps
This is a race condition fix that is difficult to reproduce manually. The fix is validated by automated tests.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I verified there are no new alerts related to the `canBeMissing` param for `useOnyx`
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>