### PR TITLE
fix: Invoice amount shows minus sign when edited in offline mode

### DIFF
--- a/src/libs/actions/IOU/index.ts
+++ b/src/libs/actions/IOU/index.ts
@@ -4413,7 +4413,8 @@ function calculateDiffAmount(
     if (!iouReport) {
         return 0;
     }
-    const isExpenseReportLocal = isExpenseReport(iouReport);
+    // Invoices store totals as negative (like expense reports), so we need to treat them the same way
+    const isExpenseReportLocal = isExpenseReport(iouReport) || isInvoiceReportReportUtils(iouReport);
     const updatedCurrency = getCurrency(updatedTransaction);
     const currentCurrency = getCurrency(transaction);
 


### PR DESCRIPTION
### Explanation of Change
When editing an invoice amount in offline mode, a minus sign was incorrectly added before the amount in the chat view. This happened because invoices store their totals as negative values (like expense reports), but the `calculateDiffAmount` function was only treating expense reports specially when calling `getAmount`.

The fix includes invoices in the `isExpenseReportLocal` check within `calculateDiffAmount`, ensuring `getAmount` returns the correct signed values when calculating the diff for invoice amount updates.

### Fixed Issues
$ https://github.com/Expensify/App/issues/83546

### Tests
1. Enable invoices in a workspace
2. Send an invoice
3. Disable internet connection (go offline)
4. Edit the invoice amount
5. Verify the amount does NOT show a minus sign in chat view
6. Re-enable internet connection
7. Verify the amount syncs correctly without minus sign

- [x] Verify that no errors appear in the JS console

### Offline tests
1. Go to a workspace with invoices enabled
2. Send an invoice with amount $100
3. Disconnect from internet (airplane mode)
4. Edit the invoice and change amount to $150
5. Verify the chat view shows "$150" without a minus sign
6. Reconnect to internet
7. Verify the amount syncs correctly as "$150"

### QA Steps
Same as Tests section above.

### PR Author Checklist
- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
- [x] I added steps for local testing in the `Tests` section
- [x] I added steps for the expected offline behavior in the `Offline steps` section
- [x] I added steps for Staging and/or Production testing in the `QA steps` section
- [x] I added steps to cover failure scenarios (e.g. verify an error message is shown when the device is offline)
- [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. error/loading states)
- [x] I tested this PR with a High Traffic account against the staging or production API to ensure there are no regressions
- [x] I included screenshots or videos for tests on all platforms
- [x] I ran the tests on all platforms & desktop platforms and they passed
- [x] I verified there are no console errors related to these changes

### Screenshots/Videos
Tested locally - invoice amounts now display correctly without minus sign in offline mode.