### PR TITLE
[No QA] Add missing avatarType test cases to useReportActionAvatars and ReportUtilsGetIcons

### DIFF
--- a/tests/ui/components/LHNOptionsListTest.tsx
+++ b/tests/ui/components/LHNOptionsListTest.tsx
@@ -323,4 +323,410 @@ describe('LHNOptionsList', () => {
             });
         });
     });
+
+    describe('LHN avatar rendering', () => {
+        const accountID1 = 1;
+        const accountID2 = 2;
+
+        const twoParticipants = {[accountID1]: {notificationPreference: 'always' as const}, [accountID2]: {notificationPreference: 'always' as const}};
+
+        const personalDetailsList = {
+            [accountID1]: {accountID: accountID1, login: 'user1@test.com', displayName: 'User One', avatar: 'https://example.com/avatar1.png'},
+            [accountID2]: {accountID: accountID2, login: 'user2@test.com', displayName: 'User Two', avatar: 'https://example.com/avatar2.png'},
+        };
+
+        // SUBSCRIPT cases
+
+        it('should render subscript avatar for policy expense chat', async () => {
+            const policyID = 'avatarPolicyExpense';
+            const reportID = 'avatarPolicyExpenseReport';
+            const policy: Policy = {
+                id: policyID,
+                name: 'Test Workspace',
+                type: CONST.POLICY.TYPE.TEAM,
+            } as Policy;
+            const report: Report = {
+                reportID,
+                reportName: 'Policy Expense Chat',
+                type: CONST.REPORT.TYPE.CHAT,
+                chatType: CONST.REPORT.CHAT_TYPE.POLICY_EXPENSE_CHAT,
+                policyID,
+                isOwnPolicyExpenseChat: false,
+                ownerAccountID: accountID1,
+                participants: twoParticipants,
+            };
+
+            mockUseIsFocused.mockReturnValue(true);
+            await act(async () => {
+                await Onyx.merge(ONYXKEYS.PERSONAL_DETAILS_LIST, personalDetailsList);
+                await Onyx.merge(`${ONYXKEYS.COLLECTION.POLICY}${policyID}`, policy);
+                await Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT}${reportID}`, report);
+            });
+
+            render(getLHNOptionsListElement({data: [report]}));
+
+            await waitFor(() => {
+                expect(screen.getByTestId('ReportActionAvatars-Subscript')).toBeTruthy();
+                expect(screen.queryByTestId('ReportActionAvatars-MultipleAvatars')).toBeNull();
+            });
+        });
+
+        it('should render subscript avatar for expense report', async () => {
+            const policyID = 'avatarExpenseReportPolicy';
+            const chatReportID = 'avatarExpenseChatReport';
+            const expenseReportID = 'avatarExpenseReport';
+            const policy: Policy = {
+                id: policyID,
+                name: 'Expense Workspace',
+                type: CONST.POLICY.TYPE.TEAM,
+            } as Policy;
+            const chatReport: Report = {
+                reportID: chatReportID,
+                reportName: 'Expense Chat',
+                type: CONST.REPORT.TYPE.CHAT,
+                chatType: CONST.REPORT.CHAT_TYPE.POLICY_EXPENSE_CHAT,
+                policyID,
+                isOwnPolicyExpenseChat: false,
+                ownerAccountID: accountID1,
+                participants: twoParticipants,
+            };
+            const expenseReport: Report = {
+                reportID: expenseReportID,
+                reportName: 'Expense Report',
+                type: CONST.REPORT.TYPE.EXPENSE,
+                policyID,
+                chatReportID,
+                ownerAccountID: accountID1,
+                participants: twoParticipants,
+            };
+
+            mockUseIsFocused.mockReturnValue(true);
+            await act(async () => {
+                await Onyx.merge(ONYXKEYS.PERSONAL_DETAILS_LIST, personalDetailsList);
+                await Onyx.merge(`${ONYXKEYS.COLLECTION.POLICY}${policyID}`, policy);
+                await Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT}${chatReportID}`, chatReport);
+                await Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT}${expenseReportID}`, expenseReport);
+            });
+
+            render(getLHNOptionsListElement({data: [expenseReport]}));
+
+            await waitFor(() => {
+                expect(screen.getByTestId('ReportActionAvatars-Subscript')).toBeTruthy();
+                expect(screen.queryByTestId('ReportActionAvatars-MultipleAvatars')).toBeNull();
+            });
+        });
+
+        it('should render subscript avatar for invoice room with individual receiver', async () => {
+            const policyID = 'avatarInvoiceIndivPolicy';
+            const reportID = 'avatarInvoiceIndivReport';
+            const policy: Policy = {
+                id: policyID,
+                name: 'Invoice Workspace',
+                type: CONST.POLICY.TYPE.TEAM,
+            } as Policy;
+            const report: Report = {
+                reportID,
+                reportName: 'Invoice Room',
+                type: CONST.REPORT.TYPE.CHAT,
+                chatType: CONST.REPORT.CHAT_TYPE.INVOICE,
+                policyID,
+                invoiceReceiver: {type: CONST.REPORT.INVOICE_RECEIVER_TYPE.INDIVIDUAL, accountID: accountID2},
+                participants: twoParticipants,
+            };
+
+            mockUseIsFocused.mockReturnValue(true);
+            await act(async () => {
+                await Onyx.merge(ONYXKEYS.PERSONAL_DETAILS_LIST, personalDetailsList);
+                await Onyx.merge(`${ONYXKEYS.COLLECTION.POLICY}${policyID}`, policy);
+                await Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT}${reportID}`, report);
+            });
+
+            render(getLHNOptionsListElement({data: [report]}));
+
+            await waitFor(() => {
+                expect(screen.getByTestId('ReportActionAvatars-Subscript')).toBeTruthy();
+                expect(screen.queryByTestId('ReportActionAvatars-MultipleAvatars')).toBeNull();
+            });
+        });
+
+        it('should render subscript avatar for invoice room with business receiver', async () => {
+            const senderPolicyID = 'avatarInvoiceBizSender';
+            const receiverPolicyID = 'avatarInvoiceBizReceiver';
+            const reportID = 'avatarInvoiceBizReport';
+            const senderPolicy: Policy = {
+                id: senderPolicyID,
+                name: 'Sender Workspace',
+                type: CONST.POLICY.TYPE.TEAM,
+            } as Policy;
+            const receiverPolicy: Policy = {
+                id: receiverPolicyID,
+                name: 'Receiver Workspace',
+                type: CONST.POLICY.TYPE.TEAM,
+            } as Policy;
+            const report: Report = {
+                reportID,
+                reportName: 'B2B Invoice Room',
+                type: CONST.REPORT.TYPE.CHAT,
+                chatType: CONST.REPORT.CHAT_TYPE.INVOICE,
+                policyID: senderPolicyID,
+                invoiceReceiver: {type: CONST.REPORT.INVOICE_RECEIVER_TYPE.BUSINESS, policyID: receiverPolicyID},
+                participants: twoParticipants,
+            };
+
+            mockUseIsFocused.mockReturnValue(true);
+            await act(async () => {
+                await Onyx.merge(ONYXKEYS.PERSONAL_DETAILS_LIST, personalDetailsList);
+                await Onyx.merge(`${ONYXKEYS.COLLECTION.POLICY}${senderPolicyID}`, senderPolicy);
+                await Onyx.merge(`${ONYXKEYS.COLLECTION.POLICY}${receiverPolicyID}`, receiverPolicy);
+                await Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT}${reportID}`, report);
+            });
+
+            render(getLHNOptionsListElement({data: [report]}));
+
+            await waitFor(() => {
+                expect(screen.getByTestId('ReportActionAvatars-Subscript')).toBeTruthy();
+                expect(screen.queryByTestId('ReportActionAvatars-MultipleAvatars')).toBeNull();
+            });
+        });
+
+        // SINGLE cases
+
+        it('should render single avatar for 1:1 DM', async () => {
+            const reportID = 'avatarDMReport';
+            const report: Report = {
+                reportID,
+                reportName: 'DM Chat',
+                type: CONST.REPORT.TYPE.CHAT,
+                participants: twoParticipants,
+            };
+
+            mockUseIsFocused.mockReturnValue(true);
+            await act(async () => {
+                await Onyx.merge(ONYXKEYS.PERSONAL_DETAILS_LIST, personalDetailsList);
+                await Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT}${reportID}`, report);
+            });
+
+            render(getLHNOptionsListElement({data: [report]}));
+
+            await waitFor(() => {
+                expect(screen.getByTestId('ReportActionAvatars-SingleAvatar')).toBeTruthy();
+                expect(screen.queryByTestId('ReportActionAvatars-Subscript')).toBeNull();
+                expect(screen.queryByTestId('ReportActionAvatars-MultipleAvatars')).toBeNull();
+            });
+        });
+
+        it('should render single avatar for self DM', async () => {
+            const reportID = 'avatarSelfDMReport';
+            const report: Report = {
+                reportID,
+                reportName: 'Self DM',
+                type: CONST.REPORT.TYPE.CHAT,
+                chatType: CONST.REPORT.CHAT_TYPE.SELF_DM,
+                participants: {[accountID1]: {notificationPreference: 'always'}},
+            };
+
+            mockUseIsFocused.mockReturnValue(true);
+            await act(async () => {
+                await Onyx.merge(ONYXKEYS.SESSION, {accountID: accountID1, email: 'user1@test.com'});
+                await Onyx.merge(ONYXKEYS.PERSONAL_DETAILS_LIST, personalDetailsList);
+                await Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT}${reportID}`, report);
+            });
+
+            render(getLHNOptionsListElement({data: [report]}));
+
+            await waitFor(() => {
+                expect(screen.getByTestId('ReportActionAvatars-SingleAvatar')).toBeTruthy();
+                expect(screen.queryByTestId('ReportActionAvatars-Subscript')).toBeNull();
+                expect(screen.queryByTestId('ReportActionAvatars-MultipleAvatars')).toBeNull();
+            });
+        });
+
+        it('should render single avatar for workspace thread', async () => {
+            const policyID = 'avatarWsThreadPolicy';
+            const parentReportID = 'avatarWsThreadParent';
+            const threadReportID = 'avatarWsThreadReport';
+            const policy: Policy = {
+                id: policyID,
+                name: 'Thread Workspace',
+                type: CONST.POLICY.TYPE.TEAM,
+            } as Policy;
+            const parentReport: Report = {
+                reportID: parentReportID,
+                reportName: 'Workspace Chat',
+                type: CONST.REPORT.TYPE.CHAT,
+                chatType: CONST.REPORT.CHAT_TYPE.POLICY_ROOM,
+                policyID,
+                participants: twoParticipants,
+            };
+            const threadReport: Report = {
+                reportID: threadReportID,
+                reportName: 'Thread in Workspace',
+                type: CONST.REPORT.TYPE.CHAT,
+                chatType: CONST.REPORT.CHAT_TYPE.POLICY_ROOM,
+                policyID,
+                parentReportID,
+                parentReportActionID: 'parentAction1',
+                participants: twoParticipants,
+            };
+
+            mockUseIsFocused.mockReturnValue(true);
+            await act(async () => {
+                await Onyx.merge(ONYXKEYS.PERSONAL_DETAILS_LIST, personalDetailsList);
+                await Onyx.merge(`${ONYXKEYS.COLLECTION.POLICY}${policyID}`, policy);
+                await Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT}${parentReportID}`, parentReport);
+                await Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT}${threadReportID}`, threadReport);
+            });
+
+            render(getLHNOptionsListElement({data: [threadReport]}));
+
+            await waitFor(() => {
+                expect(screen.getByTestId('ReportActionAvatars-SingleAvatar')).toBeTruthy();
+                expect(screen.queryByTestId('ReportActionAvatars-Subscript')).toBeNull();
+                expect(screen.queryByTestId('ReportActionAvatars-MultipleAvatars')).toBeNull();
+            });
+        });
+
+        it('should render single avatar for admin room', async () => {
+            const policyID = 'avatarAdminRoomPolicy';
+            const reportID = 'avatarAdminRoomReport';
+            const policy: Policy = {
+                id: policyID,
+                name: 'Admin Room Workspace',
+                type: CONST.POLICY.TYPE.TEAM,
+            } as Policy;
+            const report: Report = {
+                reportID,
+                reportName: '#admins',
+                type: CONST.REPORT.TYPE.CHAT,
+                chatType: CONST.REPORT.CHAT_TYPE.POLICY_ADMINS,
+                policyID,
+                participants: twoParticipants,
+            };
+
+            mockUseIsFocused.mockReturnValue(true);
+            await act(async () => {
+                await Onyx.merge(ONYXKEYS.PERSONAL_DETAILS_LIST, personalDetailsList);
+                await Onyx.merge(`${ONYXKEYS.COLLECTION.POLICY}${policyID}`, policy);
+                await Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT}${reportID}`, report);
+            });
+
+            render(getLHNOptionsListElement({data: [report]}));
+
+            await waitFor(() => {
+                expect(screen.getByTestId('ReportActionAvatars-SingleAvatar')).toBeTruthy();
+                expect(screen.queryByTestId('ReportActionAvatars-Subscript')).toBeNull();
+                expect(screen.queryByTestId('ReportActionAvatars-MultipleAvatars')).toBeNull();
+            });
+        });
+
+        // DIAGONAL/MULTIPLE case
+
+        it('should render diagonal avatar for IOU report preview with multiple senders', async () => {
+            const chatReportID = 'avatarIOUMultiChat';
+            const iouReportID = 'avatarIOUMultiIOU';
+            const chatReport: Report = {
+                reportID: chatReportID,
+                reportName: 'Personal Chat',
+                type: CONST.REPORT.TYPE.CHAT,
+                participants: twoParticipants,
+            };
+            const iouReport: Report = {
+                reportID: iouReportID,
+                reportName: 'IOU Report',
+                type: CONST.REPORT.TYPE.IOU,
+                chatReportID,
+                ownerAccountID: accountID1,
+                managerID: accountID2,
+                participants: twoParticipants,
+                parentReportID: chatReportID,
+                parentReportActionID: 'previewAction1',
+            };
+            const reportPreviewAction: ReportAction = {
+                reportActionID: 'previewAction1',
+                actionName: CONST.REPORT.ACTIONS.TYPE.REPORT_PREVIEW,
+                created: '2024-01-01 00:00:00',
+                childReportID: iouReportID,
+                message: [{type: 'COMMENT', text: 'Report preview'}],
+                originalMessage: {},
+            };
+
+            mockUseIsFocused.mockReturnValue(true);
+            await act(async () => {
+                await Onyx.merge(ONYXKEYS.PERSONAL_DETAILS_LIST, personalDetailsList);
+                await Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT}${chatReportID}`, chatReport);
+                await Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT}${iouReportID}`, iouReport);
+                await Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${chatReportID}`, {
+                    [reportPreviewAction.reportActionID]: reportPreviewAction,
+                });
+                await Onyx.merge(ONYXKEYS.DERIVED.VISIBLE_REPORT_ACTIONS, {
+                    [chatReportID]: {
+                        [reportPreviewAction.reportActionID]: true,
+                    },
+                });
+            });
+
+            render(getLHNOptionsListElement({data: [iouReport]}));
+
+            await waitFor(() => {
+                expect(screen.getByTestId('ReportActionAvatars-MultipleAvatars')).toBeTruthy();
+                expect(screen.queryByTestId('ReportActionAvatars-Subscript')).toBeNull();
+            });
+        });
+
+        // Contrast case
+
+        it('should render single avatar for IOU report preview with single sender', async () => {
+            const chatReportID = 'avatarIOUSingleChat';
+            const iouReportID = 'avatarIOUSingleIOU';
+            const chatReport: Report = {
+                reportID: chatReportID,
+                reportName: 'Personal Chat',
+                type: CONST.REPORT.TYPE.CHAT,
+                participants: twoParticipants,
+            };
+            const iouReport: Report = {
+                reportID: iouReportID,
+                reportName: 'IOU Report',
+                type: CONST.REPORT.TYPE.IOU,
+                chatReportID,
+                ownerAccountID: accountID1,
+                managerID: accountID2,
+                participants: twoParticipants,
+                parentReportID: chatReportID,
+                parentReportActionID: 'previewAction2',
+            };
+            const reportPreviewAction: ReportAction = {
+                reportActionID: 'previewAction2',
+                actionName: CONST.REPORT.ACTIONS.TYPE.REPORT_PREVIEW,
+                created: '2024-01-01 00:00:00',
+                childReportID: iouReportID,
+                childOwnerAccountID: accountID1,
+                message: [{type: 'COMMENT', text: 'Report preview'}],
+                originalMessage: {},
+            };
+
+            mockUseIsFocused.mockReturnValue(true);
+            await act(async () => {
+                await Onyx.merge(ONYXKEYS.PERSONAL_DETAILS_LIST, personalDetailsList);
+                await Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT}${chatReportID}`, chatReport);
+                await Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT}${iouReportID}`, iouReport);
+                await Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${chatReportID}`, {
+                    [reportPreviewAction.reportActionID]: reportPreviewAction,
+                });
+                await Onyx.merge(ONYXKEYS.DERIVED.VISIBLE_REPORT_ACTIONS, {
+                    [chatReportID]: {
+                        [reportPreviewAction.reportActionID]: true,
+                    },
+                });
+            });
+
+            render(getLHNOptionsListElement({data: [iouReport]}));
+
+            await waitFor(() => {
+                expect(screen.getByTestId('ReportActionAvatars-SingleAvatar')).toBeTruthy();
+                expect(screen.queryByTestId('ReportActionAvatars-Subscript')).toBeNull();
+                expect(screen.queryByTestId('ReportActionAvatars-MultipleAvatars')).toBeNull();
+            });
+        });
+    });
 });

--- a/tests/ui/components/LHNOptionsListTest.tsx
+++ b/tests/ui/components/LHNOptionsListTest.tsx
@@ -673,6 +673,67 @@ describe('LHNOptionsList', () => {
             });
         });
 
+        it('should render diagonal avatar for IOU report with personal policy and two user avatars', async () => {
+            const policyID = 'avatarIOUPersonalPolicy';
+            const chatReportID = 'avatarIOUPersonalChat';
+            const iouReportID = 'avatarIOUPersonalIOU';
+            const policy: Policy = {
+                id: policyID,
+                name: 'Personal Policy',
+                type: CONST.POLICY.TYPE.PERSONAL,
+            } as Policy;
+            const chatReport: Report = {
+                reportID: chatReportID,
+                reportName: 'Personal Chat',
+                type: CONST.REPORT.TYPE.CHAT,
+                policyID,
+                participants: twoParticipants,
+            };
+            const iouReport: Report = {
+                reportID: iouReportID,
+                reportName: 'IOU Report',
+                type: CONST.REPORT.TYPE.IOU,
+                policyID,
+                chatReportID,
+                ownerAccountID: accountID1,
+                managerID: accountID2,
+                participants: twoParticipants,
+                parentReportID: chatReportID,
+                parentReportActionID: 'previewAction3',
+            };
+            const reportPreviewAction: ReportAction = {
+                reportActionID: 'previewAction3',
+                actionName: CONST.REPORT.ACTIONS.TYPE.REPORT_PREVIEW,
+                created: '2024-01-01 00:00:00',
+                childReportID: iouReportID,
+                message: [{type: 'COMMENT', text: 'Report preview'}],
+                originalMessage: {},
+            };
+
+            mockUseIsFocused.mockReturnValue(true);
+            await act(async () => {
+                await Onyx.merge(ONYXKEYS.PERSONAL_DETAILS_LIST, personalDetailsList);
+                await Onyx.merge(`${ONYXKEYS.COLLECTION.POLICY}${policyID}`, policy);
+                await Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT}${chatReportID}`, chatReport);
+                await Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT}${iouReportID}`, iouReport);
+                await Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${chatReportID}`, {
+                    [reportPreviewAction.reportActionID]: reportPreviewAction,
+                });
+                await Onyx.merge(ONYXKEYS.DERIVED.VISIBLE_REPORT_ACTIONS, {
+                    [chatReportID]: {
+                        [reportPreviewAction.reportActionID]: true,
+                    },
+                });
+            });
+
+            render(getLHNOptionsListElement({data: [iouReport]}));
+
+            await waitFor(() => {
+                expect(screen.getByTestId('ReportActionAvatars-MultipleAvatars')).toBeTruthy();
+                expect(screen.queryByTestId('ReportActionAvatars-Subscript')).toBeNull();
+            });
+        });
+
         // Contrast case
 
         it('should render single avatar for IOU report preview with single sender', async () => {

--- a/tests/unit/ReportUtilsGetIconsTest.ts
+++ b/tests/unit/ReportUtilsGetIconsTest.ts
@@ -21,6 +21,7 @@ import {
     isSelfDM,
     isTaskReport,
     isThread,
+    isTripRoom,
     isUserCreatedPolicyRoom,
     isWorkspaceTaskReport,
     isWorkspaceThread,
@@ -99,6 +100,17 @@ const FAKE_REPORTS = {
         ...LHNTestUtils.getFakeReport([1, 2], 0, true),
         reportID: 'chatReport',
     },
+    // Invoice room with business receiver for invoice report test
+    [`${ONYXKEYS.COLLECTION.REPORT}invoiceBiz`]: {
+        ...LHNTestUtils.getFakeReport([1, 2], 0, true),
+        reportID: 'invoiceBiz',
+        chatType: CONST.REPORT.CHAT_TYPE.INVOICE,
+        policyID: '1',
+        invoiceReceiver: {
+            type: CONST.REPORT.INVOICE_RECEIVER_TYPE.BUSINESS,
+            policyID: '2',
+        },
+    },
 };
 const FAKE_POLICIES = {
     [`${ONYXKEYS.COLLECTION.POLICY}1`]: LHNTestUtils.getFakePolicy('1'),
@@ -127,6 +139,7 @@ describe('getIcons', () => {
         const report = {} as Report;
         const icons = getIcons(report, formatPhoneNumber, FAKE_PERSONAL_DETAILS);
         expect(icons).toHaveLength(1);
+        expect(icons.at(0)?.type).toBe(CONST.ICON_TYPE_AVATAR);
     });
 
     it('should return the correct icons for an expense request', () => {
@@ -144,7 +157,9 @@ describe('getIcons', () => {
 
         const icons = getIcons(report, formatPhoneNumber, FAKE_PERSONAL_DETAILS, null, '', -1, policy);
         expect(icons).toHaveLength(2);
+        expect(icons.at(0)?.type).toBe(CONST.ICON_TYPE_AVATAR);
         expect(icons.at(0)?.name).toBe('Email One');
+        expect(icons.at(1)?.type).toBe(CONST.ICON_TYPE_WORKSPACE);
     });
 
     it('should return the correct icons for archived non expense request/report', () => {
@@ -176,6 +191,7 @@ describe('getIcons', () => {
 
         const icons = getIcons(report, formatPhoneNumber, FAKE_PERSONAL_DETAILS);
         expect(icons).toHaveLength(1);
+        expect(icons.at(0)?.type).toBe(CONST.ICON_TYPE_AVATAR);
         expect(icons.at(0)?.name).toBe('Email\u00A0Two');
     });
 
@@ -191,6 +207,7 @@ describe('getIcons', () => {
 
         const icons = getIcons(report, formatPhoneNumber, FAKE_PERSONAL_DETAILS);
         expect(icons).toHaveLength(1);
+        expect(icons.at(0)?.type).toBe(CONST.ICON_TYPE_AVATAR);
         expect(icons.at(0)?.name).toBe('Email One');
     });
 
@@ -202,6 +219,7 @@ describe('getIcons', () => {
         };
         const icons = getIcons(report, formatPhoneNumber, FAKE_PERSONAL_DETAILS);
         expect(icons).toHaveLength(1);
+        expect(icons.at(0)?.type).toBe(CONST.ICON_TYPE_WORKSPACE);
         expect(icons.at(0)?.name).toBe('domain-test');
     });
 
@@ -214,6 +232,7 @@ describe('getIcons', () => {
         const policy = LHNTestUtils.getFakePolicy('1');
         const icons = getIcons(report, formatPhoneNumber, FAKE_PERSONAL_DETAILS, null, '', -1, policy);
         expect(icons).toHaveLength(1);
+        expect(icons.at(0)?.type).toBe(CONST.ICON_TYPE_WORKSPACE);
         expect(icons.at(0)?.name).toBe('Workspace-Test-001');
     });
 
@@ -287,6 +306,7 @@ describe('getIcons', () => {
 
         const icons = getIcons(report, formatPhoneNumber, FAKE_PERSONAL_DETAILS);
         expect(icons).toHaveLength(1);
+        expect(icons.at(0)?.type).toBe(CONST.ICON_TYPE_AVATAR);
         expect(icons.at(0)?.name).toBe('Email One');
     });
 
@@ -302,6 +322,7 @@ describe('getIcons', () => {
 
         const icons = getIcons(report, formatPhoneNumber, FAKE_PERSONAL_DETAILS);
         expect(icons).toHaveLength(1);
+        expect(icons.at(0)?.type).toBe(CONST.ICON_TYPE_AVATAR);
         expect(icons.at(0)?.name).toBe('Email Five');
     });
 
@@ -312,6 +333,7 @@ describe('getIcons', () => {
         };
         const icons = getIcons(report, formatPhoneNumber, FAKE_PERSONAL_DETAILS);
         expect(icons).toHaveLength(1);
+        expect(icons.at(0)?.type).toBe(CONST.ICON_TYPE_AVATAR);
         expect(icons.at(0)?.id).toBe(CONST.ACCOUNT_ID.NOTIFICATIONS);
     });
 
@@ -327,6 +349,7 @@ describe('getIcons', () => {
 
         const icons = getIcons(report, formatPhoneNumber, FAKE_PERSONAL_DETAILS);
         expect(icons).toHaveLength(1);
+        expect(icons.at(0)?.type).toBe(CONST.ICON_TYPE_AVATAR);
     });
 
     it('should return the correct icons for a group chat without an avatar', () => {
@@ -336,6 +359,7 @@ describe('getIcons', () => {
         };
         const icons = getIcons(report, formatPhoneNumber, FAKE_PERSONAL_DETAILS);
         expect(icons).toHaveLength(1);
+        expect(icons.at(0)?.type).toBe(CONST.ICON_TYPE_AVATAR);
     });
 
     it('should return the correct icons for a group chat with an avatar', () => {
@@ -346,6 +370,8 @@ describe('getIcons', () => {
         };
         const icons = getIcons(report, formatPhoneNumber, FAKE_PERSONAL_DETAILS);
         expect(icons).toHaveLength(1);
+        expect(icons.at(0)?.type).toBe(CONST.ICON_TYPE_AVATAR);
+        expect(icons.at(0)?.source).toBe('https://example.com/avatar.png');
     });
 
     it('should return the correct icons for an invoice report', () => {
@@ -372,6 +398,7 @@ describe('getIcons', () => {
         };
         const icons = getIcons(report, formatPhoneNumber, FAKE_PERSONAL_DETAILS);
         expect(icons).toHaveLength(1);
+        expect(icons.at(0)?.type).toBe(CONST.ICON_TYPE_AVATAR);
         expect(icons.at(0)?.name).toBe('Email One');
     });
 
@@ -382,6 +409,7 @@ describe('getIcons', () => {
         };
         const icons = getIcons(report, formatPhoneNumber, FAKE_PERSONAL_DETAILS);
         expect(icons).toHaveLength(4);
+        expect(icons.at(0)?.type).toBe(CONST.ICON_TYPE_AVATAR);
     });
 
     it('should return the correct icons for a workspace thread', () => {
@@ -530,7 +558,9 @@ describe('getIcons', () => {
         const icons = getIcons(report, formatPhoneNumber, FAKE_PERSONAL_DETAILS);
 
         expect(icons).toHaveLength(2);
+        expect(icons.at(0)?.type).toBe(CONST.ICON_TYPE_AVATAR);
         expect(icons.at(0)?.name).toBe('Email\u0020One');
+        expect(icons.at(1)?.type).toBe(CONST.ICON_TYPE_AVATAR);
         expect(icons.at(1)?.name).toBe('Email\u0020Two');
     });
 
@@ -545,6 +575,7 @@ describe('getIcons', () => {
         };
         const icons = getIcons(report, formatPhoneNumber, FAKE_PERSONAL_DETAILS);
         expect(icons).toHaveLength(1);
+        expect(icons.at(0)?.type).toBe(CONST.ICON_TYPE_AVATAR);
         expect(icons.at(0)?.id).toBe(CONST.ACCOUNT_ID.CONCIERGE);
     });
 
@@ -563,6 +594,73 @@ describe('getIcons', () => {
         const icons = getIcons(report, formatPhoneNumber, FAKE_PERSONAL_DETAILS, null, '', -1, policy);
         expect(icons).toHaveLength(2);
         expect(icons.at(0)?.type).toBe(CONST.ICON_TYPE_WORKSPACE);
+        expect(icons.at(1)?.type).toBe(CONST.ICON_TYPE_AVATAR);
         expect(icons.at(1)?.name).toBe('Email Three');
+    });
+
+    it('should return the correct icons for a trip room', () => {
+        const report: Report = {
+            ...LHNTestUtils.getFakeReport([], 0, true),
+            chatType: CONST.REPORT.CHAT_TYPE.TRIP_ROOM,
+            policyID: '1',
+        };
+        const policy = LHNTestUtils.getFakePolicy('1');
+
+        // Verify report type conditions
+        expect(isTripRoom(report)).toBe(true);
+        expect(isChatRoom(report)).toBe(true);
+
+        const icons = getIcons(report, formatPhoneNumber, FAKE_PERSONAL_DETAILS, null, '', -1, policy);
+        expect(icons).toHaveLength(1);
+        expect(icons.at(0)?.type).toBe(CONST.ICON_TYPE_WORKSPACE);
+    });
+
+    it('should return the correct icons for a multi-transaction IOU report where current user is manager', () => {
+        const report: Report = {
+            ...LHNTestUtils.getFakeReport([1, currentUserAccountID], 0, true),
+            reportID: 'multiTxn',
+            chatReportID: 'chatReport',
+            type: CONST.REPORT.TYPE.IOU,
+            ownerAccountID: 1,
+            managerID: currentUserAccountID, // Current user IS the manager
+            // eslint-disable-next-line @typescript-eslint/naming-convention
+            participants: {
+                // eslint-disable-next-line @typescript-eslint/naming-convention
+                '1': {notificationPreference: CONST.REPORT.NOTIFICATION_PREFERENCE.ALWAYS},
+                [currentUserAccountID]: {notificationPreference: CONST.REPORT.NOTIFICATION_PREFERENCE.ALWAYS},
+            },
+        };
+
+        // Verify report type conditions
+        expect(isIOUReport(report)).toBe(true);
+        expect(isMoneyRequestReport(report)).toBe(true);
+
+        const icons = getIcons(report, formatPhoneNumber, FAKE_PERSONAL_DETAILS);
+        expect(icons).toHaveLength(2);
+        expect(icons.at(0)?.type).toBe(CONST.ICON_TYPE_AVATAR);
+        expect(icons.at(1)?.type).toBe(CONST.ICON_TYPE_AVATAR);
+        // When current user is manager, manager icon comes first
+        expect(icons.at(0)?.name).toBe('Email\u0020Five');
+        expect(icons.at(1)?.name).toBe('Email\u0020One');
+    });
+
+    it('should return the correct icons for an invoice report with business receiver', () => {
+        const receiverPolicy = LHNTestUtils.getFakePolicy('2', 'Receiver-Policy');
+        const report: Report = {
+            ...LHNTestUtils.getFakeReport([], 0, true),
+            type: CONST.REPORT.TYPE.INVOICE,
+            chatReportID: 'invoiceBiz',
+            policyID: '1',
+        };
+        const policy = LHNTestUtils.getFakePolicy('1');
+
+        // Verify report type conditions
+        expect(isInvoiceReport(report)).toBe(true);
+
+        const icons = getIcons(report, formatPhoneNumber, FAKE_PERSONAL_DETAILS, null, '', -1, policy, receiverPolicy);
+        expect(icons).toHaveLength(2);
+        expect(icons.at(0)?.type).toBe(CONST.ICON_TYPE_WORKSPACE);
+        expect(icons.at(1)?.type).toBe(CONST.ICON_TYPE_WORKSPACE);
+        expect(icons.at(1)?.name).toBe('Receiver-Policy');
     });
 });

--- a/tests/unit/useReportActionAvatarsTest.tsx
+++ b/tests/unit/useReportActionAvatarsTest.tsx
@@ -4,9 +4,25 @@ import OnyxListItemProvider from '@components/OnyxListItemProvider';
 import useReportActionAvatars from '@components/ReportActionAvatars/useReportActionAvatars';
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
+import type {Report} from '@src/types/onyx';
 import createRandomPolicy from '../utils/collections/policies';
 import createRandomReportAction from '../utils/collections/reportActions';
-import {createInvoiceReport, createInvoiceRoom} from '../utils/collections/reports';
+import {
+    createAdminRoom,
+    createDomainRoom,
+    createExpenseReport,
+    createExpenseRequestReport,
+    createGroupChat,
+    createInvoiceReport,
+    createInvoiceRoom,
+    createPolicyExpenseChat,
+    createPolicyExpenseChatThread,
+    createRegularChat,
+    createRegularTaskReport,
+    createSelfDM,
+    createWorkspaceTaskReport,
+    createWorkspaceThread,
+} from '../utils/collections/reports';
 import waitForBatchedUpdates from '../utils/waitForBatchedUpdates';
 
 const mockPolicyID = '123456';
@@ -63,6 +79,342 @@ describe('useReportActionAvatars', () => {
             });
 
             expect(data.details.isWorkspaceActor).toEqual(expected);
+        });
+    });
+
+    describe('avatarType for LHN reports (no action)', () => {
+        const testPolicyID = '500';
+        const chatReportForNonChatID = '600';
+
+        beforeEach(async () => {
+            /* eslint-disable @typescript-eslint/naming-convention */
+            await Onyx.merge(ONYXKEYS.PERSONAL_DETAILS_LIST, {
+                1: {accountID: 1, login: 'user1@test.com', displayName: 'User One', avatar: ''},
+                2: {accountID: 2, login: 'user2@test.com', displayName: 'User Two', avatar: ''},
+            });
+            /* eslint-enable @typescript-eslint/naming-convention */
+            const policy = {...createRandomPolicy(Number(testPolicyID), CONST.POLICY.TYPE.TEAM, 'TestWorkspace'), id: testPolicyID};
+            await Onyx.merge(`${ONYXKEYS.COLLECTION.POLICY}${testPolicyID}`, policy);
+
+            // A non-thread chat report for expense/task/invoice reports to reference via chatReportID
+            const chatReport: Report = {
+                reportID: chatReportForNonChatID,
+                type: CONST.REPORT.TYPE.CHAT,
+                chatType: CONST.REPORT.CHAT_TYPE.POLICY_EXPENSE_CHAT,
+                policyID: testPolicyID,
+                parentReportID: undefined,
+                parentReportActionID: undefined,
+            };
+            await Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT}${chatReportForNonChatID}`, chatReport);
+        });
+
+        afterEach(() => Onyx.clear());
+
+        describe('should return SUBSCRIPT', () => {
+            it('for a policy expense chat', async () => {
+                const report: Report = {
+                    ...createPolicyExpenseChat(701, false),
+                    policyID: testPolicyID,
+                };
+                await Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT}${report.reportID}`, report);
+
+                const {result} = renderHook(() => useReportActionAvatars({report, action: undefined}), {wrapper});
+                expect(result.current.avatarType).toBe(CONST.REPORT_ACTION_AVATARS.TYPE.SUBSCRIPT);
+            });
+
+            it('for an expense report', async () => {
+                const report: Report = {
+                    ...createExpenseReport(702),
+                    policyID: testPolicyID,
+                    chatReportID: chatReportForNonChatID,
+                };
+                await Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT}${report.reportID}`, report);
+
+                const {result} = renderHook(() => useReportActionAvatars({report, action: undefined}), {wrapper});
+                expect(result.current.avatarType).toBe(CONST.REPORT_ACTION_AVATARS.TYPE.SUBSCRIPT);
+            });
+
+            it('for a workspace task report', async () => {
+                const report: Report = {
+                    ...createWorkspaceTaskReport(703, [1, 2], chatReportForNonChatID),
+                    policyID: testPolicyID,
+                    chatReportID: chatReportForNonChatID,
+                };
+                await Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT}${report.reportID}`, report);
+
+                const {result} = renderHook(() => useReportActionAvatars({report, action: undefined}), {wrapper});
+                expect(result.current.avatarType).toBe(CONST.REPORT_ACTION_AVATARS.TYPE.SUBSCRIPT);
+            });
+
+            it('for an invoice room', async () => {
+                const report: Report = {
+                    ...createInvoiceRoom(704),
+                    policyID: testPolicyID,
+                    invoiceReceiver: {type: CONST.REPORT.INVOICE_RECEIVER_TYPE.INDIVIDUAL, accountID: 2},
+                };
+                await Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT}${report.reportID}`, report);
+
+                const {result} = renderHook(() => useReportActionAvatars({report, action: undefined}), {wrapper});
+                expect(result.current.avatarType).toBe(CONST.REPORT_ACTION_AVATARS.TYPE.SUBSCRIPT);
+            });
+
+            it('for an invoice report', async () => {
+                const invoiceRoom: Report = {
+                    ...createInvoiceRoom(705),
+                    policyID: testPolicyID,
+                    invoiceReceiver: {type: CONST.REPORT.INVOICE_RECEIVER_TYPE.INDIVIDUAL, accountID: 2},
+                };
+                await Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT}${invoiceRoom.reportID}`, invoiceRoom);
+
+                const report: Report = {
+                    ...createInvoiceReport(706),
+                    policyID: testPolicyID,
+                    chatReportID: invoiceRoom.reportID,
+                };
+                await Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT}${report.reportID}`, report);
+
+                const {result} = renderHook(() => useReportActionAvatars({report, action: undefined}), {wrapper});
+                expect(result.current.avatarType).toBe(CONST.REPORT_ACTION_AVATARS.TYPE.SUBSCRIPT);
+            });
+
+            it('for an expense request (single expense thread)', async () => {
+                // Parent expense report
+                const parentExpenseReport: Report = {
+                    ...createExpenseReport(710),
+                    policyID: testPolicyID,
+                    chatReportID: chatReportForNonChatID,
+                };
+                await Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT}${parentExpenseReport.reportID}`, parentExpenseReport);
+
+                // Parent IOU action in the expense report (transaction thread origin)
+                const parentAction = {
+                    ...createRandomReportAction(711),
+                    actionName: CONST.REPORT.ACTIONS.TYPE.IOU as typeof CONST.REPORT.ACTIONS.TYPE.ADD_COMMENT,
+                    originalMessage: {type: CONST.IOU.REPORT_ACTION_TYPE.CREATE},
+                };
+                await Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${parentExpenseReport.reportID}`, {
+                    [parentAction.reportActionID]: parentAction,
+                });
+
+                // Expense request thread report (child of expense report)
+                const report: Report = {
+                    ...createExpenseRequestReport(712, parentExpenseReport.reportID, parentAction.reportActionID),
+                    policyID: testPolicyID,
+                };
+                await Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT}${report.reportID}`, report);
+
+                const {result} = renderHook(() => useReportActionAvatars({report, action: undefined}), {wrapper});
+                expect(result.current.avatarType).toBe(CONST.REPORT_ACTION_AVATARS.TYPE.SUBSCRIPT);
+            });
+
+            it('for an invoice room with business receiver', async () => {
+                const report: Report = {
+                    ...createInvoiceRoom(713),
+                    policyID: testPolicyID,
+                    invoiceReceiver: {type: CONST.REPORT.INVOICE_RECEIVER_TYPE.BUSINESS, policyID: '2'},
+                };
+                await Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT}${report.reportID}`, report);
+
+                const {result} = renderHook(() => useReportActionAvatars({report, action: undefined}), {wrapper});
+                expect(result.current.avatarType).toBe(CONST.REPORT_ACTION_AVATARS.TYPE.SUBSCRIPT);
+            });
+
+            it('for an own policy expense chat', async () => {
+                const report: Report = {
+                    ...createPolicyExpenseChat(714, true),
+                    policyID: testPolicyID,
+                };
+                await Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT}${report.reportID}`, report);
+
+                const {result} = renderHook(() => useReportActionAvatars({report, action: undefined}), {wrapper});
+                expect(result.current.avatarType).toBe(CONST.REPORT_ACTION_AVATARS.TYPE.SUBSCRIPT);
+            });
+        });
+
+        describe('should return SINGLE', () => {
+            it('for a 1:1 DM chat', async () => {
+                const report: Report = {
+                    ...createRegularChat(801, [1, 2]),
+                };
+                await Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT}${report.reportID}`, report);
+
+                const {result} = renderHook(() => useReportActionAvatars({report, action: undefined}), {wrapper});
+                expect(result.current.avatarType).toBe(CONST.REPORT_ACTION_AVATARS.TYPE.SINGLE);
+            });
+
+            it('for a group chat', async () => {
+                const report: Report = {
+                    ...createGroupChat(802, [1, 2]),
+                };
+                await Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT}${report.reportID}`, report);
+
+                const {result} = renderHook(() => useReportActionAvatars({report, action: undefined}), {wrapper});
+                expect(result.current.avatarType).toBe(CONST.REPORT_ACTION_AVATARS.TYPE.SINGLE);
+            });
+
+            it('for a self DM', async () => {
+                const report: Report = {
+                    ...createSelfDM(803, 1),
+                };
+                await Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT}${report.reportID}`, report);
+
+                const {result} = renderHook(() => useReportActionAvatars({report, action: undefined}), {wrapper});
+                expect(result.current.avatarType).toBe(CONST.REPORT_ACTION_AVATARS.TYPE.SINGLE);
+            });
+
+            it('for an admin room', async () => {
+                const report: Report = {
+                    ...createAdminRoom(804),
+                    policyID: testPolicyID,
+                };
+                await Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT}${report.reportID}`, report);
+
+                const {result} = renderHook(() => useReportActionAvatars({report, action: undefined}), {wrapper});
+                expect(result.current.avatarType).toBe(CONST.REPORT_ACTION_AVATARS.TYPE.SINGLE);
+            });
+
+            it('for a domain room', async () => {
+                const report: Report = {
+                    ...createDomainRoom(805),
+                    policyID: testPolicyID,
+                };
+                await Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT}${report.reportID}`, report);
+
+                const {result} = renderHook(() => useReportActionAvatars({report, action: undefined}), {wrapper});
+                expect(result.current.avatarType).toBe(CONST.REPORT_ACTION_AVATARS.TYPE.SINGLE);
+            });
+
+            it('for an IOU report', async () => {
+                const report: Report = {
+                    reportID: '806',
+                    type: CONST.REPORT.TYPE.IOU,
+                    chatReportID: chatReportForNonChatID,
+                    ownerAccountID: 1,
+                    managerID: 2,
+                };
+                await Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT}${report.reportID}`, report);
+
+                const {result} = renderHook(() => useReportActionAvatars({report, action: undefined}), {wrapper});
+                expect(result.current.avatarType).toBe(CONST.REPORT_ACTION_AVATARS.TYPE.SINGLE);
+            });
+
+            it('for a workspace thread', async () => {
+                const report: Report = {
+                    ...createWorkspaceThread(807),
+                    policyID: testPolicyID,
+                };
+                await Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT}${report.reportID}`, report);
+
+                const {result} = renderHook(() => useReportActionAvatars({report, action: undefined}), {wrapper});
+                expect(result.current.avatarType).toBe(CONST.REPORT_ACTION_AVATARS.TYPE.SINGLE);
+            });
+
+            it('for a regular task (no workspace)', async () => {
+                const report: Report = {
+                    ...createRegularTaskReport(808, 1),
+                };
+                await Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT}${report.reportID}`, report);
+
+                const {result} = renderHook(() => useReportActionAvatars({report, action: undefined}), {wrapper});
+                expect(result.current.avatarType).toBe(CONST.REPORT_ACTION_AVATARS.TYPE.SINGLE);
+            });
+
+            it('for a policy expense chat that is a thread', async () => {
+                const report: Report = {
+                    ...createPolicyExpenseChatThread(815),
+                    type: CONST.REPORT.TYPE.CHAT,
+                    policyID: testPolicyID,
+                };
+                await Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT}${report.reportID}`, report);
+
+                const {result} = renderHook(() => useReportActionAvatars({report, action: undefined}), {wrapper});
+                expect(result.current.avatarType).toBe(CONST.REPORT_ACTION_AVATARS.TYPE.SINGLE);
+            });
+
+            it('for an IOU report with single sender (not diagonal)', async () => {
+                const personalChatReportID = '910';
+                const reportPreviewActionID = '911';
+
+                // Personal chat report (not workspace) — the IOU's parent chat
+                const personalChat: Report = {
+                    reportID: personalChatReportID,
+                    type: CONST.REPORT.TYPE.CHAT,
+                    chatType: undefined,
+                    policyID: undefined,
+                    parentReportID: undefined,
+                    parentReportActionID: undefined,
+                };
+                await Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT}${personalChatReportID}`, personalChat);
+
+                // REPORT_PREVIEW action WITH childOwnerAccountID (single sender)
+                const reportPreviewAction = {
+                    ...createRandomReportAction(Number(reportPreviewActionID)),
+                    actionName: CONST.REPORT.ACTIONS.TYPE.REPORT_PREVIEW as typeof CONST.REPORT.ACTIONS.TYPE.ADD_COMMENT,
+                    childOwnerAccountID: 1,
+                    childMoneyRequestCount: 2,
+                };
+                await Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${personalChatReportID}`, {
+                    [reportPreviewActionID]: reportPreviewAction,
+                });
+
+                // IOU report pointing to the chat and the REPORT_PREVIEW action
+                const iouReport: Report = {
+                    reportID: '912',
+                    type: CONST.REPORT.TYPE.IOU,
+                    chatReportID: personalChatReportID,
+                    parentReportActionID: reportPreviewActionID,
+                    ownerAccountID: 1,
+                    managerID: 2,
+                };
+                await Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT}${iouReport.reportID}`, iouReport);
+
+                const {result} = renderHook(() => useReportActionAvatars({report: iouReport, action: undefined}), {wrapper});
+                expect(result.current.avatarType).toBe(CONST.REPORT_ACTION_AVATARS.TYPE.SINGLE);
+            });
+        });
+
+        describe('should return MULTIPLE (diagonal)', () => {
+            it('for an IOU report with expenses from multiple users', async () => {
+                const personalChatReportID = '900';
+                const reportPreviewActionID = '901';
+
+                // Personal chat report (not workspace) — the IOU's parent chat
+                const personalChat: Report = {
+                    reportID: personalChatReportID,
+                    type: CONST.REPORT.TYPE.CHAT,
+                    chatType: undefined,
+                    policyID: undefined,
+                    parentReportID: undefined,
+                    parentReportActionID: undefined,
+                };
+                await Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT}${personalChatReportID}`, personalChat);
+
+                // REPORT_PREVIEW action in the chat — no childOwnerAccountID means multiple senders
+                const reportPreviewAction = {
+                    ...createRandomReportAction(Number(reportPreviewActionID)),
+                    actionName: CONST.REPORT.ACTIONS.TYPE.REPORT_PREVIEW,
+                    childOwnerAccountID: undefined,
+                    childManagerAccountID: undefined,
+                    childMoneyRequestCount: 3,
+                };
+                await Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${personalChatReportID}`, {
+                    [reportPreviewActionID]: reportPreviewAction,
+                });
+
+                // IOU report pointing to the chat and the REPORT_PREVIEW action
+                const iouReport: Report = {
+                    reportID: '902',
+                    type: CONST.REPORT.TYPE.IOU,
+                    chatReportID: personalChatReportID,
+                    parentReportActionID: reportPreviewActionID,
+                    ownerAccountID: 1,
+                    managerID: 2,
+                };
+                await Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT}${iouReport.reportID}`, iouReport);
+
+                const {result} = renderHook(() => useReportActionAvatars({report: iouReport, action: undefined}), {wrapper});
+                expect(result.current.avatarType).toBe(CONST.REPORT_ACTION_AVATARS.TYPE.MULTIPLE);
+            });
         });
     });
 });


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
This PR adds 5 missing test cases to `tests/unit/useReportActionAvatarsTest.tsx` covering avatar type determination in the `useReportActionAvatars` hook, and also strengthens existing tests in `tests/unit/ReportUtilsGetIconsTest.ts` by adding explicit `type` assertions alongside existing `name`/`length` checks.

The 5 new `avatarType` tests cover cases that were previously untested:
1. Expense request (single expense thread) → SUBSCRIPT
2. Invoice room with business receiver → SUBSCRIPT
3. Own policy expense chat → SUBSCRIPT
4. Policy expense chat that is a thread → SINGLE
5. IOU report with single sender (not diagonal) → SINGLE

Two new helper imports were added from `tests/utils/collections/reports`: `createExpenseRequestReport` and `createPolicyExpenseChatThread`.

No production code was changed — only test files were modified.

### Fixed Issues
$ https://github.com/Expensify/App/issues/82544
PROPOSAL:


### Tests

- [x] Verify that no errors appear in the JS console

### Offline tests
N/A

### QA Steps
Same as tests

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>