### PR TITLE
[No QA] Fix workspace name overflow on WorkspaceUserRestrictedAction page

### DIFF
--- a/src/pages/RestrictedAction/Workspace/WorkspaceUserRestrictedAction.tsx
+++ b/src/pages/RestrictedAction/Workspace/WorkspaceUserRestrictedAction.tsx
@@ -51,7 +51,7 @@ function WorkspaceUserRestrictedAction({policyID}: WorkspaceUserRestrictedAction
                         width={variables.restrictedActionIllustrationHeight}
                         height={variables.restrictedActionIllustrationHeight}
                     />
-                    <Text style={[styles.textHeadlineH1, styles.textAlignCenter]}>{translate('workspace.restrictedAction.actionsAreCurrentlyRestricted', policy?.name ?? '')}</Text>
+                    <Text style={[styles.textHeadlineH1, styles.textAlignCenter, styles.breakWord]}>{translate('workspace.restrictedAction.actionsAreCurrentlyRestricted', policy?.name ?? '')}</Text>
                     <Text style={[styles.textLabelSupportingEmptyValue, styles.textAlignCenter, styles.lh20, styles.mt2]}>
                         {translate('workspace.restrictedAction.pleaseReachOutToYourWorkspaceAdmin')}
                     </Text>


### PR DESCRIPTION
## Fixed Issues
$ https://github.com/Expensify/App/issues/79517

## Tests
- [x] Verify that no errors appear in the JS console

## Offline Tests
N/A - visual styling fix

## QA Steps
N/A - No QA

## PR Author Checklist
- [x] I linked the correct issue in the `Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
- [x] I made this PR small and easy to review
- [x] I tagged the correct reviewers
- [x] I labeled this PR correctly

## Screenshots/Videos

### Before
Workspace name overflows outside the container when the name is long.

### After
Workspace name wraps properly using `styles.breakWord`.

### Root Cause
The text element displaying the workspace name was missing word-break styling.

### Fix
Added `styles.breakWord` to the Text component style array at line 54 in `WorkspaceUserRestrictedAction.tsx`.