### PR TITLE
[No QA] Optimize ExpenseReportListItemRow - Lift heavy computation out of ExpenseReportListItemRow

### DIFF
--- a/src/components/Search/SearchList/index.tsx
+++ b/src/components/Search/SearchList/index.tsx
@@ -48,7 +48,7 @@ import useWindowDimensions from '@hooks/useWindowDimensions';
 import {turnOnMobileSelectionMode} from '@libs/actions/MobileSelectionMode';
 import DateUtils from '@libs/DateUtils';
 import navigationRef from '@libs/Navigation/navigationRef';
-import {getTableMinWidth, isTransactionReportGroupListItemType} from '@libs/SearchUIUtils';
+import {applySelectionToItem, getTableMinWidth} from '@libs/SearchUIUtils';
 import variables from '@styles/variables';
 import type {TransactionPreviewData} from '@userActions/Search';
 import CONST from '@src/CONST';
@@ -285,54 +285,7 @@ function SearchList({
         return selectableTransactions.length;
     }, [data, type, flattenedItems, emptyReports]);
 
-    const itemsWithSelection = useMemo(() => {
-        return data.map((item) => {
-            let isSelected = false;
-            let itemWithSelection: SearchListItem = item;
-
-            if ('transactions' in item && item.transactions) {
-                if (!canSelectMultiple) {
-                    itemWithSelection = {...item, isSelected: false};
-                } else {
-                    const isEmptyReportSelected =
-                        item.transactions.length === 0 && isTransactionReportGroupListItemType(item) && !!(item.keyForList && selectedTransactions[item.keyForList]?.isSelected);
-
-                    const hasAnySelected = item.transactions.some((t) => t.keyForList && selectedTransactions[t.keyForList]?.isSelected) || isEmptyReportSelected;
-
-                    if (!hasAnySelected) {
-                        itemWithSelection = {...item, isSelected: false};
-                    } else if (isEmptyReportSelected) {
-                        isSelected = true;
-                        itemWithSelection = {...item, isSelected};
-                    } else {
-                        let allNonDeletedSelected = true;
-                        let hasNonDeletedTransactions = false;
-
-                        const mappedTransactions = item.transactions.map((transaction) => {
-                            const isTransactionSelected = !!(transaction.keyForList && selectedTransactions[transaction.keyForList]?.isSelected);
-
-                            if (transaction.pendingAction !== CONST.RED_BRICK_ROAD_PENDING_ACTION.DELETE) {
-                                hasNonDeletedTransactions = true;
-                                if (!isTransactionSelected) {
-                                    allNonDeletedSelected = false;
-                                }
-                            }
-
-                            return {...transaction, isSelected: isTransactionSelected};
-                        });
-
-                        isSelected = hasNonDeletedTransactions && allNonDeletedSelected;
-                        itemWithSelection = {...item, isSelected, transactions: mappedTransactions};
-                    }
-                }
-            } else {
-                isSelected = !!(canSelectMultiple && item.keyForList && selectedTransactions[item.keyForList]?.isSelected);
-                itemWithSelection = {...item, isSelected};
-            }
-
-            return {originalItem: item, itemWithSelection, isSelected};
-        });
-    }, [data, canSelectMultiple, selectedTransactions]);
+    const itemsWithSelection = useMemo(() => data.map((item) => applySelectionToItem(item, canSelectMultiple, selectedTransactions)), [data, canSelectMultiple, selectedTransactions]);
 
     const {translate} = useLocalize();
     const {isOffline} = useNetwork();

--- a/src/components/SelectionListWithSections/Search/ExpenseReportListItemRow.tsx
+++ b/src/components/SelectionListWithSections/Search/ExpenseReportListItemRow.tsx
@@ -13,8 +13,6 @@ import useStyleUtils from '@hooks/useStyleUtils';
 import useTheme from '@hooks/useTheme';
 import useThemeStyles from '@hooks/useThemeStyles';
 import getBase62ReportID from '@libs/getBase62ReportID';
-import {getMoneyRequestSpendBreakdown} from '@libs/ReportUtils';
-import {isScanning as isTransactionScanning} from '@libs/TransactionUtils';
 import variables from '@styles/variables';
 import CONST from '@src/CONST';
 import type {Policy, ReportAction} from '@src/types/onyx';
@@ -70,17 +68,7 @@ function ExpenseReportListItemRow({
     const expensifyIcons = useMemoizedLazyExpensifyIcons(['ArrowRight']);
 
     const currency = item.currency ?? CONST.CURRENCY.USD;
-    const {totalDisplaySpend, nonReimbursableSpend, reimbursableSpend} = getMoneyRequestSpendBreakdown(item);
-
-    const isScanning = (() => {
-        if (!item.transactions || item.transactions.length === 0) {
-            return false;
-        }
-
-        const allScanning = item.transactions.every((transaction) => isTransactionScanning(transaction as Parameters<typeof isTransactionScanning>[0]));
-
-        return allScanning;
-    })();
+    const {totalDisplaySpend = 0, nonReimbursableSpend = 0, reimbursableSpend = 0, isAllScanning: isScanning = false} = item;
 
     const columnComponents = {
         [CONST.SEARCH.TABLE_COLUMNS.DATE]: (

--- a/src/components/SelectionListWithSections/types.ts
+++ b/src/components/SelectionListWithSections/types.ts
@@ -491,6 +491,18 @@ type TransactionReportGroupListItemType = TransactionGroupListItemType & {groupe
 
         /** The available actions that can be performed for the report */
         allActions?: SearchTransactionAction[];
+
+        /** Pre-computed total display spend amount */
+        totalDisplaySpend?: number;
+
+        /** Pre-computed non-reimbursable spend amount */
+        nonReimbursableSpend?: number;
+
+        /** Pre-computed reimbursable spend amount */
+        reimbursableSpend?: number;
+
+        /** Pre-computed flag indicating whether all transactions are scanning */
+        isAllScanning?: boolean;
     };
 
 type TransactionMemberGroupListItemType = TransactionGroupListItemType & {groupedBy: typeof CONST.SEARCH.GROUP_BY.FROM} & PersonalDetails &

--- a/src/libs/SearchUIUtils.ts
+++ b/src/libs/SearchUIUtils.ts
@@ -4500,65 +4500,64 @@ function applySelectionToItem(
     canSelectMultiple: boolean,
     selectedTransactions: SelectedTransactions,
 ): {originalItem: SearchListItem; itemWithSelection: SearchListItem; isSelected: boolean} {
-    let isSelected = false;
-    let itemWithSelection: SearchListItem = item;
-
-    if ('transactions' in item && item.transactions) {
-        if (!canSelectMultiple) {
-            if (item.isSelected) {
-                itemWithSelection = {...item, isSelected: false};
-            }
-        } else {
-            const isEmptyReportSelected =
-                item.transactions.length === 0 && isTransactionReportGroupListItemType(item) && !!(item.keyForList && selectedTransactions[item.keyForList]?.isSelected);
-
-            const hasAnySelected = item.transactions.some((t) => t.keyForList && selectedTransactions[t.keyForList]?.isSelected) || isEmptyReportSelected;
-
-            if (!hasAnySelected) {
-                if (item.isSelected) {
-                    itemWithSelection = {...item, isSelected: false};
-                }
-            } else if (isEmptyReportSelected) {
-                isSelected = true;
-                if (!item.isSelected) {
-                    itemWithSelection = {...item, isSelected};
-                }
-            } else {
-                let allNonDeletedSelected = true;
-                let hasNonDeletedTransactions = false;
-                let hasTransactionSelectionChanged = false;
-
-                const mappedTransactions = item.transactions.map((transaction) => {
-                    const isTransactionSelected = !!(transaction.keyForList && selectedTransactions[transaction.keyForList]?.isSelected);
-
-                    if (transaction.pendingAction !== CONST.RED_BRICK_ROAD_PENDING_ACTION.DELETE) {
-                        hasNonDeletedTransactions = true;
-                        if (!isTransactionSelected) {
-                            allNonDeletedSelected = false;
-                        }
-                    }
-
-                    if (!!transaction.isSelected !== isTransactionSelected) {
-                        hasTransactionSelectionChanged = true;
-                    }
-
-                    return isTransactionSelected === !!transaction.isSelected ? transaction : {...transaction, isSelected: isTransactionSelected};
-                });
-
-                isSelected = hasNonDeletedTransactions && allNonDeletedSelected;
-                if (hasTransactionSelectionChanged || !!item.isSelected !== isSelected) {
-                    itemWithSelection = {...item, isSelected, transactions: hasTransactionSelectionChanged ? mappedTransactions : item.transactions};
-                }
-            }
-        }
-    } else {
-        isSelected = !!(canSelectMultiple && item.keyForList && selectedTransactions[item.keyForList]?.isSelected);
-        if (!!item.isSelected !== isSelected) {
-            itemWithSelection = {...item, isSelected};
-        }
+    // Simple items without transactions
+    if (!('transactions' in item) || !item.transactions) {
+        const isSelected = !!(canSelectMultiple && item.keyForList && selectedTransactions[item.keyForList]?.isSelected);
+        const itemWithSelection = !!item.isSelected !== isSelected ? {...item, isSelected} : item;
+        return {originalItem: item, itemWithSelection, isSelected};
     }
 
-    return {originalItem: item, itemWithSelection, isSelected};
+    // Single-select mode: group items are never selected via selectedTransactions
+    if (!canSelectMultiple) {
+        const itemWithSelection = item.isSelected ? {...item, isSelected: false} : item;
+        return {originalItem: item, itemWithSelection, isSelected: false};
+    }
+
+    const isEmptyReportSelected = item.transactions.length === 0 && isTransactionReportGroupListItemType(item) && !!(item.keyForList && selectedTransactions[item.keyForList]?.isSelected);
+
+    const hasAnySelected = item.transactions.some((t) => t.keyForList && selectedTransactions[t.keyForList]?.isSelected) || isEmptyReportSelected;
+
+    // Item thinks it's selected but nothing actually is → deselect
+    if (!hasAnySelected && item.isSelected) {
+        return {originalItem: item, itemWithSelection: {...item, isSelected: false}, isSelected: false};
+    }
+
+    // Empty report is selected
+    if (isEmptyReportSelected) {
+        const itemWithSelection = !item.isSelected ? {...item, isSelected: true} : item;
+        return {originalItem: item, itemWithSelection, isSelected: true};
+    }
+
+    // Map individual transactions and derive group selection state
+    let allNonDeletedSelected = true;
+    let hasNonDeletedTransactions = false;
+    let hasTransactionSelectionChanged = false;
+
+    const mappedTransactions = item.transactions.map((transaction) => {
+        const isTransactionSelected = !!(transaction.keyForList && selectedTransactions[transaction.keyForList]?.isSelected);
+
+        if (transaction.pendingAction !== CONST.RED_BRICK_ROAD_PENDING_ACTION.DELETE) {
+            hasNonDeletedTransactions = true;
+            if (!isTransactionSelected) {
+                allNonDeletedSelected = false;
+            }
+        }
+
+        if (!!transaction.isSelected !== isTransactionSelected) {
+            hasTransactionSelectionChanged = true;
+        }
+
+        return isTransactionSelected === !!transaction.isSelected ? transaction : {...transaction, isSelected: isTransactionSelected};
+    });
+
+    const isSelected = hasNonDeletedTransactions && allNonDeletedSelected;
+
+    if (!hasTransactionSelectionChanged && !!item.isSelected === isSelected) {
+        return {originalItem: item, itemWithSelection: item, isSelected};
+    }
+
+    const transactions = hasTransactionSelectionChanged ? mappedTransactions : item.transactions;
+    return {originalItem: item, itemWithSelection: {...item, isSelected, transactions}, isSelected};
 }
 
 export {

--- a/src/libs/SearchUIUtils.ts
+++ b/src/libs/SearchUIUtils.ts
@@ -2253,6 +2253,7 @@ function getReportSections({
                         allReportTransactions,
                     );
 
+                const {totalDisplaySpend, nonReimbursableSpend, reimbursableSpend} = getMoneyRequestSpendBreakdown(reportItem);
                 reportIDToTransactions[reportKey] = {
                     ...reportItem,
                     action: allActions.at(0) ?? CONST.SEARCH.ACTION_TYPES.VIEW,
@@ -2273,6 +2274,10 @@ function getReportSections({
                     shouldShowYearApproved: shouldShowYearApprovedReport,
                     shouldShowYearExported: shouldShowYearExportedReport,
                     hasVisibleViolations: hasVisibleViolationsForReport,
+                    totalDisplaySpend,
+                    nonReimbursableSpend,
+                    reimbursableSpend,
+                    isAllScanning: false,
                 };
 
                 if (isIOUReport) {
@@ -2331,26 +2336,17 @@ function getReportSections({
                 isTaxAmountColumnWide: shouldShowTaxAmountInWideColumn,
                 category: isIOUReport ? '' : transactionItem?.category,
             };
-            if (reportIDToTransactions[reportKey]?.transactions) {
-                reportIDToTransactions[reportKey].transactions.push(transaction);
-                reportIDToTransactions[reportKey].from = data?.personalDetailsList?.[data?.[reportKey as ReportKey]?.ownerAccountID ?? CONST.DEFAULT_NUMBER_ID] ?? emptyPersonalDetails;
-            } else if (reportIDToTransactions[reportKey]) {
-                reportIDToTransactions[reportKey].transactions = [transaction];
-                reportIDToTransactions[reportKey].from = data?.personalDetailsList?.[data?.[reportKey as ReportKey]?.ownerAccountID ?? CONST.DEFAULT_NUMBER_ID] ?? emptyPersonalDetails;
+            if (reportIDToTransactions[reportKey]) {
+                const reportSection = reportIDToTransactions[reportKey];
+                const hadTransactions = reportSection.transactions.length > 0;
+                reportSection.transactions.push(transaction);
+                reportSection.from = data?.personalDetailsList?.[data?.[reportKey as ReportKey]?.ownerAccountID ?? CONST.DEFAULT_NUMBER_ID] ?? emptyPersonalDetails;
+                reportSection.isAllScanning = hadTransactions ? !!reportSection.isAllScanning && isScanning(transaction) : isScanning(transaction);
             }
         }
     }
 
-    const reportIDToTransactionsValues = Object.values(reportIDToTransactions).map((reportItem) => {
-        const {totalDisplaySpend, nonReimbursableSpend, reimbursableSpend} = getMoneyRequestSpendBreakdown(reportItem);
-        return {
-            ...reportItem,
-            totalDisplaySpend,
-            nonReimbursableSpend,
-            reimbursableSpend,
-            isAllScanning: reportItem.transactions.length > 0 && reportItem.transactions.every(isScanning),
-        };
-    });
+    const reportIDToTransactionsValues = Object.values(reportIDToTransactions);
 
     return [reportIDToTransactionsValues, reportIDToTransactionsValues.length];
 }

--- a/src/libs/SearchUIUtils.ts
+++ b/src/libs/SearchUIUtils.ts
@@ -26,6 +26,7 @@ import type {
     SearchWithdrawalType,
     SelectedReports,
     SelectedTransactionInfo,
+    SelectedTransactions,
     SingularSearchStatus,
     SortOrder,
 } from '@components/Search/types';
@@ -117,6 +118,7 @@ import {
     findSelfDMReportID,
     generateReportID,
     getIcons,
+    getMoneyRequestSpendBreakdown,
     getPersonalDetailsForAccountID,
     getPolicyName,
     getReportName,
@@ -2339,7 +2341,17 @@ function getReportSections({
         }
     }
 
-    const reportIDToTransactionsValues = Object.values(reportIDToTransactions);
+    const reportIDToTransactionsValues = Object.values(reportIDToTransactions).map((reportItem) => {
+        const {totalDisplaySpend, nonReimbursableSpend, reimbursableSpend} = getMoneyRequestSpendBreakdown(reportItem);
+        return {
+            ...reportItem,
+            totalDisplaySpend,
+            nonReimbursableSpend,
+            reimbursableSpend,
+            isAllScanning: reportItem.transactions.length > 0 && reportItem.transactions.every((t) => isScanning(t as Parameters<typeof isScanning>[0])),
+        };
+    });
+
     return [reportIDToTransactionsValues, reportIDToTransactionsValues.length];
 }
 
@@ -4483,6 +4495,72 @@ function shouldShowDeleteOption(
           });
 }
 
+function applySelectionToItem(
+    item: SearchListItem,
+    canSelectMultiple: boolean,
+    selectedTransactions: SelectedTransactions,
+): {originalItem: SearchListItem; itemWithSelection: SearchListItem; isSelected: boolean} {
+    let isSelected = false;
+    let itemWithSelection: SearchListItem = item;
+
+    if ('transactions' in item && item.transactions) {
+        if (!canSelectMultiple) {
+            if (item.isSelected) {
+                itemWithSelection = {...item, isSelected: false};
+            }
+        } else {
+            const isEmptyReportSelected =
+                item.transactions.length === 0 && isTransactionReportGroupListItemType(item) && !!(item.keyForList && selectedTransactions[item.keyForList]?.isSelected);
+
+            const hasAnySelected = item.transactions.some((t) => t.keyForList && selectedTransactions[t.keyForList]?.isSelected) || isEmptyReportSelected;
+
+            if (!hasAnySelected) {
+                if (item.isSelected) {
+                    itemWithSelection = {...item, isSelected: false};
+                }
+            } else if (isEmptyReportSelected) {
+                isSelected = true;
+                if (!item.isSelected) {
+                    itemWithSelection = {...item, isSelected};
+                }
+            } else {
+                let allNonDeletedSelected = true;
+                let hasNonDeletedTransactions = false;
+                let hasTransactionSelectionChanged = false;
+
+                const mappedTransactions = item.transactions.map((transaction) => {
+                    const isTransactionSelected = !!(transaction.keyForList && selectedTransactions[transaction.keyForList]?.isSelected);
+
+                    if (transaction.pendingAction !== CONST.RED_BRICK_ROAD_PENDING_ACTION.DELETE) {
+                        hasNonDeletedTransactions = true;
+                        if (!isTransactionSelected) {
+                            allNonDeletedSelected = false;
+                        }
+                    }
+
+                    if (!!transaction.isSelected !== isTransactionSelected) {
+                        hasTransactionSelectionChanged = true;
+                    }
+
+                    return isTransactionSelected === !!transaction.isSelected ? transaction : {...transaction, isSelected: isTransactionSelected};
+                });
+
+                isSelected = hasNonDeletedTransactions && allNonDeletedSelected;
+                if (hasTransactionSelectionChanged || !!item.isSelected !== isSelected) {
+                    itemWithSelection = {...item, isSelected, transactions: hasTransactionSelectionChanged ? mappedTransactions : item.transactions};
+                }
+            }
+        }
+    } else {
+        isSelected = !!(canSelectMultiple && item.keyForList && selectedTransactions[item.keyForList]?.isSelected);
+        if (!!item.isSelected !== isSelected) {
+            itemWithSelection = {...item, isSelected};
+        }
+    }
+
+    return {originalItem: item, itemWithSelection, isSelected};
+}
+
 export {
     getSuggestedSearches,
     getDefaultActionableSearchMenuItem,
@@ -4549,5 +4627,6 @@ export {
     isTodoSearch,
     adjustTimeRangeToDateFilters,
     isEligibleForApproveSuggestion,
+    applySelectionToItem,
 };
 export type {SavedSearchMenuItem, SearchTypeMenuSection, SearchTypeMenuItem, SearchDateModifier, SearchDateModifierLower, SearchKey, ArchivedReportsIDSet};

--- a/src/libs/SearchUIUtils.ts
+++ b/src/libs/SearchUIUtils.ts
@@ -2348,7 +2348,7 @@ function getReportSections({
             totalDisplaySpend,
             nonReimbursableSpend,
             reimbursableSpend,
-            isAllScanning: reportItem.transactions.length > 0 && reportItem.transactions.every((t) => isScanning(t as Parameters<typeof isScanning>[0])),
+            isAllScanning: reportItem.transactions.length > 0 && reportItem.transactions.every(isScanning),
         };
     });
 

--- a/tests/unit/Search/SearchUIUtilsTest.ts
+++ b/tests/unit/Search/SearchUIUtilsTest.ts
@@ -4245,6 +4245,129 @@ describe('SearchUIUtils', () => {
                 expect(typeof item.transactionsQueryJSON?.hash).toBe('number');
             }
         });
+
+        describe('getReportSections computed fields (totalDisplaySpend, nonReimbursableSpend, reimbursableSpend, isAllScanning)', () => {
+            const testReportID = 'spend-test-report';
+            const testTxID1 = 'spend-tx-1';
+            const testTxID2 = 'spend-tx-2';
+
+            function makeSpendTestData(reportOverrides: Partial<OnyxTypes.Report>, transactionOverrides: Array<{transactionID: string; overrides?: Partial<OnyxTypes.Transaction>}>) {
+                const baseData = {
+                    ...searchResults.data,
+                    [`${ONYXKEYS.COLLECTION.REPORT}${testReportID}`]: {
+                        ...report1,
+                        reportID: testReportID,
+                        transactionCount: transactionOverrides.length,
+                        ...reportOverrides,
+                    },
+                    [`${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${testReportID}`]: {},
+                };
+
+                for (const tx of transactionOverrides) {
+                    Object.assign(baseData, {
+                        [`${ONYXKEYS.COLLECTION.TRANSACTION}${tx.transactionID}`]: {
+                            ...searchResults.data[`${ONYXKEYS.COLLECTION.TRANSACTION}${transactionID2}`],
+                            transactionID: tx.transactionID,
+                            reportID: testReportID,
+                            ...tx.overrides,
+                        },
+                    });
+                }
+
+                return baseData;
+            }
+
+            function getComputedFields(data: typeof searchResults.data) {
+                const sections = SearchUIUtils.getSections({
+                    type: CONST.SEARCH.DATA_TYPES.EXPENSE_REPORT,
+                    data,
+                    currentAccountID: adminAccountID,
+                    currentUserEmail: '',
+                    translate: translateLocal,
+                    formatPhoneNumber,
+                    bankAccountList: {},
+                    allReportMetadata: {},
+                })[0] as TransactionReportGroupListItemType[];
+
+                const item = sections.find((s) => s.keyForList === testReportID);
+                expect(item).toBeDefined();
+                return {
+                    totalDisplaySpend: item?.totalDisplaySpend,
+                    nonReimbursableSpend: item?.nonReimbursableSpend,
+                    reimbursableSpend: item?.reimbursableSpend,
+                    isAllScanning: item?.isAllScanning,
+                };
+            }
+
+            it('should compute spend breakdown for expense report with only reimbursable spend', () => {
+                const data = makeSpendTestData({total: -3000, nonReimbursableTotal: 0, type: CONST.REPORT.TYPE.EXPENSE}, [{transactionID: testTxID1}]);
+                const fields = getComputedFields(data);
+                expect(fields.totalDisplaySpend).toBe(3000);
+                expect(fields.reimbursableSpend).toBe(3000);
+                expect(fields.nonReimbursableSpend).toBe(-0);
+            });
+
+            it('should compute spend breakdown for expense report with mixed reimbursable and non-reimbursable spend', () => {
+                const data = makeSpendTestData(
+                    {total: -5000, nonReimbursableTotal: -2000, type: CONST.REPORT.TYPE.EXPENSE},
+                    [{transactionID: testTxID1}, {transactionID: testTxID2}],
+                );
+                const fields = getComputedFields(data);
+                expect(fields.totalDisplaySpend).toBe(5000);
+                expect(fields.nonReimbursableSpend).toBe(2000);
+                expect(fields.reimbursableSpend).toBe(3000);
+            });
+
+            it('should compute spend breakdown for expense report with only non-reimbursable spend', () => {
+                const data = makeSpendTestData({total: -4000, nonReimbursableTotal: -4000, type: CONST.REPORT.TYPE.EXPENSE}, [{transactionID: testTxID1}]);
+                const fields = getComputedFields(data);
+                expect(fields.totalDisplaySpend).toBe(4000);
+                expect(fields.nonReimbursableSpend).toBe(4000);
+                expect(fields.reimbursableSpend).toBe(0);
+            });
+
+            it('should compute spend breakdown for IOU report (non-expense type)', () => {
+                const data = makeSpendTestData({total: 7500, nonReimbursableTotal: 2500, type: CONST.REPORT.TYPE.IOU}, [{transactionID: testTxID1}]);
+                const fields = getComputedFields(data);
+                expect(fields.totalDisplaySpend).toBe(7500);
+                expect(fields.nonReimbursableSpend).toBe(2500);
+                expect(fields.reimbursableSpend).toBe(5000);
+            });
+
+            it('should return zero spend breakdown when total and nonReimbursableTotal are both 0', () => {
+                const data = makeSpendTestData({total: 0, nonReimbursableTotal: 0, type: CONST.REPORT.TYPE.EXPENSE}, [{transactionID: testTxID1}]);
+                const fields = getComputedFields(data);
+                expect(fields.totalDisplaySpend).toBe(0);
+                expect(fields.nonReimbursableSpend).toBe(0);
+                expect(fields.reimbursableSpend).toBe(0);
+            });
+
+            it('should set isAllScanning=true when all transactions are scanning', () => {
+                const scanningReceipt = {state: CONST.IOU.RECEIPT_STATE.SCANNING};
+                const data = makeSpendTestData({total: -2000, type: CONST.REPORT.TYPE.EXPENSE}, [
+                    {transactionID: testTxID1, overrides: {receipt: scanningReceipt, merchant: '', modifiedMerchant: ''}},
+                    {transactionID: testTxID2, overrides: {receipt: scanningReceipt, merchant: '', modifiedMerchant: ''}},
+                ]);
+                const fields = getComputedFields(data);
+                expect(fields.isAllScanning).toBe(true);
+            });
+
+            it('should set isAllScanning=false when some transactions are not scanning', () => {
+                const scanningReceipt = {state: CONST.IOU.RECEIPT_STATE.SCANNING};
+                const data = makeSpendTestData({total: -2000, type: CONST.REPORT.TYPE.EXPENSE}, [
+                    {transactionID: testTxID1, overrides: {receipt: scanningReceipt, merchant: '', modifiedMerchant: ''}},
+                    {transactionID: testTxID2},
+                ]);
+                const fields = getComputedFields(data);
+                expect(fields.isAllScanning).toBe(false);
+            });
+
+            it('should set isAllScanning=false when there are no transactions', () => {
+                const data = makeSpendTestData({total: 0, transactionCount: 0, type: CONST.REPORT.TYPE.EXPENSE}, []);
+                const fields = getComputedFields(data);
+                expect(fields.isAllScanning).toBe(false);
+            });
+        });
     });
 
     describe('Test getSortedSections', () => {

--- a/tests/unit/Search/SearchUIUtilsTest.ts
+++ b/tests/unit/Search/SearchUIUtilsTest.ts
@@ -7208,7 +7208,7 @@ describe('SearchUIUtils', () => {
             });
         });
 
-        // ─── Reference identity (the core optimization) ───────────────────────────
+        // ─── Preserving reference identity ───────────────────────────
 
         describe('reference identity — avoids unnecessary object creation', () => {
             test('unchanged transaction keeps its original reference inside mappedTransactions', () => {

--- a/tests/unit/Search/SearchUIUtilsTest.ts
+++ b/tests/unit/Search/SearchUIUtilsTest.ts
@@ -1165,8 +1165,8 @@ const transactionReportGroupListItems = [
     {
         groupedBy: 'expense-report',
         accountID: 18439984,
-        action: 'view',
-        allActions: ['view'],
+        action: 'approve',
+        allActions: ['approve'],
         chatReportID: '1706144653204915',
         created: '2024-12-21 13:05:20',
         submitted: '2024-12-21 13:05:20',

--- a/tests/unit/Search/SearchUIUtilsTest.ts
+++ b/tests/unit/Search/SearchUIUtilsTest.ts
@@ -1096,6 +1096,10 @@ const transactionReportGroupListItems = [
         statusNum: 0,
         to: emptyPersonalDetails,
         total: -5000,
+        totalDisplaySpend: 5000,
+        nonReimbursableSpend: -0,
+        reimbursableSpend: 5000,
+        isAllScanning: false,
         transactionCount: 1,
         transactions: [
             {
@@ -1161,8 +1165,8 @@ const transactionReportGroupListItems = [
     {
         groupedBy: 'expense-report',
         accountID: 18439984,
-        action: 'approve',
-        allActions: ['approve'],
+        action: 'view',
+        allActions: ['view'],
         chatReportID: '1706144653204915',
         created: '2024-12-21 13:05:20',
         submitted: '2024-12-21 13:05:20',
@@ -1202,6 +1206,10 @@ const transactionReportGroupListItems = [
             login: adminEmail,
         },
         total: -5000,
+        totalDisplaySpend: 5000,
+        nonReimbursableSpend: -0,
+        reimbursableSpend: 5000,
+        isAllScanning: false,
         transactionCount: 1,
         transactions: [
             {
@@ -1307,6 +1315,10 @@ const transactionReportGroupListItems = [
         stateNum: 1,
         statusNum: 1,
         total: 4400,
+        totalDisplaySpend: 4400,
+        nonReimbursableSpend: 0,
+        reimbursableSpend: 4400,
+        isAllScanning: false,
         transactionCount: 2,
         type: 'iou',
         unheldTotal: 4400,
@@ -1487,6 +1499,10 @@ const transactionReportGroupListItems = [
         statusNum: 0,
         to: emptyPersonalDetails,
         total: 0,
+        totalDisplaySpend: 0,
+        nonReimbursableSpend: 0,
+        reimbursableSpend: 0,
+        isAllScanning: false,
         transactionCount: 0,
         transactions: [],
         type: 'expense',
@@ -6865,6 +6881,242 @@ describe('SearchUIUtils', () => {
             const result = SearchUIUtils.filterValidHasValues(hasValues, CONST.SEARCH.DATA_TYPES.EXPENSE, translateLocal);
 
             expect(result).toEqual([CONST.SEARCH.HAS_VALUES.RECEIPT, CONST.SEARCH.HAS_VALUES.TAG]);
+        });
+    });
+
+    describe('applySelectionToItem', () => {
+        // Minimal factories — only fields the function actually reads are required.
+        function makeTxn(key: string, opts: {isSelected?: boolean; pendingAction?: string} = {}): TransactionListItemType {
+            return {
+                keyForList: key,
+                isSelected: opts.isSelected,
+                pendingAction: opts.pendingAction,
+            } as unknown as TransactionListItemType;
+        }
+
+        function makeGroupItem(key: string, transactions: TransactionListItemType[], opts: {isSelected?: boolean; groupedBy?: string} = {}): TransactionGroupListItemType {
+            return {
+                keyForList: key,
+                isSelected: opts.isSelected,
+                transactions,
+                groupedBy: opts.groupedBy ?? CONST.SEARCH.DATA_TYPES.EXPENSE,
+            } as unknown as TransactionGroupListItemType;
+        }
+
+        function makeReportGroupItem(key: string, transactions: TransactionListItemType[], opts: {isSelected?: boolean} = {}): TransactionReportGroupListItemType {
+            return {
+                keyForList: key,
+                isSelected: opts.isSelected,
+                transactions,
+                groupedBy: CONST.SEARCH.DATA_TYPES.EXPENSE_REPORT,
+            } as unknown as TransactionReportGroupListItemType;
+        }
+
+        function selectedMap(...keys: string[]): Record<string, SelectedTransactionInfo> {
+            return Object.fromEntries(keys.map((k) => [k, {isSelected: true} as SelectedTransactionInfo]));
+        }
+
+        // ─── Non-transaction items ────────────────────────────────────────────────
+
+        describe('non-transaction items (no transactions field)', () => {
+            test('canSelectMultiple=false: isSelected is always false', () => {
+                const item = makeTxn('t1', {isSelected: true}) as unknown as TransactionListItemType;
+                const result = SearchUIUtils.applySelectionToItem(item, false, selectedMap('t1'));
+                expect(result.isSelected).toBe(false);
+                expect(result.originalItem).toBe(item);
+                // item.isSelected was true → needs to flip, so a new object is created
+                expect(result.itemWithSelection).not.toBe(item);
+                expect(result.itemWithSelection.isSelected).toBe(false);
+            });
+
+            test('canSelectMultiple=false: already not selected → same reference returned', () => {
+                const item = makeTxn('t1', {isSelected: false}) as unknown as TransactionListItemType;
+                const result = SearchUIUtils.applySelectionToItem(item, false, selectedMap('t1'));
+                expect(result.isSelected).toBe(false);
+                expect(result.itemWithSelection).toBe(item);
+            });
+
+            test('canSelectMultiple=true, key selected: isSelected=true and new object is returned', () => {
+                const item = makeTxn('t1');
+                const result = SearchUIUtils.applySelectionToItem(item, true, selectedMap('t1'));
+                expect(result.isSelected).toBe(true);
+                expect(result.itemWithSelection).not.toBe(item);
+                expect(result.itemWithSelection.isSelected).toBe(true);
+                expect(result.originalItem).toBe(item);
+            });
+
+            test('canSelectMultiple=true, key not selected: isSelected=false and original reference is returned', () => {
+                const item = makeTxn('t1');
+                const result = SearchUIUtils.applySelectionToItem(item, true, {});
+                expect(result.isSelected).toBe(false);
+                expect(result.itemWithSelection).toBe(item);
+            });
+
+            test('canSelectMultiple=true, already correctly marked: same reference returned (no unnecessary spread)', () => {
+                const item = makeTxn('t1', {isSelected: true});
+                const result = SearchUIUtils.applySelectionToItem(item, true, selectedMap('t1'));
+                expect(result.isSelected).toBe(true);
+                expect(result.itemWithSelection).toBe(item);
+            });
+        });
+
+        // ─── Transaction group items — !canSelectMultiple ─────────────────────────
+
+        describe('transaction group items — canSelectMultiple=false', () => {
+            test('item.isSelected=false: same reference returned', () => {
+                const item = makeGroupItem('r1', [makeTxn('t1')], {isSelected: false});
+                const result = SearchUIUtils.applySelectionToItem(item, false, selectedMap('t1'));
+                expect(result.isSelected).toBe(false);
+                expect(result.itemWithSelection).toBe(item);
+            });
+
+            test('item.isSelected=true: new object with isSelected:false is returned', () => {
+                const item = makeGroupItem('r1', [makeTxn('t1')], {isSelected: true});
+                const result = SearchUIUtils.applySelectionToItem(item, false, {});
+                expect(result.isSelected).toBe(false);
+                expect(result.itemWithSelection).not.toBe(item);
+                expect(result.itemWithSelection.isSelected).toBe(false);
+            });
+        });
+
+        // ─── Transaction group items — canSelectMultiple=true, empty transactions ─
+
+        describe('transaction group items — canSelectMultiple=true, empty transactions', () => {
+            test('non-report-grouped empty item: isSelected=false, same reference', () => {
+                const item = makeGroupItem('r1', [], {groupedBy: CONST.SEARCH.DATA_TYPES.EXPENSE});
+                const result = SearchUIUtils.applySelectionToItem(item, true, selectedMap('r1'));
+                // isEmptyReportSelected is false (not EXPENSE_REPORT type), hasAnySelected=false
+                expect(result.isSelected).toBe(false);
+                expect(result.itemWithSelection).toBe(item);
+            });
+
+            test('report-grouped empty item with key in selectedTransactions: isSelected=true, new object', () => {
+                const item = makeReportGroupItem('r1', [], {isSelected: false});
+                const result = SearchUIUtils.applySelectionToItem(item, true, selectedMap('r1'));
+                expect(result.isSelected).toBe(true);
+                expect(result.itemWithSelection).not.toBe(item);
+                expect(result.itemWithSelection.isSelected).toBe(true);
+            });
+
+            test('report-grouped empty item already marked selected: same reference returned', () => {
+                const item = makeReportGroupItem('r1', [], {isSelected: true});
+                const result = SearchUIUtils.applySelectionToItem(item, true, selectedMap('r1'));
+                expect(result.isSelected).toBe(true);
+                expect(result.itemWithSelection).toBe(item);
+            });
+
+            test('report-grouped empty item with key NOT in selectedTransactions: isSelected=false, same reference', () => {
+                const item = makeReportGroupItem('r1', [], {isSelected: false});
+                const result = SearchUIUtils.applySelectionToItem(item, true, {});
+                expect(result.isSelected).toBe(false);
+                expect(result.itemWithSelection).toBe(item);
+            });
+        });
+
+        // ─── Transaction group items — canSelectMultiple=true, non-empty transactions
+
+        describe('transaction group items — canSelectMultiple=true, non-empty transactions', () => {
+            test('no transactions selected: isSelected=false, same item reference', () => {
+                const t1 = makeTxn('t1');
+                const t2 = makeTxn('t2');
+                const item = makeGroupItem('r1', [t1, t2]);
+                const result = SearchUIUtils.applySelectionToItem(item, true, {});
+                expect(result.isSelected).toBe(false);
+                expect(result.itemWithSelection).toBe(item);
+            });
+
+            test('partial selection (not all selected): isSelected=false, new item with updated transactions', () => {
+                const t1 = makeTxn('t1');
+                const t2 = makeTxn('t2');
+                const item = makeGroupItem('r1', [t1, t2]);
+                const result = SearchUIUtils.applySelectionToItem(item, true, selectedMap('t1'));
+                expect(result.isSelected).toBe(false);
+                expect(result.itemWithSelection).not.toBe(item);
+                const withSel = result.itemWithSelection as TransactionGroupListItemType;
+                expect(withSel.transactions[0].isSelected).toBe(true);
+                // t2 unchanged — same reference kept, isSelected remains undefined (not explicitly false)
+                expect(withSel.transactions[1]).toBe(t2);
+                expect(withSel.transactions[1].isSelected).toBeFalsy();
+            });
+
+            test('all non-deleted selected: isSelected=true', () => {
+                const t1 = makeTxn('t1');
+                const t2 = makeTxn('t2');
+                const item = makeGroupItem('r1', [t1, t2]);
+                const result = SearchUIUtils.applySelectionToItem(item, true, selectedMap('t1', 't2'));
+                expect(result.isSelected).toBe(true);
+                expect(result.itemWithSelection).not.toBe(item);
+                expect(result.itemWithSelection.isSelected).toBe(true);
+            });
+
+            test('all transactions have DELETE pending action: isSelected=false (no non-deleted transactions)', () => {
+                const t1 = makeTxn('t1', {pendingAction: CONST.RED_BRICK_ROAD_PENDING_ACTION.DELETE});
+                const t2 = makeTxn('t2', {pendingAction: CONST.RED_BRICK_ROAD_PENDING_ACTION.DELETE});
+                const item = makeGroupItem('r1', [t1, t2]);
+                const result = SearchUIUtils.applySelectionToItem(item, true, selectedMap('t1', 't2'));
+                expect(result.isSelected).toBe(false);
+            });
+
+            test('report isSelected flips but no transaction selection changed: original transactions array reference is preserved', () => {
+                // All transactions become delete-pending → hasNonDeletedTransactions=false → isSelected flips false
+                // but no individual transaction.isSelected changed → hasTransactionSelectionChanged=false
+                // The fix: transactions reference must NOT be the new mappedTransactions array
+                const t1 = makeTxn('t1', {pendingAction: CONST.RED_BRICK_ROAD_PENDING_ACTION.DELETE});
+                const item = makeGroupItem('r1', [t1], {isSelected: true});
+                const result = SearchUIUtils.applySelectionToItem(item, true, {});
+                expect(result.isSelected).toBe(false);
+                expect(result.itemWithSelection).not.toBe(item);
+                const withSel = result.itemWithSelection as TransactionGroupListItemType;
+                expect(withSel.transactions).toBe(item.transactions);
+            });
+
+            test('mix of deleted and non-deleted — all non-deleted selected: isSelected=true', () => {
+                const deleted = makeTxn('t1', {pendingAction: CONST.RED_BRICK_ROAD_PENDING_ACTION.DELETE});
+                const active = makeTxn('t2');
+                const item = makeGroupItem('r1', [deleted, active]);
+                // Only t2 selected — the only non-deleted one
+                const result = SearchUIUtils.applySelectionToItem(item, true, selectedMap('t2'));
+                expect(result.isSelected).toBe(true);
+            });
+
+            test('mix of deleted and non-deleted — non-deleted NOT selected: isSelected=false', () => {
+                const deleted = makeTxn('t1', {pendingAction: CONST.RED_BRICK_ROAD_PENDING_ACTION.DELETE});
+                const active = makeTxn('t2');
+                const item = makeGroupItem('r1', [deleted, active]);
+                const result = SearchUIUtils.applySelectionToItem(item, true, {});
+                expect(result.isSelected).toBe(false);
+            });
+        });
+
+        // ─── Reference identity (the core optimization) ───────────────────────────
+
+        describe('reference identity — avoids unnecessary object creation', () => {
+            test('unchanged transaction keeps its original reference inside mappedTransactions', () => {
+                const t1 = makeTxn('t1', {isSelected: true});
+                const t2 = makeTxn('t2');
+                const item = makeGroupItem('r1', [t1, t2], {isSelected: false});
+                // t1 already selected, t2 newly selected → only t2 gets a spread
+                const result = SearchUIUtils.applySelectionToItem(item, true, selectedMap('t1', 't2'));
+                const withSel = result.itemWithSelection as TransactionGroupListItemType;
+                expect(withSel.transactions[0]).toBe(t1); // unchanged — same reference
+                expect(withSel.transactions[1]).not.toBe(t2); // changed — new object
+            });
+
+            test('when selection state is already correct, originalItem reference is returned unchanged', () => {
+                const t1 = makeTxn('t1', {isSelected: true});
+                const t2 = makeTxn('t2', {isSelected: true});
+                const item = makeGroupItem('r1', [t1, t2], {isSelected: true});
+                const result = SearchUIUtils.applySelectionToItem(item, true, selectedMap('t1', 't2'));
+                expect(result.itemWithSelection).toBe(item);
+            });
+
+            test('originalItem is always the unchanged input regardless of selection changes', () => {
+                const t1 = makeTxn('t1');
+                const item = makeGroupItem('r1', [t1]);
+                const result = SearchUIUtils.applySelectionToItem(item, true, selectedMap('t1'));
+                expect(result.originalItem).toBe(item);
+                expect(result.itemWithSelection).not.toBe(item);
+            });
         });
     });
 });

--- a/tests/unit/Search/SearchUIUtilsTest.ts
+++ b/tests/unit/Search/SearchUIUtilsTest.ts
@@ -7033,10 +7033,10 @@ describe('SearchUIUtils', () => {
                 expect(result.isSelected).toBe(false);
                 expect(result.itemWithSelection).not.toBe(item);
                 const withSel = result.itemWithSelection as TransactionGroupListItemType;
-                expect(withSel.transactions[0].isSelected).toBe(true);
+                expect(withSel.transactions.at(0)?.isSelected).toBe(true);
                 // t2 unchanged — same reference kept, isSelected remains undefined (not explicitly false)
-                expect(withSel.transactions[1]).toBe(t2);
-                expect(withSel.transactions[1].isSelected).toBeFalsy();
+                expect(withSel.transactions.at(1)).toBe(t2);
+                expect(withSel.transactions.at(1)?.isSelected).toBeFalsy();
             });
 
             test('all non-deleted selected: isSelected=true', () => {
@@ -7098,8 +7098,8 @@ describe('SearchUIUtils', () => {
                 // t1 already selected, t2 newly selected → only t2 gets a spread
                 const result = SearchUIUtils.applySelectionToItem(item, true, selectedMap('t1', 't2'));
                 const withSel = result.itemWithSelection as TransactionGroupListItemType;
-                expect(withSel.transactions[0]).toBe(t1); // unchanged — same reference
-                expect(withSel.transactions[1]).not.toBe(t2); // changed — new object
+                expect(withSel.transactions.at(0)).toBe(t1); // unchanged — same reference
+                expect(withSel.transactions.at(1)).not.toBe(t2); // changed — new object
             });
 
             test('when selection state is already correct, originalItem reference is returned unchanged', () => {

--- a/tests/unit/Search/SearchUIUtilsTest.ts
+++ b/tests/unit/Search/SearchUIUtilsTest.ts
@@ -4308,10 +4308,7 @@ describe('SearchUIUtils', () => {
             });
 
             it('should compute spend breakdown for expense report with mixed reimbursable and non-reimbursable spend', () => {
-                const data = makeSpendTestData(
-                    {total: -5000, nonReimbursableTotal: -2000, type: CONST.REPORT.TYPE.EXPENSE},
-                    [{transactionID: testTxID1}, {transactionID: testTxID2}],
-                );
+                const data = makeSpendTestData({total: -5000, nonReimbursableTotal: -2000, type: CONST.REPORT.TYPE.EXPENSE}, [{transactionID: testTxID1}, {transactionID: testTxID2}]);
                 const fields = getComputedFields(data);
                 expect(fields.totalDisplaySpend).toBe(5000);
                 expect(fields.nonReimbursableSpend).toBe(2000);


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
<!-- Explain what your change does and how it addresses the linked issue -->

The PR
1. Lifts expensive computations (`getMoneyRequestSpendBreakdown` and the "all scanning" check) out of the `ExpenseReportListItemRow` render function. These values are now pre-computed once in `SearchUIUtils.getReportSections` and stored directly on the list item data (`totalDisplaySpend`, `nonReimbursableSpend`, `reimbursableSpend`, `isAllScanning`), so the component just reads them directly instead of recalculating on every render.
2. The `itemsWithSelection` logic in `SearchList` was extracted into a dedicated, testable `applySelectionToItem` function in `SearchUIUtils`, with optimizations to avoid creating new object references when nothing has actually changed (reducing unnecessary re-renders). Unit tests for the new function were added in `SearchUIUtilsTest.ts`.

#### Performance gains 

~ 15 - 20% faster render time for `ExpenseReportListRowItem` 
~ 9 - 17% for the whole SearchList and flow

#### Methodology

Tests run on `expensifail` account.
2 tools used:
- One is based on `<Profiler>` component 
-  other on traces from the Profiler Chrome Plugin

Both show consistent improvement for the component.

Action performed: 
Navigate from `Home` to `Reports` 
For `Render Profiler` x10 times
For Profiler plugin 10x times (10 separate traces)\*

\* The results were suprisingly good, so run more traces than usual to confirm.


### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/82428

PROPOSAL:


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

1. Open the app
2. Go to Reports page
3. Verify that Search list is working as expected

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->
N/A

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->

N/A


### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos

<img width="625" height="277" alt="image" src="https://github.com/user-attachments/assets/9726c64a-d8e4-42c2-84d0-3fde4e1f6e26" />

<img width="1467" height="282" alt="image" src="https://github.com/user-attachments/assets/d3beb8b7-57f6-410f-b119-696f9ed7858d" />

<img width="1475" height="233" alt="image" src="https://github.com/user-attachments/assets/4fe941b7-2227-40f0-a248-be9892ad045e" />

