### PR TITLE
Extract SavedSearchList component to isolate Onyx subscriptions in SearchTypeMenu

### DIFF
--- a/src/pages/Search/SavedSearchList.tsx
+++ b/src/pages/Search/SavedSearchList.tsx
@@ -1,0 +1,130 @@
+import {useIsFocused} from '@react-navigation/native';
+import {accountIDSelector} from '@selectors/Session';
+import React from 'react';
+import MenuItemList from '@components/MenuItemList';
+import {usePersonalDetails} from '@components/OnyxListItemProvider';
+import {useProductTrainingContext} from '@components/ProductTrainingContext';
+import type {SearchQueryJSON} from '@components/Search/types';
+import useDeleteSavedSearch from '@hooks/useDeleteSavedSearch';
+import useFeedKeysWithAssignedCards from '@hooks/useFeedKeysWithAssignedCards';
+import {useMemoizedLazyExpensifyIcons} from '@hooks/useLazyAsset';
+import useLocalize from '@hooks/useLocalize';
+import useOnyx from '@hooks/useOnyx';
+import useSearchTypeMenuSections from '@hooks/useSearchTypeMenuSections';
+import useThemeStyles from '@hooks/useThemeStyles';
+import {setSearchContext} from '@libs/actions/Search';
+import {mergeCardListWithWorkspaceFeeds} from '@libs/CardUtils';
+import Navigation from '@libs/Navigation/Navigation';
+import {getAllTaxRates} from '@libs/PolicyUtils';
+import {buildSearchQueryJSON, buildUserReadableQueryString} from '@libs/SearchQueryUtils';
+import type {SavedSearchMenuItem} from '@libs/SearchUIUtils';
+import {createBaseSavedSearchMenuItem, getOverflowMenu as getOverflowMenuUtil} from '@libs/SearchUIUtils';
+import variables from '@styles/variables';
+import CONST from '@src/CONST';
+import ONYXKEYS from '@src/ONYXKEYS';
+import ROUTES from '@src/ROUTES';
+import type {SaveSearchItem} from '@src/types/onyx/SaveSearch';
+import SavedSearchItemThreeDotMenu from './SavedSearchItemThreeDotMenu';
+
+type SavedSearchListProps = {
+    hash: number | undefined;
+};
+
+function SavedSearchList({hash}: SavedSearchListProps) {
+    const styles = useThemeStyles();
+    const {translate} = useLocalize();
+    const isFocused = useIsFocused();
+    const {typeMenuSections} = useSearchTypeMenuSections();
+
+    const [savedSearches] = useOnyx(ONYXKEYS.SAVED_SEARCHES);
+    const [allPolicies] = useOnyx(ONYXKEYS.COLLECTION.POLICY);
+    const personalDetails = usePersonalDetails();
+    const [cardList] = useOnyx(ONYXKEYS.CARD_LIST);
+    const [workspaceCardList] = useOnyx(ONYXKEYS.COLLECTION.WORKSPACE_CARDS_LIST);
+    const [reports] = useOnyx(ONYXKEYS.COLLECTION.REPORT);
+    const [allFeeds] = useOnyx(ONYXKEYS.COLLECTION.SHARED_NVP_PRIVATE_DOMAIN_MEMBER);
+    const feedKeysWithCards = useFeedKeysWithAssignedCards();
+    const [currentUserAccountID = -1] = useOnyx(ONYXKEYS.SESSION, {selector: accountIDSelector});
+
+    const {showDeleteModal} = useDeleteSavedSearch();
+    const {
+        shouldShowProductTrainingTooltip: shouldShowSavedSearchTooltip,
+        renderProductTrainingTooltip: renderSavedSearchTooltip,
+        hideProductTrainingTooltip: hideSavedSearchTooltip,
+    } = useProductTrainingContext(
+        CONST.PRODUCT_TRAINING_TOOLTIP_NAMES.RENAME_SAVED_SEARCH,
+        !!typeMenuSections.find((section) => section.translationPath === 'search.savedSearchesMenuItemTitle') && isFocused,
+    );
+
+    const expensifyIcons = useMemoizedLazyExpensifyIcons(['Bookmark', 'Pencil'] as const);
+
+    const taxRates = getAllTaxRates(allPolicies);
+    const cardsForSavedSearchDisplay = mergeCardListWithWorkspaceFeeds(workspaceCardList ?? CONST.EMPTY_OBJECT, cardList);
+
+    const getOverflowMenu = (itemName: string, itemHash: number, itemQuery: string) => getOverflowMenuUtil(expensifyIcons, itemName, itemHash, itemQuery, translate, showDeleteModal);
+
+    const createSavedSearchMenuItem = (item: SaveSearchItem, key: string, index: number) => {
+        let title = item.name;
+        if (title === item.query) {
+            const jsonQuery = buildSearchQueryJSON(item.query) ?? ({} as SearchQueryJSON);
+            title = buildUserReadableQueryString({
+                queryJSON: jsonQuery,
+                PersonalDetails: personalDetails,
+                reports,
+                taxRates,
+                cardList: cardsForSavedSearchDisplay,
+                cardFeeds: allFeeds,
+                policies: allPolicies,
+                currentUserAccountID,
+                autoCompleteWithSpace: false,
+                translate,
+                feedKeysWithCards,
+            });
+        }
+
+        const isItemFocused = Number(key) === hash;
+        const baseMenuItem: SavedSearchMenuItem = createBaseSavedSearchMenuItem(item, key, index, title, isItemFocused);
+
+        return {
+            ...baseMenuItem,
+            sentryLabel: CONST.SENTRY_LABEL.SEARCH.SAVED_SEARCH_MENU_ITEM,
+            onPress: () => {
+                setSearchContext(false);
+                Navigation.navigate(ROUTES.SEARCH_ROOT.getRoute({query: item?.query ?? '', name: item?.name}));
+            },
+            rightComponent: (
+                <SavedSearchItemThreeDotMenu
+                    menuItems={getOverflowMenu(title, Number(key), item.query)}
+                    isDisabledItem={item.pendingAction === CONST.RED_BRICK_ROAD_PENDING_ACTION.DELETE}
+                    hideProductTrainingTooltip={index === 0 && shouldShowSavedSearchTooltip ? hideSavedSearchTooltip : undefined}
+                    shouldRenderTooltip={index === 0 && shouldShowSavedSearchTooltip}
+                    renderTooltipContent={renderSavedSearchTooltip}
+                />
+            ),
+            style: [styles.alignItemsCenter],
+            tooltipAnchorAlignment: {
+                horizontal: CONST.MODAL.ANCHOR_ORIGIN_HORIZONTAL.RIGHT,
+                vertical: CONST.MODAL.ANCHOR_ORIGIN_VERTICAL.BOTTOM,
+            },
+            tooltipShiftHorizontal: variables.savedSearchShiftHorizontal,
+            tooltipShiftVertical: variables.savedSearchShiftVertical,
+            tooltipWrapperStyle: [styles.mh4, styles.pv2, styles.productTrainingTooltipWrapper],
+            renderTooltipContent: renderSavedSearchTooltip,
+        };
+    };
+
+    const savedSearchesMenuItems = savedSearches ? Object.entries(savedSearches).map(([key, item], index) => createSavedSearchMenuItem(item, key, index)) : [];
+
+    return (
+        <MenuItemList
+            menuItems={savedSearchesMenuItems}
+            wrapperStyle={styles.sectionMenuItem}
+            icon={expensifyIcons.Bookmark}
+            iconWidth={variables.iconSizeNormal}
+            iconHeight={variables.iconSizeNormal}
+            shouldUseSingleExecution
+        />
+    );
+}
+
+export default SavedSearchList;

--- a/src/pages/Search/SavedSearchList.tsx
+++ b/src/pages/Search/SavedSearchList.tsx
@@ -10,7 +10,6 @@ import useFeedKeysWithAssignedCards from '@hooks/useFeedKeysWithAssignedCards';
 import {useMemoizedLazyExpensifyIcons} from '@hooks/useLazyAsset';
 import useLocalize from '@hooks/useLocalize';
 import useOnyx from '@hooks/useOnyx';
-import useSearchTypeMenuSections from '@hooks/useSearchTypeMenuSections';
 import useThemeStyles from '@hooks/useThemeStyles';
 import {setSearchContext} from '@libs/actions/Search';
 import {mergeCardListWithWorkspaceFeeds} from '@libs/CardUtils';
@@ -34,7 +33,6 @@ function SavedSearchList({hash}: SavedSearchListProps) {
     const styles = useThemeStyles();
     const {translate} = useLocalize();
     const isFocused = useIsFocused();
-    const {typeMenuSections} = useSearchTypeMenuSections();
 
     const [savedSearches] = useOnyx(ONYXKEYS.SAVED_SEARCHES);
     const [allPolicies] = useOnyx(ONYXKEYS.COLLECTION.POLICY);
@@ -51,10 +49,7 @@ function SavedSearchList({hash}: SavedSearchListProps) {
         shouldShowProductTrainingTooltip: shouldShowSavedSearchTooltip,
         renderProductTrainingTooltip: renderSavedSearchTooltip,
         hideProductTrainingTooltip: hideSavedSearchTooltip,
-    } = useProductTrainingContext(
-        CONST.PRODUCT_TRAINING_TOOLTIP_NAMES.RENAME_SAVED_SEARCH,
-        !!typeMenuSections.find((section) => section.translationPath === 'search.savedSearchesMenuItemTitle') && isFocused,
-    );
+    } = useProductTrainingContext(CONST.PRODUCT_TRAINING_TOOLTIP_NAMES.RENAME_SAVED_SEARCH, isFocused);
 
     const expensifyIcons = useMemoizedLazyExpensifyIcons(['Bookmark', 'Pencil'] as const);
 

--- a/src/pages/Search/SearchTypeMenu.tsx
+++ b/src/pages/Search/SearchTypeMenu.tsx
@@ -1,21 +1,14 @@
-import {useIsFocused, useRoute} from '@react-navigation/native';
-import {accountIDSelector} from '@selectors/Session';
+import {useRoute} from '@react-navigation/native';
 import React, {useCallback, useContext, useLayoutEffect, useMemo, useRef} from 'react';
 import {View} from 'react-native';
 // eslint-disable-next-line no-restricted-imports
 import type {ScrollView as RNScrollView, ScrollViewProps} from 'react-native';
 import MenuItem from '@components/MenuItem';
-import type {MenuItemWithLink} from '@components/MenuItemList';
-import MenuItemList from '@components/MenuItemList';
-import {usePersonalDetails} from '@components/OnyxListItemProvider';
-import {useProductTrainingContext} from '@components/ProductTrainingContext';
 import {ScrollOffsetContext} from '@components/ScrollOffsetContextProvider';
 import ScrollView from '@components/ScrollView';
 import {useSearchActionsContext} from '@components/Search/SearchContext';
 import type {SearchQueryJSON} from '@components/Search/types';
 import Text from '@components/Text';
-import useDeleteSavedSearch from '@hooks/useDeleteSavedSearch';
-import useFeedKeysWithAssignedCards from '@hooks/useFeedKeysWithAssignedCards';
 import {useMemoizedLazyExpensifyIcons} from '@hooks/useLazyAsset';
 import useLocalize from '@hooks/useLocalize';
 import useOnyx from '@hooks/useOnyx';
@@ -24,19 +17,15 @@ import useSingleExecution from '@hooks/useSingleExecution';
 import useSuggestedSearchDefaultNavigation from '@hooks/useSuggestedSearchDefaultNavigation';
 import useThemeStyles from '@hooks/useThemeStyles';
 import {setSearchContext} from '@libs/actions/Search';
-import {mergeCardListWithWorkspaceFeeds} from '@libs/CardUtils';
 import Navigation from '@libs/Navigation/Navigation';
-import {getAllTaxRates} from '@libs/PolicyUtils';
-import {buildSearchQueryJSON, buildUserReadableQueryString, shouldSkipSuggestedSearchNavigation as shouldSkipSuggestedSearchNavigationForQuery} from '@libs/SearchQueryUtils';
-import type {SavedSearchMenuItem} from '@libs/SearchUIUtils';
-import {createBaseSavedSearchMenuItem, getItemBadgeText, getOverflowMenu as getOverflowMenuUtil} from '@libs/SearchUIUtils';
+import {shouldSkipSuggestedSearchNavigation as shouldSkipSuggestedSearchNavigationForQuery} from '@libs/SearchQueryUtils';
+import {getItemBadgeText} from '@libs/SearchUIUtils';
 import variables from '@styles/variables';
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
 import ROUTES from '@src/ROUTES';
 import todosReportCountsSelector from '@src/selectors/Todos';
-import type {SaveSearchItem} from '@src/types/onyx/SaveSearch';
-import SavedSearchItemThreeDotMenu from './SavedSearchItemThreeDotMenu';
+import SavedSearchList from './SavedSearchList';
 import SuggestedSearchSkeleton from './SuggestedSearchSkeleton';
 
 type SearchTypeMenuProps = {
@@ -52,20 +41,9 @@ function SearchTypeMenu({queryJSON}: SearchTypeMenuProps) {
     const {translate} = useLocalize();
     const [savedSearches] = useOnyx(ONYXKEYS.SAVED_SEARCHES);
     const {typeMenuSections, CreateReportConfirmationModal, shouldShowSuggestedSearchSkeleton} = useSearchTypeMenuSections();
-    const isFocused = useIsFocused();
-    const {
-        shouldShowProductTrainingTooltip: shouldShowSavedSearchTooltip,
-        renderProductTrainingTooltip: renderSavedSearchTooltip,
-        hideProductTrainingTooltip: hideSavedSearchTooltip,
-    } = useProductTrainingContext(
-        CONST.PRODUCT_TRAINING_TOOLTIP_NAMES.RENAME_SAVED_SEARCH,
-        !!typeMenuSections.find((section) => section.translationPath === 'search.savedSearchesMenuItemTitle') && isFocused,
-    );
     const expensifyIcons = useMemoizedLazyExpensifyIcons([
         'Basket',
-        'Bookmark',
         'CalendarSolid',
-        'Pencil',
         'Receipt',
         'ChatBubbles',
         'MoneyBag',
@@ -76,18 +54,7 @@ function SearchTypeMenu({queryJSON}: SearchTypeMenuProps) {
         'User',
         'Folder',
     ] as const);
-    const {showDeleteModal} = useDeleteSavedSearch();
-    const [allPolicies] = useOnyx(ONYXKEYS.COLLECTION.POLICY);
-    const personalDetails = usePersonalDetails();
-    const [cardList] = useOnyx(ONYXKEYS.CARD_LIST);
-    const [workspaceCardList] = useOnyx(ONYXKEYS.COLLECTION.WORKSPACE_CARDS_LIST);
-    const [reports] = useOnyx(ONYXKEYS.COLLECTION.REPORT);
-    const [allFeeds] = useOnyx(ONYXKEYS.COLLECTION.SHARED_NVP_PRIVATE_DOMAIN_MEMBER);
-    const feedKeysWithCards = useFeedKeysWithAssignedCards();
-    const taxRates = getAllTaxRates(allPolicies);
-    const [currentUserAccountID = -1] = useOnyx(ONYXKEYS.SESSION, {selector: accountIDSelector});
     const {clearSelectedTransactions} = useSearchActionsContext();
-    const cardsForSavedSearchDisplay = useMemo(() => mergeCardListWithWorkspaceFeeds(workspaceCardList ?? CONST.EMPTY_OBJECT, cardList), [workspaceCardList, cardList]);
     const [reportCounts = CONST.EMPTY_TODOS_REPORT_COUNTS] = useOnyx(ONYXKEYS.DERIVED.TODOS, {selector: todosReportCountsSelector});
 
     const flattenedMenuItems = useMemo(() => typeMenuSections.flatMap((section) => section.menuItems), [typeMenuSections]);
@@ -100,81 +67,7 @@ function SearchTypeMenu({queryJSON}: SearchTypeMenuProps) {
         shouldSkipNavigation: shouldSkipSuggestedSearchNavigation,
     });
 
-    const getOverflowMenu = useCallback(
-        (itemName: string, itemHash: number, itemQuery: string) => getOverflowMenuUtil(expensifyIcons, itemName, itemHash, itemQuery, translate, showDeleteModal),
-        [translate, showDeleteModal, expensifyIcons],
-    );
-    const createSavedSearchMenuItem = useCallback(
-        (item: SaveSearchItem, key: string, index: number) => {
-            let title = item.name;
-            if (title === item.query) {
-                const jsonQuery = buildSearchQueryJSON(item.query) ?? ({} as SearchQueryJSON);
-                title = buildUserReadableQueryString({
-                    queryJSON: jsonQuery,
-                    PersonalDetails: personalDetails,
-                    reports,
-                    taxRates,
-                    cardList: cardsForSavedSearchDisplay,
-                    cardFeeds: allFeeds,
-                    policies: allPolicies,
-                    currentUserAccountID,
-                    autoCompleteWithSpace: false,
-                    translate,
-                    feedKeysWithCards,
-                });
-            }
-
-            const isItemFocused = Number(key) === hash;
-            const baseMenuItem: SavedSearchMenuItem = createBaseSavedSearchMenuItem(item, key, index, title, isItemFocused);
-
-            return {
-                ...baseMenuItem,
-                sentryLabel: CONST.SENTRY_LABEL.SEARCH.SAVED_SEARCH_MENU_ITEM,
-                onPress: () => {
-                    setSearchContext(false);
-                    Navigation.navigate(ROUTES.SEARCH_ROOT.getRoute({query: item?.query ?? '', name: item?.name}));
-                },
-                rightComponent: (
-                    <SavedSearchItemThreeDotMenu
-                        menuItems={getOverflowMenu(title, Number(key), item.query)}
-                        isDisabledItem={item.pendingAction === CONST.RED_BRICK_ROAD_PENDING_ACTION.DELETE}
-                        hideProductTrainingTooltip={index === 0 && shouldShowSavedSearchTooltip ? hideSavedSearchTooltip : undefined}
-                        shouldRenderTooltip={index === 0 && shouldShowSavedSearchTooltip}
-                        renderTooltipContent={renderSavedSearchTooltip}
-                    />
-                ),
-                style: [styles.alignItemsCenter],
-                tooltipAnchorAlignment: {
-                    horizontal: CONST.MODAL.ANCHOR_ORIGIN_HORIZONTAL.RIGHT,
-                    vertical: CONST.MODAL.ANCHOR_ORIGIN_VERTICAL.BOTTOM,
-                },
-                tooltipShiftHorizontal: variables.savedSearchShiftHorizontal,
-                tooltipShiftVertical: variables.savedSearchShiftVertical,
-                tooltipWrapperStyle: [styles.mh4, styles.pv2, styles.productTrainingTooltipWrapper],
-                renderTooltipContent: renderSavedSearchTooltip,
-            };
-        },
-        [
-            hash,
-            getOverflowMenu,
-            shouldShowSavedSearchTooltip,
-            hideSavedSearchTooltip,
-            renderSavedSearchTooltip,
-            styles.alignItemsCenter,
-            styles.mh4,
-            styles.pv2,
-            styles.productTrainingTooltipWrapper,
-            personalDetails,
-            reports,
-            taxRates,
-            cardsForSavedSearchDisplay,
-            allFeeds,
-            feedKeysWithCards,
-            currentUserAccountID,
-            allPolicies,
-            translate,
-        ],
-    );
+    const isSavedSearchActive = !!savedSearches && Object.keys(savedSearches).some((key) => Number(key) === hash);
 
     const route = useRoute();
     const scrollViewRef = useRef<RNScrollView>(null);
@@ -198,42 +91,6 @@ function SearchTypeMenu({queryJSON}: SearchTypeMenuProps) {
         }
         scrollViewRef.current.scrollTo({y: scrollOffset, animated: false});
     }, [getScrollOffset, route]);
-
-    const {savedSearchesMenuItems, isSavedSearchActive} = useMemo(() => {
-        let savedSearchFocused = false;
-
-        if (!savedSearches) {
-            return {
-                isSavedSearchActive: false,
-                savedSearchesMenuItems: [],
-            };
-        }
-
-        const menuItems = Object.entries(savedSearches).map(([key, item], index) => {
-            const baseMenuItem = createSavedSearchMenuItem(item, key, index);
-            savedSearchFocused ||= !!baseMenuItem.focused;
-            return baseMenuItem;
-        });
-
-        return {
-            savedSearchesMenuItems: menuItems,
-            isSavedSearchActive: savedSearchFocused,
-        };
-    }, [createSavedSearchMenuItem, savedSearches]);
-
-    const renderSavedSearchesSection = useCallback(
-        (menuItems: MenuItemWithLink[]) => (
-            <MenuItemList
-                menuItems={menuItems}
-                wrapperStyle={styles.sectionMenuItem}
-                icon={expensifyIcons.Bookmark}
-                iconWidth={variables.iconSizeNormal}
-                iconHeight={variables.iconSizeNormal}
-                shouldUseSingleExecution
-            />
-        ),
-        [expensifyIcons.Bookmark, styles.sectionMenuItem],
-    );
 
     const activeItemIndex = useMemo(() => {
         // If we have a suggested search, then none of the menu items are active
@@ -268,7 +125,7 @@ function SearchTypeMenu({queryJSON}: SearchTypeMenuProps) {
                                 </Text>
 
                                 {section.translationPath === 'search.savedSearchesMenuItemTitle' ? (
-                                    renderSavedSearchesSection(savedSearchesMenuItems)
+                                    <SavedSearchList hash={hash} />
                                 ) : (
                                     <>
                                         {section.menuItems.map((item, itemIndex) => {


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->
@rlinoz @mountiny @luacmartins 

### Explanation of Change
<!-- Explain what your change does and how it addresses the linked issue -->

TLDR: A small, low-risk improvement to the SearchTypeMenu on Search. This limits rerenders and trims down another ~100ms of wasted compute time during many unrelated interactions.

---

Extracted a new `SavedSearchList` component from `SearchTypeMenu.tsx` to isolate the 6 Onyx subscriptions that were only needed for building saved search titles and rendering saved search items.

<img width="1081" height="1324" alt="Screenshot 2026-02-27 at 15 00 43" src="https://github.com/user-attachments/assets/aeb9d9db-8f13-44df-9d0b-279a2daad1a8" />

Additional cleanup:
- Removed `renderSavedSearchesSection` internal render helper (inline render function anti-pattern)
- Removed `createSavedSearchMenuItem` `useCallback` and its large dependency array
- Removed `cardsForSavedSearchDisplay` `useMemo`
- The new `SavedSearchList` component uses no manual memoization and is React Compiler compliant
- `SearchTypeMenu` reduced from 317 → 162 lines (-49%)

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/77174
PROPOSAL:


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

1. Open up Search
2. See that it behaves properly on the left sidebar (Saved Searches)

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->
N/A

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and reviews one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
3. Upload an image via copy paste
4. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->
Same as tests

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>