### PR TITLE
[No QA] ci: Fix Remote Build Android failure on hybrid cache hits

### DIFF
--- a/.github/workflows/buildAndroid.yml
+++ b/.github/workflows/buildAndroid.yml
@@ -8,7 +8,7 @@ on:
         type: string
         required: true
       variant:
-        description: "'Release' or 'Adhoc'"
+        description: "'Release', 'Adhoc', or 'Debug'"
         type: string
         required: true
       mobile-expensify-ref:
@@ -94,6 +94,7 @@ jobs:
           IS_HYBRID_BUILD: 'true'
 
       - name: Run grunt build
+        if: ${{ inputs.variant != 'Debug' }}
         run: |
           cd Mobile-Expensify
           npm run grunt:build:shared
@@ -124,12 +125,14 @@ jobs:
         uses: gradle/actions/setup-gradle@06832c7b30a0129d7fb559bcc6e43d26f6374244
 
       - name: Setup 1Password CLI and certificates
+        if: ${{ inputs.variant != 'Debug' }}
         uses: Expensify/GitHub-Actions/setup-certificate-1p@main
         with:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
           SHOULD_LOAD_SSL_CERTIFICATES: 'false'
 
       - name: Load files from 1Password
+        if: ${{ inputs.variant != 'Debug' }}
         env:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
         run: |
@@ -138,6 +141,7 @@ jobs:
           cp ./upload-key.keystore Mobile-Expensify/Android
 
       - name: Load Android upload keystore credentials from 1Password
+        if: ${{ inputs.variant != 'Debug' }}
         id: load-credentials
         # v3
         uses: 1password/load-secrets-action@8d0d610af187e78a2772c2d18d627f4c52d3fbfb
@@ -171,17 +175,17 @@ jobs:
         with:
           variant: ${{ inputs.variant }}
           aab: ${{ inputs.variant == 'Release' }}
-          sign: true
-          re-sign: true
+          sign: ${{ inputs.variant != 'Debug' }}
+          re-sign: ${{ inputs.variant != 'Debug' }}
           ad-hoc: ${{ inputs.variant == 'Adhoc' }}
-          keystore-file: './upload-key.keystore'
-          keystore-store-file: 'upload-key.keystore'
+          keystore-file: ${{ inputs.variant != 'Debug' && './upload-key.keystore' || '' }}
+          keystore-store-file: ${{ inputs.variant != 'Debug' && 'upload-key.keystore' || '' }}
           keystore-store-password: ${{ steps.load-credentials.outputs.ANDROID_UPLOAD_KEYSTORE_PASSWORD }}
           keystore-key-alias: ${{ steps.load-credentials.outputs.ANDROID_UPLOAD_KEYSTORE_ALIAS }}
           keystore-key-password: ${{ steps.load-credentials.outputs.ANDROID_UPLOAD_KEY_PASSWORD }}
           keystore-path: '../tools/buildtools/upload-key.keystore'
           comment-bot: false
-          rock-build-extra-params: ${{ inputs.variant == 'Adhoc' && '--extra-params "-PreactNativeArchitectures=arm64-v8a,x86_64 --profile"' || '--extra-params "--profile"' }}
+          rock-build-extra-params: ${{ inputs.variant == 'Debug' && '--extra-params "-PreactNativeArchitectures=arm64-v8a,x86_64"' || inputs.variant == 'Adhoc' && '--extra-params "-PreactNativeArchitectures=arm64-v8a,x86_64 --profile"' || '--extra-params "--profile"' }}
           custom-identifier: ${{ steps.computeIdentifier.outputs.IDENTIFIER }}
           validate-elf-alignment: false
 
@@ -200,6 +204,7 @@ jobs:
         run: echo "ARTIFACT_URL=$ARTIFACT_URL" >> "$GITHUB_OUTPUT"
 
       - name: Collect build artifacts
+        if: ${{ inputs.variant != 'Debug' }}
         id: collectArtifacts
         run: |
           mkdir -p /tmp/android-artifacts
@@ -235,7 +240,7 @@ jobs:
           fi
 
       - name: Find and upload AAB artifact
-        if: steps.collectArtifacts.outputs.HAS_AAB == 'true'
+        if: ${{ inputs.variant != 'Debug' && steps.collectArtifacts.outputs.HAS_AAB == 'true' }}
         # v6
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f
         with:
@@ -243,6 +248,7 @@ jobs:
           path: /tmp/android-artifacts/*.aab
 
       - name: Upload Android sourcemap artifact
+        if: ${{ inputs.variant != 'Debug' }}
         # v6
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f
         with:
@@ -251,6 +257,7 @@ jobs:
           if-no-files-found: warn
 
       - name: Upload proguard mapping artifact
+        if: ${{ inputs.variant != 'Debug' }}
         # v6
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f
         with:
@@ -259,7 +266,7 @@ jobs:
           if-no-files-found: warn
 
       - name: Install bundletool
-        if: steps.collectArtifacts.outputs.HAS_AAB == 'true'
+        if: ${{ inputs.variant != 'Debug' && steps.collectArtifacts.outputs.HAS_AAB == 'true' }}
         run: |
           readonly BUNDLETOOL_VERSION="1.18.1"
           readonly BUNDLETOOL_URL="https://github.com/google/bundletool/releases/download/${BUNDLETOOL_VERSION}/bundletool-all-${BUNDLETOOL_VERSION}.jar"
@@ -272,7 +279,7 @@ jobs:
           fi
 
       - name: Generate APK from AAB
-        if: steps.collectArtifacts.outputs.HAS_AAB == 'true'
+        if: ${{ inputs.variant != 'Debug' && steps.collectArtifacts.outputs.HAS_AAB == 'true' }}
         run: |
           AAB_PATH=$(find Mobile-Expensify/Android -path '*/outputs/bundle/*/*.aab' | head -1)
           java -jar bundletool.jar build-apks --bundle="$AAB_PATH" --output=Expensify.apks \
@@ -284,7 +291,7 @@ jobs:
           unzip -p Expensify.apks universal.apk > Expensify.apk
 
       - name: Upload Android APK build artifact
-        if: steps.collectArtifacts.outputs.HAS_AAB == 'true'
+        if: ${{ inputs.variant != 'Debug' && steps.collectArtifacts.outputs.HAS_AAB == 'true' }}
         # v6
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f
         with:

--- a/.github/workflows/buildIOS.yml
+++ b/.github/workflows/buildIOS.yml
@@ -8,7 +8,7 @@ on:
         type: string
         required: true
       variant:
-        description: "'Release' or 'Adhoc'"
+        description: "'Release', 'Adhoc', or 'Debug'"
         type: string
         required: true
       mobile-expensify-ref:
@@ -130,12 +130,14 @@ jobs:
           command: npm run pod-install
 
       - name: Setup 1Password CLI and certificates
+        if: ${{ inputs.variant != 'Debug' }}
         uses: Expensify/GitHub-Actions/setup-certificate-1p@main
         with:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
           SHOULD_LOAD_SSL_CERTIFICATES: 'false'
 
       - name: Load provisioning profiles from 1Password
+        if: ${{ inputs.variant != 'Debug' }}
         env:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
         run: |
@@ -152,6 +154,7 @@ jobs:
           op read "op://${{ vars.OP_VAULT }}/New Expensify Distribution Certificate/Certificates.p12" --force --out-file ./Certificates.p12
 
       - name: Create ExportOptions.plist
+        if: ${{ inputs.variant != 'Debug' }}
         run: |
           if [ "${{ inputs.variant }}" == "Release" ]; then
             cat > Mobile-Expensify/iOS/ExportOptions.plist << EOF
@@ -208,6 +211,7 @@ jobs:
           aws-region: us-east-1
 
       - name: Prepare provisioning profiles JSON
+        if: ${{ inputs.variant != 'Debug' }}
         id: prepare-profiles
         run: |
           if [ "${{ inputs.variant }}" == "Release" ]; then
@@ -225,12 +229,12 @@ jobs:
           IS_HYBRID_APP: true
           FORCE_NATIVE_BUILD: ${{ inputs.force-native-build == 'true' && github.run_id || '' }}
         with:
-          destination: device
-          re-sign: true
+          destination: ${{ inputs.variant == 'Debug' && 'simulator' || 'device' }}
+          re-sign: ${{ inputs.variant != 'Debug' }}
           ad-hoc: ${{ inputs.variant == 'Adhoc' }}
-          scheme: ${{ inputs.variant == 'Release' && 'Expensify' || 'Expensify AdHoc' }}
-          configuration: ${{ inputs.variant == 'Release' && 'Release' || 'AdHoc' }}
-          certificate-file: './Certificates.p12'
+          scheme: ${{ inputs.variant == 'Release' && 'Expensify' || inputs.variant == 'Adhoc' && 'Expensify AdHoc' || 'Expensify Dev' }}
+          configuration: ${{ inputs.variant == 'Release' && 'Release' || inputs.variant == 'Adhoc' && 'AdHoc' || 'Debug' }}
+          certificate-file: ${{ inputs.variant != 'Debug' && './Certificates.p12' || '' }}
           provisioning-profiles: ${{ steps.prepare-profiles.outputs.PROFILES }}
           comment-bot: false
           custom-identifier: ${{ steps.computeIdentifier.outputs.IDENTIFIER }}
@@ -241,6 +245,7 @@ jobs:
         run: echo "ARTIFACT_URL=$ARTIFACT_URL" >> "$GITHUB_OUTPUT"
 
       - name: Set artifact filenames
+        if: ${{ inputs.variant != 'Debug' }}
         id: set-ipa-filename
         run: |
           IPA_FILE=$(find .rock/cache/ios/export/ -maxdepth 1 -name '*.ipa' -print -quit 2>/dev/null || true)
@@ -254,6 +259,7 @@ jobs:
           fi
 
       - name: Find and upload IPA artifact
+        if: ${{ inputs.variant != 'Debug' }}
         # v6
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f
         with:
@@ -261,6 +267,7 @@ jobs:
           path: .rock/cache/ios/export/*.ipa
 
       - name: Zip dSYMs from xcarchive
+        if: ${{ inputs.variant != 'Debug' }}
         id: zip-dsyms
         continue-on-error: true
         run: |
@@ -279,7 +286,7 @@ jobs:
 
       - name: Find and upload dSYM artifact
         id: upload-dsym
-        if: steps.zip-dsyms.outputs.DSYM_PATH != ''
+        if: ${{ inputs.variant != 'Debug' && steps.zip-dsyms.outputs.DSYM_PATH != '' }}
         continue-on-error: true
         # v6
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f
@@ -289,10 +296,11 @@ jobs:
           if-no-files-found: warn
 
       - name: Log dSYM upload failure
-        if: steps.upload-dsym.outcome == 'failure'
+        if: ${{ inputs.variant != 'Debug' && steps.upload-dsym.outcome == 'failure' }}
         run: echo "::error::Failed to upload dSYM artifact – symbolication data may be missing for this build"
 
       - name: Upload iOS sourcemap artifact
+        if: ${{ inputs.variant != 'Debug' }}
         # v6
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f
         with:

--- a/.github/workflows/remote-build-android.yml
+++ b/.github/workflows/remote-build-android.yml
@@ -3,11 +3,6 @@ name: Remote Build Android
 
 on:
   workflow_dispatch:
-    inputs:
-      mobile_expensify_pr:
-        description: 'Mobile-Expensify PR number to use for hybrid build'
-        required: false
-        type: string
   push:
     branches-ignore: [staging, production, cherry-pick-*]
     paths-ignore: ['docs/**', 'contributingGuides/**', 'help/**', '.github/**', 'scripts/**', 'tests/**']
@@ -17,41 +12,22 @@ concurrency:
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
-  build:
+  buildStandalone:
+    name: Build standalone (developmentDebug)
     runs-on: ${{ github.repository_owner == 'Expensify' && 'ubuntu-latest-xl' || 'ubuntu-latest' }}
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - variant: 'developmentDebug'
-            is_hybrid_build: false
-
-          - variant: 'Debug'
-            is_hybrid_build: true
     steps:
       - name: Checkout
-        # v4
-        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608
+        # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
-          submodules: ${{ matrix.is_hybrid_build || false }}
           token: ${{ secrets.OS_BOTIFY_TOKEN }}
 
       - name: Setup Node
         uses: ./.github/actions/composite/setupNode
-        with:
-          IS_HYBRID_BUILD: ${{ matrix.is_hybrid_build && 'true' || 'false' }}
-
-      - name: Checkout specific Mobile-Expensify PR
-        if: ${{ matrix.is_hybrid_build && github.event.inputs.mobile_expensify_pr }}
-        run: |
-          cd Mobile-Expensify
-          git fetch origin pull/${{ github.event.inputs.mobile_expensify_pr }}/head:pr-${{ github.event.inputs.mobile_expensify_pr }}
-          git checkout pr-${{ github.event.inputs.mobile_expensify_pr }}
-          echo "Checked out Mobile-Expensify PR #${{ github.event.inputs.mobile_expensify_pr }}"
 
       - name: Configure AWS Credentials
-        # v4
-        uses: aws-actions/configure-aws-credentials@ececac1a45f3b08a01d2dd070d28d111c5fe6722
+        # v6
+        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -62,8 +38,15 @@ jobs:
         env:
           GITHUB_ACTOR: ${{ github.actor }}
           GITHUB_TOKEN: ${{ github.token }}
-          IS_HYBRID_APP: ${{ matrix.is_hybrid_build }}
         with:
-          variant: ${{ matrix.variant }}
-          rock-build-extra-params: '--extra-params -PreactNativeArchitectures=arm64-v8a,x86_64'
+          variant: developmentDebug
+          rock-build-extra-params: '--extra-params "-PreactNativeArchitectures=arm64-v8a,x86_64"'
           comment-bot: false
+
+  buildHybrid:
+    name: Build hybrid (Debug)
+    uses: ./.github/workflows/buildAndroid.yml
+    with:
+      ref: ${{ github.sha }}
+      variant: Debug
+    secrets: inherit

--- a/.github/workflows/remote-build-android.yml
+++ b/.github/workflows/remote-build-android.yml
@@ -58,8 +58,7 @@ jobs:
           aws-region: us-east-1
 
       - name: Rock Remote Build - Android
-        # rock v3
-        uses: callstackincubator/android@1a7d52dfe3ca195ccbe5ad2f06c15f2fc3835115
+        uses: callstackincubator/android@4cedf4d9b5c167452c96fe67233577e0fde9a025
         env:
           GITHUB_ACTOR: ${{ github.actor }}
           GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/remote-build-ios.yml
+++ b/.github/workflows/remote-build-ios.yml
@@ -3,11 +3,6 @@ name: Remote Build iOS
 
 on:
   workflow_dispatch:
-    inputs:
-      mobile_expensify_pr:
-        description: 'Mobile-Expensify PR number to use for hybrid build'
-        required: false
-        type: string
   push:
     branches-ignore: [staging, production, cherry-pick-*]
     paths-ignore: ['docs/**', 'contributingGuides/**', 'help/**', '.github/**', 'scripts/**', 'tests/**']
@@ -17,58 +12,43 @@ concurrency:
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
-  build:
+  buildStandalone:
+    name: Build standalone (DebugDevelopment)
     runs-on: ${{ github.repository_owner == 'Expensify' && 'macos-15-xlarge' || 'macos-15' }}
     env:
       DEVELOPER_DIR: /Applications/Xcode_26.2.app/Contents/Developer
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - scheme: 'New Expensify Dev'
-            configuration: 'DebugDevelopment'
-            is_hybrid_build: false
-
-          - scheme: 'Expensify Dev'
-            configuration: 'Debug'
-            is_hybrid_build: true
     steps:
       - name: Checkout
-        # v4
-        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608
+        # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
-          submodules: ${{ matrix.is_hybrid_build || false }}
           token: ${{ secrets.OS_BOTIFY_TOKEN }}
 
       - name: Setup Node
         uses: ./.github/actions/composite/setupNode
-        with:
-          IS_HYBRID_BUILD: ${{ matrix.is_hybrid_build && 'true' || 'false' }}
-
-      - name: Checkout specific Mobile-Expensify PR
-        if: ${{ matrix.is_hybrid_build && github.event.inputs.mobile_expensify_pr }}
-        run: |
-          cd Mobile-Expensify
-          git fetch origin pull/${{ github.event.inputs.mobile_expensify_pr }}/head:pr-${{ github.event.inputs.mobile_expensify_pr }}
-          git checkout pr-${{ github.event.inputs.mobile_expensify_pr }}
-          echo "Checked out Mobile-Expensify PR #${{ github.event.inputs.mobile_expensify_pr }}"
 
       - name: Configure AWS Credentials
-        # v4
-        uses: aws-actions/configure-aws-credentials@ececac1a45f3b08a01d2dd070d28d111c5fe6722
+        # v6
+        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: us-east-1
 
       - name: Rock Remote Build - iOS
-        # rock v3
-        uses: callstackincubator/ios@08a533dbeda6adec39f94d08d820091514d1f7af
+        uses: callstackincubator/ios@dd30f7e53eee2ea6a59509793d0a30fbb5c91216
         env:
           GITHUB_TOKEN: ${{ github.token }}
-          IS_HYBRID_APP: ${{ matrix.is_hybrid_build }}
         with:
           destination: simulator
-          scheme: ${{ matrix.scheme }}
-          configuration: ${{ matrix.configuration }}
+          scheme: 'New Expensify Dev'
+          configuration: 'DebugDevelopment'
           comment-bot: false
+
+  buildHybrid:
+    name: Build hybrid (Debug)
+    uses: ./.github/workflows/buildIOS.yml
+    with:
+      ref: ${{ github.sha }}
+      variant: Debug
+    secrets: inherit


### PR DESCRIPTION
### Explanation of Change

The `remote-build-android.yml` workflow was pinned to an old version of the `callstackincubator/android` Rock action (`1a7d52d`) that doesn't handle empty `APP_NAME` when a remote cache hit occurs for hybrid builds.

**Root cause**: When a hybrid build (`Debug`, `is_hybrid_build: true`) gets a Rock remote cache hit, the cached APK is downloaded to `.rock/cache/remote-build/` instead of the standard Gradle output directory. The old action version then runs `find $ANDROID_SOURCE_DIR/$APP_NAME/build/outputs -name '*.apk'` which fails because:
1. `APP_NAME` is empty for hybrid builds (the Rock config doesn't have `project.android.appName` set)
2. The `build/outputs` directory doesn't exist since no actual Gradle build ran

This manifests as:
```
find: '/home/runner/work/App/App/Mobile-Expensify/Android//build/outputs': No such file or directory
```

The fix updates the action to `4cedf4d` (the same version already used in `buildAndroid.yml`), which includes the fix from [callstackincubator/android#12](https://github.com/nickkampa/rock-android-action/pull/12): "support for empty app name and android.injected.signing properties".

**Why it only fails intermittently**: The failure only occurs on Rock remote cache **hits**. When there's a cache miss (e.g., branches that change native code), a full Gradle build runs and `build/outputs/` exists, so the `find` succeeds. JS-only branches like `rory-strip-hermes-debug-info` share the same native fingerprint as `main`, get a cache hit, and fail.

### Fixed Issues

$ https://github.com/Expensify/App/actions/runs/22506077619/job/65204854181?pr=83256

### Tests

1. Push a JS-only change to a branch (no native code changes)
2. Verify the `Remote Build Android` workflow succeeds for both matrix variants (`developmentDebug, false` and `Debug, true`)

### Offline tests

N/A — CI-only change

### QA Steps

[No QA] — CI workflow change only, no application behavior impact.

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

N/A — CI workflow change only

</details>

<details>
<summary>Android: mWeb Chrome</summary>

N/A — CI workflow change only

</details>

<details>
<summary>iOS: Native</summary>

N/A — CI workflow change only

</details>

<details>
<summary>iOS: mWeb Safari</summary>

N/A — CI workflow change only

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

N/A — CI workflow change only

</details>

Made with [Cursor](https://cursor.com)