### PR TITLE
[Android] Keep video controls visible while seeking

### DIFF
--- a/src/components/VideoPlayer/BaseVideoPlayer.tsx
+++ b/src/components/VideoPlayer/BaseVideoPlayer.tsx
@@ -6,7 +6,7 @@ import type {RefObject} from 'react';
 import React, {useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState} from 'react';
 import type {GestureResponderEvent} from 'react-native';
 import {View} from 'react-native';
-import {useAnimatedStyle, useSharedValue, withTiming} from 'react-native-reanimated';
+import {cancelAnimation, useAnimatedStyle, useSharedValue, withTiming} from 'react-native-reanimated';
 import {scheduleOnRN} from 'react-native-worklets';
 import AttachmentOfflineIndicator from '@components/AttachmentOfflineIndicator';
 import Hoverable from '@components/Hoverable';
@@ -69,6 +69,8 @@ function BaseVideoPlayer({
     const [isPopoverVisible, setIsPopoverVisible] = useState(false);
     const [popoverAnchorPosition, setPopoverAnchorPosition] = useState({horizontal: 0, vertical: 0});
     const [controlStatusState, setControlStatusState] = useState(controlsStatus);
+    const [isSeeking, setIsSeeking] = useState(false);
+    const isSeekingRef = useRef(false);
     const controlsOpacity = useSharedValue(1);
     const controlsAnimatedStyle = useAnimatedStyle(() => ({
         opacity: controlsOpacity.get(),
@@ -171,13 +173,24 @@ function BaseVideoPlayer({
     }, [isCurrentlyURLSet, isLoading, isEnded, currentTime, duration, playVideo, updateCurrentURLAndReportID, url, reportID, pauseVideo, replayVideo]);
 
     const hideControl = useCallback(() => {
-        if (isEnded) {
+        if (isEnded || isSeekingRef.current) {
             return;
         }
 
-        controlsOpacity.set(withTiming(0, {duration: 500}, () => scheduleOnRN(setControlStatusState, CONST.VIDEO_PLAYER.CONTROLS_STATUS.HIDE)));
+        controlsOpacity.set(
+            withTiming(0, {duration: 500}, (finished) => {
+                if (!finished || isSeekingRef.current) {
+                    return;
+                }
+                scheduleOnRN(setControlStatusState, CONST.VIDEO_PLAYER.CONTROLS_STATUS.HIDE);
+            }),
+        );
     }, [controlsOpacity, isEnded]);
     const debouncedHideControl = useMemo(() => debounce(hideControl, 1500), [hideControl]);
+
+    useEffect(() => {
+        isSeekingRef.current = isSeeking;
+    }, [isSeeking]);
 
     useEffect(() => {
         if (canUseTouchScreen) {
@@ -196,7 +209,7 @@ function BaseVideoPlayer({
         if (controlStatusState !== CONST.VIDEO_PLAYER.CONTROLS_STATUS.SHOW) {
             return;
         }
-        if (!isPlaying || isPopoverVisible) {
+        if (!isPlaying || isPopoverVisible || isSeeking) {
             debouncedHideControl.cancel();
             return;
         }
@@ -520,7 +533,6 @@ function BaseVideoPlayer({
                             {shouldShowLoadingIndicator && <LoadingIndicator style={[styles.opacity1, styles.bgTransparent]} />}
                             {shouldShowOfflineIndicator && <AttachmentOfflineIndicator isPreview={isPreview} />}
                             {controlStatusState !== CONST.VIDEO_PLAYER.CONTROLS_STATUS.HIDE &&
-                                !shouldShowLoadingIndicator &&
                                 !shouldShowOfflineIndicator &&
                                 !shouldShowErrorIndicator &&
                                 (isPopoverVisible || isHovered || canUseTouchScreen || isEnded) && (
@@ -537,6 +549,21 @@ function BaseVideoPlayer({
                                         controlsStatus={controlStatusState}
                                         showPopoverMenu={showPopoverMenu}
                                         reportID={reportID}
+                                        onSeekStart={() => {
+                                            isSeekingRef.current = true;
+                                            debouncedHideControl.cancel();
+                                            cancelAnimation(controlsOpacity);
+                                            controlsOpacity.set(1);
+                                            setIsSeeking(true);
+                                            setControlStatusState(CONST.VIDEO_PLAYER.CONTROLS_STATUS.SHOW);
+                                        }}
+                                        onSeekEnd={() => {
+                                            isSeekingRef.current = false;
+                                            setIsSeeking(false);
+                                            if (controlStatusState === CONST.VIDEO_PLAYER.CONTROLS_STATUS.SHOW && isPlaying && canUseTouchScreen && !isPopoverVisible) {
+                                                debouncedHideControl();
+                                            }
+                                        }}
                                     />
                                 )}
                         </View>

--- a/src/components/VideoPlayer/VideoPlayerControls/ProgressBar/index.tsx
+++ b/src/components/VideoPlayer/VideoPlayerControls/ProgressBar/index.tsx
@@ -16,13 +16,19 @@ type ProgressBarProps = {
 
     /** Function to seek to a specific position in the video. */
     seekPosition: (newPosition: number) => void;
+
+    /** Callback when user starts dragging the slider. */
+    onSeekStart?: () => void;
+
+    /** Callback when user finishes dragging the slider. */
+    onSeekEnd?: () => void;
 };
 
 function getProgress(currentPosition: number, maxPosition: number): number {
     return Math.min(Math.max((currentPosition / maxPosition) * 100, 0), 100);
 }
 
-function ProgressBar({duration, position, seekPosition}: ProgressBarProps) {
+function ProgressBar({duration, position, seekPosition, onSeekStart, onSeekEnd}: ProgressBarProps) {
     const styles = useThemeStyles();
     const {pauseVideo, playVideo, checkIfVideoIsPlaying} = usePlaybackActionsContext();
     const [sliderWidth, setSliderWidth] = useState(1);
@@ -51,6 +57,7 @@ function ProgressBar({duration, position, seekPosition}: ProgressBarProps) {
         .activateAfterLongPress(0)
         .onBegin((event) => {
             setIsSliderPressed(true);
+            onSeekStart?.();
             checkIfVideoIsPlaying(onCheckIfVideoIsPlaying);
             pauseVideo();
             progressBarInteraction(event);
@@ -60,6 +67,7 @@ function ProgressBar({duration, position, seekPosition}: ProgressBarProps) {
         })
         .onFinalize(() => {
             setIsSliderPressed(false);
+            onSeekEnd?.();
             if (!wasVideoPlayingOnCheck.get()) {
                 return;
             }

--- a/src/components/VideoPlayer/VideoPlayerControls/index.tsx
+++ b/src/components/VideoPlayer/VideoPlayerControls/index.tsx
@@ -50,6 +50,12 @@ type VideoPlayerControlsProps = {
     controlsStatus: ValueOf<typeof CONST.VIDEO_PLAYER.CONTROLS_STATUS>;
 
     reportID: string | undefined;
+
+    /** Callback when user starts dragging the progress bar. */
+    onSeekStart?: () => void;
+
+    /** Callback when user finishes dragging the progress bar. */
+    onSeekEnd?: () => void;
 };
 
 function VideoPlayerControls({
@@ -65,6 +71,8 @@ function VideoPlayerControls({
     togglePlayCurrentVideo,
     controlsStatus = CONST.VIDEO_PLAYER.CONTROLS_STATUS.SHOW,
     reportID,
+    onSeekStart,
+    onSeekEnd,
 }: VideoPlayerControlsProps) {
     const icons = useMemoizedLazyExpensifyIcons(['ThreeDots', 'Pause', 'Play', 'Fullscreen']);
     const styles = useThemeStyles();
@@ -150,6 +158,8 @@ function VideoPlayerControls({
                         duration={duration}
                         position={position}
                         seekPosition={seekPosition}
+                        onSeekStart={onSeekStart}
+                        onSeekEnd={onSeekEnd}
                     />
                 </View>
                 {controlsStatus === CONST.VIDEO_PLAYER.CONTROLS_STATUS.VOLUME_ONLY && <VolumeButton style={styles.ml3} />}


### PR DESCRIPTION
### Goal
Fix Android DM video seeking: keep controls visible while dragging the progress bar.

### Problem
On Android, dragging the video progress bar causes the controls to fade out/disappear mid-gesture, preventing seeking.

### Solution
- Track an `isSeeking` state and short-circuit auto-hide while the progress bar is being dragged.
- Cancel any in-flight opacity animation and force controls visible on seek start.
- Resume the debounced auto-hide after seek ends (only when appropriate: playing, touchscreen, popover not visible).

### Testing
- Android: Open a DM with a video attachment, play the video, drag the progress bar forward/backward and confirm the controls remain visible and the seek completes.
- iOS/Web: No behavior change expected.

$ https://github.com/Expensify/App/issues/82026

### PR Author Checklist
- [x] I have read and followed the guidelines in the Contributing document.
- [x] I have performed a self-review of my code.
- [x] I have tested my changes and confirmed they work as expected.

### Screenshots/Videos
N/A
