### PR TITLE
[$250] Add select all functionality to AddUnreportedExpense page

### DIFF
--- a/src/pages/AddUnreportedExpense.tsx
+++ b/src/pages/AddUnreportedExpense.tsx
@@ -218,6 +218,20 @@ function AddUnreportedExpense({route}: AddUnreportedExpensePageType) {
         [errorMessage],
     );
 
+    const onSelectAll = useCallback(() => {
+        setSelectedIds((prevIds) => {
+            const allTransactionIDs = unreportedExpenses.map((item) => item.transactionID);
+            const allSelected = allTransactionIDs.every((id) => prevIds.has(id));
+
+            if (allSelected) {
+                // Deselect all
+                return new Set<string>();
+            }
+            // Select all
+            return new Set(allTransactionIDs);
+        });
+    }, [unreportedExpenses]);
+
     const hasSearchTerm = debouncedSearchValue.trim().length > 0;
     const isShowingEmptyState = !hasSearchTerm && transactions.length === 0;
 
@@ -301,6 +315,8 @@ function AddUnreportedExpense({route}: AddUnreportedExpensePageType) {
                 data={unreportedExpenses}
                 ref={selectionListRef}
                 onSelectRow={onSelectRow}
+                onSelectAll={onSelectAll}
+                shouldShowSelectAllButton
                 textInputOptions={textInputOptions}
                 shouldShowTextInput={shouldShowTextInput}
                 canSelectMultiple


### PR DESCRIPTION
### Details
$ #83741

### Fixed Issues
$ https://github.com/Expensify/App/issues/83741

### Proposed Changes
Added "Select All" functionality to the top of the Add Unreported Expenses page. Users can now:
- Click "Select All" to select all unreported expenses at once
- Click again to deselect all

### Implementation Details
- Added `onSelectAll` callback in `AddUnreportedExpense.tsx`
- Passed `shouldShowSelectAllButton` prop to `SelectionList` component
- Leverages existing `SelectionList` infrastructure for consistent UX

### Testing Steps
1. Create multiple unreported expenses
2. Create a report and navigate to Add expense > Add unreported expenses
3. Verify "Select All" button appears at the top of the list
4. Click "Select All" - all items should be selected
5. Click again - all items should be deselected
6. Individual selection should still work as expected

### Platforms Tested
- [x] Web
- [ ] iOS (pending)
- [ ] Android (pending)

### Screenshots/Videos
Will add after initial review feedback.