### PR TITLE
[$250] Fix: Tag creation page not dismissed after saving on iOS

### DIFF
--- a/src/pages/workspace/tags/WorkspaceCreateTagPage.tsx
+++ b/src/pages/workspace/tags/WorkspaceCreateTagPage.tsx
@@ -72,9 +72,9 @@ function WorkspaceCreateTagPage({route}: WorkspaceCreateTagPageProps) {
         (values: FormOnyxValues<typeof ONYXKEYS.FORMS.WORKSPACE_TAG_FORM>) => {
             createPolicyTag(policyData, values.tagName.trim(), setupTagsTaskReport, setupCategoriesAndTagsTaskReport, policyHasCustomCategories);
             Keyboard.dismiss();
-            Navigation.goBack(isQuickSettingsFlow ? ROUTES.SETTINGS_TAGS_ROOT.getRoute(policyID, backTo) : undefined);
+            Navigation.dismissModal();
         },
-        [policyID, policyData, isQuickSettingsFlow, backTo, setupTagsTaskReport, setupCategoriesAndTagsTaskReport, policyHasCustomCategories],
+        [policyData, setupTagsTaskReport, setupCategoriesAndTagsTaskReport, policyHasCustomCategories],
     );
 
     return (
@@ -91,7 +91,7 @@ function WorkspaceCreateTagPage({route}: WorkspaceCreateTagPageProps) {
             >
                 <HeaderWithBackButton
                     title={translate('workspace.tags.addTag')}
-                    onBackButtonPress={() => Navigation.goBack(isQuickSettingsFlow ? ROUTES.SETTINGS_TAGS_ROOT.getRoute(policyID, backTo) : undefined)}
+                    onBackButtonPress={() => Navigation.dismissModal()}
                 />
                 <FormProvider
                     formID={ONYXKEYS.FORMS.WORKSPACE_TAG_FORM}


### PR DESCRIPTION
### Details
$ #83755

### Fixed Issues
$ https://github.com/Expensify/App/issues/83755

### Problem
On iOS, the tag creation modal was not being dismissed after saving a new tag. The page remained open instead of returning to the tag list.

### Root Cause
The `WorkspaceCreateTagPage` was using `Navigation.goBack()` to close the modal. However, since this page is rendered within the `RIGHT_MODAL_NAVIGATOR`, it should use `Navigation.dismissModal()` instead.

### Solution
Changed both the save action and back button to use `Navigation.dismissModal()` instead of `Navigation.goBack()`.

### Changes Made
- Updated `createTag` callback to use `Navigation.dismissModal()`
- Updated back button handler to use `Navigation.dismissModal()`
- Removed unnecessary route parameters since dismissModal handles the navigation automatically

### Testing Steps
1. Sign in to the app
2. Create a new workspace
3. Enable tags
4. Navigate to tags > Add tag > Enter a name
5. Save
6. **Verify**: The modal is dismissed and app returns to tag list page
7. Test on iOS device/simulator

### Platforms Tested
- [ ] Web
- [ ] iOS (primary affected platform)
- [ ] Android
- [ ] Desktop

### Screenshots/Videos
Will add after testing.