### PR TITLE
Revert "fix: Screen Reader: Workspace: 3-dot More button in Workspace container not focusable or operable"

### DIFF
--- a/src/CONST/index.ts
+++ b/src/CONST/index.ts
@@ -8729,8 +8729,6 @@ const CONST = {
                 NEW_WORKSPACE_BUTTON: 'WorkspaceList-NewWorkspaceButton',
                 NEW_DOMAIN_BUTTON: 'WorkspaceList-NewDomainButton',
                 THREE_DOT_MENU: 'WorkspaceList-ThreeDotMenu',
-                ROW: 'WorkspaceList-Row',
-                ROW_ARROW: 'WorkspaceList-RowArrow',
             },
             INITIAL: {
                 PROFILE: 'WorkspaceInitial-Profile',

--- a/src/pages/workspace/WorkspacesListPage.tsx
+++ b/src/pages/workspace/WorkspacesListPage.tsx
@@ -54,6 +54,7 @@ import {
     getConnectionExporters,
     getPolicyBrickRoadIndicatorStatus,
     getUberConnectionErrorDirectlyFromPolicy,
+    getUserFriendlyWorkspaceType,
     isPendingDeletePolicy,
     isPolicyAdmin,
     isPolicyAuditor,
@@ -430,6 +431,17 @@ function WorkspacesListPage() {
             });
         }
 
+        const ownerDisplayName = personalDetails?.[item.ownerAccountID ?? CONST.DEFAULT_NUMBER_ID]?.displayName ?? '';
+        const workspaceType = item.type ? getUserFriendlyWorkspaceType(item.type, translate) : '';
+        const accessibilityLabel = [
+            `${translate('workspace.common.workspace')}: ${item.title}`,
+            isDefault ? translate('common.default') : '',
+            `${translate('workspace.common.workspaceOwner')}: ${ownerDisplayName}`,
+            `${translate('workspace.common.workspaceType')}: ${workspaceType}`,
+        ]
+            .filter(Boolean)
+            .join(', ');
+
         return (
             <OfflineWithFeedback
                 key={`${item.title}_${index}`}
@@ -442,9 +454,11 @@ function WorkspacesListPage() {
                 shouldHideOnDelete={false}
             >
                 <PressableWithoutFeedback
-                    accessible={false}
+                    role={isLessThanMediumScreen ? CONST.ROLE.BUTTON : CONST.ROLE.ROW}
+                    accessibilityLabel={accessibilityLabel}
                     style={[styles.mh5]}
                     disabled={item.disabled}
+                    onPress={item.action}
                     sentryLabel={CONST.SENTRY_LABEL.WORKSPACE.WORKSPACE_MENU_ITEM}
                 >
                     {({hovered}) => (
@@ -466,8 +480,6 @@ function WorkspacesListPage() {
                             isLoadingBill={isLoadingBill}
                             resetLoadingSpinnerIconIndex={resetLoadingSpinnerIconIndex}
                             isHovered={hovered}
-                            disabled={item.disabled}
-                            onPress={item.action}
                         />
                     )}
                 </PressableWithoutFeedback>

--- a/src/pages/workspace/WorkspacesListRow.tsx
+++ b/src/pages/workspace/WorkspacesListRow.tsx
@@ -9,7 +9,6 @@ import Avatar from '@components/Avatar';
 import Badge from '@components/Badge';
 import Icon from '@components/Icon';
 import type {PopoverMenuItem} from '@components/PopoverMenu';
-import PressableWithoutFeedback from '@components/Pressable/PressableWithoutFeedback';
 import Text from '@components/Text';
 import TextWithTooltip from '@components/TextWithTooltip';
 import ThreeDotsMenu from '@components/ThreeDotsMenu';
@@ -85,12 +84,6 @@ type WorkspacesListRowProps = WithCurrentUserPersonalDetailsProps & {
 
     /** Whether the list item is hovered */
     isHovered?: boolean;
-
-    /** Whether the row press is disabled */
-    disabled?: boolean;
-
-    /** Callback when the row is pressed */
-    onPress?: () => void;
 };
 
 type BrickRoadIndicatorIconProps = {
@@ -129,8 +122,6 @@ function WorkspacesListRow({
     isLoadingBill,
     resetLoadingSpinnerIconIndex,
     isHovered,
-    disabled,
-    onPress,
 }: WorkspacesListRowProps) {
     const styles = useThemeStyles();
     const {translate} = useLocalize();
@@ -186,92 +177,58 @@ function WorkspacesListRow({
 
     const isDeleted = style && Array.isArray(style) ? style.includes(styles.offlineFeedbackDeleted) : false;
 
-    const ownerName = ownerDetails ? getDisplayNameOrDefault(ownerDetails) : '';
-    const workspaceTypeName = workspaceType ? getUserFriendlyWorkspaceType(workspaceType, translate) : '';
-    const accessibilityLabel = [
-        `${translate('workspace.common.workspaceName')}: ${title}`,
-        isDefault ? translate('common.default') : '',
-        isJoinRequestPending ? translate('workspace.common.requested') : '',
-        ownerName ? `${translate('workspace.common.workspaceOwner')}: ${ownerName}` : '',
-        workspaceTypeName ? `${translate('workspace.common.workspaceType')}: ${workspaceTypeName}` : '',
-    ]
-        .filter(Boolean)
-        .join(', ');
-
-    const RequestedBadge = isJoinRequestPending ? (
-        <View style={[styles.flexRow, styles.gap2, styles.alignItemsCenter, styles.justifyContentEnd]}>
-            <Badge
-                text={translate('workspace.common.requested')}
-                textStyles={styles.textStrong}
-                badgeStyles={[styles.alignSelfCenter, styles.badgeBordered]}
-                icon={icons.Hourglass}
-            />
-        </View>
-    ) : null;
-
-    const DefaultBadge = isDefault ? (
-        <Tooltip
-            maxWidth={variables.w184}
-            text={translate('workspace.common.defaultNote')}
-            numberOfLines={4}
-        >
-            <View style={[styles.flexRow, styles.gap2, styles.alignItemsCenter, styles.justifyContentEnd]}>
-                <Badge
-                    text={translate('common.default')}
-                    textStyles={styles.textStrong}
-                    badgeStyles={[styles.alignSelfCenter, styles.badgeBordered, styles.badgeSuccess]}
-                />
-            </View>
-        </Tooltip>
-    ) : null;
-
-    const ThreeDotsSection = !isJoinRequestPending ? (
-        <View style={[styles.flexRow, styles.gap1, !isNarrow && styles.ml2, isNarrow && styles.alignItemsCenter]}>
-            <View style={[styles.flexRow, styles.gap2, styles.alignItemsCenter, isNarrow && styles.workspaceListRBR]}>
-                <BrickRoadIndicatorIcon brickRoadIndicator={brickRoadIndicator} />
-            </View>
-            <ThreeDotsMenu
-                isContainerFocused={isFocused}
-                shouldSelfPosition
-                menuItems={menuItems}
-                anchorAlignment={{horizontal: CONST.MODAL.ANCHOR_ORIGIN_HORIZONTAL.RIGHT, vertical: CONST.MODAL.ANCHOR_ORIGIN_VERTICAL.TOP}}
-                shouldOverlay
-                disabled={shouldDisableThreeDotsMenu}
-                isNested
-                threeDotsMenuRef={threeDotsMenuRef}
-                sentryLabel={CONST.SENTRY_LABEL.WORKSPACE.LIST.THREE_DOT_MENU}
-            />
-        </View>
-    ) : null;
-
-    const NarrowBadges =
-        isJoinRequestPending || isDefault ? (
-            <View style={[styles.flexRow, styles.gap1, styles.alignItemsCenter]}>
-                {RequestedBadge}
-                {DefaultBadge}
-            </View>
-        ) : null;
-
     const ThreeDotMenuOrPendingIcon = (
         <View style={[styles.flexRow, !shouldUseNarrowLayout && styles.workspaceThreeDotMenu]}>
-            {RequestedBadge}
-            {DefaultBadge}
-            {ThreeDotsSection}
+            {!!isJoinRequestPending && (
+                <View style={[styles.flexRow, styles.gap2, styles.alignItemsCenter, styles.justifyContentEnd]}>
+                    <Badge
+                        text={translate('workspace.common.requested')}
+                        textStyles={styles.textStrong}
+                        badgeStyles={[styles.alignSelfCenter, styles.badgeBordered]}
+                        icon={icons.Hourglass}
+                    />
+                </View>
+            )}
+            {!!isDefault && (
+                <Tooltip
+                    maxWidth={variables.w184}
+                    text={translate('workspace.common.defaultNote')}
+                    numberOfLines={4}
+                >
+                    <View style={[styles.flexRow, styles.gap2, styles.alignItemsCenter, styles.justifyContentEnd]}>
+                        <Badge
+                            text={translate('common.default')}
+                            textStyles={styles.textStrong}
+                            badgeStyles={[styles.alignSelfCenter, styles.badgeBordered, styles.badgeSuccess]}
+                        />
+                    </View>
+                </Tooltip>
+            )}
+            {!isJoinRequestPending && (
+                <View style={[styles.flexRow, styles.ml2, styles.gap1]}>
+                    <View style={[styles.flexRow, styles.gap2, styles.alignItemsCenter, isNarrow && styles.workspaceListRBR]}>
+                        <BrickRoadIndicatorIcon brickRoadIndicator={brickRoadIndicator} />
+                    </View>
+                    <ThreeDotsMenu
+                        isContainerFocused={isFocused}
+                        shouldSelfPosition
+                        menuItems={menuItems}
+                        anchorAlignment={{horizontal: CONST.MODAL.ANCHOR_ORIGIN_HORIZONTAL.RIGHT, vertical: CONST.MODAL.ANCHOR_ORIGIN_VERTICAL.TOP}}
+                        shouldOverlay
+                        disabled={shouldDisableThreeDotsMenu}
+                        isNested
+                        threeDotsMenuRef={threeDotsMenuRef}
+                        sentryLabel={CONST.SENTRY_LABEL.WORKSPACE.LIST.THREE_DOT_MENU}
+                    />
+                </View>
+            )}
         </View>
     );
 
     return (
         <View style={[styles.flexRow, styles.highlightBG, rowStyles, style, styles.br3]}>
             <Animated.View style={[styles.flex1, styles.flexRow, styles.bgTransparent, isWide && styles.gap5, styles.p5, styles.pr3, animatedHighlightStyle]}>
-                <PressableWithoutFeedback
-                    accessible
-                    accessibilityLabel={accessibilityLabel}
-                    role={isWide ? CONST.ROLE.ROW : CONST.ROLE.BUTTON}
-                    onPress={onPress}
-                    disabled={disabled}
-                    style={[isWide ? styles.flexRow : styles.flexColumn, styles.flex1, isWide && styles.gap5]}
-                    sentryLabel={CONST.SENTRY_LABEL.WORKSPACE.LIST.ROW}
-                >
+                <View style={[isWide ? styles.flexRow : styles.flexColumn, styles.flex1, isWide && styles.gap5]}>
                     <View
                         role={isWide ? CONST.ROLE.CELL : undefined}
                         style={[styles.flexRow, styles.justifyContentBetween, styles.flex2, isNarrow && styles.mb3, styles.alignItemsCenter]}
@@ -292,7 +249,7 @@ function WorkspacesListRow({
                                 style={[styles.flex1, styles.flexGrow1, styles.textStrong, isDeleted ? styles.offlineFeedbackDeleted : {}]}
                             />
                         </View>
-                        {isNarrow && NarrowBadges}
+                        {isNarrow && ThreeDotMenuOrPendingIcon}
                     </View>
                     <View
                         role={isWide ? CONST.ROLE.CELL : undefined}
@@ -349,22 +306,15 @@ function WorkspacesListRow({
                             </Text>
                         </View>
                     </View>
-                </PressableWithoutFeedback>
+                </View>
 
                 <View
                     role={isWide ? CONST.ROLE.CELL : undefined}
-                    style={[styles.flexRow, styles.alignItemsCenter, isNarrow && styles.alignSelfStart]}
+                    style={[styles.flexRow, styles.alignItemsCenter]}
                 >
-                    {isNarrow && ThreeDotsSection}
                     {!isNarrow && ThreeDotMenuOrPendingIcon}
                     {!isNarrow && (
-                        <PressableWithoutFeedback
-                            onPress={onPress}
-                            disabled={disabled}
-                            accessible={false}
-                            sentryLabel={CONST.SENTRY_LABEL.WORKSPACE.LIST.ROW_ARROW}
-                            style={[styles.justifyContentCenter, styles.alignItemsCenter, styles.touchableButtonImage]}
-                        >
+                        <View style={[styles.justifyContentCenter, styles.alignItemsCenter, styles.touchableButtonImage]}>
                             <Icon
                                 src={icons.ArrowRight}
                                 fill={theme.icon}
@@ -372,7 +322,7 @@ function WorkspacesListRow({
                                 isButtonIcon
                                 medium
                             />
-                        </PressableWithoutFeedback>
+                        </View>
                     )}
                 </View>
             </Animated.View>


### PR DESCRIPTION
https://expensify.slack.com/archives/C01GTK53T8Q/p1772497533864769?thread_ts=1772496949.298269&cid=C01GTK53T8Q

Reverts Expensify/App#83324

$ https://github.com/Expensify/App/issues/83965


### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>
