### PR TITLE
Fix QBD linked credit card displayed incorrectly

### DIFF
--- a/src/pages/workspace/companyCards/WorkspaceCompanyCardAccountSelectCardPage.tsx
+++ b/src/pages/workspace/companyCards/WorkspaceCompanyCardAccountSelectCardPage.tsx
@@ -56,7 +56,7 @@ function WorkspaceCompanyCardAccountSelectCardPage({route}: WorkspaceCompanyCard
     const companyFeeds = getCompanyFeeds(cardFeeds);
     const domainOrWorkspaceAccountID = getDomainOrWorkspaceAccountID(workspaceAccountID, companyFeeds[feed]);
 
-    const searchedListOptions = tokenizedSearch(exportMenuItem?.data ?? [], searchText, (option) => [option.value]);
+    const searchedListOptions = tokenizedSearch(exportMenuItem?.data ?? [], searchText, (option) => [option.text ?? option.value]);
 
     const listEmptyContent = (
         <BlockingView

--- a/src/pages/workspace/companyCards/utils.tsx
+++ b/src/pages/workspace/companyCards/utils.tsx
@@ -321,7 +321,9 @@ function getExportMenuItem(
                 case CONST.QUICKBOOKS_DESKTOP_REIMBURSABLE_ACCOUNT_TYPE.VENDOR_BILL:
                 case CONST.QUICKBOOKS_DESKTOP_NON_REIMBURSABLE_EXPORT_ACCOUNT_TYPE.CREDIT_CARD: {
                     data = creditCardAccounts ?? [];
-                    selectedAccount = (creditCardAccounts ?? []).find((account) => account.id === (companyCard?.nameValuePairs?.quickbooks_desktop_export_account_credit ?? defaultAccount));
+                    selectedAccount =
+                        (creditCardAccounts ?? []).find((account) => account.id === companyCard?.nameValuePairs?.quickbooks_desktop_export_account_credit) ??
+                        (creditCardAccounts ?? []).find((account) => account.name === companyCard?.nameValuePairs?.quickbooks_desktop_export_account_credit);
                     isDefaultTitle = !!(
                         companyCard?.nameValuePairs?.quickbooks_desktop_export_account_credit === CONST.COMPANY_CARDS.DEFAULT_EXPORT_TYPE ||
                         (defaultAccount && !companyCard?.nameValuePairs?.quickbooks_desktop_export_account_credit)

--- a/src/pages/workspace/companyCards/utils.tsx
+++ b/src/pages/workspace/companyCards/utils.tsx
@@ -310,7 +310,7 @@ function getExportMenuItem(
                 nonReimbursableExpenses !== CONST.QUICKBOOKS_DESKTOP_NON_REIMBURSABLE_EXPORT_ACCOUNT_TYPE.CHECK &&
                 nonReimbursableExpenses !== CONST.QUICKBOOKS_DESKTOP_NON_REIMBURSABLE_EXPORT_ACCOUNT_TYPE.VENDOR_BILL;
             let title: string | undefined = '';
-            let selectedAccount: string | undefined = '';
+            let selectedAccount: Account | undefined;
             const defaultAccount = exportQBD?.nonReimbursableAccount ?? exportQBD?.reimbursableAccount;
             let isDefaultTitle = false;
             let exportType: ValueOf<typeof CONST.COMPANY_CARDS.EXPORT_CARD_TYPES> | undefined;
@@ -321,12 +321,14 @@ function getExportMenuItem(
                 case CONST.QUICKBOOKS_DESKTOP_REIMBURSABLE_ACCOUNT_TYPE.VENDOR_BILL:
                 case CONST.QUICKBOOKS_DESKTOP_NON_REIMBURSABLE_EXPORT_ACCOUNT_TYPE.CREDIT_CARD: {
                     data = creditCardAccounts ?? [];
+                    selectedAccount = (creditCardAccounts ?? []).find(
+                        (account) => account.id === (companyCard?.nameValuePairs?.quickbooks_desktop_export_account_credit ?? defaultAccount)
+                    );
                     isDefaultTitle = !!(
                         companyCard?.nameValuePairs?.quickbooks_desktop_export_account_credit === CONST.COMPANY_CARDS.DEFAULT_EXPORT_TYPE ||
                         (defaultAccount && !companyCard?.nameValuePairs?.quickbooks_desktop_export_account_credit)
                     );
-                    title = isDefaultTitle ? defaultCard : companyCard?.nameValuePairs?.quickbooks_desktop_export_account_credit;
-                    selectedAccount = companyCard?.nameValuePairs?.quickbooks_desktop_export_account_credit ?? defaultAccount;
+                    title = isDefaultTitle ? defaultCard : selectedAccount?.name;
                     exportType = CONST.COMPANY_CARDS.EXPORT_CARD_TYPES.NVP_QUICKBOOKS_DESKTOP_EXPORT_ACCOUNT_CREDIT;
                     break;
                 }
@@ -344,10 +346,10 @@ function getExportMenuItem(
                 shouldShowMenuItem,
                 exportPageLink: ROUTES.POLICY_ACCOUNTING_QUICKBOOKS_DESKTOP_EXPORT.getRoute(policyID, backTo),
                 data: resultData.map((card) => ({
-                    value: card.name,
+                    value: card.id,
                     text: card.name,
                     keyForList: card.name,
-                    isSelected: isDefaultTitle ? card.name === defaultCard : card.name === selectedAccount,
+                    isSelected: isDefaultTitle ? card.name === defaultCard : card.id === selectedAccount?.id,
                 })),
             };
         }

--- a/src/pages/workspace/companyCards/utils.tsx
+++ b/src/pages/workspace/companyCards/utils.tsx
@@ -321,9 +321,7 @@ function getExportMenuItem(
                 case CONST.QUICKBOOKS_DESKTOP_REIMBURSABLE_ACCOUNT_TYPE.VENDOR_BILL:
                 case CONST.QUICKBOOKS_DESKTOP_NON_REIMBURSABLE_EXPORT_ACCOUNT_TYPE.CREDIT_CARD: {
                     data = creditCardAccounts ?? [];
-                    selectedAccount = (creditCardAccounts ?? []).find(
-                        (account) => account.id === (companyCard?.nameValuePairs?.quickbooks_desktop_export_account_credit ?? defaultAccount)
-                    );
+                    selectedAccount = (creditCardAccounts ?? []).find((account) => account.id === (companyCard?.nameValuePairs?.quickbooks_desktop_export_account_credit ?? defaultAccount));
                     isDefaultTitle = !!(
                         companyCard?.nameValuePairs?.quickbooks_desktop_export_account_credit === CONST.COMPANY_CARDS.DEFAULT_EXPORT_TYPE ||
                         (defaultAccount && !companyCard?.nameValuePairs?.quickbooks_desktop_export_account_credit)

--- a/tests/unit/CompanyCardExportTest.ts
+++ b/tests/unit/CompanyCardExportTest.ts
@@ -128,10 +128,10 @@ describe('getExportMenuItem - QBD credit card account resolution', () => {
 
         expect(result).toBeDefined();
 
-        const nonDefaultOptions = result?.data?.filter((item) => item.value !== translateLocal('workspace.moreFeatures.companyCards.defaultCard'));
-        nonDefaultOptions?.forEach((option) => {
+        const nonDefaultOptions = result?.data?.filter((item) => item.value !== translateLocal('workspace.moreFeatures.companyCards.defaultCard')) ?? [];
+        for (const option of nonDefaultOptions) {
             const matchingAccount = QBD_CREDIT_CARD_ACCOUNTS.find((account) => account.id === option.value);
             expect(matchingAccount).toBeDefined();
-        });
+        }
     });
 });

--- a/tests/unit/CompanyCardExportTest.ts
+++ b/tests/unit/CompanyCardExportTest.ts
@@ -1,0 +1,137 @@
+import type {LocaleContextProps} from '@components/LocaleContextProvider';
+import CONST from '@src/CONST';
+import type {Card, Policy} from '@src/types/onyx';
+import {getExportMenuItem} from '../../src/pages/workspace/companyCards/utils';
+import {translateLocal} from '../utils/TestHelper';
+
+const MOCK_POLICY_ID = 'ABC123';
+
+const QBD_CREDIT_CARD_ACCOUNTS = [
+    {id: '80000103-1746639410', name: 'American Express (91000)', currency: 'USD'},
+    {id: '80000104-1746639411', name: 'Visa Business (92000)', currency: 'USD'},
+];
+
+function createQBDPolicy(overrides?: Partial<Policy>): Policy {
+    return {
+        id: MOCK_POLICY_ID,
+        name: 'Test Policy',
+        type: CONST.POLICY.TYPE.TEAM,
+        role: CONST.POLICY.ROLE.ADMIN,
+        owner: 'test@qbdcc.com',
+        ownerAccountID: 1,
+        isPolicyExpenseChatEnabled: false,
+        outputCurrency: 'USD',
+        connections: {
+            quickbooksDesktop: {
+                config: {
+                    export: {
+                        nonReimbursable: CONST.QUICKBOOKS_DESKTOP_NON_REIMBURSABLE_EXPORT_ACCOUNT_TYPE.CREDIT_CARD,
+                        nonReimbursableAccount: '80000103-1746639410',
+                        reimbursable: CONST.QUICKBOOKS_DESKTOP_REIMBURSABLE_ACCOUNT_TYPE.CHECK,
+                        reimbursableAccount: '',
+                        exportDate: CONST.QUICKBOOKS_EXPORT_DATE.LAST_EXPENSE,
+                        nonReimbursableBillDefaultVendor: '',
+                        accountingMethod: 'accrual',
+                    },
+                },
+                data: {
+                    creditCardAccounts: QBD_CREDIT_CARD_ACCOUNTS,
+                },
+            },
+        },
+        ...overrides,
+    } as Policy;
+}
+
+function createCard(nvpExportAccount?: string): Card {
+    const nameValuePairs: Record<string, string> = {};
+    if (nvpExportAccount !== undefined) {
+        nameValuePairs.quickbooks_desktop_export_account_credit = nvpExportAccount;
+    }
+
+    return {
+        cardID: 1001,
+        state: CONST.EXPENSIFY_CARD.STATE.OPEN,
+        bank: CONST.COMPANY_CARD.FEED_BANK_NAME.VISA,
+        domainName: 'test.exfy',
+        fraud: 'none',
+        lastUpdated: '',
+        nameValuePairs,
+    } as unknown as Card;
+}
+
+describe('getExportMenuItem - QBD credit card account resolution', () => {
+    const translate = translateLocal as unknown as LocaleContextProps['translate'];
+
+    it('resolves account by ID when NVP contains a QBD ListID (Classic-saved)', () => {
+        const policy = createQBDPolicy();
+        const card = createCard('80000103-1746639410');
+
+        const result = getExportMenuItem(CONST.POLICY.CONNECTIONS.NAME.QBD, MOCK_POLICY_ID, translate, policy, card);
+
+        expect(result).toBeDefined();
+        expect(result?.title).toBe('American Express (91000)');
+
+        const selectedOption = result?.data?.find((item) => item.isSelected);
+        expect(selectedOption).toBeDefined();
+        expect(selectedOption?.value).toBe('80000103-1746639410');
+        expect(selectedOption?.text).toBe('American Express (91000)');
+    });
+
+    it('resolves account by name fallback when NVP contains a display name (pre-fix NewDot-saved)', () => {
+        const policy = createQBDPolicy();
+        const card = createCard('American Express (91000)');
+
+        const result = getExportMenuItem(CONST.POLICY.CONNECTIONS.NAME.QBD, MOCK_POLICY_ID, translate, policy, card);
+
+        expect(result).toBeDefined();
+        expect(result?.title).toBe('American Express (91000)');
+
+        const selectedOption = result?.data?.find((item) => item.isSelected);
+        expect(selectedOption).toBeDefined();
+        expect(selectedOption?.text).toBe('American Express (91000)');
+    });
+
+    it('selects default when NVP is not set', () => {
+        const policy = createQBDPolicy();
+        const card = createCard();
+
+        const result = getExportMenuItem(CONST.POLICY.CONNECTIONS.NAME.QBD, MOCK_POLICY_ID, translate, policy, card);
+
+        expect(result).toBeDefined();
+
+        const defaultCard = translateLocal('workspace.moreFeatures.companyCards.defaultCard');
+        expect(result?.title).toBe(defaultCard);
+
+        const selectedOption = result?.data?.find((item) => item.isSelected);
+        expect(selectedOption).toBeDefined();
+        expect(selectedOption?.text).toBe(defaultCard);
+    });
+
+    it('selects default when NVP is set to DEFAULT_EXPORT_TYPE', () => {
+        const policy = createQBDPolicy();
+        const card = createCard(CONST.COMPANY_CARDS.DEFAULT_EXPORT_TYPE);
+
+        const result = getExportMenuItem(CONST.POLICY.CONNECTIONS.NAME.QBD, MOCK_POLICY_ID, translate, policy, card);
+
+        expect(result).toBeDefined();
+
+        const defaultCard = translateLocal('workspace.moreFeatures.companyCards.defaultCard');
+        expect(result?.title).toBe(defaultCard);
+    });
+
+    it('uses card.id (not card.name) as the option value for all items', () => {
+        const policy = createQBDPolicy();
+        const card = createCard('80000103-1746639410');
+
+        const result = getExportMenuItem(CONST.POLICY.CONNECTIONS.NAME.QBD, MOCK_POLICY_ID, translate, policy, card);
+
+        expect(result).toBeDefined();
+
+        const nonDefaultOptions = result?.data?.filter((item) => item.value !== translateLocal('workspace.moreFeatures.companyCards.defaultCard'));
+        nonDefaultOptions?.forEach((option) => {
+            const matchingAccount = QBD_CREDIT_CARD_ACCOUNTS.find((account) => account.id === option.value);
+            expect(matchingAccount).toBeDefined();
+        });
+    });
+});


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
<!-- Explain what your change does and how it addresses the linked issue -->

1. `utils.tsx` (QBD case): Changed value from card.name to card.id so the correct QBD ListID gets saved to the NVP (matching Classic behavior). Added a fallback lookup -- first by account.id, then by account.name -- to handle NVPs written by either Classic or pre-fix NewDot.
2. `WorkspaceCompanyCardAccountSelectCardPage.tsx`: Updated the search to use option.text (display name) instead of option.value (now an ID), so users can still search accounts by name.

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/81035
PROPOSAL:


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

Tested by running isSelected logic on customer's account

<img width="563" height="213" alt="Screenshot 2026-03-03 at 3 01 48 PM" src="https://github.com/user-attachments/assets/1b6d6e4c-ccec-4c90-83cb-66ae8232f5e1" />

And ensuring, name resolves properly 

- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->

1. Test this QBD suite for regression https://test-management.browserstack.com/projects/2219752/folder/13176907/test-cases
2. Ping me, so I can supportal and check for broken account

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>