### PR TITLE
fix: prevent split expense amount overflow when description is long

### DIFF
--- a/src/components/ReportActionItem/TransactionPreview/TransactionPreviewContent.tsx
+++ b/src/components/ReportActionItem/TransactionPreview/TransactionPreviewContent.tsx
@@ -321,13 +321,15 @@ function TransactionPreviewContent({
                                                 ]}
                                             >
                                                 {shouldShowMerchantOrDescription && (
-                                                    <Text
-                                                        fontSize={variables.fontSizeNormal}
-                                                        style={[isDeleted && styles.lineThrough, styles.flexShrink1, styles.preWrap]}
-                                                        numberOfLines={2}
-                                                    >
-                                                        {merchantOrDescription}
-                                                    </Text>
+                                                    <View style={[styles.flex1, styles.mnw0]}>
+                                                        <Text
+                                                            fontSize={variables.fontSizeNormal}
+                                                            style={[isDeleted && styles.lineThrough, styles.flexShrink1, styles.preWrap]}
+                                                            numberOfLines={2}
+                                                        >
+                                                            {merchantOrDescription}
+                                                        </Text>
+                                                    </View>
                                                 )}
                                                 {!shouldWrapDisplayAmount && (
                                                     <Text


### PR DESCRIPTION
### Explanation of Change

When a split expense has a long description (especially one containing long unbreakable strings like emails), the amount text overflows outside the preview card boundary.

**Root cause:** In the flex row that contains both the merchant/description `Text` and the amount `Text`, the description `Text` has `flexShrink1` and `preWrap` styles with `numberOfLines={2}`. In React Native, a flex item's minimum intrinsic size is determined by its longest unbreakable word. Without `minWidth: 0` on the container, `flexShrink` cannot shrink the item below that intrinsic size, causing the sibling amount text to be pushed outside the card.

**Fix:** Wrap the merchant/description `Text` in a `View` with `flex1` and `mnw0` (minWidth: 0). This is the standard React Native pattern to allow a flex item to shrink below its intrinsic content size, keeping the amount text within the preview boundary.

### Fixed Issues
$ https://github.com/Expensify/App/issues/83987

### Tests

1. Go to staging.new.expensify.com
2. Open 1:1 DM with any user
3. Click + > Split expense > Manual
4. Enter amount > Next
5. On confirm page, click Description
6. Enter a long multi-line description (e.g. two lines of `sjodinjsojnsoidsjnionji@gmail.com`) and save
7. Click Split

**Expected:** Amount stays inside the split preview card.
**Before fix:** Amount was pushed outside the preview boundary.
**After fix:** Amount stays inside the preview; description shows up to 2 lines and is properly truncated.

### Platforms
- [x] MacOS: Chrome / Safari

### Screenshots

**Before:**
Amount overflows the preview card when description is long.

**After:**
Amount stays inside the preview card; description is contained within its flex area.