### PR TITLE
[Home Page] Filter cancelled travel reservations from trip data

### DIFF
--- a/src/CONST/index.ts
+++ b/src/CONST/index.ts
@@ -6994,6 +6994,15 @@ const CONST = {
         TRAIN: 'train',
     },
 
+    PNR_STATUS: {
+        CANCELLED: 'CANCELLED',
+        VOIDED: 'VOIDED',
+    },
+
+    LEG_STATUS: {
+        CANCELLED: 'CANCELLED_STATUS',
+    },
+
     UPCOMING_TRAVEL_WINDOW_DAYS: 7,
 
     RESERVATION_ADDRESS_TEST_ID: 'ReservationAddress',

--- a/src/libs/TripReservationUtils.ts
+++ b/src/libs/TripReservationUtils.ts
@@ -157,7 +157,12 @@ function getAirReservations(pnr: Pnr, travelers: PnrTraveler[]): Array<{reservat
             for (const [index, flightDetails] of flightCoupons.sort((a, b) => a.legIdx - b.legIdx).entries()) {
                 const legIdx = flightDetails.legIdx;
                 const flightIdx = flightDetails.flightIdx;
-                const flightObject = pnrData.legs?.at(legIdx)?.flights.at(flightIdx);
+                const leg = pnrData.legs?.at(legIdx);
+                const flightObject = leg?.flights.at(flightIdx);
+
+                if (leg?.legStatus === CONST.LEG_STATUS.CANCELLED || isCancelledPnrStatus(flightObject?.flightStatus ?? '')) {
+                    continue;
+                }
 
                 const airlineCode = flightObject?.marketing.airlineCode;
                 const longAirlineName = airlineInfo.find((info) => info.airlineCode === airlineCode)?.airlineName ?? airlineCode;
@@ -394,12 +399,37 @@ function getRailReservations(pnr: Pnr, travelers: PnrTraveler[]): Array<{reserva
     return reservationList;
 }
 
+function isCancelledPnrStatus(status: string): boolean {
+    return status === CONST.PNR_STATUS.CANCELLED || status === CONST.PNR_STATUS.VOIDED;
+}
+
+function isPnrCancelled(pnr: Pnr): boolean {
+    const {data} = pnr;
+
+    if (data.hotelPnr) {
+        return isCancelledPnrStatus(data.hotelPnr.pnrStatus);
+    }
+    if (data.carPnr) {
+        return isCancelledPnrStatus(data.carPnr.pnrStatus);
+    }
+    if (data.airPnr) {
+        return data.airPnr.legs.length > 0 && data.airPnr.legs.every((leg) => leg.legStatus === CONST.LEG_STATUS.CANCELLED);
+    }
+    if (data.railPnr) {
+        const {outwardJourney, inwardJourney} = data.railPnr;
+        return isCancelledPnrStatus(outwardJourney.journeyStatus) && isCancelledPnrStatus(inwardJourney.journeyStatus);
+    }
+
+    return false;
+}
+
 function getReservationsFromSpotnanaPayload(reportID: string, tripData?: TripData): ReservationData[] {
     if (!tripData?.pnrs) {
         return [];
     }
 
     const reservations: ReservationData[] = tripData.pnrs
+        .filter((pnr) => !isPnrCancelled(pnr))
         .flatMap((pnr) => {
             const travelers = pnr.data.pnrTravelers ?? [];
 
@@ -517,5 +547,6 @@ export {
     formatAirportInfo,
     getPNRReservationDataFromTripReport,
     getAirReservations,
+    isPnrCancelled,
 };
 export type {ReservationData};

--- a/src/libs/TripReservationUtils.ts
+++ b/src/libs/TripReservationUtils.ts
@@ -406,6 +406,10 @@ function isCancelledPnrStatus(status: string): boolean {
 function isPnrCancelled(pnr: Pnr): boolean {
     const {data} = pnr;
 
+    if (data.bookingStatus && isCancelledPnrStatus(data.bookingStatus)) {
+        return true;
+    }
+
     if (data.hotelPnr) {
         return isCancelledPnrStatus(data.hotelPnr.pnrStatus);
     }

--- a/src/types/onyx/TripData.ts
+++ b/src/types/onyx/TripData.ts
@@ -231,6 +231,9 @@ type PnrData = {
     /** Reason for suspending the booking. */
     suspendReason: string;
 
+    /** Overall booking status of the PNR. */
+    bookingStatus?: string;
+
     /**
      * Fare Amount details for the PNR.
      */

--- a/tests/unit/TripReservationUtilsTest.ts
+++ b/tests/unit/TripReservationUtilsTest.ts
@@ -1,5 +1,5 @@
 /* cspell:disable */
-import {getAirReservations, getPNRReservationDataFromTripReport, getReservationsFromTripReport} from '@libs/TripReservationUtils';
+import {getAirReservations, getPNRReservationDataFromTripReport, getReservationsFromTripReport, isPnrCancelled} from '@libs/TripReservationUtils';
 import CONST from '@src/CONST';
 import type {Pnr, TripData} from '@src/types/onyx/TripData';
 import {airReservationPnrData, airReservationTravelers} from '../data/TripAirReservationData';
@@ -2266,6 +2266,19 @@ const tripWithAllReservations: TripData = {
     pnrs: [airPnrDirect, airPnrConnecting, railPnr, carPnr, hotelPnr],
 };
 
+function asDefined<T>(value: T | undefined | null): T {
+    if (value == null) {
+        throw new Error('Expected value to be defined');
+    }
+    return value;
+}
+
+const directAirPnrData = asDefined(airPnrDirect.data.airPnr);
+const connectingAirPnrData = asDefined(airPnrConnecting.data.airPnr);
+const hotelPnrData = asDefined(hotelPnr.data.hotelPnr);
+const carPnrData = asDefined(carPnr.data.carPnr);
+const railPnrData = asDefined(railPnr.data.railPnr);
+
 describe('TripReservationUtils', () => {
     describe('getAirReservations', () => {
         it('should return air reservations in the correct order', () => {
@@ -2296,6 +2309,141 @@ describe('TripReservationUtils', () => {
             expect(seatNumber).not.toContain('{');
             expect(seatNumber).not.toContain('amount');
             expect(seatNumber).not.toContain('legIdx');
+        });
+
+        it('should skip flights with cancelled leg status (CANCELLED_STATUS)', () => {
+            const firstLeg = asDefined(directAirPnrData.legs.at(0));
+            const cancelledLegPnr: Pnr = {
+                ...airPnrDirect,
+                data: {
+                    ...airPnrDirect.data,
+                    airPnr: {
+                        ...directAirPnrData,
+                        legs: [
+                            {
+                                ...firstLeg,
+                                legStatus: CONST.LEG_STATUS.CANCELLED,
+                            },
+                        ],
+                    },
+                },
+            };
+            const result = getAirReservations(cancelledLegPnr, cancelledLegPnr.data.pnrTravelers);
+            expect(result).toHaveLength(0);
+        });
+
+        it('should skip flights with CANCELLED flight status', () => {
+            const firstLeg = asDefined(directAirPnrData.legs.at(0));
+            const firstFlight = asDefined(firstLeg.flights.at(0));
+            const cancelledFlightPnr: Pnr = {
+                ...airPnrDirect,
+                data: {
+                    ...airPnrDirect.data,
+                    airPnr: {
+                        ...directAirPnrData,
+                        legs: [
+                            {
+                                ...firstLeg,
+                                flights: [
+                                    {
+                                        ...firstFlight,
+                                        flightStatus: CONST.PNR_STATUS.CANCELLED,
+                                    },
+                                ],
+                            },
+                        ],
+                    },
+                },
+            };
+            const result = getAirReservations(cancelledFlightPnr, cancelledFlightPnr.data.pnrTravelers);
+            expect(result).toHaveLength(0);
+        });
+
+        it('should skip flights with VOIDED flight status', () => {
+            const firstLeg = asDefined(directAirPnrData.legs.at(0));
+            const firstFlight = asDefined(firstLeg.flights.at(0));
+            const voidedFlightPnr: Pnr = {
+                ...airPnrDirect,
+                data: {
+                    ...airPnrDirect.data,
+                    airPnr: {
+                        ...directAirPnrData,
+                        legs: [
+                            {
+                                ...firstLeg,
+                                flights: [
+                                    {
+                                        ...firstFlight,
+                                        flightStatus: CONST.PNR_STATUS.VOIDED,
+                                    },
+                                ],
+                            },
+                        ],
+                    },
+                },
+            };
+            const result = getAirReservations(voidedFlightPnr, voidedFlightPnr.data.pnrTravelers);
+            expect(result).toHaveLength(0);
+        });
+
+        it('should still return non-cancelled flights when only some legs are cancelled', () => {
+            const firstLeg = asDefined(connectingAirPnrData.legs.at(0));
+            const secondLeg = connectingAirPnrData.legs.at(1);
+            const partiallyCancelledPnr: Pnr = {
+                ...airPnrConnecting,
+                data: {
+                    ...airPnrConnecting.data,
+                    airPnr: {
+                        ...connectingAirPnrData,
+                        legs: [
+                            {
+                                ...firstLeg,
+                                legStatus: CONST.LEG_STATUS.CANCELLED,
+                            },
+                            ...(secondLeg ? [secondLeg] : []),
+                        ],
+                    },
+                },
+            };
+            const result = getAirReservations(partiallyCancelledPnr, partiallyCancelledPnr.data.pnrTravelers);
+            expect(result).toHaveLength(1);
+            expect(result.at(0)?.reservation.start?.shortName).toBe('EWR');
+            expect(result.at(0)?.reservation.end?.shortName).toBe('LAX');
+        });
+
+        it('should still return non-cancelled flights when only some flights in a leg have cancelled status', () => {
+            const firstLeg = asDefined(connectingAirPnrData.legs.at(0));
+            const firstFlight = asDefined(firstLeg.flights.at(0));
+            const secondFlight = firstLeg.flights.at(1);
+            const secondLeg = connectingAirPnrData.legs.at(1);
+            const partialFlightCancelPnr: Pnr = {
+                ...airPnrConnecting,
+                data: {
+                    ...airPnrConnecting.data,
+                    airPnr: {
+                        ...connectingAirPnrData,
+                        legs: [
+                            {
+                                ...firstLeg,
+                                flights: [
+                                    {
+                                        ...firstFlight,
+                                        flightStatus: CONST.PNR_STATUS.CANCELLED,
+                                    },
+                                    ...(secondFlight ? [secondFlight] : []),
+                                ],
+                            },
+                            ...(secondLeg ? [secondLeg] : []),
+                        ],
+                    },
+                },
+            };
+            const result = getAirReservations(partialFlightCancelPnr, partialFlightCancelPnr.data.pnrTravelers);
+            expect(result).toHaveLength(2);
+            expect(result.at(0)?.reservation.start?.shortName).toBe('MSP');
+            expect(result.at(0)?.reservation.end?.shortName).toBe('EWR');
+            expect(result.at(1)?.reservation.start?.shortName).toBe('EWR');
+            expect(result.at(1)?.reservation.end?.shortName).toBe('LAX');
         });
     });
     describe('getReservationsFromTripReport', () => {
@@ -2334,6 +2482,93 @@ describe('TripReservationUtils', () => {
             expect(resultWithSingleReservation).toHaveLength(1);
             expect(resultWithSingleReservation.at(0)?.reservation.reservationID).toEqual('PNR_HOTEL_789');
             expect(resultWithSingleReservation.at(0)?.reservation.type).toEqual(CONST.RESERVATION_TYPE.HOTEL);
+        });
+
+        it('should filter out cancelled PNRs from results', () => {
+            const cancelledHotelPnr: Pnr = {
+                ...hotelPnr,
+                pnrId: 'PNR_HOTEL_CANCELLED',
+                data: {
+                    ...hotelPnr.data,
+                    hotelPnr: {
+                        ...hotelPnrData,
+                        pnrStatus: CONST.PNR_STATUS.CANCELLED,
+                    },
+                },
+            };
+
+            const report = createRandomReport(1, undefined);
+            report.tripData = {
+                tripID: 'trip123',
+                payload: {
+                    ...basicTripData,
+                    pnrs: [airPnrDirect, cancelledHotelPnr, carPnr],
+                },
+            };
+
+            const result = getReservationsFromTripReport(report, []);
+            expect(result).toHaveLength(2);
+            expect(result.every((r) => r.reservation.reservationID !== 'PNR_HOTEL_CANCELLED')).toBe(true);
+            expect(result.at(0)?.reservation.reservationID).toEqual('PNR_AIR_789');
+            expect(result.at(1)?.reservation.reservationID).toEqual('PNR_CAR_789');
+        });
+
+        it('should filter out PNRs with cancelled bookingStatus', () => {
+            const cancelledByBookingStatus: Pnr = {
+                ...carPnr,
+                pnrId: 'PNR_CAR_CANCELLED',
+                data: {
+                    ...carPnr.data,
+                    bookingStatus: CONST.PNR_STATUS.VOIDED,
+                },
+            };
+
+            const report = createRandomReport(1, undefined);
+            report.tripData = {
+                tripID: 'trip123',
+                payload: {
+                    ...basicTripData,
+                    pnrs: [airPnrDirect, cancelledByBookingStatus, hotelPnr],
+                },
+            };
+
+            const result = getReservationsFromTripReport(report, []);
+            expect(result).toHaveLength(2);
+            expect(result.every((r) => r.reservation.reservationID !== 'PNR_CAR_CANCELLED')).toBe(true);
+            expect(result.at(0)?.reservation.reservationID).toEqual('PNR_AIR_789');
+            expect(result.at(1)?.reservation.reservationID).toEqual('PNR_HOTEL_789');
+        });
+
+        it('should return empty when all PNRs are cancelled', () => {
+            const cancelledHotelPnr: Pnr = {
+                ...hotelPnr,
+                data: {
+                    ...hotelPnr.data,
+                    bookingStatus: CONST.PNR_STATUS.CANCELLED,
+                },
+            };
+            const cancelledCarPnr: Pnr = {
+                ...carPnr,
+                data: {
+                    ...carPnr.data,
+                    carPnr: {
+                        ...carPnrData,
+                        pnrStatus: CONST.PNR_STATUS.VOIDED,
+                    },
+                },
+            };
+
+            const report = createRandomReport(1, undefined);
+            report.tripData = {
+                tripID: 'trip123',
+                payload: {
+                    ...basicTripData,
+                    pnrs: [cancelledHotelPnr, cancelledCarPnr],
+                },
+            };
+
+            const result = getReservationsFromTripReport(report, []);
+            expect(result).toHaveLength(0);
         });
     });
 
@@ -2487,6 +2722,173 @@ describe('TripReservationUtils', () => {
             expect(pnrReservation?.reservations.at(1)?.reservation?.end?.shortName).toEqual('MSP');
             expect(pnrReservation?.reservations.at(2)?.reservation?.start?.shortName).toEqual('MSP');
             expect(pnrReservation?.reservations.at(2)?.reservation?.end?.shortName).toEqual('EWR');
+        });
+    });
+
+    describe('isPnrCancelled', () => {
+        it('should return true for hotel PNR with CANCELLED pnrStatus', () => {
+            const cancelledHotel: Pnr = {
+                ...hotelPnr,
+                data: {
+                    ...hotelPnr.data,
+                    hotelPnr: {
+                        ...hotelPnrData,
+                        pnrStatus: CONST.PNR_STATUS.CANCELLED,
+                    },
+                },
+            };
+            expect(isPnrCancelled(cancelledHotel)).toBe(true);
+        });
+
+        it('should return true for hotel PNR with VOIDED pnrStatus', () => {
+            const voidedHotel: Pnr = {
+                ...hotelPnr,
+                data: {
+                    ...hotelPnr.data,
+                    hotelPnr: {
+                        ...hotelPnrData,
+                        pnrStatus: CONST.PNR_STATUS.VOIDED,
+                    },
+                },
+            };
+            expect(isPnrCancelled(voidedHotel)).toBe(true);
+        });
+
+        it('should return false for hotel PNR with active status', () => {
+            const activeHotel: Pnr = {
+                ...hotelPnr,
+                data: {
+                    ...hotelPnr.data,
+                    hotelPnr: {
+                        ...hotelPnrData,
+                        pnrStatus: 'CONFIRMED',
+                    },
+                },
+            };
+            expect(isPnrCancelled(activeHotel)).toBe(false);
+        });
+
+        it('should return true for car PNR with CANCELLED pnrStatus', () => {
+            const cancelledCar: Pnr = {
+                ...carPnr,
+                data: {
+                    ...carPnr.data,
+                    carPnr: {
+                        ...carPnrData,
+                        pnrStatus: CONST.PNR_STATUS.CANCELLED,
+                    },
+                },
+            };
+            expect(isPnrCancelled(cancelledCar)).toBe(true);
+        });
+
+        it('should return true for air PNR where all legs are cancelled', () => {
+            const cancelledAir: Pnr = {
+                ...airPnrDirect,
+                data: {
+                    ...airPnrDirect.data,
+                    airPnr: {
+                        ...directAirPnrData,
+                        legs: directAirPnrData.legs.map((leg) => ({
+                            ...leg,
+                            legStatus: CONST.LEG_STATUS.CANCELLED,
+                        })),
+                    },
+                },
+            };
+            expect(isPnrCancelled(cancelledAir)).toBe(true);
+        });
+
+        it('should return false for air PNR where only some legs are cancelled', () => {
+            const partiallyCancelledAir: Pnr = {
+                ...airPnrConnecting,
+                data: {
+                    ...airPnrConnecting.data,
+                    airPnr: {
+                        ...connectingAirPnrData,
+                        legs: connectingAirPnrData.legs.map((leg, index) => ({
+                            ...leg,
+                            legStatus: index === 0 ? CONST.LEG_STATUS.CANCELLED : 'CONFIRMED_STATUS',
+                        })),
+                    },
+                },
+            };
+            expect(isPnrCancelled(partiallyCancelledAir)).toBe(false);
+        });
+
+        it('should return true for rail PNR with both journeys cancelled', () => {
+            const cancelledRail: Pnr = {
+                ...railPnr,
+                data: {
+                    ...railPnr.data,
+                    railPnr: {
+                        ...railPnrData,
+                        outwardJourney: {
+                            ...railPnrData.outwardJourney,
+                            journeyStatus: CONST.PNR_STATUS.CANCELLED,
+                        },
+                        inwardJourney: {
+                            ...railPnrData.inwardJourney,
+                            journeyStatus: CONST.PNR_STATUS.CANCELLED,
+                        },
+                    },
+                },
+            };
+            expect(isPnrCancelled(cancelledRail)).toBe(true);
+        });
+
+        it('should return false for rail PNR with only one journey cancelled', () => {
+            const partialRail: Pnr = {
+                ...railPnr,
+                data: {
+                    ...railPnr.data,
+                    railPnr: {
+                        ...railPnrData,
+                        outwardJourney: {
+                            ...railPnrData.outwardJourney,
+                            journeyStatus: CONST.PNR_STATUS.CANCELLED,
+                        },
+                        inwardJourney: {
+                            ...railPnrData.inwardJourney,
+                            journeyStatus: 'CONFIRMED',
+                        },
+                    },
+                },
+            };
+            expect(isPnrCancelled(partialRail)).toBe(false);
+        });
+
+        it('should return true when top-level bookingStatus is CANCELLED', () => {
+            const cancelledByBookingStatus: Pnr = {
+                ...hotelPnr,
+                data: {
+                    ...hotelPnr.data,
+                    bookingStatus: CONST.PNR_STATUS.CANCELLED,
+                    hotelPnr: {
+                        ...hotelPnrData,
+                        pnrStatus: 'CONFIRMED',
+                    },
+                },
+            };
+            expect(isPnrCancelled(cancelledByBookingStatus)).toBe(true);
+        });
+
+        it('should return true when top-level bookingStatus is VOIDED', () => {
+            const voidedByBookingStatus: Pnr = {
+                ...carPnr,
+                data: {
+                    ...carPnr.data,
+                    bookingStatus: CONST.PNR_STATUS.VOIDED,
+                },
+            };
+            expect(isPnrCancelled(voidedByBookingStatus)).toBe(true);
+        });
+
+        it('should return false for PNR with no cancellation indicators', () => {
+            expect(isPnrCancelled(hotelPnr)).toBe(false);
+            expect(isPnrCancelled(carPnr)).toBe(false);
+            expect(isPnrCancelled(airPnrDirect)).toBe(false);
+            expect(isPnrCancelled(railPnr)).toBe(false);
         });
     });
 });


### PR DESCRIPTION
### Explanation of Change
Filter out cancelled travel reservations (flights, hotels, cars, and rail) from trip data so they are not displayed in the app. This adds:
- `PNR_STATUS` and `LEG_STATUS` constants for identifying cancelled/voided reservations
- `isPnrCancelled` helper that checks cancellation status across all reservation types (hotel, car, air, rail)
- Filtering of cancelled PNRs in `getReservationsFromSpotnanaPayload`
- Skipping of cancelled individual flight legs in `getAirReservations`

### Fixed Issues
$ https://github.com/Expensify/App/issues/81529

### Tests
1. Open a trip report that contains cancelled reservations
2. Verify that cancelled reservations are no longer displayed
3. Verify that non-cancelled reservations still appear correctly
- [x] Verify that no errors appear in the JS console

### Offline tests
N/A - this change only affects data filtering logic, no network requests are modified.

### QA Steps
1. Open a trip report that contains cancelled reservations (hotel, car, flight, or rail)
2. Verify that cancelled reservations are filtered out and not shown
3. Verify that active reservations are still displayed correctly
- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>