### PR TITLE
[CP Staging] fix: revert multi-line wrapping in narrow layout and transaction preview

### DIFF
--- a/src/components/ReportActionItem/TransactionPreview/TransactionPreviewContent.tsx
+++ b/src/components/ReportActionItem/TransactionPreview/TransactionPreviewContent.tsx
@@ -323,8 +323,8 @@ function TransactionPreviewContent({
                                                 {shouldShowMerchantOrDescription && (
                                                     <Text
                                                         fontSize={variables.fontSizeNormal}
-                                                        style={[isDeleted && styles.lineThrough, styles.flexShrink1, styles.preWrap]}
-                                                        numberOfLines={2}
+                                                        style={[isDeleted && styles.lineThrough, styles.flexShrink1]}
+                                                        numberOfLines={1}
                                                     >
                                                         {merchantOrDescription}
                                                     </Text>
@@ -368,8 +368,8 @@ function TransactionPreviewContent({
                                                         fill={theme.icon}
                                                     />
                                                     <Text
-                                                        numberOfLines={2}
-                                                        style={[isDeleted && styles.lineThrough, styles.textMicroSupporting, styles.preWrap, styles.flexShrink1]}
+                                                        numberOfLines={1}
+                                                        style={[isDeleted && styles.lineThrough, styles.textMicroSupporting, styles.pre, styles.flexShrink1]}
                                                     >
                                                         {getDecodedCategoryName(category ?? '')}
                                                     </Text>
@@ -384,8 +384,8 @@ function TransactionPreviewContent({
                                                         fill={theme.icon}
                                                     />
                                                     <Text
-                                                        numberOfLines={2}
-                                                        style={[isDeleted && styles.lineThrough, styles.textMicroSupporting, styles.preWrap, styles.flexShrink1]}
+                                                        numberOfLines={1}
+                                                        style={[isDeleted && styles.lineThrough, styles.textMicroSupporting, styles.pre, styles.flexShrink1]}
                                                     >
                                                         {getCommaSeparatedTagNameWithSanitizedColons(tag)}
                                                     </Text>

--- a/src/components/TransactionItemRow/DataCells/CategoryCell.tsx
+++ b/src/components/TransactionItemRow/DataCells/CategoryCell.tsx
@@ -18,7 +18,6 @@ function CategoryCell({shouldUseNarrowLayout, shouldShowTooltip, transactionItem
             showTooltip={shouldShowTooltip}
             text={categoryForDisplay}
             textStyle={[styles.textMicro, styles.mnh0]}
-            numberOfLines={2}
         />
     ) : (
         <TextWithTooltip

--- a/src/components/TransactionItemRow/DataCells/MerchantCell.tsx
+++ b/src/components/TransactionItemRow/DataCells/MerchantCell.tsx
@@ -27,8 +27,8 @@ function MerchantOrDescriptionCell({
         <TextWithTooltip
             shouldShowTooltip={shouldShowTooltip}
             text={text}
-            numberOfLines={2}
-            style={[!shouldUseNarrowLayout ? styles.lineHeightLarge : styles.lh20, styles.preWrap, styles.justifyContentCenter, styles.flex1]}
+            numberOfLines={shouldUseNarrowLayout ? 1 : 2}
+            style={[!shouldUseNarrowLayout ? styles.lineHeightLarge : styles.lh20, shouldUseNarrowLayout ? styles.pre : styles.preWrap, styles.justifyContentCenter, styles.flex1]}
         />
     );
 }

--- a/src/components/TransactionItemRow/DataCells/MerchantCell.tsx
+++ b/src/components/TransactionItemRow/DataCells/MerchantCell.tsx
@@ -28,7 +28,7 @@ function MerchantOrDescriptionCell({
             shouldShowTooltip={shouldShowTooltip}
             text={text}
             numberOfLines={shouldUseNarrowLayout ? 1 : 2}
-            style={[!shouldUseNarrowLayout ? styles.lineHeightLarge : styles.lh20, shouldUseNarrowLayout ? styles.pre : styles.preWrap, styles.justifyContentCenter, styles.flex1]}
+            style={[shouldUseNarrowLayout ? styles.lh20 : styles.lineHeightLarge, shouldUseNarrowLayout ? styles.pre : styles.preWrap, styles.justifyContentCenter, styles.flex1]}
         />
     );
 }

--- a/src/components/TransactionItemRow/DataCells/TagCell.tsx
+++ b/src/components/TransactionItemRow/DataCells/TagCell.tsx
@@ -15,7 +15,6 @@ function TagCell({shouldUseNarrowLayout, shouldShowTooltip, transactionItem}: Tr
             showTooltip={shouldShowTooltip}
             text={getTagForDisplay(transactionItem)}
             textStyle={[styles.textMicro, styles.mnh0]}
-            numberOfLines={2}
         />
     ) : (
         <TextWithTooltip

--- a/src/components/TransactionItemRow/index.tsx
+++ b/src/components/TransactionItemRow/index.tsx
@@ -661,7 +661,7 @@ function TransactionItemRow({
                             style={styles.mr3}
                         />
                         <View style={[styles.flex2, styles.flexColumn, styles.justifyContentEvenly]}>
-                            <View style={[styles.flexRow, styles.alignItemsCenter, styles.minHeight5]}>
+                            <View style={[styles.flexRow, styles.alignItemsCenter, styles.minHeight5, styles.maxHeight5]}>
                                 <DateCell
                                     date={createdAt}
                                     showTooltip={shouldShowTooltip}
@@ -724,7 +724,7 @@ function TransactionItemRow({
                     <View style={[styles.flexRow, styles.justifyContentBetween, styles.alignItemsStart]}>
                         <View style={[styles.flexColumn, styles.flex1]}>
                             {hasCategoryOrTag && !isIOUReport(report) && (
-                                <View style={[styles.flexRow, styles.alignItemsCenter, styles.gap2, styles.mt2, styles.minHeight6]}>
+                                <View style={[styles.flexRow, styles.alignItemsCenter, styles.gap2, styles.mt2, styles.minHeight4]}>
                                     <CategoryCell
                                         transactionItem={transactionItem}
                                         shouldShowTooltip={shouldShowTooltip}


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
<!-- Explain what your change does and how it addresses the linked issue -->
Reverts out-of-scope changes from #82967 that caused three deploy blockers.

  The original issue only required multi-line wrapping on large screen table rows ([design scope](https://github.com/Expensify/App/issues/81419#issuecomment-3856216515)). This PR reverts:

  1. **TransactionPreviewContent** back to single line ($ #83987, #83989) — chat preview wrapping caused amount overflow and icon alignment mismatch.
  2. **Narrow layout** back to single line ($ #84032) — caused amount clipping and tag/category overlap in the merge view.

  Large screen table wrapping remains intact.

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/83987
$ https://github.com/Expensify/App/issues/83989
$ https://github.com/Expensify/App/issues/84032
PROPOSAL:


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

**#83987 — Split preview amount overflow**
  1. Open a 1:1 DM with any user.
  2. Click + > Split expense > Manual.
  3. Enter amount > Next.
  4. On confirm page, enter a long description and save.
  5. Click Split.
  6. Verify the amount stays inside the preview.

  **#83989 — Icon alignment mismatch**
  Prerequisite: Workspace with long category and tag names.
  1. Go to workspace chat.
  2. Create two expenses with long category and long tag.
  3. Verify category/tag icons are aligned consistently in the expense preview.
  4. Open the expense report and verify icons align the same as in the preview.

  **#84032 — Merge view amount/tag clipping**
  Prerequisite: Workspace with long category, tag, and merchant names.
  1. Open any workspace chat.
  2. Create two manual expenses with long merchant names, tags and categories.
  3. Open the report, select one expense, click dropdown > Merge.
  4. Verify the amount is fully visible and tag icon does not overlap category in the eligible expenses list.
 
- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->
Same as tests

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->
// TODO: These must be filled out, or the issue title must include "[No QA]."

Same as tests

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I verified there are no new alerts related to the `canBeMissing` param for `useOnyx`
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->
<img width="568" height="1084" alt="Screenshot 2026-03-03 at 7 26 42 in the evening" src="https://github.com/user-attachments/assets/fe7b4abc-f88e-44c6-97a5-4eeae356d75c" />
<img width="568" height="1084" alt="Screenshot 2026-03-03 at 7 26 57 in the evening" src="https://github.com/user-attachments/assets/f85efc39-3651-4f73-8ad6-d7968e7cef52" />
<img width="568" height="1084" alt="Screenshot 2026-03-03 at 7 27 10 in the evening" src="https://github.com/user-attachments/assets/3eefae5a-57db-4ac0-a053-a68d056e34cc" />


</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>
<img width="1912" height="1242" alt="Screenshot 2026-03-03 at 7 06 32 in the evening" src="https://github.com/user-attachments/assets/504b96d6-923d-4140-aeac-6c5c104bf310" />
<img width="1912" height="1242" alt="Screenshot 2026-03-03 at 7 06 46 in the evening" src="https://github.com/user-attachments/assets/224157f9-0343-49cc-8f4b-1c1843d0e0e5" />
<img width="1912" height="1242" alt="Screenshot 2026-03-03 at 7 08 29 in the evening" src="https://github.com/user-attachments/assets/4b14025d-9490-4d7b-9fca-d4789d867c5a" />

<!-- add screenshots or videos here -->

</details>