### PR TITLE
[No-QA] fix: use contextLineCount counter instead of storing context lines in hunk.lines

### DIFF
--- a/.github/actions/javascript/getPullRequestIncrementalChanges/index.js
+++ b/.github/actions/javascript/getPullRequestIncrementalChanges/index.js
@@ -12506,6 +12506,7 @@ class Git {
                         newStart,
                         newCount,
                         lines: [],
+                        contextLineCount: 0,
                     };
                 }
                 continue;
@@ -12533,7 +12534,8 @@ class Git {
                     });
                 }
                 else if (firstChar === ' ') {
-                    // Context line - skip it (we only care about added/removed lines)
+                    // Context line - count it so calculateLineNumber accounts for position advancement
+                    currentHunk.contextLineCount++;
                     continue;
                 }
                 else if (firstChar === '\\') {
@@ -12597,9 +12599,9 @@ class Git {
         const removedCount = hunk.lines.filter((l) => l.type === 'removed').length;
         switch (lineType) {
             case 'added':
-                return hunk.newStart + addedCount;
+                return hunk.newStart + hunk.contextLineCount + addedCount;
             case 'removed':
-                return hunk.oldStart + removedCount;
+                return hunk.oldStart + hunk.contextLineCount + removedCount;
             default:
                 throw new Error(`Unknown line type: ${String(lineType)}`);
         }
@@ -12795,6 +12797,7 @@ class Git {
                 newStart: 1,
                 newCount: lines.length,
                 lines: diffLines,
+                contextLineCount: 0,
             };
             const fileDiff = {
                 filePath,

--- a/scripts/utils/Git.ts
+++ b/scripts/utils/Git.ts
@@ -39,7 +39,7 @@ const GITHUB_BASE_REF = process.env.GITHUB_BASE_REF as string | undefined;
 
 /**
  * Represents a single changed line in a git diff.
- * Only added and removed lines are tracked (context lines are skipped during parsing).
+ * Only added and removed lines are tracked (context lines are counted separately).
  */
 type DiffLine = {
     number: number;
@@ -56,6 +56,7 @@ type DiffHunk = {
     newStart: number;
     newCount: number;
     lines: DiffLine[];
+    contextLineCount: number;
 };
 
 /**
@@ -239,6 +240,7 @@ class Git {
                         newStart,
                         newCount,
                         lines: [],
+                        contextLineCount: 0,
                     };
                 }
                 continue;
@@ -268,7 +270,8 @@ class Git {
                         content,
                     });
                 } else if (firstChar === ' ') {
-                    // Context line - skip it (we only care about added/removed lines)
+                    // Context line - count it so calculateLineNumber accounts for position advancement
+                    currentHunk.contextLineCount++;
                     continue;
                 } else if (firstChar === '\\') {
                     // "No newline at end of file" marker - skip it (metadata, not content)
@@ -339,9 +342,9 @@ class Git {
 
         switch (lineType) {
             case 'added':
-                return hunk.newStart + addedCount;
+                return hunk.newStart + hunk.contextLineCount + addedCount;
             case 'removed':
-                return hunk.oldStart + removedCount;
+                return hunk.oldStart + hunk.contextLineCount + removedCount;
             default:
                 throw new Error(`Unknown line type: ${String(lineType)}`);
         }
@@ -560,6 +563,7 @@ class Git {
                 newStart: 1,
                 newCount: lines.length,
                 lines: diffLines,
+                contextLineCount: 0,
             };
 
             const fileDiff: FileDiff = {

--- a/tests/unit/GitTest.ts
+++ b/tests/unit/GitTest.ts
@@ -982,6 +982,209 @@ describe('Git', () => {
         });
     });
 
+    describe('parseDiff with context lines', () => {
+        it('calculates correct line numbers when context lines are present', () => {
+            // GitHub API diffs include 3 context lines by default
+            const diffWithContext = dedent(`
+                diff --git a/src/languages/en.ts b/src/languages/en.ts
+                --- a/src/languages/en.ts
+                +++ b/src/languages/en.ts
+                @@ -100,6 +100,7 @@
+                 formatPolicyRules
+                 exportToCSV
+                 duplicateExpense
+                +cannotDuplicateDistanceExpense
+                 reportField
+                 reportFieldList
+                 reportFieldRule
+            `);
+
+            const result = Git.parseDiff(diffWithContext);
+
+            expect(result.hasChanges).toBe(true);
+            expect(result.files).toHaveLength(1);
+
+            const file = result.files.at(0);
+            expect(file).toBeDefined();
+            if (!file) {
+                return;
+            }
+
+            const hunk = file.hunks.at(0);
+            expect(hunk).toBeDefined();
+            if (!hunk) {
+                return;
+            }
+
+            // Context lines should NOT appear in hunk.lines
+            expect(hunk.lines).toHaveLength(1);
+            expect(hunk.lines.at(0)).toEqual({
+                number: 103,
+                type: 'added',
+                content: 'cannotDuplicateDistanceExpense',
+            });
+
+            // Context lines should be counted
+            expect(hunk.contextLineCount).toBe(6);
+
+            // addedLines should reflect the correct line number
+            expect(file.addedLines.has(103)).toBe(true);
+        });
+
+        it('calculates correct line numbers with zero context lines', () => {
+            // Local git diff uses -U0
+            const diffWithoutContext = dedent(`
+                diff --git a/src/languages/en.ts b/src/languages/en.ts
+                --- a/src/languages/en.ts
+                +++ b/src/languages/en.ts
+                @@ -102,0 +103 @@
+                +cannotDuplicateDistanceExpense
+            `);
+
+            const result = Git.parseDiff(diffWithoutContext);
+
+            const hunk = result.files.at(0)?.hunks.at(0);
+            expect(hunk).toBeDefined();
+            if (!hunk) {
+                return;
+            }
+
+            expect(hunk.lines).toHaveLength(1);
+            expect(hunk.lines.at(0)?.number).toBe(103);
+            expect(hunk.contextLineCount).toBe(0);
+        });
+
+        it('handles context lines interleaved with additions and removals', () => {
+            const diff = dedent(`
+                diff --git a/file.ts b/file.ts
+                --- a/file.ts
+                +++ b/file.ts
+                @@ -10,5 +10,6 @@
+                 unchanged1
+                -removed1
+                +replaced1
+                +added1
+                 unchanged2
+                 unchanged3
+            `);
+
+            const result = Git.parseDiff(diff);
+            const hunk = result.files.at(0)?.hunks.at(0);
+            expect(hunk).toBeDefined();
+            if (!hunk) {
+                return;
+            }
+
+            // Only changed lines in hunk.lines
+            expect(hunk.lines).toHaveLength(3);
+            expect(hunk.lines.at(0)).toEqual({number: 11, type: 'removed', content: 'removed1'});
+            expect(hunk.lines.at(1)).toEqual({number: 11, type: 'added', content: 'replaced1'});
+            expect(hunk.lines.at(2)).toEqual({number: 12, type: 'added', content: 'added1'});
+
+            expect(hunk.contextLineCount).toBe(3);
+        });
+
+        it('produces same line numbers for -U0 and context diffs', () => {
+            // Same logical change, different context levels
+            const withContext = dedent(`
+                diff --git a/file.ts b/file.ts
+                --- a/file.ts
+                +++ b/file.ts
+                @@ -8,4 +8,5 @@
+                 line8
+                 line9
+                 line10
+                +newLine11
+                 line11
+            `);
+
+            const withoutContext = dedent(`
+                diff --git a/file.ts b/file.ts
+                --- a/file.ts
+                +++ b/file.ts
+                @@ -10,0 +11 @@
+                +newLine11
+            `);
+
+            const resultWithContext = Git.parseDiff(withContext);
+            const resultWithoutContext = Git.parseDiff(withoutContext);
+
+            const lineWithContext = resultWithContext.files.at(0)?.hunks.at(0)?.lines.at(0)?.number;
+            const lineWithoutContext = resultWithoutContext.files.at(0)?.hunks.at(0)?.lines.at(0)?.number;
+
+            expect(lineWithContext).toBe(11);
+            expect(lineWithoutContext).toBe(11);
+            expect(lineWithContext).toBe(lineWithoutContext);
+        });
+
+        it('calculates correct removed line numbers with context lines', () => {
+            const diff = dedent(`
+                diff --git a/file.ts b/file.ts
+                --- a/file.ts
+                +++ b/file.ts
+                @@ -5,4 +5,3 @@
+                 context1
+                 context2
+                -removedLine
+                 context3
+            `);
+
+            const result = Git.parseDiff(diff);
+            const file = result.files.at(0);
+            expect(file).toBeDefined();
+            if (!file) {
+                return;
+            }
+
+            const hunk = file.hunks.at(0);
+            expect(hunk).toBeDefined();
+            if (!hunk) {
+                return;
+            }
+
+            expect(hunk.lines).toHaveLength(1);
+            expect(hunk.lines.at(0)).toEqual({number: 7, type: 'removed', content: 'removedLine'});
+            expect(hunk.contextLineCount).toBe(3);
+            expect(file.removedLines.has(7)).toBe(true);
+        });
+
+        it('tracks contextLineCount independently per hunk', () => {
+            const diff = dedent(`
+                diff --git a/file.ts b/file.ts
+                --- a/file.ts
+                +++ b/file.ts
+                @@ -1,3 +1,4 @@
+                 ctx1
+                 ctx2
+                +addedInFirstHunk
+                 ctx3
+                @@ -20,2 +21,3 @@
+                 ctx4
+                +addedInSecondHunk
+                 ctx5
+            `);
+
+            const result = Git.parseDiff(diff);
+            const file = result.files.at(0);
+            expect(file).toBeDefined();
+            if (!file) {
+                return;
+            }
+
+            expect(file.hunks).toHaveLength(2);
+
+            const firstHunk = file.hunks.at(0);
+            expect(firstHunk?.contextLineCount).toBe(3);
+            expect(firstHunk?.lines).toHaveLength(1);
+            expect(firstHunk?.lines.at(0)).toEqual({number: 3, type: 'added', content: 'addedInFirstHunk'});
+
+            const secondHunk = file.hunks.at(1);
+            expect(secondHunk?.contextLineCount).toBe(2);
+            expect(secondHunk?.lines).toHaveLength(1);
+            expect(secondHunk?.lines.at(0)).toEqual({number: 22, type: 'added', content: 'addedInSecondHunk'});
+        });
+    });
+
     describe('getUntrackedFiles', () => {
         it('returns array of untracked file paths', () => {
             mockExecSync.mockReturnValue('src/new-file.ts\nsrc/another-file.tsx\n');


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
<!-- Explain what your change does and how it addresses the linked issue -->
`calculateLineNumber()` didn't account for context lines in GitHub API diffs, causing every added line to be reported 3 positions too early translating the wrong key. Fixed by tracking context lines via a `contextLineCount` counter on `DiffHunk`.

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/84020
PROPOSAL:


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

1. Run `npx ts-node ./scripts/generateTranslations.ts --dry-run --verbose --compare-ref=main`
2. Verify context lines are counted correctly (line numbers match expected positions)
3. Verify `hunk.lines` contains only `added` and `removed` entries (no `context` type)
 
- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->
Same as tests

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->
// TODO: These must be filled out, or the issue title must include "[No QA]."
Same as tests

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I verified there are no new alerts related to the `canBeMissing` param for `useOnyx`
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>