### PR TITLE
fix: deduplicate repeated integration export error messages

### DIFF
--- a/src/libs/ReportActionsUtils.ts
+++ b/src/libs/ReportActionsUtils.ts
@@ -2065,7 +2065,8 @@ function getMessageOfOldDotReportAction(translate: LocalizedTranslate, oldDotAct
             return translate('report.actions.type.exportedToCSV');
         case CONST.REPORT.ACTIONS.TYPE.INTEGRATIONS_MESSAGE: {
             const {result, label} = originalMessage;
-            const errorMessage = result?.messages?.join(', ') ?? '';
+            const uniqueErrorMessages = [...new Set((result?.messages ?? []).filter((message) => !!message))];
+            const errorMessage = uniqueErrorMessages.join(', ');
             const linkText = result?.link?.text ?? '';
             const linkURL = result?.link?.url ?? '';
             if (errorMessage.includes(CONST.ERROR.INTEGRATION_MESSAGE_INVALID_CREDENTIALS)) {

--- a/tests/unit/ReportActionsUtilsTest.ts
+++ b/tests/unit/ReportActionsUtilsTest.ts
@@ -1260,6 +1260,27 @@ describe('ReportActionsUtils', () => {
             const expectedHtml = `<muted-text>${expectedText}</muted-text>`;
             expect(fragments).toEqual([{text: expectedText, html: expectedHtml, type: 'COMMENT'}]);
         });
+
+        it('should deduplicate repeated integration export error messages', () => {
+            const repeatedError = 'Invalid account mapping';
+            const action: ReportAction<typeof CONST.REPORT.ACTIONS.TYPE.INTEGRATIONS_MESSAGE> = {
+                actionName: CONST.REPORT.ACTIONS.TYPE.INTEGRATIONS_MESSAGE,
+                reportActionID: '1',
+                created: '1',
+                message: [],
+                originalMessage: {
+                    label: 'QuickBooks Online',
+                    result: {
+                        messages: [repeatedError, repeatedError, repeatedError],
+                    },
+                },
+            };
+
+            const fragments = ReportActionsUtils.getReportActionMessageFragments(translateLocal, action);
+            const expectedText = translateLocal('report.actions.type.integrationsMessage', repeatedError, 'QuickBooks Online', '', '');
+            const expectedHtml = `<muted-text>${expectedText}</muted-text>`;
+            expect(fragments).toEqual([{text: expectedText, html: expectedHtml, type: 'COMMENT'}]);
+        });
     });
 
     describe('getSendMoneyFlowAction', () => {


### PR DESCRIPTION
## Summary
- deduplicate repeated `result.messages` entries for `INTEGRATIONS_MESSAGE` report actions before building the export failure text
- preserve existing message formatting and link handling
- add unit coverage to ensure repeated backend messages render once in chat

## Repro
1. Create an `INTEGRATIONS_MESSAGE` action whose `originalMessage.result.messages` contains the same error repeated (once per transaction).
2. Open the report actions feed.
3. Observe the export error text.

## Before
- The UI joined all message entries directly (`messages.join(', ')`), so identical errors were repeated for each transaction.

## After
- The UI removes duplicate message entries while preserving order, then renders a single concise error sentence.

## Testing
- `npm test -- tests/unit/ReportActionsUtilsTest.ts --runInBand`
  - ✅ Pass (172/172)
  - Includes new test: `should deduplicate repeated integration export error messages`

$ #82957
