### PR TITLE
Revert "Make NewChatPage use new SelectionListWithSections"

### DIFF
--- a/src/components/SelectionList/SelectionListWithSections/BaseSelectionListWithSections.tsx
+++ b/src/components/SelectionList/SelectionListWithSections/BaseSelectionListWithSections.tsx
@@ -1,7 +1,7 @@
 import {useIsFocused} from '@react-navigation/native';
 import {FlashList} from '@shopify/flash-list';
 import type {FlashListRef, ListRenderItemInfo} from '@shopify/flash-list';
-import React, {useCallback, useImperativeHandle, useRef} from 'react';
+import React, {useImperativeHandle, useRef} from 'react';
 import type {TextInputKeyPressEvent} from 'react-native';
 import {View} from 'react-native';
 import type {ValueOf} from 'type-fest';
@@ -97,26 +97,23 @@ function BaseSelectionListWithSections<TItem extends ListItem>({
         hasKeyBeenPressed.current = true;
     };
 
-    const scrollToIndex = useCallback(
-        (index: number) => {
-            if (index < 0 || index >= flattenedData.length || !listRef.current) {
-                return;
-            }
-            const item = flattenedData.at(index);
-            if (!item) {
-                return;
-            }
-            try {
-                listRef.current.scrollToIndex({index});
-            } catch (error) {
-                // FlashList may throw if layout for this index doesn't exist yet
-                // This can happen when data changes rapidly (e.g., during search filtering)
-                // The layout will be computed on next render, so we can safely ignore this
-                Log.warn('SelectionListWithSections: error scrolling to index', {error});
-            }
-        },
-        [flattenedData],
-    );
+    const scrollToIndex = (index: number) => {
+        if (index < 0 || index >= flattenedData.length || !listRef.current) {
+            return;
+        }
+        const item = flattenedData.at(index);
+        if (!item) {
+            return;
+        }
+        try {
+            listRef.current.scrollToIndex({index});
+        } catch (error) {
+            // FlashList may throw if layout for this index doesn't exist yet
+            // This can happen when data changes rapidly (e.g., during search filtering)
+            // The layout will be computed on next render, so we can safely ignore this
+            Log.warn('SelectionListWithSections: error scrolling to index', {error});
+        }
+    };
 
     const debouncedScrollToIndex = useDebounce(scrollToIndex, CONST.TIMING.LIST_SCROLLING_DEBOUNCE_TIME, {leading: true, trailing: true});
 
@@ -182,10 +179,6 @@ function BaseSelectionListWithSections<TItem extends ListItem>({
         innerTextInputRef.current?.focus();
     };
 
-    const clearInputAfterSelect = () => {
-        textInputOptions?.onChangeText?.('');
-    };
-
     const updateAndScrollToFocusedIndex = (index: number, shouldScroll = true) => {
         setFocusedIndex(index);
         if (shouldScroll) {
@@ -202,8 +195,6 @@ function BaseSelectionListWithSections<TItem extends ListItem>({
 
     useImperativeHandle(ref, () => ({
         focusTextInput,
-        scrollToIndex,
-        clearInputAfterSelect,
         updateAndScrollToFocusedIndex,
         updateExternalTextInputFocus,
         getFocusedOption: getFocusedItem,

--- a/src/components/SelectionList/SelectionListWithSections/types.ts
+++ b/src/components/SelectionList/SelectionListWithSections/types.ts
@@ -53,8 +53,6 @@ type SelectionListWithSectionsProps<TItem extends ListItem> = BaseSelectionListP
 
 type SelectionListWithSectionsHandle<TItem extends ListItem = ListItem> = {
     focusTextInput: () => void;
-    scrollToIndex: (index: number) => void;
-    clearInputAfterSelect: () => void;
     updateAndScrollToFocusedIndex: (index: number, shouldScroll?: boolean) => void;
     updateExternalTextInputFocus: (isTextInputFocused: boolean) => void;
     getFocusedOption: () => TItem | undefined;

--- a/src/components/SelectionList/components/TextInput.tsx
+++ b/src/components/SelectionList/components/TextInput.tsx
@@ -65,22 +65,7 @@ function TextInput({
 }: TextInputProps) {
     const styles = useThemeStyles();
     const {translate} = useLocalize();
-    const {
-        label,
-        value,
-        onChangeText,
-        errorText,
-        headerMessage,
-        hint,
-        disableAutoFocus,
-        placeholder,
-        maxLength,
-        inputMode,
-        ref: optionsRef,
-        style,
-        disableAutoCorrect,
-        shouldInterceptSwipe,
-    } = options ?? {};
+    const {label, value, onChangeText, errorText, headerMessage, hint, disableAutoFocus, placeholder, maxLength, inputMode, ref: optionsRef, style, disableAutoCorrect} = options ?? {};
     const resultsFound = headerMessage !== translate('common.noResultsFound');
     const noData = dataLength === 0 && !showLoadingPlaceholder;
     const shouldShowHeaderMessage = !!headerMessage && (!isLoadingNewOptions || resultsFound || noData);
@@ -149,8 +134,8 @@ function TextInput({
                     isLoading={isLoading}
                     testID="selection-list-text-input"
                     errorText={errorText}
+                    shouldInterceptSwipe={false}
                     autoCorrect={!disableAutoCorrect}
-                    shouldInterceptSwipe={shouldInterceptSwipe ?? false}
                 />
             </View>
             {shouldShowHeaderMessage && (

--- a/src/components/SelectionList/types.ts
+++ b/src/components/SelectionList/types.ts
@@ -250,9 +250,6 @@ type TextInputOptions = {
     /** Whether the text input auto correct should be disabled */
     disableAutoCorrect?: boolean;
 
-    /** Whether the text input should intercept swipes */
-    shouldInterceptSwipe?: boolean;
-
     /** Styles for the text input */
     style?: {
         /** Styles for the text input container */

--- a/src/hooks/useFilteredOptions.ts
+++ b/src/hooks/useFilteredOptions.ts
@@ -103,11 +103,15 @@ function useFilteredOptions(config: UseFilteredOptionsConfig = {}): UseFilteredO
         if (!options || isLoadingMore) {
             return;
         }
-        setIsLoadingMore(true);
-        setReportsLimit((prev) => prev + batchSize);
+
+        const hasMoreToLoad = options.reports.length < totalReports;
+        if (hasMoreToLoad) {
+            setIsLoadingMore(true);
+            setReportsLimit((prev) => prev + batchSize);
+        }
     };
 
-    const hasMore = options ? reportsLimit < totalReports : false;
+    const hasMore = options ? options.reports.length < totalReports : false;
 
     return {
         options,

--- a/src/libs/OptionsListUtils/index.ts
+++ b/src/libs/OptionsListUtils/index.ts
@@ -2969,6 +2969,19 @@ function formatSectionsFromSearchTerm(
     };
 }
 
+/**
+ * Helper method to get the `keyForList` for the first option in the OptionsList
+ */
+function getFirstKeyForList(data?: Option[] | null) {
+    if (!data?.length) {
+        return '';
+    }
+
+    const firstNonEmptyDataObj = data.at(0);
+
+    return firstNonEmptyDataObj?.keyForList ? firstNonEmptyDataObj?.keyForList : '';
+}
+
 function getPersonalDetailSearchTerms(item: Partial<SearchOptionData>, currentUserAccountID: number) {
     if (item.accountID === currentUserAccountID) {
         return getCurrentUserSearchTerms(item);
@@ -3366,6 +3379,7 @@ export {
     getFilteredRecentAttendees,
     getCurrentUserSearchTerms,
     getEmptyOptions,
+    getFirstKeyForList,
     getHeaderMessage,
     getHeaderMessageForNonUserList,
     getIOUConfirmationOptionsFromPayeePersonalDetail,

--- a/src/pages/NewChatPage.tsx
+++ b/src/pages/NewChatPage.tsx
@@ -1,19 +1,19 @@
-import {useFocusEffect, useIsFocused} from '@react-navigation/native';
-import reportsSelector from '@selectors/Attributes';
+import {useFocusEffect} from '@react-navigation/native';
+import isEmpty from 'lodash/isEmpty';
 import reject from 'lodash/reject';
 import type {Ref} from 'react';
-import React, {useCallback, useEffect, useImperativeHandle, useRef, useState} from 'react';
-import {Keyboard, Platform} from 'react-native';
+import React, {useEffect, useImperativeHandle, useRef, useState} from 'react';
+import {Keyboard} from 'react-native';
 import Button from '@components/Button';
 import {usePersonalDetails} from '@components/OnyxListItemProvider';
 import {PressableWithFeedback} from '@components/Pressable';
 import ReferralProgramCTA from '@components/ReferralProgramCTA';
 import ScreenWrapper from '@components/ScreenWrapper';
 import SelectCircle from '@components/SelectCircle';
-import UserListItem from '@components/SelectionList/ListItem/UserListItem';
-import SelectionListWithSections from '@components/SelectionList/SelectionListWithSections';
-import type {Section} from '@components/SelectionList/SelectionListWithSections/types';
-import type {ListItem, SelectionListWithSectionsHandle} from '@components/SelectionList/types';
+// eslint-disable-next-line no-restricted-imports
+import SelectionList from '@components/SelectionListWithSections';
+import type {ListItem, SelectionListHandle} from '@components/SelectionListWithSections/types';
+import UserListItem from '@components/SelectionListWithSections/UserListItem';
 import useContactImport from '@hooks/useContactImport';
 import useCurrentUserPersonalDetails from '@hooks/useCurrentUserPersonalDetails';
 import useDebouncedState from '@hooks/useDebouncedState';
@@ -29,16 +29,17 @@ import {navigateToAndOpenReport, searchInServer, setGroupDraft} from '@libs/acti
 import {canUseTouchScreen} from '@libs/DeviceCapabilities';
 import Log from '@libs/Log';
 import Navigation from '@libs/Navigation/Navigation';
+import type {Option, Section} from '@libs/OptionsListUtils';
 import {
     filterAndOrderOptions,
     filterSelectedOptions,
     formatSectionsFromSearchTerm,
+    getFirstKeyForList,
     getHeaderMessage,
     getPersonalDetailSearchTerms,
     getUserToInviteOption,
     getValidOptions,
 } from '@libs/OptionsListUtils';
-import type {OptionWithKey} from '@libs/OptionsListUtils/types';
 import type {OptionData} from '@libs/ReportUtils';
 import variables from '@styles/variables';
 import CONST from '@src/CONST';
@@ -46,7 +47,6 @@ import ONYXKEYS from '@src/ONYXKEYS';
 import ROUTES from '@src/ROUTES';
 import type {ReportAttributesDerivedValue} from '@src/types/onyx/DerivedValues';
 import type {SelectedParticipant} from '@src/types/onyx/NewGroupChatDraft';
-import getEmptyArray from '@src/types/utils/getEmptyArray';
 import KeyboardUtils from '@src/utils/keyboard';
 
 const excludedGroupEmails = new Set<string>(CONST.EXPENSIFY_EMAILS.filter((value) => value !== CONST.EMAIL.CONCIERGE));
@@ -71,7 +71,6 @@ function useOptions(reportAttributesDerived: ReportAttributesDerivedValue['repor
     const {contacts} = useContactImport();
     const [draftComments] = useOnyx(ONYXKEYS.COLLECTION.REPORT_DRAFT_COMMENT);
     const allPersonalDetails = usePersonalDetails();
-    const isScreenFocused = useIsFocused();
 
     const {
         options: listOptions,
@@ -203,7 +202,7 @@ function useOptions(reportAttributesDerived: ReportAttributesDerivedValue['repor
     }, [draftSelectedOptions, setSelectedOptions]);
 
     const handleEndReached = () => {
-        if (!hasMore || isLoadingMore || !areOptionsInitialized || !isScreenFocused) {
+        if (!hasMore || isLoadingMore || !areOptionsInitialized) {
             return;
         }
         loadMore();
@@ -242,10 +241,9 @@ function NewChatPage({ref}: NewChatPageProps) {
     const {top} = useSafeAreaInsets();
     const [isSearchingForReports] = useOnyx(ONYXKEYS.IS_SEARCHING_FOR_REPORTS, {initWithStoredValues: false});
     const [introSelected] = useOnyx(ONYXKEYS.NVP_INTRO_SELECTED);
-    const selectionListRef = useRef<SelectionListWithSectionsHandle | null>(null);
-    const [reportAttributesDerived] = useOnyx(ONYXKEYS.DERIVED.REPORT_ATTRIBUTES, {
-        selector: reportsSelector,
-    });
+    const [reportAttributesDerivedFull] = useOnyx(ONYXKEYS.DERIVED.REPORT_ATTRIBUTES);
+    const reportAttributesDerived = reportAttributesDerivedFull?.reports;
+    const selectionListRef = useRef<SelectionListHandle | null>(null);
 
     const allPersonalDetails = usePersonalDetails();
     const {singleExecution} = useSingleExecution();
@@ -253,25 +251,6 @@ function NewChatPage({ref}: NewChatPageProps) {
     useImperativeHandle(ref, () => ({
         focus: selectionListRef.current?.focusTextInput,
     }));
-
-    // Opacity toggle to fix FlashList layout issue when navigating back.
-    // FlashList compacts its layout when the screen is hidden but still mounted.
-    // Briefly setting opacity to 0 when the screen regains focus triggers a re-render
-    // that forces FlashList to recalculate its layout without a full remount.
-    const [listOpacity, setListOpacity] = useState(1);
-    const isFirstRender = useRef(true);
-    useFocusEffect(
-        useCallback(() => {
-            if (isFirstRender.current || Platform.OS !== 'web') {
-                isFirstRender.current = false;
-                return;
-            }
-            setListOpacity(0);
-            requestAnimationFrame(() => {
-                setListOpacity(1);
-            });
-        }, []),
-    );
 
     const {
         headerMessage,
@@ -288,7 +267,8 @@ function NewChatPage({ref}: NewChatPageProps) {
         areOptionsInitialized,
     } = useOptions(reportAttributesDerived);
 
-    const sections: Array<Section<OptionWithKey>> = [];
+    const sections: Section[] = [];
+    let firstKeyForList = '';
 
     const formatResults = formatSectionsFromSearchTerm(
         debouncedSearchTerm,
@@ -301,26 +281,41 @@ function NewChatPage({ref}: NewChatPageProps) {
         undefined,
         reportAttributesDerived,
     );
-    sections.push({...formatResults.section, title: undefined, sectionIndex: 0});
+    // Just a temporary fix to satisfy the type checker
+    // Will be fixed when migrating to use new SelectionListWithSections
+    sections.push({...formatResults.section, title: undefined, shouldShow: true});
+
+    if (!firstKeyForList) {
+        firstKeyForList = getFirstKeyForList(formatResults.section.data);
+    }
 
     sections.push({
         title: translate('common.recents'),
         data: selectedOptions.length ? recentReports.filter((option) => !option.isSelfDM) : recentReports,
-        sectionIndex: 1,
+        shouldShow: !isEmpty(recentReports),
     });
+    if (!firstKeyForList) {
+        firstKeyForList = getFirstKeyForList(recentReports);
+    }
 
     sections.push({
         title: translate('common.contacts'),
         data: personalDetails,
-        sectionIndex: 2,
+        shouldShow: !isEmpty(personalDetails),
     });
+    if (!firstKeyForList) {
+        firstKeyForList = getFirstKeyForList(personalDetails);
+    }
 
     if (userToInvite) {
         sections.push({
             title: undefined,
             data: [userToInvite],
-            sectionIndex: 3,
+            shouldShow: true,
         });
+        if (!firstKeyForList) {
+            firstKeyForList = getFirstKeyForList([userToInvite]);
+        }
     }
 
     /**
@@ -335,10 +330,10 @@ function NewChatPage({ref}: NewChatPageProps) {
             newSelectedOptions = reject(selectedOptions, (selectedOption) => selectedOption.login === option.login);
         } else {
             newSelectedOptions = [...selectedOptions, {...option, isSelected: true, selected: true, reportID: option.reportID, keyForList: `${option.keyForList ?? option.reportID}`}];
-            selectionListRef?.current?.scrollToIndex(0);
+            selectionListRef?.current?.scrollToIndex(0, true);
         }
 
-        selectionListRef.current?.clearInputAfterSelect();
+        selectionListRef?.current?.clearInputAfterSelect?.();
         if (!canUseTouchScreen()) {
             selectionListRef.current?.focusTextInput();
         }
@@ -364,7 +359,7 @@ function NewChatPage({ref}: NewChatPageProps) {
      * creates a new 1:1 chat with the option and the current user,
      * or navigates to the existing chat if one with those participants already exists.
      */
-    const selectOption = (option?: OptionWithKey) => {
+    const selectOption = (option?: Option) => {
         if (option?.isSelfDM) {
             if (!option.reportID) {
                 Navigation.dismissModal();
@@ -408,7 +403,7 @@ function NewChatPage({ref}: NewChatPageProps) {
         });
     };
 
-    const itemRightSideComponent = (item: OptionWithKey, isFocused?: boolean) => {
+    const itemRightSideComponent = (item: ListItem & Option, isFocused?: boolean) => {
         if (!!item.isSelfDM || (item.login && excludedGroupEmails.has(item.login)) || !item.login) {
             return null;
         }
@@ -477,16 +472,6 @@ function NewChatPage({ref}: NewChatPageProps) {
         </>
     );
 
-    const textInputOptions = {
-        label: translate('selectionList.nameEmailOrPhoneNumber'),
-        hint: isOffline ? `${translate('common.youAppearToBeOffline')} ${translate('search.resultsAreLimited')}` : '',
-        value: searchTerm,
-        onChangeText: setSearchTerm,
-        headerMessage,
-        disableAutoFocus: true,
-        shouldInterceptSwipe: true,
-    };
-
     return (
         <ScreenWrapper
             enableEdgeToEdgeBottomSafeAreaPadding
@@ -499,17 +484,18 @@ function NewChatPage({ref}: NewChatPageProps) {
             focusTrapSettings={{active: false}}
             testID="NewChatPage"
         >
-            <SelectionListWithSections<OptionWithKey>
+            <SelectionList<Option & ListItem>
                 ref={selectionListRef}
                 ListItem={UserListItem}
-                sections={areOptionsInitialized ? sections : getEmptyArray<Section<OptionWithKey>>()}
+                sections={areOptionsInitialized ? sections : CONST.EMPTY_ARRAY}
+                textInputValue={searchTerm}
+                textInputHint={isOffline ? `${translate('common.youAppearToBeOffline')} ${translate('search.resultsAreLimited')}` : ''}
+                onChangeText={setSearchTerm}
+                textInputLabel={translate('selectionList.nameEmailOrPhoneNumber')}
+                headerMessage={headerMessage}
                 onSelectRow={selectOption}
-                shouldShowTextInput
-                textInputOptions={textInputOptions}
                 shouldSingleExecuteRowSelect
-                confirmButtonOptions={{
-                    onConfirm: (e, option) => (selectedOptions.length > 0 ? createGroup() : selectOption(option)),
-                }}
+                onConfirm={(e, option) => (selectedOptions.length > 0 ? createGroup() : selectOption(option))}
                 rightHandSideComponent={itemRightSideComponent}
                 footerContent={footerContent}
                 showLoadingPlaceholder={!areOptionsInitialized}
@@ -517,9 +503,10 @@ function NewChatPage({ref}: NewChatPageProps) {
                 isLoadingNewOptions={!!isSearchingForReports || isLoadingMore}
                 onEndReached={handleEndReached}
                 onEndReachedThreshold={0.75}
-                disableMaintainingScrollPosition
+                initiallyFocusedOptionKey={firstKeyForList}
+                shouldTextInputInterceptSwipe
                 addBottomSafeAreaPadding
-                style={{listStyle: {opacity: listOpacity}}}
+                textInputAutoFocus={false}
             />
         </ScreenWrapper>
     );

--- a/tests/ui/NewChatPageTest.tsx
+++ b/tests/ui/NewChatPageTest.tsx
@@ -1,8 +1,7 @@
 import * as NativeNavigation from '@react-navigation/native';
 import {act, fireEvent, render, screen, waitFor, within} from '@testing-library/react-native';
 import React from 'react';
-// eslint-disable-next-line no-restricted-imports
-import {ScrollView} from 'react-native';
+import {SectionList} from 'react-native';
 import Onyx from 'react-native-onyx';
 import HTMLEngineProvider from '@components/HTMLEngineProvider';
 import {LocaleContextProvider} from '@components/LocaleContextProvider';
@@ -78,11 +77,11 @@ describe('NewChatPage', () => {
         act(() => {
             (NativeNavigation as NativeNavigationMock).triggerTransitionEnd();
         });
-        const scrollToSpy = jest.spyOn(ScrollView.prototype, 'scrollTo');
+        const spy = jest.spyOn(SectionList.prototype, 'scrollToLocation');
         const addButton = await waitFor(() => screen.getAllByText(translateLocal('newChatPage.addToGroup')).at(0));
         if (addButton) {
             fireEvent.press(addButton);
-            expect(scrollToSpy).toHaveBeenCalled();
+            expect(spy).toHaveBeenCalledWith(expect.objectContaining({itemIndex: 0}));
         }
     });
 


### PR DESCRIPTION
### Explanation of Change
Reverts https://github.com/Expensify/App/pull/81869 which is causing the app to freeze when creating a group chat. See the deploy blocker issue and Slack discussion linked below for context.

### Fixed Issues
$ https://github.com/Expensify/App/issues/83976

Slack discussion: https://expensify.slack.com/archives/C01GTK53T8Q/p1772505811208959

### Tests
1. Click on the `+` button
2. Navigate to `Start Chat`
3. Select some users and add them to the chat group
4. Click Next
5. On the Group page, verify you can go back, remove any selected member, or click "Start Group"
6. Verify the app does not freeze

- [x] Verify that no errors appear in the JS console

### Offline tests
N/A - This is a revert of a UI change, offline behavior is unchanged.

### QA Steps
Same as tests

- [x] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I verified there are no new alerts related to the `canBeMissing` param for `useOnyx`
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>
N/A - Revert PR
</details>

<details>
<summary>Android: mWeb Chrome</summary>
N/A - Revert PR
</details>

<details>
<summary>iOS: Native</summary>
N/A - Revert PR
</details>

<details>
<summary>iOS: mWeb Safari</summary>
N/A - Revert PR
</details>

<details>
<summary>MacOS: Chrome / Safari</summary>
N/A - Revert PR
</details>