### PR TITLE
Fix: Mentions no longer auto-insert trailing space

### DIFF
--- a/src/CONST/index.ts
+++ b/src/CONST/index.ts
@@ -4081,7 +4081,7 @@ const CONST = {
         SPECIAL_CHAR: /[,/?"{}[\]()&^%;`$=#<>!*]/g,
         FIRST_SPACE: /.+?(?=\s)/,
         TRAILING_DOTS: /\.$/,
-        STARTS_WITH_PUNCTUATION_WITHOUT_SPACE: /^[.,!?]/,
+        STARTS_WITH_PUNCTUATION: /^[.,!?]/,
 
         get SPECIAL_CHAR_OR_EMOJI() {
             return new RegExp(`[~\\n\\s]|(_\\b(?!$))|${this.SPECIAL_CHAR.source}|${this.EMOJI.source}`, 'gu');

--- a/src/CONST/index.ts
+++ b/src/CONST/index.ts
@@ -4081,6 +4081,7 @@ const CONST = {
         SPECIAL_CHAR: /[,/?"{}[\]()&^%;`$=#<>!*]/g,
         FIRST_SPACE: /.+?(?=\s)/,
         TRAILING_DOTS: /\.$/,
+        STARTS_WITH_PUNCTUATION_WITHOUT_SPACE: /^[.,!?]/,
 
         get SPECIAL_CHAR_OR_EMOJI() {
             return new RegExp(`[~\\n\\s]|(_\\b(?!$))|${this.SPECIAL_CHAR.source}|${this.EMOJI.source}`, 'gu');

--- a/src/pages/inbox/report/ReportActionCompose/SuggestionMention.tsx
+++ b/src/pages/inbox/report/ReportActionCompose/SuggestionMention.tsx
@@ -242,8 +242,11 @@ function SuggestionMention({
                 suggestionValues.atSignIndex + Math.max(mentionToReplace.length, suggestionValues.mentionPrefix.length + suggestionValues.prefixType.length),
             );
 
-            updateComment(`${commentBeforeAtSign}${mentionCode}${dotToAppend} ${trimLeadingSpace(commentAfterMention)}`, true);
-            const selectionPosition = suggestionValues.atSignIndex + mentionCode.length + dotToAppend.length + CONST.SPACE_LENGTH;
+            const trimmedCommentAfterMention = trimLeadingSpace(commentAfterMention);
+            const spacer = !trimmedCommentAfterMention || !CONST.REGEX.STARTS_WITH_PUNCTUATION_WITHOUT_SPACE.test(trimmedCommentAfterMention) ? ' ' : '';
+
+            updateComment(`${commentBeforeAtSign}${mentionCode}${dotToAppend}${spacer}${trimmedCommentAfterMention}`, true);
+            const selectionPosition = suggestionValues.atSignIndex + mentionCode.length + dotToAppend.length + spacer.length;
             setSelection({
                 start: selectionPosition,
                 end: selectionPosition,

--- a/src/pages/inbox/report/ReportActionCompose/SuggestionMention.tsx
+++ b/src/pages/inbox/report/ReportActionCompose/SuggestionMention.tsx
@@ -242,8 +242,8 @@ function SuggestionMention({
                 suggestionValues.atSignIndex + Math.max(mentionToReplace.length, suggestionValues.mentionPrefix.length + suggestionValues.prefixType.length),
             );
 
-            updateComment(`${commentBeforeAtSign}${mentionCode}${dotToAppend}${trimLeadingSpace(commentAfterMention)}`, true);
-            const selectionPosition = suggestionValues.atSignIndex + mentionCode.length + CONST.SPACE_LENGTH;
+            updateComment(`${commentBeforeAtSign}${mentionCode}${dotToAppend} ${trimLeadingSpace(commentAfterMention)}`, true);
+            const selectionPosition = suggestionValues.atSignIndex + mentionCode.length + dotToAppend.length + CONST.SPACE_LENGTH;
             setSelection({
                 start: selectionPosition,
                 end: selectionPosition,

--- a/src/pages/inbox/report/ReportActionCompose/SuggestionMention.tsx
+++ b/src/pages/inbox/report/ReportActionCompose/SuggestionMention.tsx
@@ -243,7 +243,7 @@ function SuggestionMention({
             );
 
             const trimmedCommentAfterMention = trimLeadingSpace(commentAfterMention);
-            const spacer = !trimmedCommentAfterMention || !CONST.REGEX.STARTS_WITH_PUNCTUATION_WITHOUT_SPACE.test(trimmedCommentAfterMention) ? ' ' : '';
+            const spacer = !trimmedCommentAfterMention || !CONST.REGEX.STARTS_WITH_PUNCTUATION.test(trimmedCommentAfterMention) ? ' ' : '';
 
             updateComment(`${commentBeforeAtSign}${mentionCode}${dotToAppend}${spacer}${trimmedCommentAfterMention}`, true);
             const selectionPosition = suggestionValues.atSignIndex + mentionCode.length + dotToAppend.length + spacer.length;

--- a/tests/unit/SuggestionMentionTest.tsx
+++ b/tests/unit/SuggestionMentionTest.tsx
@@ -202,4 +202,46 @@ describe('SuggestionMention', () => {
         expect(updateComment).toHaveBeenCalledWith('@a.smith@example.com ', true);
         expect(setSelection).toHaveBeenCalledWith({start: 21, end: 21});
     });
+
+    it('does not insert trailing space when mention is followed by a comma (punctuation)', async () => {
+        mockPersonalDetails = {};
+        mockPersonalDetails[2] = {
+            accountID: 2,
+            login: 'adam@example.com',
+            firstName: 'Adam',
+            lastName: 'Tester',
+        };
+
+        const updateComment = jest.fn();
+        const {setSelection} = renderSuggestionMention('@a, thanks', updateComment, {start: 2, end: 2});
+
+        await waitFor(() => expect(mockMentionSuggestionsSpy).toHaveBeenCalled());
+        const {onSelect} = getLastMentionSuggestionsProps();
+
+        act(() => onSelect(0));
+
+        expect(updateComment).toHaveBeenCalledWith('@adam@example.com, thanks', true);
+        expect(setSelection).toHaveBeenCalledWith({start: 17, end: 17});
+    });
+
+    it('inserts trailing space when mention is followed by a regular word', async () => {
+        mockPersonalDetails = {};
+        mockPersonalDetails[2] = {
+            accountID: 2,
+            login: 'adam@example.com',
+            firstName: 'Adam',
+            lastName: 'Tester',
+        };
+
+        const updateComment = jest.fn();
+        const {setSelection} = renderSuggestionMention('@a thanks', updateComment, {start: 2, end: 2});
+
+        await waitFor(() => expect(mockMentionSuggestionsSpy).toHaveBeenCalled());
+        const {onSelect} = getLastMentionSuggestionsProps();
+
+        act(() => onSelect(0));
+
+        expect(updateComment).toHaveBeenCalledWith('@adam@example.com thanks', true);
+        expect(setSelection).toHaveBeenCalledWith({start: 18, end: 18});
+    });
 });

--- a/tests/unit/SuggestionMentionTest.tsx
+++ b/tests/unit/SuggestionMentionTest.tsx
@@ -161,7 +161,7 @@ describe('SuggestionMention', () => {
         );
     });
 
-    it('preserves trailing punctuation dot when selected mention does not include dotted prefix', async () => {
+    it('preserves trailing punctuation dot and inserts trailing space when selected mention does not include dotted prefix', async () => {
         mockPersonalDetails = {};
         mockPersonalDetails[2] = {
             accountID: 2,
@@ -178,11 +178,11 @@ describe('SuggestionMention', () => {
 
         act(() => onSelect(0));
 
-        expect(updateComment).toHaveBeenCalledWith('@adam@example.com.', true);
-        expect(setSelection).toHaveBeenCalledWith({start: 18, end: 18});
+        expect(updateComment).toHaveBeenCalledWith('@adam@example.com. ', true);
+        expect(setSelection).toHaveBeenCalledWith({start: 19, end: 19});
     });
 
-    it('does not append an extra trailing dot when selected mention already matches dotted prefix', async () => {
+    it('does not append an extra trailing dot and inserts trailing space when selected mention already matches dotted prefix', async () => {
         mockPersonalDetails = {};
         mockPersonalDetails[2] = {
             accountID: 2,
@@ -199,7 +199,7 @@ describe('SuggestionMention', () => {
 
         act(() => onSelect(0));
 
-        expect(updateComment).toHaveBeenCalledWith('@a.smith@example.com', true);
+        expect(updateComment).toHaveBeenCalledWith('@a.smith@example.com ', true);
         expect(setSelection).toHaveBeenCalledWith({start: 21, end: 21});
     });
 });


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
This PR adds a trailing space after a mention so that the user can continue typing without breaking the mention. This PR also updates the cursor position calculation to account for the `dotToAppend` case, ensuring the cursor remains in the correct position when a mention ends with a dot

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/83510
PROPOSAL: https://github.com/Expensify/App/issues/83510#issuecomment-3963017309


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
Same as QA Steps

- [x] Verify that no errors appear in the JS console

### Offline tests
Same as QA Steps

### QA Steps
1. Open any chat
2. Type @ and begin typing a user’s name
3. Select the user from the dropdown
4. Immediately continue typing
5. Verify that after selecting a user, a space is automatically inserted

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

https://github.com/user-attachments/assets/50eda50d-6701-4c6f-bed7-13912c8fa036

</details>

<details>
<summary>Android: mWeb Chrome</summary>

https://github.com/user-attachments/assets/20eebdc1-5836-416a-bca3-2cb042b4e887

</details>

<details>
<summary>iOS: Native</summary>

https://github.com/user-attachments/assets/4f5a626a-89a0-41b7-b2ca-ff71b4fadfa7

</details>

<details>
<summary>iOS: mWeb Safari</summary>

https://github.com/user-attachments/assets/0b09d0ac-654f-47e8-a541-8f731d0408d9

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

https://github.com/user-attachments/assets/2414173f-52e7-4681-9711-051734f109b7

</details>