### PR TITLE
fix(VideoPlayer): Fix Android progress bar disappearing when seeking

### DIFF
--- a/src/components/VideoPlayer/VideoPlayerControls/ProgressBar/index.tsx
+++ b/src/components/VideoPlayer/VideoPlayerControls/ProgressBar/index.tsx
@@ -1,7 +1,9 @@
 import React, {useEffect, useState} from 'react';
 import type {LayoutChangeEvent} from 'react-native';
+import {Platform} from 'react-native';
 import type {GestureStateChangeEvent, GestureUpdateEvent, PanGestureChangeEventPayload, PanGestureHandlerEventPayload} from 'react-native-gesture-handler';
 import {Gesture, GestureDetector} from 'react-native-gesture-handler';
+import {VideoView} from 'expo-video';
 import Animated, {useAnimatedStyle, useSharedValue} from 'react-native-reanimated';
 import {scheduleOnRN} from 'react-native-worklets';
 import {usePlaybackActionsContext} from '@components/VideoPlayerContexts/PlaybackContext';
@@ -48,7 +50,10 @@ function ProgressBar({duration, position, seekPosition}: ProgressBarProps) {
         .runOnJS(true)
         // Reduce gesture threshold so quick taps trigger onFinalize on iOS.
         .minDistance(0)
-        .activateAfterLongPress(0)
+        // On Android, use a small delay to avoid conflict with native VideoView gestures
+        .activateAfterLongPress(Platform.OS === 'android' ? 100 : 0)
+        // Allow the gesture to work alongside the native VideoView on Android
+        .simultaneousWithExternalGesture(VideoView)
         .onBegin((event) => {
             setIsSliderPressed(true);
             checkIfVideoIsPlaying(onCheckIfVideoIsPlaying);


### PR DESCRIPTION
## Summary
$ #82026 - Android video progress bar disappears when trying to seek

## Changes
1. Added Platform.OS check for activateAfterLongPress (100ms on Android vs 0 on iOS)
2. Added simultaneousWithExternalGesture to allow gesture to work with native VideoView on Android

## Testing
Test on Android device:
1. Open DM chat
2. Send a video attachment  
3. Play the video
4. Try to drag the progress bar - it should no longer disappear

## Related Issue
[$250] Android - DM - Video progress bar disappears when trying to seek