### PR TITLE
fix: Use computed title instead of Chat Report placeholder in chat search

### DIFF
--- a/src/components/AvatarWithDisplayName.tsx
+++ b/src/components/AvatarWithDisplayName.tsx
@@ -121,7 +121,7 @@ function getCustomDisplayName(
 
             if (!hasTransactions) {
                 return {
-                    fullTitle: reportName,
+                    fullTitle: title,
                     shouldUseFullTitle,
                     ...baseProps,
                     ...styleProps,


### PR DESCRIPTION
$ #84140

The chat search was briefly displaying 'Chat Report' label before resolving to the correct chat name. This happened because when shouldUseCustomSearchTitleName is true and there are no transactions, the code was using reportName which defaults to 'Chat Report' when report.reportName is undefined.

The fix changes the code to use 'title' (which is properly computed from getReportName) instead of 'reportName' (which has the 'Chat Report' fallback).

---
*Contributed by [theluckystrike](https://github.com/theluckystrike) | [Zovo](https://zovo.one)*