### PR TITLE
Create per-diem in selfDM if auto reporting is disabled (2)

### DIFF
--- a/src/libs/IOUUtils.ts
+++ b/src/libs/IOUUtils.ts
@@ -401,17 +401,27 @@ function getInitialPerDiemTargetReport(
     iouType: IOUType,
     defaultExpensePolicy: OnyxEntry<Pick<Policy, 'autoReporting'>>,
     personalPolicy: OnyxEntry<Pick<Policy, 'autoReporting'>>,
+    isFromGlobalCreate: boolean,
 ): {targetReport: OnyxEntry<Report>; targetIouType: IOUType; transactionReportID: string | undefined} {
     let targetReport = report;
     let targetIouType = iouType;
-    const shouldAutoReport = !!defaultExpensePolicy?.autoReporting || !!personalPolicy?.autoReporting;
-    if (!shouldAutoReport || targetIouType === CONST.IOU.TYPE.TRACK) {
+
+    if (isFromGlobalCreate) {
+        const shouldAutoReport = !!defaultExpensePolicy?.autoReporting || !!personalPolicy?.autoReporting;
+        if (!shouldAutoReport) {
+            targetReport = selfDMReport;
+        }
+    }
+
+    if (targetIouType === CONST.IOU.TYPE.TRACK) {
         targetReport = selfDMReport;
     }
+
     const transactionReportID = isSelfDM(targetReport) ? CONST.REPORT.UNREPORTED_REPORT_ID : targetReport?.reportID;
     if (transactionReportID === CONST.REPORT.UNREPORTED_REPORT_ID) {
         targetIouType = CONST.IOU.TYPE.TRACK;
     }
+
     return {targetReport, targetIouType, transactionReportID};
 }
 

--- a/src/libs/IOUUtils.ts
+++ b/src/libs/IOUUtils.ts
@@ -11,7 +11,7 @@ import {getCurrencyUnit} from './CurrencyUtils';
 import Navigation from './Navigation/Navigation';
 import {isPaidGroupPolicy} from './PolicyUtils';
 import {getOriginalMessage, isMoneyRequestAction} from './ReportActionsUtils';
-import {getReportTransactions} from './ReportUtils';
+import {getReportTransactions, isSelfDM} from './ReportUtils';
 import {endSpan, getSpan, startSpan} from './telemetry/activeSpans';
 import {getCurrency, getTagArrayFromName} from './TransactionUtils';
 
@@ -395,6 +395,26 @@ function calculateDefaultReimbursable({
     return (isPolicyExpenseChat && isPaidGroupPolicy(reportPolicy)) || isCreatingTrackExpense ? (reportPolicy?.defaultReimbursable ?? true) : true;
 }
 
+function getInitialPerDiemTargetReport(
+    report: OnyxEntry<Report>,
+    selfDMReport: OnyxEntry<Report>,
+    iouType: IOUType,
+    defaultExpensePolicy: OnyxEntry<Pick<Policy, 'autoReporting'>>,
+    personalPolicy: OnyxEntry<Pick<Policy, 'autoReporting'>>,
+): {targetReport: OnyxEntry<Report>; targetIouType: IOUType; transactionReportID: string | undefined} {
+    let targetReport = report;
+    let targetIouType = iouType;
+    const shouldAutoReport = !!defaultExpensePolicy?.autoReporting || !!personalPolicy?.autoReporting;
+    if (!shouldAutoReport || targetIouType === CONST.IOU.TYPE.TRACK) {
+        targetReport = selfDMReport;
+    }
+    const transactionReportID = isSelfDM(targetReport) ? CONST.REPORT.UNREPORTED_REPORT_ID : targetReport?.reportID;
+    if (transactionReportID === CONST.REPORT.UNREPORTED_REPORT_ID) {
+        targetIouType = CONST.IOU.TYPE.TRACK;
+    }
+    return {targetReport, targetIouType, transactionReportID};
+}
+
 export {
     calculateAmount,
     calculateSplitAmountFromPercentage,
@@ -412,4 +432,5 @@ export {
     shouldShowReceiptEmptyState,
     navigateToConfirmationPage,
     calculateDefaultReimbursable,
+    getInitialPerDiemTargetReport,
 };

--- a/src/pages/iou/request/step/IOURequestStepDestination.tsx
+++ b/src/pages/iou/request/step/IOURequestStepDestination.tsx
@@ -11,14 +11,17 @@ import ScreenWrapper from '@components/ScreenWrapper';
 import type {ListItem, SelectionListWithSectionsHandle} from '@components/SelectionList/SelectionListWithSections/types';
 import WorkspaceEmptyStateSection from '@components/WorkspaceEmptyStateSection';
 import useCurrentUserPersonalDetails from '@hooks/useCurrentUserPersonalDetails';
+import useDefaultExpensePolicy from '@hooks/useDefaultExpensePolicy';
 import {useMemoizedLazyIllustrations} from '@hooks/useLazyAsset';
 import useLocalize from '@hooks/useLocalize';
 import useNetwork from '@hooks/useNetwork';
 import useOnyx from '@hooks/useOnyx';
+import usePersonalPolicy from '@hooks/usePersonalPolicy';
 import useSafeAreaInsets from '@hooks/useSafeAreaInsets';
 import useThemeStyles from '@hooks/useThemeStyles';
 import {fetchPerDiemRates} from '@libs/actions/Policy/PerDiem';
 import {setTransactionReport} from '@libs/actions/Transaction';
+import {getInitialPerDiemTargetReport} from '@libs/IOUUtils';
 import Navigation from '@libs/Navigation/Navigation';
 import {getPerDiemCustomUnit, getPolicyByCustomUnitID, isPolicyAdmin} from '@libs/PolicyUtils';
 import {findSelfDMReportID, getPolicyExpenseChat} from '@libs/ReportUtils';
@@ -73,11 +76,12 @@ function IOURequestStepDestination({
     const [policy, policyMetadata] = useOnyx(`${ONYXKEYS.COLLECTION.POLICY}${explicitPolicyID ?? policyID}`);
     const {accountID} = useCurrentUserPersonalDetails();
     const policyExpenseReport = policy?.id ? getPolicyExpenseChat(accountID, policy.id) : undefined;
+    const defaultExpensePolicy = useDefaultExpensePolicy();
+    const personalPolicy = usePersonalPolicy();
     const {top} = useSafeAreaInsets();
     const customUnit = getPerDiemCustomUnit(policy);
     const selectedDestination = transaction?.comment?.customUnit?.customUnitRateID;
     const [selfDMReport] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT}${findSelfDMReportID()}`);
-    const currentUserPersonalDetails = useCurrentUserPersonalDetails();
 
     const styles = useThemeStyles();
     const illustrations = useMemoizedLazyIllustrations(['EmptyStateExpenses']);
@@ -110,15 +114,14 @@ function IOURequestStepDestination({
         if (isEmptyObject(customUnit)) {
             return;
         }
-        const targetReport: OnyxEntry<Report> = explicitPolicyID && transaction?.isFromGlobalCreate ? policyExpenseReport : report;
+        let targetReport: OnyxEntry<Report> = explicitPolicyID && transaction?.isFromGlobalCreate ? policyExpenseReport : report;
+        let targetIouType = iouType;
+        let transactionReportID;
         if (selectedDestination !== destination.keyForList) {
             if (openedFromStartPage) {
-                setTransactionReport(transactionID, {reportID: targetReport?.reportID}, true);
-                if (iouType === CONST.IOU.TYPE.TRACK) {
-                    setMoneyRequestParticipantsFromReport(transactionID, selfDMReport, currentUserPersonalDetails.accountID, false);
-                } else {
-                    setMoneyRequestParticipantsFromReport(transactionID, targetReport, accountID);
-                }
+                ({targetReport, targetIouType, transactionReportID} = getInitialPerDiemTargetReport(targetReport, selfDMReport, targetIouType, defaultExpensePolicy, personalPolicy));
+                setTransactionReport(transactionID, {reportID: transactionReportID}, true);
+                setMoneyRequestParticipantsFromReport(transactionID, targetReport, accountID, targetIouType !== CONST.IOU.TYPE.TRACK);
                 setCustomUnitID(transactionID, customUnit.customUnitID);
                 setMoneyRequestCategory(transactionID, customUnit?.defaultCategory ?? '', undefined);
             }
@@ -130,7 +133,7 @@ function IOURequestStepDestination({
         if (backTo) {
             navigateBack();
         } else {
-            Navigation.navigate(ROUTES.MONEY_REQUEST_STEP_TIME.getRoute(action, iouType, transactionID, targetReport?.reportID ?? reportID));
+            Navigation.navigate(ROUTES.MONEY_REQUEST_STEP_TIME.getRoute(action, targetIouType, transactionID, targetReport?.reportID ?? reportID));
         }
     };
 

--- a/src/pages/iou/request/step/IOURequestStepDestination.tsx
+++ b/src/pages/iou/request/step/IOURequestStepDestination.tsx
@@ -119,7 +119,14 @@ function IOURequestStepDestination({
         let transactionReportID;
         if (selectedDestination !== destination.keyForList) {
             if (openedFromStartPage) {
-                ({targetReport, targetIouType, transactionReportID} = getInitialPerDiemTargetReport(targetReport, selfDMReport, targetIouType, defaultExpensePolicy, personalPolicy));
+                ({targetReport, targetIouType, transactionReportID} = getInitialPerDiemTargetReport(
+                    targetReport,
+                    selfDMReport,
+                    targetIouType,
+                    defaultExpensePolicy,
+                    personalPolicy,
+                    transaction?.isFromGlobalCreate ?? false,
+                ));
                 setTransactionReport(transactionID, {reportID: transactionReportID}, true);
                 setMoneyRequestParticipantsFromReport(transactionID, targetReport, accountID, targetIouType !== CONST.IOU.TYPE.TRACK);
                 setCustomUnitID(transactionID, customUnit.customUnitID);

--- a/src/pages/iou/request/step/IOURequestStepPerDiemWorkspace.tsx
+++ b/src/pages/iou/request/step/IOURequestStepPerDiemWorkspace.tsx
@@ -1,6 +1,9 @@
 import React from 'react';
 import useCurrentUserPersonalDetails from '@hooks/useCurrentUserPersonalDetails';
+import useDefaultExpensePolicy from '@hooks/useDefaultExpensePolicy';
 import useOnyx from '@hooks/useOnyx';
+import usePersonalPolicy from '@hooks/usePersonalPolicy';
+import {getInitialPerDiemTargetReport} from '@libs/IOUUtils';
 import Navigation from '@libs/Navigation/Navigation';
 import type {PlatformStackScreenProps} from '@libs/Navigation/PlatformStackNavigation/types';
 import type {MoneyRequestNavigatorParamList} from '@libs/Navigation/types';
@@ -22,6 +25,8 @@ function IOURequestStepPerDiemWorkspace({route, navigation}: IOURequestStepPerDi
     } = route;
     const {accountID} = useCurrentUserPersonalDetails();
     const [selfDMReport] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT}${findSelfDMReportID()}`);
+    const defaultExpensePolicy = useDefaultExpensePolicy();
+    const personalPolicy = usePersonalPolicy();
 
     return (
         <BaseRequestStepWorkspace
@@ -29,28 +34,40 @@ function IOURequestStepPerDiemWorkspace({route, navigation}: IOURequestStepPerDi
             navigation={navigation}
             getPolicies={getActivePoliciesWithExpenseChatAndPerDiemEnabled}
             onSelectWorkspace={(policy) => {
-                const policyExpenseReportID = getPolicyExpenseChat(accountID, policy?.id)?.reportID;
-                if (!policyExpenseReportID) {
+                const {targetReport, targetIouType, transactionReportID} = getInitialPerDiemTargetReport(
+                    getPolicyExpenseChat(accountID, policy?.id),
+                    selfDMReport,
+                    iouType,
+                    defaultExpensePolicy,
+                    personalPolicy,
+                );
+
+                if (!targetReport) {
                     return;
                 }
+
                 const perDiemUnit = getPerDiemCustomUnit(policy);
-                setTransactionReport(transactionID, {reportID: policyExpenseReportID}, true);
-                if (iouType === CONST.IOU.TYPE.TRACK) {
-                    setMoneyRequestParticipantsFromReport(transactionID, selfDMReport, accountID, false);
+                if (!perDiemUnit) {
+                    return;
+                }
+
+                setTransactionReport(transactionID, {reportID: transactionReportID}, true);
+                if (targetIouType === CONST.IOU.TYPE.TRACK) {
+                    setMoneyRequestParticipantsFromReport(transactionID, targetReport, accountID, false);
                 } else {
                     setMoneyRequestParticipants(transactionID, [
                         {
                             selected: true,
                             accountID: 0,
                             isPolicyExpenseChat: true,
-                            reportID: policyExpenseReportID,
+                            reportID: targetReport.reportID,
                             policyID: policy?.id,
                         },
                     ]);
                 }
                 setCustomUnitID(transactionID, perDiemUnit?.customUnitID ?? CONST.CUSTOM_UNITS.FAKE_P2P_ID);
                 setMoneyRequestCategory(transactionID, perDiemUnit?.defaultCategory ?? '', undefined);
-                Navigation.navigate(ROUTES.MONEY_REQUEST_STEP_DESTINATION.getRoute(action, iouType, transactionID, policyExpenseReportID));
+                Navigation.navigate(ROUTES.MONEY_REQUEST_STEP_DESTINATION.getRoute(action, targetIouType, transactionID, targetReport.reportID));
             }}
         />
     );

--- a/src/pages/iou/request/step/IOURequestStepPerDiemWorkspace.tsx
+++ b/src/pages/iou/request/step/IOURequestStepPerDiemWorkspace.tsx
@@ -5,8 +5,6 @@ import useOnyx from '@hooks/useOnyx';
 import usePersonalPolicy from '@hooks/usePersonalPolicy';
 import {getInitialPerDiemTargetReport} from '@libs/IOUUtils';
 import Navigation from '@libs/Navigation/Navigation';
-import type {PlatformStackScreenProps} from '@libs/Navigation/PlatformStackNavigation/types';
-import type {MoneyRequestNavigatorParamList} from '@libs/Navigation/types';
 import {getActivePoliciesWithExpenseChatAndPerDiemEnabled, getPerDiemCustomUnit} from '@libs/PolicyUtils';
 import {findSelfDMReportID, getPolicyExpenseChat} from '@libs/ReportUtils';
 import {setCustomUnitID, setMoneyRequestCategory, setMoneyRequestParticipants, setMoneyRequestParticipantsFromReport} from '@userActions/IOU';
@@ -16,10 +14,12 @@ import ONYXKEYS from '@src/ONYXKEYS';
 import ROUTES from '@src/ROUTES';
 import type SCREENS from '@src/SCREENS';
 import BaseRequestStepWorkspace from './BaseRequestStepWorkspace';
+import type {WithFullTransactionOrNotFoundProps} from './withFullTransactionOrNotFound';
+import withFullTransactionOrNotFound from './withFullTransactionOrNotFound';
 
-type IOURequestStepPerDiemWorkspaceProps = PlatformStackScreenProps<MoneyRequestNavigatorParamList, typeof SCREENS.MONEY_REQUEST.CREATE>;
+type IOURequestStepPerDiemWorkspaceProps = WithFullTransactionOrNotFoundProps<typeof SCREENS.MONEY_REQUEST.CREATE>;
 
-function IOURequestStepPerDiemWorkspace({route, navigation}: IOURequestStepPerDiemWorkspaceProps) {
+function IOURequestStepPerDiemWorkspace({route, navigation, transaction}: IOURequestStepPerDiemWorkspaceProps) {
     const {
         params: {action, iouType, transactionID},
     } = route;
@@ -40,6 +40,7 @@ function IOURequestStepPerDiemWorkspace({route, navigation}: IOURequestStepPerDi
                     iouType,
                     defaultExpensePolicy,
                     personalPolicy,
+                    transaction?.isFromGlobalCreate ?? false,
                 );
 
                 if (!targetReport) {
@@ -73,4 +74,4 @@ function IOURequestStepPerDiemWorkspace({route, navigation}: IOURequestStepPerDi
     );
 }
 
-export default IOURequestStepPerDiemWorkspace;
+export default withFullTransactionOrNotFound(IOURequestStepPerDiemWorkspace);


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change

2nd attempt of https://github.com/Expensify/App/pull/82230 after fixing regression https://github.com/Expensify/App/issues/84167

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/Expensify/issues/595920
PROPOSAL:


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests

**Test 1**:
- Enable auto reporting on the default workspace
- Enable Per-Diem only on the default workspace and add rates

1. Click on FAB > Create expense > Per diem
2. Complete process
3. Verify the per-diem expense is created on the default workspace's expense chat




https://github.com/user-attachments/assets/7a1bec43-bbd1-4579-8037-b65c692d519a




**Test 2**:
- Enable auto reporting on the default workspace
- Enable Per-Diem on the multiple workspaces and add rates

1. Click on FAB > Create expense > Per diem
2. Select any workspace
3. Complete process
4. Verify the per-diem expense is created on the selected workspace's expense chat


https://github.com/user-attachments/assets/ed47f5c5-3958-4686-9376-74f59a8899a5


**Test 3**:
- Disable auto reporting on the default workspace
- Enable Per-Diem only on the default workspace and add rates

1. Click on FAB > Create expense > Per diem
2. Complete process
3. Verify the per-diem expense is created unreported (in your selfDM)


https://github.com/user-attachments/assets/32d40eb0-8e5e-4b76-9a4b-64099be3defe


**Test 4**:
- Disable auto reporting on the default workspace
- Enable Per-Diem on the multiple workspaces and add rates

1. Click on FAB > Create expense > Per diem
2. Select any workspace
3. Complete process
4. Verify the per-diem expense is created unreported (in your selfDM)

https://github.com/user-attachments/assets/50b0bef3-bf78-485b-bda8-ec2e6f0b69d8

**Test 5**:
- Disable auto reporting on the default workspace
- Enable Per-Diem on the multiple workspaces and add rates

1. Open workspace expense chat
2. Click on + grey button > Create expense (Per diem)
3. Complete process
4. Verify the per-diem expense is created on the opened workspace expense chat


https://github.com/user-attachments/assets/e1e1d2f3-9131-48fb-b5c5-bc528c9ca932



- [X] Verify that no errors appear in the JS console

### Offline tests

Same as Tests

### QA Steps

Same as Tests

- [X] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [X] I linked the correct issue in the `### Fixed Issues` section above
- [X] I wrote clear testing steps that cover the changes made in this PR
    - [X] I added steps for local testing in the `Tests` section
    - [X] I added steps for the expected offline behavior in the `Offline steps` section
    - [X] I added steps for Staging and/or Production testing in the `QA steps` section
    - [X] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [X] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [X] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [X] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [X] I ran the tests on **all platforms** & verified they passed on:
    - [X] Android: Native
    - [X] Android: mWeb Chrome
    - [X] iOS: Native
    - [X] iOS: mWeb Safari
    - [X] MacOS: Chrome / Safari
- [X] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [X] I verified there are no new alerts related to the `canBeMissing` param for `useOnyx`
- [X] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [X] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [X] I verified that comments were added to code that is not self explanatory
    - [X] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [X] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [X] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [X] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [X] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [X] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [X] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [X] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [X] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [X] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [X] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [X] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [X] I verified that if a function's arguments changed that all usages have also been updated correctly
- [X] If any new file was added I verified that:
    - [X] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [X] If a new CSS style is added I verified that:
    - [X] A similar style doesn't already exist
    - [X] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [X] If new assets were added or existing ones were modified, I verified that:
    - [X] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [X] The assets load correctly across all supported platforms.
- [X] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [X] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [X] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [X] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [X] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [X] I verified that all the inputs inside a form are aligned with each other.
    - [X] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [X] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [X] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [X] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>