### PR TITLE
fix: prevent infinite timezone update loop for delegate sessions

### DIFF
--- a/src/hooks/useAutoUpdateTimezone.ts
+++ b/src/hooks/useAutoUpdateTimezone.ts
@@ -1,18 +1,24 @@
-import {useEffect} from 'react';
+import {useEffect, useRef} from 'react';
 import {updateAutomaticTimezone} from '@userActions/PersonalDetails';
 import {isActingAsDelegateSelector} from '@selectors/Account';
 import type {SelectedTimezone} from '@src/types/onyx/PersonalDetails';
 import useCurrentUserPersonalDetails from './useCurrentUserPersonalDetails';
+import useOnyx from './useOnyx';
+import ONYXKEYS from '@src/ONYXKEYS';
 
 const THROTTLE_INTERVAL_MS = 60 * 60 * 1000; // 1 hour
-
-let lastUpdateTimestamp = 0;
 
 const useAutoUpdateTimezone = () => {
     const currentUserPersonalDetails = useCurrentUserPersonalDetails();
     const timezone = currentUserPersonalDetails?.timezone ?? {};
-    const account = currentUserPersonalDetails?.account;
+    const accountID = currentUserPersonalDetails?.accountID;
+    
+    // Use useOnyx to get the Account data (contains delegatedAccess)
+    const [account] = useOnyx(ONYXKEYS.ACCOUNT);
     const isDelegate = isActingAsDelegateSelector(account);
+    
+    // Use useRef to store per-account timestamps
+    const lastUpdateTimestamps = useRef<Record<number, number>>({});
 
     useEffect(() => {
         // Skip auto-timezone updates for copilot/delegate sessions
@@ -21,8 +27,11 @@ const useAutoUpdateTimezone = () => {
         }
 
         const currentTime = Date.now();
+        
+        // Get the last update timestamp for this specific account
+        const lastUpdateTimestamp = lastUpdateTimestamps.current[accountID] ?? 0;
 
-        // Throttle timezone updates to once per hour
+        // Throttle timezone updates to once per hour (per account)
         if (currentTime - lastUpdateTimestamp < THROTTLE_INTERVAL_MS) {
             return;
         }
@@ -31,17 +40,18 @@ const useAutoUpdateTimezone = () => {
         const hasValidCurrentTimezone = typeof currentTimezone === 'string' && currentTimezone.trim().length > 0;
 
         if (hasValidCurrentTimezone && timezone?.automatic && timezone?.selected !== currentTimezone) {
-            lastUpdateTimestamp = currentTime;
+            // Update the timestamp for this specific account
+            lastUpdateTimestamps.current[accountID] = currentTime;
             updateAutomaticTimezone(
                 {
                     automatic: true,
                     selected: currentTimezone,
                 },
-                currentUserPersonalDetails.accountID,
+                accountID,
             );
         }
         // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [timezone?.automatic, timezone?.selected, isDelegate]);
+    }, [timezone?.automatic, timezone?.selected, isDelegate, accountID]);
 };
 
 export default useAutoUpdateTimezone;

--- a/src/hooks/useAutoUpdateTimezone.ts
+++ b/src/hooks/useAutoUpdateTimezone.ts
@@ -1,16 +1,37 @@
 import {useEffect} from 'react';
 import {updateAutomaticTimezone} from '@userActions/PersonalDetails';
+import {isActingAsDelegateSelector} from '@selectors/Account';
 import type {SelectedTimezone} from '@src/types/onyx/PersonalDetails';
 import useCurrentUserPersonalDetails from './useCurrentUserPersonalDetails';
+
+const THROTTLE_INTERVAL_MS = 60 * 60 * 1000; // 1 hour
+
+let lastUpdateTimestamp = 0;
 
 const useAutoUpdateTimezone = () => {
     const currentUserPersonalDetails = useCurrentUserPersonalDetails();
     const timezone = currentUserPersonalDetails?.timezone ?? {};
+    const account = currentUserPersonalDetails?.account;
+    const isDelegate = isActingAsDelegateSelector(account);
+
     useEffect(() => {
+        // Skip auto-timezone updates for copilot/delegate sessions
+        if (isDelegate) {
+            return;
+        }
+
+        const currentTime = Date.now();
+
+        // Throttle timezone updates to once per hour
+        if (currentTime - lastUpdateTimestamp < THROTTLE_INTERVAL_MS) {
+            return;
+        }
+
         const currentTimezone = Intl.DateTimeFormat().resolvedOptions().timeZone as SelectedTimezone;
         const hasValidCurrentTimezone = typeof currentTimezone === 'string' && currentTimezone.trim().length > 0;
 
         if (hasValidCurrentTimezone && timezone?.automatic && timezone?.selected !== currentTimezone) {
+            lastUpdateTimestamp = currentTime;
             updateAutomaticTimezone(
                 {
                     automatic: true,
@@ -20,7 +41,7 @@ const useAutoUpdateTimezone = () => {
             );
         }
         // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [timezone?.automatic, timezone?.selected]);
+    }, [timezone?.automatic, timezone?.selected, isDelegate]);
 };
 
 export default useAutoUpdateTimezone;


### PR DESCRIPTION
## Context
Fixes issue #83765 - Infinite timezone update loop on multi-device setups with different timezones.

## Changes
- Skip auto-timezone updates for copilot/delegate sessions
- Throttle timezone updates to once per hour to prevent infinite loop

## Related Issues
$ #83765