### PR TITLE
Fix: Prevent infinite UpdateAutomaticTimezone loop on multi-device setups

### DIFF
--- a/src/hooks/useAutoUpdateTimezone.ts
+++ b/src/hooks/useAutoUpdateTimezone.ts
@@ -1,16 +1,37 @@
 import {useEffect} from 'react';
 import {updateAutomaticTimezone} from '@userActions/PersonalDetails';
+import {isActingAsDelegateSelector} from '@selectors/Account';
 import type {SelectedTimezone} from '@src/types/onyx/PersonalDetails';
 import useCurrentUserPersonalDetails from './useCurrentUserPersonalDetails';
+
+const THROTTLE_INTERVAL_MS = 60 * 60 * 1000; // 1 hour
+
+let lastUpdateTimestamp = 0;
 
 const useAutoUpdateTimezone = () => {
     const currentUserPersonalDetails = useCurrentUserPersonalDetails();
     const timezone = currentUserPersonalDetails?.timezone ?? {};
+    const account = currentUserPersonalDetails?.account;
+    const isDelegate = isActingAsDelegateSelector(account);
+
     useEffect(() => {
+        // Skip auto-timezone updates for copilot/delegate sessions
+        if (isDelegate) {
+            return;
+        }
+
+        const currentTime = Date.now();
+
+        // Throttle timezone updates to once per hour
+        if (currentTime - lastUpdateTimestamp < THROTTLE_INTERVAL_MS) {
+            return;
+        }
+
         const currentTimezone = Intl.DateTimeFormat().resolvedOptions().timeZone as SelectedTimezone;
         const hasValidCurrentTimezone = typeof currentTimezone === 'string' && currentTimezone.trim().length > 0;
 
         if (hasValidCurrentTimezone && timezone?.automatic && timezone?.selected !== currentTimezone) {
+            lastUpdateTimestamp = currentTime;
             updateAutomaticTimezone(
                 {
                     automatic: true,
@@ -20,7 +41,7 @@ const useAutoUpdateTimezone = () => {
             );
         }
         // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [timezone?.automatic, timezone?.selected]);
+    }, [timezone?.automatic, timezone?.selected, isDelegate]);
 };
 
 export default useAutoUpdateTimezone;


### PR DESCRIPTION
## Summary
This PR fixes the infinite UpdateAutomaticTimezone loop issue when two devices with auto-timezone enabled are logged into the same account in different timezones.

## Root Cause
The `useAutoUpdateTimezone` hook has a useEffect that depends on `timezone?.selected`. When Device A updates the timezone, it pushes that change to Device B via Onyx. Device B sees a mismatch and fires `UpdateAutomaticTimezone` with its timezone, which pushes back to Device A, creating an infinite loop.

## Solution
1. **Skip auto-timezone for delegate/copilot sessions** - A copilot should never change the primary user's timezone.
2. **Throttle timezone updates to once per hour** - This breaks the infinite loop by preventing rapid successive updates.

## Changes
- Modified `src/hooks/useAutoUpdateTimezone.ts`
- Added `isActingAsDelegateSelector` check to skip updates for delegate sessions
- Added 1-hour throttle to prevent infinite loop

## Testing
The fix should be tested by:
1. Logging into the same account on two devices in different timezones
2. Verifying no infinite API calls occur
3. Testing with a copilot/delegate account to ensure timezone isn't updated

## Related Issue
$ #83765