### PR TITLE
[Home Page] Add a Time Sensitive case for failed billing for existing customers

### DIFF
--- a/src/languages/de.ts
+++ b/src/languages/de.ts
@@ -995,6 +995,7 @@ const translations: TranslationDeepObject<typeof en> = {
                 subtitle: 'Wallet',
             },
             validateAccount: {title: 'Bestätigen Sie Ihr Konto, um Expensify weiter zu verwenden', subtitle: 'Konto', cta: 'Bestätigen'},
+            fixFailedBilling: {title: 'Wir konnten Ihre hinterlegte Karte nicht belasten', subtitle: 'Abonnement'},
         },
         assignedCards: 'Ihre Expensify Karten',
         assignedCardsRemaining: ({amount}: {amount: string}) => `${amount} verbleibend`,

--- a/src/languages/en.ts
+++ b/src/languages/en.ts
@@ -1039,6 +1039,10 @@ const translations = {
                 subtitle: 'Account',
                 cta: 'Validate',
             },
+            fixFailedBilling: {
+                title: "We couldn't bill your card on file",
+                subtitle: 'Subscription',
+            },
         },
         assignedCards: 'Your Expensify Cards',
         assignedCardsRemaining: ({amount}: {amount: string}) => `${amount} remaining`,

--- a/src/languages/es.ts
+++ b/src/languages/es.ts
@@ -908,6 +908,10 @@ const translations: TranslationDeepObject<typeof en> = {
                 subtitle: 'Cuenta',
                 cta: 'Validar',
             },
+            fixFailedBilling: {
+                title: 'No pudimos cobrar a la tarjeta registrada.',
+                subtitle: 'Suscripción',
+            },
         },
         assignedCards: 'Tus tarjetas Expensify',
         assignedCardsRemaining: ({amount}: {amount: string}) => `${amount} restantes`,

--- a/src/languages/fr.ts
+++ b/src/languages/fr.ts
@@ -998,6 +998,7 @@ const translations: TranslationDeepObject<typeof en> = {
                 subtitle: 'Portefeuille',
             },
             validateAccount: {title: 'Validez votre compte pour continuer à utiliser Expensify', subtitle: 'Compte', cta: 'Valider'},
+            fixFailedBilling: {title: 'Nous n’avons pas pu débiter votre carte enregistrée', subtitle: 'Abonnement'},
         },
         assignedCards: 'Vos cartes Expensify',
         assignedCardsRemaining: ({amount}: {amount: string}) => `${amount} restant`,

--- a/src/languages/it.ts
+++ b/src/languages/it.ts
@@ -995,6 +995,7 @@ const translations: TranslationDeepObject<typeof en> = {
                 subtitle: 'Portafoglio',
             },
             validateAccount: {title: 'Conferma il tuo account per continuare a usare Expensify', subtitle: 'Account', cta: 'Conferma'},
+            fixFailedBilling: {title: 'Non abbiamo potuto addebitare la carta salvata nel profilo', subtitle: 'Abbonamento'},
         },
         assignedCards: 'Le tue Carte Expensify',
         assignedCardsRemaining: ({amount}: {amount: string}) => `${amount} rimanenti`,

--- a/src/languages/ja.ts
+++ b/src/languages/ja.ts
@@ -978,6 +978,7 @@ const translations: TranslationDeepObject<typeof en> = {
             },
             fixPersonalCardConnection: {title: ({cardName}: {cardName?: string}) => (cardName ? `${cardName}個人カードの接続を修正` : '個人カードの連携を修正'), subtitle: 'ウォレット'},
             validateAccount: {title: 'Expensify を引き続きご利用いただくには、アカウントを認証してください', subtitle: 'アカウント', cta: '検証する'},
+            fixFailedBilling: {title: '登録されているカードから請求できませんでした', subtitle: 'サブスクリプション'},
         },
         assignedCards: 'お客様の Expensify カード',
         assignedCardsRemaining: ({amount}: {amount: string}) => `残額：${amount}`,

--- a/src/languages/nl.ts
+++ b/src/languages/nl.ts
@@ -994,6 +994,7 @@ const translations: TranslationDeepObject<typeof en> = {
                 subtitle: 'Portemonnee',
             },
             validateAccount: {title: 'Valideer je account om Expensify te blijven gebruiken', subtitle: 'Account', cta: 'Valideren'},
+            fixFailedBilling: {title: 'We konden je kaart in ons bestand niet belasten', subtitle: 'Abonnement'},
         },
         assignedCards: 'Je Expensify Kaarten',
         assignedCardsRemaining: ({amount}: {amount: string}) => `${amount} resterend`,

--- a/src/languages/pl.ts
+++ b/src/languages/pl.ts
@@ -995,6 +995,7 @@ const translations: TranslationDeepObject<typeof en> = {
                 subtitle: 'Portfel',
             },
             validateAccount: {title: 'Zweryfikuj swoje konto, aby dalej korzystać z Expensify', subtitle: 'Konto', cta: 'Zatwierdź'},
+            fixFailedBilling: {title: 'Nie mogliśmy obciążyć zapisanej karty', subtitle: 'Subskrypcja'},
         },
         assignedCards: 'Twoje Karty Expensify',
         assignedCardsRemaining: ({amount}: {amount: string}) => `Pozostało ${amount}`,

--- a/src/languages/pt-BR.ts
+++ b/src/languages/pt-BR.ts
@@ -993,6 +993,7 @@ const translations: TranslationDeepObject<typeof en> = {
                 subtitle: 'Carteira',
             },
             validateAccount: {title: 'Valide sua conta para continuar usando o Expensify', subtitle: 'Conta', cta: 'Validar'},
+            fixFailedBilling: {title: 'Não foi possível cobrar o cartão cadastrado', subtitle: 'Assinatura'},
         },
         assignedCards: 'Seus Cartões Expensify',
         assignedCardsRemaining: ({amount}: {amount: string}) => `${amount} restante`,

--- a/src/languages/zh-hans.ts
+++ b/src/languages/zh-hans.ts
@@ -961,6 +961,7 @@ const translations: TranslationDeepObject<typeof en> = {
                 subtitle: ({policyName}: {policyName: string}) => `${policyName} > 会计`,
             },
             validateAccount: {title: '验证您的账户以继续使用 Expensify', subtitle: '账户', cta: '验证'},
+            fixFailedBilling: {title: '我们无法向您档案中的银行卡收费', subtitle: '订阅'},
         },
         assignedCards: '你的 Expensify 卡',
         assignedCardsRemaining: ({amount}: {amount: string}) => `剩余 ${amount}`,

--- a/src/libs/SubscriptionUtils.ts
+++ b/src/libs/SubscriptionUtils.ts
@@ -644,6 +644,7 @@ export {
     getSubscriptionPrice,
     shouldShowTrialEndedUI,
     isSubscriptionTypeOfInvoicing,
+    hasInsufficientFundsError,
 };
 
 export type {SubscriptionPlanIllustrations};

--- a/src/libs/SubscriptionUtils.ts
+++ b/src/libs/SubscriptionUtils.ts
@@ -628,6 +628,7 @@ export {
     getFreeTrialText,
     getSubscriptionStatus,
     hasCardAuthenticatedError,
+    hasCardExpiredError,
     hasGracePeriodOverdue,
     hasRetryBillingError,
     hasSubscriptionGreenDotInfo,

--- a/src/pages/home/TimeSensitiveSection/hooks/useTimeSensitiveBilling.ts
+++ b/src/pages/home/TimeSensitiveSection/hooks/useTimeSensitiveBilling.ts
@@ -5,8 +5,9 @@ import ONYXKEYS from '@src/ONYXKEYS';
 function useTimeSensitiveBilling() {
     const [billingStatus] = useOnyx(ONYXKEYS.NVP_PRIVATE_BILLING_STATUS);
     const [account] = useOnyx(ONYXKEYS.ACCOUNT);
+    const [amountOwed] = useOnyx(ONYXKEYS.NVP_PRIVATE_AMOUNT_OWED);
 
-    const hasBillingError = hasCardExpiredError(billingStatus) || hasInsufficientFundsError(billingStatus);
+    const hasBillingError = !!amountOwed && (hasCardExpiredError(billingStatus) || hasInsufficientFundsError(billingStatus));
     const shouldShowFixFailedBilling = hasBillingError && account?.hasPurchases === true;
 
     return {

--- a/src/pages/home/TimeSensitiveSection/hooks/useTimeSensitiveBilling.ts
+++ b/src/pages/home/TimeSensitiveSection/hooks/useTimeSensitiveBilling.ts
@@ -1,6 +1,16 @@
+import useOnyx from '@hooks/useOnyx';
+import {hasCardExpiredError, hasInsufficientFundsError} from '@libs/SubscriptionUtils';
+import ONYXKEYS from '@src/ONYXKEYS';
+
 function useTimeSensitiveBilling() {
+    const [billingStatus] = useOnyx(ONYXKEYS.NVP_PRIVATE_BILLING_STATUS);
+    const [account] = useOnyx(ONYXKEYS.ACCOUNT);
+
+    const hasBillingError = hasCardExpiredError(billingStatus) || hasInsufficientFundsError(billingStatus);
+    const shouldShowFixFailedBilling = hasBillingError && account?.hasPurchases === true;
+
     return {
-        shouldShowFixFailedBilling: false,
+        shouldShowFixFailedBilling,
     };
 }
 

--- a/src/pages/home/TimeSensitiveSection/hooks/useTimeSensitiveBilling.ts
+++ b/src/pages/home/TimeSensitiveSection/hooks/useTimeSensitiveBilling.ts
@@ -7,7 +7,7 @@ function useTimeSensitiveBilling() {
     const [account] = useOnyx(ONYXKEYS.ACCOUNT);
     const [amountOwed] = useOnyx(ONYXKEYS.NVP_PRIVATE_AMOUNT_OWED);
 
-    const hasBillingError = !!amountOwed && (hasCardExpiredError(billingStatus) || hasInsufficientFundsError(billingStatus));
+    const hasBillingError = !!amountOwed && (hasCardExpiredError(billingStatus, amountOwed) || hasInsufficientFundsError(billingStatus, amountOwed));
     const shouldShowFixFailedBilling = hasBillingError && account?.hasPurchases === true;
 
     return {

--- a/src/pages/home/TimeSensitiveSection/hooks/useTimeSensitiveBilling.ts
+++ b/src/pages/home/TimeSensitiveSection/hooks/useTimeSensitiveBilling.ts
@@ -1,0 +1,7 @@
+function useTimeSensitiveBilling() {
+    return {
+        shouldShowFixFailedBilling: false,
+    };
+}
+
+export default useTimeSensitiveBilling;

--- a/src/pages/home/TimeSensitiveSection/index.tsx
+++ b/src/pages/home/TimeSensitiveSection/index.tsx
@@ -17,6 +17,7 @@ import {isCurrentUserValidated} from '@libs/UserUtils';
 import ONYXKEYS from '@src/ONYXKEYS';
 import type {Policy} from '@src/types/onyx';
 import type {ConnectionName, PolicyConnectionName} from '@src/types/onyx/Policy';
+import useTimeSensitiveBilling from './hooks/useTimeSensitiveBilling';
 import useTimeSensitiveCards from './hooks/useTimeSensitiveCards';
 import useTimeSensitiveOffers from './hooks/useTimeSensitiveOffers';
 import ActivateCard from './items/ActivateCard';
@@ -24,6 +25,7 @@ import AddPaymentCard from './items/AddPaymentCard';
 import AddShippingAddress from './items/AddShippingAddress';
 import FixAccountingConnection from './items/FixAccountingConnection';
 import FixCompanyCardConnection from './items/FixCompanyCardConnection';
+import FixFailedBilling from './items/FixFailedBilling';
 import FixPersonalCardConnection from './items/FixPersonalCardConnection';
 import Offer25off from './items/Offer25off';
 import Offer50off from './items/Offer50off';
@@ -67,6 +69,7 @@ function TimeSensitiveSection() {
     // Use custom hooks for offers and cards (Release 3)
     const {shouldShow50off, shouldShow25off, shouldShowAddPaymentCard, firstDayFreeTrial, discountInfo} = useTimeSensitiveOffers();
     const {shouldShowAddShippingAddress, shouldShowActivateCard, shouldShowReviewCardFraud, cardsNeedingShippingAddress, cardsNeedingActivation, cardsWithFraud} = useTimeSensitiveCards();
+    const {shouldShowFixFailedBilling} = useTimeSensitiveBilling();
 
     // Selector for filtering admin policies (Release 4)
     const adminPoliciesSelectorWrapper = useCallback((policies: OnyxCollection<Policy>) => activeAdminPoliciesSelector(policies, login ?? ''), [login]);
@@ -152,6 +155,7 @@ function TimeSensitiveSection() {
     // must be reflected here to avoid showing an empty "Time sensitive" section.
     const hasAnyTimeSensitiveContent =
         shouldShowValidateAccount ||
+        shouldShowFixFailedBilling ||
         shouldShowReviewCardFraud ||
         shouldShowAddPaymentCard ||
         shouldShow50off ||
@@ -168,21 +172,24 @@ function TimeSensitiveSection() {
 
     // Priority order:
     // 1. Validate account
-    // 2. Potential card fraud
-    // 3. Add payment card (trial ended, no payment card)
-    // 4. Broken bank connections (company cards)
-    // 5. Broken bank connections (personal cards)
-    // 6. Broken accounting connections
-    // 7. Early adoption discount (50% or 25%)
-    // 8. Expensify card shipping
-    // 9. Expensify card activation
+    // 2. Fix failed billing (existing customers with declined cards)
+    // 3. Potential card fraud
+    // 4. Add payment card (trial ended, no payment card)
+    // 5. Broken bank connections (company cards)
+    // 6. Broken bank connections (personal cards)
+    // 7. Broken accounting connections
+    // 8. Early adoption discount (50% or 25%)
+    // 9. Expensify card shipping
+    // 10. Expensify card activation
     return (
         <WidgetContainer title={translate('homePage.timeSensitiveSection.title')}>
             <View style={styles.getForYouSectionContainerStyle(shouldUseNarrowLayout)}>
                 {/* Priority 1: Validate account */}
                 {shouldShowValidateAccount && <ValidateAccount />}
+                {/* Priority 2: Failed billing for existing customers */}
+                {!!shouldShowFixFailedBilling && <FixFailedBilling />}
 
-                {/* Priority 2: Card fraud alerts */}
+                {/* Priority 3: Card fraud alerts */}
                 {shouldShowReviewCardFraud &&
                     cardsWithFraud.map((card) => {
                         if (!card.nameValuePairs?.possibleFraud) {
@@ -196,9 +203,9 @@ function TimeSensitiveSection() {
                         );
                     })}
 
-                {/* Priority 3: Add payment card (trial ended, no payment card) */}
+                {/* Priority 4: Add payment card (trial ended, no payment card) */}
                 {shouldShowAddPaymentCard && <AddPaymentCard />}
-                {/* Priority 4: Broken company card connections */}
+                {/* Priority 5: Broken company card connections */}
                 {brokenCompanyCardConnections.map((connection) => {
                     const card = cardFeedErrors.cardsWithBrokenFeedConnection[connection.cardID];
                     if (!card) {
@@ -214,7 +221,7 @@ function TimeSensitiveSection() {
                     );
                 })}
 
-                {/* Priority 5: Broken personal card connections */}
+                {/* Priority 6: Broken personal card connections */}
                 {brokenPersonalCardConnections.map((connection) => {
                     const card = cardFeedErrors.personalCardsWithBrokenConnection[connection.cardID];
                     if (!card) {
@@ -228,7 +235,7 @@ function TimeSensitiveSection() {
                     );
                 })}
 
-                {/* Priority 6: Broken accounting connections */}
+                {/* Priority 7: Broken accounting connections */}
                 {brokenAccountingConnections.map((connection) => (
                     <FixAccountingConnection
                         key={`accounting-${connection.policyID}-${connection.connectionName}`}
@@ -238,11 +245,11 @@ function TimeSensitiveSection() {
                     />
                 ))}
 
-                {/* Priority 7: Early adoption discount offers */}
+                {/* Priority 8: Early adoption discount offers */}
                 {shouldShow50off && <Offer50off firstDayFreeTrial={firstDayFreeTrial} />}
                 {shouldShow25off && !!discountInfo && <Offer25off days={discountInfo.days} />}
 
-                {/* Priority 8: Expensify card shipping */}
+                {/* Priority 9: Expensify card shipping */}
                 {shouldShowAddShippingAddress &&
                     cardsNeedingShippingAddress.map((card) => (
                         <AddShippingAddress
@@ -251,7 +258,7 @@ function TimeSensitiveSection() {
                         />
                     ))}
 
-                {/* Priority 9: Expensify card activation */}
+                {/* Priority 10: Expensify card activation */}
                 {shouldShowActivateCard &&
                     cardsNeedingActivation.map((card) => (
                         <ActivateCard

--- a/src/pages/home/TimeSensitiveSection/items/FixFailedBilling.tsx
+++ b/src/pages/home/TimeSensitiveSection/items/FixFailedBilling.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import BaseWidgetItem from '@components/BaseWidgetItem';
+import {useMemoizedLazyExpensifyIcons} from '@hooks/useLazyAsset';
+import useLocalize from '@hooks/useLocalize';
+import colors from '@styles/theme/colors';
+import navigateFromAddPaymentCardItem from './AddPaymentCard/navigateFromAddPaymentCardItem';
+
+function FixFailedBilling() {
+    const {translate} = useLocalize();
+    const icons = useMemoizedLazyExpensifyIcons(['CreditCard']);
+
+    return (
+        <BaseWidgetItem
+            icon={icons.CreditCard}
+            iconBackgroundColor={colors.tangerine100}
+            iconFill={colors.tangerine500}
+            title={translate('homePage.timeSensitiveSection.fixFailedBilling.title')}
+            subtitle={translate('homePage.timeSensitiveSection.fixFailedBilling.subtitle')}
+            ctaText={translate('homePage.timeSensitiveSection.ctaFix')}
+            onCtaPress={navigateFromAddPaymentCardItem}
+            buttonProps={{danger: true}}
+        />
+    );
+}
+
+export default FixFailedBilling;

--- a/tests/unit/hooks/useTimeSensitiveBilling.test.ts
+++ b/tests/unit/hooks/useTimeSensitiveBilling.test.ts
@@ -43,7 +43,7 @@ describe('useTimeSensitiveBilling', () => {
             await Onyx.merge(ONYXKEYS.ACCOUNT, {hasPurchases: true});
             await waitForBatchedUpdates();
 
-            mockedHasInsufficientFundsError.mockReturnValue(false);
+            mockedHasInsufficientFundsError.mockReturnValue(true);
 
             const {result} = renderHook(() => useTimeSensitiveBilling());
 
@@ -54,8 +54,6 @@ describe('useTimeSensitiveBilling', () => {
             await Onyx.merge(ONYXKEYS.NVP_PRIVATE_AMOUNT_OWED, 100);
             await Onyx.merge(ONYXKEYS.ACCOUNT, {hasPurchases: true});
             await waitForBatchedUpdates();
-
-            mockedHasInsufficientFundsError.mockReturnValue(false);
 
             const {result} = renderHook(() => useTimeSensitiveBilling());
 
@@ -85,16 +83,12 @@ describe('useTimeSensitiveBilling', () => {
             await Onyx.merge(ONYXKEYS.ACCOUNT, {hasPurchases: true});
             await waitForBatchedUpdates();
 
-            mockedHasInsufficientFundsError.mockReturnValue(false);
-
             const {result} = renderHook(() => useTimeSensitiveBilling());
 
             expect(result.current.shouldShowFixFailedBilling).toBe(false);
         });
 
         it('returns false when all Onyx values are undefined/empty', () => {
-            mockedHasInsufficientFundsError.mockReturnValue(false);
-
             const {result} = renderHook(() => useTimeSensitiveBilling());
 
             expect(result.current.shouldShowFixFailedBilling).toBe(false);
@@ -144,8 +138,6 @@ describe('useTimeSensitiveBilling', () => {
             await Onyx.merge(ONYXKEYS.NVP_PRIVATE_AMOUNT_OWED, 100);
             await Onyx.merge(ONYXKEYS.ACCOUNT, {hasPurchases: true});
             await waitForBatchedUpdates();
-
-            mockedHasInsufficientFundsError.mockReturnValue(false);
 
             const {result, rerender} = renderHook(() => useTimeSensitiveBilling());
             expect(result.current.shouldShowFixFailedBilling).toBe(false);

--- a/tests/unit/hooks/useTimeSensitiveBilling.test.ts
+++ b/tests/unit/hooks/useTimeSensitiveBilling.test.ts
@@ -1,0 +1,189 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+import {renderHook} from '@testing-library/react-native';
+import Onyx from 'react-native-onyx';
+import {hasCardExpiredError, hasInsufficientFundsError} from '@libs/SubscriptionUtils';
+import useTimeSensitiveBilling from '@pages/home/TimeSensitiveSection/hooks/useTimeSensitiveBilling';
+import ONYXKEYS from '@src/ONYXKEYS';
+import waitForBatchedUpdates from '../../utils/waitForBatchedUpdates';
+
+jest.mock('@libs/SubscriptionUtils', () => ({
+    hasCardExpiredError: jest.fn(() => false),
+    hasInsufficientFundsError: jest.fn(() => false),
+}));
+
+const mockedHasCardExpiredError = hasCardExpiredError as jest.Mock;
+const mockedHasInsufficientFundsError = hasInsufficientFundsError as jest.Mock;
+
+describe('useTimeSensitiveBilling', () => {
+    beforeAll(() => {
+        Onyx.init({keys: ONYXKEYS});
+    });
+
+    beforeEach(async () => {
+        await Onyx.clear();
+        await waitForBatchedUpdates();
+        jest.clearAllMocks();
+        mockedHasCardExpiredError.mockReturnValue(false);
+        mockedHasInsufficientFundsError.mockReturnValue(false);
+    });
+
+    afterEach(async () => {
+        await Onyx.clear();
+    });
+
+    describe('when failed billing should NOT be shown', () => {
+        it('returns false when amountOwed is 0', async () => {
+            await Onyx.merge(ONYXKEYS.NVP_PRIVATE_AMOUNT_OWED, 0);
+            await Onyx.merge(ONYXKEYS.NVP_PRIVATE_BILLING_STATUS, {
+                action: 'action',
+                periodMonth: '01',
+                periodYear: '2026',
+                declineReason: 'insufficient_funds',
+            });
+            await Onyx.merge(ONYXKEYS.ACCOUNT, {hasPurchases: true});
+            await waitForBatchedUpdates();
+
+            mockedHasInsufficientFundsError.mockReturnValue(false);
+
+            const {result} = renderHook(() => useTimeSensitiveBilling());
+
+            expect(result.current.shouldShowFixFailedBilling).toBe(false);
+        });
+
+        it('returns false when billingStatus has no decline reason', async () => {
+            await Onyx.merge(ONYXKEYS.NVP_PRIVATE_AMOUNT_OWED, 100);
+            await Onyx.merge(ONYXKEYS.ACCOUNT, {hasPurchases: true});
+            await waitForBatchedUpdates();
+
+            mockedHasInsufficientFundsError.mockReturnValue(false);
+
+            const {result} = renderHook(() => useTimeSensitiveBilling());
+
+            expect(result.current.shouldShowFixFailedBilling).toBe(false);
+        });
+
+        it('returns false when declineReason is present but hasPurchases is false', async () => {
+            await Onyx.merge(ONYXKEYS.NVP_PRIVATE_AMOUNT_OWED, 100);
+            await Onyx.merge(ONYXKEYS.NVP_PRIVATE_BILLING_STATUS, {
+                action: 'action',
+                periodMonth: '01',
+                periodYear: '2026',
+                declineReason: 'insufficient_funds',
+            });
+            await Onyx.merge(ONYXKEYS.ACCOUNT, {hasPurchases: false});
+            await waitForBatchedUpdates();
+
+            mockedHasInsufficientFundsError.mockReturnValue(true);
+
+            const {result} = renderHook(() => useTimeSensitiveBilling());
+
+            expect(result.current.shouldShowFixFailedBilling).toBe(false);
+        });
+
+        it('returns false when hasPurchases is true but no billing error', async () => {
+            await Onyx.merge(ONYXKEYS.NVP_PRIVATE_AMOUNT_OWED, 100);
+            await Onyx.merge(ONYXKEYS.ACCOUNT, {hasPurchases: true});
+            await waitForBatchedUpdates();
+
+            mockedHasInsufficientFundsError.mockReturnValue(false);
+
+            const {result} = renderHook(() => useTimeSensitiveBilling());
+
+            expect(result.current.shouldShowFixFailedBilling).toBe(false);
+        });
+
+        it('returns false when all Onyx values are undefined/empty', () => {
+            mockedHasInsufficientFundsError.mockReturnValue(false);
+
+            const {result} = renderHook(() => useTimeSensitiveBilling());
+
+            expect(result.current.shouldShowFixFailedBilling).toBe(false);
+        });
+    });
+
+    describe('when failed billing SHOULD be shown', () => {
+        it('returns true for insufficient_funds with amountOwed > 0 and hasPurchases', async () => {
+            await Onyx.merge(ONYXKEYS.NVP_PRIVATE_AMOUNT_OWED, 500);
+            await Onyx.merge(ONYXKEYS.NVP_PRIVATE_BILLING_STATUS, {
+                action: 'action',
+                periodMonth: '01',
+                periodYear: '2026',
+                declineReason: 'insufficient_funds',
+            });
+            await Onyx.merge(ONYXKEYS.ACCOUNT, {hasPurchases: true});
+            await waitForBatchedUpdates();
+
+            mockedHasInsufficientFundsError.mockReturnValue(true);
+
+            const {result} = renderHook(() => useTimeSensitiveBilling());
+
+            expect(result.current.shouldShowFixFailedBilling).toBe(true);
+        });
+
+        it('returns true for expired_card with amountOwed > 0 and hasPurchases', async () => {
+            await Onyx.merge(ONYXKEYS.NVP_PRIVATE_AMOUNT_OWED, 250);
+            await Onyx.merge(ONYXKEYS.NVP_PRIVATE_BILLING_STATUS, {
+                action: 'action',
+                periodMonth: '01',
+                periodYear: '2026',
+                declineReason: 'expired_card',
+            });
+            await Onyx.merge(ONYXKEYS.ACCOUNT, {hasPurchases: true});
+            await waitForBatchedUpdates();
+
+            mockedHasCardExpiredError.mockReturnValue(true);
+
+            const {result} = renderHook(() => useTimeSensitiveBilling());
+
+            expect(result.current.shouldShowFixFailedBilling).toBe(true);
+        });
+    });
+
+    describe('reactivity to Onyx changes', () => {
+        it('updates when billing status changes', async () => {
+            await Onyx.merge(ONYXKEYS.NVP_PRIVATE_AMOUNT_OWED, 100);
+            await Onyx.merge(ONYXKEYS.ACCOUNT, {hasPurchases: true});
+            await waitForBatchedUpdates();
+
+            mockedHasInsufficientFundsError.mockReturnValue(false);
+
+            const {result, rerender} = renderHook(() => useTimeSensitiveBilling());
+            expect(result.current.shouldShowFixFailedBilling).toBe(false);
+
+            mockedHasInsufficientFundsError.mockReturnValue(true);
+            await Onyx.merge(ONYXKEYS.NVP_PRIVATE_BILLING_STATUS, {
+                action: 'action',
+                periodMonth: '01',
+                periodYear: '2026',
+                declineReason: 'insufficient_funds',
+            });
+            await waitForBatchedUpdates();
+            rerender({});
+
+            expect(result.current.shouldShowFixFailedBilling).toBe(true);
+        });
+
+        it('updates when account.hasPurchases changes', async () => {
+            await Onyx.merge(ONYXKEYS.NVP_PRIVATE_AMOUNT_OWED, 100);
+            await Onyx.merge(ONYXKEYS.NVP_PRIVATE_BILLING_STATUS, {
+                action: 'action',
+                periodMonth: '01',
+                periodYear: '2026',
+                declineReason: 'expired_card',
+            });
+            await Onyx.merge(ONYXKEYS.ACCOUNT, {hasPurchases: false});
+            await waitForBatchedUpdates();
+
+            mockedHasCardExpiredError.mockReturnValue(true);
+
+            const {result, rerender} = renderHook(() => useTimeSensitiveBilling());
+            expect(result.current.shouldShowFixFailedBilling).toBe(false);
+
+            await Onyx.merge(ONYXKEYS.ACCOUNT, {hasPurchases: true});
+            await waitForBatchedUpdates();
+            rerender({});
+
+            expect(result.current.shouldShowFixFailedBilling).toBe(true);
+        });
+    });
+});


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
This PR adds a new "Fix Failed Billing" widget to the Time Sensitive Section on the home page. When a user has an existing subscription (`hasPurchases === true`) and their billing card has been declined (due to either an expired card or insufficient funds), a high-priority widget is shown prompting them to update their payment card.

**Changes:**
- Added `useTimeSensitiveBilling` hook that checks `NVP_PRIVATE_BILLING_STATUS` for card-expired or insufficient-funds errors and `ACCOUNT.hasPurchases` to determine visibility.
- Added `FixFailedBilling` widget component with a danger-styled CTA button that navigates to the payment card update flow.
- Added English and Spanish translations for the widget title and subtitle.
- Exported `hasCardExpiredError` and `hasInsufficientFundsError` from `SubscriptionUtils`.
- Inserted the widget at **priority 1** (highest) in the Time Sensitive Section, above card fraud alerts.
- Added comprehensive unit tests for the `useTimeSensitiveBilling` hook covering positive/negative cases and Onyx reactivity.

### Fixed Issues
$ https://github.com/Expensify/App/issues/81726
PROPOSAL:


### Tests

1. Log in with an account that has an active subscription (`hasPurchases: true`)
2. Simulate a declined billing card (expired card or insufficient funds via `NVP_PRIVATE_BILLING_STATUS`)
3. Navigate to the home page
4. Verify the "We couldn't bill your card on file" widget appears in the Time Sensitive Section at the top (before card fraud alerts)
5. Verify the widget displays "Subscription" as subtitle and a red "Fix" CTA button
6. Tap the "Fix" CTA button and verify it navigates to the payment card update flow
7. Verify that users without `hasPurchases` do NOT see the widget even if billing errors exist
8. Verify that users with `hasPurchases` but no billing errors do NOT see the widget
- [x] Verify that no errors appear in the JS console

### Offline tests
1. Go offline and navigate to the home page
2. Verify the widget still renders correctly based on cached Onyx data (offline-first)
3. Verify tapping the CTA does not crash while offline

### QA Steps
1. Log in with a staging account that has `hasPurchases: true` and a declined billing card (expired or insufficient funds)
2. Navigate to the home page
3. Verify the "We couldn't bill your card on file" widget appears at the top of the Time Sensitive Section
4. Tap the "Fix" button and verify it navigates to the payment card update screen
5. Verify accounts without billing errors do not see the widget
6. Verify accounts without purchases do not see the widget
- [x] Verify that no errors appear in the JS console

### PR Author Checklist
- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

https://github.com/user-attachments/assets/fe50118c-3e56-43b0-b8ea-1d8d375f3d57

</details>
