### PR TITLE
Revert "Migrate `useBeforeRemove` to `usePreventRemove`  in `DiscardChangesConfirmation`"

### DIFF
--- a/src/pages/iou/request/step/DiscardChangesConfirmation/index.native.tsx
+++ b/src/pages/iou/request/step/DiscardChangesConfirmation/index.native.tsx
@@ -1,20 +1,25 @@
-import {usePreventRemove} from '@react-navigation/native';
 import type {NavigationAction} from '@react-navigation/native';
+import {useIsFocused, usePreventRemove} from '@react-navigation/native';
 import React, {memo, useCallback, useRef, useState} from 'react';
 import ConfirmModal from '@components/ConfirmModal';
 import useLocalize from '@hooks/useLocalize';
 import navigationRef from '@libs/Navigation/navigationRef';
 import type DiscardChangesConfirmationProps from './types';
 
-function DiscardChangesConfirmation({hasUnsavedChanges}: DiscardChangesConfirmationProps) {
+function DiscardChangesConfirmation({getHasUnsavedChanges, isEnabled = true}: DiscardChangesConfirmationProps) {
     const {translate} = useLocalize();
+    const isFocused = useIsFocused();
     const [isVisible, setIsVisible] = useState(false);
+    const shouldAllowNavigation = useRef(false);
     const blockedNavigationAction = useRef<NavigationAction | undefined>(undefined);
 
+    const hasUnsavedChanges = isEnabled && isFocused && getHasUnsavedChanges();
+    const shouldPrevent = hasUnsavedChanges && !shouldAllowNavigation.current;
+
     usePreventRemove(
-        hasUnsavedChanges,
-        useCallback((e) => {
-            blockedNavigationAction.current = e.data.action;
+        shouldPrevent,
+        useCallback(({data}) => {
+            blockedNavigationAction.current = data.action;
             setIsVisible(true);
         }, []),
     );
@@ -29,6 +34,7 @@ function DiscardChangesConfirmation({hasUnsavedChanges}: DiscardChangesConfirmat
             cancelText={translate('common.cancel')}
             onConfirm={() => {
                 setIsVisible(false);
+                shouldAllowNavigation.current = true;
                 if (blockedNavigationAction.current) {
                     navigationRef.current?.dispatch(blockedNavigationAction.current);
                     blockedNavigationAction.current = undefined;

--- a/src/pages/iou/request/step/DiscardChangesConfirmation/index.tsx
+++ b/src/pages/iou/request/step/DiscardChangesConfirmation/index.tsx
@@ -1,7 +1,8 @@
 import type {NavigationAction} from '@react-navigation/native';
-import {useNavigation, usePreventRemove} from '@react-navigation/native';
+import {useIsFocused, useNavigation} from '@react-navigation/native';
 import React, {memo, useCallback, useEffect, useRef, useState} from 'react';
 import ConfirmModal from '@components/ConfirmModal';
+import useBeforeRemove from '@hooks/useBeforeRemove';
 import useLocalize from '@hooks/useLocalize';
 import setNavigationActionToMicrotaskQueue from '@libs/Navigation/helpers/setNavigationActionToMicrotaskQueue';
 import navigateAfterInteraction from '@libs/Navigation/navigateAfterInteraction';
@@ -10,21 +11,29 @@ import type {PlatformStackNavigationProp} from '@libs/Navigation/PlatformStackNa
 import type {RootNavigatorParamList} from '@libs/Navigation/types';
 import type DiscardChangesConfirmationProps from './types';
 
-function DiscardChangesConfirmation({hasUnsavedChanges, onCancel}: DiscardChangesConfirmationProps) {
+function DiscardChangesConfirmation({getHasUnsavedChanges, onCancel, isEnabled = true}: DiscardChangesConfirmationProps) {
     const navigation = useNavigation<PlatformStackNavigationProp<RootNavigatorParamList>>();
+    const isFocused = useIsFocused();
     const {translate} = useLocalize();
     const [isVisible, setIsVisible] = useState(false);
     const blockedNavigationAction = useRef<NavigationAction>(undefined);
-    const [shouldNavigateBack, setShouldNavigateBack] = useState(false);
+    const shouldNavigateBack = useRef(false);
     const isConfirmed = useRef(false);
-    const [discardConfirmed, setDiscardConfirmed] = useState(false);
 
-    usePreventRemove(
-        (hasUnsavedChanges || shouldNavigateBack) && !discardConfirmed,
-        useCallback((e) => {
-            blockedNavigationAction.current = e.data.action;
-            navigateAfterInteraction(() => setIsVisible(true));
-        }, []),
+    useBeforeRemove(
+        useCallback(
+            (e) => {
+                if (!isEnabled || !isFocused || !getHasUnsavedChanges() || shouldNavigateBack.current) {
+                    return;
+                }
+
+                e.preventDefault();
+                blockedNavigationAction.current = e.data.action;
+                navigateAfterInteraction(() => setIsVisible((prev) => !prev));
+            },
+            [getHasUnsavedChanges, isFocused, isEnabled],
+        ),
+        isEnabled && isFocused,
     );
 
     /**
@@ -33,33 +42,48 @@ function DiscardChangesConfirmation({hasUnsavedChanges, onCancel}: DiscardChange
      * So we need to go forward to get back to the current page
      */
     useEffect(() => {
+        if (!isEnabled || !isFocused) {
+            return undefined;
+        }
+        // transitionStart is triggered before the previous page is fully loaded so RHP sliding animation
+        // could be less "glitchy" when going back and forth between the previous and current pages
         const unsubscribe = navigation.addListener('transitionStart', ({data: {closing}}) => {
-            if (!hasUnsavedChanges || isConfirmed.current) {
+            // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+            if (!getHasUnsavedChanges()) {
                 return;
             }
-            setShouldNavigateBack(true);
+            shouldNavigateBack.current = true;
             if (closing) {
                 window.history.go(1);
                 return;
             }
             // Navigation.navigate() rerenders the current page and resets its states
             window.history.go(1);
-            navigateAfterInteraction(() => setIsVisible(true));
+            navigateAfterInteraction(() => setIsVisible((prev) => !prev));
         });
 
         return unsubscribe;
-    }, [hasUnsavedChanges, navigation]);
+    }, [navigation, getHasUnsavedChanges, isFocused, isEnabled]);
+
+    useEffect(() => {
+        if ((isFocused && isEnabled) || !isVisible) {
+            return;
+        }
+        setIsVisible(false);
+        blockedNavigationAction.current = undefined;
+        shouldNavigateBack.current = false;
+    }, [isFocused, isVisible, isEnabled]);
 
     const navigateBack = useCallback(() => {
         if (blockedNavigationAction.current) {
             navigationRef.current?.dispatch(blockedNavigationAction.current);
             return;
         }
-        if (!shouldNavigateBack) {
+        if (!shouldNavigateBack.current) {
             return;
         }
         navigationRef.current?.goBack();
-    }, [shouldNavigateBack]);
+    }, []);
 
     return (
         <ConfirmModal
@@ -71,19 +95,19 @@ function DiscardChangesConfirmation({hasUnsavedChanges, onCancel}: DiscardChange
             cancelText={translate('common.cancel')}
             onConfirm={() => {
                 isConfirmed.current = true;
-                setDiscardConfirmed(true);
                 setIsVisible(false);
             }}
             onCancel={() => {
                 setIsVisible(false);
                 blockedNavigationAction.current = undefined;
-                setShouldNavigateBack(false);
+                shouldNavigateBack.current = false;
             }}
             onModalHide={() => {
                 if (isConfirmed.current) {
+                    isConfirmed.current = false;
                     setNavigationActionToMicrotaskQueue(navigateBack);
                 } else {
-                    setShouldNavigateBack(false);
+                    shouldNavigateBack.current = false;
                     onCancel?.();
                 }
             }}

--- a/src/pages/iou/request/step/DiscardChangesConfirmation/types.ts
+++ b/src/pages/iou/request/step/DiscardChangesConfirmation/types.ts
@@ -1,6 +1,7 @@
 type DiscardChangesConfirmationProps = {
+    getHasUnsavedChanges: () => boolean;
     onCancel?: () => void;
-    hasUnsavedChanges: boolean;
+    isEnabled?: boolean;
 };
 
 export default DiscardChangesConfirmationProps;

--- a/src/pages/iou/request/step/IOURequestStepDescription.tsx
+++ b/src/pages/iou/request/step/IOURequestStepDescription.tsx
@@ -1,5 +1,5 @@
 import lodashIsEmpty from 'lodash/isEmpty';
-import React, {useCallback, useMemo, useState} from 'react';
+import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import {InteractionManager, View} from 'react-native';
 import type {OnyxEntry} from 'react-native-onyx';
 import FormProvider from '@components/Form/FormProvider';
@@ -73,7 +73,9 @@ function IOURequestStepDescription({
         return isEditingSplit && !lodashIsEmpty(splitDraftTransaction) ? (splitDraftTransaction?.comment?.comment ?? '') : (transaction?.comment?.comment ?? '');
     }, [isTransactionDraft, iouType, isEditingSplit, splitDraftTransaction, transaction?.comment?.comment]);
 
-    const [hasUnsavedChanges, setHasUnsavedChanges] = useState(false);
+    const [currentDescription, setCurrentDescription] = useState(currentDescriptionInMarkdown);
+    const [isSaved, setIsSaved] = useState(false);
+    const shouldNavigateAfterSaveRef = useRef(false);
     useRestartOnReceiptFailure(transaction, reportID, iouType, action);
     const currentUserPersonalDetails = useCurrentUserPersonalDetails();
     const currentUserAccountIDParam = currentUserPersonalDetails.accountID;
@@ -119,31 +121,35 @@ function IOURequestStepDescription({
         Navigation.goBack(backTo);
     }, [backTo]);
 
-    const updateHasUnsavedChanges = useCallback(
-        (value: string) => {
-            if (value === currentDescriptionInMarkdown) {
-                setHasUnsavedChanges(false);
-                return;
-            }
-            setHasUnsavedChanges(true);
-        },
-        [currentDescriptionInMarkdown],
-    );
+    useEffect(() => {
+        if (!isSaved || !shouldNavigateAfterSaveRef.current) {
+            return;
+        }
+        shouldNavigateAfterSaveRef.current = false;
+        navigateBack();
+    }, [isSaved, navigateBack]);
+
+    const updateDescriptionRef = (value: string) => {
+        setCurrentDescription(value);
+    };
 
     const updateComment = (value: FormOnyxValues<typeof ONYXKEYS.FORMS.MONEY_REQUEST_DESCRIPTION_FORM>) => {
         if (!transaction?.transactionID) {
             return;
         }
 
-        setHasUnsavedChanges(false);
         const newComment = value.moneyRequestComment.trim();
 
         if (newComment === currentDescriptionInMarkdown) {
+            setIsSaved(true);
+            shouldNavigateAfterSaveRef.current = true;
             return;
         }
 
         if (isEditingSplit) {
             setDraftSplitTransaction(transaction?.transactionID, splitDraftTransaction, {comment: newComment});
+            setIsSaved(true);
+            shouldNavigateAfterSaveRef.current = true;
             return;
         }
 
@@ -164,6 +170,9 @@ function IOURequestStepDescription({
                 parentReportNextStep,
             });
         }
+
+        setIsSaved(true);
+        shouldNavigateAfterSaveRef.current = true;
     };
 
     // eslint-disable-next-line rulesdir/no-negated-variables
@@ -198,7 +207,7 @@ function IOURequestStepDescription({
                         inputID={INPUT_IDS.MONEY_REQUEST_COMMENT}
                         name={INPUT_IDS.MONEY_REQUEST_COMMENT}
                         defaultValue={currentDescriptionInMarkdown}
-                        onValueChange={updateHasUnsavedChanges}
+                        onValueChange={updateDescriptionRef}
                         label={translate('moneyRequestConfirmationList.whatsItFor')}
                         accessibilityLabel={translate('moneyRequestConfirmationList.whatsItFor')}
                         role={CONST.ROLE.PRESENTATION}
@@ -219,7 +228,12 @@ function IOURequestStepDescription({
                         inputRef.current?.focus();
                     });
                 }}
-                hasUnsavedChanges={hasUnsavedChanges}
+                getHasUnsavedChanges={() => {
+                    if (isSaved) {
+                        return false;
+                    }
+                    return currentDescription !== currentDescriptionInMarkdown;
+                }}
             />
         </StepScreenWrapper>
     );

--- a/src/pages/iou/request/step/IOURequestStepDistanceOdometer.tsx
+++ b/src/pages/iou/request/step/IOURequestStepDistanceOdometer.tsx
@@ -80,14 +80,16 @@ function IOURequestStepDistanceOdometer({
     // Key to force TextInput remount when resetting state after tab switch
     const [inputKey, setInputKey] = useState<number>(0);
 
-    // Baseline readings for DiscardChangesConfirmation
-    const [initialReadings, setInitialReadings] = useState<{start: string; end: string}>({start: '', end: ''});
-    const [odometerImage, setOdometerImage] = useState<{start?: FileObject | string; end?: FileObject | string}>({});
+    // Track initial values for DiscardChangesConfirmation
+    const initialStartReadingRef = useRef<string>('');
+    const initialEndReadingRef = useRef<string>('');
     const hasInitializedRefs = useRef(false);
     // Track local state via refs to avoid including them in useEffect dependencies
+    const startReadingRef = useRef<string>('');
+    const endReadingRef = useRef<string>('');
+    const initialStartImageRef = useRef<FileObject | string | undefined>(undefined);
+    const initialEndImageRef = useRef<FileObject | string | undefined>(undefined);
     const prevSelectedTabRef = useRef<string | undefined>(undefined);
-    // Compute local state presence
-    const hasLocalState = useMemo(() => !!startReading || !!endReading, [startReading, endReading]);
 
     const [reportNameValuePairs] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT_NAME_VALUE_PAIRS}${report?.reportID}`);
     const isArchived = isArchivedReport(reportNameValuePairs);
@@ -153,8 +155,12 @@ function IOURequestStepDistanceOdometer({
         if (prevSelectedTab === CONST.TAB_REQUEST.DISTANCE_ODOMETER && selectedTab !== CONST.TAB_REQUEST.DISTANCE_ODOMETER) {
             setStartReading('');
             setEndReading('');
-            setInitialReadings({start: '', end: ''});
-            setOdometerImage({start: undefined, end: undefined});
+            startReadingRef.current = '';
+            endReadingRef.current = '';
+            initialStartReadingRef.current = '';
+            initialEndReadingRef.current = '';
+            initialStartImageRef.current = undefined;
+            initialEndImageRef.current = undefined;
             setFormError('');
             // Force TextInput remount to reset label position
             setInputKey((prev) => prev + 1);
@@ -173,8 +179,10 @@ function IOURequestStepDistanceOdometer({
         const currentEnd = currentTransaction?.comment?.odometerEnd;
         const startValue = currentStart !== null && currentStart !== undefined ? currentStart.toString() : '';
         const endValue = currentEnd !== null && currentEnd !== undefined ? currentEnd.toString() : '';
-        setInitialReadings({start: startValue, end: endValue});
-        setOdometerImage({start: currentTransaction?.comment?.odometerStartImage, end: currentTransaction?.comment?.odometerEndImage});
+        initialStartReadingRef.current = startValue;
+        initialEndReadingRef.current = endValue;
+        initialStartImageRef.current = currentTransaction?.comment?.odometerStartImage;
+        initialEndImageRef.current = currentTransaction?.comment?.odometerEndImage;
         hasInitializedRefs.current = true;
     }, [
         currentTransaction?.comment?.odometerStart,
@@ -194,6 +202,7 @@ function IOURequestStepDistanceOdometer({
         // 2. We're editing and transaction has data (to load existing values), OR
         // 3. Transaction has data but local state is empty (user navigated back from another page)
         const hasTransactionData = (currentStart !== null && currentStart !== undefined) || (currentEnd !== null && currentEnd !== undefined);
+        const hasLocalState = startReadingRef.current || endReadingRef.current;
         const shouldInitialize =
             (!hasInitializedRefs.current && hasTransactionData) ||
             (isEditing && hasTransactionData && !hasLocalState) ||
@@ -206,9 +215,11 @@ function IOURequestStepDistanceOdometer({
             if (startValue || endValue) {
                 setStartReading(startValue);
                 setEndReading(endValue);
+                startReadingRef.current = startValue;
+                endReadingRef.current = endValue;
             }
         }
-    }, [currentTransaction?.comment?.odometerStart, currentTransaction?.comment?.odometerEnd, isEditing, hasLocalState]);
+    }, [currentTransaction?.comment?.odometerStart, currentTransaction?.comment?.odometerEnd, isEditing]);
 
     // Calculate total distance - updated live after every input change
     const totalDistance = (() => {
@@ -307,6 +318,7 @@ function IOURequestStepDistanceOdometer({
             return;
         }
         setStartReading(text);
+        startReadingRef.current = text;
         if (formError) {
             setFormError('');
         }
@@ -317,6 +329,7 @@ function IOURequestStepDistanceOdometer({
             return;
         }
         setEndReading(text);
+        endReadingRef.current = text;
         if (formError) {
             setFormError('');
         }
@@ -497,13 +510,6 @@ function IOURequestStepDistanceOdometer({
         navigateToNextPage();
     };
 
-    const hasUnsavedChanges = useMemo(
-        () =>
-            shouldEnableDiscardConfirmation &&
-            (startReading !== initialReadings.start || endReading !== initialReadings.end || odometerImage.start !== odometerStartImage || odometerImage.end !== odometerEndImage),
-        [shouldEnableDiscardConfirmation, startReading, endReading, initialReadings.start, initialReadings.end, odometerImage.start, odometerImage.end, odometerStartImage, odometerEndImage],
-    );
-
     return (
         <StepScreenWrapper
             headerTitle={translate('common.distance')}
@@ -643,7 +649,15 @@ function IOURequestStepDistanceOdometer({
                     />
                 </View>
             </View>
-            <DiscardChangesConfirmation hasUnsavedChanges={hasUnsavedChanges} />
+            <DiscardChangesConfirmation
+                isEnabled={shouldEnableDiscardConfirmation}
+                getHasUnsavedChanges={() => {
+                    const hasReadingChanges = startReadingRef.current !== initialStartReadingRef.current || endReadingRef.current !== initialEndReadingRef.current;
+                    const hasImageChanges =
+                        transaction?.comment?.odometerStartImage !== initialStartImageRef.current || transaction?.comment?.odometerEndImage !== initialEndImageRef.current;
+                    return hasReadingChanges || hasImageChanges;
+                }}
+            />
         </StepScreenWrapper>
     );
 }

--- a/src/pages/iou/request/step/IOURequestStepMerchant.tsx
+++ b/src/pages/iou/request/step/IOURequestStepMerchant.tsx
@@ -1,4 +1,4 @@
-import React, {useCallback, useState} from 'react';
+import React, {useCallback, useEffect, useRef, useState} from 'react';
 import {InteractionManager, View} from 'react-native';
 import FormProvider from '@components/Form/FormProvider';
 import InputWrapper from '@components/Form/InputWrapper';
@@ -60,29 +60,28 @@ function IOURequestStepMerchant({
     const merchant = getTransactionDetails(isEditingSplitBill && !isEmptyObject(splitDraftTransaction) ? splitDraftTransaction : transaction)?.merchant;
     const isEmptyMerchant = isInvalidMerchantValue(merchant);
     const initialMerchant = isEmptyMerchant ? '' : merchant;
+    const [currentMerchant, setCurrentMerchant] = useState(initialMerchant);
+    const [isSaved, setIsSaved] = useState(false);
+    const shouldNavigateAfterSaveRef = useRef(false);
     const currentUserPersonalDetails = useCurrentUserPersonalDetails();
     const currentUserAccountIDParam = currentUserPersonalDetails.accountID;
     const currentUserEmailParam = currentUserPersonalDetails.login ?? '';
     const {isBetaEnabled} = usePermissions();
     const isASAPSubmitBetaEnabled = isBetaEnabled(CONST.BETAS.ASAP_SUBMIT);
-    const [hasUnsavedChanges, setHasUnsavedChanges] = useState(false);
-
-    const updateHasUnsavedChanges = useCallback(
-        (value: string) => {
-            if (value === initialMerchant) {
-                setHasUnsavedChanges(false);
-                return;
-            }
-            setHasUnsavedChanges(true);
-        },
-        [initialMerchant],
-    );
 
     const isMerchantRequired = isPolicyExpenseChat(report) || isExpenseRequest(report) || transaction?.participants?.some((participant) => !!participant.isPolicyExpenseChat);
 
     const navigateBack = useCallback(() => {
         Navigation.goBack(backTo);
     }, [backTo]);
+
+    useEffect(() => {
+        if (!isSaved || !shouldNavigateAfterSaveRef.current) {
+            return;
+        }
+        shouldNavigateAfterSaveRef.current = false;
+        navigateBack();
+    }, [isSaved, navigateBack]);
 
     const validate = useCallback(
         (value: FormOnyxValues<typeof ONYXKEYS.FORMS.MONEY_REQUEST_MERCHANT_FORM>) => {
@@ -103,16 +102,23 @@ function IOURequestStepMerchant({
         [isMerchantRequired, translate],
     );
 
+    const updateMerchantRef = (value: string) => {
+        setCurrentMerchant(value);
+    };
+
     const updateMerchant = (value: FormOnyxValues<typeof ONYXKEYS.FORMS.MONEY_REQUEST_MERCHANT_FORM>) => {
-        setHasUnsavedChanges(false);
         const newMerchant = value.moneyRequestMerchant?.trim();
 
         if (isEditingSplitBill) {
             setDraftSplitTransaction(transactionID, splitDraftTransaction, {merchant: newMerchant});
+            setIsSaved(true);
+            shouldNavigateAfterSaveRef.current = true;
             return;
         }
 
         if (newMerchant === merchant || (newMerchant === '' && merchant === CONST.TRANSACTION.PARTIAL_TRANSACTION_MERCHANT)) {
+            setIsSaved(true);
+            shouldNavigateAfterSaveRef.current = true;
             return;
         }
         setMoneyRequestMerchant(transactionID, newMerchant || CONST.TRANSACTION.PARTIAL_TRANSACTION_MERCHANT, !isEditing);
@@ -131,6 +137,8 @@ function IOURequestStepMerchant({
                 parentReportNextStep,
             });
         }
+        setIsSaved(true);
+        shouldNavigateAfterSaveRef.current = true;
     };
 
     return (
@@ -158,7 +166,7 @@ function IOURequestStepMerchant({
                         inputID={INPUT_IDS.MONEY_REQUEST_MERCHANT}
                         name={INPUT_IDS.MONEY_REQUEST_MERCHANT}
                         defaultValue={initialMerchant}
-                        onValueChange={updateHasUnsavedChanges}
+                        onValueChange={updateMerchantRef}
                         label={translate('common.merchant')}
                         accessibilityLabel={translate('common.merchant')}
                         role={CONST.ROLE.PRESENTATION}
@@ -173,7 +181,12 @@ function IOURequestStepMerchant({
                         inputRef.current?.focus();
                     });
                 }}
-                hasUnsavedChanges={hasUnsavedChanges}
+                getHasUnsavedChanges={() => {
+                    if (isSaved) {
+                        return false;
+                    }
+                    return currentMerchant !== initialMerchant;
+                }}
             />
         </StepScreenWrapper>
     );

--- a/src/pages/settings/Profile/Avatar/AvatarPage.tsx
+++ b/src/pages/settings/Profile/Avatar/AvatarPage.tsx
@@ -51,7 +51,7 @@ function ProfileAvatar() {
 
     const [selected, setSelected] = useState<string | undefined>();
     const avatarCaptureRef = useRef<AvatarCaptureHandle>(null);
-    const [isSaving, setIsSaving] = useState(false);
+    const isSavingRef = useRef(false);
 
     const icons = useMemoizedLazyExpensifyIcons(['Upload']);
     const styles = useThemeStyles();
@@ -149,7 +149,7 @@ function ProfileAvatar() {
     });
 
     const onPress = useCallback(() => {
-        setIsSaving(true);
+        isSavingRef.current = true;
 
         if (imageData.file) {
             updateAvatar(imageData.file, {
@@ -180,7 +180,7 @@ function ProfileAvatar() {
             return;
         }
         if (!selected || !avatarCaptureRef.current) {
-            setIsSaving(false);
+            isSavingRef.current = false;
             return;
         }
         // User selected a letter avatar
@@ -197,7 +197,7 @@ function ProfileAvatar() {
                 Navigation.dismissModal();
             })
             .catch(() => {
-                setIsSaving(false);
+                isSavingRef.current = false;
             });
     }, [currentUserPersonalDetails?.accountID, currentUserPersonalDetails?.avatar, currentUserPersonalDetails?.avatarThumbnail, imageData.file, selected]);
 
@@ -315,7 +315,7 @@ function ProfileAvatar() {
                 imageType={cropImageData.type}
                 buttonLabel={translate('avatarPage.upload')}
             />
-            <DiscardChangesConfirmation hasUnsavedChanges={!isSaving && isDirty} />
+            <DiscardChangesConfirmation getHasUnsavedChanges={() => !isSavingRef.current && isDirty} />
         </ScreenWrapper>
     );
 }


### PR DESCRIPTION
Reverts Expensify/App#78291 to fix a couple of issues, including a blocker

- https://github.com/Expensify/App/issues/84218
- https://github.com/Expensify/App/issues/84160