### PR TITLE
Fix export todo visibility mismatch between Home and Reports pages

### DIFF
--- a/src/libs/actions/OnyxDerived/configs/todos.ts
+++ b/src/libs/actions/OnyxDerived/configs/todos.ts
@@ -1,5 +1,4 @@
 import type {OnyxCollection, OnyxEntry} from 'react-native-onyx';
-import {isPreferredExporter} from '@libs/PolicyUtils';
 import {isApproveAction, isExportAction, isPrimaryPayAction, isSubmitAction} from '@libs/ReportPrimaryActionUtils';
 import createOnyxDerivedValueConfig from '@userActions/OnyxDerived/createOnyxDerivedValueConfig';
 import CONST from '@src/CONST';
@@ -68,7 +67,7 @@ const createTodosReportsAndTransactions = ({
         if (isPrimaryPayAction(report, currentUserAccountID, login, bankAccountList, policy, reportNameValuePair)) {
             reportsToPay.push(report);
         }
-        if (isExportAction(report, login, policy, reportActions) && policy && isPreferredExporter(policy, login)) {
+        if (isExportAction(report, login, policy, reportActions) && policy?.exporter === login) {
             reportsToExport.push(report);
         }
     }

--- a/tests/unit/OnyxDerivedTest.tsx
+++ b/tests/unit/OnyxDerivedTest.tsx
@@ -741,6 +741,7 @@ describe('OnyxDerived', () => {
                 const policyWithConnection = {
                     ...createMockPolicy(POLICY_WITH_CONNECTION_ID, {
                         role: CONST.POLICY.ROLE.ADMIN,
+                        exporter: CURRENT_USER_EMAIL,
                     }),
                     connections: {
                         // QuickBooks Online connection with auto-sync disabled
@@ -919,6 +920,54 @@ describe('OnyxDerived', () => {
                 expect(todos?.transactionsByReportID[reportID]).toHaveLength(1);
                 expect(todos?.transactionsByReportID[reportID]?.at(0)?.transactionID).toBe(transactionID);
             });
+        });
+
+        it('excludes export reports when user is connection-level exporter but not policy.exporter', async () => {
+            const EXPORT_POLICY_ID = 'policy_export_mismatch';
+            const reportID = 'export_mismatch_report';
+
+            const report = createMockReport(reportID, {
+                policyID: EXPORT_POLICY_ID,
+                stateNum: CONST.REPORT.STATE_NUM.APPROVED,
+                statusNum: CONST.REPORT.STATUS_NUM.APPROVED,
+                ownerAccountID: OTHER_USER_ACCOUNT_ID,
+                isWaitingOnBankAccount: false,
+            });
+
+            const policy = {
+                ...createMockPolicy(EXPORT_POLICY_ID, {
+                    role: CONST.POLICY.ROLE.ADMIN,
+                    exporter: 'someone-else@mail.com',
+                }),
+                connections: {
+                    [CONST.POLICY.CONNECTIONS.NAME.QBO]: {
+                        lastSync: {
+                            isConnected: true,
+                            isSuccessful: true,
+                            isAuthenticationError: false,
+                            source: 'DIRECT',
+                        },
+                        config: {
+                            autoSync: {
+                                jobID: 'job123',
+                                enabled: false,
+                            },
+                            export: {
+                                exporter: CURRENT_USER_EMAIL,
+                            },
+                        },
+                    },
+                },
+            } as Policy;
+
+            await Onyx.set(ONYXKEYS.SESSION, {email: CURRENT_USER_EMAIL, accountID: CURRENT_USER_ACCOUNT_ID});
+            await Onyx.set(`${ONYXKEYS.COLLECTION.POLICY}${EXPORT_POLICY_ID}`, policy);
+            await Onyx.set(`${ONYXKEYS.COLLECTION.REPORT}${reportID}`, report);
+
+            await waitForBatchedUpdates();
+            const todos = await OnyxUtils.get(ONYXKEYS.DERIVED.TODOS);
+
+            expect(todos?.reportsToExport).toHaveLength(0);
         });
 
         describe('uses primary login from personalDetailsList', () => {


### PR DESCRIPTION
### Explanation of Change
Follow-up to #81705. The Home page "For you" section used \`isPreferredExporter()\` (which checks connection-specific exporter fields like \`policy.connections.<connection>.config.export.exporter\`) to filter export todos, while the Reports page sidebar uses \`policy.exporter\` (top-level policy field). When these diverge, the Home page shows "Export N reports" but the Reports sidebar has no Export option.

The Reports sidebar (\`policy.exporter\`) is the source of truth. This PR changes \`todos.ts\` to use \`policy.exporter\` instead of \`isPreferredExporter()\`, aligning the Home page with the Reports sidebar.

### Fixed Issues
$ https://github.com/Expensify/App/issues/81228

### Tests
1. Have a workspace with an accounting integration connected (auto-sync off) and some approved/closed expense reports
2. Set **User A** as the preferred exporter in the integration export settings AND as \`policy.exporter\`
3. Verify User A sees "Export X reports" in the Home page "For you" section AND the "Export" option in the Reports To-do sidebar
4. Set **User B** as the connection-level exporter but NOT as \`policy.exporter\`
5. Verify User B does NOT see the Export todo on the Home page (matching the Reports sidebar behavior)
- [ ] Verify that no errors appear in the JS console

### Offline tests
- [ ] Verify the Home page For You section and Reports sidebar To-do section render consistently when offline

### QA Steps
1. Log in as a user who is \`policy.exporter\` on a workspace with an accounting integration
2. Navigate to the Home page - verify "Export N reports" appears in "For you"
3. Navigate to the Reports page - verify "Export" appears in the To-do sidebar
4. Both should be consistent (either both show Export or neither does)
- [ ] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>