### PR TITLE
badge style fixes

### DIFF
--- a/src/components/SelectionList/ListItem/InviteMemberListItem.tsx
+++ b/src/components/SelectionList/ListItem/InviteMemberListItem.tsx
@@ -5,6 +5,7 @@ import PressableWithFeedback from '@components/Pressable/PressableWithFeedback';
 import {useProductTrainingContext} from '@components/ProductTrainingContext';
 import ReportActionAvatars from '@components/ReportActionAvatars';
 import SelectCircle from '@components/SelectCircle';
+import {ListItemFocusContext} from '@components/SelectionList/ListItemFocusContext';
 import Text from '@components/Text';
 import TextWithTooltip from '@components/TextWithTooltip';
 import EducationalTooltip from '@components/Tooltip/EducationalTooltip';
@@ -153,7 +154,7 @@ function InviteMemberListItem<TItem extends ListItem>({
                                 />
                             )}
                         </View>
-                        {!!item.rightElement && item.rightElement}
+                        {!!item.rightElement && <ListItemFocusContext.Provider value={{isFocused: !!isFocused}}>{item.rightElement}</ListItemFocusContext.Provider>}
                         {!!shouldShowCheckBox && (
                             <PressableWithFeedback
                                 onPress={handleCheckboxPress}

--- a/src/components/SelectionList/ListItem/InviteMemberListItem.tsx
+++ b/src/components/SelectionList/ListItem/InviteMemberListItem.tsx
@@ -154,7 +154,7 @@ function InviteMemberListItem<TItem extends ListItem>({
                                 />
                             )}
                         </View>
-                        {!!item.rightElement && <ListItemFocusContext.Provider value={{isFocused: !!isFocused}}>{item.rightElement}</ListItemFocusContext.Provider>}
+                        {!!item.rightElement && <ListItemFocusContext.Provider value={{isFocused}}>{item.rightElement}</ListItemFocusContext.Provider>}
                         {!!shouldShowCheckBox && (
                             <PressableWithFeedback
                                 onPress={handleCheckboxPress}

--- a/src/components/SelectionList/ListItem/UserListItem.tsx
+++ b/src/components/SelectionList/ListItem/UserListItem.tsx
@@ -5,6 +5,7 @@ import type {OnyxEntry} from 'react-native-onyx';
 import Icon from '@components/Icon';
 import PressableWithFeedback from '@components/Pressable/PressableWithFeedback';
 import ReportActionAvatars from '@components/ReportActionAvatars';
+import {ListItemFocusContext} from '@components/SelectionList/ListItemFocusContext';
 import Text from '@components/Text';
 import TextWithTooltip from '@components/TextWithTooltip';
 import {useMemoizedLazyExpensifyIcons} from '@hooks/useLazyAsset';
@@ -162,7 +163,7 @@ function UserListItem<TItem extends ListItem>({
                                 />
                             )}
                         </View>
-                        {!!item.rightElement && item.rightElement}
+                        {!!item.rightElement && <ListItemFocusContext.Provider value={{isFocused: !!isFocused}}>{item.rightElement}</ListItemFocusContext.Provider>}
                         {!!item.shouldShowRightCaret && (
                             <View style={[styles.popoverMenuIcon, styles.pointerEventsAuto, isDisabled && styles.cursorDisabled]}>
                                 <Icon

--- a/src/components/SelectionList/ListItem/UserListItem.tsx
+++ b/src/components/SelectionList/ListItem/UserListItem.tsx
@@ -163,7 +163,7 @@ function UserListItem<TItem extends ListItem>({
                                 />
                             )}
                         </View>
-                        {!!item.rightElement && <ListItemFocusContext.Provider value={{isFocused: !!isFocused}}>{item.rightElement}</ListItemFocusContext.Provider>}
+                        {!!item.rightElement && <ListItemFocusContext.Provider value={{isFocused}}>{item.rightElement}</ListItemFocusContext.Provider>}
                         {!!item.shouldShowRightCaret && (
                             <View style={[styles.popoverMenuIcon, styles.pointerEventsAuto, isDisabled && styles.cursorDisabled]}>
                                 <Icon

--- a/src/components/SelectionList/ListItemFocusContext.tsx
+++ b/src/components/SelectionList/ListItemFocusContext.tsx
@@ -1,7 +1,7 @@
 import {createContext, useContext} from 'react';
 
 type ListItemFocusContextValue = {
-    isFocused: boolean;
+    isFocused?: boolean;
 };
 
 const ListItemFocusContext = createContext<ListItemFocusContextValue>({isFocused: false});

--- a/src/components/SelectionList/ListItemFocusContext.tsx
+++ b/src/components/SelectionList/ListItemFocusContext.tsx
@@ -1,0 +1,13 @@
+import {createContext, useContext} from 'react';
+
+type ListItemFocusContextValue = {
+    isFocused: boolean;
+};
+
+const ListItemFocusContext = createContext<ListItemFocusContextValue>({isFocused: false});
+
+function useListItemFocus() {
+    return useContext(ListItemFocusContext);
+}
+
+export {ListItemFocusContext, useListItemFocus};

--- a/src/components/SelectionListWithSections/InviteMemberListItem.tsx
+++ b/src/components/SelectionListWithSections/InviteMemberListItem.tsx
@@ -151,7 +151,7 @@ function InviteMemberListItem<TItem extends ListItem>({
                                 />
                             )}
                         </View>
-                        {!!item.rightElement && <ListItemFocusContext.Provider value={{isFocused: !!isFocused}}>{item.rightElement}</ListItemFocusContext.Provider>}
+                        {!!item.rightElement && <ListItemFocusContext.Provider value={{isFocused}}>{item.rightElement}</ListItemFocusContext.Provider>}
                         {!!shouldShowCheckBox && (
                             <PressableWithFeedback
                                 onPress={handleCheckboxPress}

--- a/src/components/SelectionListWithSections/InviteMemberListItem.tsx
+++ b/src/components/SelectionListWithSections/InviteMemberListItem.tsx
@@ -159,6 +159,7 @@ function InviteMemberListItem<TItem extends ListItem>({
                                 role={CONST.ROLE.BUTTON}
                                 accessibilityLabel={item.text ?? ''}
                                 style={[styles.ml2, styles.optionSelectCircle]}
+                                sentryLabel={CONST.SENTRY_LABEL.LIST_ITEM.INVITE_MEMBER_CHECKBOX}
                             >
                                 <SelectCircle
                                     isChecked={item.isSelected ?? false}

--- a/src/components/SelectionListWithSections/InviteMemberListItem.tsx
+++ b/src/components/SelectionListWithSections/InviteMemberListItem.tsx
@@ -5,6 +5,7 @@ import PressableWithFeedback from '@components/Pressable/PressableWithFeedback';
 import {useProductTrainingContext} from '@components/ProductTrainingContext';
 import ReportActionAvatars from '@components/ReportActionAvatars';
 import SelectCircle from '@components/SelectCircle';
+import {ListItemFocusContext} from '@components/SelectionList/ListItemFocusContext';
 import Text from '@components/Text';
 import TextWithTooltip from '@components/TextWithTooltip';
 import EducationalTooltip from '@components/Tooltip/EducationalTooltip';
@@ -150,7 +151,7 @@ function InviteMemberListItem<TItem extends ListItem>({
                                 />
                             )}
                         </View>
-                        {!!item.rightElement && item.rightElement}
+                        {!!item.rightElement && <ListItemFocusContext.Provider value={{isFocused: !!isFocused}}>{item.rightElement}</ListItemFocusContext.Provider>}
                         {!!shouldShowCheckBox && (
                             <PressableWithFeedback
                                 onPress={handleCheckboxPress}

--- a/src/components/SelectionListWithSections/Search/ActionCell/BadgeActionCell.tsx
+++ b/src/components/SelectionListWithSections/Search/ActionCell/BadgeActionCell.tsx
@@ -23,7 +23,16 @@ function BadgeActionCell({action, isLargeScreenWidth, shouldDisablePointerEvents
     const StyleUtils = useStyleUtils();
     const text = translate(actionTranslationsMap[action]);
 
-    const badgeTheme = action === CONST.SEARCH.ACTION_TYPES.PAID ? theme.reportStatusBadge.paid : theme.reportStatusBadge.approved;
+    const getBadgeTheme = () => {
+        if (action === CONST.SEARCH.ACTION_TYPES.PAID) {
+            return theme.reportStatusBadge.paid;
+        }
+        if (action === CONST.SEARCH.ACTION_TYPES.DONE) {
+            return theme.reportStatusBadge.closed;
+        }
+        return theme.reportStatusBadge.approved;
+    };
+    const badgeTheme = getBadgeTheme();
 
     return (
         <View

--- a/src/components/SelectionListWithSections/Search/ActionCell/BadgeActionCell.tsx
+++ b/src/components/SelectionListWithSections/Search/ActionCell/BadgeActionCell.tsx
@@ -23,16 +23,7 @@ function BadgeActionCell({action, isLargeScreenWidth, shouldDisablePointerEvents
     const StyleUtils = useStyleUtils();
     const text = translate(actionTranslationsMap[action]);
 
-    const getBadgeTheme = () => {
-        if (action === CONST.SEARCH.ACTION_TYPES.PAID) {
-            return theme.reportStatusBadge.paid;
-        }
-        if (action === CONST.SEARCH.ACTION_TYPES.DONE) {
-            return theme.reportStatusBadge.closed;
-        }
-        return theme.reportStatusBadge.approved;
-    };
-    const badgeTheme = getBadgeTheme();
+    const badgeTheme = action === CONST.SEARCH.ACTION_TYPES.PAID ? theme.reportStatusBadge.paid : theme.reportStatusBadge.closed;
 
     return (
         <View

--- a/src/components/SelectionListWithSections/UserListItem.tsx
+++ b/src/components/SelectionListWithSections/UserListItem.tsx
@@ -4,6 +4,7 @@ import {View} from 'react-native';
 import Icon from '@components/Icon';
 import PressableWithFeedback from '@components/Pressable/PressableWithFeedback';
 import ReportActionAvatars from '@components/ReportActionAvatars';
+import {ListItemFocusContext} from '@components/SelectionList/ListItemFocusContext';
 import Text from '@components/Text';
 import TextWithTooltip from '@components/TextWithTooltip';
 import {useMemoizedLazyExpensifyIcons} from '@hooks/useLazyAsset';
@@ -160,7 +161,7 @@ function UserListItem<TItem extends ListItem>({
                                 />
                             )}
                         </View>
-                        {!!item.rightElement && item.rightElement}
+                        {!!item.rightElement && <ListItemFocusContext.Provider value={{isFocused: !!isFocused}}>{item.rightElement}</ListItemFocusContext.Provider>}
                         {!!item.shouldShowRightIcon && (
                             <View style={[styles.popoverMenuIcon, styles.pointerEventsAuto, isDisabled && styles.cursorDisabled]}>
                                 <Icon

--- a/src/components/SelectionListWithSections/UserListItem.tsx
+++ b/src/components/SelectionListWithSections/UserListItem.tsx
@@ -161,7 +161,7 @@ function UserListItem<TItem extends ListItem>({
                                 />
                             )}
                         </View>
-                        {!!item.rightElement && <ListItemFocusContext.Provider value={{isFocused: !!isFocused}}>{item.rightElement}</ListItemFocusContext.Provider>}
+                        {!!item.rightElement && <ListItemFocusContext.Provider value={{isFocused}}>{item.rightElement}</ListItemFocusContext.Provider>}
                         {!!item.shouldShowRightIcon && (
                             <View style={[styles.popoverMenuIcon, styles.pointerEventsAuto, isDisabled && styles.cursorDisabled]}>
                                 <Icon

--- a/src/pages/workspace/MemberRightIcon.tsx
+++ b/src/pages/workspace/MemberRightIcon.tsx
@@ -1,7 +1,9 @@
 import React from 'react';
 import type {StyleProp, ViewStyle} from 'react-native';
 import Badge from '@components/Badge';
+import {useListItemFocus} from '@components/SelectionList/ListItemFocusContext';
 import useLocalize from '@hooks/useLocalize';
+import useThemeStyles from '@hooks/useThemeStyles';
 import CONST from '@src/CONST';
 import type {TranslationPaths} from '@src/languages/types';
 
@@ -14,6 +16,8 @@ type MemberRightIconProps = {
 
 export default function MemberRightIcon({role, owner, login, badgeStyles}: MemberRightIconProps) {
     const {translate} = useLocalize();
+    const styles = useThemeStyles();
+    const {isFocused} = useListItemFocus();
 
     let badgeText: TranslationPaths | undefined;
     if (owner && owner === login) {
@@ -27,7 +31,7 @@ export default function MemberRightIcon({role, owner, login, badgeStyles}: Membe
         return (
             <Badge
                 text={translate(badgeText)}
-                badgeStyles={badgeStyles}
+                badgeStyles={[isFocused && styles.badgeDefaultActive, badgeStyles]}
             />
         );
     }


### PR DESCRIPTION


### Explanation of Change


**Badge outline invisible on selected row (#84358):**
- Added a `ListItemFocusContext` that `InviteMemberListItem` provides with the actual `isFocused` state from the list. `MemberRightIcon` consumes this context and applies `styles.badgeDefaultActive` (uses `buttonHoveredBG`) when the row is focused, preventing the badge from blending into the `activeComponentBG` highlight.
- No changes needed at any call site — the focus state flows automatically via context.

**Done action badge color mismatch (#84360):**
- Updated `BadgeActionCell` to explicitly map `DONE` → `reportStatusBadge.closed` (pink) instead of falling through to `reportStatusBadge.approved` (teal), matching the color used by `StatusCell` for Done reports.

### Fixed Issues

$ https://github.com/Expensify/App/issues/84358
$ https://github.com/Expensify/App/issues/84360

### Tests

**Badge visibility on selected rows (#84358):**
1. Go to a workspace with Workflows enabled
2. Navigate to Workspace Settings > Workflows
3. Click on a workflow > Click Approver > Approver
4. Select an approver from the list
5. Verify the badge (Admin/Owner/Auditor) is visible on the selected (highlighted) row



**Done action badge color (#84360):**
1. Have a report in Done status
2. Go to Reports search
3. Verify the "Done" action badge color (pink) matches the "Done" status badge color
4. Verify the "Paid" action badge still shows the correct green color


### Offline tests

N/A — these are purely visual/styling changes with no network dependency.

### QA Steps

Same as Tests

- [x] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [X] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [X] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->


https://github.com/user-attachments/assets/a88512c2-5c78-401b-b6d0-c00db8a28473



https://github.com/user-attachments/assets/6c5cb0ef-199e-4def-a28b-b6fbba969048

</details>