### PR TITLE
Use native BootSplash fade for splash screen dismissal

### DIFF
--- a/src/components/SplashScreenHider/index.native.tsx
+++ b/src/components/SplashScreenHider/index.native.tsx
@@ -1,71 +1,13 @@
-import {useCallback, useRef} from 'react';
-import type {ViewStyle} from 'react-native';
-import {StyleSheet} from 'react-native';
-import Reanimated, {Easing, useAnimatedStyle, useSharedValue, withTiming} from 'react-native-reanimated';
-import {scheduleOnRN} from 'react-native-worklets';
-import Logo from '@assets/images/new-expensify-dark.svg';
-import ImageSVG from '@components/ImageSVG';
-import useThemeStyles from '@hooks/useThemeStyles';
+import {useEffect} from 'react';
 import BootSplash from '@libs/BootSplash';
 import type {SplashScreenHiderProps, SplashScreenHiderReturnType} from './types';
 
 function SplashScreenHider({onHide = () => {}}: SplashScreenHiderProps): SplashScreenHiderReturnType {
-    const styles = useThemeStyles();
-    const logoSizeRatio = BootSplash.logoSizeRatio || 1;
+    useEffect(() => {
+        BootSplash.hide().then(() => onHide());
+    }, [onHide]);
 
-    const opacity = useSharedValue(1);
-    const scale = useSharedValue(1);
-
-    const opacityStyle = useAnimatedStyle<ViewStyle>(() => ({
-        opacity: opacity.get(),
-    }));
-    const scaleStyle = useAnimatedStyle<ViewStyle>(() => ({
-        transform: [{scale: scale.get()}],
-    }));
-
-    const hideHasBeenCalled = useRef(false);
-
-    const hide = useCallback(() => {
-        // hide can only be called once
-        if (hideHasBeenCalled.current) {
-            return;
-        }
-
-        hideHasBeenCalled.current = true;
-
-        BootSplash.hide().then(() => {
-            scale.set(
-                withTiming(0, {
-                    duration: 200,
-                    easing: Easing.back(2),
-                }),
-            );
-
-            opacity.set(
-                withTiming(
-                    0,
-                    {
-                        duration: 250,
-                        easing: Easing.out(Easing.ease),
-                    },
-                    () => scheduleOnRN(onHide),
-                ),
-            );
-        });
-    }, [opacity, scale, onHide]);
-
-    return (
-        <Reanimated.View style={[StyleSheet.absoluteFill, styles.splashScreenHider, opacityStyle]}>
-            <Reanimated.View style={scaleStyle}>
-                <ImageSVG
-                    onLoadEnd={hide}
-                    contentFit="fill"
-                    style={{width: 100 * logoSizeRatio, height: 100 * logoSizeRatio}}
-                    src={Logo}
-                />
-            </Reanimated.View>
-        </Reanimated.View>
-    );
+    return null;
 }
 
 export default SplashScreenHider;

--- a/src/libs/BootSplash/index.native.ts
+++ b/src/libs/BootSplash/index.native.ts
@@ -6,7 +6,7 @@ const BootSplash = NativeModules.BootSplash;
 function hide(): Promise<void> {
     Log.info('[BootSplash] hiding splash screen', false);
 
-    return BootSplash.hide();
+    return BootSplash.hide(true);
 }
 
 export default {

--- a/src/styles/index.ts
+++ b/src/styles/index.ts
@@ -4212,13 +4212,6 @@ const staticStyles = (theme: ThemeColors) =>
             margin: 'auto',
         },
 
-        splashScreenHider: {
-            backgroundColor: theme.splashBG,
-            alignItems: 'center',
-            justifyContent: 'center',
-            zIndex: 20,
-        },
-
         headerEnvBadge: {
             position: 'absolute',
             bottom: -8,


### PR DESCRIPTION
### Explanation of Change

Replace the JS-side Reanimated scale+opacity animation with the native `fade` option built into react-native-bootsplash. This moves the splash-to-app transition entirely to the native layer, eliminating JS thread overhead during startup when the thread is most congested.

Changes:
- Pass `fade: true` to `BootSplash.hide()` in the native wrapper
- Simplify `SplashScreenHider/index.native.tsx` to match the web version (no Reanimated)
- Remove unused `splashScreenHider` style

### Fixed Issues
$

### Tests

1. Kill the app completely
2. Open the app
3. Verify the splash screen fades out smoothly without a jarring flash
4. Verify the app loads to the expected screen

- [x] Verify that no errors appear in the JS console

### QA Steps
1. Cold start the app on iOS and Android
2. Verify splash screen dismisses with a smooth native fade
3. Verify no visual glitches or flash between splash and app content
4. Verify no errors in JS console

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] iOS: Native
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors

### Screenshots/Videos