### PR TITLE
[Home Page] Upcoming Travel slot - Only show user's own trips

### DIFF
--- a/src/pages/home/UpcomingTravelSection/useUpcomingTravelReservations.ts
+++ b/src/pages/home/UpcomingTravelSection/useUpcomingTravelReservations.ts
@@ -36,6 +36,7 @@ function useUpcomingTravelReservations(): UpcomingReservation[] {
         const upcoming: UpcomingReservation[] = [];
 
         for (const report of reports) {
+            // Only include reservations where the current user is the traveller
             if (!report || report.ownerAccountID !== accountID) {
                 continue;
             }

--- a/src/pages/home/UpcomingTravelSection/useUpcomingTravelReservations.ts
+++ b/src/pages/home/UpcomingTravelSection/useUpcomingTravelReservations.ts
@@ -1,3 +1,4 @@
+import {accountIDSelector} from '@selectors/Session';
 import {useMemo} from 'react';
 import type {OnyxCollection, OnyxEntry} from 'react-native-onyx';
 import useOnyx from '@hooks/useOnyx';
@@ -24,6 +25,7 @@ const allTripRoomsSelector = (reports: OnyxCollection<Report>) => mapOnyxCollect
 
 function useUpcomingTravelReservations(): UpcomingReservation[] {
     const [tripRoomReports] = useOnyx(ONYXKEYS.COLLECTION.REPORT, {selector: allTripRoomsSelector});
+    const [accountID] = useOnyx(ONYXKEYS.SESSION, {selector: accountIDSelector});
 
     return useMemo(() => {
         const now = new Date();
@@ -34,7 +36,7 @@ function useUpcomingTravelReservations(): UpcomingReservation[] {
         const upcoming: UpcomingReservation[] = [];
 
         for (const report of reports) {
-            if (!report) {
+            if (!report || report.ownerAccountID !== accountID) {
                 continue;
             }
             const reservations = getReservationsFromTripReport(report);
@@ -50,7 +52,7 @@ function useUpcomingTravelReservations(): UpcomingReservation[] {
         }
 
         return upcoming.sort((a, b) => new Date(a.reservation.start.date).getTime() - new Date(b.reservation.start.date).getTime());
-    }, [tripRoomReports]);
+    }, [tripRoomReports, accountID]);
 }
 
 export default useUpcomingTravelReservations;

--- a/src/pages/home/UpcomingTravelSection/useUpcomingTravelReservations.ts
+++ b/src/pages/home/UpcomingTravelSection/useUpcomingTravelReservations.ts
@@ -36,7 +36,7 @@ function useUpcomingTravelReservations(): UpcomingReservation[] {
         const upcoming: UpcomingReservation[] = [];
 
         for (const report of reports) {
-            // Only include reservations where the current user is the traveller
+            // Only include reservations where the current user is the traveler
             if (!report || report.ownerAccountID !== accountID) {
                 continue;
             }

--- a/tests/unit/hooks/useUpcomingTravelReservations.test.ts
+++ b/tests/unit/hooks/useUpcomingTravelReservations.test.ts
@@ -406,9 +406,12 @@ function makeRailPnr(pnrId: string, departISO: string, arriveISO: string): Pnr {
     };
 }
 
-function makeTripRoomReport(reportID: string, pnrs: Pnr[]): Report {
+const TEST_ACCOUNT_ID = 12345;
+
+function makeTripRoomReport(reportID: string, pnrs: Pnr[], ownerAccountID: number = TEST_ACCOUNT_ID): Report {
     return {
         reportID,
+        ownerAccountID,
         type: CONST.REPORT.TYPE.CHAT,
         chatType: CONST.REPORT.CHAT_TYPE.TRIP_ROOM,
         reportName: `Trip ${reportID}`,
@@ -427,6 +430,7 @@ describe('useUpcomingTravelReservations', () => {
 
     beforeEach(async () => {
         await Onyx.clear();
+        await Onyx.merge(ONYXKEYS.SESSION, {accountID: TEST_ACCOUNT_ID});
         await waitForBatchedUpdates();
     });
 
@@ -572,5 +576,84 @@ describe('useUpcomingTravelReservations', () => {
         expect(result.current.at(0)?.reportID).toBe('501');
         expect(result.current.at(1)?.reservation.reservationID).toBe('PNR_TRIP1');
         expect(result.current.at(1)?.reportID).toBe('500');
+    });
+
+    it('should exclude trips owned by other users', async () => {
+        const flight = makeAirPnr('PNR_OTHER', daysFromNow(2), daysFromNow(2, 15));
+        const tripRoom = makeTripRoomReport('600', [flight], 99999);
+
+        await Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT}600`, tripRoom);
+        await waitForBatchedUpdates();
+
+        const {result} = renderHook(() => useUpcomingTravelReservations());
+
+        await waitFor(() => {
+            expect(result.current).toEqual([]);
+        });
+    });
+
+    it('should show only the current user trips when mixed with other users trips', async () => {
+        const ownFlight = makeAirPnr('PNR_OWN', daysFromNow(3), daysFromNow(3, 15));
+        const otherFlight = makeAirPnr('PNR_OTHER_MIX', daysFromNow(2), daysFromNow(2, 15));
+
+        const ownTripRoom = makeTripRoomReport('700', [ownFlight], TEST_ACCOUNT_ID);
+        const otherTripRoom = makeTripRoomReport('701', [otherFlight], 88888);
+
+        await Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT}700`, ownTripRoom);
+        await Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT}701`, otherTripRoom);
+        await waitForBatchedUpdates();
+
+        const {result} = renderHook(() => useUpcomingTravelReservations());
+
+        await waitFor(() => {
+            expect(result.current).toHaveLength(1);
+        });
+        expect(result.current.at(0)?.reservation.reservationID).toBe('PNR_OWN');
+        expect(result.current.at(0)?.reportID).toBe('700');
+    });
+
+    it('should exclude trips with undefined ownerAccountID', async () => {
+        const flight = makeAirPnr('PNR_NO_OWNER', daysFromNow(2), daysFromNow(2, 15));
+        const tripRoom = {
+            reportID: '800',
+            type: CONST.REPORT.TYPE.CHAT,
+            chatType: CONST.REPORT.CHAT_TYPE.TRIP_ROOM,
+            reportName: 'Trip 800',
+            policyID: 'policy1',
+            tripData: {
+                tripID: 'trip-800',
+                payload: {pnrs: [flight]},
+            },
+        } as Report;
+
+        await Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT}800`, tripRoom);
+        await waitForBatchedUpdates();
+
+        const {result} = renderHook(() => useUpcomingTravelReservations());
+
+        await waitFor(() => {
+            expect(result.current).toEqual([]);
+        });
+    });
+
+    it('should return empty when all trips belong to other users', async () => {
+        const flight1 = makeAirPnr('PNR_OTHER_A', daysFromNow(1), daysFromNow(1, 15));
+        const flight2 = makeAirPnr('PNR_OTHER_B', daysFromNow(3), daysFromNow(3, 15));
+        const flight3 = makeAirPnr('PNR_OTHER_C', daysFromNow(5), daysFromNow(5, 15));
+
+        const tripRoom1 = makeTripRoomReport('900', [flight1], 11111);
+        const tripRoom2 = makeTripRoomReport('901', [flight2], 22222);
+        const tripRoom3 = makeTripRoomReport('902', [flight3], 33333);
+
+        await Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT}900`, tripRoom1);
+        await Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT}901`, tripRoom2);
+        await Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT}902`, tripRoom3);
+        await waitForBatchedUpdates();
+
+        const {result} = renderHook(() => useUpcomingTravelReservations());
+
+        await waitFor(() => {
+            expect(result.current).toEqual([]);
+        });
     });
 });


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
<!-- Explain what your change does and how it addresses the linked issue -->

The Upcoming Travel section on the Home Page was showing trip rooms for all trips the user had access to, including trips for other employees when the user manages a central/corporate card. This happened because central card managers are participants in trip room reports for bookings paid through their card.

This PR adds an `ownerAccountID` filter in the `useUpcomingTravelReservations` hook to only include trip rooms where the current signed-in user is the owner (i.e. the actual traveler). The `ownerAccountID` on trip room reports identifies the traveler, so comparing it against the session's `accountID` correctly scopes the widget to only the user's own trips.

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/84403
PROPOSAL:


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

1. Log in as a user who manages a central/corporate card and has travel bookings for other employees
2. Navigate to the Home Page
3. Look at the Upcoming Travel section
4. Verify that only the user's own trips are shown (trips for other employees booked through the central card should not appear)
5. Log in as a user with their own upcoming travel booking
6. Navigate to the Home Page
7. Verify that the user's own trip still appears correctly in the Upcoming Travel section
8. Log in as a user with no travel bookings
9. Verify the Upcoming Travel section is not shown (or shows empty state)

- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

1. Load the Home Page while online and verify Upcoming Travel shows only own trips
2. Turn off network connection
3. Verify the Upcoming Travel section continues to display the same (correct) trips from cache
4. Turn the network back on
5. Verify the section updates correctly if any trip data changes

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->

1. Log in as a user who manages a central/corporate card and has travel bookings for other employees
2. Navigate to the Home Page
3. Verify the Upcoming Travel section only shows the user's own trips (not trips for other employees paid through the central card)
4. Log in as a user with their own upcoming travel booking
5. Verify the Upcoming Travel section correctly shows their trip
6. Log in as a user with no upcoming trips
7. Verify the Upcoming Travel section is hidden or empty

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>

Made with [Cursor](https://cursor.com)