### PR TITLE
[No QA] Fix steps on Global Reimbursement docs 

### DIFF
--- a/docs/articles/expensify-classic/bank-accounts-and-payments/payments/Global-Reimbursement-UK.md
+++ b/docs/articles/expensify-classic/bank-accounts-and-payments/payments/Global-Reimbursement-UK.md
@@ -73,7 +73,7 @@ This is a signed document authorizing a client’s bank to pull payments via dir
 Once the bank account is approved for global reimbursement:
 1. Go to **Settings > Workspaces > [Workspace Name] > Workflows**.
 2. Scroll to **Make or track payments**.
-3. Choose your verified EU account as the default reimbursement method.
+3. Choose your verified UK/GBP account as the default reimbursement method.
 4. Instruct employees to connect their deposit account:
    - Go to **Settings > Account > Wallet**.
    - Click **Add deposit-only bank account** and input their account details.

--- a/docs/articles/new-expensify/wallet-and-payments/Global-Reimbursement-Europe.md
+++ b/docs/articles/new-expensify/wallet-and-payments/Global-Reimbursement-Europe.md
@@ -31,10 +31,11 @@ To comply with financial regulations, the following documents are needed:
 # Step 1: Set Your Workspace Currency and Enable Payments
 
 1. In the navigation tabs (on the left on web, and at the bottom on mobile), select **Workspaces > [Workspace Name] > Overview**.
-2. Under **Default currency**, select **AUD A$**.
-3. From the workspace settings left-hand menu, click **Workflows > enable Make or track payments**
-4. Under **Connect bank account > Confirm currency and country (Singapore - SGD)**
-5. Click **Confirm**.
+2. Under **Default currency**, select **EUR €**.
+3. From the Workspace settings menu, select **Workflows** > **Add Bank Account**
+   - **Note** To add a bank account, **Payments** must be enabled. 
+4. Confirm the bank account currency (EUR €) and country. 
+7. Click **Confirm**.
 
 ---
 

--- a/docs/articles/new-expensify/wallet-and-payments/Global-Reimbursement-Europe.md
+++ b/docs/articles/new-expensify/wallet-and-payments/Global-Reimbursement-Europe.md
@@ -33,9 +33,9 @@ To comply with financial regulations, the following documents are needed:
 1. In the navigation tabs (on the left on web, and at the bottom on mobile), select **Workspaces > [Workspace Name] > Overview**.
 2. Under **Default currency**, select **EUR €**.
 3. From the Workspace settings menu, select **Workflows** > **Add Bank Account**
-   - **Note** To add a bank account, **Payments** must be enabled. 
-4. Confirm the bank account currency (EUR €) and country. 
-7. Click **Confirm**.
+   - **Note:** To add a bank account, **Payments** must be enabled.
+4. Confirm the bank account currency (EUR €) and country.
+5. Click **Confirm**.
 
 ---
 

--- a/docs/articles/new-expensify/wallet-and-payments/Global-Reimbursement-Singapore.md
+++ b/docs/articles/new-expensify/wallet-and-payments/Global-Reimbursement-Singapore.md
@@ -25,20 +25,13 @@ If your business operates in Singapore, you can enable global reimbursements to 
 ---
 
 # Step 1: Connect Your Singaporean Bank Account
-1. Go to **Settings > Workspaces [Workspace Name] > Overview**.
-2. In the **Report Currency** dropdown, select **SGD**.
-3. Navigate to **Settings > Workspaces [Workspace Name] > Workflows**.
-4. Scroll to **Make or track payments**.
-5. Set the reimbursement method to **Direct**.
-6. Click **Add business bank account**.
-7. Select **Singapore** as the country and confirm the currency is SGD.
-8. Fill in your account details and click **Save & Continue**.
 
-1. From the **navigation tabs** (on the left on web, and at the bottom on mobile), go to **Workspaces > [Workspace Name] > Overview**.
-2. Under **Default currency**, choose **SGD**.
-3. Return to the left-hand menu and select **Workflows > Make or Track Payments**.
-4. Click **Connect bank account**, then confirm your **currency and country** (choose a supported European country – EUR €).
-5. Click **Confirm** to proceed.
+1. In the navigation tabs (on the left on web, and at the bottom on mobile), select **Workspaces > [Workspace Name] > Overview**.
+2. Under **Default currency**, select **SGD**.
+3. From the Workspace settings menu, select **Workflows** > **Add Bank Account**
+   - **Note** To add a bank account, **Payments** must be enabled. 
+4. Confirm the bank account currency (SGD) and country (Singapore). 
+5. Click **Confirm**.
 
 ---
 

--- a/docs/articles/new-expensify/wallet-and-payments/Global-Reimbursement-Singapore.md
+++ b/docs/articles/new-expensify/wallet-and-payments/Global-Reimbursement-Singapore.md
@@ -1,7 +1,7 @@
 ---
 title: Global Reimbursement - Singapore
 description: Learn how to enable international reimbursements if your business bank account is in Singapore.
-keywords: [Expensify Classic, global reimbursement, Singapore, SGD, international payments, DocuSign, compliance, UBO]
+keywords: [New Expensify, global reimbursement, Singapore, SGD, international payments, DocuSign, compliance, UBO]
 ---
 
 If your business operates in Singapore, you can enable global reimbursements to send international payments from your SGD account. This article walks you through the setup process and required documentation.


### PR DESCRIPTION
From: https://github.com/Expensify/Expensify/issues/606974

> ### Errors in Global Reimbursement docs
> 1. **New Expensify Europe doc** (`new-expensify/wallet-and-payments/Global-Reimbursement-Europe.md:33-37`) — Step 1 references "AUD A$" as the currency and "Singapore - SGD" as the country instead of EUR and a European country.
> 2. **New Expensify Singapore doc** (`new-expensify/wallet-and-payments/Global-Reimbursement-Singapore.md:37-41`) — Has TWO conflicting Step 1 sections: one with correct instructions and one referencing "European country – EUR €."
> 3. **New Expensify Singapore doc** (`new-expensify/wallet-and-payments/Global-Reimbursement-Singapore.md:4`) — Frontmatter keywords say "Expensify Classic" instead of "New Expensify."
> 4. **Classic UK doc** (`expensify-classic/bank-accounts-and-payments/payments/Global-Reimbursement-UK.md:77`) — Says "Choose your verified EU account" instead of UK/GBP account.
