### PR TITLE
Add search filtering for merchant rules

### DIFF
--- a/src/pages/workspace/rules/MerchantRulesSection.tsx
+++ b/src/pages/workspace/rules/MerchantRulesSection.tsx
@@ -1,4 +1,4 @@
-import React, {useMemo} from 'react';
+import React, {useEffect, useMemo} from 'react';
 import {View} from 'react-native';
 import Badge from '@components/Badge';
 import MenuItem from '@components/MenuItem';
@@ -107,6 +107,16 @@ function MerchantRulesSection({policyID}: MerchantRulesSectionProps) {
 
     const [merchantSearchInput, setMerchantSearchInput, filteredRules] = useSearchResults(sortedRules, filterMerchantRule);
 
+    useEffect(() => {
+        if (sortedRules.length > CONST.APPROVAL_WORKFLOW_SEARCH_LIMIT) {
+            return;
+        }
+        setMerchantSearchInput('');
+    }, [sortedRules.length, setMerchantSearchInput]);
+
+    const shouldShowSearchBar =
+        sortedRules.length > CONST.APPROVAL_WORKFLOW_SEARCH_LIMIT || merchantSearchInput.length > 0;
+
     const renderTitle = () => (
         <View style={[styles.flexRow, styles.alignItemsCenter, styles.gap1]}>
             <Text style={[styles.textHeadline, styles.cardSectionTitle, styles.accountSettingsSectionTitle, {color: theme.text}]}>{translate('workspace.rules.merchantRules.title')}</Text>
@@ -127,20 +137,14 @@ function MerchantRulesSection({policyID}: MerchantRulesSectionProps) {
         >
             {hasRules && (
                 <View style={[styles.mt3]}>
-                    {sortedRules.length > CONST.APPROVAL_WORKFLOW_SEARCH_LIMIT && (
+                    {shouldShowSearchBar && (
                         <SearchBar
                             label={translate('workspace.rules.merchantRules.findRule')}
                             inputValue={merchantSearchInput}
                             onChangeText={setMerchantSearchInput}
+                            shouldShowEmptyState={filteredRules.length === 0}
                             style={[styles.mt6, styles.mb3, {marginHorizontal: 0}]}
                         />
-                    )}
-                    {filteredRules.length === 0 && merchantSearchInput.length > 0 && (
-                        <View style={[styles.pt3, styles.pb5]}>
-                            <Text style={[styles.textNormal, styles.colorMuted]}>
-                                {translate('common.noResultsFoundMatching', merchantSearchInput)}
-                            </Text>
-                        </View>
                     )}
                     {filteredRules.map((rule) => {
                         const merchantName = rule.filters?.right ?? '';

--- a/src/pages/workspace/rules/MerchantRulesSection.tsx
+++ b/src/pages/workspace/rules/MerchantRulesSection.tsx
@@ -6,6 +6,8 @@ import MenuItemWithTopDescription from '@components/MenuItemWithTopDescription';
 import OfflineWithFeedback from '@components/OfflineWithFeedback';
 import Section from '@components/Section';
 import Text from '@components/Text';
+import SearchBar from '@components/SearchBar';
+import useSearchResults from '@hooks/useSearchResults';
 import {useMemoizedLazyExpensifyIcons} from '@hooks/useLazyAsset';
 import useLocalize from '@hooks/useLocalize';
 import usePolicy from '@hooks/usePolicy';
@@ -63,6 +65,8 @@ function getRuleDescription(rule: CodingRule, translate: ReturnType<typeof useLo
     // Lowercase any subsequent rule after the first one
     return actions.map((action, index) => (index === 0 ? action : action.charAt(0).toLowerCase() + action.slice(1))).join(', ');
 }
+const filterMerchantRule = (rule: {filters?: {right?: string}}, searchInput: string) =>
+    (rule.filters?.right ?? '').toLowerCase().includes(searchInput);
 
 function MerchantRulesSection({policyID}: MerchantRulesSectionProps) {
     const {translate} = useLocalize();
@@ -101,6 +105,8 @@ function MerchantRulesSection({policyID}: MerchantRulesSectionProps) {
             });
     }, [codingRules]);
 
+    const [merchantSearchInput, setMerchantSearchInput, filteredRules] = useSearchResults(sortedRules, filterMerchantRule);
+
     const renderTitle = () => (
         <View style={[styles.flexRow, styles.alignItemsCenter, styles.gap1]}>
             <Text style={[styles.textHeadline, styles.cardSectionTitle, styles.accountSettingsSectionTitle, {color: theme.text}]}>{translate('workspace.rules.merchantRules.title')}</Text>
@@ -121,7 +127,22 @@ function MerchantRulesSection({policyID}: MerchantRulesSectionProps) {
         >
             {hasRules && (
                 <View style={[styles.mt3]}>
-                    {sortedRules.map((rule) => {
+                    {sortedRules.length > CONST.APPROVAL_WORKFLOW_SEARCH_LIMIT && (
+                        <SearchBar
+                            label={translate('workspace.rules.merchantRules.findRule')}
+                            inputValue={merchantSearchInput}
+                            onChangeText={setMerchantSearchInput}
+                            style={[styles.mt6, styles.mb3, {marginHorizontal: 0}]}
+                        />
+                    )}
+                    {filteredRules.length === 0 && merchantSearchInput.length > 0 && (
+                        <View style={[styles.pt3, styles.pb5]}>
+                            <Text style={[styles.textNormal, styles.colorMuted]}>
+                                {translate('common.noResultsFoundMatching', merchantSearchInput)}
+                            </Text>
+                        </View>
+                    )}
+                    {filteredRules.map((rule) => {
                         const merchantName = rule.filters?.right ?? '';
                         const isExactMatch = rule.filters?.operator === CONST.SEARCH.SYNTAX_OPERATORS.EQUAL_TO;
                         const matchDescription = translate('workspace.rules.merchantRules.ruleSummaryTitle', merchantName, isExactMatch);


### PR DESCRIPTION
### Explanation of Change
This PR adds search functionality to the Merchant Rules section. A search bar is displayed when there are more than three merchant rules, allowing users to filter rules by merchant name. The list dynamically updates as the user types, making it easier to locate specific rules in large workspaces.

### Fixed Issues
$ <ISSUE_LINK>
PROPOSAL: [[<PROPOSAL_LINK>](https://github.com/Expensify/App/issues/84496#issuecomment-4016717726)](https://github.com/Expensify/App/issues/84496#issuecomment-4016863824)

### Tests
1. Navigate to Workspace → Rules → Merchant Rules.
2. Create more than 3 merchant rules.
3. Verify that the search bar appears above the list of rules.
4. Type a merchant name in the search bar.
5. Verify that the list filters dynamically based on the entered text.
6. Verify that partial matches return relevant rules.
7. Enter a search term that does not match any rule.
8. Verify that a "No results found" message appears.

- [x] Verify that no errors appear in the JS console

### Offline tests
1. Disconnect the network.
2. Navigate to Workspace → Rules → Merchant Rules.
3. Verify that existing merchant rules still appear.
4. Verify that the search bar still filters rules locally without network connection.

### QA Steps
Same as tests.

- [x] Verify that no errors appear in the JS console