### PR TITLE
Fix keyboard reordering by restoring focus on sortable wrapper

### DIFF
--- a/src/components/DraggableList/SortableItem.tsx
+++ b/src/components/DraggableList/SortableItem.tsx
@@ -12,27 +12,44 @@ function SortableItem({id, children, disabled = false}: SortableItemProps) {
         transition,
     };
 
-    // Prevent Enter key from reaching MenuItem when dragging to avoid navigation conflicts
     const handleKeyDown = (e: React.KeyboardEvent) => {
-        if (!isDragging || e.key !== 'Enter') {
+        if (e.key !== 'Enter') {
             return;
         }
-        e.preventDefault();
-        e.stopPropagation();
+        if (isDragging) {
+            e.preventDefault();
+            e.stopPropagation();
+            return;
+        }
+        // Forward Enter to inner button since nested elements are non-tabbable
+        const btn = (e.currentTarget as HTMLElement).querySelector<HTMLElement>('button, [role="button"]');
+        if (btn) {
+            e.preventDefault();
+            btn.click();
+        }
     };
 
     return (
         <div
             ref={setNodeRef}
             style={style}
-            // Use capture phase to intercept Enter before MenuItem handles it
             onKeyDownCapture={handleKeyDown}
+            // Maintain single tab stop per item (WCAG 1.3.2): when focus lands on a
+            // nested interactive element via Tab, pull it back to the sortable wrapper
+            // and remove the child from tab order so the next Tab advances correctly.
+            onFocus={(e) => {
+                for (const element of e.currentTarget.querySelectorAll<HTMLElement>('button, [tabindex]:not([tabindex="-1"])')) {
+                    element.tabIndex = -1;
+                }
+                if (e.target === e.currentTarget) {
+                    return;
+                }
+                e.currentTarget.focus();
+            }}
             // eslint-disable-next-line react/jsx-props-no-spreading
             {...attributes}
             // eslint-disable-next-line react/jsx-props-no-spreading
             {...(disabled ? {} : listeners)}
-            // Override dnd-kit's tabIndex to prevent double focus (outer wrapper + inner MenuItem)
-            tabIndex={-1}
         >
             {children}
         </div>


### PR DESCRIPTION
### Explanation of Change
Removes the `tabIndex={-1}` override on the SortableItem wrapper that was preventing dnd-kit's KeyboardSensor from activating. Adds an `onFocus` handler to maintain WCAG single-tab-stop behavior by making nested interactive children non-tabbable and redirecting stray focus to the wrapper. Extends `handleKeyDown` to forward Enter to inner buttons since they are no longer directly tabbable.

### Fixed Issues
$ https://github.com/Expensify/App/issues/83903
PROPOSAL: https://github.com/Expensify/App/issues/83903#issuecomment-4025124646

### Tests

1. Navigate to a workspace with Track Distance enabled (Settings > Workspaces > [workspace] > Distance > Track Distance)
2. Open the Track Distance page so you see the list of waypoints (start, stop, etc.)
3. **Keyboard reordering**: Tab to a waypoint row, press Space to grab it, use Arrow Up/Down to move it, press Space to drop it -- verify the item is reordered correctly
4. **Single tab stop (WCAG)**: Tab through the waypoint list and verify each row only receives one tab stop (the wrapper), not two (wrapper + inner button)
5. **Enter to navigate**: Tab to a waypoint row and press Enter -- verify it opens the waypoint editor (address picker)
6. **Enter blocked during drag**: Tab to a waypoint, press Space to grab, press Enter, then press Space to drop -- verify Enter does NOT navigate away while dragging
7. **Ghost drag cleanup**: Start a keyboard drag (Space), navigate away (e.g. browser back), return to the page -- verify there is no lingering ghost drag state
8. **Mouse drag after keyboard**: Do a keyboard reorder, then click-and-drag a different waypoint -- verify both input methods work independently
9. **Pointer drag still works**: Click and drag a waypoint row to reorder -- verify pointer-based drag works
10. Verify that no errors appear in the JS console

### Offline tests
1. Go offline (disconnect network)
2. Navigate to Track Distance page
3. Attempt keyboard reordering (Space to grab, arrows to move, Space to drop)
4. Verify the reorder UI works (optimistic update)
5. Go back online and verify the change persists

### QA Steps
1. Navigate to a workspace > Distance > Track Distance
2. Tab to a waypoint and press Space, then Arrow Down, then Space -- verify the item moved down
3. Tab through waypoints and confirm only one tab stop per row
4. Press Enter on a focused waypoint -- verify it opens the editor
5. Space to grab, Enter (should be blocked), Space to drop -- verify no navigation during drag
6. Click-and-drag a waypoint to reorder -- verify mouse drag still works
7. Verify no console errors

- [x] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/f66b7b64-0043-41b6-853b-92034b1269c5


</details>
