### PR TITLE
[$250] Screen Reader: Announce informative check image in manual bank flow

### DIFF
--- a/src/pages/ReimbursementAccount/USD/BankInfo/ExampleCheck.tsx
+++ b/src/pages/ReimbursementAccount/USD/BankInfo/ExampleCheck.tsx
@@ -8,13 +8,13 @@ import CONST from '@src/CONST';
 function ExampleCheckImage() {
     const styles = useThemeStyles();
     const illustrations = useThemeIllustrations();
-    const {preferredLocale} = useLocalize();
+    const {preferredLocale, translate} = useLocalize();
     const isSpanish = (preferredLocale ?? CONST.LOCALES.DEFAULT) === CONST.LOCALES.ES;
 
     return (
         <Image
             accessibilityLabel={translate('bankAccount.checkHelpLine')}
-            accessibilityRole={CONST.ROLE.IMAGE}
+            accessibilityRole={CONST.ROLE.IMG}
             resizeMode="contain"
             style={[styles.exampleCheckImage, styles.mb5]}
             source={isSpanish ? illustrations.ExampleCheckES : illustrations.ExampleCheckEN}

--- a/src/pages/ReimbursementAccount/USD/BankInfo/ExampleCheck.tsx
+++ b/src/pages/ReimbursementAccount/USD/BankInfo/ExampleCheck.tsx
@@ -13,6 +13,8 @@ function ExampleCheckImage() {
 
     return (
         <Image
+            accessibilityLabel={translate('bankAccount.checkHelpLine')}
+            accessibilityRole={CONST.ROLE.IMAGE}
             resizeMode="contain"
             style={[styles.exampleCheckImage, styles.mb5]}
             source={isSpanish ? illustrations.ExampleCheckES : illustrations.ExampleCheckEN}


### PR DESCRIPTION
## Proposal

### Please re-state the problem that we are trying to solve in this issue.
In the manual bank connection flow, the check illustration is informative but is skipped by screen readers.

### What is the root cause of that problem?
The image is rendered without an accessibility label, so assistive technologies do not announce useful context.

### What changes did you make to solve the problem?
- Added an `accessibilityLabel` to the manual check example image
- Added `accessibilityRole="image"` so the element is exposed as an image to screen readers
- Reused existing copy (`bankAccount.checkHelpLine`) as the descriptive text

### What specific scenarios should we cover in automated tests to prevent reintroducing this issue in the future?
- The check example image in manual bank setup exposes a non-empty accessible label
- The image is announced as an image role by screen readers

## Testing

- [ ] Not run (UI accessibility change only)
