### PR TITLE
[$250] Prevent back-stack loop when deleting currently viewed report

### DIFF
--- a/src/libs/actions/Report/index.ts
+++ b/src/libs/actions/Report/index.ts
@@ -3740,6 +3740,13 @@ function deleteReport(reportID: string | undefined, shouldDeleteChildReports = f
         Log.warn('[Report] deleteReport called with no reportID');
         return;
     }
+
+    // If the currently displayed report is being removed, pop to the sidebar first.
+    // This prevents back-stack loops on a now-missing report route.
+    if (Navigation.getTopmostReportId() === reportID) {
+        Navigation.popToSidebar();
+    }
+
     const report = allReports?.[`${ONYXKEYS.COLLECTION.REPORT}${reportID}`];
     const onyxData: Record<string, null> = {
         [`${ONYXKEYS.COLLECTION.REPORT}${reportID}`]: null,


### PR DESCRIPTION
## Proposal

### Please re-state the problem that we are trying to solve in this issue.
After deleting reports, pressing back can loop on workspace chat / not-here states instead of returning cleanly to Inbox.

### What is the root cause of that problem?
The current report route can remain on stack while the underlying report data is deleted, leaving stale navigation targets.

### What changes did you make to solve the problem?
- Before deleting a report, if it is currently displayed, pop navigation to sidebar first.
- Then proceed with report/onyx deletion as before.

### What specific scenarios should we cover in automated tests to prevent reintroducing this issue in the future?
- Deleting currently viewed expense/report should not leave back-stack loops.
- Back navigation after deletion should return to a valid screen (Inbox/sidebar) instead of stale report routes.

## Testing
- [ ] Not run (navigation safety change)
