### PR TITLE
[No QA] Add reasonAttributes to accounting and company cards skeleton usages

### DIFF
--- a/src/pages/workspace/accounting/PolicyAccountingPage.tsx
+++ b/src/pages/workspace/accounting/PolicyAccountingPage.tsx
@@ -47,6 +47,7 @@ import {
     settingsPendingAction,
     shouldShowSyncError,
 } from '@libs/PolicyUtils';
+import type {SkeletonSpanReasonAttributes} from '@libs/telemetry/useSkeletonSpan';
 import Navigation from '@navigation/Navigation';
 import AccessOrNotFoundWrapper from '@pages/workspace/AccessOrNotFoundWrapper';
 import withPolicyConnections from '@pages/workspace/withPolicyConnections';
@@ -417,6 +418,10 @@ function PolicyAccountingPage({policy}: PolicyAccountingPageProps) {
             },
         ];
 
+        const syncActivityReasonAttributes: SkeletonSpanReasonAttributes = {
+            context: 'PolicyAccountingPage.connectionsMenuItems',
+            isSyncInProgress,
+        };
         return [
             {
                 ...iconProps,
@@ -429,7 +434,10 @@ function PolicyAccountingPage({policy}: PolicyAccountingPageProps) {
                 shouldShowRedDotIndicator: true,
                 description: connectionMessage,
                 rightComponent: isSyncInProgress ? (
-                    <ActivityIndicator style={[styles.popoverMenuIcon]} />
+                    <ActivityIndicator
+                        style={[styles.popoverMenuIcon]}
+                        reasonAttributes={syncActivityReasonAttributes}
+                    />
                 ) : (
                     <ThreeDotsMenu
                         shouldSelfPosition

--- a/src/pages/workspace/accounting/qbd/QuickBooksDesktopSetupPage.tsx
+++ b/src/pages/workspace/accounting/qbd/QuickBooksDesktopSetupPage.tsx
@@ -1,199 +1,150 @@
-import React, { useCallback, useEffect, useState } from "react";
-import { View } from "react-native";
-import ActivityIndicator from "@components/ActivityIndicator";
-import FullPageOfflineBlockingView from "@components/BlockingViews/FullPageOfflineBlockingView";
-import Button from "@components/Button";
-import CopyTextToClipboard from "@components/CopyTextToClipboard";
-import FixedFooter from "@components/FixedFooter";
-import HeaderWithBackButton from "@components/HeaderWithBackButton";
-import Icon from "@components/Icon";
-import ImageSVG from "@components/ImageSVG";
-import RenderHTML from "@components/RenderHTML";
-import ScreenWrapper from "@components/ScreenWrapper";
-import Text from "@components/Text";
-import useEnvironment from "@hooks/useEnvironment";
-import { useMemoizedLazyIllustrations } from "@hooks/useLazyAsset";
-import useLocalize from "@hooks/useLocalize";
-import useNetwork from "@hooks/useNetwork";
-import useThemeStyles from "@hooks/useThemeStyles";
-import Navigation from "@libs/Navigation/Navigation";
-import type { PlatformStackScreenProps } from "@libs/Navigation/PlatformStackNavigation/types";
-import type { SettingsNavigatorParamList } from "@libs/Navigation/types";
-import type { SkeletonSpanReasonAttributes } from "@libs/telemetry/useSkeletonSpan";
-import { setConnectionError } from "@userActions/connections";
-import { getQuickbooksDesktopCodatSetupLink } from "@userActions/connections/QuickbooksDesktop";
-import { enablePolicyTaxes } from "@userActions/Policy/Policy";
-import CONST from "@src/CONST";
-import ROUTES from "@src/ROUTES";
-import type SCREENS from "@src/SCREENS";
+import React, {useCallback, useEffect, useState} from 'react';
+import {View} from 'react-native';
+import ActivityIndicator from '@components/ActivityIndicator';
+import FullPageOfflineBlockingView from '@components/BlockingViews/FullPageOfflineBlockingView';
+import Button from '@components/Button';
+import CopyTextToClipboard from '@components/CopyTextToClipboard';
+import FixedFooter from '@components/FixedFooter';
+import HeaderWithBackButton from '@components/HeaderWithBackButton';
+import Icon from '@components/Icon';
+import ImageSVG from '@components/ImageSVG';
+import RenderHTML from '@components/RenderHTML';
+import ScreenWrapper from '@components/ScreenWrapper';
+import Text from '@components/Text';
+import useEnvironment from '@hooks/useEnvironment';
+import {useMemoizedLazyIllustrations} from '@hooks/useLazyAsset';
+import useLocalize from '@hooks/useLocalize';
+import useNetwork from '@hooks/useNetwork';
+import useThemeStyles from '@hooks/useThemeStyles';
+import Navigation from '@libs/Navigation/Navigation';
+import type {PlatformStackScreenProps} from '@libs/Navigation/PlatformStackNavigation/types';
+import type {SettingsNavigatorParamList} from '@libs/Navigation/types';
+import type {SkeletonSpanReasonAttributes} from '@libs/telemetry/useSkeletonSpan';
+import {setConnectionError} from '@userActions/connections';
+import {getQuickbooksDesktopCodatSetupLink} from '@userActions/connections/QuickbooksDesktop';
+import {enablePolicyTaxes} from '@userActions/Policy/Policy';
+import CONST from '@src/CONST';
+import ROUTES from '@src/ROUTES';
+import type SCREENS from '@src/SCREENS';
 
-type RequireQuickBooksDesktopModalProps = PlatformStackScreenProps<
-  SettingsNavigatorParamList,
-  typeof SCREENS.WORKSPACE.ACCOUNTING.QUICKBOOKS_DESKTOP_SETUP_REQUIRED_DEVICE_MODAL
->;
+type RequireQuickBooksDesktopModalProps = PlatformStackScreenProps<SettingsNavigatorParamList, typeof SCREENS.WORKSPACE.ACCOUNTING.QUICKBOOKS_DESKTOP_SETUP_REQUIRED_DEVICE_MODAL>;
 
-function RequireQuickBooksDesktopModal({
-  route,
-}: RequireQuickBooksDesktopModalProps) {
-  const { translate } = useLocalize();
-  const styles = useThemeStyles();
-  const { environmentURL } = useEnvironment();
-  const illustrations = useMemoizedLazyIllustrations([
-    "BrokenMagnifyingGlass",
-    "LaptopWithSecondScreenSync",
-  ]);
-  const policyID: string = route.params.policyID;
-  const [hasError, setHasError] = useState(false);
-  const [codatSetupLink, setCodatSetupLink] = useState<string>("");
-  const hasResultOfFetchingSetupLink = !!codatSetupLink || hasError;
+function RequireQuickBooksDesktopModal({route}: RequireQuickBooksDesktopModalProps) {
+    const {translate} = useLocalize();
+    const styles = useThemeStyles();
+    const {environmentURL} = useEnvironment();
+    const illustrations = useMemoizedLazyIllustrations(['BrokenMagnifyingGlass', 'LaptopWithSecondScreenSync']);
+    const policyID: string = route.params.policyID;
+    const [hasError, setHasError] = useState(false);
+    const [codatSetupLink, setCodatSetupLink] = useState<string>('');
+    const hasResultOfFetchingSetupLink = !!codatSetupLink || hasError;
 
-  const fetchSetupLink = useCallback(() => {
-    setHasError(false);
-    // eslint-disable-next-line rulesdir/no-thenable-actions-in-views
-    getQuickbooksDesktopCodatSetupLink(policyID).then((response) => {
-      if (!response?.jsonCode) {
-        return;
-      }
+    const fetchSetupLink = useCallback(() => {
+        setHasError(false);
+        // eslint-disable-next-line rulesdir/no-thenable-actions-in-views
+        getQuickbooksDesktopCodatSetupLink(policyID).then((response) => {
+            if (!response?.jsonCode) {
+                return;
+            }
 
-      if (response.jsonCode === CONST.JSON_CODE.SUCCESS) {
-        setCodatSetupLink(String(response?.setupUrl ?? ""));
-      } else {
-        setConnectionError(
-          policyID,
-          CONST.POLICY.CONNECTIONS.NAME.QBD,
-          translate("workspace.qbd.setupPage.setupErrorTitle"),
-        );
-        setHasError(true);
-      }
+            if (response.jsonCode === CONST.JSON_CODE.SUCCESS) {
+                setCodatSetupLink(String(response?.setupUrl ?? ''));
+            } else {
+                setConnectionError(policyID, CONST.POLICY.CONNECTIONS.NAME.QBD, translate('workspace.qbd.setupPage.setupErrorTitle'));
+                setHasError(true);
+            }
+        });
+    }, [policyID, translate]);
+
+    useEffect(() => {
+        // Since QBD doesn't support Taxes, we should disable them from the LHN when connecting to QBD
+        enablePolicyTaxes(policyID, false);
+
+        fetchSetupLink();
+        // disabling this rule, as we want this to run only on the first render
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
+
+    useNetwork({
+        onReconnect: () => {
+            if (hasResultOfFetchingSetupLink) {
+                return;
+            }
+            fetchSetupLink();
+        },
     });
-  }, [policyID, translate]);
 
-  useEffect(() => {
-    // Since QBD doesn't support Taxes, we should disable them from the LHN when connecting to QBD
-    enablePolicyTaxes(policyID, false);
+    const shouldShowError = hasError;
 
-    fetchSetupLink();
-    // disabling this rule, as we want this to run only on the first render
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+    const activityReasonAttributes: SkeletonSpanReasonAttributes = {
+        context: 'RequireQuickBooksDesktopModal',
+        hasResultOfFetchingSetupLink,
+    };
 
-  useNetwork({
-    onReconnect: () => {
-      if (hasResultOfFetchingSetupLink) {
-        return;
-      }
-      fetchSetupLink();
-    },
-  });
-
-  const shouldShowError = hasError;
-
-  const activityReasonAttributes: SkeletonSpanReasonAttributes = {
-    context: "RequireQuickBooksDesktopModal",
-    hasResultOfFetchingSetupLink,
-  };
-
-  const children = (
-    <>
-      {shouldShowError && (
-        <View
-          style={[
-            styles.flex1,
-            styles.justifyContentCenter,
-            styles.alignItemsCenter,
-            styles.ph5,
-            styles.mb9,
-          ]}
-        >
-          <Icon
-            src={illustrations.BrokenMagnifyingGlass}
-            width={116}
-            height={168}
-          />
-          <Text style={[styles.textHeadlineLineHeightXXL, styles.mt3]}>
-            {translate("workspace.qbd.setupPage.setupErrorTitle")}
-          </Text>
-          <View style={[styles.renderHTML, styles.ph5, styles.mv3]}>
-            <RenderHTML
-              html={translate(
-                "workspace.qbd.setupPage.setupErrorBody",
-                `${environmentURL}/${ROUTES.CONCIERGE}`,
-              )}
-            />
-          </View>
-        </View>
-      )}
-      {!shouldShowError && (
-        <View style={[styles.flex1, styles.ph5]}>
-          <View
-            style={[
-              styles.alignSelfCenter,
-              styles.computerIllustrationContainer,
-              styles.pv6,
-            ]}
-          >
-            <ImageSVG src={illustrations.LaptopWithSecondScreenSync} />
-          </View>
-
-          <Text style={[styles.textHeadlineH1, styles.pt5]}>
-            {translate("workspace.qbd.setupPage.title")}
-          </Text>
-          <Text style={[styles.textSupporting, styles.textNormal, styles.pt4]}>
-            {translate("workspace.qbd.setupPage.body")}
-          </Text>
-          <View style={[styles.qbdSetupLinkBox, styles.mt5]}>
-            {!hasResultOfFetchingSetupLink ? (
-              <ActivityIndicator reasonAttributes={activityReasonAttributes} />
-            ) : (
-              <CopyTextToClipboard
-                text={codatSetupLink}
-                textStyles={[styles.textSupporting]}
-              />
+    const children = (
+        <>
+            {shouldShowError && (
+                <View style={[styles.flex1, styles.justifyContentCenter, styles.alignItemsCenter, styles.ph5, styles.mb9]}>
+                    <Icon
+                        src={illustrations.BrokenMagnifyingGlass}
+                        width={116}
+                        height={168}
+                    />
+                    <Text style={[styles.textHeadlineLineHeightXXL, styles.mt3]}>{translate('workspace.qbd.setupPage.setupErrorTitle')}</Text>
+                    <View style={[styles.renderHTML, styles.ph5, styles.mv3]}>
+                        <RenderHTML html={translate('workspace.qbd.setupPage.setupErrorBody', `${environmentURL}/${ROUTES.CONCIERGE}`)} />
+                    </View>
+                </View>
             )}
-          </View>
-          <FixedFooter
-            style={[styles.mtAuto, styles.ph0]}
-            addBottomSafeAreaPadding
-          >
-            <Button
-              success
-              text={translate("common.done")}
-              onPress={() =>
-                Navigation.navigate(
-                  ROUTES.POLICY_ACCOUNTING_QUICKBOOKS_DESKTOP_TRIGGER_FIRST_SYNC.getRoute(
-                    policyID,
-                  ),
-                )
-              }
-              pressOnEnter
-              large
-            />
-          </FixedFooter>
-        </View>
-      )}
-    </>
-  );
+            {!shouldShowError && (
+                <View style={[styles.flex1, styles.ph5]}>
+                    <View style={[styles.alignSelfCenter, styles.computerIllustrationContainer, styles.pv6]}>
+                        <ImageSVG src={illustrations.LaptopWithSecondScreenSync} />
+                    </View>
 
-  return (
-    <ScreenWrapper
-      shouldEnablePickerAvoiding={false}
-      shouldShowOfflineIndicatorInWideScreen
-      testID="RequireQuickBooksDesktopModal"
-    >
-      <HeaderWithBackButton
-        title={translate("workspace.qbd.qbdSetup")}
-        shouldShowBackButton
-        onBackButtonPress={() => Navigation.dismissModal()}
-      />
-      {hasResultOfFetchingSetupLink ? (
-        children
-      ) : (
-        <FullPageOfflineBlockingView addBottomSafeAreaPadding>
-          {children}
-        </FullPageOfflineBlockingView>
-      )}
-    </ScreenWrapper>
-  );
+                    <Text style={[styles.textHeadlineH1, styles.pt5]}>{translate('workspace.qbd.setupPage.title')}</Text>
+                    <Text style={[styles.textSupporting, styles.textNormal, styles.pt4]}>{translate('workspace.qbd.setupPage.body')}</Text>
+                    <View style={[styles.qbdSetupLinkBox, styles.mt5]}>
+                        {!hasResultOfFetchingSetupLink ? (
+                            <ActivityIndicator reasonAttributes={activityReasonAttributes} />
+                        ) : (
+                            <CopyTextToClipboard
+                                text={codatSetupLink}
+                                textStyles={[styles.textSupporting]}
+                            />
+                        )}
+                    </View>
+                    <FixedFooter
+                        style={[styles.mtAuto, styles.ph0]}
+                        addBottomSafeAreaPadding
+                    >
+                        <Button
+                            success
+                            text={translate('common.done')}
+                            onPress={() => Navigation.navigate(ROUTES.POLICY_ACCOUNTING_QUICKBOOKS_DESKTOP_TRIGGER_FIRST_SYNC.getRoute(policyID))}
+                            pressOnEnter
+                            large
+                        />
+                    </FixedFooter>
+                </View>
+            )}
+        </>
+    );
+
+    return (
+        <ScreenWrapper
+            shouldEnablePickerAvoiding={false}
+            shouldShowOfflineIndicatorInWideScreen
+            testID="RequireQuickBooksDesktopModal"
+        >
+            <HeaderWithBackButton
+                title={translate('workspace.qbd.qbdSetup')}
+                shouldShowBackButton
+                onBackButtonPress={() => Navigation.dismissModal()}
+            />
+            {hasResultOfFetchingSetupLink ? children : <FullPageOfflineBlockingView addBottomSafeAreaPadding>{children}</FullPageOfflineBlockingView>}
+        </ScreenWrapper>
+    );
 }
 
 export default RequireQuickBooksDesktopModal;

--- a/src/pages/workspace/accounting/qbd/QuickBooksDesktopSetupPage.tsx
+++ b/src/pages/workspace/accounting/qbd/QuickBooksDesktopSetupPage.tsx
@@ -19,6 +19,7 @@ import useThemeStyles from '@hooks/useThemeStyles';
 import Navigation from '@libs/Navigation/Navigation';
 import type {PlatformStackScreenProps} from '@libs/Navigation/PlatformStackNavigation/types';
 import type {SettingsNavigatorParamList} from '@libs/Navigation/types';
+import type {SkeletonSpanReasonAttributes} from '@libs/telemetry/useSkeletonSpan';
 import {setConnectionError} from '@userActions/connections';
 import {getQuickbooksDesktopCodatSetupLink} from '@userActions/connections/QuickbooksDesktop';
 import {enablePolicyTaxes} from '@userActions/Policy/Policy';
@@ -75,6 +76,11 @@ function RequireQuickBooksDesktopModal({route}: RequireQuickBooksDesktopModalPro
 
     const shouldShowError = hasError;
 
+    const activityReasonAttributes: SkeletonSpanReasonAttributes = {
+        context: 'RequireQuickBooksDesktopModal',
+        hasResultOfFetchingSetupLink: !hasResultOfFetchingSetupLink,
+    };
+
     const children = (
         <>
             {shouldShowError && (
@@ -100,7 +106,7 @@ function RequireQuickBooksDesktopModal({route}: RequireQuickBooksDesktopModalPro
                     <Text style={[styles.textSupporting, styles.textNormal, styles.pt4]}>{translate('workspace.qbd.setupPage.body')}</Text>
                     <View style={[styles.qbdSetupLinkBox, styles.mt5]}>
                         {!hasResultOfFetchingSetupLink ? (
-                            <ActivityIndicator />
+                            <ActivityIndicator reasonAttributes={activityReasonAttributes} />
                         ) : (
                             <CopyTextToClipboard
                                 text={codatSetupLink}

--- a/src/pages/workspace/accounting/qbd/QuickBooksDesktopSetupPage.tsx
+++ b/src/pages/workspace/accounting/qbd/QuickBooksDesktopSetupPage.tsx
@@ -1,150 +1,199 @@
-import React, {useCallback, useEffect, useState} from 'react';
-import {View} from 'react-native';
-import ActivityIndicator from '@components/ActivityIndicator';
-import FullPageOfflineBlockingView from '@components/BlockingViews/FullPageOfflineBlockingView';
-import Button from '@components/Button';
-import CopyTextToClipboard from '@components/CopyTextToClipboard';
-import FixedFooter from '@components/FixedFooter';
-import HeaderWithBackButton from '@components/HeaderWithBackButton';
-import Icon from '@components/Icon';
-import ImageSVG from '@components/ImageSVG';
-import RenderHTML from '@components/RenderHTML';
-import ScreenWrapper from '@components/ScreenWrapper';
-import Text from '@components/Text';
-import useEnvironment from '@hooks/useEnvironment';
-import {useMemoizedLazyIllustrations} from '@hooks/useLazyAsset';
-import useLocalize from '@hooks/useLocalize';
-import useNetwork from '@hooks/useNetwork';
-import useThemeStyles from '@hooks/useThemeStyles';
-import Navigation from '@libs/Navigation/Navigation';
-import type {PlatformStackScreenProps} from '@libs/Navigation/PlatformStackNavigation/types';
-import type {SettingsNavigatorParamList} from '@libs/Navigation/types';
-import type {SkeletonSpanReasonAttributes} from '@libs/telemetry/useSkeletonSpan';
-import {setConnectionError} from '@userActions/connections';
-import {getQuickbooksDesktopCodatSetupLink} from '@userActions/connections/QuickbooksDesktop';
-import {enablePolicyTaxes} from '@userActions/Policy/Policy';
-import CONST from '@src/CONST';
-import ROUTES from '@src/ROUTES';
-import type SCREENS from '@src/SCREENS';
+import React, { useCallback, useEffect, useState } from "react";
+import { View } from "react-native";
+import ActivityIndicator from "@components/ActivityIndicator";
+import FullPageOfflineBlockingView from "@components/BlockingViews/FullPageOfflineBlockingView";
+import Button from "@components/Button";
+import CopyTextToClipboard from "@components/CopyTextToClipboard";
+import FixedFooter from "@components/FixedFooter";
+import HeaderWithBackButton from "@components/HeaderWithBackButton";
+import Icon from "@components/Icon";
+import ImageSVG from "@components/ImageSVG";
+import RenderHTML from "@components/RenderHTML";
+import ScreenWrapper from "@components/ScreenWrapper";
+import Text from "@components/Text";
+import useEnvironment from "@hooks/useEnvironment";
+import { useMemoizedLazyIllustrations } from "@hooks/useLazyAsset";
+import useLocalize from "@hooks/useLocalize";
+import useNetwork from "@hooks/useNetwork";
+import useThemeStyles from "@hooks/useThemeStyles";
+import Navigation from "@libs/Navigation/Navigation";
+import type { PlatformStackScreenProps } from "@libs/Navigation/PlatformStackNavigation/types";
+import type { SettingsNavigatorParamList } from "@libs/Navigation/types";
+import type { SkeletonSpanReasonAttributes } from "@libs/telemetry/useSkeletonSpan";
+import { setConnectionError } from "@userActions/connections";
+import { getQuickbooksDesktopCodatSetupLink } from "@userActions/connections/QuickbooksDesktop";
+import { enablePolicyTaxes } from "@userActions/Policy/Policy";
+import CONST from "@src/CONST";
+import ROUTES from "@src/ROUTES";
+import type SCREENS from "@src/SCREENS";
 
-type RequireQuickBooksDesktopModalProps = PlatformStackScreenProps<SettingsNavigatorParamList, typeof SCREENS.WORKSPACE.ACCOUNTING.QUICKBOOKS_DESKTOP_SETUP_REQUIRED_DEVICE_MODAL>;
+type RequireQuickBooksDesktopModalProps = PlatformStackScreenProps<
+  SettingsNavigatorParamList,
+  typeof SCREENS.WORKSPACE.ACCOUNTING.QUICKBOOKS_DESKTOP_SETUP_REQUIRED_DEVICE_MODAL
+>;
 
-function RequireQuickBooksDesktopModal({route}: RequireQuickBooksDesktopModalProps) {
-    const {translate} = useLocalize();
-    const styles = useThemeStyles();
-    const {environmentURL} = useEnvironment();
-    const illustrations = useMemoizedLazyIllustrations(['BrokenMagnifyingGlass', 'LaptopWithSecondScreenSync']);
-    const policyID: string = route.params.policyID;
-    const [hasError, setHasError] = useState(false);
-    const [codatSetupLink, setCodatSetupLink] = useState<string>('');
-    const hasResultOfFetchingSetupLink = !!codatSetupLink || hasError;
+function RequireQuickBooksDesktopModal({
+  route,
+}: RequireQuickBooksDesktopModalProps) {
+  const { translate } = useLocalize();
+  const styles = useThemeStyles();
+  const { environmentURL } = useEnvironment();
+  const illustrations = useMemoizedLazyIllustrations([
+    "BrokenMagnifyingGlass",
+    "LaptopWithSecondScreenSync",
+  ]);
+  const policyID: string = route.params.policyID;
+  const [hasError, setHasError] = useState(false);
+  const [codatSetupLink, setCodatSetupLink] = useState<string>("");
+  const hasResultOfFetchingSetupLink = !!codatSetupLink || hasError;
 
-    const fetchSetupLink = useCallback(() => {
-        setHasError(false);
-        // eslint-disable-next-line rulesdir/no-thenable-actions-in-views
-        getQuickbooksDesktopCodatSetupLink(policyID).then((response) => {
-            if (!response?.jsonCode) {
-                return;
-            }
+  const fetchSetupLink = useCallback(() => {
+    setHasError(false);
+    // eslint-disable-next-line rulesdir/no-thenable-actions-in-views
+    getQuickbooksDesktopCodatSetupLink(policyID).then((response) => {
+      if (!response?.jsonCode) {
+        return;
+      }
 
-            if (response.jsonCode === CONST.JSON_CODE.SUCCESS) {
-                setCodatSetupLink(String(response?.setupUrl ?? ''));
-            } else {
-                setConnectionError(policyID, CONST.POLICY.CONNECTIONS.NAME.QBD, translate('workspace.qbd.setupPage.setupErrorTitle'));
-                setHasError(true);
-            }
-        });
-    }, [policyID, translate]);
-
-    useEffect(() => {
-        // Since QBD doesn't support Taxes, we should disable them from the LHN when connecting to QBD
-        enablePolicyTaxes(policyID, false);
-
-        fetchSetupLink();
-        // disabling this rule, as we want this to run only on the first render
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, []);
-
-    useNetwork({
-        onReconnect: () => {
-            if (hasResultOfFetchingSetupLink) {
-                return;
-            }
-            fetchSetupLink();
-        },
+      if (response.jsonCode === CONST.JSON_CODE.SUCCESS) {
+        setCodatSetupLink(String(response?.setupUrl ?? ""));
+      } else {
+        setConnectionError(
+          policyID,
+          CONST.POLICY.CONNECTIONS.NAME.QBD,
+          translate("workspace.qbd.setupPage.setupErrorTitle"),
+        );
+        setHasError(true);
+      }
     });
+  }, [policyID, translate]);
 
-    const shouldShowError = hasError;
+  useEffect(() => {
+    // Since QBD doesn't support Taxes, we should disable them from the LHN when connecting to QBD
+    enablePolicyTaxes(policyID, false);
 
-    const activityReasonAttributes: SkeletonSpanReasonAttributes = {
-        context: 'RequireQuickBooksDesktopModal',
-        hasResultOfFetchingSetupLink: !hasResultOfFetchingSetupLink,
-    };
+    fetchSetupLink();
+    // disabling this rule, as we want this to run only on the first render
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
-    const children = (
-        <>
-            {shouldShowError && (
-                <View style={[styles.flex1, styles.justifyContentCenter, styles.alignItemsCenter, styles.ph5, styles.mb9]}>
-                    <Icon
-                        src={illustrations.BrokenMagnifyingGlass}
-                        width={116}
-                        height={168}
-                    />
-                    <Text style={[styles.textHeadlineLineHeightXXL, styles.mt3]}>{translate('workspace.qbd.setupPage.setupErrorTitle')}</Text>
-                    <View style={[styles.renderHTML, styles.ph5, styles.mv3]}>
-                        <RenderHTML html={translate('workspace.qbd.setupPage.setupErrorBody', `${environmentURL}/${ROUTES.CONCIERGE}`)} />
-                    </View>
-                </View>
-            )}
-            {!shouldShowError && (
-                <View style={[styles.flex1, styles.ph5]}>
-                    <View style={[styles.alignSelfCenter, styles.computerIllustrationContainer, styles.pv6]}>
-                        <ImageSVG src={illustrations.LaptopWithSecondScreenSync} />
-                    </View>
+  useNetwork({
+    onReconnect: () => {
+      if (hasResultOfFetchingSetupLink) {
+        return;
+      }
+      fetchSetupLink();
+    },
+  });
 
-                    <Text style={[styles.textHeadlineH1, styles.pt5]}>{translate('workspace.qbd.setupPage.title')}</Text>
-                    <Text style={[styles.textSupporting, styles.textNormal, styles.pt4]}>{translate('workspace.qbd.setupPage.body')}</Text>
-                    <View style={[styles.qbdSetupLinkBox, styles.mt5]}>
-                        {!hasResultOfFetchingSetupLink ? (
-                            <ActivityIndicator reasonAttributes={activityReasonAttributes} />
-                        ) : (
-                            <CopyTextToClipboard
-                                text={codatSetupLink}
-                                textStyles={[styles.textSupporting]}
-                            />
-                        )}
-                    </View>
-                    <FixedFooter
-                        style={[styles.mtAuto, styles.ph0]}
-                        addBottomSafeAreaPadding
-                    >
-                        <Button
-                            success
-                            text={translate('common.done')}
-                            onPress={() => Navigation.navigate(ROUTES.POLICY_ACCOUNTING_QUICKBOOKS_DESKTOP_TRIGGER_FIRST_SYNC.getRoute(policyID))}
-                            pressOnEnter
-                            large
-                        />
-                    </FixedFooter>
-                </View>
-            )}
-        </>
-    );
+  const shouldShowError = hasError;
 
-    return (
-        <ScreenWrapper
-            shouldEnablePickerAvoiding={false}
-            shouldShowOfflineIndicatorInWideScreen
-            testID="RequireQuickBooksDesktopModal"
+  const activityReasonAttributes: SkeletonSpanReasonAttributes = {
+    context: "RequireQuickBooksDesktopModal",
+    hasResultOfFetchingSetupLink,
+  };
+
+  const children = (
+    <>
+      {shouldShowError && (
+        <View
+          style={[
+            styles.flex1,
+            styles.justifyContentCenter,
+            styles.alignItemsCenter,
+            styles.ph5,
+            styles.mb9,
+          ]}
         >
-            <HeaderWithBackButton
-                title={translate('workspace.qbd.qbdSetup')}
-                shouldShowBackButton
-                onBackButtonPress={() => Navigation.dismissModal()}
+          <Icon
+            src={illustrations.BrokenMagnifyingGlass}
+            width={116}
+            height={168}
+          />
+          <Text style={[styles.textHeadlineLineHeightXXL, styles.mt3]}>
+            {translate("workspace.qbd.setupPage.setupErrorTitle")}
+          </Text>
+          <View style={[styles.renderHTML, styles.ph5, styles.mv3]}>
+            <RenderHTML
+              html={translate(
+                "workspace.qbd.setupPage.setupErrorBody",
+                `${environmentURL}/${ROUTES.CONCIERGE}`,
+              )}
             />
-            {hasResultOfFetchingSetupLink ? children : <FullPageOfflineBlockingView addBottomSafeAreaPadding>{children}</FullPageOfflineBlockingView>}
-        </ScreenWrapper>
-    );
+          </View>
+        </View>
+      )}
+      {!shouldShowError && (
+        <View style={[styles.flex1, styles.ph5]}>
+          <View
+            style={[
+              styles.alignSelfCenter,
+              styles.computerIllustrationContainer,
+              styles.pv6,
+            ]}
+          >
+            <ImageSVG src={illustrations.LaptopWithSecondScreenSync} />
+          </View>
+
+          <Text style={[styles.textHeadlineH1, styles.pt5]}>
+            {translate("workspace.qbd.setupPage.title")}
+          </Text>
+          <Text style={[styles.textSupporting, styles.textNormal, styles.pt4]}>
+            {translate("workspace.qbd.setupPage.body")}
+          </Text>
+          <View style={[styles.qbdSetupLinkBox, styles.mt5]}>
+            {!hasResultOfFetchingSetupLink ? (
+              <ActivityIndicator reasonAttributes={activityReasonAttributes} />
+            ) : (
+              <CopyTextToClipboard
+                text={codatSetupLink}
+                textStyles={[styles.textSupporting]}
+              />
+            )}
+          </View>
+          <FixedFooter
+            style={[styles.mtAuto, styles.ph0]}
+            addBottomSafeAreaPadding
+          >
+            <Button
+              success
+              text={translate("common.done")}
+              onPress={() =>
+                Navigation.navigate(
+                  ROUTES.POLICY_ACCOUNTING_QUICKBOOKS_DESKTOP_TRIGGER_FIRST_SYNC.getRoute(
+                    policyID,
+                  ),
+                )
+              }
+              pressOnEnter
+              large
+            />
+          </FixedFooter>
+        </View>
+      )}
+    </>
+  );
+
+  return (
+    <ScreenWrapper
+      shouldEnablePickerAvoiding={false}
+      shouldShowOfflineIndicatorInWideScreen
+      testID="RequireQuickBooksDesktopModal"
+    >
+      <HeaderWithBackButton
+        title={translate("workspace.qbd.qbdSetup")}
+        shouldShowBackButton
+        onBackButtonPress={() => Navigation.dismissModal()}
+      />
+      {hasResultOfFetchingSetupLink ? (
+        children
+      ) : (
+        <FullPageOfflineBlockingView addBottomSafeAreaPadding>
+          {children}
+        </FullPageOfflineBlockingView>
+      )}
+    </ScreenWrapper>
+  );
 }
 
 export default RequireQuickBooksDesktopModal;

--- a/src/pages/workspace/companyCards/BankConnection/index.native.tsx
+++ b/src/pages/workspace/companyCards/BankConnection/index.native.tsx
@@ -19,6 +19,7 @@ import {setAssignCardStepAndData} from '@libs/actions/CompanyCards';
 import {checkIfNewFeedConnected, getBankName, getCompanyCardFeed, isSelectedFeedExpired} from '@libs/CardUtils';
 import getUAForWebView from '@libs/getUAForWebView';
 import Navigation from '@libs/Navigation/Navigation';
+import type {SkeletonSpanReasonAttributes} from '@libs/telemetry/useSkeletonSpan';
 import type {PlatformStackRouteProp} from '@navigation/PlatformStackNavigation/types';
 import type {SettingsNavigatorParamList} from '@navigation/types';
 import WorkspaceCompanyCardsErrorConfirmation from '@pages/workspace/companyCards/WorkspaceCompanyCardsErrorConfirmation';
@@ -71,7 +72,17 @@ function BankConnection({policyID: policyIDFromProps, feed, route}: BankConnecti
     const isNewFeedHasError = !!(newFeed && cardFeeds?.[newFeed]?.errors);
     const {isBlockedToAddNewFeeds, isAllFeedsResultLoading} = useIsBlockedToAddFeed(policyID);
 
-    const renderLoading = () => <FullScreenLoadingIndicator />;
+    const fullscreenReasonAttributes: SkeletonSpanReasonAttributes = {
+        context: 'BankConnection',
+    };
+    const activityReasonAttributes: SkeletonSpanReasonAttributes = {
+        context: 'BankConnection',
+        isAllFeedsResultLoading,
+        isBlockedToAddNewFeedsWithoutFeed: isBlockedToAddNewFeeds && !feed,
+        isConnectionCompleted,
+        isPlaid,
+    };
+    const renderLoading = () => <FullScreenLoadingIndicator reasonAttributes={fullscreenReasonAttributes} />;
 
     useEffect(() => {
         if (!policyID || !isBlockedToAddNewFeeds || feed) {
@@ -189,6 +200,7 @@ function BankConnection({policyID: policyIDFromProps, feed, route}: BankConnecti
                     <ActivityIndicator
                         size={CONST.ACTIVITY_INDICATOR_SIZE.LARGE}
                         style={styles.flex1}
+                        reasonAttributes={activityReasonAttributes}
                     />
                 )}
                 {isNewFeedHasError && (

--- a/src/pages/workspace/companyCards/BankConnection/index.tsx
+++ b/src/pages/workspace/companyCards/BankConnection/index.tsx
@@ -19,6 +19,7 @@ import useUpdateFeedBrokenConnection from '@hooks/useUpdateFeedBrokenConnection'
 import {setAssignCardStepAndData} from '@libs/actions/CompanyCards';
 import {checkIfNewFeedConnected, getBankName, getCompanyCardFeed, isSelectedFeedExpired} from '@libs/CardUtils';
 import Navigation from '@libs/Navigation/Navigation';
+import type {SkeletonSpanReasonAttributes} from '@libs/telemetry/useSkeletonSpan';
 import type {PlatformStackRouteProp} from '@navigation/PlatformStackNavigation/types';
 import type {SettingsNavigatorParamList} from '@navigation/types';
 import WorkspaceCompanyCardsErrorConfirmation from '@pages/workspace/companyCards/WorkspaceCompanyCardsErrorConfirmation';
@@ -214,10 +215,17 @@ function BankConnection({policyID: policyIDFromProps, feed, route}: BankConnecti
                 />
             );
         }
+        const activityReasonAttributes: SkeletonSpanReasonAttributes = {
+            context: 'BankConnection',
+            isPlaid,
+            isAllFeedsResultLoading,
+            isBlockedToAddNewFeedsWithoutFeed: isBlockedToAddNewFeeds && !feed,
+        };
         return (
             <ActivityIndicator
                 size={CONST.ACTIVITY_INDICATOR_SIZE.LARGE}
                 style={styles.flex1}
+                reasonAttributes={activityReasonAttributes}
             />
         );
     };

--- a/src/pages/workspace/companyCards/WorkspaceCompanyCardDetailsPage.tsx
+++ b/src/pages/workspace/companyCards/WorkspaceCompanyCardDetailsPage.tsx
@@ -30,6 +30,7 @@ import type {SettingsNavigatorParamList} from '@libs/Navigation/types';
 import {getDisplayNameOrDefault} from '@libs/PersonalDetailsUtils';
 import {getConnectedIntegration} from '@libs/PolicyUtils';
 import {buildCannedSearchQuery} from '@libs/SearchQueryUtils';
+import type {SkeletonSpanReasonAttributes} from '@libs/telemetry/useSkeletonSpan';
 import Navigation from '@navigation/Navigation';
 import NotFoundPage from '@pages/ErrorPage/NotFoundPage';
 import AccessOrNotFoundWrapper from '@pages/workspace/AccessOrNotFoundWrapper';
@@ -119,6 +120,11 @@ function WorkspaceCompanyCardDetailsPage({route}: WorkspaceCompanyCardDetailsPag
         }
         return format(getLocalDateFromDatetime(card?.lastScrape), CONST.DATE.FNS_DATE_TIME_FORMAT_STRING);
     }, [getLocalDateFromDatetime, card?.lastScrape, translate]);
+
+    const lastUpdatedActivityReasonAttributes: SkeletonSpanReasonAttributes = {
+        context: 'WorkspaceCompanyCardDetailsPage',
+        isLoadingLastUpdated: card?.isLoadingLastUpdated,
+    };
 
     // Don't show NotFoundPage if card is being unassigned or data is still loading
     if ((!card && !isUnassigningRef.current && !isLoadingOnyxValue(allBankCardsMetadata) && !isLoadingOnyxValue(cardListMetadata)) || (isCardBeingUnassigned && !isUnassigningRef.current)) {
@@ -221,7 +227,12 @@ function WorkspaceCompanyCardDetailsPage({route}: WorkspaceCompanyCardDetailsPag
                     ) : null}
                     <MenuItemWithTopDescription
                         shouldShowRightComponent={card?.isLoadingLastUpdated}
-                        rightComponent={<ActivityIndicator style={[styles.popoverMenuIcon]} />}
+                        rightComponent={
+                            <ActivityIndicator
+                                style={[styles.popoverMenuIcon]}
+                                reasonAttributes={lastUpdatedActivityReasonAttributes}
+                            />
+                        }
                         description={translate('workspace.moreFeatures.companyCards.lastUpdated')}
                         title={card?.isLoadingLastUpdated ? translate('workspace.moreFeatures.companyCards.updating') : lastScrape}
                         interactive={false}

--- a/src/pages/workspace/companyCards/addNew/PlaidConnectionStep.tsx
+++ b/src/pages/workspace/companyCards/addNew/PlaidConnectionStep.tsx
@@ -16,6 +16,7 @@ import {setAddNewCompanyCardStepAndData, setAssignCardStepAndData} from '@libs/a
 import KeyboardShortcut from '@libs/KeyboardShortcut';
 import Log from '@libs/Log';
 import {getDomainNameForPolicy} from '@libs/PolicyUtils';
+import type {SkeletonSpanReasonAttributes} from '@libs/telemetry/useSkeletonSpan';
 import Navigation from '@navigation/Navigation';
 import {handleRestrictedEvent} from '@userActions/App';
 import {setPlaidEvent} from '@userActions/BankAccounts';
@@ -194,9 +195,16 @@ function PlaidConnectionStep({feed, policyID, onExit}: {feed?: CompanyCardFeedWi
         }
 
         if (plaidData?.isLoading) {
+            const reasonAttributes: SkeletonSpanReasonAttributes = {
+                context: 'PlaidConnectionStep.renderPlaidLink',
+                isPlaidDataLoading: plaidData?.isLoading,
+            };
             return (
                 <View style={[styles.flex1, styles.alignItemsCenter, styles.justifyContentCenter]}>
-                    <ActivityIndicator size={CONST.ACTIVITY_INDICATOR_SIZE.LARGE} />
+                    <ActivityIndicator
+                        size={CONST.ACTIVITY_INDICATOR_SIZE.LARGE}
+                        reasonAttributes={reasonAttributes}
+                    />
                 </View>
             );
         }

--- a/src/pages/workspace/companyCards/assignCard/TransactionStartDateStep.tsx
+++ b/src/pages/workspace/companyCards/assignCard/TransactionStartDateStep.tsx
@@ -11,6 +11,7 @@ import Text from '@components/Text';
 import useLocalize from '@hooks/useLocalize';
 import useOnyx from '@hooks/useOnyx';
 import useThemeStyles from '@hooks/useThemeStyles';
+import type {SkeletonSpanReasonAttributes} from '@libs/telemetry/useSkeletonSpan';
 import {isRequiredFulfilled} from '@libs/ValidationUtils';
 import Navigation from '@navigation/Navigation';
 import {setAssignCardStepAndData} from '@userActions/CompanyCards';
@@ -85,6 +86,10 @@ function TransactionStartDateStep() {
     ];
 
     const isLoading = isLoadingOnyxValue(assignCardMeta);
+    const activityReasonAttributes: SkeletonSpanReasonAttributes = {
+        context: 'TransactionStartDateStep',
+        isLoading,
+    };
 
     return (
         <InteractiveStepWrapper
@@ -97,6 +102,7 @@ function TransactionStartDateStep() {
                 <ActivityIndicator
                     size={CONST.ACTIVITY_INDICATOR_SIZE.LARGE}
                     style={styles.h100}
+                    reasonAttributes={activityReasonAttributes}
                 />
             ) : (
                 <>


### PR DESCRIPTION
### Explanation of Change

Adds `reasonAttributes` prop to `ActivityIndicator` and `FullscreenLoadingIndicator` usages in accounting and company cards pages so engineers can debug infinite skeleton spans in Sentry. Each usage includes a `context` string and relevant boolean loading state variables.

Files updated:
- `src/pages/workspace/accounting/PolicyAccountingPage.tsx`
- `src/pages/workspace/accounting/qbd/QuickBooksDesktopSetupPage.tsx`
- `src/pages/workspace/companyCards/addNew/PlaidConnectionStep.tsx`
- `src/pages/workspace/companyCards/assignCard/TransactionStartDateStep.tsx`
- `src/pages/workspace/companyCards/BankConnection/index.native.tsx`
- `src/pages/workspace/companyCards/BankConnection/index.tsx`
- `src/pages/workspace/companyCards/WorkspaceCompanyCardDetailsPage.tsx`

### Fixed Issues
$ https://github.com/Expensify/App/issues/83394
PROPOSAL:

### Tests

- [x] Verify that no errors appear in the JS console

### Offline tests

N/A - these are telemetry-only changes with no user-visible behavior.

### QA Steps

- [x] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>