### PR TITLE
[NO QA] Add comment to iouRequestPolicyCollectionSelector

### DIFF
--- a/src/selectors/Policy.ts
+++ b/src/selectors/Policy.ts
@@ -87,8 +87,7 @@ const groupPaidPoliciesWithExpenseChatEnabledSelector = (policies: OnyxCollectio
 
 const shouldRedirectToExpensifyClassicSelector = (policies: OnyxCollection<Policy>) => areAllGroupPoliciesExpenseChatDisabled(policies);
 
-// Thin projection — deepEqual on ~15 fields is cheaper than re-rendering IOURequestStartPage's full hook/memo tree.
-// See https://github.com/Expensify/App/pull/84286#discussion_r2178531498
+// deepEqual on ~15 fields is cheaper than re-rendering IOURequestStartPage's full hook/memo tree.
 const iouRequestPolicyCollectionSelector = (policies: OnyxCollection<Policy>): OnyxCollection<Policy> => {
     if (!policies) {
         return {};

--- a/src/selectors/Policy.ts
+++ b/src/selectors/Policy.ts
@@ -87,6 +87,8 @@ const groupPaidPoliciesWithExpenseChatEnabledSelector = (policies: OnyxCollectio
 
 const shouldRedirectToExpensifyClassicSelector = (policies: OnyxCollection<Policy>) => areAllGroupPoliciesExpenseChatDisabled(policies);
 
+// Thin projection — deepEqual on ~15 fields is cheaper than re-rendering IOURequestStartPage's full hook/memo tree.
+// See https://github.com/Expensify/App/pull/84286#discussion_r2178531498
 const iouRequestPolicyCollectionSelector = (policies: OnyxCollection<Policy>): OnyxCollection<Policy> => {
     if (!policies) {
         return {};


### PR DESCRIPTION
## Summary
- Adds a clarifying comment above `iouRequestPolicyCollectionSelector` explaining why a collection selector is used despite the general PERF-11 guidance against them.
- References the original discussion: https://github.com/Expensify/App/pull/84286#discussion_r2178531498

## Test plan
No functional changes.