### PR TITLE
Fix mWeb Safari onboarding flow by dismissing SignIn modal after openApp

### DIFF
--- a/AUTODEV_REPORT.md
+++ b/AUTODEV_REPORT.md
@@ -1,0 +1,32 @@
+# AUTODEV Report
+
+## Issue
+- #83092 - `[$250] mWeb/Safari - Public room-Onboarding flow not appear when sign in from reply thread of public room`
+- URL: https://github.com/Expensify/App/issues/83092
+
+## Changed Files
+- `src/pages/signin/SignInModal.tsx`
+- `tests/unit/SignInModalTest.tsx`
+
+## What Changed
+- Updated `SignInModal` anonymous-to-auth transition sequencing to:
+  1. wait for sequential queue idle,
+  2. run `openApp(true)`,
+  3. then dismiss the sign-in modal.
+- Added regression test to verify modal dismissal happens only after `openApp(true)` resolves.
+
+## Validation Commands
+1. `npm test -- tests/unit/SignInModalTest.tsx --runInBand`
+2. `npx prettier --write src/pages/signin/SignInModal.tsx tests/unit/SignInModalTest.tsx`
+3. `npx eslint src/pages/signin/SignInModal.tsx tests/unit/SignInModalTest.tsx --max-warnings=0`
+4. `npm test -- tests/unit/SignInModalTest.tsx --runInBand`
+
+## Validation Results
+- Targeted unit test: **PASS**
+- Prettier: **PASS**
+- ESLint on changed files: **PASS**
+- Note: Jest reports existing repository warnings about duplicate manual mock names (`index`) during test startup; tests still execute and pass.
+
+## Risks
+- `SignInModal` dismissal now waits for `openApp(true)` completion. If `openApp(true)` is delayed by network latency, modal close can be delayed accordingly.
+- Dismiss still runs in `.finally()`, so failures in `openApp(true)` will still close the modal; this preserves prior failure behavior while fixing ordering.

--- a/src/pages/signin/SignInModal.tsx
+++ b/src/pages/signin/SignInModal.tsx
@@ -34,17 +34,17 @@ function SignInModal() {
     useEffect(() => {
         const isAnonymousUser = session?.authTokenType === CONST.AUTH_TOKEN_TYPES.ANONYMOUS;
         if (!isAnonymousUser) {
-            // Signing in RHP is only for anonymous users
-            Navigation.isNavigationReady().then(() => {
-                Navigation.dismissModal();
-            });
-
             // To prevent deadlock when OpenReport and OpenApp overlap, wait for the queue to be idle before calling openApp.
             // This ensures that any communication gaps between the client and server during OpenReport processing do not cause the queue to pause,
             // which would prevent us from processing or clearing the queue.
-            waitForIdle().then(() => {
-                openApp(true);
-            });
+            waitForIdle()
+                .then(() => openApp(true))
+                .finally(() => {
+                    // Signing in RHP is only for anonymous users
+                    Navigation.isNavigationReady().then(() => {
+                        Navigation.dismissModal();
+                    });
+                });
         }
     }, [session?.authTokenType]);
 

--- a/tests/unit/SignInModalTest.tsx
+++ b/tests/unit/SignInModalTest.tsx
@@ -1,0 +1,129 @@
+import {act, render, waitFor} from '@testing-library/react-native';
+import React from 'react';
+import {useSession} from '@components/OnyxListItemProvider';
+import {openApp} from '@libs/actions/App';
+import Navigation from '@libs/Navigation/Navigation';
+import {waitForIdle} from '@libs/Network/SequentialQueue';
+import SignInModal from '@pages/signin/SignInModal';
+import type {Session} from '@src/types/onyx';
+
+type Deferred<T> = {
+    promise: Promise<T>;
+    resolve: (value: T | PromiseLike<T>) => void;
+    reject: (reason?: unknown) => void;
+};
+
+function createDeferred<T>(): Deferred<T> {
+    let resolve: Deferred<T>['resolve'];
+    let reject: Deferred<T>['reject'];
+    const promise = new Promise<T>((res, rej) => {
+        resolve = res;
+        reject = rej;
+    });
+
+    return {
+        promise,
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        resolve: resolve!,
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        reject: reject!,
+    };
+}
+
+jest.mock('@components/HeaderWithBackButton', () => () => null);
+jest.mock(
+    '@components/ScreenWrapper',
+    () =>
+        ({children}: {children: React.ReactNode}) =>
+            children,
+);
+jest.mock('@components/OnyxListItemProvider', () => ({
+    useSession: jest.fn(),
+}));
+jest.mock('@hooks/useAndroidBackButtonHandler', () => jest.fn());
+jest.mock('@hooks/useStyleUtils', () =>
+    jest.fn(() => ({
+        getBackgroundColorStyle: jest.fn(() => ({})),
+    })),
+);
+jest.mock('@hooks/useTheme', () => {
+    const pageThemes = new Proxy<Record<string, {backgroundColor: string}>>(
+        {},
+        {
+            get: () => ({backgroundColor: '#fff'}),
+        },
+    );
+
+    return jest.fn(() => ({
+        PAGE_THEMES: pageThemes,
+    }));
+});
+jest.mock('@libs/actions/App', () => ({
+    openApp: jest.fn(),
+}));
+jest.mock('@libs/Browser', () => ({
+    isMobileSafari: jest.fn(() => false),
+}));
+jest.mock('@libs/Network/SequentialQueue', () => ({
+    waitForIdle: jest.fn(),
+}));
+jest.mock('@libs/Navigation/Navigation', () => ({
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    __esModule: true,
+    default: {
+        dismissModal: jest.fn(),
+        goBack: jest.fn(),
+        isNavigationReady: jest.fn(() => Promise.resolve()),
+    },
+}));
+jest.mock('@pages/signin/SignInPage', () => {
+    function MockSignInPage() {
+        return null;
+    }
+
+    return {
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        __esModule: true,
+        default: MockSignInPage,
+        SignInPage: MockSignInPage,
+    };
+});
+
+const mockUseSession = jest.mocked(useSession);
+const mockOpenApp = jest.mocked(openApp);
+const mockWaitForIdle = jest.mocked(waitForIdle);
+const mockNavigation = Navigation as jest.Mocked<typeof Navigation>;
+
+describe('SignInModal', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockWaitForIdle.mockResolvedValue(undefined);
+        mockNavigation.isNavigationReady.mockResolvedValue(undefined);
+    });
+
+    it('should dismiss the sign-in modal only after openApp resolves for non-anonymous users', async () => {
+        const deferredOpenApp = createDeferred<void>();
+        mockOpenApp.mockReturnValue(deferredOpenApp.promise);
+        mockUseSession.mockReturnValue({
+            authTokenType: 'google',
+        } as Session);
+
+        render(<SignInModal />);
+
+        await waitFor(() => expect(mockWaitForIdle).toHaveBeenCalledTimes(1));
+        await waitFor(() => expect(mockOpenApp).toHaveBeenCalledWith(true));
+        expect(mockNavigation.dismissModal).not.toHaveBeenCalled();
+
+        await act(async () => {
+            deferredOpenApp.resolve();
+            await deferredOpenApp.promise;
+        });
+
+        await waitFor(() => expect(mockNavigation.dismissModal).toHaveBeenCalledTimes(1));
+        const openAppCallOrder = mockOpenApp.mock.invocationCallOrder.at(0) ?? 0;
+        const dismissCallOrder = mockNavigation.dismissModal.mock.invocationCallOrder.at(0) ?? 0;
+        expect(openAppCallOrder).toBeGreaterThan(0);
+        expect(dismissCallOrder).toBeGreaterThan(0);
+        expect(openAppCallOrder).toBeLessThan(dismissCallOrder);
+    });
+});


### PR DESCRIPTION
## Brief summary
$ #83092 by correcting sign-in modal sequencing so the public room onboarding flow appears reliably when users sign in from a public-room reply thread on mWeb/Safari.

## What changed
- Updated `SignInModal` for non-anonymous sessions to run `waitForIdle()` -> `openApp(true)` before closing the modal.
- Moved `Navigation.dismissModal()` into a `.finally()` after the `openApp(true)` promise chain, while still waiting for `Navigation.isNavigationReady()`.
- Added a regression unit test (`tests/unit/SignInModalTest.tsx`) that verifies the modal is dismissed only after `openApp(true)` resolves and confirms call order.

## Validation done
- `npm test -- tests/unit/SignInModalTest.tsx --runInBand`
- `npx prettier --write src/pages/signin/SignInModal.tsx tests/unit/SignInModalTest.tsx`
- `npx eslint src/pages/signin/SignInModal.tsx tests/unit/SignInModalTest.tsx --max-warnings=0`
- Re-ran `npm test -- tests/unit/SignInModalTest.tsx --runInBand`

## Risks/notes
- Modal dismissal now waits for `openApp(true)` completion, so the modal can remain visible slightly longer if `openApp` is delayed.
- Dismissal remains in `.finally()`, so if `openApp(true)` fails, the modal still closes (same failure behavior as before, with corrected ordering).