### PR TITLE
Fix Wallet BA country step using stale reimbursement account state

### DIFF
--- a/AUTODEV_REPORT.md
+++ b/AUTODEV_REPORT.md
@@ -1,0 +1,27 @@
+# AUTODEV Report
+
+## Issue
+- #82763 - `[$250] Add bank account- Successful page is shown after clicking Next on BA location page in Wallet`
+- URL: https://github.com/Expensify/App/issues/82763
+
+## Changed Files
+- `src/pages/settings/Wallet/BankAccountPurposePage/substeps/CountrySelection.tsx`
+- `tests/unit/WalletBankAccountCountrySelectionTest.tsx`
+
+## What Changed
+- Added `clearReimbursementAccount()` in Wallet `CountrySelection.onConfirm()` before draft updates/navigation to clear stale `REIMBURSEMENT_ACCOUNT` Onyx state from prior workspace contexts.
+- Added unit test verifying the flow clears reimbursement account state before navigation and still updates draft + routes to bank account setup.
+
+## Validation Commands
+1. `npx prettier --write src/pages/settings/Wallet/BankAccountPurposePage/substeps/CountrySelection.tsx tests/unit/WalletBankAccountCountrySelectionTest.tsx`
+2. `npx eslint src/pages/settings/Wallet/BankAccountPurposePage/substeps/CountrySelection.tsx tests/unit/WalletBankAccountCountrySelectionTest.tsx --max-warnings=0`
+3. `npm test -- tests/unit/WalletBankAccountCountrySelectionTest.tsx --runInBand`
+
+## Validation Results
+- Prettier: PASS
+- ESLint (changed files): PASS
+- Unit test: PASS
+- Note: Existing repository Jest warnings about duplicate manual mocks are unchanged and non-blocking for this test.
+
+## Risks
+- The fix intentionally clears reimbursement account state at country confirmation time; if future flows rely on carrying previous reimbursement account state into this path, those flows should be reviewed.

--- a/src/pages/settings/Wallet/BankAccountPurposePage/substeps/CountrySelection.tsx
+++ b/src/pages/settings/Wallet/BankAccountPurposePage/substeps/CountrySelection.tsx
@@ -5,7 +5,7 @@ import useOnyx from '@hooks/useOnyx';
 import usePersonalPolicy from '@hooks/usePersonalPolicy';
 import useThemeStyles from '@hooks/useThemeStyles';
 import CountrySelectionList from '@pages/settings/Wallet/CountrySelectionList';
-import {clearReimbursementAccountDraft, navigateToBankAccountRoute, updateReimbursementAccountDraft} from '@userActions/ReimbursementAccount';
+import {clearReimbursementAccount, clearReimbursementAccountDraft, navigateToBankAccountRoute, updateReimbursementAccountDraft} from '@userActions/ReimbursementAccount';
 import type {Country} from '@src/CONST';
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
@@ -61,6 +61,7 @@ function CountrySelection() {
             setShouldShowError(true);
             return;
         }
+        clearReimbursementAccount();
         clearReimbursementAccountDraft();
         updateReimbursementAccountDraft({country: selectedCountry as Country, currency: CONST.BBA_COUNTRY_CURRENCY_MAP[selectedCountry]});
         navigateToBankAccountRoute({backTo: ROUTES.SETTINGS_BANK_ACCOUNT_PURPOSE});

--- a/tests/unit/WalletBankAccountCountrySelectionTest.tsx
+++ b/tests/unit/WalletBankAccountCountrySelectionTest.tsx
@@ -1,0 +1,60 @@
+import {act, render} from '@testing-library/react-native';
+import React from 'react';
+import CountrySelection from '@pages/settings/Wallet/BankAccountPurposePage/substeps/CountrySelection';
+import {clearReimbursementAccount, clearReimbursementAccountDraft, navigateToBankAccountRoute, updateReimbursementAccountDraft} from '@userActions/ReimbursementAccount';
+import ROUTES from '@src/ROUTES';
+
+type CountrySelectionListProps = {
+    onConfirm: () => void;
+};
+
+const mockCountrySelectionList = jest.fn<(props: CountrySelectionListProps) => null>(() => null);
+
+jest.mock('@hooks/useOnyx', () => jest.fn(() => ['GB']));
+jest.mock('@hooks/usePersonalPolicy', () => jest.fn(() => ({outputCurrency: 'GBP'})));
+jest.mock('@hooks/useLocalize', () => jest.fn(() => ({translate: (key: string) => key})));
+jest.mock('@hooks/useThemeStyles', () => jest.fn(() => ({mt5: {}})));
+jest.mock('@components/FormAlertWithSubmitButton', () => 'FormAlertWithSubmitButton');
+jest.mock('@pages/settings/Wallet/CountrySelectionList', () => (props: CountrySelectionListProps) => {
+    return mockCountrySelectionList(props);
+});
+jest.mock('@userActions/ReimbursementAccount', () => ({
+    clearReimbursementAccount: jest.fn(),
+    clearReimbursementAccountDraft: jest.fn(),
+    navigateToBankAccountRoute: jest.fn(),
+    updateReimbursementAccountDraft: jest.fn(),
+}));
+
+describe('Wallet country selection', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('clears reimbursement account data before navigating on confirm', () => {
+        render(<CountrySelection />);
+
+        const calls = mockCountrySelectionList.mock.calls as Array<[CountrySelectionListProps]>;
+        const onConfirm: (() => void) | undefined = calls.at(-1)?.[0].onConfirm;
+
+        expect(onConfirm).toBeDefined();
+        if (!onConfirm) {
+            throw new Error('Expected CountrySelectionList onConfirm callback to be defined');
+        }
+
+        act(() => {
+            onConfirm();
+        });
+
+        expect(clearReimbursementAccountDraft).toHaveBeenCalledTimes(1);
+        expect(clearReimbursementAccount).toHaveBeenCalledTimes(1);
+        expect(updateReimbursementAccountDraft).toHaveBeenCalledWith({country: 'GB', currency: 'GBP'});
+        expect(navigateToBankAccountRoute).toHaveBeenCalledWith({backTo: ROUTES.SETTINGS_BANK_ACCOUNT_PURPOSE});
+
+        const clearCallOrder = (clearReimbursementAccount as jest.Mock).mock.invocationCallOrder.at(0);
+        const navigateCallOrder = (navigateToBankAccountRoute as jest.Mock).mock.invocationCallOrder.at(0);
+
+        expect(clearCallOrder).toBeDefined();
+        expect(navigateCallOrder).toBeDefined();
+        expect(clearCallOrder).toBeLessThan(navigateCallOrder);
+    });
+});


### PR DESCRIPTION
## Summary
$ #82763 by preventing stale reimbursement account data from sending users to the bank account success page after pressing Next on the Wallet bank account location step.

## What changed
- Added `clearReimbursementAccount()` in `CountrySelection.onConfirm()` before draft reset/update and navigation.
- Kept the intended flow to clear draft, update draft with selected `country`/`currency`, then navigate to the bank account setup route.
- Added `WalletBankAccountCountrySelectionTest` to verify state clearing, draft update, navigation, and call order (clear happens before navigate).

## Validation done
- `npx prettier --write src/pages/settings/Wallet/BankAccountPurposePage/substeps/CountrySelection.tsx tests/unit/WalletBankAccountCountrySelectionTest.tsx`
- `npx eslint src/pages/settings/Wallet/BankAccountPurposePage/substeps/CountrySelection.tsx tests/unit/WalletBankAccountCountrySelectionTest.tsx --max-warnings=0`
- `npm test -- tests/unit/WalletBankAccountCountrySelectionTest.tsx --runInBand`

## Risks / notes
- This change intentionally clears `REIMBURSEMENT_ACCOUNT` at country confirmation time. If any future flow expects previous reimbursement account state to persist into this path, that flow should be reviewed.