### PR TITLE
[NoQA] enforce accessibility rules in AI reviewer

### DIFF
--- a/.claude/skills/coding-standards/SKILL.md
+++ b/.claude/skills/coding-standards/SKILL.md
@@ -52,6 +52,9 @@ Coding standards for the Expensify App. Each standard is a standalone file in `r
 - [CLEAN-REACT-PATTERNS-5](rules/clean-react-5-narrow-state.md) — Keep state narrow
 
 ### Accessibility (WCAG 2.2 AA)
+
+**Use React Native accessibility props.** React Native Web translates them to ARIA attributes automatically. Only use `aria-*` when a React Native equivalent isn't available.
+
 - [A11Y-1](rules/a11y-1-label-interactive-elements.md) — Label interactive elements
 - [A11Y-2](rules/a11y-2-semantic-roles.md) — Semantic accessibilityRole
 - [A11Y-3](rules/a11y-3-communicate-state.md) — Communicate component state

--- a/.claude/skills/coding-standards/SKILL.md
+++ b/.claude/skills/coding-standards/SKILL.md
@@ -53,7 +53,7 @@ Coding standards for the Expensify App. Each standard is a standalone file in `r
 
 ### Accessibility (WCAG 2.2 AA)
 
-**Use React Native accessibility props.** React Native Web translates them to ARIA attributes automatically. Only use `aria-*` when a React Native equivalent isn't available.
+**Use React Native accessibility props.** React Native Web translates them to ARIA attributes automatically. Only use `aria-*` when a React Native equivalent isn't available. Reference: [React Native Accessibility](https://reactnative.dev/docs/accessibility)
 
 - [A11Y-1](rules/a11y-1-label-interactive-elements.md) — Label interactive elements
 - [A11Y-2](rules/a11y-2-semantic-roles.md) — Semantic accessibilityRole

--- a/.claude/skills/coding-standards/SKILL.md
+++ b/.claude/skills/coding-standards/SKILL.md
@@ -15,6 +15,7 @@ Coding standards for the Expensify App. Each standard is a standalone file in `r
 | Performance | `PERF-*` | Render optimization, memo patterns, useEffect hygiene, data selection |
 | Consistency | `CONSISTENCY-*` | Platform checks, magic values, unused props, ESLint discipline |
 | Clean React Patterns | `CLEAN-REACT-PATTERNS-*` | Composition, component ownership, state structure |
+| Accessibility | `A11Y-*` | WCAG 2.2 AA compliance, screen reader support, inclusive interaction patterns |
 
 ## Quick Reference
 
@@ -49,6 +50,20 @@ Coding standards for the Expensify App. Each standard is a standalone file in `r
 - [CLEAN-REACT-PATTERNS-3](rules/clean-react-3-context-free-contracts.md) — Context-free component contracts
 - [CLEAN-REACT-PATTERNS-4](rules/clean-react-4-no-side-effect-spaghetti.md) — No side-effect spaghetti
 - [CLEAN-REACT-PATTERNS-5](rules/clean-react-5-narrow-state.md) — Keep state narrow
+
+### Accessibility (WCAG 2.2 AA)
+- [A11Y-1](rules/a11y-1-label-interactive-elements.md) — Label interactive elements
+- [A11Y-2](rules/a11y-2-semantic-roles.md) — Semantic accessibilityRole
+- [A11Y-3](rules/a11y-3-communicate-state.md) — Communicate component state
+- [A11Y-4](rules/a11y-4-touch-target-size.md) — Minimum 44x44 touch targets
+- [A11Y-5](rules/a11y-5-announce-dynamic-content.md) — Announce dynamic content
+- [A11Y-6](rules/a11y-6-accessible-images.md) — Accessible images
+- [A11Y-7](rules/a11y-7-no-color-only-info.md) — No color-only information
+- [A11Y-8](rules/a11y-8-modal-focus-management.md) — Modal focus management
+- [A11Y-9](rules/a11y-9-drag-alternatives.md) — Drag interaction alternatives
+- [A11Y-10](rules/a11y-10-respect-text-scaling.md) — Respect text scaling
+- [A11Y-11](rules/a11y-11-form-accessibility.md) — Form accessibility
+- [A11Y-12](rules/a11y-12-logical-focus-order.md) — Logical focus order
 
 ## Usage
 

--- a/.claude/skills/coding-standards/rules/a11y-1-label-interactive-elements.md
+++ b/.claude/skills/coding-standards/rules/a11y-1-label-interactive-elements.md
@@ -51,12 +51,12 @@ Flag ONLY when ALL of these are true:
 
 - Element is interactive (`Pressable`, `TouchableOpacity`, `TouchableWithoutFeedback`, `PressableWithFeedback`, `Button`, or has `onPress`/`onLongPress`)
 - Element contains **no visible `<Text>` child** (icon-only, image-only, or SVG-only)
-- Element has **no** `accessibilityLabel` or `aria-label` prop
+- Element has **no** `accessibilityLabel` prop
 
 **DO NOT flag if:**
 
 - Element has a `<Text>` child that clearly describes the action
-- Element is explicitly hidden from accessibility (`accessible={false}`, `aria-hidden={true}`, `importantForAccessibility="no"`)
+- Element is explicitly hidden from accessibility (`accessible={false}`, `accessibilityElementsHidden={true}` on iOS, `importantForAccessibility="no"` on Android)
 - Element is a list item wrapper where the child component handles its own accessibility
 
 **Search Patterns** (hints for reviewers):

--- a/.claude/skills/coding-standards/rules/a11y-1-label-interactive-elements.md
+++ b/.claude/skills/coding-standards/rules/a11y-1-label-interactive-elements.md
@@ -1,0 +1,65 @@
+---
+ruleId: A11Y-1
+title: Interactive elements must have accessible labels
+---
+
+## [A11Y-1] Interactive elements must have accessible labels
+
+### Reasoning
+
+Screen readers (VoiceOver/TalkBack) cannot convey the purpose of an interactive element without a text label. Icon-only buttons, image-only touchables, and components whose visible text is insufficient for context must provide `accessibilityLabel`. Without it, assistive technology announces the element as an unnamed control, making the app unusable for screen reader users. (WCAG 1.1.1, 4.1.2)
+
+### Incorrect
+
+```tsx
+// Icon-only button with no label — screen reader says "button"
+<Pressable onPress={onClose}>
+    <Icon src={Expensicons.Close} />
+</Pressable>
+
+// Image-only touchable with no description
+<TouchableOpacity onPress={openProfile}>
+    <Avatar source={avatarURL} />
+</TouchableOpacity>
+```
+
+### Correct
+
+```tsx
+<Pressable
+    onPress={onClose}
+    accessibilityLabel={translate('common.close')}
+    accessibilityRole="button"
+>
+    <Icon src={Expensicons.Close} />
+</Pressable>
+
+<TouchableOpacity
+    onPress={openProfile}
+    accessibilityLabel={translate('common.profile')}
+    accessibilityRole="imagebutton"
+>
+    <Avatar source={avatarURL} />
+</TouchableOpacity>
+```
+
+---
+
+### Review Metadata
+
+Flag ONLY when ALL of these are true:
+
+- Element is interactive (`Pressable`, `TouchableOpacity`, `TouchableWithoutFeedback`, `PressableWithFeedback`, `Button`, or has `onPress`/`onLongPress`)
+- Element contains **no visible `<Text>` child** (icon-only, image-only, or SVG-only)
+- Element has **no** `accessibilityLabel` or `aria-label` prop
+
+**DO NOT flag if:**
+
+- Element has a `<Text>` child that clearly describes the action
+- Element is explicitly hidden from accessibility (`accessible={false}`, `aria-hidden={true}`, `importantForAccessibility="no"`)
+- Element is a list item wrapper where the child component handles its own accessibility
+
+**Search Patterns** (hints for reviewers):
+- `<Pressable` / `<TouchableOpacity` / `<TouchableWithoutFeedback`
+- `<Icon` without sibling `<Text`
+- `onPress` without `accessibilityLabel`

--- a/.claude/skills/coding-standards/rules/a11y-10-respect-text-scaling.md
+++ b/.claude/skills/coding-standards/rules/a11y-10-respect-text-scaling.md
@@ -7,7 +7,7 @@ title: Respect user text scaling preferences
 
 ### Reasoning
 
-Users with low vision rely on system-level font size settings (iOS Dynamic Type / Android Font Size) to enlarge text. Setting `allowFontScaling={false}` or `maxFontSizeMultiplier={1}` disables this, making text unreadable for these users. Layouts must accommodate scaled text using flexible containers (`flexShrink`, `flexWrap`, `minHeight`) instead of fixed pixel heights. (WCAG 1.4.4)
+Users with low vision rely on system-level font size settings (iOS Dynamic Type / Android Font Size) to enlarge text. Setting `allowFontScaling={false}` or `maxFontSizeMultiplier={1}` disables this, making text unreadable for these users. Layouts must accommodate scaled text using flexible containers (`minHeight`, `flexWrap`) instead of fixed pixel heights. (WCAG 1.4.4)
 
 ### Incorrect
 
@@ -32,8 +32,8 @@ Users with low vision rely on system-level font size settings (iOS Dynamic Type 
 
 // Flexible container that accommodates scaled text
 <View style={{minHeight: 40, paddingVertical: 8}}>
-    <Text style={{fontSize: 16, flexShrink: 1}}>
-        This text reflows at larger scales
+    <Text style={{fontSize: 16}}>
+        This text grows with the container at larger scales
     </Text>
 </View>
 
@@ -49,13 +49,13 @@ Flag ONLY when ANY of these patterns is found:
 
 - `allowFontScaling={false}` on `<Text>` or `<TextInput>` displaying user-facing content
 - `maxFontSizeMultiplier={1}` effectively disabling scaling on readable text
-- Fixed `height` on a container with text content and no `minHeight` / `flexShrink` / overflow accommodation
+- Fixed `height` on a container with text content and no `minHeight` or overflow accommodation
 
 **DO NOT flag if:**
 
 - `allowFontScaling={false}` on purely decorative text (icons rendered as text, single-character badges)
 - `maxFontSizeMultiplier` set to a reasonable value (>= 1.5) to prevent extreme layout breakage
-- Container uses `minHeight` instead of `height`, or text has `flexShrink: 1`
+- Container uses `minHeight` instead of `height`
 - Text is inside a component that manages scaling internally
 
 **Search Patterns** (hints for reviewers):

--- a/.claude/skills/coding-standards/rules/a11y-10-respect-text-scaling.md
+++ b/.claude/skills/coding-standards/rules/a11y-10-respect-text-scaling.md
@@ -1,0 +1,65 @@
+---
+ruleId: A11Y-10
+title: Respect user text scaling preferences
+---
+
+## [A11Y-10] Respect user text scaling preferences
+
+### Reasoning
+
+Users with low vision rely on system-level font size settings (iOS Dynamic Type / Android Font Size) to enlarge text. Setting `allowFontScaling={false}` or `maxFontSizeMultiplier={1}` disables this, making text unreadable for these users. Layouts must accommodate scaled text using flexible containers (`flexShrink`, `flexWrap`, `minHeight`) instead of fixed pixel heights. (WCAG 1.4.4)
+
+### Incorrect
+
+```tsx
+// Globally disabling font scaling
+<Text allowFontScaling={false}>Account Balance</Text>
+
+// Capping font scaling to prevent layout issues instead of fixing the layout
+<Text maxFontSizeMultiplier={1}>$2,450.00</Text>
+
+// Fixed height container that clips scaled text
+<View style={{height: 40}}>
+    <Text style={{fontSize: 16}}>This text will be clipped at larger scales</Text>
+</View>
+```
+
+### Correct
+
+```tsx
+// Text respects system scaling (default behavior — don't override it)
+<Text>Account Balance</Text>
+
+// Flexible container that accommodates scaled text
+<View style={{minHeight: 40, paddingVertical: 8}}>
+    <Text style={{fontSize: 16, flexShrink: 1}}>
+        This text reflows at larger scales
+    </Text>
+</View>
+
+// Acceptable: limiting scaling on tiny decorative text only (e.g., badge count)
+<Text maxFontSizeMultiplier={1.5} style={styles.badgeCount}>3</Text>
+```
+
+---
+
+### Review Metadata
+
+Flag ONLY when ANY of these patterns is found:
+
+- `allowFontScaling={false}` on `<Text>` or `<TextInput>` displaying user-facing content
+- `maxFontSizeMultiplier={1}` effectively disabling scaling on readable text
+- Fixed `height` on a container with text content and no `minHeight` / `flexShrink` / overflow accommodation
+
+**DO NOT flag if:**
+
+- `allowFontScaling={false}` on purely decorative text (icons rendered as text, single-character badges)
+- `maxFontSizeMultiplier` set to a reasonable value (>= 1.5) to prevent extreme layout breakage
+- Container uses `minHeight` instead of `height`, or text has `flexShrink: 1`
+- Text is inside a component that manages scaling internally
+
+**Search Patterns** (hints for reviewers):
+- `allowFontScaling={false}`
+- `maxFontSizeMultiplier={1}`
+- `maxFontSizeMultiplier={1.0}`
+- Fixed `height:` on text containers

--- a/.claude/skills/coding-standards/rules/a11y-11-form-accessibility.md
+++ b/.claude/skills/coding-standards/rules/a11y-11-form-accessibility.md
@@ -7,7 +7,7 @@ title: Forms must have accessible labels, errors, and instructions
 
 ### Reasoning
 
-Screen reader users navigate forms field by field. Each input must be associated with a descriptive label so users know what to enter. Error messages must be announced when they appear and linked to the relevant field. Without proper labeling, users hear "edit text" with no context. Without announced errors, users submit forms repeatedly without knowing what's wrong. (WCAG 1.3.1, 3.3.1, 3.3.2)
+Screen reader users navigate forms field by field. Each input must be associated with a descriptive label so users know what to enter. While React Native uses `placeholder` as a fallback accessible name, it disappears once the user starts typing, leaving the field unlabeled. An explicit `accessibilityLabel` (or `accessibilityLabelledBy` on Android) persists regardless of input state. Error messages must be announced when they appear. Note: `accessibilityHint` and `accessibilityActions`/`onAccessibilityAction` have no ARIA equivalents — use the RN-specific props directly. (WCAG 1.3.1, 3.3.1, 3.3.2)
 
 ### Incorrect
 
@@ -44,12 +44,11 @@ Screen reader users navigate forms field by field. Each input must be associated
     accessibilityLabelledBy="emailLabel"
 />
 
-// Error announced and associated with the input
+// Error announced via live region (Android) + announceForAccessibility (iOS)
 <TextInput
     value={email}
     onChangeText={setEmail}
     accessibilityLabel={translate('common.email')}
-    accessibilityState={{disabled: false}}
 />
 {emailError && (
     <Text
@@ -69,7 +68,7 @@ Screen reader users navigate forms field by field. Each input must be associated
 Flag ONLY when ANY of these patterns is found:
 
 - `<TextInput>` with **no** `accessibilityLabel`, **no** `accessibilityLabelledBy`, and **no** `aria-label`
-- `<TextInput>` relying **only** on `placeholder` for labeling (placeholder disappears on input and is not reliably read by all screen readers)
+- `<TextInput>` relying **only** on `placeholder` for labeling (placeholder disappears once user types, leaving the field unlabeled for screen readers)
 - Form validation error text rendered without `accessibilityLiveRegion` or `accessibilityRole="alert"`
 
 **DO NOT flag if:**

--- a/.claude/skills/coding-standards/rules/a11y-11-form-accessibility.md
+++ b/.claude/skills/coding-standards/rules/a11y-11-form-accessibility.md
@@ -7,7 +7,7 @@ title: Forms must have accessible labels, errors, and instructions
 
 ### Reasoning
 
-Screen reader users navigate forms field by field. Each input must be associated with a descriptive label so users know what to enter. While React Native uses `placeholder` as a fallback accessible name, it disappears once the user starts typing, leaving the field unlabeled. An explicit `accessibilityLabel` (or `accessibilityLabelledBy` on Android) persists regardless of input state. Error messages must be announced when they appear. Note: `accessibilityHint` and `accessibilityActions`/`onAccessibilityAction` have no ARIA equivalents — use the RN-specific props directly. (WCAG 1.3.1, 3.3.1, 3.3.2)
+Screen reader users navigate forms field by field. Each input must be associated with a descriptive label so users know what to enter. While React Native uses `placeholder` as a fallback accessible name, it disappears once the user starts typing, leaving the field unlabeled. An explicit `accessibilityLabel` (or `accessibilityLabelledBy` on Android) persists regardless of input state. Error messages must be announced when they appear using `accessibilityLiveRegion` (Android) and `AccessibilityInfo.announceForAccessibility()` (iOS). (WCAG 1.3.1, 3.3.1, 3.3.2)
 
 ### Incorrect
 
@@ -59,6 +59,13 @@ Screen reader users navigate forms field by field. Each input must be associated
         {emailError}
     </Text>
 )}
+
+// iOS: announce error to VoiceOver
+useEffect(() => {
+    if (emailError) {
+        AccessibilityInfo.announceForAccessibility(emailError);
+    }
+}, [emailError]);
 ```
 
 ---
@@ -67,7 +74,7 @@ Screen reader users navigate forms field by field. Each input must be associated
 
 Flag ONLY when ANY of these patterns is found:
 
-- `<TextInput>` with **no** `accessibilityLabel`, **no** `accessibilityLabelledBy`, and **no** `aria-label`
+- `<TextInput>` with **no** `accessibilityLabel` and **no** `accessibilityLabelledBy`
 - `<TextInput>` relying **only** on `placeholder` for labeling (placeholder disappears once user types, leaving the field unlabeled for screen readers)
 - Form validation error text rendered without `accessibilityLiveRegion` or `accessibilityRole="alert"`
 
@@ -75,7 +82,7 @@ Flag ONLY when ANY of these patterns is found:
 
 - Using a form component library that wraps inputs with labels internally
 - `accessibilityLabel` is set on the input or a parent `accessible` container
-- `accessibilityLabelledBy` / `aria-labelledby` links to a visible label
+- `accessibilityLabelledBy` links to a visible label via `nativeID`
 
 **Search Patterns** (hints for reviewers):
 - `<TextInput` without `accessibilityLabel`

--- a/.claude/skills/coding-standards/rules/a11y-11-form-accessibility.md
+++ b/.claude/skills/coding-standards/rules/a11y-11-form-accessibility.md
@@ -1,0 +1,84 @@
+---
+ruleId: A11Y-11
+title: Forms must have accessible labels, errors, and instructions
+---
+
+## [A11Y-11] Forms must have accessible labels, errors, and instructions
+
+### Reasoning
+
+Screen reader users navigate forms field by field. Each input must be associated with a descriptive label so users know what to enter. Error messages must be announced when they appear and linked to the relevant field. Without proper labeling, users hear "edit text" with no context. Without announced errors, users submit forms repeatedly without knowing what's wrong. (WCAG 1.3.1, 3.3.1, 3.3.2)
+
+### Incorrect
+
+```tsx
+// Input with no accessible label — screen reader says "edit text"
+<TextInput
+    value={email}
+    onChangeText={setEmail}
+    placeholder="Email"
+/>
+
+// Error not announced, not associated with input
+<TextInput value={email} onChangeText={setEmail} />
+{emailError && <Text style={styles.error}>{emailError}</Text>}
+```
+
+### Correct
+
+```tsx
+// Input with accessible label
+<TextInput
+    value={email}
+    onChangeText={setEmail}
+    placeholder="Email"
+    accessibilityLabel={translate('common.email')}
+    accessibilityHint={translate('common.enterYourEmail')}
+/>
+
+// Android: label linked to input via nativeID
+<Text nativeID="emailLabel">{translate('common.email')}</Text>
+<TextInput
+    value={email}
+    onChangeText={setEmail}
+    accessibilityLabelledBy="emailLabel"
+/>
+
+// Error announced and associated with the input
+<TextInput
+    value={email}
+    onChangeText={setEmail}
+    accessibilityLabel={translate('common.email')}
+    accessibilityState={{disabled: false}}
+/>
+{emailError && (
+    <Text
+        style={styles.error}
+        accessibilityLiveRegion="assertive"
+        accessibilityRole="alert"
+    >
+        {emailError}
+    </Text>
+)}
+```
+
+---
+
+### Review Metadata
+
+Flag ONLY when ANY of these patterns is found:
+
+- `<TextInput>` with **no** `accessibilityLabel`, **no** `accessibilityLabelledBy`, and **no** `aria-label`
+- `<TextInput>` relying **only** on `placeholder` for labeling (placeholder disappears on input and is not reliably read by all screen readers)
+- Form validation error text rendered without `accessibilityLiveRegion` or `accessibilityRole="alert"`
+
+**DO NOT flag if:**
+
+- Using a form component library that wraps inputs with labels internally
+- `accessibilityLabel` is set on the input or a parent `accessible` container
+- `accessibilityLabelledBy` / `aria-labelledby` links to a visible label
+
+**Search Patterns** (hints for reviewers):
+- `<TextInput` without `accessibilityLabel`
+- `placeholder=` as sole labeling mechanism
+- Error text rendering without `accessibilityLiveRegion`

--- a/.claude/skills/coding-standards/rules/a11y-11-form-accessibility.md
+++ b/.claude/skills/coding-standards/rules/a11y-11-form-accessibility.md
@@ -82,7 +82,7 @@ Flag ONLY when ANY of these patterns is found:
 
 - Using a form component library that wraps inputs with labels internally
 - `accessibilityLabel` is set on the input or a parent `accessible` container
-- `accessibilityLabelledBy` links to a visible label via `nativeID`
+- `accessibilityLabelledBy` links to a visible label via `nativeID` (Android-only — ensure `accessibilityLabel` is also set as iOS fallback)
 
 **Search Patterns** (hints for reviewers):
 - `<TextInput` without `accessibilityLabel`

--- a/.claude/skills/coding-standards/rules/a11y-12-logical-focus-order.md
+++ b/.claude/skills/coding-standards/rules/a11y-12-logical-focus-order.md
@@ -1,0 +1,67 @@
+---
+ruleId: A11Y-12
+title: Maintain logical focus order matching visual layout
+---
+
+## [A11Y-12] Maintain logical focus order matching visual layout
+
+### Reasoning
+
+Screen readers traverse elements in JSX/DOM order, not visual order. When absolute positioning, `flexDirection: 'row-reverse'`, or `zIndex` rearranges elements visually, the screen reader focus order diverges from what sighted users see. This creates a confusing navigation experience where focus jumps unpredictably. JSX order must match the intended reading/interaction order. (WCAG 2.4.3, 1.3.2)
+
+### Incorrect
+
+```tsx
+// Visual order: [Cancel] [Submit] but JSX order is reversed
+<View style={{flexDirection: 'row-reverse'}}>
+    <Pressable onPress={onSubmit}><Text>Submit</Text></Pressable>
+    <Pressable onPress={onCancel}><Text>Cancel</Text></Pressable>
+</View>
+
+// Header visually on top via absolute positioning, but last in JSX
+<View>
+    <View style={styles.content}><Text>Body content</Text></View>
+    <View style={[styles.header, {position: 'absolute', top: 0}]}>
+        <Text accessibilityRole="header">Title</Text>
+    </View>
+</View>
+```
+
+### Correct
+
+```tsx
+// JSX order matches visual reading order
+<View style={{flexDirection: 'row'}}>
+    <Pressable onPress={onCancel}><Text>Cancel</Text></Pressable>
+    <Pressable onPress={onSubmit}><Text>Submit</Text></Pressable>
+</View>
+
+// Header first in JSX, matching visual order
+<View>
+    <View style={styles.header}>
+        <Text accessibilityRole="header">Title</Text>
+    </View>
+    <View style={styles.content}><Text>Body content</Text></View>
+</View>
+```
+
+---
+
+### Review Metadata
+
+Flag ONLY when ANY of these patterns is found:
+
+- `flexDirection: 'row-reverse'` or `'column-reverse'` on a container with multiple interactive children
+- Absolute positioning causing an element to appear visually before its JSX siblings
+- `zIndex` layering that places interactive elements in a different visual order than JSX order
+
+**DO NOT flag if:**
+
+- `row-reverse` is used on a container with a single child or non-interactive children
+- Visual reordering is purely decorative (no interactive elements affected)
+- The component uses `experimental_accessibilityOrder` to explicitly control focus order
+
+**Search Patterns** (hints for reviewers):
+- `flexDirection: 'row-reverse'` / `'column-reverse'`
+- `position: 'absolute'` on interactive elements
+- `zIndex` on containers with multiple interactive children

--- a/.claude/skills/coding-standards/rules/a11y-2-semantic-roles.md
+++ b/.claude/skills/coding-standards/rules/a11y-2-semantic-roles.md
@@ -30,9 +30,7 @@ React Native components have no implicit semantic meaning — assistive technolo
 
 ```tsx
 <Pressable
-    accessible
     accessibilityRole="button"
-    accessibilityLabel={translate('common.submit')}
     onPress={handleSubmit}
 >
     <Text>Submit</Text>

--- a/.claude/skills/coding-standards/rules/a11y-2-semantic-roles.md
+++ b/.claude/skills/coding-standards/rules/a11y-2-semantic-roles.md
@@ -7,15 +7,15 @@ title: Use semantic accessibilityRole for interactive elements
 
 ### Reasoning
 
-React Native `<View>` has no semantic meaning — assistive technology treats it as a generic container. When a `<View>` handles `onPress` or acts as a button, link, header, checkbox, switch, or tab, it must declare its role via `accessibilityRole` (or `role`). Without this, screen reader users cannot understand what the element does or how to interact with it. (WCAG 4.1.2)
+React Native components have no implicit semantic meaning — assistive technology treats them as generic containers. Interactive elements must declare their role via `accessibilityRole` or `role` so screen readers can convey what the element does. Note: `role` is a cross-platform alias that takes precedence over `accessibilityRole` when both are set. (WCAG 4.1.2)
 
 ### Incorrect
 
 ```tsx
-// View acting as button with no role — screen reader doesn't know it's tappable
-<View accessible onPress={handleSubmit}>
+// Pressable with no role — screen reader doesn't convey it's a button
+<Pressable onPress={handleSubmit}>
     <Text>Submit</Text>
-</View>
+</Pressable>
 
 // Pressable acting as link with no role
 <Pressable onPress={() => openURL(href)}>
@@ -59,7 +59,7 @@ React Native `<View>` has no semantic meaning — assistive technology treats it
 
 Flag ONLY when ANY of these patterns is found:
 
-- `<View>` or generic container with `onPress`/`onLongPress` handler but **no** `accessibilityRole` or `role` prop
+- `<Pressable>` or interactive component with `onPress`/`onLongPress` handler but **no** `accessibilityRole` or `role` prop
 - `<Pressable>` or `<TouchableOpacity>` navigating to a URL without `accessibilityRole="link"`
 - Text styled as a heading (large/bold, section title) without `accessibilityRole="header"`
 - Toggle/switch UI without `accessibilityRole="switch"` or `"checkbox"`
@@ -72,6 +72,6 @@ Flag ONLY when ANY of these patterns is found:
 - Element is not interactive and not a semantic landmark
 
 **Search Patterns** (hints for reviewers):
-- `onPress` without `accessibilityRole`
-- `<View` with `onPress`
+- `onPress` without `accessibilityRole` or `role`
+- `<Pressable` without `accessibilityRole`
 - Heading-styled `<Text` without `accessibilityRole="header"`

--- a/.claude/skills/coding-standards/rules/a11y-2-semantic-roles.md
+++ b/.claude/skills/coding-standards/rules/a11y-2-semantic-roles.md
@@ -1,0 +1,77 @@
+---
+ruleId: A11Y-2
+title: Use semantic accessibilityRole for interactive elements
+---
+
+## [A11Y-2] Use semantic accessibilityRole for interactive elements
+
+### Reasoning
+
+React Native `<View>` has no semantic meaning — assistive technology treats it as a generic container. When a `<View>` handles `onPress` or acts as a button, link, header, checkbox, switch, or tab, it must declare its role via `accessibilityRole` (or `role`). Without this, screen reader users cannot understand what the element does or how to interact with it. (WCAG 4.1.2)
+
+### Incorrect
+
+```tsx
+// View acting as button with no role — screen reader doesn't know it's tappable
+<View accessible onPress={handleSubmit}>
+    <Text>Submit</Text>
+</View>
+
+// Pressable acting as link with no role
+<Pressable onPress={() => openURL(href)}>
+    <Text style={styles.link}>Learn more</Text>
+</Pressable>
+
+// Section heading with no role
+<Text style={styles.heading}>Account Settings</Text>
+```
+
+### Correct
+
+```tsx
+<Pressable
+    accessible
+    accessibilityRole="button"
+    accessibilityLabel={translate('common.submit')}
+    onPress={handleSubmit}
+>
+    <Text>Submit</Text>
+</Pressable>
+
+<Pressable
+    accessibilityRole="link"
+    onPress={() => openURL(href)}
+>
+    <Text style={styles.link}>Learn more</Text>
+</Pressable>
+
+<Text
+    accessibilityRole="header"
+    style={styles.heading}
+>
+    Account Settings
+</Text>
+```
+
+---
+
+### Review Metadata
+
+Flag ONLY when ANY of these patterns is found:
+
+- `<View>` or generic container with `onPress`/`onLongPress` handler but **no** `accessibilityRole` or `role` prop
+- `<Pressable>` or `<TouchableOpacity>` navigating to a URL without `accessibilityRole="link"`
+- Text styled as a heading (large/bold, section title) without `accessibilityRole="header"`
+- Toggle/switch UI without `accessibilityRole="switch"` or `"checkbox"`
+- Tab UI without `accessibilityRole="tab"`
+
+**DO NOT flag if:**
+
+- Component already has `accessibilityRole` or `role` set
+- Using a design system component that sets the role internally (e.g., `<Button>`, `<Switch>`, `<Checkbox>`)
+- Element is not interactive and not a semantic landmark
+
+**Search Patterns** (hints for reviewers):
+- `onPress` without `accessibilityRole`
+- `<View` with `onPress`
+- Heading-styled `<Text` without `accessibilityRole="header"`

--- a/.claude/skills/coding-standards/rules/a11y-3-communicate-state.md
+++ b/.claude/skills/coding-standards/rules/a11y-3-communicate-state.md
@@ -72,7 +72,7 @@ Screen readers must announce the current state of interactive elements — wheth
 
 Flag ONLY when ANY of these patterns is found:
 
-- Element has `disabled` prop but **no** `accessibilityState={{disabled: ...}}`
+- Element has `disabled` prop but **no** `accessibilityState={{disabled: ...}}` (only on custom components — `Pressable`, `TouchableOpacity`, and `TouchableWithoutFeedback` auto-merge `disabled` into `accessibilityState`)
 - Element has `accessibilityRole="checkbox"` or `"switch"` but **no** `accessibilityState={{checked: ...}}`
 - Element visually toggles expanded/collapsed but **no** `accessibilityState={{expanded: ...}}`
 - Element visually indicates selection (active tab, selected item) but **no** `accessibilityState={{selected: ...}}`
@@ -80,6 +80,8 @@ Flag ONLY when ANY of these patterns is found:
 **DO NOT flag if:**
 
 - Using a design system component that handles state internally (e.g., `<Switch>`, `<Checkbox>`, `<RadioButton>`)
+- Using `Pressable`, `TouchableOpacity`, or `TouchableWithoutFeedback` with `disabled` prop (these auto-merge `disabled` into `accessibilityState`)
+- Using Expensify's `GenericPressable` or `PressableWithFeedback` (they set `accessibilityState={{disabled}}` internally)
 - State is already communicated via `accessibilityState` on a parent or wrapper component
 
 **Search Patterns** (hints for reviewers):

--- a/.claude/skills/coding-standards/rules/a11y-3-communicate-state.md
+++ b/.claude/skills/coding-standards/rules/a11y-3-communicate-state.md
@@ -80,7 +80,7 @@ Flag ONLY when ANY of these patterns is found:
 **DO NOT flag if:**
 
 - Using a design system component that handles state internally (e.g., `<Switch>`, `<Checkbox>`, `<RadioButton>`)
-- State is communicated via `aria-*` props instead of `accessibilityState`
+- State is communicated via the equivalent `aria-*` props (`aria-disabled`, `aria-checked`, `aria-expanded`, `aria-selected`) — these map to `accessibilityState` internally
 
 **Search Patterns** (hints for reviewers):
 - `disabled={` without `accessibilityState`

--- a/.claude/skills/coding-standards/rules/a11y-3-communicate-state.md
+++ b/.claude/skills/coding-standards/rules/a11y-3-communicate-state.md
@@ -72,15 +72,15 @@ Screen readers must announce the current state of interactive elements — wheth
 
 Flag ONLY when ANY of these patterns is found:
 
-- Element has `disabled` prop but **no** `accessibilityState={{disabled: ...}}` or `aria-disabled`
-- Element has `accessibilityRole="checkbox"` or `"switch"` but **no** `accessibilityState={{checked: ...}}` or `aria-checked`
-- Element visually toggles expanded/collapsed but **no** `accessibilityState={{expanded: ...}}` or `aria-expanded`
-- Element visually indicates selection (active tab, selected item) but **no** `accessibilityState={{selected: ...}}` or `aria-selected`
+- Element has `disabled` prop but **no** `accessibilityState={{disabled: ...}}`
+- Element has `accessibilityRole="checkbox"` or `"switch"` but **no** `accessibilityState={{checked: ...}}`
+- Element visually toggles expanded/collapsed but **no** `accessibilityState={{expanded: ...}}`
+- Element visually indicates selection (active tab, selected item) but **no** `accessibilityState={{selected: ...}}`
 
 **DO NOT flag if:**
 
 - Using a design system component that handles state internally (e.g., `<Switch>`, `<Checkbox>`, `<RadioButton>`)
-- State is communicated via the equivalent `aria-*` props (`aria-disabled`, `aria-checked`, `aria-expanded`, `aria-selected`) — these map to `accessibilityState` internally
+- State is already communicated via `accessibilityState` on a parent or wrapper component
 
 **Search Patterns** (hints for reviewers):
 - `disabled={` without `accessibilityState`

--- a/.claude/skills/coding-standards/rules/a11y-3-communicate-state.md
+++ b/.claude/skills/coding-standards/rules/a11y-3-communicate-state.md
@@ -7,7 +7,7 @@ title: Communicate component state to assistive technology
 
 ### Reasoning
 
-Screen readers must announce the current state of interactive elements — whether a button is disabled, a checkbox is checked, an accordion is expanded, or a tab is selected. Without `accessibilityState` (or equivalent `aria-*` props), state changes are invisible to assistive technology users. They cannot determine if a toggle is on/off, a form field is disabled, or a section is expanded. (WCAG 4.1.2)
+Screen readers must announce the current state of interactive elements — whether a button is disabled, a checkbox is checked, an accordion is expanded, or a tab is selected. Without `accessibilityState`, state changes are invisible to assistive technology users. They cannot determine if a toggle is on/off, a form field is disabled, or a section is expanded. (WCAG 4.1.2)
 
 ### Incorrect
 

--- a/.claude/skills/coding-standards/rules/a11y-3-communicate-state.md
+++ b/.claude/skills/coding-standards/rules/a11y-3-communicate-state.md
@@ -1,0 +1,89 @@
+---
+ruleId: A11Y-3
+title: Communicate component state to assistive technology
+---
+
+## [A11Y-3] Communicate component state to assistive technology
+
+### Reasoning
+
+Screen readers must announce the current state of interactive elements — whether a button is disabled, a checkbox is checked, an accordion is expanded, or a tab is selected. Without `accessibilityState` (or equivalent `aria-*` props), state changes are invisible to assistive technology users. They cannot determine if a toggle is on/off, a form field is disabled, or a section is expanded. (WCAG 4.1.2)
+
+### Incorrect
+
+```tsx
+// Disabled button — screen reader doesn't know it's disabled
+<Pressable
+    onPress={onSubmit}
+    style={isDisabled && styles.disabled}
+    disabled={isDisabled}
+>
+    <Text>Submit</Text>
+</Pressable>
+
+// Checkbox with no checked state communicated
+<Pressable onPress={toggleCheck} accessibilityRole="checkbox">
+    <Icon src={isChecked ? Expensicons.Checkmark : Expensicons.Square} />
+    <Text>I agree</Text>
+</Pressable>
+
+// Expandable section with no expanded state
+<Pressable onPress={toggleExpand}>
+    <Text>Details</Text>
+    <Icon src={isExpanded ? Expensicons.UpArrow : Expensicons.DownArrow} />
+</Pressable>
+```
+
+### Correct
+
+```tsx
+<Pressable
+    onPress={onSubmit}
+    style={isDisabled && styles.disabled}
+    disabled={isDisabled}
+    accessibilityRole="button"
+    accessibilityState={{disabled: isDisabled}}
+>
+    <Text>Submit</Text>
+</Pressable>
+
+<Pressable
+    onPress={toggleCheck}
+    accessibilityRole="checkbox"
+    accessibilityState={{checked: isChecked}}
+>
+    <Icon src={isChecked ? Expensicons.Checkmark : Expensicons.Square} />
+    <Text>I agree</Text>
+</Pressable>
+
+<Pressable
+    onPress={toggleExpand}
+    accessibilityRole="button"
+    accessibilityState={{expanded: isExpanded}}
+>
+    <Text>Details</Text>
+    <Icon src={isExpanded ? Expensicons.UpArrow : Expensicons.DownArrow} />
+</Pressable>
+```
+
+---
+
+### Review Metadata
+
+Flag ONLY when ANY of these patterns is found:
+
+- Element has `disabled` prop but **no** `accessibilityState={{disabled: ...}}` or `aria-disabled`
+- Element has `accessibilityRole="checkbox"` or `"switch"` but **no** `accessibilityState={{checked: ...}}` or `aria-checked`
+- Element visually toggles expanded/collapsed but **no** `accessibilityState={{expanded: ...}}` or `aria-expanded`
+- Element visually indicates selection (active tab, selected item) but **no** `accessibilityState={{selected: ...}}` or `aria-selected`
+
+**DO NOT flag if:**
+
+- Using a design system component that handles state internally (e.g., `<Switch>`, `<Checkbox>`, `<RadioButton>`)
+- State is communicated via `aria-*` props instead of `accessibilityState`
+
+**Search Patterns** (hints for reviewers):
+- `disabled={` without `accessibilityState`
+- `accessibilityRole="checkbox"` without `checked`
+- `accessibilityRole="switch"` without `checked`
+- Visual expand/collapse toggling without `expanded`

--- a/.claude/skills/coding-standards/rules/a11y-4-touch-target-size.md
+++ b/.claude/skills/coding-standards/rules/a11y-4-touch-target-size.md
@@ -1,0 +1,68 @@
+---
+ruleId: A11Y-4
+title: Minimum touch target size of 44x44 points
+---
+
+## [A11Y-4] Minimum touch target size of 44x44 points
+
+### Reasoning
+
+Users with motor impairments, tremors, or limited dexterity struggle to tap small targets. WCAG 2.5.8 requires a minimum target size of 24x24 CSS pixels, but Apple HIG and Android guidelines recommend 44x44pt / 48x48dp respectively. React Native targets both platforms, so interactive elements should meet the 44x44pt minimum. Use `hitSlop` to enlarge the tappable area without changing visual layout when the visual element must be smaller.
+
+### Incorrect
+
+```tsx
+// Small icon button with no hit area expansion
+<Pressable onPress={onClose} style={{width: 24, height: 24}}>
+    <Icon src={Expensicons.Close} width={16} height={16} />
+</Pressable>
+
+// Inline link-style button that's too small to tap reliably
+<Pressable onPress={onRetry} style={{padding: 4}}>
+    <Text style={styles.smallText}>Retry</Text>
+</Pressable>
+```
+
+### Correct
+
+```tsx
+// Properly sized touch target
+<Pressable
+    onPress={onClose}
+    accessibilityLabel={translate('common.close')}
+    accessibilityRole="button"
+    style={{width: 44, height: 44, alignItems: 'center', justifyContent: 'center'}}
+>
+    <Icon src={Expensicons.Close} width={16} height={16} />
+</Pressable>
+
+// Using hitSlop to expand tappable area without changing layout
+<Pressable
+    onPress={onRetry}
+    hitSlop={{top: 10, bottom: 10, left: 10, right: 10}}
+    style={{padding: 4}}
+>
+    <Text style={styles.smallText}>Retry</Text>
+</Pressable>
+```
+
+---
+
+### Review Metadata
+
+Flag ONLY when ALL of these are true:
+
+- Element is interactive (`Pressable`, `TouchableOpacity`, `TouchableWithoutFeedback`, or has `onPress`)
+- Element has explicit dimensions (width/height in style) **less than 44** on either axis
+- Element has **no** `hitSlop` prop to compensate
+
+**DO NOT flag if:**
+
+- Element uses `hitSlop` to expand the tappable area
+- Element is within a larger tappable parent that meets the minimum
+- Element is an inline text link within a paragraph (WCAG exception)
+- Dimensions are not explicitly set (defaults may be adequate)
+
+**Search Patterns** (hints for reviewers):
+- `width: 2` / `height: 2` / `width: 3` (small explicit dimensions on interactive elements)
+- `onPress` with small explicit sizing and no `hitSlop`

--- a/.claude/skills/coding-standards/rules/a11y-4-touch-target-size.md
+++ b/.claude/skills/coding-standards/rules/a11y-4-touch-target-size.md
@@ -64,5 +64,5 @@ Flag ONLY when ALL of these are true:
 - Dimensions are not explicitly set (defaults may be adequate)
 
 **Search Patterns** (hints for reviewers):
-- `width: 2` / `height: 2` / `width: 3` (small explicit dimensions on interactive elements)
+- Explicit `width` or `height` under 44 on interactive elements (e.g., `width: 24`, `height: 32`)
 - `onPress` with small explicit sizing and no `hitSlop`

--- a/.claude/skills/coding-standards/rules/a11y-4-touch-target-size.md
+++ b/.claude/skills/coding-standards/rules/a11y-4-touch-target-size.md
@@ -52,7 +52,7 @@ Users with motor impairments, tremors, or limited dexterity struggle to tap smal
 
 Flag ONLY when ALL of these are true:
 
-- Element is interactive (`Pressable`, `TouchableOpacity`, `TouchableWithoutFeedback`, or has `onPress`)
+- Element is interactive (`Pressable`, `TouchableOpacity`, `TouchableWithoutFeedback`, `PressableWithFeedback`, `Button`, or has `onPress`)
 - Element has explicit dimensions (width/height in style) **less than 44** on either axis
 - Element has **no** `hitSlop` prop to compensate
 

--- a/.claude/skills/coding-standards/rules/a11y-4-touch-target-size.md
+++ b/.claude/skills/coding-standards/rules/a11y-4-touch-target-size.md
@@ -58,10 +58,11 @@ Flag ONLY when ALL of these are true:
 
 **DO NOT flag if:**
 
-- Element uses `hitSlop` to expand the tappable area
+- Element uses `hitSlop` or `shouldUseAutoHitSlop={true}` to expand the tappable area
 - Element is within a larger tappable parent that meets the minimum
 - Element is an inline text link within a paragraph (WCAG exception)
 - Dimensions are not explicitly set (defaults may be adequate)
+- Using Expensify's `GenericPressable` or `PressableWithFeedback` with `shouldUseAutoHitSlop` (auto-computes hitSlop to meet 44x44)
 
 **Search Patterns** (hints for reviewers):
 - Explicit `width` or `height` under 44 on interactive elements (e.g., `width: 24`, `height: 32`)

--- a/.claude/skills/coding-standards/rules/a11y-5-announce-dynamic-content.md
+++ b/.claude/skills/coding-standards/rules/a11y-5-announce-dynamic-content.md
@@ -7,7 +7,7 @@ title: Announce dynamic content changes to assistive technology
 
 ### Reasoning
 
-Screen reader users cannot see visual changes — toast messages, success/error banners, loading completions, and counter updates are invisible unless explicitly announced. On Android, use `accessibilityLiveRegion` on the changing text node. On iOS, use `AccessibilityInfo.announceForAccessibility()`. Without announcements, dynamic feedback is silently lost. (WCAG 4.1.3)
+Screen reader users cannot see visual changes — toast messages, success/error banners, loading completions, and counter updates are invisible unless explicitly announced. Cross-platform coverage requires **both** approaches: `accessibilityLiveRegion` (or `aria-live`) works **only on Android** (TalkBack), while `AccessibilityInfo.announceForAccessibility()` works **only on iOS** (VoiceOver). Neither has a cross-platform equivalent — you must handle both platforms. (WCAG 4.1.3)
 
 ### Incorrect
 
@@ -31,33 +31,31 @@ Screen reader users cannot see visual changes — toast messages, success/error 
 ### Correct
 
 ```tsx
-// Android: live region announces when text content changes
+// Cross-platform: use BOTH live region (Android) and announceForAccessibility (iOS)
 {showSuccess && (
     <View style={styles.toast}>
         <Text accessibilityLiveRegion="polite">Changes saved successfully</Text>
     </View>
 )}
 
-// Error messages should interrupt — use assertive for errors
-{error && (
-    <Text accessibilityLiveRegion="assertive" accessibilityRole="alert">
-        {error}
-    </Text>
-)}
-
-// iOS: programmatic announcement for transient messages
 useEffect(() => {
     if (showSuccess) {
         AccessibilityInfo.announceForAccessibility(translate('common.changesSaved'));
     }
 }, [showSuccess]);
 
-// Cross-platform: announce loading completion
+// Error messages should interrupt — use assertive (Android) + announcement (iOS)
+{error && (
+    <Text accessibilityLiveRegion="assertive" accessibilityRole="alert">
+        {error}
+    </Text>
+)}
+
 useEffect(() => {
-    if (!isLoading) {
-        AccessibilityInfo.announceForAccessibility(translate('common.loaded'));
+    if (error) {
+        AccessibilityInfo.announceForAccessibility(error);
     }
-}, [isLoading]);
+}, [error]);
 ```
 
 ---
@@ -66,7 +64,7 @@ useEffect(() => {
 
 Flag ONLY when ANY of these patterns is found:
 
-- Toast, snackbar, banner, or success/error message rendered conditionally with **no** `accessibilityLiveRegion` and **no** `AccessibilityInfo.announceForAccessibility` call
+- Toast, snackbar, banner, or success/error message rendered conditionally with **no** `accessibilityLiveRegion`/`aria-live` (Android) and **no** `AccessibilityInfo.announceForAccessibility` call (iOS)
 - Form validation error text appears dynamically with **no** live region or announcement
 - Loading state transitions (loading -> loaded) with **no** announcement
 - Counter or status text updates with **no** live region

--- a/.claude/skills/coding-standards/rules/a11y-5-announce-dynamic-content.md
+++ b/.claude/skills/coding-standards/rules/a11y-5-announce-dynamic-content.md
@@ -7,7 +7,7 @@ title: Announce dynamic content changes to assistive technology
 
 ### Reasoning
 
-Screen reader users cannot see visual changes — toast messages, success/error banners, loading completions, and counter updates are invisible unless explicitly announced. Cross-platform coverage requires **both** approaches: `accessibilityLiveRegion` works on Android and web (React Native Web maps it to `aria-live`), while `AccessibilityInfo.announceForAccessibility()` works only on iOS (VoiceOver). Use both together for full platform coverage. (WCAG 4.1.3)
+Screen reader users cannot see visual changes — toast messages, success/error banners, loading completions, and counter updates are invisible unless explicitly announced. Full platform coverage requires **both** approaches: `accessibilityLiveRegion` works on Android (TalkBack) and web (React Native Web maps it to `aria-live`), but is a no-op on iOS. `AccessibilityInfo.announceForAccessibility()` works on iOS and Android natively, but not on web. Use both together for iOS + Android + web coverage. (WCAG 4.1.3)
 
 ### Incorrect
 
@@ -31,7 +31,7 @@ Screen reader users cannot see visual changes — toast messages, success/error 
 ### Correct
 
 ```tsx
-// Cross-platform: use BOTH live region (Android) and announceForAccessibility (iOS)
+// Cross-platform: live region (Android + web) + announceForAccessibility (iOS + Android native)
 {showSuccess && (
     <View style={styles.toast}>
         <Text accessibilityLiveRegion="polite">Changes saved successfully</Text>
@@ -44,7 +44,7 @@ useEffect(() => {
     }
 }, [showSuccess]);
 
-// Error messages should interrupt — use assertive (Android) + announcement (iOS)
+// Error messages should interrupt — use assertive (Android + web) + announcement (iOS + Android)
 {error && (
     <Text accessibilityLiveRegion="assertive" accessibilityRole="alert">
         {error}
@@ -64,7 +64,7 @@ useEffect(() => {
 
 Flag ONLY when ANY of these patterns is found:
 
-- Toast, snackbar, banner, or success/error message rendered conditionally with **no** `accessibilityLiveRegion` (Android) and **no** `AccessibilityInfo.announceForAccessibility` call (iOS)
+- Toast, snackbar, banner, or success/error message rendered conditionally with **no** `accessibilityLiveRegion` (Android + web) and **no** `AccessibilityInfo.announceForAccessibility` call (iOS + Android)
 - Form validation error text appears dynamically with **no** live region or announcement
 - Loading state transitions (loading -> loaded) with **no** announcement
 - Counter or status text updates with **no** live region

--- a/.claude/skills/coding-standards/rules/a11y-5-announce-dynamic-content.md
+++ b/.claude/skills/coding-standards/rules/a11y-5-announce-dynamic-content.md
@@ -1,0 +1,83 @@
+---
+ruleId: A11Y-5
+title: Announce dynamic content changes to assistive technology
+---
+
+## [A11Y-5] Announce dynamic content changes to assistive technology
+
+### Reasoning
+
+Screen reader users cannot see visual changes — toast messages, success/error banners, loading completions, and counter updates are invisible unless explicitly announced. On Android, use `accessibilityLiveRegion` on the changing text node. On iOS, use `AccessibilityInfo.announceForAccessibility()`. Without announcements, dynamic feedback is silently lost. (WCAG 4.1.3)
+
+### Incorrect
+
+```tsx
+// Success message appears but screen reader is not informed
+{showSuccess && (
+    <View style={styles.toast}>
+        <Text>Changes saved successfully</Text>
+    </View>
+)}
+
+// Error message rendered without live region
+{error && (
+    <Text style={styles.errorText}>{error}</Text>
+)}
+
+// Loading completes with no announcement
+{!isLoading && <Text>Data loaded</Text>}
+```
+
+### Correct
+
+```tsx
+// Android: live region announces when text content changes
+{showSuccess && (
+    <View style={styles.toast}>
+        <Text accessibilityLiveRegion="polite">Changes saved successfully</Text>
+    </View>
+)}
+
+// Error messages should interrupt — use assertive for errors
+{error && (
+    <Text accessibilityLiveRegion="assertive" accessibilityRole="alert">
+        {error}
+    </Text>
+)}
+
+// iOS: programmatic announcement for transient messages
+useEffect(() => {
+    if (showSuccess) {
+        AccessibilityInfo.announceForAccessibility(translate('common.changesSaved'));
+    }
+}, [showSuccess]);
+
+// Cross-platform: announce loading completion
+useEffect(() => {
+    if (!isLoading) {
+        AccessibilityInfo.announceForAccessibility(translate('common.loaded'));
+    }
+}, [isLoading]);
+```
+
+---
+
+### Review Metadata
+
+Flag ONLY when ANY of these patterns is found:
+
+- Toast, snackbar, banner, or success/error message rendered conditionally with **no** `accessibilityLiveRegion` and **no** `AccessibilityInfo.announceForAccessibility` call
+- Form validation error text appears dynamically with **no** live region or announcement
+- Loading state transitions (loading -> loaded) with **no** announcement
+- Counter or status text updates with **no** live region
+
+**DO NOT flag if:**
+
+- Component uses a shared notification/toast system that already handles announcements internally
+- Focus is explicitly moved to the new content via `AccessibilityInfo.setAccessibilityFocus()`
+- Content change is within a focused input field (screen reader already tracks it)
+
+**Search Patterns** (hints for reviewers):
+- Conditional rendering of success/error messages without `accessibilityLiveRegion`
+- `Toast` / `Growl` / `Banner` / `SnackBar` components
+- `AccessibilityInfo.announceForAccessibility` (presence = good)

--- a/.claude/skills/coding-standards/rules/a11y-5-announce-dynamic-content.md
+++ b/.claude/skills/coding-standards/rules/a11y-5-announce-dynamic-content.md
@@ -7,7 +7,7 @@ title: Announce dynamic content changes to assistive technology
 
 ### Reasoning
 
-Screen reader users cannot see visual changes — toast messages, success/error banners, loading completions, and counter updates are invisible unless explicitly announced. Cross-platform coverage requires **both** approaches: `accessibilityLiveRegion` works **only on Android** (TalkBack), while `AccessibilityInfo.announceForAccessibility()` works **only on iOS** (VoiceOver). Neither has a cross-platform equivalent — you must handle both platforms. (WCAG 4.1.3)
+Screen reader users cannot see visual changes — toast messages, success/error banners, loading completions, and counter updates are invisible unless explicitly announced. Cross-platform coverage requires **both** approaches: `accessibilityLiveRegion` works on Android and web (React Native Web maps it to `aria-live`), while `AccessibilityInfo.announceForAccessibility()` works only on iOS (VoiceOver). Use both together for full platform coverage. (WCAG 4.1.3)
 
 ### Incorrect
 

--- a/.claude/skills/coding-standards/rules/a11y-5-announce-dynamic-content.md
+++ b/.claude/skills/coding-standards/rules/a11y-5-announce-dynamic-content.md
@@ -7,7 +7,7 @@ title: Announce dynamic content changes to assistive technology
 
 ### Reasoning
 
-Screen reader users cannot see visual changes — toast messages, success/error banners, loading completions, and counter updates are invisible unless explicitly announced. Cross-platform coverage requires **both** approaches: `accessibilityLiveRegion` (or `aria-live`) works **only on Android** (TalkBack), while `AccessibilityInfo.announceForAccessibility()` works **only on iOS** (VoiceOver). Neither has a cross-platform equivalent — you must handle both platforms. (WCAG 4.1.3)
+Screen reader users cannot see visual changes — toast messages, success/error banners, loading completions, and counter updates are invisible unless explicitly announced. Cross-platform coverage requires **both** approaches: `accessibilityLiveRegion` works **only on Android** (TalkBack), while `AccessibilityInfo.announceForAccessibility()` works **only on iOS** (VoiceOver). Neither has a cross-platform equivalent — you must handle both platforms. (WCAG 4.1.3)
 
 ### Incorrect
 
@@ -64,7 +64,7 @@ useEffect(() => {
 
 Flag ONLY when ANY of these patterns is found:
 
-- Toast, snackbar, banner, or success/error message rendered conditionally with **no** `accessibilityLiveRegion`/`aria-live` (Android) and **no** `AccessibilityInfo.announceForAccessibility` call (iOS)
+- Toast, snackbar, banner, or success/error message rendered conditionally with **no** `accessibilityLiveRegion` (Android) and **no** `AccessibilityInfo.announceForAccessibility` call (iOS)
 - Form validation error text appears dynamically with **no** live region or announcement
 - Loading state transitions (loading -> loaded) with **no** announcement
 - Counter or status text updates with **no** live region

--- a/.claude/skills/coding-standards/rules/a11y-6-accessible-images.md
+++ b/.claude/skills/coding-standards/rules/a11y-6-accessible-images.md
@@ -7,7 +7,7 @@ title: Images must have labels or be hidden from assistive technology
 
 ### Reasoning
 
-Screen readers attempt to announce every image. Informative images (photos, charts, meaningful icons) need descriptive `accessibilityLabel` so users understand the content. Decorative images (background patterns, visual separators, ornamental icons) must be hidden with `accessible={false}` or `aria-hidden={true}` to avoid cluttering the screen reader experience with meaningless announcements. (WCAG 1.1.1)
+Screen readers attempt to announce every image. Informative images (photos, charts, meaningful icons) need descriptive `accessibilityLabel` so users understand the content. Decorative images (background patterns, visual separators, ornamental icons) must be hidden with `accessible={false}` to avoid cluttering the screen reader experience with meaningless announcements. (WCAG 1.1.1)
 
 ### Incorrect
 
@@ -54,7 +54,7 @@ Screen readers attempt to announce every image. Informative images (photos, char
 
 Flag ONLY when ANY of these patterns is found:
 
-- `<Image>` with a meaningful `source` (not a decorative pattern) and **no** `accessibilityLabel` and **not** hidden (`accessible={false}` / `aria-hidden`)
+- `<Image>` with a meaningful `source` (not a decorative pattern) and **no** `accessibilityLabel` and **not** hidden (`accessible={false}`)
 - Icon used to convey information (status, type, category) with **no** label and **not** hidden
 - Decorative/ornamental image that is **not** hidden from assistive technology
 

--- a/.claude/skills/coding-standards/rules/a11y-6-accessible-images.md
+++ b/.claude/skills/coding-standards/rules/a11y-6-accessible-images.md
@@ -1,0 +1,70 @@
+---
+ruleId: A11Y-6
+title: Images must have labels or be hidden from assistive technology
+---
+
+## [A11Y-6] Images must have labels or be hidden from assistive technology
+
+### Reasoning
+
+Screen readers attempt to announce every image. Informative images (photos, charts, meaningful icons) need descriptive `accessibilityLabel` so users understand the content. Decorative images (background patterns, visual separators, ornamental icons) must be hidden with `accessible={false}` or `aria-hidden={true}` to avoid cluttering the screen reader experience with meaningless announcements. (WCAG 1.1.1)
+
+### Incorrect
+
+```tsx
+// Informative image with no label — screen reader says "image"
+<Image source={{uri: receiptURL}} style={styles.receiptImage} />
+
+// Decorative separator announced to screen reader unnecessarily
+<Image source={require('./divider.png')} style={styles.divider} />
+
+// Avatar with no description
+<Avatar source={avatarURL} size={CONST.AVATAR_SIZE.DEFAULT} />
+```
+
+### Correct
+
+```tsx
+// Informative image with descriptive label
+<Image
+    source={{uri: receiptURL}}
+    style={styles.receiptImage}
+    accessibilityLabel={translate('common.receipt')}
+    accessibilityRole="image"
+/>
+
+// Decorative image hidden from screen reader
+<Image
+    source={require('./divider.png')}
+    style={styles.divider}
+    accessible={false}
+/>
+
+// Avatar with meaningful label
+<Avatar
+    source={avatarURL}
+    size={CONST.AVATAR_SIZE.DEFAULT}
+    accessibilityLabel={`${displayName} avatar`}
+/>
+```
+
+---
+
+### Review Metadata
+
+Flag ONLY when ANY of these patterns is found:
+
+- `<Image>` with a meaningful `source` (not a decorative pattern) and **no** `accessibilityLabel` and **not** hidden (`accessible={false}` / `aria-hidden`)
+- Icon used to convey information (status, type, category) with **no** label and **not** hidden
+- Decorative/ornamental image that is **not** hidden from assistive technology
+
+**DO NOT flag if:**
+
+- Image is inside an interactive parent that already has an `accessibilityLabel`
+- Image component internally handles accessibility (design system components)
+- Image is part of a group wrapped with `accessible={true}` and a group label
+
+**Search Patterns** (hints for reviewers):
+- `<Image` without `accessibilityLabel` or `accessible={false}`
+- `<Avatar` without `accessibilityLabel`
+- `<Icon` used for status indication without parent label

--- a/.claude/skills/coding-standards/rules/a11y-7-no-color-only-info.md
+++ b/.claude/skills/coding-standards/rules/a11y-7-no-color-only-info.md
@@ -1,0 +1,76 @@
+---
+ruleId: A11Y-7
+title: Do not convey information through color alone
+---
+
+## [A11Y-7] Do not convey information through color alone
+
+### Reasoning
+
+Users with color vision deficiencies (8% of men, 0.5% of women) cannot distinguish information conveyed solely through color. Status indicators, error states, required fields, and success/failure feedback must include a non-color cue — text labels, icons, patterns, or shape changes. Text must also meet minimum contrast ratios: 4.5:1 for normal text, 3:1 for large text (18pt+ or 14pt bold+), and 3:1 for non-text UI components and graphical objects. (WCAG 1.3.3, 1.4.1, 1.4.3, 1.4.11)
+
+### Incorrect
+
+```tsx
+// Status conveyed only by color — colorblind users can't distinguish
+<View style={{backgroundColor: isOnline ? 'green' : 'red', width: 8, height: 8, borderRadius: 4}} />
+
+// Error indicated only by red border color
+<TextInput style={[styles.input, hasError && {borderColor: 'red'}]} />
+
+// Required field indicated only by red asterisk color
+<Text style={{color: 'red'}}>*</Text>
+```
+
+### Correct
+
+```tsx
+// Status uses color + icon + label
+<View style={styles.statusContainer}>
+    <View style={{backgroundColor: isOnline ? theme.success : theme.danger, width: 8, height: 8, borderRadius: 4}} />
+    <Text accessibilityLabel={isOnline ? translate('common.online') : translate('common.offline')}>
+        {isOnline ? translate('common.online') : translate('common.offline')}
+    </Text>
+</View>
+
+// Error uses color + icon + text message
+<TextInput
+    style={[styles.input, hasError && styles.inputError]}
+    accessibilityState={{disabled: false}}
+/>
+{hasError && (
+    <View style={styles.errorRow}>
+        <Icon src={Expensicons.Exclamation} fill={theme.danger} />
+        <Text style={styles.errorText} accessibilityLiveRegion="assertive">
+            {errorMessage}
+        </Text>
+    </View>
+)}
+
+// Required field uses label text, not just color
+<Text>
+    {fieldLabel} <Text accessibilityLabel={translate('common.required')}>*</Text>
+</Text>
+```
+
+---
+
+### Review Metadata
+
+Flag ONLY when ANY of these patterns is found:
+
+- Status dot/indicator using **only** background color with **no** accompanying text or icon
+- Error/validation state indicated **only** by changing border or text color with **no** error message text
+- Success/failure feedback using **only** green/red color with **no** text or icon explanation
+- Colored badge/tag with **no** text label inside it
+
+**DO NOT flag if:**
+
+- Color is supplementary — text label or icon also conveys the same information
+- Element is purely decorative with no informational purpose
+- Color distinction is between text and background (contrast issue, not color-only issue)
+
+**Search Patterns** (hints for reviewers):
+- `backgroundColor:` conditionally set based on status with no sibling `<Text`
+- `borderColor: 'red'` / `borderColor: theme.danger` without error text
+- Status indicators using only colored dots/circles

--- a/.claude/skills/coding-standards/rules/a11y-7-no-color-only-info.md
+++ b/.claude/skills/coding-standards/rules/a11y-7-no-color-only-info.md
@@ -7,7 +7,7 @@ title: Do not convey information through color alone
 
 ### Reasoning
 
-Users with color vision deficiencies (8% of men, 0.5% of women) cannot distinguish information conveyed solely through color. Status indicators, error states, required fields, and success/failure feedback must include a non-color cue — text labels, icons, patterns, or shape changes. Text must also meet minimum contrast ratios: 4.5:1 for normal text, 3:1 for large text (18pt+ or 14pt bold+), and 3:1 for non-text UI components and graphical objects. (WCAG 1.3.3, 1.4.1, 1.4.3, 1.4.11)
+Users with color vision deficiencies cannot distinguish information conveyed solely through color. Status indicators, error states, required fields, and success/failure feedback must include a non-color cue — text labels, icons, patterns, or shape changes. (WCAG 1.4.1)
 
 ### Incorrect
 

--- a/.claude/skills/coding-standards/rules/a11y-7-no-color-only-info.md
+++ b/.claude/skills/coding-standards/rules/a11y-7-no-color-only-info.md
@@ -26,11 +26,10 @@ Users with color vision deficiencies (8% of men, 0.5% of women) cannot distingui
 
 ```tsx
 // Status uses color + icon + label
+const statusLabel = isOnline ? translate('common.online') : translate('common.offline');
 <View style={styles.statusContainer}>
     <View style={{backgroundColor: isOnline ? theme.success : theme.danger, width: 8, height: 8, borderRadius: 4}} />
-    <Text accessibilityLabel={isOnline ? translate('common.online') : translate('common.offline')}>
-        {isOnline ? translate('common.online') : translate('common.offline')}
-    </Text>
+    <Text accessibilityLabel={statusLabel}>{statusLabel}</Text>
 </View>
 
 // Error uses color + icon + text message

--- a/.claude/skills/coding-standards/rules/a11y-7-no-color-only-info.md
+++ b/.claude/skills/coding-standards/rules/a11y-7-no-color-only-info.md
@@ -36,7 +36,6 @@ Users with color vision deficiencies (8% of men, 0.5% of women) cannot distingui
 // Error uses color + icon + text message
 <TextInput
     style={[styles.input, hasError && styles.inputError]}
-    accessibilityState={{disabled: false}}
 />
 {hasError && (
     <View style={styles.errorRow}>

--- a/.claude/skills/coding-standards/rules/a11y-8-modal-focus-management.md
+++ b/.claude/skills/coding-standards/rules/a11y-8-modal-focus-management.md
@@ -1,0 +1,94 @@
+---
+ruleId: A11Y-8
+title: Manage focus for modals and overlays
+---
+
+## [A11Y-8] Manage focus for modals and overlays
+
+### Reasoning
+
+When a modal, bottom sheet, or popover opens, screen reader users can still navigate to content behind it unless focus is trapped inside the overlay. On iOS, use `accessibilityViewIsModal={true}` to make VoiceOver ignore sibling views. Focus should move to the modal's first interactive element on open and return to the trigger element on close. Without this, screen reader users can interact with obscured content, creating a confusing and broken experience. (WCAG 2.4.3, WCAG 2.4.11)
+
+### Incorrect
+
+```tsx
+// Modal with no focus management — screen reader can navigate behind it
+<Modal visible={isVisible}>
+    <View style={styles.modalContent}>
+        <Text>Confirm deletion?</Text>
+        <Pressable onPress={onConfirm}><Text>Delete</Text></Pressable>
+        <Pressable onPress={onCancel}><Text>Cancel</Text></Pressable>
+    </View>
+</Modal>
+
+// Bottom sheet that doesn't trap focus
+{isSheetOpen && (
+    <View style={styles.bottomSheet}>
+        <Text>Options</Text>
+        <Pressable onPress={onEdit}><Text>Edit</Text></Pressable>
+    </View>
+)}
+```
+
+### Correct
+
+```tsx
+// Modal with accessibility focus trapping
+<Modal visible={isVisible} onRequestClose={onCancel}>
+    <View
+        style={styles.modalContent}
+        accessibilityViewIsModal={true}
+    >
+        <Text accessibilityRole="header">Confirm deletion?</Text>
+        <Pressable
+            ref={firstFocusRef}
+            onPress={onConfirm}
+            accessibilityRole="button"
+            accessibilityLabel={translate('common.delete')}
+        >
+            <Text>Delete</Text>
+        </Pressable>
+        <Pressable
+            onPress={onCancel}
+            accessibilityRole="button"
+            accessibilityLabel={translate('common.cancel')}
+        >
+            <Text>Cancel</Text>
+        </Pressable>
+    </View>
+</Modal>
+
+// Bottom sheet with focus management
+{isSheetOpen && (
+    <View
+        style={styles.bottomSheet}
+        accessibilityViewIsModal={true}
+    >
+        <Text accessibilityRole="header">Options</Text>
+        <Pressable onPress={onEdit} accessibilityRole="button">
+            <Text>Edit</Text>
+        </Pressable>
+    </View>
+)}
+```
+
+---
+
+### Review Metadata
+
+Flag ONLY when ANY of these patterns is found:
+
+- `<Modal>` or custom modal/overlay component with **no** `accessibilityViewIsModal` on the content container
+- Bottom sheet or popover overlay with **no** `accessibilityViewIsModal`
+- Modal/overlay that does **not** handle `onRequestClose` (Android back button dismissal)
+
+**DO NOT flag if:**
+
+- Using a shared modal/dialog component that already sets `accessibilityViewIsModal` internally
+- Overlay is non-blocking (e.g., tooltip that doesn't obscure primary content)
+- Component uses React Navigation modal which handles focus management
+
+**Search Patterns** (hints for reviewers):
+- `<Modal` without `accessibilityViewIsModal`
+- Custom overlay/sheet components
+- `visible={` / `isVisible` conditionally rendered overlays

--- a/.claude/skills/coding-standards/rules/a11y-8-modal-focus-management.md
+++ b/.claude/skills/coding-standards/rules/a11y-8-modal-focus-management.md
@@ -9,8 +9,8 @@ title: Manage focus for modals and overlays
 
 When a modal, bottom sheet, or popover opens, screen reader users can still navigate to content behind it unless focus is trapped inside the overlay. Platform-specific handling is required:
 
-- **iOS**: Use `accessibilityViewIsModal={true}` (or `aria-modal`) on the modal container — VoiceOver will ignore sibling views. No `aria-*` alternative exists for hiding background content on Android.
-- **Android**: Use `importantForAccessibility="no-hide-descendants"` on the background content to hide it from TalkBack. There is no ARIA equivalent for this prop.
+- **iOS**: Use `accessibilityViewIsModal={true}` on the modal container — VoiceOver will ignore sibling views.
+- **Android**: Use `importantForAccessibility="no-hide-descendants"` on the background content to hide it from TalkBack.
 
 Focus should move to the modal's first interactive element on open and return to the trigger on close. (WCAG 2.4.3, 2.1.2)
 

--- a/.claude/skills/coding-standards/rules/a11y-8-modal-focus-management.md
+++ b/.claude/skills/coding-standards/rules/a11y-8-modal-focus-management.md
@@ -7,7 +7,12 @@ title: Manage focus for modals and overlays
 
 ### Reasoning
 
-When a modal, bottom sheet, or popover opens, screen reader users can still navigate to content behind it unless focus is trapped inside the overlay. On iOS, use `accessibilityViewIsModal={true}` to make VoiceOver ignore sibling views. Focus should move to the modal's first interactive element on open and return to the trigger element on close. Without this, screen reader users can interact with obscured content, creating a confusing and broken experience. (WCAG 2.4.3, WCAG 2.4.11)
+When a modal, bottom sheet, or popover opens, screen reader users can still navigate to content behind it unless focus is trapped inside the overlay. Platform-specific handling is required:
+
+- **iOS**: Use `accessibilityViewIsModal={true}` (or `aria-modal`) on the modal container — VoiceOver will ignore sibling views. No `aria-*` alternative exists for hiding background content on Android.
+- **Android**: Use `importantForAccessibility="no-hide-descendants"` on the background content to hide it from TalkBack. There is no ARIA equivalent for this prop.
+
+Focus should move to the modal's first interactive element on open and return to the trigger on close. (WCAG 2.4.3, 2.1.2)
 
 ### Incorrect
 
@@ -33,43 +38,35 @@ When a modal, bottom sheet, or popover opens, screen reader users can still navi
 ### Correct
 
 ```tsx
-// Modal with accessibility focus trapping
+// Modal with cross-platform focus trapping
 <Modal visible={isVisible} onRequestClose={onCancel}>
     <View
         style={styles.modalContent}
-        accessibilityViewIsModal={true}
+        accessibilityViewIsModal={true}  // iOS: VoiceOver ignores siblings
     >
         <Text accessibilityRole="header">Confirm deletion?</Text>
         <Pressable
             ref={firstFocusRef}
             onPress={onConfirm}
             accessibilityRole="button"
-            accessibilityLabel={translate('common.delete')}
         >
             <Text>Delete</Text>
         </Pressable>
         <Pressable
             onPress={onCancel}
             accessibilityRole="button"
-            accessibilityLabel={translate('common.cancel')}
         >
             <Text>Cancel</Text>
         </Pressable>
     </View>
 </Modal>
-
-// Bottom sheet with focus management
-{isSheetOpen && (
-    <View
-        style={styles.bottomSheet}
-        accessibilityViewIsModal={true}
-    >
-        <Text accessibilityRole="header">Options</Text>
-        <Pressable onPress={onEdit} accessibilityRole="button">
-            <Text>Edit</Text>
-        </Pressable>
-    </View>
-)}
+{/* Android: hide background from TalkBack when modal is open */}
+<View
+    style={styles.backgroundContent}
+    importantForAccessibility={isVisible ? 'no-hide-descendants' : 'auto'}
+>
+    {/* ... app content ... */}
+</View>
 ```
 
 ---
@@ -78,8 +75,8 @@ When a modal, bottom sheet, or popover opens, screen reader users can still navi
 
 Flag ONLY when ANY of these patterns is found:
 
-- `<Modal>` or custom modal/overlay component with **no** `accessibilityViewIsModal` on the content container
-- Bottom sheet or popover overlay with **no** `accessibilityViewIsModal`
+- `<Modal>` or custom modal/overlay component with **no** `accessibilityViewIsModal` (iOS) and **no** `importantForAccessibility="no-hide-descendants"` on background (Android)
+- Bottom sheet or popover overlay with **no** focus trapping mechanism
 - Modal/overlay that does **not** handle `onRequestClose` (Android back button dismissal)
 
 **DO NOT flag if:**
@@ -89,6 +86,6 @@ Flag ONLY when ANY of these patterns is found:
 - Component uses React Navigation modal which handles focus management
 
 **Search Patterns** (hints for reviewers):
-- `<Modal` without `accessibilityViewIsModal`
+- `<Modal` without `accessibilityViewIsModal` or `importantForAccessibility`
 - Custom overlay/sheet components
 - `visible={` / `isVisible` conditionally rendered overlays

--- a/.claude/skills/coding-standards/rules/a11y-8-modal-focus-management.md
+++ b/.claude/skills/coding-standards/rules/a11y-8-modal-focus-management.md
@@ -81,6 +81,7 @@ Flag ONLY when ANY of these patterns is found:
 
 **DO NOT flag if:**
 
+- Using React Native's built-in `<Modal>` component (it renders in a separate native window/dialog that already isolates focus)
 - Using a shared modal/dialog component that already sets `accessibilityViewIsModal` internally
 - Overlay is non-blocking (e.g., tooltip that doesn't obscure primary content)
 - Component uses React Navigation modal which handles focus management

--- a/.claude/skills/coding-standards/rules/a11y-8-modal-focus-management.md
+++ b/.claude/skills/coding-standards/rules/a11y-8-modal-focus-management.md
@@ -9,7 +9,7 @@ title: Manage focus for modals and overlays
 
 When a modal, bottom sheet, or popover opens, screen reader users can still navigate to content behind it unless focus is trapped inside the overlay. Platform-specific handling is required:
 
-- **iOS**: Use `accessibilityViewIsModal={true}` on the modal container — VoiceOver will ignore sibling views.
+- **iOS/Web**: Use `accessibilityViewIsModal={true}` on the modal container — VoiceOver ignores sibling views, and React Native Web maps it to `aria-modal`.
 - **Android**: Use `importantForAccessibility="no-hide-descendants"` on the background content to hide it from TalkBack.
 
 Focus should move to the modal's first interactive element on open and return to the trigger on close. (WCAG 2.4.3, 2.1.2)

--- a/.claude/skills/coding-standards/rules/a11y-9-drag-alternatives.md
+++ b/.claude/skills/coding-standards/rules/a11y-9-drag-alternatives.md
@@ -1,0 +1,98 @@
+---
+ruleId: A11Y-9
+title: Provide single-pointer alternatives for drag interactions
+---
+
+## [A11Y-9] Provide single-pointer alternatives for drag interactions
+
+### Reasoning
+
+Drag-and-drop, swipe-to-delete, pinch-to-zoom, and other gesture-based interactions are inaccessible to users relying on screen readers, switch controls, or keyboard navigation. WCAG 2.5.7 requires that every dragging operation has a single-pointer alternative (tap/click). Provide buttons, menus, or other accessible controls that achieve the same result. (WCAG 2.5.1, 2.5.7)
+
+### Incorrect
+
+```tsx
+// Reorderable list with drag-only reordering — no alternative for assistive tech
+<DraggableFlatList
+    data={items}
+    renderItem={({item, drag}) => (
+        <Pressable onLongPress={drag}>
+            <Text>{item.name}</Text>
+        </Pressable>
+    )}
+    onDragEnd={({data}) => setItems(data)}
+/>
+
+// Swipe-to-delete with no button alternative
+<Swipeable renderRightActions={() => <DeleteAction />}>
+    <ListItem title={item.name} />
+</Swipeable>
+```
+
+### Correct
+
+```tsx
+// Reorderable list with move up/down buttons as accessible alternative
+<DraggableFlatList
+    data={items}
+    renderItem={({item, drag, getIndex}) => (
+        <View style={styles.row}>
+            <Pressable onLongPress={drag} accessibilityLabel={translate('common.dragToReorder')}>
+                <Icon src={Expensicons.DragHandle} />
+            </Pressable>
+            <Text>{item.name}</Text>
+            <Pressable
+                onPress={() => moveItem(getIndex(), 'up')}
+                accessibilityLabel={translate('common.moveUp')}
+                accessibilityRole="button"
+            >
+                <Icon src={Expensicons.UpArrow} />
+            </Pressable>
+            <Pressable
+                onPress={() => moveItem(getIndex(), 'down')}
+                accessibilityLabel={translate('common.moveDown')}
+                accessibilityRole="button"
+            >
+                <Icon src={Expensicons.DownArrow} />
+            </Pressable>
+        </View>
+    )}
+    onDragEnd={({data}) => setItems(data)}
+/>
+
+// Swipeable with accessible delete action via context menu or button
+<Swipeable renderRightActions={() => <DeleteAction />}>
+    <ListItem
+        title={item.name}
+        accessibilityActions={[{name: 'delete', label: translate('common.delete')}]}
+        onAccessibilityAction={(event) => {
+            if (event.nativeEvent.actionName === 'delete') {
+                deleteItem(item.id);
+            }
+        }}
+    />
+</Swipeable>
+```
+
+---
+
+### Review Metadata
+
+Flag ONLY when ANY of these patterns is found:
+
+- `DraggableFlatList` or drag-and-drop with **no** visible move/reorder buttons or `accessibilityActions`
+- `Swipeable` component with **no** accessible alternative (button, menu item, or `accessibilityActions`)
+- Pinch-to-zoom with **no** zoom buttons
+- Any gesture-only interaction (`onLongPress` for drag, pan gestures for reorder) with **no** tap-based alternative
+
+**DO NOT flag if:**
+
+- Accessible alternative controls are provided (buttons, menus, accessibility actions)
+- The gesture is supplementary to an existing tap-based primary interaction
+- Component is purely decorative or non-functional (e.g., animation)
+
+**Search Patterns** (hints for reviewers):
+- `DraggableFlatList` / `Draggable` / `drag`
+- `Swipeable` / `SwipeableRow`
+- `onLongPress` used for drag initiation
+- `PanGestureHandler` for reordering

--- a/.claude/skills/coding-standards/rules/a11y-9-drag-alternatives.md
+++ b/.claude/skills/coding-standards/rules/a11y-9-drag-alternatives.md
@@ -86,12 +86,13 @@ Flag ONLY when ANY of these patterns is found:
 - `DraggableFlatList` or drag-and-drop with **no** visible move/reorder buttons or `accessibilityActions`
 - `Swipeable` component with **no** accessible alternative (button, menu item, or `accessibilityActions`)
 - Pinch-to-zoom with **no** zoom buttons
-- Any gesture-only interaction (`onLongPress` for drag, pan gestures for reorder) with **no** tap-based alternative
+- `onLongPress` used specifically to initiate a drag/reorder operation (e.g., `onLongPress={drag}`) with **no** tap-based alternative — do NOT flag `onLongPress` used for context menus or secondary actions, as long press is accessible via double-tap-and-hold
 
 **DO NOT flag if:**
 
 - Accessible alternative controls are provided (buttons, menus, accessibility actions)
 - The gesture is supplementary to an existing tap-based primary interaction
+- `onLongPress` is used for context menus or secondary actions (not drag initiation)
 - Component is purely decorative or non-functional (e.g., animation)
 
 **Search Patterns** (hints for reviewers):

--- a/.claude/skills/coding-standards/rules/a11y-9-drag-alternatives.md
+++ b/.claude/skills/coding-standards/rules/a11y-9-drag-alternatives.md
@@ -35,28 +35,31 @@ Drag-and-drop, swipe-to-delete, pinch-to-zoom, and other gesture-based interacti
 // Reorderable list with move up/down buttons as accessible alternative
 <DraggableFlatList
     data={items}
-    renderItem={({item, drag, getIndex}) => (
-        <View style={styles.row}>
-            <Pressable onLongPress={drag} accessibilityLabel={translate('common.dragToReorder')}>
-                <Icon src={Expensicons.DragHandle} />
-            </Pressable>
-            <Text>{item.name}</Text>
-            <Pressable
-                onPress={() => moveItem(getIndex(), 'up')}
-                accessibilityLabel={translate('common.moveUp')}
-                accessibilityRole="button"
-            >
-                <Icon src={Expensicons.UpArrow} />
-            </Pressable>
-            <Pressable
-                onPress={() => moveItem(getIndex(), 'down')}
-                accessibilityLabel={translate('common.moveDown')}
-                accessibilityRole="button"
-            >
-                <Icon src={Expensicons.DownArrow} />
-            </Pressable>
-        </View>
-    )}
+    renderItem={({item, drag, isActive}) => {
+        const index = items.indexOf(item);
+        return (
+            <View style={styles.row}>
+                <Pressable onLongPress={drag} accessibilityLabel={translate('common.dragToReorder')}>
+                    <Icon src={Expensicons.DragHandle} />
+                </Pressable>
+                <Text>{item.name}</Text>
+                <Pressable
+                    onPress={() => moveItem(index, 'up')}
+                    accessibilityLabel={translate('common.moveUp')}
+                    accessibilityRole="button"
+                >
+                    <Icon src={Expensicons.UpArrow} />
+                </Pressable>
+                <Pressable
+                    onPress={() => moveItem(index, 'down')}
+                    accessibilityLabel={translate('common.moveDown')}
+                    accessibilityRole="button"
+                >
+                    <Icon src={Expensicons.DownArrow} />
+                </Pressable>
+            </View>
+        );
+    }}
     onDragEnd={({data}) => setItems(data)}
 />
 


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
<!-- Explain what your change does and how it addresses the linked issue -->

Note: I used claude to generate this PR

Tested here 
- https://github.com/Expensify/App/pull/85025#issuecomment-4048003232

Added 12 accessibility review rules

Rules enforce WCAG 2.2 AA compliance for React Native, covering: accessible labels, semantic roles, state communication, touch target sizes, dynamic content announcements, image accessibility, color-only information, modal focus management, drag alternatives, text scaling, form accessibility, and logical focus order

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/95910
PROPOSAL:


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->
// TODO: These must be filled out, or the issue title must include "[No QA]."

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>