### PR TITLE
Fix iOS phone number input showing random Go button

### DIFF
--- a/src/pages/settings/Profile/PersonalDetails/PhoneNumberPage.tsx
+++ b/src/pages/settings/Profile/PersonalDetails/PhoneNumberPage.tsx
@@ -113,6 +113,7 @@ function PhoneNumberPage() {
                                 defaultValue={phoneNumber}
                                 spellCheck={false}
                                 inputMode={CONST.INPUT_MODE.TEL}
+                                enterKeyHint="done"
                                 onBlur={() => {
                                     if (!validateLoginError) {
                                         return;


### PR DESCRIPTION
## Fixed Issues
$ #85005

## Changes
- Added enterKeyHint=done to the phone number TextInput component in PhoneNumberPage.tsx
- This prevents iOS from displaying the default Go button on the keyboard

## Tests
- [x] Verified the fix addresses the issue described in #85005
- [x] No regression in other input fields
- [x] Form submission still works correctly