### PR TITLE
Fix onboarding flow for BYOC users selecting 'Get paid back from my employer'

### DIFF
--- a/src/pages/OnboardingPersonalDetails/BaseOnboardingPersonalDetails.tsx
+++ b/src/pages/OnboardingPersonalDetails/BaseOnboardingPersonalDetails.tsx
@@ -133,7 +133,11 @@ function BaseOnboardingPersonalDetails({currentUserPersonalDetails, shouldUseNat
                 return;
             }
 
-            if (onboardingPurposeSelected === CONST.ONBOARDING_CHOICES.PERSONAL_SPEND || onboardingPurposeSelected === CONST.ONBOARDING_CHOICES.TRACK_WORKSPACE) {
+            if (
+                onboardingPurposeSelected === CONST.ONBOARDING_CHOICES.PERSONAL_SPEND ||
+                onboardingPurposeSelected === CONST.ONBOARDING_CHOICES.TRACK_WORKSPACE ||
+                onboardingPurposeSelected === CONST.ONBOARDING_CHOICES.EMPLOYER
+            ) {
                 updateDisplayName(firstName, lastName, formatPhoneNumber, session?.accountID ?? CONST.DEFAULT_NUMBER_ID, session?.email ?? '');
                 Navigation.navigate(ROUTES.ONBOARDING_WORKSPACE.getRoute(route.params?.backTo));
                 return;


### PR DESCRIPTION
## Problem

BYOC (Bring Your Own Company) users who select "Get paid back from my employer" during onboarding were not properly supported. These users are signing up for Expensify because their employer uses it, but they have not yet been invited to their company's workspace.

**Current behavior:**
- When BYOC users select "Get paid back from my employer" (EMPLOYER choice), the flow directly calls `completeOnboarding()` without giving them the option to create a workspace or proceed with expense tracking.
- Users are effectively forced to skip the step.

**Expected behavior:**
- BYOC users should have the option to:
  1. Create a workspace, or
  2. Continue with "Track and budget expenses" if reimbursement via Expensify is not applicable yet.

## Solution

Modified `BaseOnboardingPersonalDetails.tsx` to include EMPLOYER choice in the condition that navigates users to the workspace page. This allows BYOC users to create a workspace or proceed with expense tracking options.

## Testing

1. Create a new Expensify account without being invited to a workspace
2. During onboarding, select "Get paid back from my employer"
3. Enter personal details
4. Verify that the user is navigated to the workspace page
5. Verify that the user can create a new workspace or continue with expense tracking options

## Related

$ https://github.com/Expensify/App/issues/84994
