### PR TITLE
[CP Staging] Revert "fix: Confirm page shows Amount field with 0.00 amount when receipt is scanning v2"

### DIFF
--- a/src/components/MoneyRequestConfirmationList.tsx
+++ b/src/components/MoneyRequestConfirmationList.tsx
@@ -55,7 +55,6 @@ import {
     hasRoute as hasRouteUtil,
     hasTaxRateWithMatchingValue,
     isMerchantMissing,
-    isScanning,
     isScanRequest as isScanRequestUtil,
 } from '@libs/TransactionUtils';
 import {getIsViolationFixed} from '@libs/Violations/ViolationsUtils';
@@ -405,12 +404,7 @@ function MoneyRequestConfirmationList({
         amountToBeUsed = perDiemRequestAmount;
     }
 
-    let formattedAmount = convertToDisplayString(amountToBeUsed, isDistanceRequest ? currency : iouCurrencyCode);
-    if (isDistanceRequestWithPendingRoute) {
-        formattedAmount = '';
-    } else if (isScanning(transaction)) {
-        formattedAmount = translate('iou.receiptStatusTitle');
-    }
+    const formattedAmount = isDistanceRequestWithPendingRoute ? '' : convertToDisplayString(amountToBeUsed, isDistanceRequest ? currency : iouCurrencyCode);
     const formattedAmountPerAttendee =
         isDistanceRequestWithPendingRoute || isScanRequest
             ? ''

--- a/src/libs/actions/IOU/index.ts
+++ b/src/libs/actions/IOU/index.ts
@@ -1430,21 +1430,12 @@ function startDistanceRequest(
     }
 }
 
-function setMoneyRequestReceiptState(transactionID: string, isDraft: boolean) {
-    if (!isDraft) {
-        return;
-    }
-    Onyx.merge(`${ONYXKEYS.COLLECTION.TRANSACTION_DRAFT}${transactionID}`, {receipt: {state: CONST.IOU.RECEIPT_STATE.OPEN}});
-}
-
 function setMoneyRequestAmount(transactionID: string, amount: number, currency: string, shouldShowOriginalAmount = false) {
     Onyx.merge(`${ONYXKEYS.COLLECTION.TRANSACTION_DRAFT}${transactionID}`, {amount, currency, shouldShowOriginalAmount});
-    setMoneyRequestReceiptState(transactionID, true);
 }
 
 function setMoneyRequestCreated(transactionID: string, created: string, isDraft: boolean) {
     Onyx.merge(`${isDraft ? ONYXKEYS.COLLECTION.TRANSACTION_DRAFT : ONYXKEYS.COLLECTION.TRANSACTION}${transactionID}`, {created});
-    setMoneyRequestReceiptState(transactionID, isDraft);
 }
 
 function setMoneyRequestDateAttribute(transactionID: string, start: string, end: string) {
@@ -1458,12 +1449,10 @@ function setMoneyRequestCurrency(transactionID: string, currency: string, isEdit
 
 function setMoneyRequestDescription(transactionID: string, comment: string, isDraft: boolean) {
     Onyx.merge(`${isDraft ? ONYXKEYS.COLLECTION.TRANSACTION_DRAFT : ONYXKEYS.COLLECTION.TRANSACTION}${transactionID}`, {comment: {comment: comment.trim()}});
-    setMoneyRequestReceiptState(transactionID, isDraft);
 }
 
 function setMoneyRequestMerchant(transactionID: string, merchant: string, isDraft: boolean) {
     Onyx.merge(`${isDraft ? ONYXKEYS.COLLECTION.TRANSACTION_DRAFT : ONYXKEYS.COLLECTION.TRANSACTION}${transactionID}`, {merchant});
-    setMoneyRequestReceiptState(transactionID, isDraft);
 }
 
 function setMoneyRequestAttendees(transactionID: string, attendees: Attendee[], isDraft: boolean) {


### PR DESCRIPTION
Reverts Expensify/App#82672

Fixes this [deploy blocker](https://github.com/Expensify/App/issues/85152)

Test:
1. Go to a 1:1 DM or Group
2. Create a split expense with only amount
3. Ensure a Receipt is missing error does not show up

<img width="1158" height="826" alt="image" src="https://github.com/user-attachments/assets/8655edd2-e302-4be1-9247-10a147c638d5" />