### PR TITLE
fix: ensure Per Diem amount and destination inputs are focused on iOS

### DIFF
--- a/src/pages/workspace/perDiem/EditPerDiemAmountPage.tsx
+++ b/src/pages/workspace/perDiem/EditPerDiemAmountPage.tsx
@@ -100,6 +100,7 @@ function EditPerDiemAmountPage({route}: EditPerDiemAmountPageProps) {
                         role={CONST.ROLE.PRESENTATION}
                         shouldAllowNegative
                         uncontrolled
+                        autoFocus
                     />
                 </FormProvider>
             </ScreenWrapper>

--- a/src/pages/workspace/perDiem/EditPerDiemDestinationPage.tsx
+++ b/src/pages/workspace/perDiem/EditPerDiemDestinationPage.tsx
@@ -106,6 +106,7 @@ function EditPerDiemDestinationPage({route}: EditPerDiemDestinationPageProps) {
                         accessibilityLabel={translate('common.destination')}
                         inputID={INPUT_IDS.DESTINATION}
                         role={CONST.ROLE.PRESENTATION}
+                        autoFocus
                     />
                 </FormProvider>
             </ScreenWrapper>


### PR DESCRIPTION
### Details
This PR adds the  autoFocus  prop to the  InputWrapper  in both  EditPerDiemAmountPage  and  EditPerDiemDestinationPage . This ensures that the input field is automatically focused when the page is opened, addressing the issue reported on iOS.

### Fixed Issues
$ https://github.com/Expensify/App/issues/85277

### Tests
1. Navigate to the Per Diem page on iOS.
2. Select a rate.
3. Edit the amount or destination.
4. Verify that the input field is automatically focused.

### Upwork Profile
https://www.upwork.com/freelancers/~0189d53c544e3e3b3c