### PR TITLE
Fix: Render the receipts email as a properly announced copy button on Contact Methods

### DIFF
--- a/src/languages/de.ts
+++ b/src/languages/de.ts
@@ -1854,8 +1854,10 @@ const translations: TranslationDeepObject<typeof en> = {
         contactMethods: 'Kontaktmethoden',
         featureRequiresValidate: 'Für diese Funktion müssen Sie Ihr Konto verifizieren.',
         validateAccount: 'Bestätige dein Konto',
-        helpText: ({email}: {email: string}) =>
-            `Füge weitere Möglichkeiten hinzu, dich anzumelden und Belege an Expensify zu senden.<br/><br/>Füge eine E‑Mail-Adresse hinzu, um Belege an <a href="mailto:${email}">${email}</a> weiterzuleiten, oder füge eine Telefonnummer hinzu, um Belege per SMS an 47777 zu senden (nur US-Nummern).`,
+        helpText: 'Füge weitere Möglichkeiten hinzu, dich anzumelden und Belege an Expensify zu senden.',
+        helpTextBeforeEmail: 'Füge eine E‑Mail-Adresse hinzu, um Belege an',
+        helpTextAfterEmail: ({phoneNumber}: {phoneNumber: string}) => `weiterzuleiten, oder füge eine Telefonnummer hinzu, um Belege per SMS an ${phoneNumber} zu senden (nur US-Nummern).`,
+        copyEmailAddress: ({email}: {email: string}) => `E-Mail-Adresse kopieren, ${email}`,
         pleaseVerify: 'Bitte bestätige diese Kontaktmethode.',
         getInTouch: 'Wir verwenden diese Methode, um Sie zu kontaktieren.',
         enterMagicCode: (contactMethod: string) => `Bitte gib den magischen Code ein, der an ${contactMethod} gesendet wurde. Er sollte innerhalb einer oder zwei Minuten ankommen.`,

--- a/src/languages/en.ts
+++ b/src/languages/en.ts
@@ -1899,8 +1899,10 @@ const translations = {
         contactMethods: 'Contact methods',
         featureRequiresValidate: 'This feature requires you to validate your account.',
         validateAccount: 'Validate your account',
-        helpText: ({email}: {email: string}) =>
-            `Add more ways to log in and send receipts to Expensify.<br/><br/>Add an email address to forward receipts to <a href="mailto:${email}">${email}</a> or add a phone number to text receipts to 47777 (US numbers only).`,
+        helpText: 'Add more ways to log in and send receipts to Expensify.',
+        helpTextBeforeEmail: 'Add an email address to forward receipts to',
+        helpTextAfterEmail: ({phoneNumber}: {phoneNumber: string}) => `or add a phone number to text receipts to ${phoneNumber} (US numbers only).`,
+        copyEmailAddress: ({email}: {email: string}) => `Copy email address, ${email}`,
         pleaseVerify: 'Please verify this contact method.',
         getInTouch: "We'll use this method to contact you.",
         enterMagicCode: (contactMethod: string) => `Please enter the magic code sent to ${contactMethod}. It should arrive within a minute or two.`,

--- a/src/languages/es.ts
+++ b/src/languages/es.ts
@@ -1728,8 +1728,10 @@ const translations: TranslationDeepObject<typeof en> = {
         contactMethods: 'Métodos de contacto',
         featureRequiresValidate: 'Esta función requiere que valides tu cuenta.',
         validateAccount: 'Valida tu cuenta',
-        helpText: ({email}: {email: string}) =>
-            `Agrega más formas de iniciar sesión y enviar recibos a Expensify.<br/><br/>Agrega una dirección de correo electrónico para reenviar recibos a <a href="mailto:${email}">${email}</a> o agrega un número de teléfono para enviar recibos por mensaje de texto al 47777 (solo números de EE. UU.).`,
+        helpText: 'Agrega más formas de iniciar sesión y enviar recibos a Expensify.',
+        helpTextBeforeEmail: 'Agrega una dirección de correo electrónico para reenviar recibos a',
+        helpTextAfterEmail: ({phoneNumber}: {phoneNumber: string}) => `o agrega un número de teléfono para enviar recibos por mensaje de texto al ${phoneNumber} (solo números de EE. UU.).`,
+        copyEmailAddress: ({email}: {email: string}) => `Copiar dirección de correo electrónico, ${email}`,
         pleaseVerify: 'Por favor, verifica este método de contacto.',
         getInTouch: 'Usaremos este método para comunicarnos contigo.',
         enterMagicCode: (contactMethod) => `Por favor, introduce el código mágico enviado a ${contactMethod}. Debería llegar en un par de minutos.`,

--- a/src/languages/fr.ts
+++ b/src/languages/fr.ts
@@ -1859,8 +1859,10 @@ const translations: TranslationDeepObject<typeof en> = {
         contactMethods: 'Moyens de contact',
         featureRequiresValidate: 'Cette fonctionnalité exige que vous validiez votre compte.',
         validateAccount: 'Validez votre compte',
-        helpText: ({email}: {email: string}) =>
-            `Ajoutez d'autres moyens de vous connecter et d'envoyer des reçus à Expensify.<br/><br/>Ajoutez une adresse e-mail pour transférer des reçus à <a href="mailto:${email}">${email}</a> ou ajoutez un numéro de téléphone pour envoyer des reçus par SMS au 47777 (numéros américains uniquement).`,
+        helpText: "Ajoutez d'autres moyens de vous connecter et d'envoyer des reçus à Expensify.",
+        helpTextBeforeEmail: 'Ajoutez une adresse e-mail pour transférer des reçus à',
+        helpTextAfterEmail: ({phoneNumber}: {phoneNumber: string}) => `ou ajoutez un numéro de téléphone pour envoyer des reçus par SMS au ${phoneNumber} (numéros américains uniquement).`,
+        copyEmailAddress: ({email}: {email: string}) => `Copier l'adresse e-mail, ${email}`,
         pleaseVerify: 'Veuillez vérifier cette méthode de contact.',
         getInTouch: 'Nous utiliserons cette méthode pour vous contacter.',
         enterMagicCode: (contactMethod: string) => `Veuillez saisir le code magique envoyé à ${contactMethod}. Il devrait arriver d'ici une à deux minutes.`,

--- a/src/languages/it.ts
+++ b/src/languages/it.ts
@@ -1850,8 +1850,10 @@ const translations: TranslationDeepObject<typeof en> = {
         contactMethods: 'Metodi di contatto',
         featureRequiresValidate: 'Questa funzione richiede la verifica del tuo account.',
         validateAccount: 'Verifica il tuo account',
-        helpText: ({email}: {email: string}) =>
-            `Aggiungi più modi per accedere e inviare ricevute a Expensify.<br/><br/>Aggiungi un indirizzo email per inoltrare le ricevute a <a href="mailto:${email}">${email}</a> oppure aggiungi un numero di telefono per inviare ricevute tramite SMS al 47777 (solo numeri statunitensi).`,
+        helpText: 'Aggiungi più modi per accedere e inviare ricevute a Expensify.',
+        helpTextBeforeEmail: 'Aggiungi un indirizzo email per inoltrare le ricevute a',
+        helpTextAfterEmail: ({phoneNumber}: {phoneNumber: string}) => `oppure aggiungi un numero di telefono per inviare ricevute tramite SMS al ${phoneNumber} (solo numeri statunitensi).`,
+        copyEmailAddress: ({email}: {email: string}) => `Copia indirizzo email, ${email}`,
         pleaseVerify: 'Verifica questo metodo di contatto.',
         getInTouch: 'Useremo questo metodo per contattarti.',
         enterMagicCode: (contactMethod: string) => `Inserisci il codice magico inviato a ${contactMethod}. Dovrebbe arrivare entro uno o due minuti.`,

--- a/src/languages/ja.ts
+++ b/src/languages/ja.ts
@@ -1839,8 +1839,11 @@ const translations: TranslationDeepObject<typeof en> = {
         contactMethods: '連絡方法',
         featureRequiresValidate: 'この機能を利用するには、アカウントの認証が必要です。',
         validateAccount: 'アカウントを認証する',
-        helpText: ({email}: {email: string}) =>
-            `Expensify へのログイン方法とレシート送信方法をさらに追加しましょう。<br/><br/>レシートを <a href="mailto:${email}">${email}</a> に転送するメールアドレスを追加するか、レシートを 47777（米国の電話番号のみ）宛てにテキスト送信する電話番号を追加してください。`,
+        helpText: 'Expensify へのログイン方法とレシート送信方法をさらに追加しましょう。',
+        helpTextBeforeEmail: 'レシートを',
+        helpTextAfterEmail: ({phoneNumber}: {phoneNumber: string}) =>
+            `に転送するメールアドレスを追加するか、レシートを ${phoneNumber}（米国の電話番号のみ）宛てにテキスト送信する電話番号を追加してください。`,
+        copyEmailAddress: ({email}: {email: string}) => `メールアドレスをコピー、${email}`,
         pleaseVerify: 'この連絡方法を確認してください。',
         getInTouch: '今後のご連絡にはこの方法を使用します。',
         enterMagicCode: (contactMethod: string) => `${contactMethod} に送信されたマジックコードを入力してください。1～2分以内に届きます。`,

--- a/src/languages/nl.ts
+++ b/src/languages/nl.ts
@@ -1847,8 +1847,10 @@ const translations: TranslationDeepObject<typeof en> = {
         contactMethods: 'Contactmethoden',
         featureRequiresValidate: 'Voor deze functie moet je je account verifiëren.',
         validateAccount: 'Valideer je account',
-        helpText: ({email}: {email: string}) =>
-            `Voeg meer manieren toe om in te loggen en bonnetjes naar Expensify te sturen.<br/><br/>Voeg een e-mailadres toe om bonnetjes door te sturen naar <a href="mailto:${email}">${email}</a> of voeg een telefoonnummer toe om bonnetjes te sms'en naar 47777 (alleen voor Amerikaanse nummers).`,
+        helpText: 'Voeg meer manieren toe om in te loggen en bonnetjes naar Expensify te sturen.',
+        helpTextBeforeEmail: 'Voeg een e-mailadres toe om bonnetjes door te sturen naar',
+        helpTextAfterEmail: ({phoneNumber}: {phoneNumber: string}) => `of voeg een telefoonnummer toe om bonnetjes te sms'en naar ${phoneNumber} (alleen voor Amerikaanse nummers).`,
+        copyEmailAddress: ({email}: {email: string}) => `E-mailadres kopiëren, ${email}`,
         pleaseVerify: 'Verifieer deze contactmethode.',
         getInTouch: 'We gebruiken deze methode om contact met je op te nemen.',
         enterMagicCode: (contactMethod: string) => `Voer de magische code in die naar ${contactMethod} is verzonden. Deze zou binnen een minuut of twee moeten aankomen.`,

--- a/src/languages/pl.ts
+++ b/src/languages/pl.ts
@@ -1848,8 +1848,10 @@ const translations: TranslationDeepObject<typeof en> = {
         contactMethods: 'Metody kontaktu',
         featureRequiresValidate: 'Ta funkcja wymaga zweryfikowania Twojego konta.',
         validateAccount: 'Zweryfikuj swoje konto',
-        helpText: ({email}: {email: string}) =>
-            `Dodaj więcej sposobów logowania i wysyłania paragonów do Expensify.<br/><br/>Dodaj adres e-mail, aby przekazywać paragony na <a href="mailto:${email}">${email}</a>, lub dodaj numer telefonu, aby wysyłać paragony SMS-em na 47777 (tylko numery z USA).`,
+        helpText: 'Dodaj więcej sposobów logowania i wysyłania paragonów do Expensify.',
+        helpTextBeforeEmail: 'Dodaj adres e-mail, aby przekazywać paragony na',
+        helpTextAfterEmail: ({phoneNumber}: {phoneNumber: string}) => `lub dodaj numer telefonu, aby wysyłać paragony SMS-em na ${phoneNumber} (tylko numery z USA).`,
+        copyEmailAddress: ({email}: {email: string}) => `Kopiuj adres e-mail, ${email}`,
         pleaseVerify: 'Zweryfikuj tę metodę kontaktu.',
         getInTouch: 'Użyjemy tej metody, aby się z Tobą skontaktować.',
         enterMagicCode: (contactMethod: string) => `Wpisz magiczny kod wysłany na ${contactMethod}. Powinien dotrzeć w ciągu minuty lub dwóch.`,

--- a/src/languages/pt-BR.ts
+++ b/src/languages/pt-BR.ts
@@ -1844,8 +1844,10 @@ const translations: TranslationDeepObject<typeof en> = {
         contactMethods: 'Métodos de contato',
         featureRequiresValidate: 'Este recurso exige que você valide sua conta.',
         validateAccount: 'Validar sua conta',
-        helpText: ({email}: {email: string}) =>
-            `Adicione mais formas de entrar e enviar recibos para o Expensify.<br/><br/>Adicione um endereço de e-mail para encaminhar recibos para <a href="mailto:${email}">${email}</a> ou adicione um número de telefone para enviar recibos por SMS para 47777 (apenas números dos EUA).`,
+        helpText: 'Adicione mais formas de entrar e enviar recibos para o Expensify.',
+        helpTextBeforeEmail: 'Adicione um endereço de e-mail para encaminhar recibos para',
+        helpTextAfterEmail: ({phoneNumber}: {phoneNumber: string}) => `ou adicione um número de telefone para enviar recibos por SMS para ${phoneNumber} (apenas números dos EUA).`,
+        copyEmailAddress: ({email}: {email: string}) => `Copiar endereço de e-mail, ${email}`,
         pleaseVerify: 'Verifique este método de contato.',
         getInTouch: 'Usaremos este método para entrar em contato com você.',
         enterMagicCode: (contactMethod: string) => `Insira o código mágico enviado para ${contactMethod}. Ele deve chegar em um ou dois minutos.`,

--- a/src/languages/zh-hans.ts
+++ b/src/languages/zh-hans.ts
@@ -1814,8 +1814,10 @@ const translations: TranslationDeepObject<typeof en> = {
         contactMethods: '联系方式',
         featureRequiresValidate: '此功能需要您验证您的账户。',
         validateAccount: '验证您的账户',
-        helpText: ({email}: {email: string}) =>
-            `添加更多登录方式并向 Expensify 发送收据。<br/><br/>添加一个电子邮箱地址，以便将收据转发到 <a href="mailto:${email}">${email}</a>，或者添加一个电话号码，以短信方式将收据发送到 47777（仅限美国号码）。`,
+        helpText: '添加更多登录方式并向 Expensify 发送收据。',
+        helpTextBeforeEmail: '添加一个电子邮箱地址，以便将收据转发到',
+        helpTextAfterEmail: ({phoneNumber}: {phoneNumber: string}) => `，或者添加一个电话号码，以短信方式将收据发送到 ${phoneNumber}（仅限美国号码）。`,
+        copyEmailAddress: ({email}: {email: string}) => `复制电子邮箱地址，${email}`,
         pleaseVerify: '请验证此联系方法。',
         getInTouch: '我们将通过此方式联系你。',
         enterMagicCode: (contactMethod: string) => `请输入发送至 ${contactMethod} 的魔法验证码。它应会在一两分钟内送达。`,

--- a/src/pages/settings/Profile/Contacts/ContactMethodsPage.tsx
+++ b/src/pages/settings/Profile/Contacts/ContactMethodsPage.tsx
@@ -8,12 +8,15 @@ import HeaderWithBackButton from '@components/HeaderWithBackButton';
 import {useLockedAccountActions, useLockedAccountState} from '@components/LockedAccountModalProvider';
 import MenuItem from '@components/MenuItem';
 import OfflineWithFeedback from '@components/OfflineWithFeedback';
-import RenderHTML from '@components/RenderHTML';
+import PressableWithDelayToggle from '@components/Pressable/PressableWithDelayToggle';
 import ScreenWrapper from '@components/ScreenWrapper';
 import ScrollView from '@components/ScrollView';
+import Text from '@components/Text';
+import {useMemoizedLazyExpensifyIcons} from '@hooks/useLazyAsset';
 import useLocalize from '@hooks/useLocalize';
 import useOnyx from '@hooks/useOnyx';
 import useThemeStyles from '@hooks/useThemeStyles';
+import Clipboard from '@libs/Clipboard';
 import Navigation from '@libs/Navigation/Navigation';
 import type {PlatformStackScreenProps} from '@libs/Navigation/PlatformStackNavigation/types';
 import type {SettingsNavigatorParamList} from '@libs/Navigation/types';
@@ -26,6 +29,7 @@ import type SCREENS from '@src/SCREENS';
 type ContactMethodsPageProps = PlatformStackScreenProps<SettingsNavigatorParamList, typeof SCREENS.SETTINGS.PROFILE.CONTACT_METHODS>;
 
 function ContactMethodsPage({route}: ContactMethodsPageProps) {
+    const icons = useMemoizedLazyExpensifyIcons(['Copy'] as const);
     const styles = useThemeStyles();
     const {translate} = useLocalize();
     const [loginList] = useOnyx(ONYXKEYS.LOGIN_LIST);
@@ -69,8 +73,24 @@ function ContactMethodsPage({route}: ContactMethodsPageProps) {
                 onBackButtonPress={() => Navigation.goBack()}
             />
             <ScrollView contentContainerStyle={styles.flexGrow1}>
-                <View style={[styles.ph5, styles.mv3, styles.flexRow, styles.flexWrap]}>
-                    <RenderHTML html={translate('contacts.helpText', {email: CONST.EMAIL.RECEIPTS})} />
+                <View style={[styles.ph5, styles.mv3]}>
+                    <Text style={styles.textLabelSupporting}>{translate('contacts.helpText')}</Text>
+                    <View style={[styles.mt4, styles.flexRow, styles.flexWrap, styles.alignItemsCenter, styles.gap1]}>
+                        <Text style={styles.textLabelSupporting}>{translate('contacts.helpTextBeforeEmail')}</Text>
+                        <PressableWithDelayToggle
+                            text={CONST.EMAIL.RECEIPTS}
+                            tooltipText=""
+                            tooltipTextChecked=""
+                            accessibilityLabel={translate('contacts.copyEmailAddress', {email: CONST.EMAIL.RECEIPTS})}
+                            icon={icons.Copy}
+                            inline={false}
+                            onPress={() => Clipboard.setString(CONST.EMAIL.RECEIPTS)}
+                            styles={styles.flexShrink1}
+                            textStyles={[styles.textLabelSupporting, styles.link, styles.flexShrink1]}
+                            sentryLabel={CONST.SENTRY_LABEL.COPY_TEXT_TO_CLIPBOARD.COPY_BUTTON}
+                        />
+                        <Text style={styles.textLabelSupporting}>{translate('contacts.helpTextAfterEmail', {phoneNumber: CONST.SMS.RECEIPTS_PHONE_NUMBER})}</Text>
+                    </View>
                 </View>
                 {options.map(
                     (option) =>

--- a/src/pages/settings/Profile/Contacts/ContactMethodsPage.tsx
+++ b/src/pages/settings/Profile/Contacts/ContactMethodsPage.tsx
@@ -31,7 +31,7 @@ type ContactMethodsPageProps = PlatformStackScreenProps<SettingsNavigatorParamLi
 function ContactMethodsPage({route}: ContactMethodsPageProps) {
     const icons = useMemoizedLazyExpensifyIcons(['Copy'] as const);
     const styles = useThemeStyles();
-    const {translate} = useLocalize();
+    const {translate, preferredLocale} = useLocalize();
     const [loginList] = useOnyx(ONYXKEYS.LOGIN_LIST);
     const [session] = useOnyx(ONYXKEYS.SESSION);
     const navigateBackTo = route?.params?.backTo;
@@ -43,6 +43,8 @@ function ContactMethodsPage({route}: ContactMethodsPageProps) {
     const {showLockedAccountModal} = useLockedAccountActions();
 
     const options = useMemo(() => getContactMethodsOptions(translate, loginList, session?.email), [translate, loginList, session?.email]);
+    const inlineSpacing = preferredLocale === CONST.LOCALES.JA || preferredLocale === CONST.LOCALES.ZH_HANS ? '' : ' ';
+    const receiptsEmailForDisplay = CONST.EMAIL.RECEIPTS.split('').join('\u2060');
 
     const onNewContactMethodButtonPress = useCallback(() => {
         if (isActingAsDelegate) {
@@ -75,22 +77,22 @@ function ContactMethodsPage({route}: ContactMethodsPageProps) {
             <ScrollView contentContainerStyle={styles.flexGrow1}>
                 <View style={[styles.ph5, styles.mv3]}>
                     <Text style={styles.textLabelSupporting}>{translate('contacts.helpText')}</Text>
-                    <View style={[styles.mt4, styles.flexRow, styles.flexWrap, styles.alignItemsCenter, styles.gap1]}>
-                        <Text style={styles.textLabelSupporting}>{translate('contacts.helpTextBeforeEmail')}</Text>
+                    <Text style={[styles.textLabelSupporting, styles.mt4]}>
+                        {translate('contacts.helpTextBeforeEmail')}
+                        {inlineSpacing}
                         <PressableWithDelayToggle
-                            text={CONST.EMAIL.RECEIPTS}
+                            text={receiptsEmailForDisplay}
                             tooltipText=""
                             tooltipTextChecked=""
                             accessibilityLabel={translate('contacts.copyEmailAddress', {email: CONST.EMAIL.RECEIPTS})}
                             icon={icons.Copy}
-                            inline={false}
                             onPress={() => Clipboard.setString(CONST.EMAIL.RECEIPTS)}
-                            styles={styles.flexShrink1}
-                            textStyles={[styles.textLabelSupporting, styles.link, styles.flexShrink1]}
+                            textStyles={[styles.textLabelSupporting, styles.link]}
                             sentryLabel={CONST.SENTRY_LABEL.COPY_TEXT_TO_CLIPBOARD.COPY_BUTTON}
                         />
-                        <Text style={styles.textLabelSupporting}>{translate('contacts.helpTextAfterEmail', {phoneNumber: CONST.SMS.RECEIPTS_PHONE_NUMBER})}</Text>
-                    </View>
+                        {inlineSpacing}
+                        {translate('contacts.helpTextAfterEmail', {phoneNumber: CONST.SMS.RECEIPTS_PHONE_NUMBER})}
+                    </Text>
                 </View>
                 {options.map(
                     (option) =>

--- a/src/pages/settings/Profile/Contacts/ContactMethodsPage.tsx
+++ b/src/pages/settings/Profile/Contacts/ContactMethodsPage.tsx
@@ -31,7 +31,7 @@ type ContactMethodsPageProps = PlatformStackScreenProps<SettingsNavigatorParamLi
 function ContactMethodsPage({route}: ContactMethodsPageProps) {
     const icons = useMemoizedLazyExpensifyIcons(['Copy'] as const);
     const styles = useThemeStyles();
-    const {translate, preferredLocale} = useLocalize();
+    const {translate} = useLocalize();
     const [loginList] = useOnyx(ONYXKEYS.LOGIN_LIST);
     const [session] = useOnyx(ONYXKEYS.SESSION);
     const navigateBackTo = route?.params?.backTo;
@@ -43,8 +43,6 @@ function ContactMethodsPage({route}: ContactMethodsPageProps) {
     const {showLockedAccountModal} = useLockedAccountActions();
 
     const options = useMemo(() => getContactMethodsOptions(translate, loginList, session?.email), [translate, loginList, session?.email]);
-    const inlineSpacing = preferredLocale === CONST.LOCALES.JA || preferredLocale === CONST.LOCALES.ZH_HANS ? '' : ' ';
-    const receiptsEmailForDisplay = CONST.EMAIL.RECEIPTS.split('').join('\u2060');
 
     const onNewContactMethodButtonPress = useCallback(() => {
         if (isActingAsDelegate) {
@@ -77,22 +75,22 @@ function ContactMethodsPage({route}: ContactMethodsPageProps) {
             <ScrollView contentContainerStyle={styles.flexGrow1}>
                 <View style={[styles.ph5, styles.mv3]}>
                     <Text style={styles.textLabelSupporting}>{translate('contacts.helpText')}</Text>
-                    <Text style={[styles.textLabelSupporting, styles.mt4]}>
-                        {translate('contacts.helpTextBeforeEmail')}
-                        {inlineSpacing}
+                    <View style={[styles.mt4, styles.flexRow, styles.flexWrap, styles.alignItemsCenter, styles.gap1]}>
+                        <Text style={styles.textLabelSupporting}>{translate('contacts.helpTextBeforeEmail')}</Text>
                         <PressableWithDelayToggle
-                            text={receiptsEmailForDisplay}
+                            text={CONST.EMAIL.RECEIPTS}
                             tooltipText=""
                             tooltipTextChecked=""
                             accessibilityLabel={translate('contacts.copyEmailAddress', {email: CONST.EMAIL.RECEIPTS})}
                             icon={icons.Copy}
+                            inline={false}
                             onPress={() => Clipboard.setString(CONST.EMAIL.RECEIPTS)}
-                            textStyles={[styles.textLabelSupporting, styles.link]}
+                            styles={styles.flexShrink1}
+                            textStyles={[styles.textLabelSupporting, styles.link, styles.flexShrink1]}
                             sentryLabel={CONST.SENTRY_LABEL.COPY_TEXT_TO_CLIPBOARD.COPY_BUTTON}
                         />
-                        {inlineSpacing}
-                        {translate('contacts.helpTextAfterEmail', {phoneNumber: CONST.SMS.RECEIPTS_PHONE_NUMBER})}
-                    </Text>
+                        <Text style={styles.textLabelSupporting}>{translate('contacts.helpTextAfterEmail', {phoneNumber: CONST.SMS.RECEIPTS_PHONE_NUMBER})}</Text>
+                    </View>
                 </View>
                 {options.map(
                     (option) =>

--- a/tests/ui/ContactMethodsPageTest.tsx
+++ b/tests/ui/ContactMethodsPageTest.tsx
@@ -1,14 +1,17 @@
-import {render, screen, waitFor} from '@testing-library/react-native';
+import {fireEvent, render, screen, waitFor} from '@testing-library/react-native';
 import React from 'react';
 import Onyx from 'react-native-onyx';
 import type {ValueOf} from 'type-fest';
 import ComposeProviders from '@components/ComposeProviders';
+import {LocaleContextProvider} from '@components/LocaleContextProvider';
+import Clipboard from '@libs/Clipboard';
 import ContactMethodsPage from '@pages/settings/Profile/Contacts/ContactMethodsPage';
 import DelegateNoAccessModalProvider from '@src/components/DelegateNoAccessModalProvider';
 import LockedAccountModalProvider from '@src/components/LockedAccountModalProvider';
-import type CONST from '@src/CONST';
+import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
 import waitForBatchedUpdates from '../utils/waitForBatchedUpdates';
+import waitForBatchedUpdatesWithAct from '../utils/waitForBatchedUpdatesWithAct';
 
 // Mock navigation used by the page
 jest.mock('@libs/Navigation/Navigation', () => ({
@@ -16,17 +19,6 @@ jest.mock('@libs/Navigation/Navigation', () => ({
     goBack: jest.fn(),
     getActiveRoute: jest.fn(() => ''),
 }));
-
-// Mock RenderHTML component
-jest.mock('@components/RenderHTML', () => {
-    const ReactMock = require('react') as typeof React;
-    const {Text} = require('react-native') as {Text: React.ComponentType<{children?: React.ReactNode}>};
-
-    return ({html}: {html: string}) => {
-        const plainText = html.replaceAll(/<[^>]*>/g, '');
-        return ReactMock.createElement(Text, null, plainText);
-    };
-});
 
 // Replace MenuItem with a simple test double that exposes props in the tree
 jest.mock('@components/MenuItem', () => {
@@ -44,12 +36,13 @@ describe('ContactMethodsPage', () => {
     });
 
     beforeEach(() => {
+        jest.clearAllMocks();
         return Onyx.clear();
     });
 
     function renderPage() {
         return render(
-            <ComposeProviders components={[LockedAccountModalProvider, DelegateNoAccessModalProvider]}>
+            <ComposeProviders components={[LocaleContextProvider, LockedAccountModalProvider, DelegateNoAccessModalProvider]}>
                 {/* @ts-expect-error - route typing is not necessary for this test */}
                 <ContactMethodsPage route={{params: {}}} />
             </ComposeProviders>,
@@ -147,5 +140,22 @@ describe('ContactMethodsPage', () => {
             // ContactMethodsPage sets brickRoadIndicator to 'info' for non-default unvalidated logins
             expect(node).toHaveTextContent('none-brickRoadIndicator');
         });
+    });
+
+    it('renders a dedicated copy control for the receipts email and copies it to the clipboard', async () => {
+        const setStringSpy = jest.spyOn(Clipboard, 'setString').mockImplementation(() => undefined);
+
+        renderPage();
+        await waitForBatchedUpdatesWithAct();
+
+        expect(screen.getByText('Add more ways to log in and send receipts to Expensify.')).toBeOnTheScreen();
+        expect(screen.getByText('Add an email address to forward receipts to')).toBeOnTheScreen();
+        expect(screen.getByText('or add a phone number to text receipts to 47777 (US numbers only).')).toBeOnTheScreen();
+        expect(screen.getByText(CONST.EMAIL.RECEIPTS)).toBeOnTheScreen();
+
+        const copyButton = screen.getByLabelText(`Copy email address, ${CONST.EMAIL.RECEIPTS}`);
+        fireEvent.press(copyButton);
+
+        expect(setStringSpy).toHaveBeenCalledWith(CONST.EMAIL.RECEIPTS);
     });
 });

--- a/tests/ui/ContactMethodsPageTest.tsx
+++ b/tests/ui/ContactMethodsPageTest.tsx
@@ -159,6 +159,9 @@ describe('ContactMethodsPage', () => {
         await waitForBatchedUpdatesWithAct();
 
         expect(screen.getByText('Add more ways to log in and send receipts to Expensify.')).toBeOnTheScreen();
+        expect(screen.getByText('Add an email address to forward receipts to')).toBeOnTheScreen();
+        expect(screen.getByText('or add a phone number to text receipts to 47777 (US numbers only).')).toBeOnTheScreen();
+        expect(screen.getByText(CONST.EMAIL.RECEIPTS)).toBeOnTheScreen();
 
         const copyButton = screen.getByLabelText(`Copy email address, ${CONST.EMAIL.RECEIPTS}`);
         fireEvent.press(copyButton);
@@ -203,13 +206,16 @@ describe('ContactMethodsPage', () => {
             helpTextAfterEmail: `，或者添加一个电话号码，以短信方式将收据发送到 ${CONST.SMS.RECEIPTS_PHONE_NUMBER}（仅限美国号码）。`,
             copyLabel: `复制电子邮箱地址，${CONST.EMAIL.RECEIPTS}`,
         },
-    ])('renders localized help copy for $locale', async ({locale, helpText, copyLabel}) => {
+    ])('renders localized help copy for $locale', async ({locale, helpText, helpTextBeforeEmail, helpTextAfterEmail, copyLabel}) => {
         await setPreferredLocale(locale);
 
         renderPage();
         await waitForBatchedUpdatesWithAct();
 
         expect(screen.getByText(helpText)).toBeOnTheScreen();
+        expect(screen.getByText(helpTextBeforeEmail)).toBeOnTheScreen();
+        expect(screen.getByText(helpTextAfterEmail)).toBeOnTheScreen();
+        expect(screen.getByText(CONST.EMAIL.RECEIPTS)).toBeOnTheScreen();
         expect(screen.getByLabelText(copyLabel)).toBeOnTheScreen();
     });
 });

--- a/tests/ui/ContactMethodsPageTest.tsx
+++ b/tests/ui/ContactMethodsPageTest.tsx
@@ -1,14 +1,16 @@
-import {fireEvent, render, screen, waitFor} from '@testing-library/react-native';
+import {act, fireEvent, render, screen, waitFor} from '@testing-library/react-native';
 import React from 'react';
 import Onyx from 'react-native-onyx';
 import type {ValueOf} from 'type-fest';
 import ComposeProviders from '@components/ComposeProviders';
 import {LocaleContextProvider} from '@components/LocaleContextProvider';
 import Clipboard from '@libs/Clipboard';
+import Navigation from '@libs/Navigation/Navigation';
 import ContactMethodsPage from '@pages/settings/Profile/Contacts/ContactMethodsPage';
 import DelegateNoAccessModalProvider from '@src/components/DelegateNoAccessModalProvider';
 import LockedAccountModalProvider from '@src/components/LockedAccountModalProvider';
 import CONST from '@src/CONST';
+import IntlStore from '@src/languages/IntlStore';
 import ONYXKEYS from '@src/ONYXKEYS';
 import waitForBatchedUpdates from '../utils/waitForBatchedUpdates';
 import waitForBatchedUpdatesWithAct from '../utils/waitForBatchedUpdatesWithAct';
@@ -35,9 +37,11 @@ describe('ContactMethodsPage', () => {
         });
     });
 
-    beforeEach(() => {
+    beforeEach(async () => {
         jest.clearAllMocks();
-        return Onyx.clear();
+        jest.useRealTimers();
+        await Onyx.clear();
+        await setPreferredLocale(CONST.LOCALES.EN);
     });
 
     function renderPage() {
@@ -47,6 +51,12 @@ describe('ContactMethodsPage', () => {
                 <ContactMethodsPage route={{params: {}}} />
             </ComposeProviders>,
         );
+    }
+
+    async function setPreferredLocale(locale: ValueOf<typeof CONST.LOCALES>) {
+        await IntlStore.load(locale);
+        await Onyx.set(ONYXKEYS.NVP_PREFERRED_LOCALE, locale);
+        await waitForBatchedUpdatesWithAct();
     }
 
     it('sets error indicator when login has error fields', async () => {
@@ -142,20 +152,64 @@ describe('ContactMethodsPage', () => {
         });
     });
 
-    it('renders a dedicated copy control for the receipts email and copies it to the clipboard', async () => {
+    it('renders a dedicated copy control for the receipts email, copies it to the clipboard, and does not navigate away', async () => {
         const setStringSpy = jest.spyOn(Clipboard, 'setString').mockImplementation(() => undefined);
 
         renderPage();
         await waitForBatchedUpdatesWithAct();
 
         expect(screen.getByText('Add more ways to log in and send receipts to Expensify.')).toBeOnTheScreen();
-        expect(screen.getByText('Add an email address to forward receipts to')).toBeOnTheScreen();
-        expect(screen.getByText('or add a phone number to text receipts to 47777 (US numbers only).')).toBeOnTheScreen();
-        expect(screen.getByText(CONST.EMAIL.RECEIPTS)).toBeOnTheScreen();
 
         const copyButton = screen.getByLabelText(`Copy email address, ${CONST.EMAIL.RECEIPTS}`);
         fireEvent.press(copyButton);
 
         expect(setStringSpy).toHaveBeenCalledWith(CONST.EMAIL.RECEIPTS);
+        expect(Navigation.navigate).not.toHaveBeenCalled();
+    });
+
+    it('throttles repeated copy presses until the delay expires', async () => {
+        jest.useFakeTimers();
+        const setStringSpy = jest.spyOn(Clipboard, 'setString').mockImplementation(() => undefined);
+
+        renderPage();
+        await waitForBatchedUpdatesWithAct();
+
+        fireEvent.press(screen.getByLabelText(`Copy email address, ${CONST.EMAIL.RECEIPTS}`));
+        fireEvent.press(screen.getByLabelText(`Copy email address, ${CONST.EMAIL.RECEIPTS}`));
+
+        expect(setStringSpy).toHaveBeenCalledTimes(1);
+
+        act(() => {
+            jest.advanceTimersByTime(1800);
+        });
+
+        fireEvent.press(screen.getByLabelText(`Copy email address, ${CONST.EMAIL.RECEIPTS}`));
+
+        expect(setStringSpy).toHaveBeenCalledTimes(2);
+    });
+
+    it.each([
+        {
+            locale: CONST.LOCALES.JA,
+            helpText: 'Expensify へのログイン方法とレシート送信方法をさらに追加しましょう。',
+            helpTextBeforeEmail: 'レシートを',
+            helpTextAfterEmail: `に転送するメールアドレスを追加するか、レシートを ${CONST.SMS.RECEIPTS_PHONE_NUMBER}（米国の電話番号のみ）宛てにテキスト送信する電話番号を追加してください。`,
+            copyLabel: `メールアドレスをコピー、${CONST.EMAIL.RECEIPTS}`,
+        },
+        {
+            locale: CONST.LOCALES.ZH_HANS,
+            helpText: '添加更多登录方式并向 Expensify 发送收据。',
+            helpTextBeforeEmail: '添加一个电子邮箱地址，以便将收据转发到',
+            helpTextAfterEmail: `，或者添加一个电话号码，以短信方式将收据发送到 ${CONST.SMS.RECEIPTS_PHONE_NUMBER}（仅限美国号码）。`,
+            copyLabel: `复制电子邮箱地址，${CONST.EMAIL.RECEIPTS}`,
+        },
+    ])('renders localized help copy for $locale', async ({locale, helpText, copyLabel}) => {
+        await setPreferredLocale(locale);
+
+        renderPage();
+        await waitForBatchedUpdatesWithAct();
+
+        expect(screen.getByText(helpText)).toBeOnTheScreen();
+        expect(screen.getByLabelText(copyLabel)).toBeOnTheScreen();
     });
 });


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
- This PR fixes the accessibility issue on `Settings --> Profile --> Contact methods` where the `receipts@expensify.com` copy action was not exposed as a separately focusable and announced control for screen readers.
- The previous implementation rendered the receipts email inside one HTML help sentence via `RenderHTML` and an inline `mailto:` anchor. On native, that stayed text-like and did not reliably produce a distinct actionable control for TalkBack or VoiceOver.
- This PR replaces that inline HTML path with native UI:
  - intro text
  - text before the email
  - a dedicated `PressableWithDelayToggle` for `receipts@expensify.com`
  - text after the email
- The new copy control uses an explicit accessibility label: `Copy email address, receipts@expensify.com`
- The translations were split into native-friendly keys across the touched locale files so the copy control can be inserted between text segments instead of being embedded inside HTML.
- `ContactMethodsPageTest.tsx` was updated to assert that the dedicated copy control renders and copies the receipts email to the clipboard.

**Root Cause:**

- `ContactMethodsPage` rendered `contacts.helpText` with `RenderHTML`
- `contacts.helpText` embedded the receipts address as an inline HTML anchor
- that produced a text-based accessibility shape on native instead of a distinct button-like copy action

**Solution:**

- stop rendering the receipts action as inline HTML on this page
- render the receipts email as its own native copy button with an explicit accessibility label
- split the translation string into separate keys so the page can compose the sentence around the control

**Notes to code reviewers:**

- This intentionally does **not** use the translation-only `<copy-text>` approach.
- Native empirical validation showed that the translation-only approach still did not produce the correct separately focusable/announced accessibility shape on Android.

### Fixed Issues
$ https://github.com/Expensify/App/issues/77548
PROPOSAL: https://github.com/Expensify/App/issues/77548#issuecomment-4043388669

### Tests
1. Start the app and log in with a test account.
2. Navigate to `Account --> Profile --> Contact methods`.
3. Verify the receipts help copy is rendered as:
   - introductory text
   - a dedicated button for `receipts@expensify.com`
   - trailing SMS guidance text
4. Verify the receipts email control is announced as a button with a label equivalent to `Copy email address, receipts@expensify.com`.
5. Activate the receipts copy control.
6. Paste into any text input and verify the clipboard value is `receipts@expensify.com`.
7. Verify the control shows the checked state after activation, then resets back to the normal copy state.
8. Verify activating the receipts copy control does not navigate away from the page.
9. Tap/click the existing contact method row and verify its details page opens.
10. Navigate back and verify you return to `Contact methods`.
11. Tap/click `New contact method` and verify the confirm-magic-code flow opens.
12. On web, focus the receipts copy control with keyboard navigation and verify both `Enter` and `Space` activate the copy action.

- [x] Verify that no errors appear in the JS console

### Offline tests
1. Log in and open `Account --> Profile --> Contact methods` while online.
2. Disable the network connection.
3. Activate the receipts copy control.
4. Paste into any text input.
5. Verify `receipts@expensify.com` is still copied successfully.
6. Verify no network-dependent error blocks the copy action once the page is already loaded.

### QA Steps
Same as tests.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [ ] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>


https://github.com/user-attachments/assets/bd7c0544-ac37-4796-96f0-f3ec1938520e


</details>

<details>
<summary>Android: mWeb Chrome</summary>


https://github.com/user-attachments/assets/cb36477c-2317-431b-ba5b-c5ec9797af6f




</details>

<details>
<summary>iOS: Native</summary>



</details>

<details>
<summary>iOS: mWeb Safari</summary>

Not captured.

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>





</details>
