### PR TITLE
Support multi-instance unbind for pusher callbacks

### DIFF
--- a/src/libs/Pusher/index.native.ts
+++ b/src/libs/Pusher/index.native.ts
@@ -10,7 +10,7 @@ import {authenticatePusher} from '@userActions/Session';
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
 import TYPE from './EventType';
-import type {Args, ChunkedDataEvents, EventCallbackError, EventData, PusherEventName, SocketEventCallback, SocketEventName, States} from './types';
+import type {Args, ChunkedDataEvents, EventCallbackError, EventData, PusherEventName, PusherSubscription, SocketEventCallback, SocketEventName, States} from './types';
 import type PusherModule from './types';
 
 let shouldForceOffline = false;
@@ -34,7 +34,9 @@ let initPromise = new Promise<void>((resolve) => {
     resolveInitPromise = resolve;
 });
 
-const eventsBoundToChannels = new Map<string, Map<PusherEventName, (eventData: EventData<PusherEventName>) => void>>();
+type BoundCallback = (eventData: EventData<PusherEventName>) => void;
+
+const eventsBoundToChannels = new Map<string, Map<PusherEventName, Set<BoundCallback>>>();
 let channels: Record<string, ValueOf<typeof CONST.PUSHER.CHANNEL_STATUS>> = {};
 
 /**
@@ -126,11 +128,16 @@ function parseEventData<EventName extends PusherEventName>(eventData: EventData<
 }
 
 /**
- * Binds an event callback to a channel + eventName
+ * Binds an event callback to a channel + eventName.
+ * Returns the wrapped callback so it can be individually unbound later.
  */
-function bindEventToChannel<EventName extends PusherEventName>(channel: string, eventName?: EventName, eventCallback: (data: EventData<EventName>) => void = () => {}) {
+function bindEventToChannel<EventName extends PusherEventName>(
+    channel: string,
+    eventName?: EventName,
+    eventCallback: (data: EventData<EventName>) => void = () => {},
+): BoundCallback | undefined {
     if (!eventName) {
-        return;
+        return undefined;
     }
 
     const chunkedDataEvents: Record<string, ChunkedDataEvents> = {};
@@ -192,24 +199,40 @@ function bindEventToChannel<EventName extends PusherEventName>(channel: string, 
     if (!eventsBoundToChannels.has(channel)) {
         eventsBoundToChannels.set(channel, new Map());
     }
+    const eventMap = eventsBoundToChannels.get(channel);
+    if (!eventMap?.has(eventName)) {
+        eventMap?.set(eventName, new Set());
+    }
+    const boundCb = callback as BoundCallback;
+    eventMap?.get(eventName)?.add(boundCb);
 
-    eventsBoundToChannels.get(channel)?.set(eventName, callback as (eventData: EventData<PusherEventName>) => void);
+    return boundCb;
 }
 
 /**
- * Subscribe to a channel and an event
+ * Subscribe to a channel and an event.
+ * Returns a PusherSubscription — a Promise (for backward-compatible .catch()/.then())
+ * with an .unsubscribe() method that removes only this specific callback.
  */
 function subscribe<EventName extends PusherEventName>(
     channelName: string,
     eventName?: EventName,
     eventCallback: (data: EventData<EventName>) => void = () => {},
     onResubscribe = () => {},
-): Promise<void> {
-    return initPromise.then(
+): PusherSubscription {
+    let wrappedCb: BoundCallback | undefined;
+    let disposed = false;
+
+    const promise = initPromise.then(
         () =>
-            new Promise((resolve, reject) => {
+            new Promise<void>((resolve, reject) => {
                 // eslint-disable-next-line @typescript-eslint/no-deprecated
                 InteractionManager.runAfterInteractions(() => {
+                    if (disposed) {
+                        resolve();
+                        return;
+                    }
+
                     // We cannot call subscribe() before init(). Prevent any attempt to do this on dev.
                     if (!socket) {
                         const error = new Error('[Pusher] instance not found. Pusher.subscribe() most likely has been called before Pusher.init()');
@@ -237,12 +260,18 @@ function subscribe<EventName extends PusherEventName>(
                         socket.subscribe({
                             channelName,
                             onEvent: (event) => {
-                                const callback = eventsBoundToChannels.get(event.channelName)?.get(event.eventName);
-                                callback?.(event.data as EventData<PusherEventName>);
+                                const callbacks = eventsBoundToChannels.get(event.channelName)?.get(event.eventName);
+                                if (callbacks) {
+                                    for (const cb of callbacks) {
+                                        cb(event.data as EventData<PusherEventName>);
+                                    }
+                                }
                             },
                             onSubscriptionSucceeded: () => {
                                 channels[channelName] = CONST.PUSHER.CHANNEL_STATUS.SUBSCRIBED;
-                                bindEventToChannel(channelName, eventName, eventCallback);
+                                if (!disposed) {
+                                    wrappedCb = bindEventToChannel(channelName, eventName, eventCallback);
+                                }
                                 resolve();
                                 // When subscribing for the first time we register a success callback that can be
                                 // called multiple times when the subscription succeeds again in the future
@@ -260,16 +289,46 @@ function subscribe<EventName extends PusherEventName>(
                             },
                         });
                     } else {
-                        bindEventToChannel(channelName, eventName, eventCallback);
+                        if (!disposed) {
+                            wrappedCb = bindEventToChannel(channelName, eventName, eventCallback);
+                        }
                         resolve();
                     }
                 });
             }),
     );
+
+    return Object.assign(promise, {
+        unsubscribe: () => {
+            disposed = true;
+            if (!wrappedCb || !eventName) {
+                return;
+            }
+
+            // 1. Remove this specific callback from tracking
+            const eventMap = eventsBoundToChannels.get(channelName);
+            const callbacks = eventMap?.get(eventName);
+            callbacks?.delete(wrappedCb);
+
+            // 2. If last callback for this event, remove the event
+            if (callbacks?.size === 0) {
+                eventMap?.delete(eventName);
+            }
+
+            // 3. If last event on this channel, unsubscribe entirely
+            if (eventMap?.size === 0) {
+                eventsBoundToChannels.delete(channelName);
+                delete channels[channelName];
+                socket?.unsubscribe({channelName});
+            }
+        },
+    });
 }
 
 /**
- * Unsubscribe from a channel and optionally a specific event
+ * Unsubscribe from a channel and optionally a specific event.
+ * This removes ALL callbacks for the given event (or all events on the channel).
+ * For per-callback removal, use the .unsubscribe() method on the PusherSubscription handle.
  */
 function unsubscribe(channelName: string, eventName: PusherEventName = '') {
     const channel = getChannel(channelName);

--- a/src/libs/Pusher/index.native.ts
+++ b/src/libs/Pusher/index.native.ts
@@ -271,6 +271,15 @@ function subscribe<EventName extends PusherEventName>(
                                 channels[channelName] = CONST.PUSHER.CHANNEL_STATUS.SUBSCRIBED;
                                 if (!disposed) {
                                     wrappedCb = bindEventToChannel(channelName, eventName, eventCallback);
+                                } else {
+                                    // Handle was disposed mid-handshake — clean up the channel
+                                    // if no other subscribers have bound callbacks to it
+                                    const eventMap = eventsBoundToChannels.get(channelName);
+                                    if (!eventMap || eventMap.size === 0) {
+                                        eventsBoundToChannels.delete(channelName);
+                                        delete channels[channelName];
+                                        socket?.unsubscribe({channelName});
+                                    }
                                 }
                                 resolve();
                                 // When subscribing for the first time we register a success callback that can be
@@ -321,6 +330,8 @@ function subscribe<EventName extends PusherEventName>(
                 delete channels[channelName];
                 socket?.unsubscribe({channelName});
             }
+
+            wrappedCb = undefined;
         },
     });
 }

--- a/src/libs/Pusher/index.ts
+++ b/src/libs/Pusher/index.ts
@@ -264,6 +264,14 @@ function subscribe<EventName extends PusherEventName>(
                                 if (!disposed) {
                                     wrappedCb = bindEventToChannel(channel, eventName, eventCallback);
                                     resolvedChannel = channel ?? undefined;
+                                } else {
+                                    // Handle was disposed mid-handshake — clean up the channel
+                                    // if no other subscribers have bound callbacks to it
+                                    const eventMap = eventsBoundToChannels.get(channel);
+                                    if (!eventMap || eventMap.size === 0) {
+                                        eventsBoundToChannels.delete(channel);
+                                        socket?.unsubscribe(channelName);
+                                    }
                                 }
                                 resolve();
                                 isBound = true;
@@ -323,6 +331,9 @@ function subscribe<EventName extends PusherEventName>(
                 eventsBoundToChannels.delete(resolvedChannel);
                 socket?.unsubscribe(channelName);
             }
+
+            wrappedCb = undefined;
+            resolvedChannel = undefined;
         },
     });
 }

--- a/src/libs/Pusher/index.ts
+++ b/src/libs/Pusher/index.ts
@@ -264,7 +264,7 @@ function subscribe<EventName extends PusherEventName>(
                                 if (!disposed) {
                                     wrappedCb = bindEventToChannel(channel, eventName, eventCallback);
                                     resolvedChannel = channel ?? undefined;
-                                } else {
+                                } else if (channel) {
                                     // Handle was disposed mid-handshake — clean up the channel
                                     // if no other subscribers have bound callbacks to it
                                     const eventMap = eventsBoundToChannels.get(channel);

--- a/src/libs/Pusher/index.ts
+++ b/src/libs/Pusher/index.ts
@@ -433,6 +433,7 @@ function disconnect() {
     socket.disconnect();
     socket = null;
     pusherSocketID = '';
+    eventsBoundToChannels.clear();
     initPromise = new Promise((resolve) => {
         resolveInitPromise = resolve;
     });

--- a/src/libs/Pusher/index.ts
+++ b/src/libs/Pusher/index.ts
@@ -13,6 +13,7 @@ import type {
     EventCallbackError,
     EventData,
     PusherEventName,
+    PusherSubscription,
     PusherSubscriptionErrorData,
     PusherWithAuthParams,
     SocketEventCallback,
@@ -45,7 +46,10 @@ let initPromise = new Promise<void>((resolve) => {
     resolveInitPromise = resolve;
 });
 
-const eventsBoundToChannels = new Map<Channel, Set<PusherEventName>>();
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Pusher callbacks have varying signatures due to chunking wrapper
+type BoundCallback = (eventData: any) => void;
+
+const eventsBoundToChannels = new Map<Channel, Map<PusherEventName, Set<BoundCallback>>>();
 
 /**
  * Trigger each of the socket event callbacks with the event information
@@ -118,11 +122,16 @@ function getChannel(channelName: string): Channel | undefined {
 }
 
 /**
- * Binds an event callback to a channel + eventName
+ * Binds an event callback to a channel + eventName.
+ * Returns the wrapped callback so it can be individually unbound later.
  */
-function bindEventToChannel<EventName extends PusherEventName>(channel: Channel | undefined, eventName?: EventName, eventCallback: (data: EventData<EventName>) => void = () => {}) {
+function bindEventToChannel<EventName extends PusherEventName>(
+    channel: Channel | undefined,
+    eventName?: EventName,
+    eventCallback: (data: EventData<EventName>) => void = () => {},
+): BoundCallback | undefined {
     if (!eventName || !channel) {
-        return;
+        return undefined;
     }
 
     const chunkedDataEvents: Record<string, ChunkedDataEvents> = {};
@@ -184,14 +193,23 @@ function bindEventToChannel<EventName extends PusherEventName>(channel: Channel 
     };
 
     channel.bind(eventName, callback);
+
     if (!eventsBoundToChannels.has(channel)) {
-        eventsBoundToChannels.set(channel, new Set());
+        eventsBoundToChannels.set(channel, new Map());
     }
-    eventsBoundToChannels.get(channel)?.add(eventName);
+    const eventMap = eventsBoundToChannels.get(channel);
+    if (!eventMap?.has(eventName)) {
+        eventMap?.set(eventName, new Set());
+    }
+    eventMap?.get(eventName)?.add(callback);
+
+    return callback;
 }
 
 /**
- * Subscribe to a channel and an event
+ * Subscribe to a channel and an event.
+ * Returns a PusherSubscription — a Promise (for backward-compatible .catch()/.then())
+ * with an .unsubscribe() method that removes only this specific callback.
  * @param [onResubscribe] Callback to be called when reconnection happen
  */
 function subscribe<EventName extends PusherEventName>(
@@ -199,12 +217,21 @@ function subscribe<EventName extends PusherEventName>(
     eventName?: EventName,
     eventCallback: (data: EventData<EventName>) => void = () => {},
     onResubscribe = () => {},
-): Promise<void> {
-    return initPromise.then(
+): PusherSubscription {
+    let wrappedCb: BoundCallback | undefined;
+    let resolvedChannel: Channel | undefined;
+    let disposed = false;
+
+    const promise = initPromise.then(
         () =>
-            new Promise((resolve, reject) => {
+            new Promise<void>((resolve, reject) => {
                 // eslint-disable-next-line @typescript-eslint/no-deprecated
                 InteractionManager.runAfterInteractions(() => {
+                    if (disposed) {
+                        resolve();
+                        return;
+                    }
+
                     // We cannot call subscribe() before init(). Prevent any attempt to do this on dev.
                     if (!socket) {
                         const error = new Error('[Pusher] instance not found. Pusher.subscribe() most likely has been called before Pusher.init()');
@@ -234,7 +261,10 @@ function subscribe<EventName extends PusherEventName>(
                         channel.bind('pusher:subscription_succeeded', () => {
                             // Check so that we do not bind another event with each reconnect attempt
                             if (!isBound) {
-                                bindEventToChannel(channel, eventName, eventCallback);
+                                if (!disposed) {
+                                    wrappedCb = bindEventToChannel(channel, eventName, eventCallback);
+                                    resolvedChannel = channel ?? undefined;
+                                }
                                 resolve();
                                 isBound = true;
                                 return;
@@ -258,16 +288,49 @@ function subscribe<EventName extends PusherEventName>(
                             reject(error);
                         });
                     } else {
-                        bindEventToChannel(channel, eventName, eventCallback);
+                        if (!disposed) {
+                            wrappedCb = bindEventToChannel(channel, eventName, eventCallback);
+                            resolvedChannel = channel;
+                        }
                         resolve();
                     }
                 });
             }),
     );
+
+    return Object.assign(promise, {
+        unsubscribe: () => {
+            disposed = true;
+            if (!wrappedCb || !resolvedChannel || !eventName) {
+                return;
+            }
+
+            // 1. Unbind this specific callback from pusher-js
+            resolvedChannel.unbind(eventName, wrappedCb);
+
+            // 2. Remove from tracking
+            const eventMap = eventsBoundToChannels.get(resolvedChannel);
+            const callbacks = eventMap?.get(eventName);
+            callbacks?.delete(wrappedCb);
+
+            // 3. If last callback for this event, remove the event
+            if (callbacks?.size === 0) {
+                eventMap?.delete(eventName);
+            }
+
+            // 4. If last event on this channel, unsubscribe entirely
+            if (eventMap?.size === 0) {
+                eventsBoundToChannels.delete(resolvedChannel);
+                socket?.unsubscribe(channelName);
+            }
+        },
+    });
 }
 
 /**
- * Unsubscribe from a channel and optionally a specific event
+ * Unsubscribe from a channel and optionally a specific event.
+ * This removes ALL callbacks for the given event (or all events on the channel).
+ * For per-callback removal, use the .unsubscribe() method on the PusherSubscription handle.
  */
 function unsubscribe(channelName: string, eventName: PusherEventName = '') {
     const channel = getChannel(channelName);
@@ -294,6 +357,7 @@ function unsubscribe(channelName: string, eventName: PusherEventName = '') {
         Log.info('[Pusher] Unsubscribing from channel', false, {channelName});
 
         channel.unbind();
+        eventsBoundToChannels.delete(channel);
         socket?.unsubscribe(channelName);
     }
 }

--- a/src/libs/Pusher/types.ts
+++ b/src/libs/Pusher/types.ts
@@ -68,6 +68,10 @@ type PusherEventName = LiteralUnion<DeepValueOf<typeof TYPE>, string>;
 
 type PusherSubscriptionErrorData = {type?: string; error?: string; status?: string};
 
+type PusherSubscription = Promise<void> & {
+    unsubscribe: () => void;
+};
+
 type PusherModule = {
     init: (args: Args) => Promise<void>;
     subscribe: <EventName extends PusherEventName>(
@@ -75,7 +79,7 @@ type PusherModule = {
         eventName?: EventName,
         eventCallback?: (data: EventData<EventName>) => void,
         onResubscribe?: () => void,
-    ) => Promise<void>;
+    ) => PusherSubscription;
     unsubscribe: (channelName: string, eventName?: PusherEventName) => void;
     getChannel: (channelName: string) => Channel | PusherChannel | undefined;
     isSubscribed: (channelName: string) => boolean;
@@ -105,5 +109,6 @@ export type {
     SocketEventCallback,
     PusherWithAuthParams,
     PusherEventName,
+    PusherSubscription,
     PusherSubscriptionErrorData,
 };

--- a/tests/unit/PusherSubscribeTest.ts
+++ b/tests/unit/PusherSubscribeTest.ts
@@ -121,7 +121,7 @@ describe('Pusher.subscribe', () => {
 });
 
 describe('Per-callback subscription handles', () => {
-    const CHANNEL = 'private-user-percb';
+    const CHANNEL = 'private-user-callback';
     const EVENT = 'testEvent';
 
     beforeEach(async () => {
@@ -196,11 +196,11 @@ describe('Per-callback subscription handles', () => {
         // Unsubscribe A only
         handleA.unsubscribe();
 
-        triggerEvent(CHANNEL, EVENT, {msg: 'after-unsub'});
+        triggerEvent(CHANNEL, EVENT, {msg: 'after-removal'});
 
         expect(callbackA).not.toHaveBeenCalled();
         expect(callbackB).toHaveBeenCalledTimes(1);
-        expect(callbackB).toHaveBeenCalledWith({msg: 'after-unsub'});
+        expect(callbackB).toHaveBeenCalledWith({msg: 'after-removal'});
 
         handleB.unsubscribe();
     });

--- a/tests/unit/PusherSubscribeTest.ts
+++ b/tests/unit/PusherSubscribeTest.ts
@@ -119,3 +119,168 @@ describe('Pusher.subscribe', () => {
         await expect(subscribePromise).resolves.toBeUndefined();
     });
 });
+
+describe('Per-callback subscription handles', () => {
+    const CHANNEL = 'private-user-percb';
+    const EVENT = 'testEvent';
+
+    beforeEach(async () => {
+        jest.spyOn(Pusher, 'isSubscribed').mockReturnValue(false);
+        jest.spyOn(Pusher, 'isAlreadySubscribing').mockReturnValue(false);
+        await initPusher();
+    });
+
+    afterEach(() => {
+        Pusher.disconnect();
+        jest.restoreAllMocks();
+    });
+
+    function triggerEvent(channelName: string, eventName: string, data: Record<string, unknown> = {value: 1}) {
+        // Access the underlying mock socket to fire events through the Pusher module's
+        // onEvent dispatcher, which iterates over eventsBoundToChannels.
+        const mockSocket = window.getPusherInstance();
+        if (mockSocket && 'trigger' in mockSocket) {
+            (mockSocket as {trigger: (event: {channelName: string; eventName: string; data: Record<string, unknown>}) => void}).trigger({
+                channelName,
+                eventName,
+                data,
+            });
+        }
+    }
+
+    it('should return a PusherSubscription with an unsubscribe method', async () => {
+        const handle = Pusher.subscribe(CHANNEL, EVENT, () => {});
+        await jest.runAllTimersAsync();
+        await handle;
+
+        expect(typeof handle.unsubscribe).toBe('function');
+    });
+
+    it('should deliver events to both subscribers on the same channel+event', async () => {
+        const callbackA = jest.fn();
+        const callbackB = jest.fn();
+
+        const handleA = Pusher.subscribe(CHANNEL, EVENT, callbackA);
+        await jest.runAllTimersAsync();
+        await handleA;
+
+        // Second subscribe to same channel — goes through the "already subscribed" branch
+        jest.spyOn(Pusher, 'isSubscribed').mockReturnValue(true);
+        const handleB = Pusher.subscribe(CHANNEL, EVENT, callbackB);
+        await jest.runAllTimersAsync();
+        await handleB;
+
+        triggerEvent(CHANNEL, EVENT, {msg: 'hello'});
+
+        expect(callbackA).toHaveBeenCalledTimes(1);
+        expect(callbackB).toHaveBeenCalledTimes(1);
+        expect(callbackA).toHaveBeenCalledWith({msg: 'hello'});
+
+        handleA.unsubscribe();
+        handleB.unsubscribe();
+    });
+
+    it('should stop delivering events to an unsubscribed callback while others continue', async () => {
+        const callbackA = jest.fn();
+        const callbackB = jest.fn();
+
+        const handleA = Pusher.subscribe(CHANNEL, EVENT, callbackA);
+        await jest.runAllTimersAsync();
+        await handleA;
+
+        jest.spyOn(Pusher, 'isSubscribed').mockReturnValue(true);
+        const handleB = Pusher.subscribe(CHANNEL, EVENT, callbackB);
+        await jest.runAllTimersAsync();
+        await handleB;
+
+        // Unsubscribe A only
+        handleA.unsubscribe();
+
+        triggerEvent(CHANNEL, EVENT, {msg: 'after-unsub'});
+
+        expect(callbackA).not.toHaveBeenCalled();
+        expect(callbackB).toHaveBeenCalledTimes(1);
+        expect(callbackB).toHaveBeenCalledWith({msg: 'after-unsub'});
+
+        handleB.unsubscribe();
+    });
+
+    it('should keep the channel subscribed until the last callback unsubscribes', async () => {
+        const handleA = Pusher.subscribe(CHANNEL, EVENT, jest.fn());
+        await jest.runAllTimersAsync();
+        await handleA;
+
+        jest.spyOn(Pusher, 'isSubscribed').mockReturnValue(true);
+        const handleB = Pusher.subscribe(CHANNEL, EVENT, jest.fn());
+        await jest.runAllTimersAsync();
+        await handleB;
+
+        // After unsubscribing A, mock socket should still have the channel
+        handleA.unsubscribe();
+        const mockSocket = window.getPusherInstance();
+        if (mockSocket && 'getChannel' in mockSocket) {
+            expect((mockSocket as {getChannel: (name: string) => unknown}).getChannel(CHANNEL)).toBeTruthy();
+        }
+
+        // After unsubscribing B (last callback), channel should be cleaned up
+        handleB.unsubscribe();
+        if (mockSocket && 'getChannel' in mockSocket) {
+            expect((mockSocket as {getChannel: (name: string) => unknown}).getChannel(CHANNEL)).toBeFalsy();
+        }
+    });
+
+    it('should handle unsubscribe before subscription completes without errors', async () => {
+        const callback = jest.fn();
+
+        // Subscribe but do NOT flush timers yet — subscription is pending
+        const handle = Pusher.subscribe(CHANNEL, EVENT, callback);
+
+        // Unsubscribe immediately (sets disposed = true)
+        handle.unsubscribe();
+
+        // Now flush — the InteractionManager callback should see disposed=true and skip binding
+        await jest.runAllTimersAsync();
+        await expect(handle).resolves.toBeUndefined();
+
+        // Event should not reach the callback since it was never bound
+        triggerEvent(CHANNEL, EVENT);
+        expect(callback).not.toHaveBeenCalled();
+    });
+
+    it('should handle multiple events on the same channel with independent cleanup', async () => {
+        const callbackX = jest.fn();
+        const callbackY = jest.fn();
+
+        const handleX = Pusher.subscribe(CHANNEL, 'eventX', callbackX);
+        await jest.runAllTimersAsync();
+        await handleX;
+
+        jest.spyOn(Pusher, 'isSubscribed').mockReturnValue(true);
+        const handleY = Pusher.subscribe(CHANNEL, 'eventY', callbackY);
+        await jest.runAllTimersAsync();
+        await handleY;
+
+        // Both events should work
+        triggerEvent(CHANNEL, 'eventX', {type: 'x'});
+        triggerEvent(CHANNEL, 'eventY', {type: 'y'});
+        expect(callbackX).toHaveBeenCalledWith({type: 'x'});
+        expect(callbackY).toHaveBeenCalledWith({type: 'y'});
+
+        // Unsubscribe eventX — eventY should still work
+        handleX.unsubscribe();
+        callbackX.mockClear();
+        callbackY.mockClear();
+
+        triggerEvent(CHANNEL, 'eventX', {type: 'x2'});
+        triggerEvent(CHANNEL, 'eventY', {type: 'y2'});
+        expect(callbackX).not.toHaveBeenCalled();
+        expect(callbackY).toHaveBeenCalledWith({type: 'y2'});
+
+        // Unsubscribe eventY — channel should be fully cleaned up
+        handleY.unsubscribe();
+        const mockSocket = window.getPusherInstance();
+        if (mockSocket && 'getChannel' in mockSocket) {
+            expect((mockSocket as {getChannel: (name: string) => unknown}).getChannel(CHANNEL)).toBeFalsy();
+        }
+    });
+});

--- a/tests/unit/PusherSubscribeTest.ts
+++ b/tests/unit/PusherSubscribeTest.ts
@@ -283,4 +283,33 @@ describe('Per-callback subscription handles', () => {
             expect((mockSocket as {getChannel: (name: string) => unknown}).getChannel(CHANNEL)).toBeFalsy();
         }
     });
+
+    it('should clear all callbacks on disconnect so they do not fire after re-init', async () => {
+        const oldCallback = jest.fn();
+
+        const handle = Pusher.subscribe(CHANNEL, EVENT, oldCallback);
+        await jest.runAllTimersAsync();
+        await handle;
+
+        // Disconnect clears all callback tracking
+        Pusher.disconnect();
+        jest.restoreAllMocks();
+
+        // Re-init and subscribe a new callback
+        jest.spyOn(Pusher, 'isSubscribed').mockReturnValue(false);
+        jest.spyOn(Pusher, 'isAlreadySubscribing').mockReturnValue(false);
+        await initPusher();
+
+        const newCallback = jest.fn();
+        const newHandle = Pusher.subscribe(CHANNEL, EVENT, newCallback);
+        await jest.runAllTimersAsync();
+        await newHandle;
+
+        // Fire event — only new callback should receive it
+        triggerEvent(CHANNEL, EVENT, {session: 'new'});
+        expect(oldCallback).not.toHaveBeenCalled();
+        expect(newCallback).toHaveBeenCalledWith({session: 'new'});
+
+        newHandle.unsubscribe();
+    });
 });

--- a/tests/unit/PusherSubscribeTest.ts
+++ b/tests/unit/PusherSubscribeTest.ts
@@ -2,6 +2,8 @@ import Log from '@libs/Log';
 import Pusher from '@libs/Pusher';
 import CONFIG from '@src/CONFIG';
 import PusherConnectionManager from '@src/libs/PusherConnectionManager';
+// eslint-disable-next-line import/no-relative-packages -- Import mock class directly for proper typing
+import {Pusher as MockedPusher} from '../../__mocks__/@pusher/pusher-websocket-react-native/index';
 
 /**
  * Tests for Pusher.subscribe() graceful handling when socket is disconnected
@@ -136,16 +138,9 @@ describe('Per-callback subscription handles', () => {
     });
 
     function triggerEvent(channelName: string, eventName: string, data: Record<string, unknown> = {value: 1}) {
-        // Access the underlying mock socket to fire events through the Pusher module's
-        // onEvent dispatcher, which iterates over eventsBoundToChannels.
-        const mockSocket = window.getPusherInstance();
-        if (mockSocket && 'trigger' in mockSocket) {
-            (mockSocket as {trigger: (event: {channelName: string; eventName: string; data: Record<string, unknown>}) => void}).trigger({
-                channelName,
-                eventName,
-                data,
-            });
-        }
+        // Fire events through the mock socket's trigger, which invokes the Pusher module's
+        // onEvent dispatcher that iterates over eventsBoundToChannels.
+        MockedPusher.getInstance().trigger({channelName, eventName, data});
     }
 
     it('should return a PusherSubscription with an unsubscribe method', async () => {
@@ -217,16 +212,11 @@ describe('Per-callback subscription handles', () => {
 
         // After unsubscribing A, mock socket should still have the channel
         handleA.unsubscribe();
-        const mockSocket = window.getPusherInstance();
-        if (mockSocket && 'getChannel' in mockSocket) {
-            expect((mockSocket as {getChannel: (name: string) => unknown}).getChannel(CHANNEL)).toBeTruthy();
-        }
+        expect(MockedPusher.getInstance().getChannel(CHANNEL)).toBeTruthy();
 
         // After unsubscribing B (last callback), channel should be cleaned up
         handleB.unsubscribe();
-        if (mockSocket && 'getChannel' in mockSocket) {
-            expect((mockSocket as {getChannel: (name: string) => unknown}).getChannel(CHANNEL)).toBeFalsy();
-        }
+        expect(MockedPusher.getInstance().getChannel(CHANNEL)).toBeFalsy();
     });
 
     it('should handle unsubscribe before subscription completes without errors', async () => {
@@ -278,10 +268,7 @@ describe('Per-callback subscription handles', () => {
 
         // Unsubscribe eventY — channel should be fully cleaned up
         handleY.unsubscribe();
-        const mockSocket = window.getPusherInstance();
-        if (mockSocket && 'getChannel' in mockSocket) {
-            expect((mockSocket as {getChannel: (name: string) => unknown}).getChannel(CHANNEL)).toBeFalsy();
-        }
+        expect(MockedPusher.getInstance().getChannel(CHANNEL)).toBeFalsy();
     });
 
     it('should clear all callbacks on disconnect so they do not fire after re-init', async () => {
@@ -315,16 +302,15 @@ describe('Per-callback subscription handles', () => {
 
     it('should clean up channel when disposed mid-handshake before onSubscriptionSucceeded', async () => {
         // Capture the onSubscriptionSucceeded callback so we can fire it manually
+        const mockSocket = MockedPusher.getInstance();
         let capturedOnSuccess: (() => void) | undefined;
-        const mockSocket = window.getPusherInstance();
-        jest.spyOn(mockSocket as {subscribe: (props: {channelName: string; onEvent: unknown; onSubscriptionSucceeded: () => void}) => Promise<void>}, 'subscribe').mockImplementation(
-            ({channelName: cn, onEvent, onSubscriptionSucceeded}) => {
-                // Store the channel like the real mock, but DON'T call onSubscriptionSucceeded yet
-                (mockSocket as {channels: Map<string, unknown>}).channels.set(cn, {onEvent, onSubscriptionSucceeded});
-                capturedOnSuccess = onSubscriptionSucceeded;
-                return Promise.resolve();
-            },
-        );
+
+        jest.spyOn(mockSocket, 'subscribe').mockImplementation(({channelName: cn, onEvent, onSubscriptionSucceeded}) => {
+            // Store the channel like the real mock, but DON'T call onSubscriptionSucceeded yet
+            mockSocket.channels.set(cn, {onEvent, onSubscriptionSucceeded});
+            capturedOnSuccess = onSubscriptionSucceeded;
+            return Promise.resolve();
+        });
 
         const callback = jest.fn();
         const handle = Pusher.subscribe(CHANNEL, EVENT, callback);
@@ -342,7 +328,7 @@ describe('Per-callback subscription handles', () => {
         await handle;
 
         // Channel should be cleaned up since no callbacks are bound
-        expect((mockSocket as {channels: Map<string, unknown>}).channels.has(CHANNEL)).toBe(false);
+        expect(mockSocket.channels.has(CHANNEL)).toBe(false);
 
         // Event should not reach the callback
         triggerEvent(CHANNEL, EVENT);

--- a/tests/unit/PusherSubscribeTest.ts
+++ b/tests/unit/PusherSubscribeTest.ts
@@ -312,4 +312,40 @@ describe('Per-callback subscription handles', () => {
 
         newHandle.unsubscribe();
     });
+
+    it('should clean up channel when disposed mid-handshake before onSubscriptionSucceeded', async () => {
+        // Capture the onSubscriptionSucceeded callback so we can fire it manually
+        let capturedOnSuccess: (() => void) | undefined;
+        const mockSocket = window.getPusherInstance();
+        jest.spyOn(mockSocket as {subscribe: (props: {channelName: string; onEvent: unknown; onSubscriptionSucceeded: () => void}) => Promise<void>}, 'subscribe').mockImplementation(
+            ({channelName: cn, onEvent, onSubscriptionSucceeded}) => {
+                // Store the channel like the real mock, but DON'T call onSubscriptionSucceeded yet
+                (mockSocket as {channels: Map<string, unknown>}).channels.set(cn, {onEvent, onSubscriptionSucceeded});
+                capturedOnSuccess = onSubscriptionSucceeded;
+                return Promise.resolve();
+            },
+        );
+
+        const callback = jest.fn();
+        const handle = Pusher.subscribe(CHANNEL, EVENT, callback);
+
+        // Flush InteractionManager — socket.subscribe() fires, but onSubscriptionSucceeded is deferred
+        await jest.runAllTimersAsync();
+        expect(capturedOnSuccess).toBeDefined();
+
+        // Dispose the handle mid-handshake (wrappedCb is still undefined)
+        handle.unsubscribe();
+
+        // Now fire onSubscriptionSucceeded — the disposed handle should trigger channel cleanup
+        capturedOnSuccess?.();
+        await jest.runAllTimersAsync();
+        await handle;
+
+        // Channel should be cleaned up since no callbacks are bound
+        expect((mockSocket as {channels: Map<string, unknown>}).channels.has(CHANNEL)).toBe(false);
+
+        // Event should not reach the callback
+        triggerEvent(CHANNEL, EVENT);
+        expect(callback).not.toHaveBeenCalled();
+    });
 });


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
The Pusher module previously tracked subscriptions by channel+event key only, meaning multiple components subscribing to the same channel and event would share a single callback slot. When any one component unsubscribed, it would remove the binding for all subscribers — breaking other active listeners.

This change introduces per-callback tracking via a `Map` keyed by a unique handle ID. `subscribe()` now returns a `PusherSubscription` object (a `Promise` extended with an `unsubscribe()` method) that scopes the unbind operation to only the specific callback that was registered. Multiple components can now independently subscribe and unsubscribe from the same channel+event without interfering with each other.

This is PR 2 of a series decomposing ReportScreen into smaller, independently mountable units — a prerequisite for those components to safely manage their own Pusher subscriptions. Part of https://github.com/Expensify/App/pull/84971.

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/84895
PROPOSAL:


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

1. Typing indicators (subscribes to `USER_IS_TYPING` per report)
    - Open a chat with another user
    - Have the other user start typing → verify "is typing..." appears
    - Navigate away from the report and back → typing indicator should still work
    - Verify no duplicate typing indicators appear
  2. Room leaving status (subscribes to `USER_IS_LEAVING_ROOM`)
    - Join a group chat or room
    - Have another user leave the room → verify the membership update appears
    - Navigate away and back → verify no stale subscriptions
  3. Pusher reconnection (`onResubscribe` callback)
    - Open a chat, toggle airplane mode on/off (or kill network briefly)
    - Verify Pusher reconnects and real-time events resume (typing, new messages via push)
  4. General real-time messaging (subscribes via `PusherUtils.ts` to private user channel)
    - Send a message from another device/user → verify it appears in real-time without refresh
    - Do this across multiple reports to verify channel multiplexing works

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->
N/A

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->
Same as tests.

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>