### PR TITLE
Fix: Message disappears instead of strikethrough when deleting in offline mode

### DIFF
--- a/src/libs/actions/RequestConflictUtils.ts
+++ b/src/libs/actions/RequestConflictUtils.ts
@@ -138,17 +138,8 @@ function resolveCommentDeletionConflicts<TKey extends OnyxKey>(persistedRequests
     }
 
     if (addCommentFound) {
-        // The new message performs some changes in Onyx, so we need to rollback those changes.
-        const rollbackData: Array<OnyxUpdate<typeof ONYXKEYS.COLLECTION.REPORT_ACTIONS>> = [
-            {
-                onyxMethod: Onyx.METHOD.MERGE,
-                key: `${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${originalReportID}`,
-                value: {
-                    [reportActionID]: null,
-                },
-            },
-        ];
-        Onyx.update(rollbackData);
+        // The new message performs some changes in Onyx, but we do not rollback those changes here.
+        // The DELETE_COMMENT optimistic data will supersede the ADD_COMMENT data and set pendingAction: DELETE.
     }
 
     return {


### PR DESCRIPTION
### Details
**Problem:**
When a user sends messages while offline and then deletes one of those messages (still offline), the message disappears entirely instead of displaying with a strikethrough style indicating a pending deletion.

**Cause:**
The `resolveCommentDeletionConflicts` function has a side effect that deletes the report action from Onyx (`[reportActionID]: null`) when it finds a pending offline `ADD_COMMENT` for the same action. This conflict resolver runs during both request preparation and queue push, meaning its side effect runs twice and wipes out the optimistic delete data (`pendingAction: DELETE`) that was already applied. As a result, the action becomes `null` in Onyx, leaving the UI with nothing to render.

**Solution:**
Remove the `Onyx.update(rollbackData)` side effect from `resolveCommentDeletionConflicts`. The conflict resolver should be a pure function that returns conflict instructions (`type: 'delete'` and `pushNewRequest: false`). The optimistic delete flow in `deleteReportComment()` already handles setting `pendingAction: DELETE` while preserving `previousMessage`, which properly allows the deleted action to stay renderable offline with delete styling.