### PR TITLE
Fix: Navigate to non-existing link - Inbox opens upon clicking on Go back to home page

### DIFF
--- a/src/libs/Navigation/Navigation.ts
+++ b/src/libs/Navigation/Navigation.ts
@@ -550,18 +550,7 @@ function resetToHome() {
  * We will implement recursive pop if more use cases will appear.
  */
 function goBackToHome() {
-    const isNarrowLayout = getIsNarrowLayout();
-
-    // This set the right split navigator.
-    goBack(ROUTES.INBOX);
-
-    // We want to keep the report screen in the split navigator on wide layout.
-    if (!isNarrowLayout) {
-        return;
-    }
-
-    // This set the right route in this split navigator.
-    goBack(ROUTES.INBOX);
+    navigate(ROUTES.HOME);
 }
 
 /**


### PR DESCRIPTION
### Details
**Problem:**
When navigating to a non-existing URL, the "Page not found" screen shows a "Go back to home page" link. Clicking it takes the user to the Inbox (chat list) instead of the Home dashboard.

**Root Cause:**
`FullPageNotFoundView` defaults its `onLinkPress` to `Navigation.goBackToHome()`.
Inside `src/libs/Navigation/Navigation.ts`, the `goBackToHome()` function uses a legacy recursive `goBack(ROUTES.INBOX)` pattern. This predates the Home dashboard existing as a separate tab. Now that HOME and INBOX are distinct tabs (`ROUTES.HOME` vs `ROUTES.INBOX`), the function name and intended behavior no longer match the implementation.

**Fix:**
Replaced the `goBackToHome()` implementation with `navigate(ROUTES.HOME)`. The recursive `goBack(ROUTES.INBOX)` pattern was needed because INBOX is a split navigator (sidebar + report), but HOME is a simple screen, so `navigate(ROUTES.HOME)` correctly redirects without side-effects.

$ #85222