### PR TITLE
fix: allow bulk delete of unreported expenses

### DIFF
--- a/src/libs/ReportUtils.ts
+++ b/src/libs/ReportUtils.ts
@@ -3115,7 +3115,7 @@ function canDeleteMoneyRequestReport(report: OnyxEntry<Report>, reportTransactio
     const isUnreported = isSelfDM(report) || transaction?.reportID === CONST.REPORT.UNREPORTED_REPORT_ID;
     const canCardTransactionBeDeleted = canDeleteCardTransactionByLiabilityType(transaction);
     if (isUnreported) {
-        return isOwner && canCardTransactionBeDeleted;
+        return canCardTransactionBeDeleted;
     }
 
     if (isInvoiceReport(report)) {


### PR DESCRIPTION
$ https://github.com/Expensify/App/issues/85484

## Summary

- Removes the `isOwner` guard for unreported transactions in `canDeleteMoneyRequestReport` so the "Delete" bulk action appears for unreported expenses

## Root Cause

In `canDeleteMoneyRequestReport` (`src/libs/ReportUtils.ts:3117-3118`), the ownership check always fails for unreported transactions because:

1. Unreported expenses have `reportID = '0'` (the `UNREPORTED_REPORT_ID` constant)
2. No IOU report actions exist for this synthetic report ID
3. `getIOUActionForTransactionID([])` returns `undefined`, making `isOwner = false`
4. The function returns `isOwner && canCardTransactionBeDeleted` → `false`

## Fix

Remove the `isOwner` check from the unreported branch, changing:
```typescript
if (isUnreported) {
    return isOwner && canCardTransactionBeDeleted;
}
```
to:
```typescript
if (isUnreported) {
    return canCardTransactionBeDeleted;
}
```

**Why removing `isOwner` is safe for unreported expenses:**
1. Unreported expenses (`reportID = '0'`) are personal — they have not been submitted to any report or approver
2. The search API only returns a user's own unreported expenses; there is no admin or delegate path that surfaces another user's unreported transactions
3. The `canCardTransactionBeDeleted` check still guards against deleting corporate card transactions with the wrong liability type
4. The ownership check via IOU report actions is designed for **reported** expenses where admin/delegate access makes ownership verification necessary — this invariant does not apply to unreported expenses

## Test plan

- [ ] Navigate to Reports > Expenses
- [ ] Apply filters for unreported expenses
- [ ] Select more than 1 expense
- [ ] Click on the bulk select dropdown
- [ ] Verify the "Delete" option is now displayed
- [ ] Verify delete works correctly for selected unreported expenses
- [ ] Verify corporate card transactions with `liabilityType = RESTRICT` still cannot be deleted (guarded by `canCardTransactionBeDeleted`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)