### PR TITLE
fix: resolve onboarding navigation loop and task errors

### DIFF
--- a/src/libs/ReportUtils.ts
+++ b/src/libs/ReportUtils.ts
@@ -12097,6 +12097,7 @@ function prepareOnboardingOnyxData({
                 addExpenseApprovals: null,
                 setupCategoriesAndTags: null,
                 setupTags: null,
+                isInviteOnboardingComplete: false,
             },
         },
     );

--- a/src/pages/OnboardingAccounting/BaseOnboardingAccounting.tsx
+++ b/src/pages/OnboardingAccounting/BaseOnboardingAccounting.tsx
@@ -184,8 +184,11 @@ function BaseOnboardingAccounting({shouldUseNativeStyles, route}: BaseOnboarding
 
         setOnboardingUserReportedIntegration(userReportedIntegration);
 
-        // Navigate to the next onboarding step interested features with the selected integration
-        Navigation.navigate(ROUTES.ONBOARDING_INTERESTED_FEATURES.getRoute(route.params?.backTo));
+        // We need to have the Onyx values updated before navigating because the OnboardingGuard
+        // reads module-level variables synchronously and would see stale state, causing a redirect loop.
+        Navigation.setNavigationActionToMicrotaskQueue(() => {
+            Navigation.navigate(ROUTES.ONBOARDING_INTERESTED_FEATURES.getRoute(route.params?.backTo));
+        });
     }, [translate, userReportedIntegration, route.params?.backTo]);
 
     const handleIntegrationSelect = useCallback((integrationKey: OnboardingAccounting | null) => {

--- a/src/pages/OnboardingEmployees/BaseOnboardingEmployees.tsx
+++ b/src/pages/OnboardingEmployees/BaseOnboardingEmployees.tsx
@@ -65,7 +65,11 @@ function BaseOnboardingEmployees({shouldUseNativeStyles, route}: BaseOnboardingE
                         return;
                     }
                     setOnboardingCompanySize(selectedCompanySize);
-                    Navigation.navigate(ROUTES.ONBOARDING_ACCOUNTING.getRoute(route.params?.backTo));
+                    // We need to have the Onyx values updated before navigating because the OnboardingGuard
+                    // reads module-level variables synchronously and would see stale state, causing a redirect loop.
+                    Navigation.setNavigationActionToMicrotaskQueue(() => {
+                        Navigation.navigate(ROUTES.ONBOARDING_ACCOUNTING.getRoute(route.params?.backTo));
+                    });
                 }}
                 pressOnEnter
                 sentryLabel={CONST.SENTRY_LABEL.ONBOARDING.CONTINUE}

--- a/src/pages/OnboardingPurpose/BaseOnboardingPurpose.tsx
+++ b/src/pages/OnboardingPurpose/BaseOnboardingPurpose.tsx
@@ -93,13 +93,19 @@ function BaseOnboardingPurpose({shouldUseNativeStyles, shouldEnableMaxHeight, ro
                 setOnboardingPurposeSelected(choice);
                 setOnboardingErrorMessage(null);
                 if (choice === CONST.ONBOARDING_CHOICES.MANAGE_TEAM) {
-                    Navigation.navigate(ROUTES.ONBOARDING_EMPLOYEES.getRoute(route.params?.backTo));
+                    // We need to have the Onyx values updated before navigating because the OnboardingGuard
+                    // reads module-level variables synchronously and would see stale state, causing a redirect loop.
+                    Navigation.setNavigationActionToMicrotaskQueue(() => {
+                        Navigation.navigate(ROUTES.ONBOARDING_EMPLOYEES.getRoute(route.params?.backTo));
+                    });
                     return;
                 }
 
                 if (isPrivateDomainAndHasAccessiblePolicies && personalDetailsForm?.firstName) {
                     if (choice === CONST.ONBOARDING_CHOICES.PERSONAL_SPEND) {
-                        Navigation.navigate(ROUTES.ONBOARDING_WORKSPACE.getRoute(route.params?.backTo));
+                        Navigation.setNavigationActionToMicrotaskQueue(() => {
+                            Navigation.navigate(ROUTES.ONBOARDING_WORKSPACE.getRoute(route.params?.backTo));
+                        });
                         return;
                     }
                     completeOnboarding({
@@ -118,7 +124,9 @@ function BaseOnboardingPurpose({shouldUseNativeStyles, shouldEnableMaxHeight, ro
                     return;
                 }
 
-                Navigation.navigate(ROUTES.ONBOARDING_PERSONAL_DETAILS.getRoute(route.params?.backTo));
+                Navigation.setNavigationActionToMicrotaskQueue(() => {
+                    Navigation.navigate(ROUTES.ONBOARDING_PERSONAL_DETAILS.getRoute(route.params?.backTo));
+                });
             },
         };
     });


### PR DESCRIPTION
## Summary

$ https://github.com/Expensify/App/issues/85454

This PR addresses two interconnected onboarding bugs:

**1. Navigation loop (race condition):** During signup via "Manage Team" (10+ employees), onboarding modals get stuck cycling between steps. The `OnboardingGuard` evaluates navigation synchronously via module-level Onyx variables, but pages call `Onyx.set()` then `Navigation.navigate()` in the same execution tick, so the guard sees stale state and redirects incorrectly.

**Fix:** Wrap `Navigation.navigate()` calls in `Navigation.setNavigationActionToMicrotaskQueue()` after Onyx setters in three onboarding pages (`BaseOnboardingPurpose`, `BaseOnboardingEmployees`, `BaseOnboardingAccounting`). This defers navigation until Onyx callbacks propagate, matching the established pattern already used in `Welcome/index.ts` and `navigateAfterOnboarding.ts`.

**2. Task errors after refresh:** After refreshing to escape the loop, onboarding tasks display "Unexpected error posting the comment." The failure data in `prepareOnboardingOnyxData()` omits resetting `isInviteOnboardingComplete` to `false`. Since optimistic data sets it `true`, a failed `OPEN_REPORT` request leaves it permanently `true`, blocking retry attempts.

**Fix:** Add `isInviteOnboardingComplete: false` to the failure data for `NVP_INTRO_SELECTED` in `ReportUtils.ts`.

### Changed files
- `src/pages/OnboardingPurpose/BaseOnboardingPurpose.tsx` - Defer 3 navigation calls via microtask queue
- `src/pages/OnboardingEmployees/BaseOnboardingEmployees.tsx` - Defer 1 navigation call via microtask queue
- `src/pages/OnboardingAccounting/BaseOnboardingAccounting.tsx` - Defer 1 navigation call via microtask queue
- `src/libs/ReportUtils.ts` - Reset `isInviteOnboardingComplete` in failure data

## Test plan

- [ ] Create a new web account
- [ ] Choose "Manage a team" purpose
- [ ] Select "10+" employees
- [ ] Verify modals progress linearly without looping back
- [ ] Complete onboarding flow successfully
- [ ] Simulate API failure (e.g., via network throttle) during onboarding task creation
- [ ] Verify tasks can be retried after failure without permanent error state
- [ ] Verify other onboarding paths (Personal Spend, Employer) still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)