### PR TITLE
[50] Fix distance expense map preview cropping start/finish points

### DIFF
--- a/src/components/ImageWithSizeCalculation.tsx
+++ b/src/components/ImageWithSizeCalculation.tsx
@@ -53,6 +53,9 @@ type ImageWithSizeCalculationProps = {
 
     /** Reason attributes for skeleton span telemetry */
     reasonAttributes?: SkeletonSpanReasonAttributes;
+
+    /** Whether wide images should keep their natural aspect ratio instead of being forced to square */
+    shouldCalculateAspectRatioForWideImage?: boolean;
 };
 
 /**
@@ -74,6 +77,7 @@ function ImageWithSizeCalculation({
     onLoad,
     resizeMode,
     reasonAttributes,
+    shouldCalculateAspectRatioForWideImage = false,
 }: ImageWithSizeCalculationProps) {
     const styles = useThemeStyles();
 
@@ -104,6 +108,7 @@ function ImageWithSizeCalculation({
             loadingIconSize={loadingIconSize}
             loadingIndicatorStyles={loadingIndicatorStyles}
             reasonAttributes={reasonAttributes}
+            shouldCalculateAspectRatioForWideImage={shouldCalculateAspectRatioForWideImage}
         />
     );
 }

--- a/src/components/ReceiptImage/index.tsx
+++ b/src/components/ReceiptImage/index.tsx
@@ -73,6 +73,9 @@ type ReceiptImageProps = (
     /** Whether we should display the receipt with initial object position */
     shouldUseInitialObjectPosition?: boolean;
 
+    /** Whether wide images should keep their natural aspect ratio instead of being forced to square */
+    shouldCalculateAspectRatioForWideImage?: boolean;
+
     /** Whether the receipt image requires an authToken */
     isAuthTokenRequired?: boolean;
 
@@ -147,6 +150,7 @@ function ReceiptImage({
     fallbackIcon,
     fallbackIconSize,
     shouldUseInitialObjectPosition = false,
+    shouldCalculateAspectRatioForWideImage = false,
     fallbackIconColor,
     fallbackIconBackground,
     isEmptyReceipt = false,
@@ -227,6 +231,7 @@ function ReceiptImage({
                 fallbackIconColor={fallbackIconColor}
                 fallbackIconBackground={fallbackIconBackground}
                 objectPosition={shouldUseInitialObjectPosition ? CONST.IMAGE_OBJECT_POSITION.INITIAL : CONST.IMAGE_OBJECT_POSITION.TOP}
+                shouldCalculateAspectRatioForWideImage={shouldCalculateAspectRatioForWideImage}
                 onLoad={onLoad}
                 onLoadFailure={onLoadFailure}
                 resizeMode={resizeMode}
@@ -251,7 +256,7 @@ function ReceiptImage({
             shouldShowOfflineIndicator={false}
             objectPosition={shouldUseInitialObjectPosition ? CONST.IMAGE_OBJECT_POSITION.INITIAL : CONST.IMAGE_OBJECT_POSITION.TOP}
             onLoad={onLoad}
-            shouldCalculateAspectRatioForWideImage={shouldUseFullHeight}
+            shouldCalculateAspectRatioForWideImage={shouldUseFullHeight || shouldCalculateAspectRatioForWideImage}
             imageWidthToCalculateHeight={receiptImageWidth}
             onError={onLoadFailure}
             resizeMode={resizeMode}

--- a/src/components/ReportActionItem/ReportActionItemImage.tsx
+++ b/src/components/ReportActionItem/ReportActionItemImage.tsx
@@ -155,8 +155,6 @@ function ReportActionItemImage({
             fallbackIconSize: isSingleImage ? variables.iconSizeSuperLarge : variables.iconSizeExtraLarge,
             isAuthTokenRequired: true,
 
-            // If the image is full height, use initial position to make sure it will grow properly to fill the container
-            shouldUseInitialObjectPosition: isMapDistanceRequest && !shouldUseFullHeight,
         };
     } else if (isLocalFile && isPDF && typeof originalImageSource === 'string') {
         propsObj = {isPDFThumbnail: true, source: originalImageSource};
@@ -167,15 +165,13 @@ function ReportActionItemImage({
             shouldUseThumbnailImage: shouldUseThumbnailImage ?? true,
             isAuthTokenRequired: false,
             source: shouldUseThumbnailImage ? (thumbnail ?? image ?? '') : originalImageSource,
-
-            // If the image is full height, use initial position to make sure it will grow properly to fill the container
-            shouldUseInitialObjectPosition: isMapDistanceRequest && !shouldUseFullHeight,
             isEmptyReceipt,
             onPress,
         };
     }
 
     propsObj.isPerDiemRequest = isPerDiemRequest(transaction);
+    propsObj.shouldCalculateAspectRatioForWideImage = isMapDistanceRequest;
 
     if (enablePreviewModal) {
         return (

--- a/src/components/ReportActionItem/TransactionPreview/TransactionPreviewContent.tsx
+++ b/src/components/ReportActionItem/TransactionPreview/TransactionPreviewContent.tsx
@@ -36,7 +36,7 @@ import StringUtils from '@libs/StringUtils';
 import type {SkeletonSpanReasonAttributes} from '@libs/telemetry/useSkeletonSpan';
 import type {TranslationPathOrText} from '@libs/TransactionPreviewUtils';
 import {createTransactionPreviewConditionals, getIOUPayerAndReceiver, getTransactionPreviewTextAndTranslationPaths} from '@libs/TransactionPreviewUtils';
-import {isManagedCardTransaction as isCardTransactionUtils, isGPSDistanceRequest, isMapDistanceRequest, isScanning} from '@libs/TransactionUtils';
+import {isManagedCardTransaction as isCardTransactionUtils, isGPSDistanceRequest, isScanning} from '@libs/TransactionUtils';
 import ViolationsUtils, {filterReceiptViolations} from '@libs/Violations/ViolationsUtils';
 import variables from '@styles/variables';
 import CONST from '@src/CONST';
@@ -271,7 +271,7 @@ function TransactionPreviewContent({
                         // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
                         isHovered={isHovered || isTransactionScanning}
                         size={1}
-                        shouldUseAspectRatio={!isMapDistanceRequest(transaction) && !isGPSDistanceRequest(transaction)}
+                        shouldUseAspectRatio={!isGPSDistanceRequest(transaction)}
                     />
                     {shouldShowSkeleton ? (
                         <TransactionPreviewSkeletonView

--- a/src/components/ThumbnailImage.tsx
+++ b/src/components/ThumbnailImage.tsx
@@ -83,6 +83,9 @@ type ThumbnailImageProps = {
 
     /** Reason attributes for skeleton span telemetry */
     reasonAttributes?: SkeletonSpanReasonAttributes;
+
+    /** Whether wide images should keep their natural aspect ratio instead of being forced to square */
+    shouldCalculateAspectRatioForWideImage?: boolean;
 };
 
 function ThumbnailImage({
@@ -106,6 +109,7 @@ function ThumbnailImage({
     onLoad,
     resizeMode,
     reasonAttributes,
+    shouldCalculateAspectRatioForWideImage = false,
 }: ThumbnailImageProps) {
     const icons = useMemoizedLazyExpensifyIcons(['Gallery', 'OfflineCloud']);
     const styles = useThemeStyles();
@@ -172,6 +176,7 @@ function ThumbnailImage({
                     onLoad={onLoad}
                     resizeMode={resizeMode}
                     reasonAttributes={reasonAttributes}
+                    shouldCalculateAspectRatioForWideImage={shouldCalculateAspectRatioForWideImage}
                 />
             </View>
         </View>


### PR DESCRIPTION
## Summary
$ #84903

Distance expense map previews were cropping the start and finish route points because the landscape map image aspect ratio didn't match the portrait preview container.

## Root Cause
Two special-case code paths caused the cropping:

1. ** override** in  set  to `initial` for map distance receipts, which caused the `Image` component's `updateAspectRatio` callback to exit early (it only runs when `objectPosition` is `top`). Without aspect ratio calculation, the landscape map filled the fixed-height container and endpoints at the edges got cropped.

2. **TransactionPreviewContent** excluded map distance requests from the standard 16:9 aspect ratio container, giving them a fixed 160px height that worsened cropping in chat previews.

## Changes
1. **ReportActionItemImage.tsx**: Remove `shouldUseInitialObjectPosition: isMapDistanceRequest && !shouldUseFullHeight` (lines 159, 172) — let `objectPosition` default to `top` so aspect ratio calculation runs normally.

2. **ReceiptImage.tsx**: Add `shouldCalculateAspectRatioForWideImage` prop and pass it through both the ThumbnailImage path and the ImageWithLoading path.

3. **ThumbnailImage.tsx**: Add `shouldCalculateAspectRatioForWideImage` prop and forward to `ImageWithSizeCalculation`.

4. **ImageWithSizeCalculation.tsx**: Add `shouldCalculateAspectRatioForWideImage` prop and forward to `ImageWithLoading`.

5. **TransactionPreviewContent.tsx**: Change `shouldUseAspectRatio` condition from `!isMapDistanceRequest && !isGPSDistanceRequest` to `!isGPSDistanceRequest` so map distance receipts use the standard 16:9 container.

## Testing
- Verified that map distance images will now preserve their natural aspect ratio instead of being cropped
- GPS and manual distance requests are unaffected (isMapDistanceRequest only matches map-based distance, not GPS or manual)

## Issue
$ #84903