### PR TITLE
Sort RBR-actionable expenses first in carousel and transaction list

### DIFF
--- a/src/components/MoneyRequestReportView/MoneyRequestReportTransactionList.tsx
+++ b/src/components/MoneyRequestReportView/MoneyRequestReportTransactionList.tsx
@@ -196,6 +196,7 @@ function MoneyRequestReportTransactionList({
     const [amountOwed] = useOnyx(ONYXKEYS.NVP_PRIVATE_AMOUNT_OWED);
     const [reportDetailsColumns] = useOnyx(ONYXKEYS.NVP_REPORT_DETAILS_COLUMNS);
     const [introSelected] = useOnyx(ONYXKEYS.NVP_INTRO_SELECTED);
+    const [transactionViolations] = useOnyx(ONYXKEYS.COLLECTION.TRANSACTION_VIOLATIONS);
     const [draftTransactionIDs] = useOnyx(ONYXKEYS.COLLECTION.TRANSACTION_DRAFT, {selector: validTransactionDraftIDsSelector});
 
     const shouldShowGroupedTransactions = isExpenseReport(report) && !isIOUReport(report);
@@ -267,8 +268,19 @@ function MoneyRequestReportTransactionList({
     const {sortBy, sortOrder} = sortConfig;
 
     const sortedTransactions: TransactionWithOptionalHighlight[] = useMemo(() => {
-        return [...transactions].sort((a, b) => compareValues(getTransactionValue(a, sortBy, report), getTransactionValue(b, sortBy, report), sortOrder, sortBy, localeCompare, true));
-    }, [sortBy, sortOrder, transactions, localeCompare, report]);
+        const isDefaultSort = sortBy === CONST.SEARCH.TABLE_COLUMNS.DATE && sortOrder === CONST.SEARCH.SORT_ORDER.ASC;
+        return [...transactions].sort((a, b) => {
+            // When using default sort, prioritize RBR-actionable transactions
+            if (isDefaultSort) {
+                const aHasViolations = (transactionViolations?.[ONYXKEYS.COLLECTION.TRANSACTION_VIOLATIONS + a.transactionID]?.length ?? 0) > 0;
+                const bHasViolations = (transactionViolations?.[ONYXKEYS.COLLECTION.TRANSACTION_VIOLATIONS + b.transactionID]?.length ?? 0) > 0;
+                if (aHasViolations !== bHasViolations) {
+                    return aHasViolations ? -1 : 1;
+                }
+            }
+            return compareValues(getTransactionValue(a, sortBy, report), getTransactionValue(b, sortBy, report), sortOrder, sortBy, localeCompare, true);
+        });
+    }, [sortBy, sortOrder, transactions, localeCompare, report, transactionViolations]);
 
     const highlightedTransactionIDs = useMemo(() => new Set(newTransactions.map(({transactionID}) => transactionID)), [newTransactions]);
 

--- a/src/components/ReportActionItem/MoneyRequestReportPreview/MoneyRequestReportPreviewContent.tsx
+++ b/src/components/ReportActionItem/MoneyRequestReportPreview/MoneyRequestReportPreviewContent.tsx
@@ -504,7 +504,21 @@ function MoneyRequestReportPreviewContent({
         thumbsUpScale.set(isApprovedAnimationRunning ? withDelay(CONST.ANIMATION_THUMBS_UP_DELAY, withSpring(1, {duration: CONST.ANIMATION_THUMBS_UP_DURATION})) : 1);
     }, [isApproved, isApprovedAnimationRunning, thumbsUpScale]);
 
-    const carouselTransactions = useMemo(() => (shouldShowAccessPlaceHolder ? [] : transactions.slice(0, 11)), [shouldShowAccessPlaceHolder, transactions]);
+    const carouselTransactions = useMemo(() => {
+        if (shouldShowAccessPlaceHolder) {
+            return [];
+        }
+        // Sort RBR-actionable transactions first so users see expenses that need attention
+        const sorted = [...transactions].sort((a, b) => {
+            const aHasViolations = (transactionViolations?.[ONYXKEYS.COLLECTION.TRANSACTION_VIOLATIONS + a.transactionID]?.length ?? 0) > 0;
+            const bHasViolations = (transactionViolations?.[ONYXKEYS.COLLECTION.TRANSACTION_VIOLATIONS + b.transactionID]?.length ?? 0) > 0;
+            if (aHasViolations !== bHasViolations) {
+                return aHasViolations ? -1 : 1;
+            }
+            return 0;
+        });
+        return sorted.slice(0, 11);
+    }, [shouldShowAccessPlaceHolder, transactions, transactionViolations]);
     const prevCarouselTransactionLength = useRef(0);
 
     useEffect(() => {


### PR DESCRIPTION
## Summary
$ #85553 — Expense carousel doesn't show RBR-actionable expenses first.

## Changes

### 1. Carousel ()
- Added RBR-aware sorting before  so expenses with violations appear first in the carousel
- Uses existing `transactionViolations` from Onyx to check per-transaction violation status

### 2. Transaction List ()  
- Added `transactionViolations` from Onyx
- When default sort (Date/ASC) is active, RBR-actionable transactions are sorted to the front as a primary sort key, with date as secondary
- When user selects a different sort (merchant, amount, etc.), RBR sorting does not override user choice

## Root Cause
No RBR-aware sorting existed in the transaction display path — data flowed from Onyx → `Object.values()` (insertion order) → carousel/list without prioritizing actionable items.

## Testing
- Open a report with multiple expenses where at least one has an RBR indicator
- Verify the RBR-flagged expense appears first in the carousel
- Verify the same in the report transaction list (default Date/ASC sort)
- Verify that selecting a different sort column overrides RBR-first ordering

## Bounty
Claiming $250 bounty for #85553