### PR TITLE
[$250] Introduce the ability to add a new category within the category list

### DIFF
--- a/src/pages/iou/request/step/IOURequestStepCategory.tsx
+++ b/src/pages/iou/request/step/IOURequestStepCategory.tsx
@@ -6,8 +6,12 @@ import FullPageOfflineBlockingView from '@components/BlockingViews/FullPageOffli
 import Button from '@components/Button';
 import CategoryPicker from '@components/CategoryPicker';
 import FixedFooter from '@components/FixedFooter';
+import Icon from '@components/Icon';
+import * as Expensicons from '@components/Icon/Expensicons';
+import PressableWithoutFeedback from '@components/Pressable/PressableWithoutFeedback';
 import {useSearchStateContext} from '@components/Search/SearchContext';
 import type {ListItem} from '@components/SelectionListWithSections/types';
+import Tooltip from '@components/Tooltip';
 import WorkspaceEmptyStateSection from '@components/WorkspaceEmptyStateSection';
 import useCurrentUserPersonalDetails from '@hooks/useCurrentUserPersonalDetails';
 import {useMemoizedLazyIllustrations} from '@hooks/useLazyAsset';
@@ -19,6 +23,7 @@ import usePolicyData from '@hooks/usePolicyData';
 import usePolicyForTransaction from '@hooks/usePolicyForTransaction';
 import useRestartOnReceiptFailure from '@hooks/useRestartOnReceiptFailure';
 import useShowNotFoundPageInIOUStep from '@hooks/useShowNotFoundPageInIOUStep';
+import useTheme from '@hooks/useTheme';
 import useThemeStyles from '@hooks/useThemeStyles';
 import {getIOURequestPolicyID, setMoneyRequestCategory, updateMoneyRequestCategory} from '@libs/actions/IOU';
 import {setDraftSplitTransaction} from '@libs/actions/IOU/Split';
@@ -27,7 +32,7 @@ import {isCategoryMissing} from '@libs/CategoryUtils';
 import getNonEmptyStringOnyxID from '@libs/getNonEmptyStringOnyxID';
 import Navigation from '@libs/Navigation/Navigation';
 import {hasEnabledOptions} from '@libs/OptionsListUtils';
-import {isPolicyAdmin} from '@libs/PolicyUtils';
+import {getValidConnectedIntegration, isPolicyAdmin} from '@libs/PolicyUtils';
 import {getReportOrDraftReport, getTransactionDetails, isGroupPolicy, isReportInGroupPolicy} from '@libs/ReportUtils';
 import type {SkeletonSpanReasonAttributes} from '@libs/telemetry/useSkeletonSpan';
 import {getRequestType} from '@libs/TransactionUtils';
@@ -53,6 +58,7 @@ function IOURequestStepCategory({
     transaction,
 }: IOURequestStepCategoryProps) {
     const styles = useThemeStyles();
+    const theme = useTheme();
     const {translate} = useLocalize();
     const illustrations = useMemoizedLazyIllustrations(['EmptyStateExpenses']);
     const requestType = getRequestType(transaction);
@@ -123,6 +129,20 @@ function IOURequestStepCategory({
         Navigation.goBack(backTo);
     };
 
+    const navigateToCreateCategory = () => {
+        if (!policyID || !report?.reportID) {
+            return;
+        }
+        Navigation.navigate(
+            ROUTES.SETTINGS_CATEGORY_CREATE.getRoute(
+                policyID,
+                ROUTES.MONEY_REQUEST_STEP_CATEGORY.getRoute(action, iouType, transactionID, report.reportID, backTo, reportActionID),
+            ),
+        );
+    };
+
+    const canAddCategory = isPolicyAdmin(policy) && !getValidConnectedIntegration(policy);
+
     const updateCategory = (category: ListItem) => {
         const categorySearchText = category.searchText ?? '';
         const isSelectedCategory = categorySearchText === categoryForDisplay;
@@ -178,6 +198,23 @@ function IOURequestStepCategory({
             shouldShowOfflineIndicator={policyCategories !== undefined}
             testID="IOURequestStepCategory"
             shouldEnableKeyboardAvoidingView={false}
+            headerChildren={
+                canAddCategory ? (
+                    <Tooltip text={translate('workspace.categories.addCategory')}>
+                        <PressableWithoutFeedback
+                            onPress={navigateToCreateCategory}
+                            style={[styles.touchableButtonImage]}
+                            role={CONST.ROLE.BUTTON}
+                            accessibilityLabel={translate('workspace.categories.addCategory')}
+                        >
+                            <Icon
+                                src={Expensicons.Plus}
+                                fill={theme.icon}
+                            />
+                        </PressableWithoutFeedback>
+                    </Tooltip>
+                ) : null
+            }
         >
             {isLoading && (
                 <ActivityIndicator

--- a/src/pages/iou/request/step/StepScreenWrapper.tsx
+++ b/src/pages/iou/request/step/StepScreenWrapper.tsx
@@ -39,6 +39,9 @@ type StepScreenWrapperProps = {
 
     /** Flag to indicate if the keyboard avoiding view should be enabled */
     shouldEnableKeyboardAvoidingView?: boolean;
+
+    /** Optional content rendered on the right side of the header */
+    headerChildren?: ReactNode;
 };
 
 function StepScreenWrapper({
@@ -52,6 +55,7 @@ function StepScreenWrapper({
     includeSafeAreaPaddingBottom,
     shouldShowOfflineIndicator = true,
     shouldEnableKeyboardAvoidingView = true,
+    headerChildren,
 }: StepScreenWrapperProps) {
     const styles = useThemeStyles();
 
@@ -74,7 +78,9 @@ function StepScreenWrapper({
                         <HeaderWithBackButton
                             title={headerTitle}
                             onBackButtonPress={onBackButtonPress}
-                        />
+                        >
+                            {headerChildren}
+                        </HeaderWithBackButton>
                         {
                             // If props.children is a function, call it to provide the insets to the children
                             callOrReturn(children, {insets, safeAreaPaddingBottomStyle, didScreenTransitionEnd})


### PR DESCRIPTION
/claim #85681

Admins without an accounting integration can now create a category directly from the expense category selector instead of having to leave the expense, navigate to workspace settings, and come back.

Added a \`headerChildren\` prop to \`StepScreenWrapper\` so it can forward content into \`HeaderWithBackButton\`'s existing \`children\` slot — the same pattern \`WorkspaceCategoriesPage\` already uses for its Add button. In \`IOURequestStepCategory\`, a \`+\` icon button appears in the header whenever \`isPolicyAdmin\` is true and there's no connected accounting integration (since synced workspaces manage categories externally). Tapping it navigates to \`SETTINGS_CATEGORY_CREATE\` with a \`backTo\` pointing back to the category step, so the user returns automatically after saving. The new category then appears via Onyx reactivity.

$ #85681