### PR TITLE
[50] [VBBA] connectBankAccountWithPlaid can send bankAccountID as NaN after verify-account resume flow

### DIFF
--- a/src/libs/actions/BankAccounts.ts
+++ b/src/libs/actions/BankAccounts.ts
@@ -256,7 +256,7 @@ function getOnyxDataForConnectingVBBAAndLastPaymentMethod(
  */
 function connectBankAccountWithPlaid(bankAccountID: number, selectedPlaidBankAccount: PlaidBankAccount, policyID: string) {
     const parameters: ConnectBankAccountParams = {
-        bankAccountID,
+        bankAccountID: Number.isFinite(bankAccountID) ? bankAccountID : CONST.DEFAULT_NUMBER_ID,
         routingNumber: selectedPlaidBankAccount.routingNumber,
         accountNumber: selectedPlaidBankAccount.accountNumber,
         bank: selectedPlaidBankAccount.bankName,

--- a/src/pages/ReimbursementAccount/USD/BankInfo/BankInfo.tsx
+++ b/src/pages/ReimbursementAccount/USD/BankInfo/BankInfo.tsx
@@ -51,7 +51,7 @@ function BankInfo({onBackButtonPress, policyID, setUSDBankAccountStep}: BankInfo
         setupType = CONST.BANK_ACCOUNT.SETUP_TYPE.PLAID;
     }
 
-    const bankAccountID = Number(reimbursementAccount?.achData?.bankAccountID);
+    const bankAccountID = Number(reimbursementAccount?.achData?.bankAccountID ?? CONST.DEFAULT_NUMBER_ID);
     const submit = (submitData: unknown) => {
         const data = submitData as ReimbursementAccountForm;
         if (setupType === CONST.BANK_ACCOUNT.SETUP_TYPE.MANUAL) {

--- a/src/pages/ReimbursementAccount/USD/CompleteVerification/CompleteVerification.tsx
+++ b/src/pages/ReimbursementAccount/USD/CompleteVerification/CompleteVerification.tsx
@@ -32,7 +32,7 @@ function CompleteVerification({onBackButtonPress}: CompleteVerificationProps) {
 
     const submit = useCallback(() => {
         acceptACHContractForBankAccount(
-            Number(reimbursementAccount?.achData?.bankAccountID),
+            Number(reimbursementAccount?.achData?.bankAccountID ?? CONST.DEFAULT_NUMBER_ID),
             {
                 isAuthorizedToUseBankAccount: values.isAuthorizedToUseBankAccount,
                 certifyTrueInformation: values.certifyTrueInformation,

--- a/src/pages/ReimbursementAccount/USD/Requestor/PersonalInfo/PersonalInfo.tsx
+++ b/src/pages/ReimbursementAccount/USD/Requestor/PersonalInfo/PersonalInfo.tsx
@@ -37,7 +37,7 @@ function PersonalInfo({onBackButtonPress, ref}: PersonalInfoProps) {
 
     const policyID = reimbursementAccount?.achData?.policyID;
     const values = useMemo(() => getSubStepValues(PERSONAL_INFO_STEP_KEYS, reimbursementAccountDraft, reimbursementAccount), [reimbursementAccount, reimbursementAccountDraft]);
-    const bankAccountID = Number(reimbursementAccount?.achData?.bankAccountID);
+    const bankAccountID = Number(reimbursementAccount?.achData?.bankAccountID ?? CONST.DEFAULT_NUMBER_ID);
     const submit = useCallback(
         (isConfirmPage: boolean) => {
             updatePersonalInformationForBankAccount(bankAccountID, {...values}, policyID, isConfirmPage);


### PR DESCRIPTION
/claim #85747

When `achData` is undefined during the verify-account resume flow, `Number(undefined)` evaluates to `NaN`, which gets sent as the `bankAccountID` in the `ConnectBankAccountWithPlaid` API call. Fixed by falling back to `CONST.DEFAULT_NUMBER_ID` before passing through `Number()` in `BankInfo.tsx`, `CompleteVerification.tsx`, and `PersonalInfo.tsx`. Also added a `Number.isFinite` guard inside `connectBankAccountWithPlaid` itself as a last line of defense. The key insight was that `Number(undefined ?? fallback)` correctly uses the fallback while `Number(undefined)` silently produces `NaN`.

$ #85747