### PR TITLE
[50] Navigation- Web page stuck on logo when navigating to IOU while logout

### DIFF
--- a/src/libs/Network/SequentialQueue.ts
+++ b/src/libs/Network/SequentialQueue.ts
@@ -224,7 +224,7 @@ function process(): Promise<void> {
                 Log.info('[SequentialQueue] RESEND_VALIDATE_CODE throttled, not retrying', false, {
                     command: requestToProcess.command,
                 });
-                Onyx.update(requestToProcess.failureData ?? []);
+                Onyx.update([...(requestToProcess.failureData ?? []), ...(requestToProcess.finallyData ?? [])] as AnyOnyxUpdate[]);
                 endPersistedRequestAndRemoveFromQueue(requestToProcess);
                 sequentialQueueRequestThrottle.clear();
                 return process();
@@ -249,7 +249,7 @@ function process(): Promise<void> {
                         command: requestToProcess.command,
                         errorMessage: error.message,
                     });
-                    Onyx.update(requestToProcess.failureData ?? []);
+                    Onyx.update([...(requestToProcess.failureData ?? []), ...(requestToProcess.finallyData ?? [])] as AnyOnyxUpdate[]);
                     endPersistedRequestAndRemoveFromQueue(requestToProcess);
                     sequentialQueueRequestThrottle.clear();
                     if (requestToProcess.command === WRITE_COMMANDS.OPEN_APP) {


### PR DESCRIPTION
/claim #85763

When a request fails after exhausting retries or gets throttled (specifically `RESEND_VALIDATE_CODE`), only `failureData` was being applied to Onyx — `finallyData` was silently dropped. Since `finallyData` typically carries cleanup state like resetting loading flags, skipping it left the UI frozen on the logo screen during logout flows that triggered an IOU navigation. The fix mirrors the existing `shouldFailAllRequests` path (line 206) which already applied both data sets correctly — I checked all three failure branches to make sure they're now consistent.

$ #85763