### PR TITLE
[$250] Add a warning modal when hitting the back button from Travel

### DIFF
--- a/src/pages/Travel/TravelDotLinkWebview.tsx
+++ b/src/pages/Travel/TravelDotLinkWebview.tsx
@@ -1,8 +1,9 @@
 import type {StackScreenProps} from '@react-navigation/stack';
-import React, {useRef} from 'react';
+import React, {useCallback, useRef} from 'react';
 import WebView from 'react-native-webview';
 import HeaderWithBackButton from '@components/HeaderWithBackButton';
 import ScreenWrapper from '@components/ScreenWrapper';
+import useDiscardChangesConfirmation from '@hooks/useDiscardChangesConfirmation';
 import useLocalize from '@hooks/useLocalize';
 import useThemeStyles from '@hooks/useThemeStyles';
 import {buildTravelDotURL} from '@libs/actions/Link';
@@ -16,6 +17,10 @@ function TravelDotLinkWebview({route}: TravelDotLinkWebviewProps) {
     const {token, isTestAccount, redirectUrl} = route.params;
     const webViewRef = useRef<WebView>(null);
     const styles = useThemeStyles();
+
+    useDiscardChangesConfirmation({
+        getHasUnsavedChanges: useCallback(() => true, []),
+    });
 
     const url = buildTravelDotURL(token, isTestAccount === 'true', redirectUrl);
 


### PR DESCRIPTION
/claim #85675

Adds back-navigation guard to TravelDotLinkWebview using the existing useDiscardChangesConfirmation hook. The hook is already used in several other screens (AvatarPage, IOURequestStepDescription, IOURequestStepMerchant) and handles both the header back button and Android hardware back button via React Navigation's usePreventRemove. Since any navigation away from the travel booking webview destroys the Spotnana session, getHasUnsavedChanges always returns true to ensure the confirmation modal always fires.

$ #85675