### PR TITLE
[50] Navigation- Web page stuck on logo when navigating to IOU while logout

### DIFF
--- a/src/libs/Network/SequentialQueue.ts
+++ b/src/libs/Network/SequentialQueue.ts
@@ -224,7 +224,7 @@ function process(): Promise<void> {
                 Log.info('[SequentialQueue] RESEND_VALIDATE_CODE throttled, not retrying', false, {
                     command: requestToProcess.command,
                 });
-                Onyx.update(requestToProcess.failureData ?? []);
+                Onyx.update([...(requestToProcess.failureData ?? []), ...(requestToProcess.finallyData ?? [])]);
                 endPersistedRequestAndRemoveFromQueue(requestToProcess);
                 sequentialQueueRequestThrottle.clear();
                 return process();
@@ -249,7 +249,7 @@ function process(): Promise<void> {
                         command: requestToProcess.command,
                         errorMessage: error.message,
                     });
-                    Onyx.update(requestToProcess.failureData ?? []);
+                    Onyx.update([...(requestToProcess.failureData ?? []), ...(requestToProcess.finallyData ?? [])]);
                     endPersistedRequestAndRemoveFromQueue(requestToProcess);
                     sequentialQueueRequestThrottle.clear();
                     if (requestToProcess.command === WRITE_COMMANDS.OPEN_APP) {


### PR DESCRIPTION
/claim #85763

When a request fails terminally (either throttled `RESEND_VALIDATE_CODE` or exhausted retries), only `failureData` was being applied to Onyx — `finallyData` was silently skipped. This mattered for `OpenApp` failures because `finallyData` often contains the cleanup updates that unblock navigation, so the app would stay frozen on the splash/logo screen. I checked the `shouldFailAllRequests` path higher up in the same function and confirmed it already correctly spreads both `failureData` and `finallyData` together — this fix brings the two terminal failure branches in line with that existing pattern.

$ #85763