### PR TITLE
[50] Add BA - Personal information RHP remains loading after reloading the page

### DIFF
--- a/src/pages/ReimbursementAccount/ReimbursementAccountPage.tsx
+++ b/src/pages/ReimbursementAccount/ReimbursementAccountPage.tsx
@@ -239,7 +239,7 @@ function ReimbursementAccountPage({route, policy, isLoadingPolicy, navigation}: 
             return;
         }
 
-        if (policyIDParam) {
+        if (policyIDParam && !isLoadingOnyxValue(reimbursementAccountMetadata)) {
             setReimbursementAccountLoading(true);
             clearReimbursementAccountDraft();
         }


### PR DESCRIPTION
/claim #85488

The loading spinner was getting stuck on the BA Personal Information RHP after a page reload because `setReimbursementAccountLoading(true)` was being called before `reimbursementAccountMetadata` had finished loading from Onyx. This prematurely set the loading flag while the metadata was still in an indeterminate state, so the page never recovered. The fix mirrors the same `isLoadingOnyxValue` guard already used in the `fetchData` function — we now skip the loading reset until the metadata is actually ready, which is the right condition to check here. 

$ #85488