### PR TITLE
[50] Add BA - Personal information RHP remains loading after reloading the page

### DIFF
--- a/src/pages/ReimbursementAccount/ReimbursementAccountPage.tsx
+++ b/src/pages/ReimbursementAccount/ReimbursementAccountPage.tsx
@@ -234,12 +234,26 @@ function ReimbursementAccountPage({route, policy, isLoadingPolicy, navigation}: 
         openReimbursementAccountPage({stepToOpen, subStep, localCurrentStep, policyID: policyIDParam, shouldPreserveDraft: preserveCurrentStep});
     }
 
+    const isMetadataLoading = isLoadingOnyxValue(reimbursementAccountMetadata);
+
     useEffect(() => {
-        if (isPreviousPolicy && !!reimbursementAccount) {
+        // Wait until Onyx metadata is ready so fetchData() can actually fire the API call.
+        // Calling setReimbursementAccountLoading(true) before fetchData() is ready would leave
+        // isLoading stuck at true if fetchData() returns early due to metadata not being loaded.
+        if (isMetadataLoading) {
             return;
         }
 
-        if (policyIDParam && !isLoadingOnyxValue(reimbursementAccountMetadata)) {
+        if (isPreviousPolicy && !!reimbursementAccount) {
+            // If isLoading is persisted as true from a prior offline submission, fetchData() to
+            // get fresh state from the server and clear the stale loading flag.
+            if (reimbursementAccount.isLoading) {
+                fetchData();
+            }
+            return;
+        }
+
+        if (policyIDParam) {
             setReimbursementAccountLoading(true);
             clearReimbursementAccountDraft();
         }
@@ -252,7 +266,7 @@ function ReimbursementAccountPage({route, policy, isLoadingPolicy, navigation}: 
         }
         fetchData();
         // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [isPreviousPolicy]); // Only re-run this effect when isPreviousPolicy changes, which happens once when the component first loads
+    }, [isPreviousPolicy, isMetadataLoading]);
 
     useEffect(() => {
         if (policyIDParam && !isPreviousPolicy) {

--- a/src/pages/ReimbursementAccount/ReimbursementAccountPage.tsx
+++ b/src/pages/ReimbursementAccount/ReimbursementAccountPage.tsx
@@ -239,7 +239,7 @@ function ReimbursementAccountPage({route, policy, isLoadingPolicy, navigation}: 
             return;
         }
 
-        if (policyIDParam) {
+        if (policyIDParam && !isLoadingOnyxValue(reimbursementAccountMetadata)) {
             setReimbursementAccountLoading(true);
             clearReimbursementAccountDraft();
         }

--- a/src/pages/ReimbursementAccount/USD/Requestor/PersonalInfo/PersonalInfo.tsx
+++ b/src/pages/ReimbursementAccount/USD/Requestor/PersonalInfo/PersonalInfo.tsx
@@ -45,7 +45,8 @@ function PersonalInfo({onBackButtonPress, ref}: PersonalInfoProps) {
         [values, bankAccountID, policyID],
     );
     const isBankAccountVerifying = reimbursementAccount?.achData?.state === CONST.BANK_ACCOUNT.STATE.VERIFYING;
-    const startFrom = useMemo(() => (isBankAccountVerifying ? 0 : getInitialSubStepForPersonalInfo(values)), [values, isBankAccountVerifying]);
+    const initialSubStep = useMemo(() => getInitialSubStepForPersonalInfo(values), [values]);
+    const startFrom = useMemo(() => (isBankAccountVerifying && initialSubStep === 0 ? 0 : initialSubStep), [isBankAccountVerifying, initialSubStep]);
 
     const {
         componentToRender: SubStep,


### PR DESCRIPTION
/claim #85488

When you reload the Personal Information RHP during bank account setup, the page gets stuck in a loading state because `setReimbursementAccountLoading(true)` fires before Onyx metadata is ready — so `fetchData()` returns early without ever clearing the loading flag. The fix gates the effect on `isMetadataLoading` so we only proceed once Onyx has the data it needs. I also noticed that if `isLoading` is persisted as `true` from a prior session (e.g. offline), the early-return for `isPreviousPolicy` would skip `fetchData()` entirely, so that case now explicitly triggers a refresh. The `PersonalInfo` sub-step calculation also had an overly aggressive override that forced step 0 whenever `isBankAccountVerifying` was true, regardless of actual progress.

$ #85488