### PR TITLE
[50] Add a warning modal when hitting the back button from Travel

### DIFF
--- a/src/pages/Travel/TravelDotLinkWebview.tsx
+++ b/src/pages/Travel/TravelDotLinkWebview.tsx
@@ -3,6 +3,7 @@ import React, {useRef} from 'react';
 import WebView from 'react-native-webview';
 import HeaderWithBackButton from '@components/HeaderWithBackButton';
 import ScreenWrapper from '@components/ScreenWrapper';
+import useDiscardChangesConfirmation from '@hooks/useDiscardChangesConfirmation';
 import useLocalize from '@hooks/useLocalize';
 import useThemeStyles from '@hooks/useThemeStyles';
 import {buildTravelDotURL} from '@libs/actions/Link';
@@ -16,6 +17,8 @@ function TravelDotLinkWebview({route}: TravelDotLinkWebviewProps) {
     const {token, isTestAccount, redirectUrl} = route.params;
     const webViewRef = useRef<WebView>(null);
     const styles = useThemeStyles();
+
+    useDiscardChangesConfirmation({getHasUnsavedChanges: () => true});
 
     const url = buildTravelDotURL(token, isTestAccount === 'true', redirectUrl);
 


### PR DESCRIPTION
/claim #85675

When users hit the back button from the Travel webview, they'd silently lose their booking progress with no warning. I added `useDiscardChangesConfirmation` with `getHasUnsavedChanges: () => true` so the webview always prompts before navigating away — the travel booking flow is always "in progress" by nature, so hardcoding `true` is the right call here. I checked how other webviews and forms handle this hook to make sure the pattern was consistent.

$ #85675