### PR TITLE
[50] Add a warning modal when hitting the back button from Travel

### DIFF
--- a/src/pages/Travel/TravelDotLinkWebview.tsx
+++ b/src/pages/Travel/TravelDotLinkWebview.tsx
@@ -3,6 +3,7 @@ import React, {useRef} from 'react';
 import WebView from 'react-native-webview';
 import HeaderWithBackButton from '@components/HeaderWithBackButton';
 import ScreenWrapper from '@components/ScreenWrapper';
+import useDiscardChangesConfirmation from '@hooks/useDiscardChangesConfirmation';
 import useLocalize from '@hooks/useLocalize';
 import useThemeStyles from '@hooks/useThemeStyles';
 import {buildTravelDotURL} from '@libs/actions/Link';
@@ -16,6 +17,10 @@ function TravelDotLinkWebview({route}: TravelDotLinkWebviewProps) {
     const {token, isTestAccount, redirectUrl} = route.params;
     const webViewRef = useRef<WebView>(null);
     const styles = useThemeStyles();
+
+    useDiscardChangesConfirmation({
+        getHasUnsavedChanges: () => true,
+    });
 
     const url = buildTravelDotURL(token, isTestAccount === 'true', redirectUrl);
 


### PR DESCRIPTION
/claim #85675

When users hit the back button mid-booking in the Travel webview, they'd silently lose their progress with no warning. Added `useDiscardChangesConfirmation` with `getHasUnsavedChanges: () => true` so the discard warning modal always fires on back press — since any active travel session should be treated as unsaved work. I checked how this hook is used elsewhere in the app (like expense forms) to make sure the behavior would be consistent with other warning modals users already see.

$ #85675