### PR TITLE
[50] Introduce the ability to add a new category within the category list

### DIFF
--- a/src/pages/iou/request/step/IOURequestStepCategory.tsx
+++ b/src/pages/iou/request/step/IOURequestStepCategory.tsx
@@ -6,8 +6,12 @@ import FullPageOfflineBlockingView from '@components/BlockingViews/FullPageOffli
 import Button from '@components/Button';
 import CategoryPicker from '@components/CategoryPicker';
 import FixedFooter from '@components/FixedFooter';
+import Icon from '@components/Icon';
+import * as Expensicons from '@components/Icon/Expensicons';
+import PressableWithoutFeedback from '@components/Pressable/PressableWithoutFeedback';
 import {useSearchStateContext} from '@components/Search/SearchContext';
 import type {ListItem} from '@components/SelectionListWithSections/types';
+import Tooltip from '@components/Tooltip';
 import WorkspaceEmptyStateSection from '@components/WorkspaceEmptyStateSection';
 import useCurrentUserPersonalDetails from '@hooks/useCurrentUserPersonalDetails';
 import {useMemoizedLazyIllustrations} from '@hooks/useLazyAsset';
@@ -19,6 +23,7 @@ import usePolicyData from '@hooks/usePolicyData';
 import usePolicyForTransaction from '@hooks/usePolicyForTransaction';
 import useRestartOnReceiptFailure from '@hooks/useRestartOnReceiptFailure';
 import useShowNotFoundPageInIOUStep from '@hooks/useShowNotFoundPageInIOUStep';
+import useTheme from '@hooks/useTheme';
 import useThemeStyles from '@hooks/useThemeStyles';
 import {getIOURequestPolicyID, setMoneyRequestCategory, updateMoneyRequestCategory} from '@libs/actions/IOU';
 import {setDraftSplitTransaction} from '@libs/actions/IOU/Split';
@@ -27,7 +32,7 @@ import {isCategoryMissing} from '@libs/CategoryUtils';
 import getNonEmptyStringOnyxID from '@libs/getNonEmptyStringOnyxID';
 import Navigation from '@libs/Navigation/Navigation';
 import {hasEnabledOptions} from '@libs/OptionsListUtils';
-import {isPolicyAdmin} from '@libs/PolicyUtils';
+import {getValidConnectedIntegration, isPolicyAdmin} from '@libs/PolicyUtils';
 import {getReportOrDraftReport, getTransactionDetails, isGroupPolicy, isReportInGroupPolicy} from '@libs/ReportUtils';
 import type {SkeletonSpanReasonAttributes} from '@libs/telemetry/useSkeletonSpan';
 import {getRequestType} from '@libs/TransactionUtils';
@@ -53,6 +58,7 @@ function IOURequestStepCategory({
     transaction,
 }: IOURequestStepCategoryProps) {
     const styles = useThemeStyles();
+    const theme = useTheme();
     const {translate} = useLocalize();
     const illustrations = useMemoizedLazyIllustrations(['EmptyStateExpenses']);
     const requestType = getRequestType(transaction);
@@ -169,6 +175,20 @@ function IOURequestStepCategory({
         navigateBack();
     };
 
+    const canAddCategory = isPolicyAdmin(policy) && !getValidConnectedIntegration(policy);
+
+    const navigateToCreateCategory = () => {
+        if (!policyID || !report?.reportID) {
+            return;
+        }
+        Navigation.navigate(
+            ROUTES.SETTINGS_CATEGORY_CREATE.getRoute(
+                policyID,
+                ROUTES.MONEY_REQUEST_STEP_CATEGORY.getRoute(action, iouType, transactionID, report.reportID, backTo, reportActionID),
+            ),
+        );
+    };
+
     return (
         <StepScreenWrapper
             headerTitle={translate('common.category')}
@@ -178,6 +198,23 @@ function IOURequestStepCategory({
             shouldShowOfflineIndicator={policyCategories !== undefined}
             testID="IOURequestStepCategory"
             shouldEnableKeyboardAvoidingView={false}
+            headerChildren={
+                canAddCategory ? (
+                    <Tooltip text={translate('workspace.categories.addCategory')}>
+                        <PressableWithoutFeedback
+                            onPress={navigateToCreateCategory}
+                            style={[styles.touchableButtonImage]}
+                            role={CONST.ROLE.BUTTON}
+                            accessibilityLabel={translate('workspace.categories.addCategory')}
+                        >
+                            <Icon
+                                src={Expensicons.Plus}
+                                fill={theme.icon}
+                            />
+                        </PressableWithoutFeedback>
+                    </Tooltip>
+                ) : null
+            }
         >
             {isLoading && (
                 <ActivityIndicator

--- a/src/pages/iou/request/step/StepScreenWrapper.tsx
+++ b/src/pages/iou/request/step/StepScreenWrapper.tsx
@@ -39,6 +39,9 @@ type StepScreenWrapperProps = {
 
     /** Flag to indicate if the keyboard avoiding view should be enabled */
     shouldEnableKeyboardAvoidingView?: boolean;
+
+    /** Optional content rendered in the right side of the header */
+    headerChildren?: ReactNode;
 };
 
 function StepScreenWrapper({
@@ -52,6 +55,7 @@ function StepScreenWrapper({
     includeSafeAreaPaddingBottom,
     shouldShowOfflineIndicator = true,
     shouldEnableKeyboardAvoidingView = true,
+    headerChildren,
 }: StepScreenWrapperProps) {
     const styles = useThemeStyles();
 
@@ -74,7 +78,9 @@ function StepScreenWrapper({
                         <HeaderWithBackButton
                             title={headerTitle}
                             onBackButtonPress={onBackButtonPress}
-                        />
+                        >
+                            {headerChildren}
+                        </HeaderWithBackButton>
                         {
                             // If props.children is a function, call it to provide the insets to the children
                             callOrReturn(children, {insets, safeAreaPaddingBottomStyle, didScreenTransitionEnd})


### PR DESCRIPTION
/claim #85681

Added a "+" button in the header of the category step screen that lets policy admins create a new category without leaving the IOU flow. Tapping it navigates to the category creation screen with a backTo route pointing back to the current step, so after creating the category you return right where you left off. I made sure the button only appears for policy admins on workspaces without a connected accounting integration, since categories managed by integrations like QBO or Xero shouldn't be modified directly. Also extended `StepScreenWrapper` to accept optional `headerChildren` so the header slot is reusable for other steps down the line.

$ #85681