### PR TITLE
Fix: Welcome header showing after contents in workspace chat

### DIFF
--- a/src/pages/inbox/report/ReportActionsList.tsx
+++ b/src/pages/inbox/report/ReportActionsList.tsx
@@ -580,6 +580,19 @@ function ReportActionsList({
                         setTimeout(() => {
                             reportScrollManager.scrollToIndex(index);
                         }, 100);
+                    } else if (index === -1) {
+                        // The ref hasn't reflected the new action yet. Defer the scroll to the next
+                        // animation frame so the FlatList can incorporate the new item into its
+                        // layout before we scroll. This prevents the welcome header from appearing
+                        // below the expense report preview in workspace chats.
+                        requestAnimationFrame(() => {
+                            setIsFloatingMessageCounterVisible(false);
+                            reportScrollManager.scrollToBottom();
+                        });
+                        if (action?.reportActionID) {
+                            setActionIdToHighlight(action.reportActionID);
+                        }
+                        return;
                     } else {
                         setIsFloatingMessageCounterVisible(false);
                         reportScrollManager.scrollToBottom();


### PR DESCRIPTION
/claim #85487

When a user creates a manual expense from a workspace chat, the welcome header was appearing below the expense report preview instead of at the top. Workspace chats don't go through the `shouldFocusToTopOnMount` scroll path, so the bug lives in `scrollToBottomForCurrentUserAction`.

The `sortedVisibleReportActionsRef` is updated via a `useEffect` that runs asynchronously after render. When `InteractionManager.runAfterInteractions` fires, the ref may still hold the old array (just the CREATED action), making `findIndex` return `-1` for the newly added REPORT_PREVIEW. The `else` branch then calls `scrollToBottom()` immediately against stale layout data, and the subsequent `setIsScrollToBottomEnabled(true)` triggers a second scroll on the next layout event — creating a race that leaves the CREATED welcome header below the content.

The fix splits the `index === -1` case out of the `else` branch and defers the scroll to `requestAnimationFrame`, giving the FlatList one frame to incorporate the new item into its layout before scrolling. Since we scroll in the rAF callback, `setIsScrollToBottomEnabled` is not needed for this path and we return early to skip it.

$ #85487
