### PR TITLE
[50] Expense carousel doesn't show RBR-actionable expenses first

### DIFF
--- a/src/components/MoneyRequestReportView/MoneyRequestReportTransactionList.tsx
+++ b/src/components/MoneyRequestReportView/MoneyRequestReportTransactionList.tsx
@@ -55,6 +55,7 @@ import {
     isIOUReport,
 } from '@libs/ReportUtils';
 import {compareValues, getColumnsToShow, getTableMinWidth, isTransactionAmountTooLong, isTransactionTaxAmountTooLong} from '@libs/SearchUIUtils';
+import {transactionHasRBR} from '@libs/TransactionPreviewUtils';
 import {getAmount, getCategory, getCreated, getMerchant, getTag, getTransactionPendingAction, isTransactionPendingDelete, shouldShowExpenseBreakdown} from '@libs/TransactionUtils';
 import shouldShowTransactionYear from '@libs/TransactionUtils/shouldShowTransactionYear';
 import Navigation from '@navigation/Navigation';
@@ -197,6 +198,17 @@ function MoneyRequestReportTransactionList({
     const [reportDetailsColumns] = useOnyx(ONYXKEYS.NVP_REPORT_DETAILS_COLUMNS);
     const [introSelected] = useOnyx(ONYXKEYS.NVP_INTRO_SELECTED);
     const [draftTransactionIDs] = useOnyx(ONYXKEYS.COLLECTION.TRANSACTION_DRAFT, {selector: validTransactionDraftIDsSelector});
+    const transactionIDs = useMemo(() => new Set(transactions.map((t) => t.transactionID)), [transactions]);
+    const [transactionViolations] = useOnyx(ONYXKEYS.COLLECTION.TRANSACTION_VIOLATIONS, {
+        selector: (allViolations) => {
+            if (!allViolations) {
+                return {};
+            }
+            return Object.fromEntries(
+                Object.entries(allViolations).filter(([key]) => transactionIDs.has(key.replace(ONYXKEYS.COLLECTION.TRANSACTION_VIOLATIONS, ''))),
+            );
+        },
+    });
 
     const shouldShowGroupedTransactions = isExpenseReport(report) && !isIOUReport(report);
 
@@ -267,8 +279,19 @@ function MoneyRequestReportTransactionList({
     const {sortBy, sortOrder} = sortConfig;
 
     const sortedTransactions: TransactionWithOptionalHighlight[] = useMemo(() => {
-        return [...transactions].sort((a, b) => compareValues(getTransactionValue(a, sortBy, report), getTransactionValue(b, sortBy, report), sortOrder, sortBy, localeCompare, true));
-    }, [sortBy, sortOrder, transactions, localeCompare, report]);
+        const sorted = [...transactions].sort((a, b) => compareValues(getTransactionValue(a, sortBy, report), getTransactionValue(b, sortBy, report), sortOrder, sortBy, localeCompare, true));
+        if (sortBy !== CONST.SEARCH.TABLE_COLUMNS.DATE || sortOrder !== CONST.SEARCH.SORT_ORDER.ASC) {
+            return sorted;
+        }
+        return sorted.sort((a, b) => {
+            const aHasRBR = transactionHasRBR(a, report, transactionViolations?.[`${ONYXKEYS.COLLECTION.TRANSACTION_VIOLATIONS}${a.transactionID}`] ?? []);
+            const bHasRBR = transactionHasRBR(b, report, transactionViolations?.[`${ONYXKEYS.COLLECTION.TRANSACTION_VIOLATIONS}${b.transactionID}`] ?? []);
+            if (aHasRBR === bHasRBR) {
+                return 0;
+            }
+            return aHasRBR ? -1 : 1;
+        });
+    }, [sortBy, sortOrder, transactions, localeCompare, report, transactionViolations]);
 
     const highlightedTransactionIDs = useMemo(() => new Set(newTransactions.map(({transactionID}) => transactionID)), [newTransactions]);
 

--- a/src/components/ReportActionItem/MoneyRequestReportPreview/MoneyRequestReportPreviewContent.tsx
+++ b/src/components/ReportActionItem/MoneyRequestReportPreview/MoneyRequestReportPreviewContent.tsx
@@ -79,6 +79,7 @@ import {
 import shouldAdjustScroll from '@libs/shouldAdjustScroll';
 import {startSpan} from '@libs/telemetry/activeSpans';
 import type {SkeletonSpanReasonAttributes} from '@libs/telemetry/useSkeletonSpan';
+import {transactionHasRBR} from '@libs/TransactionPreviewUtils';
 import {hasPendingUI, isManagedCardTransaction, isPending} from '@libs/TransactionUtils';
 import colors from '@styles/theme/colors';
 import variables from '@styles/variables';
@@ -504,7 +505,20 @@ function MoneyRequestReportPreviewContent({
         thumbsUpScale.set(isApprovedAnimationRunning ? withDelay(CONST.ANIMATION_THUMBS_UP_DELAY, withSpring(1, {duration: CONST.ANIMATION_THUMBS_UP_DURATION})) : 1);
     }, [isApproved, isApprovedAnimationRunning, thumbsUpScale]);
 
-    const carouselTransactions = useMemo(() => (shouldShowAccessPlaceHolder ? [] : transactions.slice(0, 11)), [shouldShowAccessPlaceHolder, transactions]);
+    const carouselTransactions = useMemo(() => {
+        if (shouldShowAccessPlaceHolder) {
+            return [];
+        }
+        const sorted = [...transactions].sort((a, b) => {
+            const aHasRBR = transactionHasRBR(a, iouReport, transactionViolations?.[`${ONYXKEYS.COLLECTION.TRANSACTION_VIOLATIONS}${a.transactionID}`] ?? []);
+            const bHasRBR = transactionHasRBR(b, iouReport, transactionViolations?.[`${ONYXKEYS.COLLECTION.TRANSACTION_VIOLATIONS}${b.transactionID}`] ?? []);
+            if (aHasRBR === bHasRBR) {
+                return 0;
+            }
+            return aHasRBR ? -1 : 1;
+        });
+        return sorted.slice(0, 11);
+    }, [shouldShowAccessPlaceHolder, transactions, iouReport, transactionViolations]);
     const prevCarouselTransactionLength = useRef(0);
 
     useEffect(() => {

--- a/src/libs/TransactionPreviewUtils.ts
+++ b/src/libs/TransactionPreviewUtils.ts
@@ -463,6 +463,16 @@ function createTransactionPreviewConditionals({
     };
 }
 
+function transactionHasRBR(transaction: OnyxEntry<OnyxTypes.Transaction>, transactionReport: OnyxEntry<OnyxTypes.Report>, violations: OnyxTypes.TransactionViolations): boolean {
+    if (!transaction) {
+        return false;
+    }
+    const isTransactionOnHold = isOnHold(transaction);
+    const hasErrors = hasMissingSmartscanFields(transaction, transactionReport) || hasReceiptError(transaction);
+    const hasViolations = violations.some((violation) => violation.type === CONST.VIOLATION_TYPES.VIOLATION);
+    return isTransactionOnHold || hasErrors || hasViolations;
+}
+
 export {
     getReviewNavigationRoute,
     getIOUPayerAndReceiver,
@@ -471,5 +481,6 @@ export {
     getViolationTranslatePath,
     getUniqueActionErrorsForTransaction,
     formatLastFourPAN,
+    transactionHasRBR,
 };
 export type {TranslationPathOrText};


### PR DESCRIPTION
/claim #85553

The expense carousel was showing transactions in whatever order they came in, so expenses needing attention (violations, hold, missing fields) could be buried behind clean ones. I added a `transactionHasRBR` helper that checks for holds, field errors, and violation-type violations, then use it to sort RBR transactions to the front in both the carousel and the report transaction list. One thing I was careful about: the list sort only applies this secondary RBR ordering when the user hasn't changed the default sort (date ascending), so custom sorting isn't clobbered.

$ #85553