### PR TITLE
[50] Audit Reports navigation and prioritize navigating to report routes

### DIFF
--- a/src/libs/actions/IOU/index.ts
+++ b/src/libs/actions/IOU/index.ts
@@ -1154,11 +1154,12 @@ function handleNavigateAfterExpenseCreate({
     shouldHandleNavigation?: boolean;
 }) {
     const isUserOnInbox = isReportTopmostSplitNavigator();
+    const isUserOnSearch = isSearchTopmostFullScreenRoute();
 
     // If the expense is not created from global create or is currently on the inbox tab,
     // we just need to dismiss the money request flow screens
     // and open the report chat containing the IOU report
-    if (!isFromGlobalCreate || isUserOnInbox || !transactionID) {
+    if ((!isFromGlobalCreate && !isUserOnSearch) || isUserOnInbox || !transactionID) {
         if (shouldHandleNavigation) {
             dismissModalAndOpenReportInInboxTab(activeReportID, isInvoice);
         }

--- a/src/libs/actions/Report/index.ts
+++ b/src/libs/actions/Report/index.ts
@@ -79,6 +79,7 @@ import Log from '@libs/Log';
 import {isEmailPublicDomain} from '@libs/LoginUtils';
 import {getMovedReportID} from '@libs/ModifiedExpenseMessage';
 import type {LinkToOptions} from '@libs/Navigation/helpers/linkTo/types';
+import isSearchTopmostFullScreenRoute from '@libs/Navigation/helpers/isSearchTopmostFullScreenRoute';
 import Navigation from '@libs/Navigation/Navigation';
 import enhanceParameters from '@libs/Network/enhanceParameters';
 import * as NetworkStore from '@libs/Network/NetworkStore';
@@ -160,7 +161,7 @@ import {
     isValidReportIDFromPath,
     prepareOnboardingOnyxData,
 } from '@libs/ReportUtils';
-import {buildOptimisticSnapshotData, getCurrentSearchQueryJSON} from '@libs/SearchQueryUtils';
+import {buildCannedSearchQuery, buildOptimisticSnapshotData, getCurrentSearchQueryJSON} from '@libs/SearchQueryUtils';
 import playSound, {SOUNDS} from '@libs/Sound';
 import {getAmount, getCurrency, hasValidModifiedAmount, isOnHold, recalculateUnreportedTransactionDetails, shouldClearConvertedAmount} from '@libs/TransactionUtils';
 import addTrailingForwardSlash from '@libs/UrlUtils';
@@ -4243,6 +4244,11 @@ function doneCheckingPublicRoom() {
 
 function navigateToMostRecentReport(currentReport: OnyxEntry<Report>, conciergeReportID: string | undefined, currentUserAccountID: number, introSelected: OnyxEntry<IntroSelected>) {
     const lastAccessedReportID = findLastAccessedReport(false, false, currentReport?.reportID)?.reportID;
+
+    if (isSearchTopmostFullScreenRoute()) {
+        Navigation.goBack(ROUTES.SEARCH_ROOT.getRoute({query: buildCannedSearchQuery({type: CONST.SEARCH.DATA_TYPES.EXPENSE})}));
+        return;
+    }
 
     if (lastAccessedReportID) {
         // Check if route exists for super wide RHP vs regular full screen report


### PR DESCRIPTION
/claim #85560

When you're on the Search tab and create an expense or navigate away from a report, the app was incorrectly routing you back into the Inbox tab instead of staying in Search. The fix has two parts: in `Report/index.ts`, `navigateToMostRecentReport` now checks if the user is on the Search tab and navigates back to the search root instead of falling through to the inbox logic; in `IOU/index.ts`, `handleNavigateAfterExpenseCreate` needed the same awareness — the original condition `!isFromGlobalCreate` was too broad and would bypass search-aware navigation even when the expense was created from within Search. I also verified that inbox-tab behavior (`isUserOnInbox`) still takes priority correctly since that check remains unchanged.

$ #85560