### PR TITLE
[$250] Attachments - Markdown image URLs are not cached

### DIFF
--- a/src/CONST/index.ts
+++ b/src/CONST/index.ts
@@ -9301,6 +9301,7 @@ const CONST = {
 
     CACHE_NAME: {
         AUTH_IMAGES: 'auth-images',
+        MARKDOWN_IMAGES: 'markdown-images',
     },
 } as const;
 

--- a/src/components/HTMLEngineProvider/HTMLRenderers/ImageRenderer.tsx
+++ b/src/components/HTMLEngineProvider/HTMLRenderers/ImageRenderer.tsx
@@ -80,6 +80,7 @@ function ImageRenderer({tnode}: CustomRendererProps<TBlock>) {
             previewSourceURL={processedPreviewSource}
             style={styles.webViewStyles.tagStyles.img}
             isAuthTokenRequired={isAttachmentOrReceipt}
+            shouldForceCache={!isAttachmentOrReceipt}
             fallbackIcon={fallbackIcon}
             imageWidth={imageWidth}
             imageHeight={imageHeight}

--- a/src/components/Image/BaseImage.tsx
+++ b/src/components/Image/BaseImage.tsx
@@ -7,8 +7,8 @@ import getImageRecyclingKey from '@libs/getImageRecyclingKey';
 import {AttachmentStateContext} from '@pages/media/AttachmentModalScreen/AttachmentModalBaseContent/AttachmentStateContextProvider';
 import type {BaseImageProps} from './types';
 
-function BaseImage({onLoad, onLoadStart, source, ...props}: BaseImageProps) {
-    const cachedSource = useCachedImageSource(typeof source === 'object' && !Array.isArray(source) ? source : undefined);
+function BaseImage({onLoad, onLoadStart, source, shouldForceCache, ...props}: BaseImageProps) {
+    const cachedSource = useCachedImageSource(typeof source === 'object' && !Array.isArray(source) ? source : undefined, shouldForceCache);
     const resolvedSource = cachedSource !== undefined ? cachedSource : source;
 
     const {setAttachmentLoaded, isAttachmentLoaded} = useContext(AttachmentStateContext);

--- a/src/components/Image/types.ts
+++ b/src/components/Image/types.ts
@@ -36,6 +36,10 @@ type BaseImageProps = {
      *  the load with the higher priority will be started first.
      *  Maps to SDWebImageHighPriority (iOS) and Glide.Priority.IMMEDIATE (Android). */
     priority?: ValueOf<typeof CONST.IMAGE_LOADING_PRIORITY> | null;
+
+    /** Whether to store the image in Cache API even when no auth headers are required.
+     *  Used for markdown image URLs so they are available offline consistently. */
+    shouldForceCache?: boolean;
 };
 
 type ImageOwnProps = BaseImageProps & {

--- a/src/components/ImageWithLoading.tsx
+++ b/src/components/ImageWithLoading.tsx
@@ -16,6 +16,9 @@ type ImageWithSizeLoadingProps = {
     /** Whether the image requires an authToken */
     isAuthTokenRequired: boolean;
 
+    /** Whether to store the image in Cache API even when no auth headers are required */
+    shouldForceCache?: boolean;
+
     /** The object position of image */
     objectPosition?: ImageObjectPosition;
 

--- a/src/components/ImageWithSizeCalculation.tsx
+++ b/src/components/ImageWithSizeCalculation.tsx
@@ -36,6 +36,9 @@ type ImageWithSizeCalculationProps = {
     /** Whether the image requires an authToken */
     isAuthTokenRequired: boolean;
 
+    /** Whether to store the image in Cache API even when no auth headers are required */
+    shouldForceCache?: boolean;
+
     /** The object position of image */
     objectPosition?: ImageObjectPosition;
 
@@ -68,6 +71,7 @@ function ImageWithSizeCalculation({
     onMeasure,
     onLoadFailure,
     isAuthTokenRequired,
+    shouldForceCache,
     objectPosition = CONST.IMAGE_OBJECT_POSITION.INITIAL,
     loadingIconSize,
     loadingIndicatorStyles,
@@ -91,6 +95,7 @@ function ImageWithSizeCalculation({
             source={source}
             aria-label={altText}
             isAuthTokenRequired={isAuthTokenRequired}
+            shouldForceCache={shouldForceCache}
             resizeMode={resizeMode ?? RESIZE_MODES.cover}
             onError={onError}
             onLoad={(event: OnLoadNativeEvent) => {

--- a/src/components/ThumbnailImage.tsx
+++ b/src/components/ThumbnailImage.tsx
@@ -69,6 +69,9 @@ type ThumbnailImageProps = {
     /** Whether the image is deleted */
     isDeleted?: boolean;
 
+    /** Whether to store the image in Cache API even when no auth headers are required */
+    shouldForceCache?: boolean;
+
     /** Callback fired when the image fails to load */
     onLoadFailure?: () => void;
 
@@ -100,6 +103,7 @@ function ThumbnailImage({
     fallbackIconBackground,
     objectPosition = CONST.IMAGE_OBJECT_POSITION.INITIAL,
     isDeleted,
+    shouldForceCache,
     onLoadFailure,
     onMeasure,
     loadingIndicatorStyles,
@@ -166,6 +170,7 @@ function ThumbnailImage({
                         onLoadFailure?.();
                     }}
                     isAuthTokenRequired={isAuthTokenRequired}
+                    shouldForceCache={shouldForceCache}
                     objectPosition={objectPosition}
                     loadingIconSize={loadingIconSize}
                     loadingIndicatorStyles={loadingIndicatorStyles}

--- a/src/hooks/useCachedImageSource.ts
+++ b/src/hooks/useCachedImageSource.ts
@@ -15,9 +15,10 @@ const clearAuthImagesCache = async () => {
     }
 };
 
-function useCachedImageSource(source: ImageSource | undefined): ImageSource | null | undefined {
+function useCachedImageSource(source: ImageSource | undefined, shouldForceCache = false): ImageSource | null | undefined {
     const uri = typeof source === 'object' ? source.uri : undefined;
     const hasHeaders = typeof source === 'object' && !!source.headers;
+    const shouldCache = hasHeaders || shouldForceCache;
     const [cachedUri, setCachedUri] = useState<string | null>(null);
     const [hasError, setHasError] = useState(false);
 
@@ -25,7 +26,7 @@ function useCachedImageSource(source: ImageSource | undefined): ImageSource | nu
         setCachedUri(null);
         setHasError(false);
 
-        if (!hasHeaders || !uri) {
+        if (!shouldCache || !uri) {
             return;
         }
 
@@ -34,7 +35,8 @@ function useCachedImageSource(source: ImageSource | undefined): ImageSource | nu
 
         (async () => {
             try {
-                const cache = await caches.open(CONST.CACHE_NAME.AUTH_IMAGES);
+                const cacheName = hasHeaders ? CONST.CACHE_NAME.AUTH_IMAGES : CONST.CACHE_NAME.MARKDOWN_IMAGES;
+                const cache = await caches.open(cacheName);
                 const cachedResponse = await cache.match(uri);
 
                 if (cachedResponse) {
@@ -48,7 +50,8 @@ function useCachedImageSource(source: ImageSource | undefined): ImageSource | nu
                     return;
                 }
 
-                const response = await fetch(uri, {headers: source.headers});
+                const fetchOptions: RequestInit = hasHeaders ? {headers: source?.headers as HeadersInit} : {};
+                const response = await fetch(uri, fetchOptions);
 
                 if (!response.ok) {
                     if (!revoked) {
@@ -83,11 +86,11 @@ function useCachedImageSource(source: ImageSource | undefined): ImageSource | nu
                 URL.revokeObjectURL(objectURL);
             }
         };
-    }, [uri, hasHeaders, source?.headers]);
+    }, [uri, shouldCache, hasHeaders, source?.headers]);
 
-    // Images without headers are cached natively by the browser,
+    // Images without headers and not force-cached are cached natively by the browser,
     // so pass them through as-is — no Cache API needed
-    if (!hasHeaders) {
+    if (!shouldCache) {
         return source;
     }
 


### PR DESCRIPTION
/claim #85557

Markdown image URLs sent via `![](url)` syntax are rendered correctly in chat but never stored in the Cache API. Uploaded attachments get cached during render via `useCachedImageSource` because they carry auth headers — markdown images have no headers and were passed through as-is.

The fix extends `useCachedImageSource` to accept a `shouldForceCache` flag that triggers the Cache API path even without auth headers, using a separate `markdown-images` cache bucket. `ImageRenderer` passes `shouldForceCache={true}` for all non-attachment images. If the fetch fails (e.g., staging/prod CSP `connect-src` restrictions or CORS), the hook catches the error and falls back to the original source URL transparently — no regression.

$ #85557
