### PR TITLE
fix: debounce autocomplete query to prevent JS thread freeze on mobil…

### DIFF
--- a/src/components/Search/SearchAutocompleteList.tsx
+++ b/src/components/Search/SearchAutocompleteList.tsx
@@ -1,5 +1,5 @@
 import type {ForwardedRef, RefObject} from 'react';
-import React, {useContext, useEffect, useRef, useState} from 'react';
+import React, {useContext, useEffect, useMemo, useRef, useState} from 'react';
 import type {OnyxCollection, OnyxEntry} from 'react-native-onyx';
 import {OptionsListStateContext, useOptionsList} from '@components/OptionListContextProvider';
 import OptionsListSkeletonView from '@components/OptionsListSkeletonView';
@@ -14,6 +14,7 @@ import SearchQueryListItem, {isSearchQueryItem} from '@components/SelectionListW
 import useAutocompleteSuggestions from '@hooks/useAutocompleteSuggestions';
 import useCurrentUserPersonalDetails from '@hooks/useCurrentUserPersonalDetails';
 import useDebounce from '@hooks/useDebounce';
+import useDebouncedValue from '@hooks/useDebouncedValue';
 import useFeedKeysWithAssignedCards from '@hooks/useFeedKeysWithAssignedCards';
 import {useMemoizedLazyExpensifyIcons} from '@hooks/useLazyAsset';
 import useLocalize from '@hooks/useLocalize';
@@ -165,6 +166,7 @@ function SearchAutocompleteList({
     const taxRates = getAllTaxRates(policies);
 
     const {options, areOptionsInitialized} = useOptionsList();
+    const debouncedAutocompleteQueryValue = useDebouncedValue(autocompleteQueryValue, 150);
 
     const isRecentSearchesDataLoaded = !isLoadingOnyxValue(recentSearchesMetadata);
 
@@ -187,7 +189,7 @@ function SearchAutocompleteList({
         }
     }, [contextAreOptionsInitialized]);
 
-    const searchOptions = (() => {
+    const searchOptions = useMemo(() => {
         if (!areOptionsInitialized) {
             return defaultListOptions;
         }
@@ -198,7 +200,7 @@ function SearchAutocompleteList({
             betas: betas ?? [],
             isUsedInChatFinder: true,
             includeReadOnly: true,
-            searchQuery: autocompleteQueryValue,
+            searchQuery: debouncedAutocompleteQueryValue,
             maxResults: CONST.AUTO_COMPLETE_SUGGESTER.MAX_AMOUNT_OF_SUGGESTIONS,
             includeUserToInvite: true,
             includeRecentReports: true,
@@ -213,7 +215,7 @@ function SearchAutocompleteList({
             policyCollection: policies,
             personalDetails,
         });
-    })();
+    }, [areOptionsInitialized, options, draftComments, nvpDismissedProductTraining, betas, debouncedAutocompleteQueryValue, countryCode, loginList, visibleReportActionsData, currentUserAccountID, currentUserEmail, policies, personalDetails]);
 
     const [isInitialRender, setIsInitialRender] = useState(true);
     const prevQueryRef = useRef(autocompleteQueryValue);
@@ -291,7 +293,7 @@ function SearchAutocompleteList({
         translate,
     });
 
-    const autocompleteQueryWithoutFilters = getQueryWithoutFilters(autocompleteQueryValue);
+    const autocompleteQueryWithoutFilters = getQueryWithoutFilters(debouncedAutocompleteQueryValue);
 
     const sortedRecentSearches = Object.values(recentSearches ?? {}).sort((a, b) => localeCompare(b.timestamp, a.timestamp));
 
@@ -322,11 +324,11 @@ function SearchAutocompleteList({
     });
 
     const recentReportsOptions = (() => {
-        if (autocompleteQueryValue.trim() === '') {
+        if (debouncedAutocompleteQueryValue.trim() === '') {
             return searchOptions.recentReports;
         }
 
-        const orderedOptions = combineOrderingOfReportsAndPersonalDetails(searchOptions, autocompleteQueryValue, {
+        const orderedOptions = combineOrderingOfReportsAndPersonalDetails(searchOptions, debouncedAutocompleteQueryValue, {
             sortByReportTypeInSearch: true,
             preferChatRoomsOverThreads: true,
         });

--- a/src/components/Search/SearchAutocompleteList.tsx
+++ b/src/components/Search/SearchAutocompleteList.tsx
@@ -166,7 +166,7 @@ function SearchAutocompleteList({
     const taxRates = getAllTaxRates(policies);
 
     const {options, areOptionsInitialized} = useOptionsList();
-    const debouncedAutocompleteQueryValue = useDebouncedValue(autocompleteQueryValue, 150);
+    const debouncedAutocompleteQueryValue = useDebouncedValue(autocompleteQueryValue, 150) ?? autocompleteQueryValue;
 
     const isRecentSearchesDataLoaded = !isLoadingOnyxValue(recentSearchesMetadata);
 


### PR DESCRIPTION
…e search (#83207)

<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
`autocompleteQueryValue` in `SearchAutocompleteList.tsx` updates immediately on every keystroke, triggering expensive synchronous re-computation of `getSearchOptions()`, `combineOrderingOfReportsAndPersonalDetails()`, and multiple filter chains on the JS thread. On mobile devices, this freezes the JS thread — native gestures still work but all JS-driven interactions become unresponsive.
 
This PR makes three targeted changes:
 
1. **Debounce the autocomplete query value**: Uses Expensify's existing `useDebouncedValue` hook with a 150ms delay so filtering runs at most ~7 times/second instead of on every keystroke.
 
2. **Memoize `searchOptions`**: Converts the IIFE to `useMemo` with stable dependencies, preventing redundant recomputations when unrelated state changes trigger re-renders.
 
3. **Use debounced value for heavy operations**: `getSearchOptions()`, `getQueryWithoutFilters()`, and `combineOrderingOfReportsAndPersonalDetails()` all use the debounced value, while lightweight operations (focus management, autocomplete suggestions, highlight detection) keep using the immediate value for UI responsiveness.

### Fixed Issues
$ https://github.com/Expensify/App/issues/83207
PROPOSAL: https://github.com/Expensify/App/issues/83207#issuecomment-3944752024

### Tests
1. Open the app on a mobile device (or simulate slow CPU via Chrome DevTools → Performance → 4x CPU slowdown)
2. Navigate to the Inbox
3. Tap the search icon to open the SearchRouter
4. Type a multi-word search query quickly (e.g., "expense report travel")
5. Verify the text input remains responsive while typing — no freezing or dropped keystrokes
6. Verify search results appear after a brief delay (~150ms after last keystroke)
7. Clear the search input by deleting all text rapidly
8. Verify the UI remains responsive during rapid deletion
9. Type a query, wait for results, then type additional characters
10. Verify results update smoothly without UI freezes
 
- [ ] Verify that no errors appear in the JS console

### Offline tests

1. Enable airplane mode / disconnect from network
2. Open the Inbox and tap the search icon
3. Type a search query
4. Verify the search input remains responsive and locally cached results appear without freezing
5. Reconnect to network
6. Verify results update normally

### QA Steps
Same as Tests above. The key validation is that typing in the Inbox search no longer freezes the JS thread on mobile devices.

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist
- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [ ] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [ ] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [ ] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [ ] I ran the tests on **all platforms** & verified they passed on:
    - [ ] Android: Native
    - [ ] Android: mWeb Chrome
    - [ ] iOS: Native
    - [ ] iOS: mWeb Safari
    - [ ] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [ ] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [ ] If any new file was added I verified that:
    - [ ] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [ ] If a new CSS style is added I verified that:
    - [ ] A similar style doesn't already exist
    - [ ] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [ ] If new assets were added or existing ones were modified, I verified that:
    - [ ] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [ ] The assets load correctly across all supported platforms.
- [ ] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [ ] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [ ] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [ ] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [ ] I verified that all the inputs inside a form are aligned with each other.
    - [ ] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [ ] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [ ] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [ ] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

Unable to fully test visually due to a `No data found for key nvp_onboarding` error in the local dev environment that blocks login. The code change is minimal and scoped (debouncing + memoization only in `SearchAutocompleteList.tsx`), and the app compiles successfully with no errors. Happy to provide screenshots once this environment issue is resolved, or if a reviewer can validate on their end.

</details>

<details>
<summary>Android: mWeb Chrome</summary>

Unable to fully test visually due to a `No data found for key nvp_onboarding` error in the local dev environment that blocks login. The code change is minimal and scoped (debouncing + memoization only in `SearchAutocompleteList.tsx`), and the app compiles successfully with no errors. Happy to provide screenshots once this environment issue is resolved, or if a reviewer can validate on their end.

</details>

<details>
<summary>iOS: Native</summary>

Unable to fully test visually due to a `No data found for key nvp_onboarding` error in the local dev environment that blocks login. The code change is minimal and scoped (debouncing + memoization only in `SearchAutocompleteList.tsx`), and the app compiles successfully with no errors. Happy to provide screenshots once this environment issue is resolved, or if a reviewer can validate on their end.

</details>

<details>
<summary>iOS: mWeb Safari</summary>

Unable to fully test visually due to a `No data found for key nvp_onboarding` error in the local dev environment that blocks login. The code change is minimal and scoped (debouncing + memoization only in `SearchAutocompleteList.tsx`), and the app compiles successfully with no errors. Happy to provide screenshots once this environment issue is resolved, or if a reviewer can validate on their end.

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

Unable to fully test visually due to a `No data found for key nvp_onboarding` error in the local dev environment that blocks login. The code change is minimal and scoped (debouncing + memoization only in `SearchAutocompleteList.tsx`), and the app compiles successfully with no errors. Happy to provide screenshots once this environment issue is resolved, or if a reviewer can validate on their end.

</details>