### PR TITLE
[CP Staging] Revert "Add rhpHomePage variant (D) to onboarding A/B/C/D test" (#85273)

### DIFF
--- a/src/CONST/index.ts
+++ b/src/CONST/index.ts
@@ -6427,7 +6427,6 @@ const CONST = {
     ONBOARDING_RHP_VARIANT: {
         RHP_CONCIERGE_DM: 'rhpConciergeDm',
         RHP_ADMINS_ROOM: 'rhpAdminsRoom',
-        RHP_HOME_PAGE: 'rhpHomePage',
         CONTROL: 'control',
     },
     ACTIONABLE_TRACK_EXPENSE_WHISPER_MESSAGE: 'What would you like to do with this expense?',

--- a/src/components/SidePanel/RHPVariantTest/index.native.ts
+++ b/src/components/SidePanel/RHPVariantTest/index.native.ts
@@ -3,13 +3,11 @@ import type {HandleRHPVariantNavigation, ShouldOpenRHPVariant} from './types';
 /**
  * Side Panel is not supported on native platforms, so we always return false.
  */
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-const shouldOpenRHPVariant: ShouldOpenRHPVariant = (_variantOverride) => false;
+const shouldOpenRHPVariant: ShouldOpenRHPVariant = () => false;
 
 /**
  * No-op on native platforms since Side Panel is not supported.
  */
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-const handleRHPVariantNavigation: HandleRHPVariantNavigation = (_onboardingPolicyID, _variantOverride) => {};
+const handleRHPVariantNavigation: HandleRHPVariantNavigation = () => {};
 
 export {shouldOpenRHPVariant, handleRHPVariantNavigation};

--- a/src/components/SidePanel/RHPVariantTest/index.ts
+++ b/src/components/SidePanel/RHPVariantTest/index.ts
@@ -29,19 +29,13 @@ Onyx.connectWithoutView({
 /**
  * Determines if the user should be navigated to the RHP variant side panel after onboarding.
  * The RHP variant is only shown to micro companies that are part of the RHP experiment.
- *
- * Accepts an optional variantOverride to bypass the module-level Onyx variable, avoiding a race
- * condition where the Onyx callback hasn't fired yet when this is called immediately after the
- * CompleteGuidedSetup API response.
  */
-const shouldOpenRHPVariant: ShouldOpenRHPVariant = (variantOverride) => {
-    const variant = variantOverride ?? onboardingRHPVariant;
+const shouldOpenRHPVariant: ShouldOpenRHPVariant = () => {
     const isMicroCompany = onboardingCompanySize === CONST.ONBOARDING_COMPANY_SIZE.MICRO;
-    const isRHPConciergeDM = variant === CONST.ONBOARDING_RHP_VARIANT.RHP_CONCIERGE_DM;
-    const isRHPAdminsRoom = variant === CONST.ONBOARDING_RHP_VARIANT.RHP_ADMINS_ROOM;
-    const isRHPHomePage = variant === CONST.ONBOARDING_RHP_VARIANT.RHP_HOME_PAGE;
+    const isRHPConciergeDM = onboardingRHPVariant === CONST.ONBOARDING_RHP_VARIANT.RHP_CONCIERGE_DM;
+    const isRHPAdminsRoom = onboardingRHPVariant === CONST.ONBOARDING_RHP_VARIANT.RHP_ADMINS_ROOM;
 
-    return isMicroCompany && (isRHPConciergeDM || isRHPAdminsRoom || isRHPHomePage);
+    return isMicroCompany && (isRHPConciergeDM || isRHPAdminsRoom);
 };
 
 /**
@@ -49,18 +43,8 @@ const shouldOpenRHPVariant: ShouldOpenRHPVariant = (variantOverride) => {
  * - Control: navigate to the last accessed report on small screens, do not open side panel
  * - RHP Concierge DM: navigate to the workspace overview and open the side panel with the Concierge DM
  * - RHP Admins Room: navigate to the workspace overview and open the side panel with the Admins Room
- * - RHP Home Page: navigate to the Home page and open the side panel with the Concierge DM
- *
- * Accepts an optional variantOverride for the same race-condition reason as shouldOpenRHPVariant.
  */
-const handleRHPVariantNavigation: HandleRHPVariantNavigation = (onboardingPolicyID, variantOverride) => {
-    const variant = variantOverride ?? onboardingRHPVariant;
-    if (variant === CONST.ONBOARDING_RHP_VARIANT.RHP_HOME_PAGE) {
-        Navigation.navigate(ROUTES.HOME);
-        SidePanelActions.openSidePanel(true);
-        return;
-    }
-
+const handleRHPVariantNavigation: HandleRHPVariantNavigation = (onboardingPolicyID) => {
     Navigation.navigate(ROUTES.WORKSPACE_OVERVIEW.getRoute(onboardingPolicyID));
     SidePanelActions.openSidePanel(true);
 };

--- a/src/components/SidePanel/RHPVariantTest/types.ts
+++ b/src/components/SidePanel/RHPVariantTest/types.ts
@@ -1,6 +1,4 @@
-import type {OnboardingRHPVariant} from '@src/types/onyx';
-
-type ShouldOpenRHPVariant = (variantOverride?: OnboardingRHPVariant | null) => boolean;
-type HandleRHPVariantNavigation = (onboardingPolicyID?: string, variantOverride?: OnboardingRHPVariant | null) => void;
+type ShouldOpenRHPVariant = () => boolean;
+type HandleRHPVariantNavigation = (onboardingPolicyID?: string) => void;
 
 export type {ShouldOpenRHPVariant, HandleRHPVariantNavigation};

--- a/src/libs/navigateAfterOnboarding.ts
+++ b/src/libs/navigateAfterOnboarding.ts
@@ -1,6 +1,5 @@
 import {handleRHPVariantNavigation, shouldOpenRHPVariant} from '@components/SidePanel/RHPVariantTest';
 import ROUTES from '@src/ROUTES';
-import type {OnboardingRHPVariant} from '@src/types/onyx';
 import {setDisableDismissOnEscape} from './actions/Modal';
 import shouldOpenOnAdminRoom from './Navigation/helpers/shouldOpenOnAdminRoom';
 import Navigation from './Navigation/Navigation';
@@ -51,12 +50,11 @@ function navigateAfterOnboarding(
     onboardingPolicyID?: string,
     onboardingAdminsChatReportID?: string,
     shouldPreventOpenAdminRoom = false,
-    onboardingRHPVariant?: OnboardingRHPVariant | null,
 ) {
     setDisableDismissOnEscape(false);
 
-    if (shouldOpenRHPVariant(onboardingRHPVariant)) {
-        handleRHPVariantNavigation(onboardingPolicyID, onboardingRHPVariant);
+    if (shouldOpenRHPVariant()) {
+        handleRHPVariantNavigation(onboardingPolicyID);
         return;
     }
 
@@ -85,7 +83,6 @@ function navigateAfterOnboardingWithMicrotaskQueue(
     onboardingPolicyID?: string,
     onboardingAdminsChatReportID?: string,
     shouldPreventOpenAdminRoom = false,
-    onboardingRHPVariant?: OnboardingRHPVariant | null,
 ) {
     Navigation.dismissModal();
     Navigation.setNavigationActionToMicrotaskQueue(() => {
@@ -97,7 +94,6 @@ function navigateAfterOnboardingWithMicrotaskQueue(
             onboardingPolicyID,
             onboardingAdminsChatReportID,
             shouldPreventOpenAdminRoom,
-            onboardingRHPVariant,
         );
     });
 }

--- a/src/pages/OnboardingInterestedFeatures/BaseOnboardingInterestedFeatures.tsx
+++ b/src/pages/OnboardingInterestedFeatures/BaseOnboardingInterestedFeatures.tsx
@@ -36,7 +36,6 @@ import type {TranslationPaths} from '@src/languages/types';
 import ONYXKEYS from '@src/ONYXKEYS';
 import ROUTES from '@src/ROUTES';
 import SCREENS from '@src/SCREENS';
-import type {OnboardingRHPVariant} from '@src/types/onyx';
 import type {BaseOnboardingInterestedFeaturesProps, Feature, SectionObject} from './types';
 
 function BaseOnboardingInterestedFeatures({shouldUseNativeStyles}: BaseOnboardingInterestedFeaturesProps) {
@@ -220,7 +219,7 @@ function BaseOnboardingInterestedFeatures({shouldUseNativeStyles}: BaseOnboardin
                 setOnboardingPolicyID(policyID);
             }
 
-            const response = await completeOnboarding({
+            await completeOnboarding({
                 engagementChoice: onboardingPurposeSelected,
                 onboardingMessage: onboardingMessages[onboardingPurposeSelected],
                 adminsChatReportID,
@@ -235,11 +234,6 @@ function BaseOnboardingInterestedFeatures({shouldUseNativeStyles}: BaseOnboardin
                 isSelfTourViewed,
                 betas,
             });
-
-            // Extract the RHP variant directly from the API response to avoid a race condition
-            // where the Onyx callback hasn't fired yet when navigateAfterOnboarding is called.
-            const rhpVariantUpdate = (response?.onyxData as Array<{key: string; value: unknown}> | undefined)?.find((update) => update.key === ONYXKEYS.NVP_ONBOARDING_RHP_VARIANT);
-            const rhpVariant = rhpVariantUpdate?.value as OnboardingRHPVariant | undefined;
 
             // Avoid creating new WS because onboardingPolicyID is cleared before unmounting
             // eslint-disable-next-line @typescript-eslint/no-deprecated
@@ -259,7 +253,6 @@ function BaseOnboardingInterestedFeatures({shouldUseNativeStyles}: BaseOnboardin
                 // Onboarding tasks would show in Concierge instead of admins room for testing accounts, we should open where onboarding tasks are located
                 // See https://github.com/Expensify/App/issues/57167 for more details
                 (session?.email ?? '').includes('+'),
-                rhpVariant,
             );
         } catch (error) {
             Log.warn('[BaseOnboardingInterestedFeatures] Error completing onboarding', {error});

--- a/src/types/onyx/OnboardingRHPVariant.ts
+++ b/src/types/onyx/OnboardingRHPVariant.ts
@@ -1,10 +1,9 @@
 /**
- * The variant of the onboarding RHP for A/B/C/D testing
+ * The variant of the onboarding RHP for A/B/C testing
  * @description 'control' - The variant with the Concierge DM
  * @description 'rhpConciergeDm' - Admin of workspace with Concierge DM
  * @description 'rhpAdminsRoom' - Admin of workspace with the admins room
- * @description 'rhpHomePage' - Navigate to Home page with Concierge Anywhere accessible in #admins room
  */
-type OnboardingRHPVariant = 'rhpConciergeDm' | 'rhpAdminsRoom' | 'rhpHomePage' | 'control';
+type OnboardingRHPVariant = 'rhpConciergeDm' | 'rhpAdminsRoom' | 'control';
 
 export default OnboardingRHPVariant;


### PR DESCRIPTION
<!-- If necessary, assign someone to review your PR. -->

### Explanation of Change

Reverts [#85273](https://github.com/Expensify/App/pull/85273).

The `control` variant regressed after that PR — micro-company users assigned to `control` no longer land on the Home view after onboarding. Instead, they are navigated to the Workspace Overview / admins room chat, which is incorrect.

Reverting to restore the correct control variant behavior while the fix is reworked with proper handling for all variants including `rhpHomePage`.

### Fixed Issues

$ https://github.com/Expensify/Expensify/issues/610149

### Tests

1. Sign up with a new account
2. Select "Manage my team's expenses" during onboarding
3. Select company size "1-10 employees"
4. Complete the onboarding flow
5. Check variant via `await Onyx.get('nvp_onboardingRHPVariant')` in console
6. Verify you land on Home view

### Offline tests

N/A — variant assignment happens during onboarding which requires network.

### QA Steps

Same as Tests above.

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>