### PR TITLE
feat: follow-up for IS export templates in Exported filter options

### DIFF
--- a/src/hooks/useExportedToFilterOptions.ts
+++ b/src/hooks/useExportedToFilterOptions.ts
@@ -62,11 +62,12 @@ export default function useExportedToFilterOptions(): UseExportedToFilterDataRes
     }
 
     const combinedUniqueExportTemplates = Array.from(uniqueExportTemplatesByName.values());
+    const integrationConnectionNamesSet = new Set<string>(Object.values(CONST.POLICY.CONNECTIONS.NAME));
 
     const standardAndCustomExportTemplates: string[] = [];
     for (const template of combinedUniqueExportTemplates) {
         // Classic export formats map to in-app templates and cannot be identified in exported-to filter.
-        if (template.type === CONST.EXPORT_TEMPLATE_TYPES.IN_APP) {
+        if (template.type === CONST.EXPORT_TEMPLATE_TYPES.IN_APP || integrationConnectionNamesSet.has(template.templateName)) {
             continue;
         }
 

--- a/src/hooks/useExportedToFilterOptions.ts
+++ b/src/hooks/useExportedToFilterOptions.ts
@@ -63,14 +63,16 @@ export default function useExportedToFilterOptions(): UseExportedToFilterDataRes
 
     const combinedUniqueExportTemplates = Array.from(uniqueExportTemplatesByName.values());
 
-    const standardExportTemplates: string[] = [];
+    const standardAndCustomExportTemplates: string[] = [];
     for (const template of combinedUniqueExportTemplates) {
-        const displayName = getStandardExportTemplateDisplayName(template.templateName);
-        const isStandardTemplate = displayName !== template.templateName;
-
-        if (isStandardTemplate) {
-            standardExportTemplates.push(displayName);
+        // Classic export formats map to in-app templates and cannot be identified in exported-to filter.
+        if (template.type === CONST.EXPORT_TEMPLATE_TYPES.IN_APP) {
+            continue;
         }
+
+        const standardExportTemplateDisplayName = getStandardExportTemplateDisplayName(template.templateName);
+        const filterValue = standardExportTemplateDisplayName !== template.templateName ? standardExportTemplateDisplayName : (template.name ?? template.templateName);
+        standardAndCustomExportTemplates.push(filterValue);
     }
 
     const connectedIntegrationNames = policyIDs && policyIDs.length === 0 ? new Set<string>() : getConnectedIntegrationNamesForPolicies(policies, policyIDs);
@@ -84,7 +86,7 @@ export default function useExportedToFilterOptions(): UseExportedToFilterDataRes
         return connectionName && connectedIntegrationNames.has(connectionName);
     });
 
-    const exportedToFilterOptions = [...connectedIntegrationDisplayNames, ...standardExportTemplates];
+    const exportedToFilterOptions = [...new Set([...connectedIntegrationDisplayNames, ...standardAndCustomExportTemplates])];
 
     return {
         exportedToFilterOptions,

--- a/src/pages/Search/SearchAdvancedFiltersPage/SearchFiltersExportedToPage.tsx
+++ b/src/pages/Search/SearchAdvancedFiltersPage/SearchFiltersExportedToPage.tsx
@@ -96,27 +96,23 @@ function SearchFiltersExportedToPage() {
         }
         const deduplicatedExportTemplates = Array.from(exportTemplatesByTemplateId.values());
 
-        const standardExportTemplatePickerItems: SearchMultipleSelectionPickerItem[] = [];
+        const standardAndIntegrationCustomTemplatePickerItems: SearchMultipleSelectionPickerItem[] = [];
 
         for (const template of deduplicatedExportTemplates) {
-            if (!template.templateName || integrationConnectionNamesSet.has(template.templateName)) {
-                continue;
-            }
-
-            if (!STANDARD_EXPORT_TEMPLATE_ID_TO_DISPLAY_LABEL[template.templateName]) {
+            if (!template.templateName || integrationConnectionNamesSet.has(template.templateName) || template.type === CONST.EXPORT_TEMPLATE_TYPES.IN_APP) {
                 continue;
             }
 
             const displayName = template.name ?? template.templateName ?? '';
-            const filterValue = STANDARD_EXPORT_TEMPLATE_ID_TO_DISPLAY_LABEL[template.templateName] ?? template.templateName;
-            standardExportTemplatePickerItems.push({
+            const filterValue = STANDARD_EXPORT_TEMPLATE_ID_TO_DISPLAY_LABEL[template.templateName] ?? displayName;
+            standardAndIntegrationCustomTemplatePickerItems.push({
                 name: displayName,
                 value: filterValue,
                 leftElement: tableIconForExportOption,
             });
         }
 
-        return [...connectedIntegrationPickerItems, ...standardExportTemplatePickerItems];
+        return [...connectedIntegrationPickerItems, ...standardAndIntegrationCustomTemplatePickerItems];
     })();
 
     const initiallySelectedPickerItems: SearchMultipleSelectionPickerItem[] | undefined = (() => {

--- a/src/pages/Search/SearchAdvancedFiltersPage/SearchFiltersExportedToPage.tsx
+++ b/src/pages/Search/SearchAdvancedFiltersPage/SearchFiltersExportedToPage.tsx
@@ -46,6 +46,8 @@ function SearchFiltersExportedToPage() {
     const selectedExportedToValues = searchAdvancedFiltersForm?.exportedTo ?? [];
     const connectedIntegrationNames = getConnectedIntegrationNamesForPolicies(policies, policyIDs.length > 0 ? policyIDs : undefined);
 
+    const getPickerItemValueKey = (value: SearchMultipleSelectionPickerItem['value']): string => (typeof value === 'string' ? value : (value.at(0) ?? ''));
+
     const tableIconForExportOption = (
         <View style={[styles.mr3, styles.alignItemsCenter, styles.justifyContentCenter, StyleUtils.getWidthAndHeightStyle(variables.w28, variables.h28)]}>
             <Icon
@@ -83,6 +85,7 @@ function SearchFiltersExportedToPage() {
                 };
             });
 
+        const usedPickerValueKeys = new Set(connectedIntegrationPickerItems.map((item) => getPickerItemValueKey(item.value)));
         const policiesToLoadTemplatesFrom = policyIDs.length > 0 ? policyIDs.map((id) => policies?.[`${ONYXKEYS.COLLECTION.POLICY}${id}`]).filter(Boolean) : Object.values(policies ?? {});
         const exportTemplatesFromPolicies = policiesToLoadTemplatesFrom.flatMap((policy) => getExportTemplates([], {}, translate, policy, false));
         const exportTemplatesFromAccount = getExportTemplates(integrationsExportTemplates ?? [], csvExportLayouts ?? {}, translate, undefined, true);
@@ -105,6 +108,12 @@ function SearchFiltersExportedToPage() {
 
             const displayName = template.name ?? template.templateName ?? '';
             const filterValue = STANDARD_EXPORT_TEMPLATE_ID_TO_DISPLAY_LABEL[template.templateName] ?? displayName;
+            const filterValueKey = getPickerItemValueKey(filterValue);
+            if (usedPickerValueKeys.has(filterValueKey)) {
+                continue;
+            }
+
+            usedPickerValueKeys.add(filterValueKey);
             standardAndIntegrationCustomTemplatePickerItems.push({
                 name: displayName,
                 value: filterValue,
@@ -121,12 +130,10 @@ function SearchFiltersExportedToPage() {
         }
         const normalizedSelectedValues = new Set(selectedExportedToValues);
         const selectedOptionsPresentInCurrentList = exportedToPickerOptions.filter((option) => {
-            const optionValue = typeof option.value === 'string' ? option.value : (option.value.at(0) ?? '');
+            const optionValue = getPickerItemValueKey(option.value);
             return normalizedSelectedValues.has(optionValue);
         });
-        const selectedValueIdsFoundInCurrentOptions = new Set(
-            selectedOptionsPresentInCurrentList.map((option) => (typeof option.value === 'string' ? option.value : (option.value.at(0) ?? ''))),
-        );
+        const selectedValueIdsFoundInCurrentOptions = new Set(selectedOptionsPresentInCurrentList.map((option) => getPickerItemValueKey(option.value)));
         const unavailableSelectedValues = selectedExportedToValues.filter((value) => !selectedValueIdsFoundInCurrentOptions.has(value));
         const unavailableSelectedOptions: SearchMultipleSelectionPickerItem[] = unavailableSelectedValues.map((value) => {
             const connectionName = integrationConnectionNames.find((name) => CONST.POLICY.CONNECTIONS.NAME_USER_FRIENDLY[name] === value);

--- a/src/pages/Search/SearchAdvancedFiltersPage/SearchFiltersExportedToPage.tsx
+++ b/src/pages/Search/SearchAdvancedFiltersPage/SearchFiltersExportedToPage.tsx
@@ -29,6 +29,10 @@ const STANDARD_EXPORT_TEMPLATE_ID_TO_DISPLAY_LABEL: Record<string, string> = {
     [CONST.REPORT.EXPORT_OPTIONS.EXPENSE_LEVEL_EXPORT]: CONST.REPORT.EXPORT_OPTION_LABELS.EXPENSE_LEVEL_EXPORT,
 };
 
+function getPickerItemValueKey(value: SearchMultipleSelectionPickerItem['value']): string {
+    return typeof value === 'string' ? value : (value.at(0) ?? '');
+}
+
 function SearchFiltersExportedToPage() {
     const styles = useThemeStyles();
     const {translate} = useLocalize();
@@ -45,8 +49,6 @@ function SearchFiltersExportedToPage() {
     const integrationConnectionNames = Object.values(CONST.POLICY.CONNECTIONS.NAME);
     const selectedExportedToValues = searchAdvancedFiltersForm?.exportedTo ?? [];
     const connectedIntegrationNames = getConnectedIntegrationNamesForPolicies(policies, policyIDs.length > 0 ? policyIDs : undefined);
-
-    const getPickerItemValueKey = (value: SearchMultipleSelectionPickerItem['value']): string => (typeof value === 'string' ? value : (value.at(0) ?? ''));
 
     const tableIconForExportOption = (
         <View style={[styles.mr3, styles.alignItemsCenter, styles.justifyContentCenter, StyleUtils.getWidthAndHeightStyle(variables.w28, variables.h28)]}>

--- a/tests/unit/hooks/useExportedToFilterOptions.test.ts
+++ b/tests/unit/hooks/useExportedToFilterOptions.test.ts
@@ -77,6 +77,16 @@ describe('useExportedToFilterOptions', () => {
         expect(result.current.exportedToFilterOptions).not.toContain(templateName);
     });
 
+    it('excludes templates whose templateName matches integration connection key', () => {
+        const templateName = CONST.POLICY.CONNECTIONS.NAME.QBO;
+        const templateDisplayName = 'QBO Custom Template';
+        mockGetExportTemplates.mockReturnValue([{templateName, name: templateDisplayName, type: CONST.EXPORT_TEMPLATE_TYPES.INTEGRATIONS} as ExportTemplate]);
+
+        const {result} = renderHook(() => useExportedToFilterOptions());
+
+        expect(result.current.exportedToFilterOptions).not.toContain(templateDisplayName);
+    });
+
     it('includes standard export label in options when getExportTemplates returns standard template', () => {
         mockGetExportTemplates.mockReturnValue([{templateName: CONST.REPORT.EXPORT_OPTIONS.EXPENSE_LEVEL_EXPORT, name: expenseLevelLabel} as ExportTemplate]);
 

--- a/tests/unit/hooks/useExportedToFilterOptions.test.ts
+++ b/tests/unit/hooks/useExportedToFilterOptions.test.ts
@@ -59,13 +59,22 @@ describe('useExportedToFilterOptions', () => {
         expect(result.current.connectedIntegrationNames).toContain(CONST.POLICY.CONNECTIONS.NAME.QBO);
     });
 
-    it('excludes custom template name from options when getExportTemplates returns custom template', () => {
+    it('includes integration custom template name from options when getExportTemplates returns integration template', () => {
         const customName = 'Export Layout';
-        mockGetExportTemplates.mockReturnValue([{templateName: customName, name: customName} as ExportTemplate]);
+        mockGetExportTemplates.mockReturnValue([{templateName: customName, name: customName, type: CONST.EXPORT_TEMPLATE_TYPES.INTEGRATIONS} as ExportTemplate]);
 
         const {result} = renderHook(() => useExportedToFilterOptions());
 
-        expect(result.current.exportedToFilterOptions).not.toContain(customName);
+        expect(result.current.exportedToFilterOptions).toContain(customName);
+    });
+
+    it('excludes in-app custom templates from options', () => {
+        const templateName = 'Custom Export Format from OD';
+        mockGetExportTemplates.mockReturnValue([{templateName, name: templateName, type: CONST.EXPORT_TEMPLATE_TYPES.IN_APP} as ExportTemplate]);
+
+        const {result} = renderHook(() => useExportedToFilterOptions());
+
+        expect(result.current.exportedToFilterOptions).not.toContain(templateName);
     });
 
     it('includes standard export label in options when getExportTemplates returns standard template', () => {


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
<!-- Explain what your change does and how it addresses the linked issue -->

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/80005
PROPOSAL:


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

1. Add an IS export template (or request the internal team to add one to your test account)
2. Submit an expense and export the expense report using the IS template
3. Go to Reports page > Filters > Exported to
4. Verify that all IS export templates are available in the list
5. Select the template used to export the expense report in step 2
6. Click Save > View results
7. Verify that all expenses exported to that IS template appear in the search results

- [X] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
8. Upload an image via copy paste
9. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->
Same as test
// TODO: These must be filled out, or the issue title must include "[No QA]."

- [X] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [X] I linked the correct issue in the `### Fixed Issues` section above
- [X] I wrote clear testing steps that cover the changes made in this PR
    - [X] I added steps for local testing in the `Tests` section
    - [X] I added steps for the expected offline behavior in the `Offline steps` section
    - [X] I added steps for Staging and/or Production testing in the `QA steps` section
    - [X] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [X] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [X] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [X] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [X] I ran the tests on **all platforms** & verified they passed on:
    - [X] Android: Native
    - [X] Android: mWeb Chrome
    - [X] iOS: Native
    - [X] iOS: mWeb Safari
    - [X] MacOS: Chrome / Safari
- [X] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [X] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [X] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [X] I verified that comments were added to code that is not self explanatory
    - [X] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [X] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [X] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [X] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [X] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [X] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [X] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [X] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [X] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [X] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [X] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [X] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [X] I verified that if a function's arguments changed that all usages have also been updated correctly
- [X] If any new file was added I verified that:
    - [X] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [X] If a new CSS style is added I verified that:
    - [X] A similar style doesn't already exist
    - [X] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [X] If new assets were added or existing ones were modified, I verified that:
    - [X] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [X] The assets load correctly across all supported platforms.
- [X] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [X] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [X] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [X] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [X] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [X] I verified that all the inputs inside a form are aligned with each other.
    - [X] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [X] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [X] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [X] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.


https://github.com/user-attachments/assets/b1662abb-124a-48d5-b7ca-20aa7108063e




### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>