### PR TITLE
Delete placeholder pages leftover from the integration errors pages

### DIFF
--- a/docs/articles/expensify-classic/connections/certinia/Troubleshooting/Export-Errors/Overview.md
+++ b/docs/articles/expensify-classic/connections/certinia/Troubleshooting/Export-Errors/Overview.md
@@ -1,9 +1,0 @@
----
-title: Overview
-description: This section is under construction. Content will be added in a follow-up PR.
----
-
-# Overview
-
-This section is under construction. Content will be added in a follow-up PR.
-

--- a/docs/articles/expensify-classic/connections/quickbooks-online/Troubleshooting/Connection-errors/Overview.md
+++ b/docs/articles/expensify-classic/connections/quickbooks-online/Troubleshooting/Connection-errors/Overview.md
@@ -1,9 +1,0 @@
----
-title: Overview
-description: This section is under construction. Content will be added in a follow-up PR.
----
-
-# Overview
-
-This section is under construction. Content will be added in a follow-up PR.
-

--- a/docs/articles/new-expensify/connections/quickbooks-online/Troubleshooting/Export-Errors/Overview.md
+++ b/docs/articles/new-expensify/connections/quickbooks-online/Troubleshooting/Export-Errors/Overview.md
@@ -1,9 +1,0 @@
----
-title: Overview
-description: This section is under construction. Content will be added in a follow-up PR.
----
-
-# Overview
-
-This section is under construction. Content will be added in a follow-up PR.
-

--- a/docs/articles/new-expensify/connections/sage-intacct/Troubleshooting/Authentication-and-Login-errors/Overview.md
+++ b/docs/articles/new-expensify/connections/sage-intacct/Troubleshooting/Authentication-and-Login-errors/Overview.md
@@ -1,9 +1,0 @@
----
-title: Overview
-description: This section is under construction. Content will be added in a follow-up PR.
----
-
-# Overview
-
-This section is under construction. Content will be added in a follow-up PR.
-

--- a/docs/articles/new-expensify/connections/sage-intacct/Troubleshooting/Connection-errors/Overview.md
+++ b/docs/articles/new-expensify/connections/sage-intacct/Troubleshooting/Connection-errors/Overview.md
@@ -1,9 +1,0 @@
----
-title: Overview
-description: This section is under construction. Content will be added in a follow-up PR.
----
-
-# Overview
-
-This section is under construction. Content will be added in a follow-up PR.
-

--- a/docs/articles/new-expensify/connections/xero/Troubleshooting/Connection-errors/Overview.md
+++ b/docs/articles/new-expensify/connections/xero/Troubleshooting/Connection-errors/Overview.md
@@ -1,9 +1,0 @@
----
-title: Overview
-description: This section is under construction. Content will be added in a follow-up PR.
----
-
-# Overview
-
-This section is under construction. Content will be added in a follow-up PR.
-


### PR DESCRIPTION
Deleting a bunch of placeholders left over from the integration errors project: https://github.com/Expensify/Expensify/issues/469226