### PR TITLE
Fixes for sequential queue issues

### DIFF
--- a/src/libs/actions/PersistedRequests.ts
+++ b/src/libs/actions/PersistedRequests.ts
@@ -10,6 +10,12 @@ let persistedRequests: AnyRequest[] = [];
 let ongoingRequest: AnyRequest | null = null;
 let pendingSaveOperations: AnyRequest[] = [];
 let isInitialized = false;
+
+// Tracks all requestIDs this tab has ever seen (from disk init, save(), or other tabs).
+// Used to distinguish stale own-write callbacks (ignore) from new requests enqueued
+// by other browser tabs (merge into memory).
+const knownRequestIDs = new Set<number>();
+
 let initializationCallback: () => void;
 function triggerInitializationCallback() {
     if (typeof initializationCallback !== 'function') {
@@ -26,7 +32,32 @@ function onInitialization(callbackFunction: () => void) {
 Onyx.connectWithoutView({
     key: ONYXKEYS.PERSISTED_REQUESTS,
     callback: (val) => {
-        Log.info('[PersistedRequests] hit Onyx connect callback', false, {isValNullish: val == null});
+        Log.info('[PersistedRequests] hit Onyx connect callback', false, {isValNullish: val == null, isInitialized});
+
+        // After initialization, in-memory is authoritative — ignore stale disk
+        // callbacks to prevent out-of-order Onyx.set() from overwriting the
+        // correct in-memory state (Bug #80759 Issue 4).
+        // Exception 1: Onyx.clear() fires callback with null — allow through.
+        // Exception 2: Other browser tabs can enqueue requests. We detect these
+        // by checking for requestIDs not in knownRequestIDs, and merge them in.
+        if (isInitialized && val != null) {
+            const newFromOtherTabs = val.filter((r) => r.requestID != null && !knownRequestIDs.has(r.requestID));
+            if (newFromOtherTabs.length > 0) {
+                Log.info('[PersistedRequests] Merging requests from other tabs', false, {
+                    newCount: newFromOtherTabs.length,
+                    newCommands: getCommands(newFromOtherTabs),
+                });
+                for (const r of newFromOtherTabs) {
+                    if (r.requestID != null) {
+                        knownRequestIDs.add(r.requestID);
+                    }
+                }
+                persistedRequests = [...persistedRequests, ...newFromOtherTabs];
+                Onyx.set(ONYXKEYS.PERSISTED_REQUESTS, persistedRequests);
+            }
+            return;
+        }
+
         const previousInMemoryRequests = [...persistedRequests];
         const diskRequests = val ?? [];
         persistedRequests = diskRequests;
@@ -270,18 +301,24 @@ function processNextRequest(): AnyRequest | null {
         newQueueLength: persistedRequests.length,
     });
 
-    if (ongoingRequest && ongoingRequest.persistWhenOngoing) {
-        Log.info('[PersistedRequests] Persisting ongoingRequest to disk', false, {
-            command: ongoingRequest.command,
-        });
-        Onyx.set(ONYXKEYS.PERSISTED_ONGOING_REQUESTS, ongoingRequest);
-    } else {
-        Log.info('[PersistedRequests] NOT persisting ongoingRequest to disk (persistWhenOngoing=false)', false, {
-            command: ongoingRequest?.command ?? 'null',
-        });
-    }
+    // Persist both the updated queue and the ongoing request to disk atomically.
+    // This ensures that if the app crashes mid-flight, the ongoing request is not
+    // lost (Bug #80759 Issue 3a) and the queue on disk matches memory (Issue 3c).
+    // Skip persisting ongoingRequest when it contains non-serializable values
+    // (e.g. File objects in data.file or data.receipt). IndexedDB cannot clone
+    // native File objects (DataCloneError). These requests cannot survive a crash
+    // anyway since File references are lost on restart.
+    const hasNonSerializableData = ongoingRequest?.data && Object.values(ongoingRequest.data).some((v) => v instanceof File || v instanceof Blob);
+    Onyx.multiSet({
+        [ONYXKEYS.PERSISTED_REQUESTS]: persistedRequests,
+        ...(ongoingRequest && !hasNonSerializableData ? {[ONYXKEYS.PERSISTED_ONGOING_REQUESTS]: ongoingRequest} : {}),
+    });
 
-    return ongoingRequest;
+    // Return the local reference, not `ongoingRequest`. The Onyx.multiSet above
+    // triggers a synchronous callback (Onyx 3.0.46+) that overwrites `ongoingRequest`
+    // with a JSON-serialized copy — which destroys non-serializable values like File
+    // objects. The local `nextRequest` still holds the original object.
+    return nextRequest;
 }
 
 function rollbackOngoingRequest() {

--- a/tests/unit/APITest.ts
+++ b/tests/unit/APITest.ts
@@ -874,8 +874,8 @@ describe('API.write() persistence guarantees', () => {
             // persisted-requests queue. This avoids spy-ordering issues that caused
             // false passes on CI.
             const updateMock = jest.spyOn(Onyx, 'update').mockImplementation((data) => {
-                // We use ONYXKEYS.IS_CHECKING_PUBLIC_ROOM as a sample key to identify the marker
-                const hasMarker = data.some((entry) => entry.key === ONYXKEYS.IS_CHECKING_PUBLIC_ROOM);
+                // We use ONYXKEYS.RAM_ONLY_IS_CHECKING_PUBLIC_ROOM as a sample key to identify the marker
+                const hasMarker = data.some((entry) => entry.key === ONYXKEYS.RAM_ONLY_IS_CHECKING_PUBLIC_ROOM);
                 if (hasMarker) {
                     optimisticDataApplied = true;
                     // Note: getAll() checks the in-memory queue, not durable (disk) state.
@@ -892,7 +892,7 @@ describe('API.write() persistence guarantees', () => {
                     optimisticData: [
                         {
                             onyxMethod: Onyx.METHOD.SET,
-                            key: ONYXKEYS.IS_CHECKING_PUBLIC_ROOM,
+                            key: ONYXKEYS.RAM_ONLY_IS_CHECKING_PUBLIC_ROOM,
                             value: true,
                         },
                     ],


### PR DESCRIPTION
### Explanation of Change

This PR re-lands the sequential queue fixes from #84622 (which was reverted due to deploy blockers #85671, #85669, #85673, #85708, #85755) with additional fixes for the file upload regression.

**What was reverted PR #84622 doing:**
Fixing 4 bugs in `PersistedRequests.ts` and the write pipeline (Issue #80759):
- **Issue 2**: `API.write()` returned `Promise.resolve()` immediately — nothing in the write pipeline was awaited. Fix: `save()` returns `Promise<void>`, `push()` returns persistence promise, `processRequest()` awaits it.
- **Issue 3**: `processNextRequest()` and `rollbackOngoingRequest()` didn't persist changes to disk. Fix: both now use `Onyx.multiSet()` to atomically persist queue + ongoing request.
- **Issue 4**: Onyx connect callback blindly overwrote in-memory state with stale disk data. Fix: after initialization, callback returns early (in-memory is authoritative). Multi-tab support preserved via `knownRequestIDs` merge.
- **Issue 5**: Conflict resolver saw stale queue (consequence of Issue 4, fixed automatically).

**Why it was reverted — deploy blockers (file uploads broken):**
`processNextRequest()` now always persists `ongoingRequest` via `Onyx.multiSet()`. Combined with Onyx 3.0.46 (which made callbacks synchronous), this caused two problems:
1. The synchronous callback overwrote `ongoingRequest` with a JSON-serialized copy where `File` objects became `{}`. Then `return ongoingRequest` returned the corrupted object → server received empty file → upload failed.
2. `File`/`Blob` objects cannot be cloned into IndexedDB → `DataCloneError` red screen on every file upload.

**How we fixed the deploy blockers:**
1. `return nextRequest` instead of `return ongoingRequest` — local variable is unaffected by the synchronous callback.
2. Skip persisting `ongoingRequest` to `PERSISTED_ONGOING_REQUESTS` when request data contains `File`/`Blob`. These requests can't survive a crash anyway (File references are lost on restart).

**Additional fix:**
- `requestIndex = Date.now()` instead of `0` — prevents cross-tab requestID collisions.
- Removed `CONST.DEFAULT_NUMBER_ID` fallback in knownRequestIDs (reviewer feedback from @adhorodyski).

### Fixed Issues

$ https://github.com/Expensify/App/issues/80759
$ https://github.com/Expensify/App/issues/85671
$ https://github.com/Expensify/App/issues/85669
$ https://github.com/Expensify/App/issues/85673
$ https://github.com/Expensify/App/issues/85708
$ https://github.com/Expensify/App/issues/85755

### Tests

1. Upload an attachment in any chat → verify it uploads successfully, no "No content to add" error
2. Go to workspace settings → click workspace avatar → upload image → Save → verify avatar updates
3. Create a manual expense with receipt → verify receipt is displayed
4. Go to workspace → Tags → Import → Multi-level tags → upload CSV file → verify import succeeds
5. Open two browser tabs, create expense in tab 1, submit it in tab 2 → verify it works
6. Go offline, create several expenses, go back online → verify all requests are processed in order
7. Open DevTools console → repeat steps 1-4 → verify no `DataCloneError` appears
- [ ] Verify that no errors appear in the JS console

### Offline tests

1. Go offline (DevTools → Network → Offline)
2. Create 3 expenses with receipts
3. Go back online
4. Verify all 3 expenses are created and receipts are displayed
5. Verify no duplicate or missing requests

### QA Steps

1. **File upload (deploy blocker fix):** Go to any chat → click attachment icon → upload a file → verify it uploads without error
2. **Workspace avatar (deploy blocker fix):** Go to workspace settings → upload new avatar → Save → verify avatar changes
3. **Receipt upload (deploy blocker fix):** Create manual expense → attach receipt from computer → verify receipt is displayed
4. **Multi-level tags import (deploy blocker fix):** Go to workspace → Tags → Import → Multi-level tags → upload CSV → verify import succeeds without "Import failed" error
5. **Multi-tab (regression check):** Open two tabs → create expense in tab 1 → go to tab 2 → submit the expense → verify it submits successfully
6. **Offline resilience:** Go offline → create 2-3 expenses → go online → verify all processed
7. **Console check:** Open DevTools console → repeat steps 1-4 → verify no `DataCloneError` or other errors

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [ ] I linked the correct issue in the `### Fixed Issues` section above
- [ ] I wrote clear testing steps that cover the changes made in this PR
    - [ ] I added steps for local testing in the `Tests` section
    - [ ] I added steps for the expected offline behavior in the `Offline steps` section
    - [ ] I added steps for Staging and/or Production testing in the `QA steps` section
    - [ ] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [ ] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [ ] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [ ] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [ ] I ran the tests on **all platforms** & verified they passed on:
    - [ ] Android: Native
    - [ ] Android: mWeb Chrome
    - [ ] iOS: Native
    - [ ] iOS: mWeb Safari
    - [ ] MacOS: Chrome / Safari
- [ ] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [ ] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [ ] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [ ] I verified that comments were added to code that is not self explanatory
    - [ ] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [ ] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [ ] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [ ] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [ ] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [ ] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [ ] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [ ] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [ ] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [ ] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [ ] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [ ] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [ ] I verified that if a function's arguments changed that all usages have also been updated correctly
- [ ] If any new file was added I verified that:
    - [ ] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [ ] If a new CSS style is added I verified that:
    - [ ] A similar style doesn't already exist
    - [ ] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [ ] If new assets were added or existing ones were modified, I verified that:
    - [ ] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [ ] The assets load correctly across all supported platforms.
- [ ] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [ ] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [ ] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [ ] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [ ] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [ ] I verified that all the inputs inside a form are aligned with each other.
    - [ ] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [ ] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [ ] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [ ] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>