### PR TITLE
Fix Travel OD to ND route normalization in getInternalNewExpensifyPath

### DIFF
--- a/src/libs/actions/Link.ts
+++ b/src/libs/actions/Link.ts
@@ -159,6 +159,15 @@ function getInternalNewExpensifyPath(href: string) {
         return '';
     }
     const attrPath = Url.getPathFromURL(href);
+	
+	// UI / Flow Worker route-experience normalization
+    const normalizedAttrPath = Str.removeLeadingSlash(attrPath);
+    const isTravelRoute = normalizedAttrPath === 'trips' || normalizedAttrPath.startsWith('trips/');
+    const isNewDotOrigin = href.startsWith(CONST.NEW_EXPENSIFY_URL) || href.startsWith(CONST.NEW_EXPENSIFY_STAGING_URL) || href.startsWith(CONST.NEW_EXPENSIFY_DEV_URL);
+    if (isTravelRoute && isNewDotOrigin) {
+        return normalizedAttrPath;
+    }
+	
     return (Url.hasSameExpensifyOrigin(href, CONST.NEW_EXPENSIFY_URL) || Url.hasSameExpensifyOrigin(href, CONST.STAGING_NEW_EXPENSIFY_URL) || href.startsWith(CONST.DEV_NEW_EXPENSIFY_URL)) &&
         !CONST.PATHS_TO_TREAT_AS_EXTERNAL.find((path) => attrPath.startsWith(path))
         ? attrPath


### PR DESCRIPTION
### Explanation of Change

This PR updates `getInternalNewExpensifyPath()` to normalize Trips-style paths earlier when the link originates from a NewDot environment.

In the current routing flow, `openLink()` already contains the NewDot navigation branch once an internal NewDot path is available. Because of that, the likely failure point is upstream route classification rather than the downstream navigation branch itself.

This change adds an early normalization step for Travel / Trips routes so the existing NewDot routing flow can resolve naturally.

### Fixed Issues

PROPOSAL: <paste your approved proposal comment URL here if you have one>