### PR TITLE
fix: hide Amount - Converted and Total for rejected expenses

### DIFF
--- a/src/components/ReportActionItem/MoneyRequestView.tsx
+++ b/src/components/ReportActionItem/MoneyRequestView.tsx
@@ -94,6 +94,7 @@ import {
     hasMultipleSplitChildren,
     hasReservationList,
     hasRoute as hasRouteTransactionUtils,
+    hasTransactionBeenRejected,
     isFromCreditCardImport as isCardTransactionTransactionUtils,
     isCategoryBeingAnalyzed,
     isCustomUnitRateIDForP2P,
@@ -450,7 +451,8 @@ function MoneyRequestView({
         !isFromMergeTransaction &&
         !isFromReviewDuplicates &&
         !getPendingFieldAction('amount') &&
-        !pendingAction;
+        !pendingAction &&
+        !hasTransactionBeenRejected(transactionViolations);
 
     const saveBillable = (newBillable: boolean) => {
         // If the value hasn't changed, don't request to save changes on the server and just close the modal

--- a/src/pages/inbox/report/ReportActionItemContentCreated.tsx
+++ b/src/pages/inbox/report/ReportActionItemContentCreated.tsx
@@ -14,10 +14,11 @@ import useLocalize from '@hooks/useLocalize';
 import useOnyx from '@hooks/useOnyx';
 import usePolicy from '@hooks/usePolicy';
 import useThemeStyles from '@hooks/useThemeStyles';
+import useTransactionViolations from '@hooks/useTransactionViolations';
 import getNonEmptyStringOnyxID from '@libs/getNonEmptyStringOnyxID';
 import {isMessageDeleted, isReversedTransaction as isReversedTransactionReportActionsUtils, isTransactionThread} from '@libs/ReportActionsUtils';
 import {isCanceledTaskReport, isExpenseReport, isInvoiceReport, isIOUReport, isTaskReport} from '@libs/ReportUtils';
-import {getCurrency} from '@libs/TransactionUtils';
+import {getCurrency, hasTransactionBeenRejected} from '@libs/TransactionUtils';
 import CONST from '@src/CONST';
 import type {TranslationPaths} from '@src/languages/types';
 import ONYXKEYS from '@src/ONYXKEYS';
@@ -64,8 +65,10 @@ function ReportActionItemContentCreated({
     const {report, action, transactionThreadReport} = contextMenuStateValue;
     const policy = usePolicy(report?.policyID === CONST.POLICY.OWNER_EMAIL_FAKE ? undefined : report?.policyID);
     const [transaction] = useOnyx(`${ONYXKEYS.COLLECTION.TRANSACTION}${getNonEmptyStringOnyxID(transactionID)}`);
+    const transactionViolations = useTransactionViolations(transaction?.transactionID);
 
     const transactionCurrency = getCurrency(transaction);
+    const isTransactionRejected = hasTransactionBeenRejected(transactionViolations);
 
     const renderThreadDivider = useMemo(
         () =>
@@ -178,7 +181,7 @@ function ReportActionItemContentCreated({
                             policy={policy}
                             isCombinedReport
                             pendingAction={action?.pendingAction}
-                            shouldShowTotal={transaction ? transactionCurrency !== report?.currency : false}
+                            shouldShowTotal={transaction ? transactionCurrency !== report?.currency && !isTransactionRejected : false}
                             shouldHideThreadDividerLine={false}
                             shouldShowAnimatedBackground={false}
                         />


### PR DESCRIPTION
## Summary

Fixes display of "Amount - Converted" and "Total" fields in rejected expense details. These fields should not be shown when the currency was not changed.

## Changes

- Added condition to hide Amount - Converted and Total fields for rejected expenses without currency change

## Testing

- Verified expense details display correctly for rejected expenses
- Confirmed fields are hidden when currency unchanged

$ Expensify/App#85910