### PR TITLE
fix: Hide converted amount for rejected expenses

### DIFF
--- a/src/components/ReportActionItem/MoneyRequestView.tsx
+++ b/src/components/ReportActionItem/MoneyRequestView.tsx
@@ -56,7 +56,7 @@ import {
     isPolicyAccessible,
     isTaxTrackingEnabled,
 } from '@libs/PolicyUtils';
-import {getOriginalMessage, isMoneyRequestAction} from '@libs/ReportActionsUtils';
+import {getOriginalMessage, isMoneyRequestAction, isRejectedAction} from '@libs/ReportActionsUtils';
 import {getReportName} from '@libs/ReportNameUtils';
 import {isMarkAsCashActionForTransaction} from '@libs/ReportPrimaryActionUtils';
 import {isSplitAction} from '@libs/ReportSecondaryActionUtils';
@@ -442,6 +442,7 @@ function MoneyRequestView({
     const isEmptyUpdatedMerchant = isInvalidMerchantValue(updatedTransaction?.modifiedMerchant);
     const updatedMerchantTitle = isEmptyUpdatedMerchant ? '' : (updatedTransaction?.modifiedMerchant ?? merchantTitle);
 
+    const isRejected = parentReportAction && isRejectedAction(parentReportAction);
     const shouldShowConvertedAmount =
         transactionConvertedAmount &&
         currency !== moneyRequestReport?.currency &&
@@ -450,7 +451,8 @@ function MoneyRequestView({
         !isFromMergeTransaction &&
         !isFromReviewDuplicates &&
         !getPendingFieldAction('amount') &&
-        !pendingAction;
+        !pendingAction &&
+        !isRejected;
 
     const saveBillable = (newBillable: boolean) => {
         // If the value hasn't changed, don't request to save changes on the server and just close the modal


### PR DESCRIPTION
## Summary

This fix prevents showing 'Amount - Converted' when an expense has been rejected, as the currency was not actually changed by the user. The issue occurred when a submitter opened a rejected expense and saw the converted amount displayed even though no currency conversion had taken place.

## Changes

- Added isRejectedAction import from ReportActionsUtils
- Added isRejected check to determine if the parent report action is a rejected action
- Updated shouldShowConvertedAmount condition to exclude rejected expenses

## Testing

The fix was tested by verifying that:
- Converted amount is not shown when viewing a rejected expense
- Converted amount is still shown for normal expenses with different currencies

$ Expensify/App#85910