### PR TITLE
fix: ensure OD Report links open in app instead of browser

### DIFF
--- a/src/libs/Navigation/linkingConfig/prefixes.ts
+++ b/src/libs/Navigation/linkingConfig/prefixes.ts
@@ -12,6 +12,11 @@ const prefixes: LinkingOptions<RootNavigatorParamList>['prefixes'] = [
     CONST.NEW_EXPENSIFY_URL,
     CONST.STAGING_NEW_EXPENSIFY_URL,
     CONST.PR_TESTING_NEW_EXPENSIFY_URL,
+    // Old Dot URLs - needed to ensure OD Report links open in the app instead of browser
+    'https://www.expensify.com',
+    'https://staging.expensify.com',
+    CONST.EXPENSIFY_URL,
+    CONST.STAGING_EXPENSIFY_URL,
 ];
 
 export default prefixes;


### PR DESCRIPTION
$ Expensify/App#85924

## Problem
When clicking an OD (Old Dot) Report link, it opens in Chrome browser instead of opening in the Expensify app.

## Root Cause
The app's deep link prefixes did not include Old Dot URLs (https://www.expensify.com). When users clicked OD Report links like https://www.expensify.com/r/{reportID}, the mobile OS didn't recognize them as deep links that should open the Expensify app.

## Solution
Added Old Dot URL prefixes to the linking configuration in src/libs/Navigation/linkingConfig/prefixes.ts:
- https://www.expensify.com
- https://staging.expensify.com
- CONST.EXPENSIFY_URL
- CONST.STAGING_EXPENSIFY_URL

These prefixes allow the app to intercept Old Dot links and handle them internally via the existing deep link handling logic.

## Testing
1. On mobile device with app installed
2. Click an OD Report link (e.g., https://www.expensify.com/r/{reportID})
3. Verify the link opens in the Expensify app instead of Chrome

## Screenshots/Videos
N/A - Deep link handling fix