### PR TITLE
fix: resolve share sheet scan failure

### DIFF
--- a/src/pages/Share/SubmitDetailsPage.tsx
+++ b/src/pages/Share/SubmitDetailsPage.tsx
@@ -295,7 +295,7 @@ function SubmitDetailsPage({
                     <MoneyRequestConfirmationList
                         transaction={transaction}
                         selectedParticipants={participants}
-                        iouAmount={0}
+                        iouAmount={transactionAmount}
                         iouComment={trimmedComment}
                         iouCategory={transaction?.category}
                         onConfirm={() => onConfirm(true)}


### PR DESCRIPTION
## Summary
$ Expensify/App#85928 - Scan share sheet flow was busted

## Problem
When sharing a receipt from email to Expensify app via iOS Share sheet and using the Submit tab, the scan failed with 'Review required' error and amount showed \.00.

## Root Cause
In \src/pages/Share/SubmitDetailsPage.tsx\, the \iouAmount\ prop passed to \MoneyRequestConfirmationList\ was hardcoded to \