### PR TITLE
Fix OD Report deeplinks opening in browser instead of app

### DIFF
--- a/src/libs/Navigation/linkingConfig/prefixes.ts
+++ b/src/libs/Navigation/linkingConfig/prefixes.ts
@@ -12,6 +12,10 @@ const prefixes: LinkingOptions<RootNavigatorParamList>['prefixes'] = [
     CONST.NEW_EXPENSIFY_URL,
     CONST.STAGING_NEW_EXPENSIFY_URL,
     CONST.PR_TESTING_NEW_EXPENSIFY_URL,
+    // Old Dot URLs - to handle OD report links opening in the app instead of browser
+    CONST.EXPENSIFY_URL,
+    CONST.STAGING_EXPENSIFY_URL,
+    CONST.INTERNAL_DEV_EXPENSIFY_URL,
 ];
 
 export default prefixes;

--- a/src/libs/ReportUtils.ts
+++ b/src/libs/ReportUtils.ts
@@ -9837,6 +9837,15 @@ function getRouteFromLink(url: string | null): string {
             route = route.replace('/', '');
         }
     }
+
+    // Convert Old Dot report URLs to New Dot format
+    // Old Dot: report.php?reportID=123 or _devreport.php?reportID=123
+    // New Dot: r/123
+    const oldDotReportMatch = route.match(/^(?:_dev)?report\.php\?reportID=(\d+)/);
+    if (oldDotReportMatch) {
+        return `r/${oldDotReportMatch[1]}`;
+    }
+
     return route;
 }
 


### PR DESCRIPTION
$ #85924 - OD Report links now open in the app instead of Chrome browser.