### PR TITLE
[ECUK in-app 3DS] Enable passkeys for 3DS challenges and show prompt before allowing user to close RHP

### DIFF
--- a/src/components/MultifactorAuthentication/config/scenarios/AuthorizeTransaction.tsx
+++ b/src/components/MultifactorAuthentication/config/scenarios/AuthorizeTransaction.tsx
@@ -124,7 +124,7 @@ export {
 
 export default {
     // Allowed methods are hardcoded here; keep in sync with allowedAuthenticationMethods in useNavigateTo3DSAuthorizationChallenge.
-    allowedAuthenticationMethods: [CONST.MULTIFACTOR_AUTHENTICATION.TYPE.BIOMETRICS],
+    allowedAuthenticationMethods: [CONST.MULTIFACTOR_AUTHENTICATION.TYPE.BIOMETRICS, CONST.MULTIFACTOR_AUTHENTICATION.TYPE.PASSKEYS],
     action: authorizeTransaction,
 
     // AuthorizeTransaction's callback navigates to the outcome screen, but if it knows the user is going to see an error outcome, we explicitly deny the transaction to make sure the user can't re-approve it on another device

--- a/src/libs/actions/MultifactorAuthentication/index.ts
+++ b/src/libs/actions/MultifactorAuthentication/index.ts
@@ -335,7 +335,21 @@ async function denyTransaction({transactionID}: DenyTransactionParams) {
 
 /** Attempt to deny the transaction without handling errors or waiting for a response. We use this to clean up after something unexpected happened trying to authorize or deny a challenge */
 async function fireAndForgetDenyTransaction({transactionID}: DenyTransactionParams) {
-    makeRequestWithSideEffects(SIDE_EFFECT_REQUEST_COMMANDS.DENY_TRANSACTION, {transactionID}, {});
+    makeRequestWithSideEffects(
+        SIDE_EFFECT_REQUEST_COMMANDS.DENY_TRANSACTION,
+        {transactionID},
+        {
+            optimisticData: [
+                {
+                    key: ONYXKEYS.LOCALLY_PROCESSED_3DS_TRANSACTION_REVIEWS,
+                    onyxMethod: Onyx.METHOD.MERGE,
+                    value: {
+                        [transactionID]: CONST.MULTIFACTOR_AUTHENTICATION.LOCALLY_PROCESSED_TRANSACTION_ACTION.DENY,
+                    },
+                },
+            ],
+        },
+    );
 }
 
 function markHasAcceptedSoftPrompt() {

--- a/src/pages/MultifactorAuthentication/AuthorizeTransactionPage/index.tsx
+++ b/src/pages/MultifactorAuthentication/AuthorizeTransactionPage/index.tsx
@@ -91,6 +91,7 @@ function MultifactorAuthenticationScenarioAuthorizeTransactionPage({route}: Mult
 
     const onApproveTransaction = () => {
         addBreadcrumb('Approve tapped', {transactionID});
+        allowNavigatingAwayRef.current = true;
         executeScenario(CONST.MULTIFACTOR_AUTHENTICATION.SCENARIO.AUTHORIZE_TRANSACTION, {
             transactionID,
         });

--- a/src/pages/MultifactorAuthentication/AuthorizeTransactionPage/index.tsx
+++ b/src/pages/MultifactorAuthentication/AuthorizeTransactionPage/index.tsx
@@ -1,6 +1,6 @@
 import type {SeverityLevel} from '@sentry/react-native';
 import * as Sentry from '@sentry/react-native';
-import React, {useState} from 'react';
+import React, {useCallback, useRef, useState} from 'react';
 import {View} from 'react-native';
 import FullPageOfflineBlockingView from '@components/BlockingViews/FullPageOfflineBlockingView';
 import HeaderWithBackButton from '@components/HeaderWithBackButton';
@@ -13,6 +13,7 @@ import {
 } from '@components/MultifactorAuthentication/config/scenarios/AuthorizeTransaction';
 import {useMultifactorAuthentication} from '@components/MultifactorAuthentication/Context';
 import ScreenWrapper from '@components/ScreenWrapper';
+import useBeforeRemove from '@hooks/useBeforeRemove';
 import useLocalize from '@hooks/useLocalize';
 import useNetworkWithOfflineStatus from '@hooks/useNetworkWithOfflineStatus';
 import useOnyx from '@hooks/useOnyx';
@@ -57,21 +58,36 @@ function MultifactorAuthenticationScenarioAuthorizeTransactionPage({route}: Mult
     const {executeScenario} = useMultifactorAuthentication();
 
     const [isConfirmModalVisible, setConfirmModalVisibility] = useState(false);
+    const allowNavigatingAwayRef = useRef(false);
 
-    const showConfirmModal = () => {
+    const showConfirmModal = useCallback(() => {
         // FullPageOfflineBlockingView doesn't wrap HeaderWithBackButton, so we handle navigation manually when offline.
         // Offline mode isn't supported in MFA; navigate users away immediately without showing the confirmation modal.
         if (isOffline) {
             addBreadcrumb('Offline back-navigation (no deny sent)', {transactionID}, 'warning');
+            allowNavigatingAwayRef.current = true;
             Navigation.closeRHPFlow();
             return;
         }
         setConfirmModalVisibility(true);
-    };
+    }, [isOffline, transactionID]);
 
     const hideConfirmModal = () => {
         setConfirmModalVisibility(false);
     };
+
+    const onBeforeRemove: Parameters<typeof useBeforeRemove>[0] = useCallback(
+        (e) => {
+            if (allowNavigatingAwayRef.current) {
+                return;
+            }
+            e.preventDefault();
+            showConfirmModal();
+        },
+        [showConfirmModal],
+    );
+
+    useBeforeRemove(onBeforeRemove, !!transaction && !denyOutcomeScreen);
 
     const onApproveTransaction = () => {
         addBreadcrumb('Approve tapped', {transactionID});
@@ -96,6 +112,8 @@ function MultifactorAuthenticationScenarioAuthorizeTransactionPage({route}: Mult
     const onSilentlyDenyTransaction = () => {
         addBreadcrumb('Silent deny (user canceled flow)', {transactionID}, 'warning');
         fireAndForgetDenyTransaction({transactionID});
+        setConfirmModalVisibility(false);
+        allowNavigatingAwayRef.current = true;
         Navigation.closeRHPFlow();
     };
 


### PR DESCRIPTION
### Explanation of Change
In AuthorizeTransactionPage, use `useBeforeRemove` to prompt the user to deny the transaction before allowing them to close the RHP. Also enables passkeys for AuthorizeTransaction scenario because this change only makes sense in browsers.

### Fixed Issues
$ https://github.com/Expensify/Expensify/issues/613913
$ https://github.com/Expensify/Expensify/issues/614316
$ https://github.com/Expensify/App/issues/79470

<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
**Clicking outside the RHP**
1. Trigger a 3DS challenge
2. Open NewDot in a browser
3. Click outside the RHP
4. Verify that you see the "Deny transaction" modal
5. Press cancel
6. Verify that the RHP remains open
7. Do it again
8. Press Deny
9. Verify that the RHP closes and remains closed after a moment

**Back button**
- Same as above, but pressing the browser back button instead of clicking empty space

**Outcome screens do not show a prompt**
1. Trigger a 3DS challenge
2. Deny the transaction with the main deny button
3. On the outcome screen, press "Got it"
4. Verify that the RHP closes and remains closed

**Approve flow navigates as normal**
1. Trigger a 3DS challenge
2. Approve it
3. Verify that you are taken through the various MFA screens as normal

- [x] Verify that no errors appear in the JS console

### Offline tests
N/A

### QA Steps

Same as tests. Assign to @joekaufmanexpensify for QA

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.


### Screenshots/Videos

Note that this PR is only relevant in desktop browsers

<details>
<summary>MacOS: Chrome / Safari</summary>

https://github.com/user-attachments/assets/8dbed287-7e2b-410d-9120-591ded5feba3


https://github.com/user-attachments/assets/f820487e-b340-4d31-9859-674a99a0d231



https://github.com/user-attachments/assets/8c795e51-7f3c-4412-b968-01bb08e9f271




</details>