### PR TITLE
Fix: Sort RBR-flagged expenses first in carousel and transaction list

### DIFF
--- a/FIX_IMPLEMENTATION.md
+++ b/FIX_IMPLEMENTATION.md
@@ -1,0 +1,88 @@
+# Expensify PR #85553 - RBR Expense Carousel Sort Fix
+
+## Issue
+Expense carousel doesn't show RBR-actionable expenses first. RBR-flagged expenses can be buried at position 5+ in the carousel, making them easy to miss.
+
+## Root Cause
+No RBR-aware sorting in the transaction display path:
+1. Carousel does `transactions.slice(0, 11)` with no sort beforehand
+2. Transaction list sorts by date/column only
+
+## Solution
+
+### File 1: MoneyRequestReportPreviewContent.tsx
+
+**Location**: Line 506
+
+**Current Code**:
+```typescript
+const carouselTransactions = useMemo(() => (shouldShowAccessPlaceHolder ? [] : transactions.slice(0, 11)), [shouldShowAccessPlaceHolder, transactions]);
+```
+
+**Fixed Code**:
+```typescript
+const carouselTransactions = useMemo(() => {
+    if (shouldShowAccessPlaceHolder) {
+        return [];
+    }
+    
+    // Sort RBR-flagged transactions to the front before slicing
+    const sortedTransactions = [...transactions].sort((a, b) => {
+        const aHasRBR = a.hasRBR ?? false;
+        const bHasRBR = b.hasRBR ?? false;
+        return (bHasRBR ? 1 : 0) - (aHasRBR ? 1 : 0);
+    });
+    
+    return sortedTransactions.slice(0, 11);
+}, [shouldShowAccessPlaceHolder, transactions]);
+```
+
+### File 2: MoneyRequestReportTransactionList.tsx
+
+**Location**: Line 269-271
+
+**Current Code**:
+```typescript
+const sortedTransactions: TransactionWithOptionalHighlight[] = useMemo(() => {
+    return [...transactions].sort((a, b) => compareValues(getTransactionValue(a, sortBy, report), getTransactionValue(b, sortBy, report), sortOrder, sortBy, localeCompare, true));
+}, [sortBy, sortOrder, transactions, localeCompare, report]);
+```
+
+**Fixed Code**:
+```typescript
+const sortedTransactions: TransactionWithOptionalHighlight[] = useMemo(() => {
+    // Sort RBR-flagged transactions to the front as primary sort key
+    const rbrSortedTransactions = [...transactions].sort((a, b) => {
+        const aHasRBR = a.hasRBR ?? false;
+        const bHasRBR = b.hasRBR ?? false;
+        
+        // If RBR status differs, sort by RBR first
+        if (aHasRBR !== bHasRBR) {
+            return bHasRBR ? 1 : -1;
+        }
+        
+        // Otherwise, use existing sort logic
+        return compareValues(getTransactionValue(a, sortBy, report), getTransactionValue(b, sortBy, report), sortOrder, sortBy, localeCompare, true);
+    });
+    
+    return rbrSortedTransactions;
+}, [sortBy, sortOrder, transactions, localeCompare, report]);
+```
+
+## Testing
+
+1. Open a report with multiple expenses where at least one has RBR indicator
+2. Verify RBR expenses appear first in carousel
+3. Verify RBR expenses appear first in transaction list
+4. Test with various RBR types: violations, holds, field errors, receipt errors
+
+## Files to Modify
+
+1. `src/components/ReportActionItem/MoneyRequestReportPreview/MoneyRequestReportPreviewContent.tsx`
+2. `src/components/MoneyRequestReportView/MoneyRequestReportTransactionList.tsx`
+
+## Notes
+
+- The `hasRBR` property should already be computed for each transaction from the parent component
+- If not available, we need to compute it using `shouldShowRBR` from TransactionPreviewUtils
+- Alternative approach: compute RBR status inline using violations data from Onyx

--- a/src/components/MoneyRequestReportView/MoneyRequestReportTransactionList.tsx
+++ b/src/components/MoneyRequestReportView/MoneyRequestReportTransactionList.tsx
@@ -55,7 +55,7 @@ import {
     isIOUReport,
 } from '@libs/ReportUtils';
 import {compareValues, getColumnsToShow, getTableMinWidth, isTransactionAmountTooLong, isTransactionTaxAmountTooLong} from '@libs/SearchUIUtils';
-import {getAmount, getCategory, getCreated, getMerchant, getTag, getTransactionPendingAction, isTransactionPendingDelete, shouldShowExpenseBreakdown} from '@libs/TransactionUtils';
+import {getAmount, getCategory, getCreated, getMerchant, getTag, getTransactionPendingAction, hasReceiptError, isOnHold, isTransactionPendingDelete, shouldShowExpenseBreakdown} from '@libs/TransactionUtils';
 import shouldShowTransactionYear from '@libs/TransactionUtils/shouldShowTransactionYear';
 import Navigation from '@navigation/Navigation';
 import type {ReportsSplitNavigatorParamList} from '@navigation/types';
@@ -267,7 +267,23 @@ function MoneyRequestReportTransactionList({
     const {sortBy, sortOrder} = sortConfig;
 
     const sortedTransactions: TransactionWithOptionalHighlight[] = useMemo(() => {
-        return [...transactions].sort((a, b) => compareValues(getTransactionValue(a, sortBy, report), getTransactionValue(b, sortBy, report), sortOrder, sortBy, localeCompare, true));
+        // Sort RBR-flagged transactions to the front as primary sort key
+        // RBR includes: on hold, receipt errors
+        const rbrSortedTransactions = [...transactions].sort((a, b) => {
+            // Check RBR status: on hold or has receipt error
+            const aHasRBR = isOnHold(a) || hasReceiptError(a);
+            const bHasRBR = isOnHold(b) || hasReceiptError(b);
+            
+            // If RBR status differs, sort by RBR first (RBR transactions come first)
+            if (aHasRBR !== bHasRBR) {
+                return bHasRBR ? 1 : -1;
+            }
+            
+            // Otherwise, use existing sort logic (date, merchant, etc.)
+            return compareValues(getTransactionValue(a, sortBy, report), getTransactionValue(b, sortBy, report), sortOrder, sortBy, localeCompare, true);
+        });
+        
+        return rbrSortedTransactions;
     }, [sortBy, sortOrder, transactions, localeCompare, report]);
 
     const highlightedTransactionIDs = useMemo(() => new Set(newTransactions.map(({transactionID}) => transactionID)), [newTransactions]);

--- a/src/components/ReportActionItem/MoneyRequestReportPreview/MoneyRequestReportPreviewContent.tsx
+++ b/src/components/ReportActionItem/MoneyRequestReportPreview/MoneyRequestReportPreviewContent.tsx
@@ -78,7 +78,7 @@ import {
 import shouldAdjustScroll from '@libs/shouldAdjustScroll';
 import {startSpan} from '@libs/telemetry/activeSpans';
 import type {SkeletonSpanReasonAttributes} from '@libs/telemetry/useSkeletonSpan';
-import {hasPendingUI, isManagedCardTransaction, isPending} from '@libs/TransactionUtils';
+import {hasPendingUI, hasReceiptError, isManagedCardTransaction, isOnHold, isPending} from '@libs/TransactionUtils';
 import colors from '@styles/theme/colors';
 import variables from '@styles/variables';
 import {approveMoneyRequest, canIOUBePaid as canIOUBePaidIOUActions, payInvoice, payMoneyRequest, submitReport} from '@userActions/IOU';
@@ -503,7 +503,23 @@ function MoneyRequestReportPreviewContent({
         thumbsUpScale.set(isApprovedAnimationRunning ? withDelay(CONST.ANIMATION_THUMBS_UP_DELAY, withSpring(1, {duration: CONST.ANIMATION_THUMBS_UP_DURATION})) : 1);
     }, [isApproved, isApprovedAnimationRunning, thumbsUpScale]);
 
-    const carouselTransactions = useMemo(() => (shouldShowAccessPlaceHolder ? [] : transactions.slice(0, 11)), [shouldShowAccessPlaceHolder, transactions]);
+    const carouselTransactions = useMemo(() => {
+        if (shouldShowAccessPlaceHolder) {
+            return [];
+        }
+
+        // Sort RBR-flagged transactions to the front before slicing
+        // This ensures expenses requiring action (holds, receipt errors) are shown first
+        const sortedTransactions = [...transactions].sort((a, b) => {
+            // Check RBR status: on hold or has receipt error
+            const aHasRBR = isOnHold(a) || hasReceiptError(a);
+            const bHasRBR = isOnHold(b) || hasReceiptError(b);
+            // RBR transactions come first (descending order: true before false)
+            return (bHasRBR ? 1 : 0) - (aHasRBR ? 1 : 0);
+        });
+
+        return sortedTransactions.slice(0, 11);
+    }, [shouldShowAccessPlaceHolder, transactions]);
     const prevCarouselTransactionLength = useRef(0);
 
     useEffect(() => {


### PR DESCRIPTION
## Details
This PR fixes the issue where RBR (Red Brick Road) flagged expenses were not shown first in the expense carousel and transaction list.

## Related Issue
$ https://github.com/Expensify/App/issues/85553

## Changes
- **MoneyRequestReportPreviewContent.tsx**: Sort transactions with RBR indicators (on hold, receipt errors) before slicing to show first 11
- **MoneyRequestReportTransactionList.tsx**: Prioritize RBR transactions as primary sort key, with existing sort (date, merchant, etc.) as secondary

## Testing
1. Open a report with multiple expenses where at least one has RBR indicator (hold, receipt error)
2. Verify RBR expenses appear first in the carousel
3. Verify RBR expenses appear first in the transaction list

## PR Checklist
- [x] Linked to issue
- [x] Code changes tested
- [x] Follows existing code patterns