### PR TITLE
fix: show Reject action for expense reports with 0 or 2+ expenses

### DIFF
--- a/src/components/MoneyReportHeader.tsx
+++ b/src/components/MoneyReportHeader.tsx
@@ -84,6 +84,7 @@ import {getAllExpensesToHoldIfApplicable, getReportPrimaryAction, isMarkAsResolv
 import {getSecondaryExportReportActions, getSecondaryReportActions} from '@libs/ReportSecondaryActionUtils';
 import {
     canEditFieldOfMoneyRequest,
+    canRejectReportAction,
     canUserPerformWriteAction as canUserPerformWriteActionReportUtils,
     changeMoneyRequestHoldStatus,
     generateReportID,
@@ -2154,7 +2155,7 @@ function MoneyReportHeader({reportID: reportIDProp, shouldDisplayBackButton = fa
                     setRejectModalAction(CONST.REPORT.TRANSACTION_SECONDARY_ACTIONS.REJECT);
                 }
             },
-            shouldShow: transactions.length === 1,
+            shouldShow: !!moneyRequestReport && canRejectReportAction(email ?? '', moneyRequestReport),
         },
         [CONST.REPORT.SECONDARY_ACTIONS.ADD_EXPENSE]: {
             text: translate('iou.addExpense'),


### PR DESCRIPTION
## Proposal

### Please re-state the problem that we are trying to solve in this issue.

When an approver opens an expense report with no expenses (or 2+ expenses) in New Dot and clicks **More** (three-dot menu), the **Reject** option does not appear. Users must switch to Classic to reject.

### What is the root cause of that problem?

In `src/components/MoneyReportHeader.tsx`, the REJECT secondary action has `shouldShow: transactions.length === 1`. This hides Reject for all reports except those with exactly 1 transaction.

### What changes did you make to fix the problem?

- Added `canRejectReportAction` to the `@libs/ReportUtils` import.
- Changed `shouldShow: transactions.length === 1` to `shouldShow: !!moneyRequestReport && canRejectReportAction(email ?? '', moneyRequestReport)` which correctly checks manager role + processing state, independent of transaction count.

$ #86007

---
*Note: this PR follows the standard fix identified in contributor proposals on the issue.*