### PR TITLE
fix: sort RBR-actionable expenses first in report preview carousel

### DIFF
--- a/src/components/ReportActionItem/MoneyRequestReportPreview/MoneyRequestReportPreviewContent.tsx
+++ b/src/components/ReportActionItem/MoneyRequestReportPreview/MoneyRequestReportPreviewContent.tsx
@@ -503,7 +503,22 @@ function MoneyRequestReportPreviewContent({
         thumbsUpScale.set(isApprovedAnimationRunning ? withDelay(CONST.ANIMATION_THUMBS_UP_DELAY, withSpring(1, {duration: CONST.ANIMATION_THUMBS_UP_DURATION})) : 1);
     }, [isApproved, isApprovedAnimationRunning, thumbsUpScale]);
 
-    const carouselTransactions = useMemo(() => (shouldShowAccessPlaceHolder ? [] : transactions.slice(0, 11)), [shouldShowAccessPlaceHolder, transactions]);
+    const carouselTransactions = useMemo(() => {
+        if (shouldShowAccessPlaceHolder) {
+            return [];
+        }
+        // Sort RBR-actionable expenses to the front so they're not buried
+        // behind the +N overflow when there are more than 11 transactions.
+        const sorted = [...transactions].sort((a, b) => {
+            const aHasViolations = (lastTransactionViolations[a.transactionID]?.length ?? 0) > 0;
+            const bHasViolations = (lastTransactionViolations[b.transactionID]?.length ?? 0) > 0;
+            if (aHasViolations === bHasViolations) {
+                return 0;
+            }
+            return aHasViolations ? -1 : 1;
+        });
+        return sorted.slice(0, 11);
+    }, [shouldShowAccessPlaceHolder, transactions, lastTransactionViolations]);
     const prevCarouselTransactionLength = useRef(0);
 
     useEffect(() => {


### PR DESCRIPTION
## Proposal

### Please re-state the problem that we are trying to solve in this issue.

When a report has multiple expenses and some have RBR indicators (violations, holds, etc.), the expense carousel in the report preview shows them in backend insertion order. RBR-flagged expenses can be buried at position 5+ and hidden entirely since only 11 are shown.

### What is the root cause of that problem?

In `MoneyRequestReportPreviewContent.tsx`, `carouselTransactions` is computed as `transactions.slice(0, 11)` with no sort beforehand.

### What changes did you make to fix the problem?

Sort `transactions` by whether they have entries in `lastTransactionViolations` before slicing to 11. Expenses with violations appear first; otherwise the existing (insertion) order is preserved.

$ #85553