### PR TITLE
fix: show proper error for oversized receipt/image attachments

### DIFF
--- a/src/libs/validateAttachmentFile.ts
+++ b/src/libs/validateAttachmentFile.ts
@@ -1,4 +1,3 @@
-import {Str} from 'expensify-common';
 import type {ValueOf} from 'type-fest';
 import CONST from '@src/CONST';
 import type {FileObject} from '@src/types/utils/Attachment';
@@ -29,9 +28,8 @@ async function validateAttachmentFile(file: FileObject, item?: DataTransferItem,
         return {isValid: false, error: CONST.FILE_VALIDATION_ERRORS.HEIC_OR_HEIF_IMAGE};
     }
 
-    const isImage = Str.isImage(file.name);
     const maxFileSize = isValidatingReceipts ? CONST.API_ATTACHMENT_VALIDATIONS.RECEIPT_MAX_SIZE : CONST.API_ATTACHMENT_VALIDATIONS.MAX_SIZE;
-    if (!isImage && !hasHeicOrHeifExtension(file) && file.size > maxFileSize) {
+    if (!hasHeicOrHeifExtension(file) && file.size > maxFileSize) {
         return {isValid: false, error: CONST.FILE_VALIDATION_ERRORS.FILE_TOO_LARGE};
     }
 

--- a/tests/unit/ValidateAttachmentFileTest.ts
+++ b/tests/unit/ValidateAttachmentFileTest.ts
@@ -141,11 +141,26 @@ describe('validateAttachmentFile', () => {
             expect(error.error).toEqual(CONST.FILE_VALIDATION_ERRORS.FILE_TOO_LARGE);
         });
 
-        it('returns valid result for image over RECEIPT_MAX_SIZE (images skip non-image size check)', async () => {
-            const file = createMockFile('receipt.jpg', CONST.API_ATTACHMENT_VALIDATIONS.MAX_SIZE + 1);
+        it('returns invalid result with FILE_TOO_LARGE for image over RECEIPT_MAX_SIZE when validating receipts', async () => {
+            const file = createMockFile('receipt.jpg', CONST.API_ATTACHMENT_VALIDATIONS.RECEIPT_MAX_SIZE + 1);
             const error = await validateAttachmentFile(file, undefined, true);
 
-            expect(error.isValid).toBe(true);
+            if (error.isValid) {
+                throw new Error('validateAttachmentFile should return an invalid result');
+            }
+
+            expect(error.error).toEqual(CONST.FILE_VALIDATION_ERRORS.FILE_TOO_LARGE);
+        });
+
+        it('returns invalid result with FILE_TOO_LARGE for image over MAX_SIZE when not validating receipts', async () => {
+            const file = createMockFile('image.jpg', CONST.API_ATTACHMENT_VALIDATIONS.MAX_SIZE + 1);
+            const error = await validateAttachmentFile(file, undefined, false);
+
+            if (error.isValid) {
+                throw new Error('validateAttachmentFile should return an invalid result');
+            }
+
+            expect(error.error).toEqual(CONST.FILE_VALIDATION_ERRORS.FILE_TOO_LARGE);
         });
 
         it('returns valid result when non-image is exactly at MAX_SIZE', async () => {


### PR DESCRIPTION
## Root Cause

In `validateAttachmentFile.ts`, the file size check had an incorrect `!isImage` guard that caused images (including receipts) to skip the size validation entirely:

```typescript
// Before - images bypass size check entirely
if (!isImage && !hasHeicOrHeifExtension(file) && file.size > maxFileSize) {
    return {isValid: false, error: CONST.FILE_VALIDATION_ERRORS.FILE_TOO_LARGE};
}
```

This meant that when uploading an oversized receipt image via the Add button, the file bypassed client-side validation and hit the server — which returned a generic `Unexpected error posting the comment` toast instead of the proper `FILE_TOO_LARGE` error modal.

## Fix

Remove the `!isImage` exclusion and the unused `Str` import so all file types (including images and receipts) are properly validated:

```typescript
// After - all files validated against size limit
if (!hasHeicOrHeifExtension(file) && file.size > maxFileSize) {
    return {isValid: false, error: CONST.FILE_VALIDATION_ERRORS.FILE_TOO_LARGE};
}
```

## Testing

- [x] Existing tests updated to reflect correct behavior
- [x] New test added for image over RECEIPT_MAX_SIZE when validating receipts
- [x] New test added for image over MAX_SIZE when not validating receipts
- [x] All validation tests pass

$ #85951