### PR TITLE
feat: add markdown support and multiline input to category description hint

### DIFF
--- a/src/pages/workspace/categories/CategoryDescriptionHintPage.tsx
+++ b/src/pages/workspace/categories/CategoryDescriptionHintPage.tsx
@@ -15,6 +15,7 @@ import Navigation from '@libs/Navigation/Navigation';
 import type {PlatformStackScreenProps} from '@libs/Navigation/PlatformStackNavigation/types';
 import type {SettingsNavigatorParamList} from '@navigation/types';
 import AccessOrNotFoundWrapper from '@pages/workspace/AccessOrNotFoundWrapper';
+import variables from '@styles/variables';
 import {setWorkspaceCategoryDescriptionHint} from '@userActions/Policy/Category';
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
@@ -75,6 +76,9 @@ function CategoryDescriptionHintPage({
                             label={translate('workspace.rules.categoryRules.descriptionHintLabel')}
                             aria-label={translate('workspace.rules.categoryRules.descriptionHintLabel')}
                             ref={inputCallbackRef}
+                            type="markdown"
+                            autoGrowHeight
+                            maxAutoGrowHeight={variables.textInputAutoGrowMaxHeight}
                         />
                         <Text style={[styles.mutedTextLabel, styles.mt2]}>{translate('workspace.rules.categoryRules.descriptionHintSubtitle')}</Text>
                     </View>

--- a/src/pages/workspace/categories/CategorySettingsPage.tsx
+++ b/src/pages/workspace/categories/CategorySettingsPage.tsx
@@ -452,6 +452,7 @@ function CategorySettingsPage({
                                         Navigation.navigate(ROUTES.WORKSPACE_CATEGORY_DESCRIPTION_HINT.getRoute(policyID, policyCategory.name));
                                     }}
                                     shouldShowRightIcon
+                                    shouldParseTitle
                                 />
                             </OfflineWithFeedback>
                         </>


### PR DESCRIPTION
## Summary

Adds live markdown rendering and multiline support to the category Description hint field.

## Changes

**CategoryDescriptionHintPage.tsx** (Edit):
- Added `type="markdown"` to enable live markdown rendering while editing
- Added `autoGrowHeight` to support multiline input
- Added `maxAutoGrowHeight={variables.textInputAutoGrowMaxHeight}` to cap growth

**CategorySettingsPage.tsx** (Display):
- Added `shouldParseTitle` to the menu item so the saved hint displays rendered markdown instead of raw text

## Before / After

**Before:** Description hint showed raw markdown text (e.g. `**bold**`) in both edit and display views; single-line input only.

**After:** Live markdown preview while editing; saved hint renders formatted markdown in settings; multiline input supported.

$ #85858