### PR TITLE
fix: replace Slack emoji <img> tags with unicode characters on paste

### DIFF
--- a/src/hooks/useHtmlPaste/index.ts
+++ b/src/hooks/useHtmlPaste/index.ts
@@ -4,6 +4,33 @@ import Parser from '@libs/Parser';
 import CONST from '@src/CONST';
 import type UseHtmlPaste from './types';
 
+/**
+ * Replaces emoji <img> tags with their alt text (the actual unicode emoji character).
+ * This handles emoji images from Slack and other apps that encode emojis as <img> tags
+ * with the emoji character in the alt attribute.
+ *
+ * Slack uses: <img data-stringify-type="emoji" alt="😊" ...>
+ * Some apps use: <img data-stringify-emoji="..." alt="😊" ...>
+ */
+const replaceEmojiImagesWithAltText = (html: string): string => {
+    const domParser = new DOMParser();
+    const doc = domParser.parseFromString(html, 'text/html');
+    const images = doc.querySelectorAll('img');
+
+    for (const img of images) {
+        // Check if this is an emoji image (Slack and other apps mark them with data-stringify-type="emoji" or data-stringify-emoji)
+        const isEmojiImage = img.dataset.stringifyType === 'emoji' || img.hasAttribute('data-stringify-emoji');
+
+        if (isEmojiImage && img.alt) {
+            // Replace the img element with a text node containing the emoji
+            const textNode = doc.createTextNode(img.alt);
+            img.parentNode?.replaceChild(textNode, img);
+        }
+    }
+
+    return doc.body.innerHTML;
+};
+
 const insertAtCaret = (target: HTMLElement, insertedText: string, maxLength: number) => {
     const currentText = target.textContent ?? '';
 
@@ -95,7 +122,10 @@ const useHtmlPaste: UseHtmlPaste = (textInputRef, preHtmlPasteCallback, isActive
      */
     const handlePastedHTML = useCallback(
         (html: string) => {
-            paste(Parser.htmlToMarkdown(html, {}));
+            // Replace emoji <img> tags with their alt text before converting to markdown
+            // This handles emojis from Slack and other apps that encode them as <img> tags
+            const processedHtml = replaceEmojiImagesWithAltText(html);
+            paste(Parser.htmlToMarkdown(processedHtml, {}));
         },
         [paste],
     );
@@ -149,17 +179,6 @@ const useHtmlPaste: UseHtmlPaste = (textInputRef, preHtmlPasteCallback, isActive
             if (event.clipboardData?.types?.includes(TEXT_HTML)) {
                 const pastedHTML = event.clipboardData.getData(TEXT_HTML);
 
-                const domparser = new DOMParser();
-                const embeddedImages = domparser.parseFromString(pastedHTML, TEXT_HTML).images;
-
-                // Exclude parsing img tags in the HTML, as fetching the image via fetch triggers a connect-src Content-Security-Policy error.
-                if (embeddedImages.length > 0 && embeddedImages[0].src) {
-                    // If HTML has emoji, then treat this as plain text.
-                    if (embeddedImages[0].dataset && embeddedImages[0].dataset.stringifyType === 'emoji') {
-                        handlePastePlainText(event);
-                        return;
-                    }
-                }
                 // If HTML starts with <p dir="ltr">, it means that the text was copied from the markdown input from the native app
                 // and was saved to clipboard with additional styling, so we need to treat this as plain text to avoid adding unnecessary characters.
                 if (pastedHTML.startsWith('<p dir="ltr">')) {
@@ -202,3 +221,4 @@ const useHtmlPaste: UseHtmlPaste = (textInputRef, preHtmlPasteCallback, isActive
 };
 
 export default useHtmlPaste;
+export {replaceEmojiImagesWithAltText};

--- a/tests/ui/hooks/useHtmlPasteTest/index.tsx
+++ b/tests/ui/hooks/useHtmlPasteTest/index.tsx
@@ -1,7 +1,7 @@
 import {act, renderHook} from '@testing-library/react-native';
 import type {RefObject} from 'react';
 import type {TextInput} from 'react-native';
-import useHtmlPaste from '@hooks/useHtmlPaste';
+import useHtmlPaste, {replaceEmojiImagesWithAltText} from '@hooks/useHtmlPaste';
 import waitForBatchedUpdatesWithAct from '../../../utils/waitForBatchedUpdatesWithAct';
 
 type UseHtmlPasteReturn = {
@@ -147,5 +147,56 @@ describe('useHtmlPaste - handlePastePlainText', () => {
             expect(textInputRef.current?.textContent).toBe(textWithTrailingWhitespace);
             expect(textInputRef.current?.textContent?.endsWith('   ')).toBe(true);
         }
+    });
+});
+
+describe('replaceEmojiImagesWithAltText', () => {
+    it('should replace Slack emoji images (data-stringify-type="emoji") with alt text', () => {
+        const htmlWithSlackEmoji = '<p>Hello <img src="https://emoji.slack-edge.com/emoji.png" alt="😊" data-stringify-type="emoji"> world</p>';
+        const result = replaceEmojiImagesWithAltText(htmlWithSlackEmoji);
+        expect(result).toBe('<p>Hello 😊 world</p>');
+    });
+
+    it('should replace emoji images with data-stringify-emoji attribute', () => {
+        const htmlWithEmoji = '<p>Test <img src="https://example.com/emoji.png" alt="🎉" data-stringify-emoji=":tada:"> message</p>';
+        const result = replaceEmojiImagesWithAltText(htmlWithEmoji);
+        expect(result).toBe('<p>Test 🎉 message</p>');
+    });
+
+    it('should replace multiple emoji images in the same HTML', () => {
+        const htmlWithMultipleEmojis = '<p>Hello <img src="url1" alt="😊" data-stringify-type="emoji"><img src="url2" alt="🎉" data-stringify-type="emoji"> there</p>';
+        const result = replaceEmojiImagesWithAltText(htmlWithMultipleEmojis);
+        expect(result).toBe('<p>Hello 😊🎉 there</p>');
+    });
+
+    it('should preserve regular images (not emoji)', () => {
+        const htmlWithRegularImage = '<p>Hello <img src="https://example.com/photo.jpg" alt="A photo"> world</p>';
+        const result = replaceEmojiImagesWithAltText(htmlWithRegularImage);
+        expect(result).toBe('<p>Hello <img src="https://example.com/photo.jpg" alt="A photo"> world</p>');
+    });
+
+    it('should handle mixed content with emoji and regular images', () => {
+        const htmlWithMixedImages = '<p>Look at this <img src="photo.jpg" alt="photo"> and <img src="emoji.png" alt="😊" data-stringify-type="emoji"> emoji</p>';
+        const result = replaceEmojiImagesWithAltText(htmlWithMixedImages);
+        expect(result).toBe('<p>Look at this <img src="photo.jpg" alt="photo"> and 😊 emoji</p>');
+    });
+
+    it('should preserve HTML formatting when replacing emojis', () => {
+        const htmlWithFormatting = '<p><strong>Bold</strong> <img src="url" alt="😊" data-stringify-type="emoji"> <em>italic</em></p>';
+        const result = replaceEmojiImagesWithAltText(htmlWithFormatting);
+        expect(result).toBe('<p><strong>Bold</strong> 😊 <em>italic</em></p>');
+    });
+
+    it('should handle emoji images without alt text by keeping them unchanged', () => {
+        const htmlWithNoAlt = '<p>Test <img src="url" data-stringify-type="emoji"> message</p>';
+        const result = replaceEmojiImagesWithAltText(htmlWithNoAlt);
+        // Image without alt should remain unchanged
+        expect(result).toBe('<p>Test <img src="url" data-stringify-type="emoji"> message</p>');
+    });
+
+    it('should return original HTML if no images are present', () => {
+        const htmlWithoutImages = '<p>Hello world</p>';
+        const result = replaceEmojiImagesWithAltText(htmlWithoutImages);
+        expect(result).toBe('<p>Hello world</p>');
     });
 });


### PR DESCRIPTION
## Root Cause

When copying content from Slack, emojis are encoded as `<img>` tags with `data-stringify-type="emoji"` and the actual emoji character in the `alt` attribute:

```html
<img data-stringify-type="emoji" alt="😊" src="..." />
```

Previously, the paste handler wasn't converting these img tags, causing them to either render as broken images or get stripped entirely.

## Fix

Added `replaceEmojiImagesWithAltText()` in `useHtmlPaste/index.ts` that runs before markdown conversion. It finds all emoji img tags (identified by `data-stringify-type="emoji"` or `data-stringify-emoji` attribute) and replaces them with their `alt` text — the actual unicode emoji character. Non-emoji images are preserved unchanged.

## Testing

- [x] Single emoji in pasted content
- [x] Multiple emojis in one paste  
- [x] Mixed content (emoji + regular images — regular images preserved)
- [x] HTML formatting preservation around emojis
- [x] Edge cases (no alt text, missing attributes)
- [x] Existing paste tests still pass

$ #85907