### PR TITLE
fix: auto-focus description field on page open

### DIFF
--- a/src/pages/RoomDescriptionPage.tsx
+++ b/src/pages/RoomDescriptionPage.tsx
@@ -1,5 +1,5 @@
-import {useFocusEffect, useRoute} from '@react-navigation/native';
-import React, {useCallback, useRef, useState} from 'react';
+import {useRoute} from '@react-navigation/native';
+import React, {useCallback, useState} from 'react';
 import {View} from 'react-native';
 import type {OnyxEntry} from 'react-native-onyx';
 import FormProvider from '@components/Form/FormProvider';
@@ -11,7 +11,7 @@ import ScreenWrapper from '@components/ScreenWrapper';
 import ScrollView from '@components/ScrollView';
 import Text from '@components/Text';
 import TextInput from '@components/TextInput';
-import type {BaseTextInputRef} from '@components/TextInput/BaseTextInput/types';
+import useAutoFocusInput from '@hooks/useAutoFocusInput';
 import useCurrentUserPersonalDetails from '@hooks/useCurrentUserPersonalDetails';
 import useLocalize from '@hooks/useLocalize';
 import useReportIsArchived from '@hooks/useReportIsArchived';
@@ -21,7 +21,6 @@ import type {PlatformStackRouteProp} from '@libs/Navigation/PlatformStackNavigat
 import type {ReportDescriptionNavigatorParamList} from '@libs/Navigation/types';
 import Parser from '@libs/Parser';
 import {canEditReportDescription, getReportDescription} from '@libs/ReportUtils';
-import updateMultilineInputRange from '@libs/updateMultilineInputRange';
 import variables from '@styles/variables';
 import {updateDescription} from '@userActions/Report';
 import CONST from '@src/CONST';
@@ -45,8 +44,7 @@ function RoomDescriptionPage({report, policy}: RoomDescriptionPageProps) {
     const backTo = route.params.backTo;
     const styles = useThemeStyles();
     const [description, setDescription] = useState(() => Parser.htmlToMarkdown(getReportDescription(report)));
-    const reportDescriptionInputRef = useRef<BaseTextInputRef | null>(null);
-    const focusTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+    const {inputCallbackRef} = useAutoFocusInput();
     const {translate} = useLocalize();
     const reportIsArchived = useReportIsArchived(report?.reportID);
     const {accountID: currentUserAccountID} = useCurrentUserPersonalDetails();
@@ -76,20 +74,6 @@ function RoomDescriptionPage({report, policy}: RoomDescriptionPageProps) {
             return errors;
         },
         [translate],
-    );
-
-    useFocusEffect(
-        useCallback(() => {
-            focusTimeoutRef.current = setTimeout(() => {
-                reportDescriptionInputRef.current?.focus();
-                return () => {
-                    if (!focusTimeoutRef.current) {
-                        return;
-                    }
-                    clearTimeout(focusTimeoutRef.current);
-                };
-            }, CONST.ANIMATED_TRANSITION);
-        }, []),
     );
 
     const canEdit = canEditReportDescription(report, policy, reportIsArchived);
@@ -123,15 +107,7 @@ function RoomDescriptionPage({report, policy}: RoomDescriptionPageProps) {
                             role={CONST.ROLE.PRESENTATION}
                             autoGrowHeight
                             maxAutoGrowHeight={variables.textInputAutoGrowMaxHeight}
-                            ref={(el: BaseTextInputRef | null): void => {
-                                if (!el) {
-                                    return;
-                                }
-                                if (!reportDescriptionInputRef.current) {
-                                    updateMultilineInputRange(el, false);
-                                }
-                                reportDescriptionInputRef.current = el;
-                            }}
+                            ref={inputCallbackRef}
                             value={description}
                             onChangeText={handleReportDescriptionChange}
                             autoCapitalize="none"

--- a/src/pages/tasks/TaskDescriptionPage.tsx
+++ b/src/pages/tasks/TaskDescriptionPage.tsx
@@ -1,16 +1,16 @@
-import {useFocusEffect, useRoute} from '@react-navigation/native';
-import React, {useCallback, useRef} from 'react';
+import {useRoute} from '@react-navigation/native';
+import React, {useCallback} from 'react';
 import {View} from 'react-native';
 import FullPageNotFoundView from '@components/BlockingViews/FullPageNotFoundView';
 import FormProvider from '@components/Form/FormProvider';
 import InputWrapper from '@components/Form/InputWrapper';
 import type {FormInputErrors, FormOnyxValues} from '@components/Form/types';
 import HeaderWithBackButton from '@components/HeaderWithBackButton';
-import type {AnimatedTextInputRef} from '@components/RNTextInput';
 import ScreenWrapper from '@components/ScreenWrapper';
 import TextInput from '@components/TextInput';
 import withCurrentUserPersonalDetails from '@components/withCurrentUserPersonalDetails';
 import type {WithCurrentUserPersonalDetailsProps} from '@components/withCurrentUserPersonalDetails';
+import useAutoFocusInput from '@hooks/useAutoFocusInput';
 import useLocalize from '@hooks/useLocalize';
 import useReportIsArchived from '@hooks/useReportIsArchived';
 import useThemeStyles from '@hooks/useThemeStyles';
@@ -20,7 +20,6 @@ import type {PlatformStackRouteProp} from '@libs/Navigation/PlatformStackNavigat
 import type {ReportDescriptionNavigatorParamList} from '@libs/Navigation/types';
 import Parser from '@libs/Parser';
 import {getCommentLength, isOpenTaskReport, isTaskReport} from '@libs/ReportUtils';
-import updateMultilineInputRange from '@libs/updateMultilineInputRange';
 import withReportOrNotFound from '@pages/inbox/report/withReportOrNotFound';
 import type {WithReportOrNotFoundProps} from '@pages/inbox/report/withReportOrNotFound';
 import variables from '@styles/variables';
@@ -69,29 +68,12 @@ function TaskDescriptionPage({report, currentUserPersonalDetails}: TaskDescripti
             Navigation.dismissModalWithReport({reportID: report?.reportID});
         });
     }
-    const inputRef = useRef<AnimatedTextInputRef | null>(null);
-    const focusTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+    const {inputCallbackRef} = useAutoFocusInput();
 
     const isOpen = isOpenTaskReport(report);
     const isParentReportArchived = useReportIsArchived(report?.parentReportID);
     const canActuallyModifyTask = canModifyTask(report, currentUserPersonalDetails.accountID, isParentReportArchived);
     const isTaskNonEditable = isTaskReport(report) && (!canActuallyModifyTask || !isOpen);
-
-    useFocusEffect(
-        useCallback(() => {
-            focusTimeoutRef.current = setTimeout(() => {
-                if (inputRef.current) {
-                    inputRef.current.focus();
-                }
-                return () => {
-                    if (!focusTimeoutRef.current) {
-                        return;
-                    }
-                    clearTimeout(focusTimeoutRef.current);
-                };
-            }, CONST.ANIMATED_TRANSITION);
-        }, []),
-    );
 
     return (
         <ScreenWrapper
@@ -122,15 +104,7 @@ function TaskDescriptionPage({report, currentUserPersonalDetails}: TaskDescripti
                             label={translate('newTaskPage.descriptionOptional')}
                             accessibilityLabel={translate('newTaskPage.descriptionOptional')}
                             defaultValue={Parser.htmlToMarkdown(report?.description ?? '')}
-                            ref={(element: AnimatedTextInputRef | null) => {
-                                if (!element) {
-                                    return;
-                                }
-                                if (!inputRef.current) {
-                                    updateMultilineInputRange(inputRef.current);
-                                }
-                                inputRef.current = element;
-                            }}
+                            ref={inputCallbackRef}
                             autoGrowHeight
                             maxAutoGrowHeight={variables.textInputAutoGrowMaxHeight}
                             shouldSubmitForm


### PR DESCRIPTION
$ https://github.com/Expensify/App/issues/85846

## Root Cause

`RoomDescriptionPage` and `TaskDescriptionPage` were using a manual `useFocusEffect` + `setTimeout` pattern instead of the standard `useAutoFocusInput` hook. The pattern had a **broken cleanup function** — it was returned inside the `setTimeout` callback (where JavaScript ignores it) rather than from the `useFocusEffect` callback itself:

```js
useFocusEffect(
    useCallback(() => {
        focusTimeoutRef.current = setTimeout(() => {
            inputRef.current?.focus();
            return () => {  // BUG: This return is ignored by setTimeout
                clearTimeout(focusTimeoutRef.current);
            };
        }, CONST.ANIMATED_TRANSITION);
    }, []),
);
```

This caused the focus to only be applied after mouse movement due to timing conflicts with the focus trap system (`FocusTrapForScreen`).

## Fix

Replaced the manual focus pattern with the `useAutoFocusInput` hook, which properly handles:
- Screen transition lifecycle (waits for `transitionEnd` or 1000ms fallback)
- `InteractionManager.runAfterInteractions`
- Focus trap coordination via `isWindowReadyToFocus()`
- Splash screen state

This is the same pattern used successfully by other description pages like `IOURequestStepDescription`, `NewTaskDescriptionPage`, and various search/rules pages.

## Changes

- **src/pages/RoomDescriptionPage.tsx**: Removed manual focus logic, imported and used `useAutoFocusInput`
- **src/pages/tasks/TaskDescriptionPage.tsx**: Same changes

## Testing

1. Navigate to a room → Room details → Description
2. Verify the description field auto-focuses immediately on page open
3. Navigate to a task → Click description field
4. Verify the description field auto-focuses immediately on page open
5. Test on both web and native platforms