### PR TITLE
Fix Slack emoji images rendering as broken images when pasted

### DIFF
--- a/src/hooks/useHtmlPaste/index.ts
+++ b/src/hooks/useHtmlPaste/index.ts
@@ -150,14 +150,27 @@ const useHtmlPaste: UseHtmlPaste = (textInputRef, preHtmlPasteCallback, isActive
                 const pastedHTML = event.clipboardData.getData(TEXT_HTML);
 
                 const domparser = new DOMParser();
-                const embeddedImages = domparser.parseFromString(pastedHTML, TEXT_HTML).images;
+                const doc = domparser.parseFromString(pastedHTML, TEXT_HTML);
+                const embeddedImages = doc.images;
 
-                // Exclude parsing img tags in the HTML, as fetching the image via fetch triggers a connect-src Content-Security-Policy error.
+                // Check if ALL embedded images are Slack emoji images. If so, treat as plain text
+                // to preserve the original behavior for emoji-only pastes from Slack.
                 if (embeddedImages.length > 0 && embeddedImages[0].src) {
-                    // If HTML has emoji, then treat this as plain text.
-                    if (embeddedImages[0].dataset && embeddedImages[0].dataset.stringifyType === 'emoji') {
+                    const allImagesAreSlackEmoji = Array.from(embeddedImages).every((img) => img.dataset?.stringifyType === 'emoji');
+                    if (allImagesAreSlackEmoji) {
                         handlePastePlainText(event);
                         return;
+                    }
+
+                    // For mixed content (some emoji images, some regular images), replace Slack emoji
+                    // <img> tags with their alt text (Unicode emoji) so they don't render as broken images.
+                    // We iterate in reverse to safely modify the DOM while iterating.
+                    const images = Array.from(embeddedImages);
+                    for (let i = images.length - 1; i >= 0; i--) {
+                        const img = images[i];
+                        if (img.dataset?.stringifyType === 'emoji' && img.alt) {
+                            img.replaceWith(document.createTextNode(img.alt));
+                        }
                     }
                 }
                 // If HTML starts with <p dir="ltr">, it means that the text was copied from the markdown input from the native app
@@ -166,7 +179,7 @@ const useHtmlPaste: UseHtmlPaste = (textInputRef, preHtmlPasteCallback, isActive
                     handlePastePlainText(event);
                     return;
                 }
-                handlePastedHTML(pastedHTML);
+                handlePastedHTML(doc.body.innerHTML);
                 return;
             }
             handlePastePlainText(event);


### PR DESCRIPTION
$ https://github.com/Expensify/App/issues/85907

## Problem

When copying a message containing emojis from Slack and pasting it into an Expensify chat, the emojis render as broken images instead of displaying correctly as Unicode emoji characters.

## Root Cause

The paste handler in `src/hooks/useHtmlPaste/index.ts` only checks the **first** embedded image (`embeddedImages[0]`) for the `data-stringify-type="emoji"` attribute. When this check fails (e.g., mixed content with non-emoji images before emoji images), the paste falls through to `handlePastedHTML`, which converts Slack emoji `<img>` tags into markdown image syntax pointing to Slack CDN URLs. These URLs are inaccessible from Expensify's context, so they render as broken images.

## Solution

Updated the paste handler to properly handle Slack emoji `<img>` tags in all cases:

1. **All images are Slack emoji**: Preserved the existing behavior of falling back to plain text via `handlePastePlainText`.
2. **Mixed content (emoji + regular images)**: Before passing to `handlePastedHTML`, replace each Slack emoji `<img>` tag with a text node containing its `alt` attribute value (the Unicode emoji character). This preserves rich formatting while correctly rendering emojis.
3. Changed `handlePastedHTML` to receive the sanitized `doc.body.innerHTML` instead of the original HTML string, so DOM modifications take effect.

## Tests

- [x] Verified pasting emoji-only Slack messages renders emojis correctly (plain text path)
- [x] Verified pasting mixed content (emojis + images/formatting) from Slack renders emojis as Unicode and preserves other formatting
- [x] Verified pasting non-Slack HTML content is unaffected

### QA Steps

1. Open a Slack chat and copy a message that contains emojis
2. Go to any conversation in Expensify and paste the message
3. Verify the emojis display correctly as text characters, not as broken images
4. Also test with messages containing both emojis and other formatting (bold, links, etc.)