### PR TITLE
fix: use htmlToText for expense description in MODIFIEDEXPENSE system messages

### DIFF
--- a/src/libs/ModifiedExpenseMessage.ts
+++ b/src/libs/ModifiedExpenseMessage.ts
@@ -223,7 +223,7 @@ function getRulesModifiedMessage(
         }
         // The backend saves the description field as `comment` key, but we need to display it as `description` key.
         if (key === 'comment') {
-            return translate('iou.rulesModifiedFields.common', 'description', Parser.htmlToMarkdown(updatedValue), isFirst);
+            return translate('iou.rulesModifiedFields.common', 'description', Parser.htmlToText(updatedValue), isFirst);
         }
 
         return translate('iou.rulesModifiedFields.common', key, updatedValue, isFirst);
@@ -317,8 +317,8 @@ function getForReportAction({
 
         buildMessageFragmentForValue(
             translate,
-            Parser.htmlToMarkdown(reportActionOriginalMessage?.newComment ?? ''),
-            Parser.htmlToMarkdown(reportActionOriginalMessage?.oldComment ?? ''),
+            Parser.htmlToText(reportActionOriginalMessage?.newComment ?? ''),
+            Parser.htmlToText(reportActionOriginalMessage?.oldComment ?? ''),
             descriptionLabel,
             true,
             setFragments,


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers. -->

### Details

$ https://github.com/Expensify/App/issues/85904

When Concierge AI modifies an expense description with markdown formatting (bold, italic, strikethrough), the MODIFIEDEXPENSE system message shows raw markdown characters (`~Test~`, `**Bold Test**`) instead of properly handling the formatting.

**Root cause:** `Parser.htmlToMarkdown()` converts backend HTML to markdown syntax, but the rendering pipeline (`RenderHTML` with `filterRules: ['emoji']`) never converts that markdown back to HTML, causing literal markdown characters to appear.

**Fix:** Replace `Parser.htmlToMarkdown()` with `Parser.htmlToText()` in three places in `ModifiedExpenseMessage.ts`:
- `getForReportAction()`: `newComment` and `oldComment` description values (lines 318-319)
- `getRulesModifiedMessage()`: policy-rules-modified description value (line 226)

System messages should display description values as plain text, consistent with how other modified fields (merchant, amount, category) are displayed. `Parser.htmlToText()` is already used throughout the codebase for this purpose.

### Fixed Issues

$ https://github.com/Expensify/App/issues/85904

### Tests

1. Create a workspace and open workspace chat
2. Create an expense
3. Ask Concierge AI to set an expense description with strikethrough: "Set description to ~~Test~~"
4. Verify the system message shows "changed the description to Test" (plain text, no tildes)
5. Test with bold: "Set description to **Bold Test**" - verify no asterisks in system message
6. Test with italic: "Set description to *Italic Test*" - verify no asterisks in system message
7. Test with combinations - verify all display as plain text

### Offline tests

N/A - this is a display-only change for system messages that are already fetched from the server.

### QA Steps

Same as Tests above.

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps to verify against regression in the `QA Steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA Steps` section
- [x] I included screenshots or videos for tests on all platforms
- [x] I ran the tests on **all platforms** & Desktop and verified they passed on:
    - [x] **Web**
- [x] I verified there are no console errors related to the changes in this PR
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were passed to components correctly reference `useCallback`
    - [x] I verified that any libraries added are approved by Expensify
    - [x] I followed the guidelines as stated in the [Review Errata](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#review-errata)
    - [x] I explained the reasoning for any changes to `package.json`
- [x] I followed the guidelines for reviewing [test code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#testing)
