### PR TITLE
[$250] First @mention disappears when adding a second mention at the beginning of text

### DIFF
--- a/src/pages/inbox/report/ReportActionCompose/SuggestionMention.tsx
+++ b/src/pages/inbox/report/ReportActionCompose/SuggestionMention.tsx
@@ -226,10 +226,8 @@ function SuggestionMention({
             // We split trailing dot from the mention token so selecting `@a.` can become `@adam.`
             // (preserve sentence punctuation) instead of consuming the `.` into the replacement.
             let trailingDot = '';
-            let mentionToReplace = originalMention;
             if (suggestionValues.prefixType === '@' && suggestionValues.mentionPrefix.endsWith('.')) {
                 trailingDot = originalMention.match(CONST.REGEX.TRAILING_DOTS)?.[0] ?? '';
-                mentionToReplace = originalMention.slice(0, originalMention.length - trailingDot.length);
             }
 
             // Append a preserved trailing dot only when it is sentence punctuation, not part of the selected mention match.
@@ -238,9 +236,7 @@ function SuggestionMention({
                     ? trailingDot
                     : '';
 
-            const commentAfterMention = value.slice(
-                suggestionValues.atSignIndex + Math.max(mentionToReplace.length, suggestionValues.mentionPrefix.length + suggestionValues.prefixType.length),
-            );
+            const commentAfterMention = value.slice(suggestionValues.atSignIndex + suggestionValues.mentionPrefix.length + suggestionValues.prefixType.length);
 
             const trimmedCommentAfterMention = trimLeadingSpace(commentAfterMention);
             const spacer = !trimmedCommentAfterMention || !CONST.REGEX.STARTS_WITH_PUNCTUATION.test(trimmedCommentAfterMention) ? ' ' : '';

--- a/tests/unit/SuggestionMentionTest.tsx
+++ b/tests/unit/SuggestionMentionTest.tsx
@@ -244,4 +244,27 @@ describe('SuggestionMention', () => {
         expect(updateComment).toHaveBeenCalledWith('@adam@example.com thanks', true);
         expect(setSelection).toHaveBeenCalledWith({start: 18, end: 18});
     });
+
+    it('preserves existing mention when adding a new mention at the beginning', async () => {
+        mockPersonalDetails = {};
+        mockPersonalDetails[2] = {
+            accountID: 2,
+            login: 'adam@example.com',
+            firstName: 'Adam',
+            lastName: 'Tester',
+        };
+
+        const updateComment = jest.fn();
+        // User typed @a at the beginning of an existing mention @john@example.com
+        const {setSelection} = renderSuggestionMention('@a@john@example.com ', updateComment, {start: 2, end: 2});
+
+        await waitFor(() => expect(mockMentionSuggestionsSpy).toHaveBeenCalled());
+        const {onSelect} = getLastMentionSuggestionsProps();
+
+        act(() => onSelect(0));
+
+        // The existing mention should be preserved after the new mention
+        expect(updateComment).toHaveBeenCalledWith('@adam@example.com @john@example.com ', true);
+        expect(setSelection).toHaveBeenCalledWith({start: 18, end: 18});
+    });
 });


### PR DESCRIPTION
$ https://github.com/Expensify/App/issues/85984

Auto-generated fix by Pip + Claude Opus.