### PR TITLE
fix: prevent crash on task assignee change (#85974)

### DIFF
--- a/src/libs/ReportUtils.ts
+++ b/src/libs/ReportUtils.ts
@@ -10483,24 +10483,23 @@ function getTaskAssigneeChatOnyxData(
 
         // If assignee is created optimistically, we need to clear the optimistic personal details to prevent duplication with real data sent from BE.
         if (isOptimisticPersonalDetail(assigneeAccountID)) {
-            successData.push(
-                {
-                    onyxMethod: Onyx.METHOD.MERGE,
-                    key: ONYXKEYS.PERSONAL_DETAILS_LIST,
-                    value: {
-                        [assigneeAccountID]: null,
-                    },
+            successData.push({
+                onyxMethod: Onyx.METHOD.MERGE,
+                key: ONYXKEYS.PERSONAL_DETAILS_LIST,
+                value: {
+                    [assigneeAccountID]: null,
                 },
-                {
-                    onyxMethod: Onyx.METHOD.MERGE,
-                    key: `${ONYXKEYS.COLLECTION.REPORT}${assigneeChatReportID}`,
-                    value: {
-                        // BE will send a different participant. We clear the optimistic one to avoid duplicated entries
-                        participants: {[assigneeAccountID]: null},
-                    },
-                },
-            );
+            });
         }
+
+        // BE will send a different participant. We clear the optimistic one to avoid duplicated entries
+        successData.push({
+            onyxMethod: Onyx.METHOD.MERGE,
+            key: `${ONYXKEYS.COLLECTION.REPORT}${assigneeChatReportID}`,
+            value: {
+                participants: {[assigneeAccountID]: null},
+            },
+        });
 
         failureData.push(
             {


### PR DESCRIPTION
## Fixed Issues
$250 https://github.com/Expensify/App/issues/85974

## Tests

1. Create a task with an existing user as assignee
2. Open the task → assignee
3. Select another existing user from contacts
4. Verify app does NOT crash
5. Verify assignee is updated correctly

## Root Cause

PR #85539 moved `participants: {[assigneeAccountID]: null}` inside the `isOptimisticPersonalDetail()` conditional in `getTaskAssigneeChatOnyxData`. For existing users, `isOptimisticPersonalDetail` returns false, so the participant cleanup never runs on success. This leaves stale/duplicate participant data that crashes the app on Android when re-rendering.

## Fix

Move the participant cleanup back outside the `isOptimisticPersonalDetail` conditional so it always runs for optimistic chat reports, while keeping the personal details cleanup inside the conditional (since that only applies to optimistic users). This restores the pre-#85539 behavior for participant cleanup.