### PR TITLE
fix: approver not receiving push notification for submitted expenses (#85925)

### DIFF
--- a/src/libs/actions/Report/index.ts
+++ b/src/libs/actions/Report/index.ts
@@ -4034,7 +4034,14 @@ function shouldShowReportActionNotification(reportID: string, currentUserAccount
     }
 
     // We don't want to send a local notification if the user preference is daily, mute or hidden.
-    const notificationPreference = getReportNotificationPreference(allReports?.[`${ONYXKEYS.COLLECTION.REPORT}${reportID}`]);
+    // For expense/IOU reports, the report itself may have a "hidden" preference, so we fall back
+    // to the parent report's notification preference (the workspace chat where the expense was submitted).
+    const report = allReports?.[`${ONYXKEYS.COLLECTION.REPORT}${reportID}`];
+    let notificationPreference = getReportNotificationPreference(report);
+    if (notificationPreference !== CONST.REPORT.NOTIFICATION_PREFERENCE.ALWAYS && report?.parentReportID && isExpenseReport(report)) {
+        const parentReport = allReports?.[`${ONYXKEYS.COLLECTION.REPORT}${report.parentReportID}`];
+        notificationPreference = getReportNotificationPreference(parentReport);
+    }
     if (notificationPreference !== CONST.REPORT.NOTIFICATION_PREFERENCE.ALWAYS) {
         Log.info(`${tag} No notification because user preference is to be notified: ${notificationPreference}`);
         return false;
@@ -4061,7 +4068,6 @@ function shouldShowReportActionNotification(reportID: string, currentUserAccount
         return false;
     }
 
-    const report = allReports?.[`${ONYXKEYS.COLLECTION.REPORT}${reportID}`];
     if (!report || (report && report.pendingAction === CONST.RED_BRICK_ROAD_PENDING_ACTION.DELETE)) {
         Log.info(`${tag} No notification because the report does not exist or is pending deleted`, false);
         return false;


### PR DESCRIPTION
## Fixed Issues
$250 https://github.com/Expensify/App/issues/85925

## Tests

1. Set up a workspace with an expense submitter and an expense approver
2. Ensure approver has notification preference set to "immediately" on the workspace chat
3. Sign in as the expense submitter on one device/profile
4. Submit an expense in the workspace
5. Verify the approver receives a browser push notification about the expense

## Root Cause

`shouldShowReportActionNotification` in `src/libs/actions/Report/index.ts` checks the report's notification preference before deciding whether to show a local notification. The SUBMITTED report action lives on the **expense report** (child), which defaults to `notificationPreference: HIDDEN`. The parent workspace chat's preference (`ALWAYS`) is never consulted, so the notification is blocked.

## Fix

When the report is an expense report and its notification preference is not `ALWAYS`, fall back to the parent report's (workspace chat) notification preference via `report.parentReportID`. This preserves the intentional HIDDEN default for expense reports while respecting the user's workspace chat notification setting.