### PR TITLE
fix: revert hasAcceptedTerms on travel T&C acceptance failure (#85944)

### DIFF
--- a/src/libs/actions/Travel.ts
+++ b/src/libs/actions/Travel.ts
@@ -48,13 +48,20 @@ function acceptSpotnanaTerms(domain?: string, policyID?: string) {
         },
     ];
 
-    const failureData: Array<OnyxUpdate<typeof ONYXKEYS.TRAVEL_PROVISIONING>> = [
+    const failureData: Array<OnyxUpdate<typeof ONYXKEYS.TRAVEL_PROVISIONING | typeof ONYXKEYS.NVP_TRAVEL_SETTINGS>> = [
         {
             onyxMethod: 'merge',
             key: ONYXKEYS.TRAVEL_PROVISIONING,
             value: {
                 isLoading: false,
                 errors: getMicroSecondOnyxErrorWithTranslationKey('travel.errorMessage'),
+            },
+        },
+        {
+            onyxMethod: 'merge',
+            key: ONYXKEYS.NVP_TRAVEL_SETTINGS,
+            value: {
+                hasAcceptedTerms: false,
             },
         },
     ];


### PR DESCRIPTION
## Fixed Issues
$250 https://github.com/Expensify/App/issues/85944

## Tests

1. Open the Travel section in the app
2. Attempt to accept Terms and Conditions (if possible, simulate a backend failure by going offline right after tapping accept)
3. Verify the error modal appears: "Something went wrong. Please try again later"
4. Go back and try again
5. Verify the Terms and Conditions screen is shown again (not skipped)
6. Accept terms again — verify it works on success

## Root Cause

When `AcceptSpotnanaTerms` fails on the backend, the optimistic update sets `hasAcceptedTerms` to `true`, but the `failureData` never reverts it to `false`. On retry:
1. `BookTravelButton` sees `hasAcceptedTerms === true` and skips the T&C screen
2. Goes directly to `openTravelDotLink()` which also fails since provisioning never completed
3. User is stuck with no way to re-accept terms

## Fix

Add `{hasAcceptedTerms: false}` to the `failureData` array in `acceptSpotnanaTerms` (`src/libs/actions/Travel.ts`), so the optimistic value is correctly reverted on failure. This allows the user to retry the T&C acceptance flow.