### PR TITLE
Fix race condition in expense creation for auto-categorization

### DIFF
--- a/src/pages/iou/request/step/IOURequestStepConfirmation.tsx
+++ b/src/pages/iou/request/step/IOURequestStepConfirmation.tsx
@@ -349,7 +349,11 @@ function IOURequestStepConfirmation({
     );
     const participantsPolicyTags = useParticipantsPolicyTags(participants ?? []);
     const isPolicyExpenseChat = useMemo(() => participants?.some((participant) => participant.isPolicyExpenseChat), [participants]);
-    const shouldGenerateTransactionThreadReport = !isBetaEnabled(CONST.BETAS.NO_OPTIMISTIC_TRANSACTION_THREADS);
+
+    // For manual expenses (no receipt) without a category, auto-categorization runs immediately,
+    // so we need the thread optimistically to avoid race conditions with the background job.
+    const isEligibleForAgentZeroAutoCategorization = useMemo(() => isPolicyExpenseChat && transactions.some((item) => !item.category), [isPolicyExpenseChat, transactions]);
+    const shouldGenerateTransactionThreadReport = !isBetaEnabled(CONST.BETAS.NO_OPTIMISTIC_TRANSACTION_THREADS) || isEligibleForAgentZeroAutoCategorization;
     const formHasBeenSubmitted = useRef(false);
 
     const isASAPSubmitBetaEnabled = isBetaEnabled(CONST.BETAS.ASAP_SUBMIT);


### PR DESCRIPTION
### Explanation of Change

When creating a manual expense on a workspace without a category, a race condition occurs:
- Backend queues an auto-categorization job that creates a transaction thread for Concierge suggestions
- Frontend calls `OpenReport` with a different optimistic transaction thread `reportID`
- Transaction thread `reportID` mismatch between frontend and backend

This fix ensures the transaction thread is created optimistically when the expense is eligible for auto-categorization (workspace expense + no category). The `NO_OPTIMISTIC_TRANSACTION_THREADS` beta flag still applies for other cases, but we override it when auto-categorization will run immediately.

### Fixed Issues

$ https://github.com/Expensify/App/issues/76202

### Tests

Precondition:
- Create a new account with the workspace
- Set the network throttling to 3G

1. Click on the FAB
2. Click on the **Create expense**
3. Submit any amount
4. Set the merchant like **Starbucks** and leave the category empty
5. Submit the expense
6. Open the money request preview immediately
7. **Verify** no error appears, and the Concierge sets the category

### QA Steps

Same as tests above.

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR