### PR TITLE
fix: Always show Explore section on Search page

### DIFF
--- a/src/pages/Search/SearchTypeMenu.tsx
+++ b/src/pages/Search/SearchTypeMenu.tsx
@@ -93,53 +93,61 @@ function SearchTypeMenu({queryJSON}: SearchTypeMenuProps) {
 
     const areSuggestedSearchesLoading = !isOffline && !isSearchDataLoaded && !isLoadingOnyxValue(isSearchDataLoadedResult);
 
+    // Separate Explore section from other sections. Explore section is always visible
+    // because its items (Reports, Expenses, Chats) are static and don't depend on server data.
+    const exploreSection = typeMenuSections.find((section) => section.translationPath === 'common.explore');
+    const nonExploreSections = typeMenuSections.filter((section) => section.translationPath !== 'common.explore');
+
+    const renderSection = (section: (typeof typeMenuSections)[number], sectionIndex: number) => (
+        <View key={section.translationPath}>
+            <Text
+                style={styles.sectionTitle}
+                accessibilityRole={CONST.ROLE.HEADER}
+            >
+                {translate(section.translationPath)}
+            </Text>
+
+            {section.translationPath === 'search.savedSearchesMenuItemTitle' ? (
+                <SavedSearchList hash={hash} />
+            ) : (
+                <>
+                    {section.menuItems.map((item, itemIndex) => {
+                        const flattenedIndex = (sectionStartIndices?.at(sectionIndex) ?? 0) + itemIndex;
+                        const focused = activeItemIndex === flattenedIndex;
+                        const icon = typeof item.icon === 'string' ? expensifyIcons[item.icon] : item.icon;
+
+                        return (
+                            <SearchTypeMenuItem
+                                key={item.key}
+                                title={translate(item.translationPath)}
+                                icon={icon}
+                                badgeText={getItemBadgeText(item.key, reportCounts)}
+                                focused={focused}
+                                onPress={() => handleTypeMenuItemPress(item.searchQuery)}
+                            />
+                        );
+                    })}
+                </>
+            )}
+        </View>
+    );
+
     return (
         <ScrollView
             onScroll={onScroll}
             ref={scrollViewRef}
             showsVerticalScrollIndicator={false}
         >
-            {areSuggestedSearchesLoading ? (
-                <View style={[styles.pb4, styles.mh3, styles.gap4]}>
-                    <SuggestedSearchSkeleton />
-                </View>
-            ) : (
-                <View style={[styles.pb4, styles.mh3, styles.gap4]}>
-                    {typeMenuSections.map((section, sectionIndex) => (
-                        <View key={section.translationPath}>
-                            <Text
-                                style={styles.sectionTitle}
-                                accessibilityRole={CONST.ROLE.HEADER}
-                            >
-                                {translate(section.translationPath)}
-                            </Text>
+            <View style={[styles.pb4, styles.mh3, styles.gap4]}>
+                {/* Explore section is always visible */}
+                {!!exploreSection && renderSection(exploreSection, 0)}
 
-                            {section.translationPath === 'search.savedSearchesMenuItemTitle' ? (
-                                <SavedSearchList hash={hash} />
-                            ) : (
-                                <>
-                                    {section.menuItems.map((item, itemIndex) => {
-                                        const flattenedIndex = (sectionStartIndices?.at(sectionIndex) ?? 0) + itemIndex;
-                                        const focused = activeItemIndex === flattenedIndex;
-                                        const icon = typeof item.icon === 'string' ? expensifyIcons[item.icon] : item.icon;
-
-                                        return (
-                                            <SearchTypeMenuItem
-                                                key={item.key}
-                                                title={translate(item.translationPath)}
-                                                icon={icon}
-                                                badgeText={getItemBadgeText(item.key, reportCounts)}
-                                                focused={focused}
-                                                onPress={() => handleTypeMenuItemPress(item.searchQuery)}
-                                            />
-                                        );
-                                    })}
-                                </>
-                            )}
-                        </View>
-                    ))}
-                </View>
-            )}
+                {areSuggestedSearchesLoading ? (
+                    <SuggestedSearchSkeleton showExplore={false} />
+                ) : (
+                    nonExploreSections.map((section, index) => renderSection(section, index + (exploreSection ? 1 : 0)))
+                )}
+            </View>
         </ScrollView>
     );
 }

--- a/src/pages/Search/SuggestedSearchSkeleton.tsx
+++ b/src/pages/Search/SuggestedSearchSkeleton.tsx
@@ -10,6 +10,7 @@ import variables from '@styles/variables';
 
 const SUGGESTED_SEARCH_SKELETON_TEST_ID = 'SuggestedSearchSkeleton';
 const NAV_ITEM_HEIGHT = variables.sectionMenuItemHeightCompact;
+const DEFAULT_SKELETON_GROUPS = 2;
 const SECTION_MENU_ITEM_HORIZONTAL_PADDING = 16;
 const SECTION_HEADER_HEIGHT = 32;
 const SECTION_HEADER_RECT_HEIGHT = 4;
@@ -45,7 +46,12 @@ const LHN = {
     },
 };
 
-function SuggestedSearchSkeleton() {
+type SuggestedSearchSkeletonProps = {
+    /** Whether to show the Explore skeleton group. Defaults to true for backward compatibility. */
+    showExplore?: boolean;
+};
+
+function SuggestedSearchSkeleton({showExplore = true}: SuggestedSearchSkeletonProps) {
     const theme = useTheme();
     const styles = useThemeStyles();
     const {shouldUseNarrowLayout} = useResponsiveLayout();
@@ -71,6 +77,10 @@ function SuggestedSearchSkeleton() {
     };
 
     const shouldRenderNavigationColumn = !shouldUseNarrowLayout;
+
+    // When Explore section is already rendered, only show 2 skeleton groups (Todo and Saved)
+    // instead of 3 to accurately represent the remaining dynamic sections.
+    const skeletonGroupCount = showExplore ? 3 : DEFAULT_SKELETON_GROUPS;
 
     const navigationColumnGroup = (
         <>
@@ -100,7 +110,7 @@ function SuggestedSearchSkeleton() {
     const navigationColumn = shouldRenderNavigationColumn ? (
         <View>
             <View>
-                {[0, 1, 2].map((i) => (
+                {Array.from({length: skeletonGroupCount}, (_, i) => (
                     <View
                         key={i}
                         style={[styles.mb4]}


### PR DESCRIPTION
### Problem
When opening the Search page for the first time, a full loading skeleton covers the entire sidebar menu, hiding the Explore section (Reports, Expenses, Chats). These Explore items are static and always available — they should be visible immediately while other dynamic sections (Todo, Saved) load.

$ #86130

### Solution
- Separate Explore section from other sections in SearchTypeMenu
- Render Explore section immediately regardless of loading state
- Update SuggestedSearchSkeleton to accept showExplore prop
- Reduce skeleton groups to 2 when Explore is already rendered (to accurately represent Todo and Saved sections)

### Changes
1. **SearchTypeMenu.tsx**: 
   - Split typeMenuSections into exploreSection and nonExploreSections
   - Always render Explore section (if exists) outside the loading gate
   - Pass showExplore=false to SuggestedSearchSkeleton when Explore is already visible

2. **SuggestedSearchSkeleton.tsx**:
   - Add showExplore prop (defaults to true for backward compatibility)
   - Use 2 skeleton groups when showExplore=false, 3 when true

### Testing
- [x] Explore section (Reports, Expenses, Chats) is now visible immediately
- [x] Loading skeleton only covers Todo and Saved sections during initial load
- [x] No regression in normal loading behavior