### PR TITLE
Fix: Remove billableExpense violation when workspace has billable tracking disabled

### DIFF
--- a/src/libs/Violations/ViolationsUtils.ts
+++ b/src/libs/Violations/ViolationsUtils.ts
@@ -647,6 +647,15 @@ const ViolationsUtils = {
         if (isPolicyTrackTaxEnabled && hasTaxOutOfPolicyViolation && isTaxInPolicy) {
             newTransactionViolations = reject(newTransactionViolations, {name: CONST.VIOLATIONS.TAX_OUT_OF_POLICY});
         }
+
+        // Handle billableExpense violation
+        // Remove the billableExpense violation when the workspace has billable tracking disabled.
+        // This handles the case where personal expense rules set billable=true on a workspace
+        // that doesn't track billable expenses — the violation is irrelevant in this case.
+        const hasBillableExpenseViolation = transactionViolations.some((violation) => violation.name === CONST.VIOLATIONS.BILLABLE_EXPENSE);
+        if (hasBillableExpenseViolation && policy.disabledFields?.defaultBillable) {
+            newTransactionViolations = reject(newTransactionViolations, {name: CONST.VIOLATIONS.BILLABLE_EXPENSE});
+        }
         return {
             onyxMethod: Onyx.METHOD.SET,
             key: `${ONYXKEYS.COLLECTION.TRANSACTION_VIOLATIONS}${updatedTransaction.transactionID}`,
@@ -880,3 +889,5 @@ export {getIsViolationFixed};
 export type {ViolationFixParams};
 export default ViolationsUtils;
 export {filterReceiptViolations};
+
+


### PR DESCRIPTION
## Summary

$ #86123

When a personal expense rule sets 'Change Billable to: Billable', the expense preview incorrectly shows a 'Billable no longer valid' violation on workspaces where billable tracking is disabled.

## Root Cause
The \illableExpense\ violation is generated server-side when the backend detects \illable=true\ on a transaction belonging to a workspace where billable tracking is disabled (\disabledFields.defaultBillable: true\).

When personal expense rules apply \illable: true\ server-side to a workspace with billable tracking disabled, the server generates this violation, but the client never removes it — because there was no billable violation logic in \getViolationsOnyxData\.

## Fix
This fix adds \illableExpense\ violation handling to \getViolationsOnyxData()\ in \src/libs/Violations/ViolationsUtils.ts\. When the workspace has billable tracking disabled (\disabledFields.defaultBillable === true\), the \illableExpense\ violation is removed — since the violation is irrelevant when billable tracking is not enabled on the workspace.

## Changes
- Added \illableExpense\ violation removal logic in \getViolationsOnyxData\ when \policy.disabledFields?.defaultBillable\ is true

## Testing
1. Create a personal expense rule with 'Change Billable to: Billable'
2. Create an expense matching that rule on a workspace with billable tracking disabled
3. Verify that no 'Billable no longer valid' violation is shown in the expense preview