### PR TITLE
fix: OD Report deeplinks should open in app not Chrome

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -114,6 +114,22 @@
                 <data android:scheme="https" android:host="staging.new.expensify.com" android:pathPrefix="/track-expense"/>
                 <data android:scheme="https" android:host="staging.new.expensify.com" android:pathPrefix="/submit-expense"/>
             </intent-filter>
+
+            <!-- OldDot report deep links. Handles expensify.com/r/... URLs so they open in the app
+                 instead of Chrome. Note: autoVerify is intentionally omitted because
+                 expensify.com/.well-known/assetlinks.json currently lists the HybridApp package,
+                 not the standalone NewDot package. Without autoVerify the Android OS will present
+                 the app as a chooser target and the user can choose to always open in the app. -->
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <!-- OldDot report links -->
+                <data android:scheme="https" android:host="expensify.com" android:pathPrefix="/r"/>
+                <data android:scheme="https" android:host="www.expensify.com" android:pathPrefix="/r"/>
+            </intent-filter>
              <intent-filter>
                 <action android:name="android.intent.action.SEND" />
                 <category android:name="android.intent.category.DEFAULT" />

--- a/ios/NewExpensify/Chat.entitlements
+++ b/ios/NewExpensify/Chat.entitlements
@@ -11,6 +11,8 @@
 	<key>com.apple.developer.associated-domains</key>
 	<array>
 		<string>applinks:new.expensify.com</string>
+		<string>applinks:expensify.com</string>
+		<string>applinks:www.expensify.com</string>
 		<string>applinks:staging.new.expensify.com</string>
 		<string>webcredentials:new.expensify.com</string>
 	</array>

--- a/ios/NewExpensify/NewExpensifyDebugAdHoc.entitlements
+++ b/ios/NewExpensify/NewExpensifyDebugAdHoc.entitlements
@@ -11,6 +11,8 @@
 	<key>com.apple.developer.associated-domains</key>
 	<array>
 		<string>applinks:new.expensify.com</string>
+		<string>applinks:expensify.com</string>
+		<string>applinks:www.expensify.com</string>
 		<string>applinks:staging.new.expensify.com</string>
 		<string>webcredentials:new.expensify.com</string>
 	</array>

--- a/ios/NewExpensify/NewExpensifyDebugDevelopment.entitlements
+++ b/ios/NewExpensify/NewExpensifyDebugDevelopment.entitlements
@@ -11,6 +11,8 @@
 	<key>com.apple.developer.associated-domains</key>
 	<array>
 		<string>applinks:new.expensify.com</string>
+		<string>applinks:expensify.com</string>
+		<string>applinks:www.expensify.com</string>
 		<string>applinks:staging.new.expensify.com</string>
 		<string>webcredentials:new.expensify.com</string>
 	</array>

--- a/ios/NewExpensify/NewExpensifyDebugProduction.entitlements
+++ b/ios/NewExpensify/NewExpensifyDebugProduction.entitlements
@@ -11,6 +11,8 @@
 	<key>com.apple.developer.associated-domains</key>
 	<array>
 		<string>applinks:new.expensify.com</string>
+		<string>applinks:expensify.com</string>
+		<string>applinks:www.expensify.com</string>
 		<string>applinks:staging.new.expensify.com</string>
 		<string>webcredentials:new.expensify.com</string>
 	</array>

--- a/ios/NewExpensify/NewExpensifyReleaseAdHoc.entitlements
+++ b/ios/NewExpensify/NewExpensifyReleaseAdHoc.entitlements
@@ -11,6 +11,8 @@
 	<key>com.apple.developer.associated-domains</key>
 	<array>
 		<string>applinks:new.expensify.com</string>
+		<string>applinks:expensify.com</string>
+		<string>applinks:www.expensify.com</string>
 		<string>applinks:staging.new.expensify.com</string>
 		<string>webcredentials:new.expensify.com</string>
 	</array>

--- a/ios/NewExpensify/NewExpensifyReleaseDevelopment.entitlements
+++ b/ios/NewExpensify/NewExpensifyReleaseDevelopment.entitlements
@@ -11,6 +11,8 @@
 	<key>com.apple.developer.associated-domains</key>
 	<array>
 		<string>applinks:new.expensify.com</string>
+		<string>applinks:expensify.com</string>
+		<string>applinks:www.expensify.com</string>
 		<string>applinks:staging.new.expensify.com</string>
 		<string>webcredentials:new.expensify.com</string>
 	</array>

--- a/ios/NewExpensify/NewExpensifyReleaseProduction.entitlements
+++ b/ios/NewExpensify/NewExpensifyReleaseProduction.entitlements
@@ -11,6 +11,8 @@
 	<key>com.apple.developer.associated-domains</key>
 	<array>
 		<string>applinks:new.expensify.com</string>
+		<string>applinks:expensify.com</string>
+		<string>applinks:www.expensify.com</string>
 		<string>applinks:staging.new.expensify.com</string>
 		<string>webcredentials:new.expensify.com</string>
 	</array>

--- a/src/libs/Navigation/linkingConfig/prefixes.ts
+++ b/src/libs/Navigation/linkingConfig/prefixes.ts
@@ -12,6 +12,9 @@ const prefixes: LinkingOptions<RootNavigatorParamList>['prefixes'] = [
     CONST.NEW_EXPENSIFY_URL,
     CONST.STAGING_NEW_EXPENSIFY_URL,
     CONST.PR_TESTING_NEW_EXPENSIFY_URL,
+    // OldDot report deep links (e.g. https://expensify.com/r/<reportID>)
+    'https://expensify.com',
+    'https://www.expensify.com',
 ];
 
 export default prefixes;


### PR DESCRIPTION
$ #85924

## Problem
When a user taps an OldDot (OD) report link (e.g., `https://expensify.com/r/12345` or `https://www.expensify.com/r/12345`) from another app on Android, it opens in Chrome instead of the Expensify app. On iOS, Universal Links for the `expensify.com` domain are not registered either.

## Root Cause
1. **Android**: `AndroidManifest.xml` only declares intent filters for `new.expensify.com` and `staging.new.expensify.com`. No intent filters exist for `expensify.com` or `www.expensify.com`, so Android routes OD report URLs to the browser.
2. **React Navigation**: `prefixes.ts` does not include `expensify.com` or `www.expensify.com`, so even if the app received an OD URL, React Navigation wouldn't parse it.
3. **iOS**: The entitlements files don't include `applinks:expensify.com` or `applinks:www.expensify.com`, so Universal Links don't trigger for OD domains.

## Changes

### `android/app/src/main/AndroidManifest.xml`
Added a new `<intent-filter>` for OD report links targeting `expensify.com` and `www.expensify.com` with pathPrefix `/r`. **Note:** `android:autoVerify` is intentionally omitted because `expensify.com/.well-known/assetlinks.json` currently references the HybridApp package (`org.me.mobiexpensifyg`), not the standalone NewDot package. Without `autoVerify`, Android presents the app as a chooser target, allowing users to select "Always open in Expensify".

### `src/libs/Navigation/linkingConfig/prefixes.ts`
Added `https://expensify.com` and `https://www.expensify.com` to the navigation prefixes so React Navigation can correctly parse OD report URLs when the app receives them.

### `ios/NewExpensify/*.entitlements`
Added `applinks:expensify.com` and `applinks:www.expensify.com` to Associated Domains in all 7 entitlements files to enable iOS Universal Links for the OD domain.

## Testing
1. Install the app on an Android device
2. Send yourself an OD report link (e.g., `https://expensify.com/r/12345`) via email or another app
3. Tap the link — the app should be offered as an option in the chooser or open directly
4. Navigate to the correct report inside the app

For iOS:
1. Install the app on an iOS device
2. Tap an `expensify.com/r/...` link
3. Verify Universal Link routes to the app