### PR TITLE
fix: allow itemized receipt requirement configurable via spreadsheet upload

### DIFF
--- a/src/CONST/index.ts
+++ b/src/CONST/index.ts
@@ -8207,6 +8207,8 @@ const CONST = {
         DATE: 'date',
         MERCHANT: 'merchant',
         TRANSACTION_FIELDS: ['date', 'merchant', 'amount', 'category'] as const,
+        MAX_AMOUNT_NO_RECEIPT: 'maxAmountNoReceipt',
+        MAX_AMOUNT_NO_ITEMIZED_RECEIPT: 'maxAmountNoItemizedReceipt',
     },
 
     IMPORT_SPREADSHEET: {

--- a/src/libs/API/parameters/ImportCategoriesSpreadsheet.ts
+++ b/src/libs/API/parameters/ImportCategoriesSpreadsheet.ts
@@ -4,7 +4,13 @@ type ImportCategoriesSpreadsheetParams = {
 
     /**
      * Stringified JSON object with type of following structure:
-     * Array<{name: string;}>
+     * Array<{
+     *   name: string;
+     *   enabled?: boolean;
+     *   'GL Code'?: string;
+     *   maxAmountNoReceipt?: number;
+     *   maxAmountNoItemizedReceipt?: number;
+     * }>
      */
     categories: string;
 };

--- a/src/libs/actions/Policy/Category.ts
+++ b/src/libs/actions/Policy/Category.ts
@@ -930,7 +930,16 @@ function importPolicyCategories(policyID: string, categories: PolicyCategory[]) 
     const parameters = {
         policyID,
         // eslint-disable-next-line @typescript-eslint/naming-convention
-        categories: JSON.stringify([...categories.map((category) => ({name: category.name, enabled: category.enabled, 'GL Code': String(category['GL Code'])}))]),
+        categories: JSON.stringify([
+            ...categories.map((category) => ({
+                name: category.name,
+                enabled: category.enabled,
+                // eslint-disable-next-line @typescript-eslint/naming-convention
+                'GL Code': String(category['GL Code']),
+                ...(category.maxAmountNoReceipt !== undefined && {maxAmountNoReceipt: category.maxAmountNoReceipt}),
+                ...(category.maxAmountNoItemizedReceipt !== undefined && {maxAmountNoItemizedReceipt: category.maxAmountNoItemizedReceipt}),
+            })),
+        ]),
     };
 
     API.write(WRITE_COMMANDS.IMPORT_CATEGORIES_SPREADSHEET, parameters, onyxData);

--- a/src/pages/workspace/categories/ImportedCategoriesPage.tsx
+++ b/src/pages/workspace/categories/ImportedCategoriesPage.tsx
@@ -51,6 +51,8 @@ function ImportedCategoriesPage({route}: ImportedCategoriesPageProps) {
 
         if (isControlPolicy(policy)) {
             roles.push({text: translate('workspace.categories.glCode'), value: CONST.CSV_IMPORT_COLUMNS.GL_CODE});
+            roles.push({text: translate('workspace.rules.categoryRules.requireReceiptsOver'), value: CONST.CSV_IMPORT_COLUMNS.MAX_AMOUNT_NO_RECEIPT});
+            roles.push({text: translate('workspace.rules.categoryRules.requireItemizedReceiptsOver'), value: CONST.CSV_IMPORT_COLUMNS.MAX_AMOUNT_NO_ITEMIZED_RECEIPT});
         }
 
         return roles;
@@ -97,17 +99,54 @@ function ImportedCategoriesPage({route}: ImportedCategoriesPageProps) {
         const categoriesNamesColumn = columns.findIndex((column) => column === CONST.CSV_IMPORT_COLUMNS.NAME);
         const categoriesGLCodeColumn = columns.findIndex((column) => column === CONST.CSV_IMPORT_COLUMNS.GL_CODE);
         const categoriesEnabledColumn = columns.findIndex((column) => column === CONST.CSV_IMPORT_COLUMNS.ENABLED);
+        const categoriesMaxAmountNoReceiptColumn = columns.findIndex((column) => column === CONST.CSV_IMPORT_COLUMNS.MAX_AMOUNT_NO_RECEIPT);
+        const categoriesMaxAmountNoItemizedReceiptColumn = columns.findIndex((column) => column === CONST.CSV_IMPORT_COLUMNS.MAX_AMOUNT_NO_ITEMIZED_RECEIPT);
         const categoriesNames = spreadsheet?.data[categoriesNamesColumn].map((name) => name);
         const categoriesEnabled = categoriesEnabledColumn !== -1 ? spreadsheet?.data[categoriesEnabledColumn].map((enabled) => enabled) : [];
         const categoriesGLCode = categoriesGLCodeColumn !== -1 ? spreadsheet?.data[categoriesGLCodeColumn].map((glCode) => glCode) : [];
+        const categoriesMaxAmountNoReceipt = categoriesMaxAmountNoReceiptColumn !== -1 ? spreadsheet?.data[categoriesMaxAmountNoReceiptColumn].map((val) => val) : [];
+        const categoriesMaxAmountNoItemizedReceipt = categoriesMaxAmountNoItemizedReceiptColumn !== -1 ? spreadsheet?.data[categoriesMaxAmountNoItemizedReceiptColumn].map((val) => val) : [];
+
+        const parseCsvReceiptValue = (raw: string | undefined): number | undefined => {
+            if (!raw?.trim()) {
+                return undefined;
+            }
+            const val = raw.trim().toLowerCase();
+            if (['required', 'always', '0'].includes(val)) {
+                return 0;
+            }
+            if (['not_required', 'never'].includes(val)) {
+                return CONST.DISABLED_MAX_EXPENSE_VALUE;
+            }
+            const n = Number(val);
+            return Number.isFinite(n) ? n : undefined;
+        };
+
         const categories = categoriesNames?.slice(containsHeader ? 1 : 0).map((name, index) => {
             const categoryAlreadyExists = policyCategories?.[name];
             const existingGLCodeOrDefault = categoryAlreadyExists?.['GL Code'] ?? '';
+            const dataIndex = containsHeader ? index + 1 : index;
+
+            const parsedMaxAmountNoReceipt = categoriesMaxAmountNoReceiptColumn !== -1 ? parseCsvReceiptValue(categoriesMaxAmountNoReceipt?.[dataIndex] as string | undefined) : undefined;
+            const parsedMaxAmountNoItemizedReceipt =
+                categoriesMaxAmountNoItemizedReceiptColumn !== -1 ? parseCsvReceiptValue(categoriesMaxAmountNoItemizedReceipt?.[dataIndex] as string | undefined) : undefined;
+
+            // Apply normalization: if receipts are not required, itemized receipts must also be not required
+            let normalizedMaxAmountNoReceipt = parsedMaxAmountNoReceipt;
+            let normalizedMaxAmountNoItemizedReceipt = parsedMaxAmountNoItemizedReceipt;
+            if (parsedMaxAmountNoReceipt === CONST.DISABLED_MAX_EXPENSE_VALUE) {
+                normalizedMaxAmountNoItemizedReceipt = CONST.DISABLED_MAX_EXPENSE_VALUE;
+            } else if (parsedMaxAmountNoItemizedReceipt === 0) {
+                normalizedMaxAmountNoReceipt = 0;
+            }
+
             return {
                 name,
-                enabled: categoriesEnabledColumn !== -1 ? categoriesEnabled?.[containsHeader ? index + 1 : index] === 'true' : true,
+                enabled: categoriesEnabledColumn !== -1 ? categoriesEnabled?.[dataIndex] === 'true' : true,
                 // eslint-disable-next-line @typescript-eslint/naming-convention
-                'GL Code': categoriesGLCodeColumn !== -1 ? (categoriesGLCode?.[containsHeader ? index + 1 : index] ?? '') : existingGLCodeOrDefault,
+                'GL Code': categoriesGLCodeColumn !== -1 ? (categoriesGLCode?.[dataIndex] ?? '') : existingGLCodeOrDefault,
+                ...(normalizedMaxAmountNoReceipt !== undefined && {maxAmountNoReceipt: normalizedMaxAmountNoReceipt}),
+                ...(normalizedMaxAmountNoItemizedReceipt !== undefined && {maxAmountNoItemizedReceipt: normalizedMaxAmountNoItemizedReceipt}),
             };
         });
 


### PR DESCRIPTION
$ #86106

## Changes

- Added `MAX_AMOUNT_NO_RECEIPT` and `MAX_AMOUNT_NO_ITEMIZED_RECEIPT` to `CSV_IMPORT_COLUMNS` constants
- Added two new column roles in `ImportedCategoriesPage.tsx` for Control policies:
  - "Require receipts over" → maps to `maxAmountNoReceipt`
  - "Require itemized receipts over" → maps to `maxAmountNoItemizedReceipt`
- Implemented CSV value parsing: accepts `required`/`always`/`0` for required, `not_required`/`never` for disabled (numeric thresholds also accepted)
- Applied same normalization logic as the manual UI:
  - If receipts = not required → itemized receipts automatically set to not required
  - If itemized receipts = always required → receipts also set to always required
- When receipt columns are not mapped in the spreadsheet, existing values are preserved (no override)
- Updated `importPolicyCategories` in `Category.ts` to include `maxAmountNoReceipt` and `maxAmountNoItemizedReceipt` in the API payload (only when explicitly set)
- Updated `ImportCategoriesSpreadsheetParams` type to document the expanded category structure

## Testing

1. Go to a Control policy workspace → Categories → Import categories
2. Upload a CSV with columns including "Require receipts over" and/or "Require itemized receipts over"
3. Map the columns in the import UI
4. Verify the imported categories have the correct receipt requirement settings
5. Verify that if "Require receipts over" is set to "not_required", "Require itemized receipts over" is automatically also set to "not_required"
6. Verify that existing categories without these columns mapped retain their existing receipt settings
7. Test in a Free (non-Control) policy — the new column roles should NOT appear