### PR TITLE
fix: QBO auto-export not triggered for approved expenses in VBA workspace

### DIFF
--- a/src/languages/de.ts
+++ b/src/languages/de.ts
@@ -4366,6 +4366,8 @@ ${
                 qboInvoiceCollectionAccount: 'QuickBooks-Konto für Rechnungseingänge',
                 accountSelectDescription: 'Wählen Sie, von welchem Konto Sie Rechnungen bezahlen möchten, und wir erstellen die Zahlung in QuickBooks Online.',
                 invoiceAccountSelectorDescription: 'Wähle aus, wo Rechnungszahlungen eingehen sollen, und wir erstellen die Zahlung in QuickBooks Online.',
+                autoSyncVBAExportNote:
+                    'Ihr Arbeitsbereich verfügt über ein verbundenes verifiziertes Bankkonto. Bei der Kassenbuchhaltung werden Auslagen erst nach der Zahlung in QuickBooks Online exportiert, nicht bei der Genehmigung. Wechseln Sie zur Periodenabgrenzung, um den Export bei der Genehmigung auszulösen.',
             },
             accounts: {
                 [CONST.QUICKBOOKS_NON_REIMBURSABLE_EXPORT_ACCOUNT_TYPE.DEBIT_CARD]: 'Debitkarte',

--- a/src/languages/en.ts
+++ b/src/languages/en.ts
@@ -4429,6 +4429,8 @@ const translations = {
                 qboInvoiceCollectionAccount: 'QuickBooks invoice collections account',
                 accountSelectDescription: "Choose where to pay bills from and we'll create the payment in QuickBooks Online.",
                 invoiceAccountSelectorDescription: "Choose where to receive invoice payments and we'll create the payment in QuickBooks Online.",
+                autoSyncVBAExportNote:
+                    'Your workspace has a Verified Bank Account connected. With Cash accounting, out-of-pocket expenses will only export to QuickBooks Online after they are paid, not when approved. Switch to Accrual to export on approval.',
             },
             accounts: {
                 [CONST.QUICKBOOKS_NON_REIMBURSABLE_EXPORT_ACCOUNT_TYPE.DEBIT_CARD]: 'Debit card',

--- a/src/languages/es.ts
+++ b/src/languages/es.ts
@@ -4298,6 +4298,8 @@ ${amount} para ${merchant} - ${date}`,
                 qboInvoiceCollectionAccount: 'Cuenta de cobro de las facturas QuickBooks',
                 accountSelectDescription: 'Elige desde dónde pagar las facturas y crearemos el pago en QuickBooks Online.',
                 invoiceAccountSelectorDescription: 'Elige dónde recibir los pagos de facturas y crearemos el pago en QuickBooks Online.',
+                autoSyncVBAExportNote:
+                    'Tu espacio de trabajo tiene una Cuenta Bancaria Verificada conectada. Con la contabilidad en Efectivo, los gastos de bolsillo solo se exportarán a QuickBooks Online después de ser pagados, no cuando se aprueben. Cambia a Devengado para exportar al aprobarse.',
             },
             accounts: {
                 [CONST.QUICKBOOKS_NON_REIMBURSABLE_EXPORT_ACCOUNT_TYPE.DEBIT_CARD]: 'Tarjeta de débito',

--- a/src/languages/fr.ts
+++ b/src/languages/fr.ts
@@ -4377,6 +4377,8 @@ ${
                 qboInvoiceCollectionAccount: 'Compte de recouvrement des factures QuickBooks',
                 accountSelectDescription: 'Choisissez l’endroit depuis lequel payer les factures et nous créerons le paiement dans QuickBooks Online.',
                 invoiceAccountSelectorDescription: 'Choisissez où recevoir les paiements de factures et nous créerons le paiement dans QuickBooks Online.',
+                autoSyncVBAExportNote:
+                    "Votre espace de travail dispose d'un compte bancaire vérifié connecté. Avec la comptabilité en espèces, les dépenses de poche ne seront exportées vers QuickBooks Online qu'après avoir été payées, pas lors de leur approbation. Passez à la comptabilité d'exercice pour exporter à l'approbation.",
             },
             accounts: {
                 [CONST.QUICKBOOKS_NON_REIMBURSABLE_EXPORT_ACCOUNT_TYPE.DEBIT_CARD]: 'Carte de débit',

--- a/src/languages/it.ts
+++ b/src/languages/it.ts
@@ -4351,6 +4351,8 @@ ${
                 qboInvoiceCollectionAccount: 'Conto incassi fatture QuickBooks',
                 accountSelectDescription: 'Scegli da dove pagare le fatture e creeremo il pagamento in QuickBooks Online.',
                 invoiceAccountSelectorDescription: 'Scegli dove ricevere i pagamenti delle fatture e creeremo il pagamento in QuickBooks Online.',
+                autoSyncVBAExportNote:
+                    "Il tuo spazio di lavoro ha un conto bancario verificato collegato. Con la contabilità per cassa, le spese vive verranno esportate in QuickBooks Online solo dopo il pagamento, non all'approvazione. Passa alla contabilità per competenza per esportare all'approvazione.",
             },
             accounts: {
                 [CONST.QUICKBOOKS_NON_REIMBURSABLE_EXPORT_ACCOUNT_TYPE.DEBIT_CARD]: 'Carta di debito',

--- a/src/languages/ja.ts
+++ b/src/languages/ja.ts
@@ -4316,6 +4316,8 @@ ${
                 qboInvoiceCollectionAccount: 'QuickBooks 請求書回収口座',
                 accountSelectDescription: '請求書の支払元を選択すると、QuickBooks Online に支払いが作成されます。',
                 invoiceAccountSelectorDescription: '請求書の入金先を選択すると、QuickBooks Online に支払いを作成します。',
+                autoSyncVBAExportNote:
+                    'このワークスペースには認証済み銀行口座が接続されています。現金主義会計では、立替経費は承認時ではなく支払い後にQuickBooks Onlineにエクスポートされます。承認時にエクスポートするには発生主義に切り替えてください。',
             },
             accounts: {
                 [CONST.QUICKBOOKS_NON_REIMBURSABLE_EXPORT_ACCOUNT_TYPE.DEBIT_CARD]: 'デビットカード',

--- a/src/languages/nl.ts
+++ b/src/languages/nl.ts
@@ -4345,6 +4345,8 @@ ${
                 qboInvoiceCollectionAccount: 'QuickBooks-incassoaccount voor facturen',
                 accountSelectDescription: 'Kies vanwaar je rekeningen wilt betalen en wij maken de betaling aan in QuickBooks Online.',
                 invoiceAccountSelectorDescription: 'Kies waar je factuurbetalingen wilt ontvangen en we maken de betaling aan in QuickBooks Online.',
+                autoSyncVBAExportNote:
+                    'Je werkruimte heeft een geverifieerde bankrekening verbonden. Met kassaboekhouden worden onkostenvergoedingen pas naar QuickBooks Online geëxporteerd nadat ze zijn betaald, niet bij goedkeuring. Schakel over naar toerekening om te exporteren bij goedkeuring.',
             },
             accounts: {
                 [CONST.QUICKBOOKS_NON_REIMBURSABLE_EXPORT_ACCOUNT_TYPE.DEBIT_CARD]: 'Debetkaart',

--- a/src/languages/pl.ts
+++ b/src/languages/pl.ts
@@ -4339,6 +4339,8 @@ ${
                 qboInvoiceCollectionAccount: 'konto rozliczeń należności z faktur QuickBooks',
                 accountSelectDescription: 'Wybierz, z jakiego konta opłacać rachunki, a my utworzymy płatność w QuickBooks Online.',
                 invoiceAccountSelectorDescription: 'Wybierz, gdzie otrzymywać płatności za faktury, a my utworzymy płatność w QuickBooks Online.',
+                autoSyncVBAExportNote:
+                    'Twoje miejsce pracy ma podłączone zweryfikowane konto bankowe. W metodzie kasowej wydatki gotówkowe będą eksportowane do QuickBooks Online dopiero po zapłaceniu, a nie po zatwierdzeniu. Przełącz się na metodę memoriałową, aby eksportować przy zatwierdzeniu.',
             },
             accounts: {
                 [CONST.QUICKBOOKS_NON_REIMBURSABLE_EXPORT_ACCOUNT_TYPE.DEBIT_CARD]: 'Karta debetowa',

--- a/src/languages/pt-BR.ts
+++ b/src/languages/pt-BR.ts
@@ -4339,6 +4339,8 @@ ${
                 qboInvoiceCollectionAccount: 'Conta de cobrança de faturas do QuickBooks',
                 accountSelectDescription: 'Escolha de onde pagar as contas e nós criaremos o pagamento no QuickBooks Online.',
                 invoiceAccountSelectorDescription: 'Escolha onde receber os pagamentos de fatura e nós criaremos o pagamento no QuickBooks Online.',
+                autoSyncVBAExportNote:
+                    'Seu espaço de trabalho tem uma Conta Bancária Verificada conectada. Com contabilidade em regime de caixa, as despesas serão exportadas para o QuickBooks Online somente após o pagamento, não quando aprovadas. Mude para regime de competência para exportar na aprovação.',
             },
             accounts: {
                 [CONST.QUICKBOOKS_NON_REIMBURSABLE_EXPORT_ACCOUNT_TYPE.DEBIT_CARD]: 'Cartão de débito',

--- a/src/languages/zh-hans.ts
+++ b/src/languages/zh-hans.ts
@@ -4244,6 +4244,7 @@ ${
                 qboInvoiceCollectionAccount: 'QuickBooks 发票收款账户',
                 accountSelectDescription: '选择用于支付账单的来源，我们会在 QuickBooks Online 中创建这笔付款。',
                 invoiceAccountSelectorDescription: '选择接收发票付款的账户，我们会在 QuickBooks Online 中创建这笔付款。',
+                autoSyncVBAExportNote: '您的工作区已连接已验证的银行账户。使用现金制会计时，自付费用将在付款后才导出到 QuickBooks Online，而非在审批时。切换至应计制可在审批时导出。',
             },
             accounts: {
                 [CONST.QUICKBOOKS_NON_REIMBURSABLE_EXPORT_ACCOUNT_TYPE.DEBIT_CARD]: '借记卡',

--- a/src/pages/workspace/accounting/qbo/advanced/QuickbooksAutoSyncPage.tsx
+++ b/src/pages/workspace/accounting/qbo/advanced/QuickbooksAutoSyncPage.tsx
@@ -4,6 +4,7 @@ import HeaderWithBackButton from '@components/HeaderWithBackButton';
 import MenuItemWithTopDescription from '@components/MenuItemWithTopDescription';
 import OfflineWithFeedback from '@components/OfflineWithFeedback';
 import ScreenWrapper from '@components/ScreenWrapper';
+import Text from '@components/Text';
 import useLocalize from '@hooks/useLocalize';
 import useThemeStyles from '@hooks/useThemeStyles';
 import {updateQuickbooksOnlineAutoSync} from '@libs/actions/connections/QuickbooksOnline';
@@ -33,6 +34,9 @@ function QuickbooksAutoSyncPage({policy, route}: WithPolicyConnectionsProps) {
     const accountingMethod = config?.accountingMethod ?? COMMON_CONST.INTEGRATIONS.ACCOUNTING_METHOD.CASH;
     const pendingAction =
         settingsPendingAction([CONST.QUICKBOOKS_CONFIG.AUTO_SYNC], config?.pendingFields) ?? settingsPendingAction([CONST.QUICKBOOKS_CONFIG.ACCOUNTING_METHOD], config?.pendingFields);
+    const isVBAConnected = policy?.reimbursementChoice === CONST.POLICY.REIMBURSEMENT_CHOICES.REIMBURSEMENT_YES;
+    const isCashAccountingMethod = accountingMethod === COMMON_CONST.INTEGRATIONS.ACCOUNTING_METHOD.CASH;
+    const shouldShowVBAExportNote = !!config?.autoSync?.enabled && isVBAConnected && isCashAccountingMethod;
 
     const goBack = useCallback(() => {
         Navigation.goBack(backTo ?? ROUTES.WORKSPACE_ACCOUNTING_QUICKBOOKS_ONLINE_ADVANCED.getRoute(policyID));
@@ -78,6 +82,9 @@ function QuickbooksAutoSyncPage({policy, route}: WithPolicyConnectionsProps) {
                             shouldShowRightIcon
                             onPress={() => Navigation.navigate(ROUTES.WORKSPACE_ACCOUNTING_QUICKBOOKS_ONLINE_ACCOUNTING_METHOD.getRoute(policyID, backTo))}
                         />
+                        {shouldShowVBAExportNote && (
+                            <Text style={[styles.mutedNormalTextLabel, styles.ph5, styles.pv3]}>{translate('workspace.qbo.advancedConfig.autoSyncVBAExportNote')}</Text>
+                        )}
                     </OfflineWithFeedback>
                 )}
             </ScreenWrapper>


### PR DESCRIPTION
$ #85977

## Problem
When a workspace has both QBO auto-sync enabled and a Verified Bank Account (VBA) connected, approved expenses are not auto-exported to QuickBooks Online. Users see no Concierge message about the export, and the issue disappears when the VBA is disconnected.

## Root Cause
The root cause is the interaction between the QBO accounting method and VBA presence:
- **Cash accounting** (default): Out-of-pocket expenses export when **paid**
- **Accrual accounting**: Out-of-pocket expenses export when **final approved**

When a VBA is connected, `reimbursementChoice` becomes `REIMBURSEMENT_YES`, which enables the payment workflow. The backend auto-export logic then waits for the report to be **paid/reimbursed** before exporting (since Cash is the default). Without a VBA, there's no payment path, so the backend exports immediately on approval.

The backend auto-export trigger logic lives in `Web-Expensify` (server-side, not in this repo).

## Frontend UX Improvement
This PR adds an informational note on the `QuickbooksAutoSyncPage` when:
- Auto-sync is enabled ✓
- A VBA is connected (`reimbursementChoice === REIMBURSEMENT_YES`) ✓
- The accounting method is **Cash** ✓

The note reads:
> *Your workspace has a Verified Bank Account connected. With Cash accounting, out-of-pocket expenses will only export to QuickBooks Online after they are paid, not when approved. Switch to Accrual to export on approval.*

This prevents user confusion and clearly explains the interaction between VBA and QBO accounting methods, guiding admins to switch to Accrual if they want export-on-approval behavior.

## Changes
- `src/pages/workspace/accounting/qbo/advanced/QuickbooksAutoSyncPage.tsx`: Added VBA+Cash informational note
- `src/languages/en.ts` + 9 other language files: Added `autoSyncVBAExportNote` translation key

## Testing
1. Set up a workspace with QBO connected and auto-sync enabled
2. Connect a Verified Bank Account (Workflows → make payments enabled)
3. Keep accounting method as **Cash** (default)
4. Navigate to Workspace → Accounting → QuickBooks Online → Advanced → Auto-sync
5. ✅ Expect: Informational note appears below the accounting method selector explaining that expenses export after payment, not on approval
6. Switch accounting method to **Accrual**
7. ✅ Expect: Note disappears (Accrual correctly exports on approval)
8. Without VBA connected: note should not appear regardless of accounting method