### PR TITLE
fix: reject empty (0-byte) receipt blobs before upload

### DIFF
--- a/src/libs/isFileUploadable/index.ts
+++ b/src/libs/isFileUploadable/index.ts
@@ -1,7 +1,7 @@
 import type {FileObject} from '@src/types/utils/Attachment';
 
 function isFileUploadable(file: FileObject | undefined): boolean {
-    return file instanceof Blob;
+    return file instanceof Blob && file.size > 0;
 }
 
 export default isFileUploadable;

--- a/src/pages/iou/request/step/IOURequestStepScan/components/MobileWebCameraView.tsx
+++ b/src/pages/iou/request/step/IOURequestStepScan/components/MobileWebCameraView.tsx
@@ -317,6 +317,13 @@ function MobileWebCameraView({
 
         const originalFileName = `receipt_${Date.now()}.png`;
         const originalFile = base64ToFile(imageBase64 ?? '', originalFileName);
+
+        if (originalFile.size === 0) {
+            cancelSpan(CONST.TELEMETRY.SPAN_RECEIPT_CAPTURE);
+            cancelSpan(CONST.TELEMETRY.SPAN_SHUTTER_TO_CONFIRMATION);
+            return;
+        }
+
         const imageObject: ImageObject = {file: originalFile, filename: originalFile.name, source: URL.createObjectURL(originalFile)};
         // Some browsers center-crop the viewfinder inside the video element (due to object-position: center),
         // while other browsers let the video element overflow and the container crops it from the top.


### PR DESCRIPTION
$ #86159

## Problem

When a user captures a receipt via the web camera, a race condition in `react-webcam` can cause `canvas.toDataURL()` to be called before the video element has rendered any frames. This produces a 0-byte `Blob`/`File` that passes all client-side validation and is sent to the server, which returns error 666: "There was a problem creating the receipt."

There are two gaps:
1. **`isFileUploadable` has no size check** — it only checks `file instanceof Blob`, so a 0-byte Blob passes through to the API.
2. **The camera capture path bypasses `validateAttachmentFile` entirely** — unlike the file-picker path which goes through `useFilesValidation` → `validateAttachmentFile` (which checks `file.size < MIN_SIZE`), the camera shutter path goes directly from `getScreenshot()` → `base64ToFile()` → `cropImageToAspectRatio()` → `onCapture()` with no size validation.

## Changes

### 1. `src/libs/isFileUploadable/index.ts`
Added `file.size > 0` to the return condition. Broadest safety net — any 0-byte Blob is now rejected regardless of upload path.

### 2. `src/pages/iou/request/step/IOURequestStepScan/components/MobileWebCameraView.tsx`
Added an early-return guard in `getScreenshot()` after `base64ToFile()` produces a 0-byte file. Cancels active telemetry spans (same pattern as the `imageBase64 === null` guard above it).

## Testing

1. Open the camera receipt capture UI in a web browser.
2. Simulate the race condition by triggering a capture immediately when the camera view loads (before frames render).
3. **Before fix:** A 0-byte file is created and sent to the server → error 666.
4. **After fix:** The capture is silently dropped; user can retry.