### PR TITLE
fix: false Pay N Reports notification in Home tab

### DIFF
--- a/src/libs/actions/OnyxDerived/configs/todos.ts
+++ b/src/libs/actions/OnyxDerived/configs/todos.ts
@@ -1,5 +1,6 @@
 import type {OnyxCollection, OnyxEntry} from 'react-native-onyx';
 import {isApproveAction, isExportAction, isPrimaryPayAction, isSubmitAction} from '@libs/ReportPrimaryActionUtils';
+import {hasHeldExpenses} from '@libs/ReportUtils';
 import createOnyxDerivedValueConfig from '@userActions/OnyxDerived/createOnyxDerivedValueConfig';
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
@@ -64,7 +65,7 @@ const createTodosReportsAndTransactions = ({
         if (isApproveAction(report, reportTransactions, currentUserAccountID, reportMetadata, policy)) {
             reportsToApprove.push(report);
         }
-        if (isPrimaryPayAction(report, currentUserAccountID, login, bankAccountList, policy, reportNameValuePair)) {
+        if (isPrimaryPayAction(report, currentUserAccountID, login, bankAccountList, policy, reportNameValuePair, undefined, undefined, reportActions) && !hasHeldExpenses(report.reportID, reportTransactions)) {
             reportsToPay.push(report);
         }
         if (isExportAction(report, login, policy, reportActions) && policy?.exporter === login) {


### PR DESCRIPTION
$ #85861

## Root Cause

The "Pay N Reports" notification in the Home tab was counting reports using `isPrimaryPayAction()` in `todos.ts`, while the search results page uses `canIOUBePaid()` + `hasHeldExpenses()` checks from `SearchUIUtils`. This mismatch caused the notification count to be inflated — showing reports as payable that the search results page then filtered out.

Two specific gaps in the `todos.ts` call site:

1. **Missing `reportActions` parameter** — `isPrimaryPayAction()` accepts `reportActions` as its 9th parameter to evaluate export error state (`didExportFail`). The call in `todos.ts` omitted this argument, so `isExported` and `hasExportError` were always evaluated against `undefined`, meaning reports with failed exports were never blocked from the payable count.

2. **No `hasHeldExpenses` filter** — `SearchUIUtils` excludes reports with held expenses before showing the Pay action. `todos.ts` had no equivalent check, so reports with on-hold transactions were counted as payable but then filtered out on the display page.

## Changes

**`src/libs/actions/OnyxDerived/configs/todos.ts`**:
- Pass `reportActions` to `isPrimaryPayAction()` (was missing; uses the already-computed local variable)
- Import `hasHeldExpenses` from `@libs/ReportUtils` and guard `reportsToPay.push` with `!hasHeldExpenses(report.reportID, reportTransactions)`

Both `reportActions` and `reportTransactions` were already being computed in the loop — this change simply uses them correctly.

## Testing

**To reproduce the bug (before fix):**
1. Create an expense report with a held transaction
2. Have the report reach a state where a payer would normally see a Pay action
3. Observe "Pay 1 Report" badge in Home tab For You section
4. Click Begin — the search results page shows no payable reports (because `hasHeldExpenses` filters it out there)

**After fix:**
- The `reportsToPay` count in `todos.ts` skips reports with held expenses
- Reports with export errors are also correctly excluded from the count
- The notification badge count matches the actual number of payable reports shown in search results