### PR TITLE
fix: billable violation shown incorrectly for personal workspace rules

### DIFF
--- a/src/libs/actions/OnyxDerived/configs/todos.ts
+++ b/src/libs/actions/OnyxDerived/configs/todos.ts
@@ -1,5 +1,6 @@
 import type {OnyxCollection, OnyxEntry} from 'react-native-onyx';
 import {isApproveAction, isExportAction, isPrimaryPayAction, isSubmitAction} from '@libs/ReportPrimaryActionUtils';
+import {hasHeldExpenses} from '@libs/ReportUtils';
 import createOnyxDerivedValueConfig from '@userActions/OnyxDerived/createOnyxDerivedValueConfig';
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
@@ -64,7 +65,7 @@ const createTodosReportsAndTransactions = ({
         if (isApproveAction(report, reportTransactions, currentUserAccountID, reportMetadata, policy)) {
             reportsToApprove.push(report);
         }
-        if (isPrimaryPayAction(report, currentUserAccountID, login, bankAccountList, policy, reportNameValuePair)) {
+        if (isPrimaryPayAction(report, currentUserAccountID, login, bankAccountList, policy, reportNameValuePair, undefined, undefined, reportActions) && !hasHeldExpenses(report.reportID, reportTransactions)) {
             reportsToPay.push(report);
         }
         if (isExportAction(report, login, policy, reportActions) && policy?.exporter === login) {


### PR DESCRIPTION
$ #86123

## Problem

When a user creates a personal expense rule (Account > Expense Rules) that sets "Change Billable to: Billable", and then creates an expense matching that rule, the expense preview shows a **"Billable no longer valid"** (`billableExpense`) violation — even though the user explicitly configured the rule to set billable.

## Root Cause

The `shouldShowViolation()` function in `src/libs/TransactionUtils/index.ts` had no handler for `CONST.VIOLATIONS.BILLABLE_EXPENSE`, so it fell through to the default `return true` — meaning the violation was **always displayed** regardless of workspace billable configuration.

When a new workspace is created, it initializes with `disabledFields: { defaultBillable: true }` (billable tracking OFF). When a personal expense rule sets `billable: true` on a transaction, the backend generates a `billableExpense` violation because `billable=true` conflicts with the workspace's disabled billable tracking. Since `shouldShowViolation()` had no BILLABLE_EXPENSE case, it always showed this violation — even when not actionable.

## Changes

Added a `BILLABLE_EXPENSE` handler to `shouldShowViolation()` in `src/libs/TransactionUtils/index.ts`, following the exact same pattern already used for `MISSING_ATTENDEES`:

```typescript
if (violationName === CONST.VIOLATIONS.BILLABLE_EXPENSE) {
    return policy?.disabledFields?.defaultBillable !== true;
}
```

Only show the `billableExpense` violation when billable tracking is **enabled** on the workspace (`disabledFields.defaultBillable !== true`). When billable tracking is OFF, the violation is not actionable (user can't see/edit the billable field), so it should be suppressed — identical to how `MISSING_ATTENDEES` is suppressed when `isAttendeeTrackingEnabled` is `false`.

Also added unit tests for both cases in `tests/unit/TransactionUtilsTest.ts`.

## Testing

1. Create a personal expense rule (Account > Expense Rules) that sets "Change Billable to: Billable"
2. Create a new workspace (which defaults to billable tracking OFF)
3. Create an expense on that workspace that matches the personal expense rule
4. **Before fix:** Expense preview shows "Billable no longer valid" violation
5. **After fix:** No billable violation shown (since billable tracking is disabled, the violation is not actionable)

Unit tests:
- `shouldShowViolation` returns `false` for `BILLABLE_EXPENSE` when `disabledFields.defaultBillable === true`
- `shouldShowViolation` returns `true` for `BILLABLE_EXPENSE` when `disabledFields.defaultBillable === false`