### PR TITLE
fix: show correct fallback avatar for invited members in LHN

### DIFF
--- a/src/libs/ReportUtils.ts
+++ b/src/libs/ReportUtils.ts
@@ -3342,7 +3342,7 @@ function getIconsForParticipants(participants: number[], personalDetails: OnyxIn
     const avatars: Icon[] = [];
 
     for (const accountID of participantsList) {
-        const avatarSource = personalDetails?.[accountID]?.avatar ?? FallbackAvatar;
+        const avatarSource = personalDetails?.[accountID]?.avatar ?? getDefaultAvatarURL({accountID});
         const displayNameLogin = personalDetails?.[accountID]?.displayName ? personalDetails?.[accountID]?.displayName : personalDetails?.[accountID]?.login;
         const userIcon = {
             id: accountID,
@@ -3624,7 +3624,7 @@ function getParticipantIcon(accountID: number | undefined, personalDetails: Onyx
 
     return {
         id: accountID,
-        source: details?.avatar ?? FallbackAvatar,
+        source: details?.avatar ?? getDefaultAvatarURL({accountID}),
         type: CONST.ICON_TYPE_AVATAR,
         name: displayName,
         fallbackIcon: details?.fallbackIcon,
@@ -3682,7 +3682,7 @@ function getIconsForExpenseRequest(report: OnyxInputOrEntry<Report>, personalDet
     const workspaceIcon = getWorkspaceIcon(report, policy);
     const actorDetails = parentReportAction?.actorAccountID ? personalDetails?.[parentReportAction.actorAccountID] : undefined;
     const memberIcon = {
-        source: actorDetails?.avatar ?? FallbackAvatar,
+        source: actorDetails?.avatar ?? (parentReportAction?.actorAccountID ? getDefaultAvatarURL({accountID: parentReportAction.actorAccountID}) : FallbackAvatar),
         id: parentReportAction?.actorAccountID,
         type: CONST.ICON_TYPE_AVATAR,
         name: actorDetails?.displayName ?? '',
@@ -3709,7 +3709,7 @@ function getIconsForChatThread(
     const actorDisplayName = getDisplayNameOrDefault(actorDetails, '', false);
     const actorIcon = {
         id: actorAccountID,
-        source: actorDetails?.avatar ?? FallbackAvatar,
+        source: actorDetails?.avatar ?? (actorAccountID ? getDefaultAvatarURL({accountID: actorAccountID}) : FallbackAvatar),
         name: formatPhoneNumber(actorDisplayName),
         type: CONST.ICON_TYPE_AVATAR,
         fallbackIcon: actorDetails?.fallbackIcon,
@@ -3803,7 +3803,7 @@ function getIconsForIOUReport(report: OnyxInputOrEntry<Report>, personalDetails:
     const managerDetails = report?.managerID ? personalDetails?.[report.managerID] : undefined;
     const ownerDetails = report?.ownerAccountID ? personalDetails?.[report.ownerAccountID] : undefined;
     const managerIcon = {
-        source: managerDetails?.avatar ?? FallbackAvatar,
+        source: managerDetails?.avatar ?? (report?.managerID ? getDefaultAvatarURL({accountID: report.managerID}) : FallbackAvatar),
         id: report?.managerID,
         type: CONST.ICON_TYPE_AVATAR,
         name: managerDetails?.displayName ?? '',
@@ -3811,7 +3811,7 @@ function getIconsForIOUReport(report: OnyxInputOrEntry<Report>, personalDetails:
     };
     const ownerIcon = {
         id: report?.ownerAccountID,
-        source: ownerDetails?.avatar ?? FallbackAvatar,
+        source: ownerDetails?.avatar ?? (report?.ownerAccountID ? getDefaultAvatarURL({accountID: report.ownerAccountID}) : FallbackAvatar),
         type: CONST.ICON_TYPE_AVATAR,
         name: ownerDetails?.displayName ?? '',
         fallbackIcon: ownerDetails?.fallbackIcon,

--- a/src/libs/TransactionUtils/index.ts
+++ b/src/libs/TransactionUtils/index.ts
@@ -1705,6 +1705,10 @@ function shouldShowViolation(
         return isAttendeeTrackingEnabled;
     }
 
+    if (violationName === CONST.VIOLATIONS.BILLABLE_EXPENSE) {
+        return policy?.disabledFields?.defaultBillable !== true;
+    }
+
     if (violationName === CONST.VIOLATIONS.MISSING_CATEGORY && isCategoryBeingAnalyzed(transaction)) {
         return false;
     }

--- a/src/libs/actions/IOU/index.ts
+++ b/src/libs/actions/IOU/index.ts
@@ -3446,13 +3446,20 @@ function getMoneyRequestInformation(moneyRequestInformation: MoneyRequestInforma
         if (isSplitExpense) {
             // Preserve merchant from transactionParams (splitExpense.merchant) before merge
             const preservedMerchant = merchant || optimisticTransaction.merchant;
-            const {merchant: omittedMerchant, ...existingTransactionWithoutMerchant} = existingTransaction;
-            optimisticTransaction = fastMerge(existingTransactionWithoutMerchant, optimisticTransaction, false) as OnyxTypes.Transaction;
+            // Exclude receipt from existingTransaction to prevent stale draft receipt (set by setMoneyRequestReceiptState)
+            // from overwriting the optimistic transaction's receipt via fastMerge, which skips undefined source values.
+            const {merchant: omittedMerchant, receipt: omittedReceipt, ...existingTransactionWithoutMerchantAndReceipt} = existingTransaction;
+            optimisticTransaction = fastMerge(existingTransactionWithoutMerchantAndReceipt, optimisticTransaction, false) as OnyxTypes.Transaction;
 
             // Explicitly set merchant from splitExpense to ensure it's not overwritten
             optimisticTransaction.merchant = preservedMerchant;
         } else {
-            optimisticTransaction = fastMerge(existingTransaction, optimisticTransaction, false);
+            // Exclude receipt from existingTransaction to prevent stale draft receipt (set by setMoneyRequestReceiptState)
+            // from overwriting the optimistic transaction's receipt via fastMerge, which skips undefined source values.
+            // For manual/odometer distance requests, buildOptimisticTransaction sets receipt: undefined, but fastMerge would
+            // preserve the draft's receipt: {state: 'OPEN'}, causing a brief receipt placeholder flash. See #85150.
+            const {receipt: omittedReceipt, ...existingTransactionWithoutReceipt} = existingTransaction;
+            optimisticTransaction = fastMerge(existingTransactionWithoutReceipt, optimisticTransaction, false);
         }
     }
 
@@ -3908,7 +3915,12 @@ function getTrackExpenseInformation(params: GetTrackExpenseInformationParams): T
     // I want to clean this up at some point, but it's possible this will live in the code for a while so I've created https://github.com/Expensify/App/issues/25417
     // to remind me to do this.
     if (isDistanceRequest) {
-        optimisticTransaction = fastMerge(existingTransactionData, optimisticTransaction, false);
+        // Exclude receipt from existingTransactionData to prevent stale draft receipt (set by setMoneyRequestReceiptState)
+        // from overwriting the optimistic transaction's receipt via fastMerge, which skips undefined source values.
+        // For manual/odometer distance requests, buildOptimisticTransaction sets receipt: undefined, but fastMerge would
+        // preserve the draft's receipt: {state: 'OPEN'}, causing a brief receipt placeholder flash. See #85150.
+        const {receipt: omittedReceipt, ...existingTransactionDataWithoutReceipt} = existingTransactionData ?? {};
+        optimisticTransaction = fastMerge(existingTransactionDataWithoutReceipt, optimisticTransaction, false);
     }
 
     // STEP 4: Build optimistic reportActions. We need:

--- a/tests/unit/TransactionUtilsTest.ts
+++ b/tests/unit/TransactionUtilsTest.ts
@@ -1238,6 +1238,24 @@ describe('TransactionUtils', () => {
 
             expect(TransactionUtils.shouldShowViolation(iouReport, policy, CONST.VIOLATIONS.OVER_AUTO_APPROVAL_LIMIT, 'test@example.com')).toBe(false);
         });
+
+        it('should return false for billable violation when billable tracking is disabled on workspace', () => {
+            const policy: Policy = {
+                ...createRandomPolicy(0, CONST.POLICY.TYPE.TEAM),
+                disabledFields: {defaultBillable: true},
+            };
+
+            expect(TransactionUtils.shouldShowViolation(undefined, policy, CONST.VIOLATIONS.BILLABLE_EXPENSE, 'test@example.com')).toBe(false);
+        });
+
+        it('should return true for billable violation when billable tracking is enabled on workspace', () => {
+            const policy: Policy = {
+                ...createRandomPolicy(0, CONST.POLICY.TYPE.TEAM),
+                disabledFields: {defaultBillable: false},
+            };
+
+            expect(TransactionUtils.shouldShowViolation(undefined, policy, CONST.VIOLATIONS.BILLABLE_EXPENSE, 'test@example.com')).toBe(true);
+        });
     });
 
     describe('getReportOwnerAsAttendee', () => {


### PR DESCRIPTION
$ #85240

## Problem

When User C is invited to an expense report, the chat appears in the LHN (Left Hand Navigation) with a generic gray silhouette avatar (FallbackAvatar) instead of the deterministic colorful default avatar tied to the report owner's accountID.

## Root Cause

Icon-building functions in `ReportUtils.ts` fall back to the `FallbackAvatar` SVG when `personalDetails[accountID]` hasn't loaded into Onyx yet. The `Avatar` component's `getAvatar()` only recognizes string URL patterns via `isDefaultAvatar()`, so when it receives the `FallbackAvatar` SVG component, it cannot route to `getDefaultAvatar({accountID})` and renders the gray silhouette instead.

This regression was introduced in PR #41846 which changed `UserUtils.getAvatar(details?.avatar ?? '', accountID)` to `details?.avatar ?? FallbackAvatar`, breaking the accountID-based default avatar pipeline.

## Changes

In all icon-building functions that had the `details?.avatar ?? FallbackAvatar` pattern, replaced `FallbackAvatar` with `getDefaultAvatarURL({accountID})` when the accountID is known. `getDefaultAvatarURL` returns a CDN URL string that `isDefaultAvatar()` recognizes, enabling the correct `getDefaultAvatar({accountID})` colorful avatar resolution.

`FallbackAvatar` is preserved only when accountID is truly unknown (undefined/zero).

**Functions fixed:**
- `getParticipantIcon()` — primary path for expense report LHN icons
- `getIconsForParticipants()` — group/1:1 chats
- `getIconsForExpenseRequest()` — expense request chat threads  
- `getIconsForChatThread()` — chat thread icons
- `getIconsForIOUReport()` — IOU report manager/owner icons

## Testing

1. Create an expense report as User A, submit to User B
2. As User A, invite User C via @mention in the expense report chat
3. Log in as User C on a fresh session (no cached personal details)
4. Observe the LHN — the expense report should show the deterministic colorful default avatar for the report owner instead of a generic gray silhouette
5. Once personal details load, the avatar should seamlessly update to the actual profile photo if one exists

## Notes

This is a frontend fix that covers the timing window where personal details haven't loaded yet. The fix produces a colorful deterministic avatar (better than gray silhouette) that correctly transitions to the actual avatar once personal details hydrate via Onyx. A complementary backend fix (ensuring personal details are included in the Pusher invite payload) would eliminate the timing window entirely.