### PR TITLE
fix: prevent distance receipt placeholder flash on manual distance expenses

### DIFF
--- a/src/libs/actions/IOU/index.ts
+++ b/src/libs/actions/IOU/index.ts
@@ -3446,13 +3446,20 @@ function getMoneyRequestInformation(moneyRequestInformation: MoneyRequestInforma
         if (isSplitExpense) {
             // Preserve merchant from transactionParams (splitExpense.merchant) before merge
             const preservedMerchant = merchant || optimisticTransaction.merchant;
-            const {merchant: omittedMerchant, ...existingTransactionWithoutMerchant} = existingTransaction;
-            optimisticTransaction = fastMerge(existingTransactionWithoutMerchant, optimisticTransaction, false) as OnyxTypes.Transaction;
+            // Exclude receipt from existingTransaction to prevent stale draft receipt (set by setMoneyRequestReceiptState)
+            // from overwriting the optimistic transaction's receipt via fastMerge, which skips undefined source values.
+            const {merchant: omittedMerchant, receipt: omittedReceipt, ...existingTransactionWithoutMerchantAndReceipt} = existingTransaction;
+            optimisticTransaction = fastMerge(existingTransactionWithoutMerchantAndReceipt, optimisticTransaction, false) as OnyxTypes.Transaction;
 
             // Explicitly set merchant from splitExpense to ensure it's not overwritten
             optimisticTransaction.merchant = preservedMerchant;
         } else {
-            optimisticTransaction = fastMerge(existingTransaction, optimisticTransaction, false);
+            // Exclude receipt from existingTransaction to prevent stale draft receipt (set by setMoneyRequestReceiptState)
+            // from overwriting the optimistic transaction's receipt via fastMerge, which skips undefined source values.
+            // For manual/odometer distance requests, buildOptimisticTransaction sets receipt: undefined, but fastMerge would
+            // preserve the draft's receipt: {state: 'OPEN'}, causing a brief receipt placeholder flash. See #85150.
+            const {receipt: omittedReceipt, ...existingTransactionWithoutReceipt} = existingTransaction;
+            optimisticTransaction = fastMerge(existingTransactionWithoutReceipt, optimisticTransaction, false);
         }
     }
 
@@ -3908,7 +3915,12 @@ function getTrackExpenseInformation(params: GetTrackExpenseInformationParams): T
     // I want to clean this up at some point, but it's possible this will live in the code for a while so I've created https://github.com/Expensify/App/issues/25417
     // to remind me to do this.
     if (isDistanceRequest) {
-        optimisticTransaction = fastMerge(existingTransactionData, optimisticTransaction, false);
+        // Exclude receipt from existingTransactionData to prevent stale draft receipt (set by setMoneyRequestReceiptState)
+        // from overwriting the optimistic transaction's receipt via fastMerge, which skips undefined source values.
+        // For manual/odometer distance requests, buildOptimisticTransaction sets receipt: undefined, but fastMerge would
+        // preserve the draft's receipt: {state: 'OPEN'}, causing a brief receipt placeholder flash. See #85150.
+        const {receipt: omittedReceipt, ...existingTransactionDataWithoutReceipt} = existingTransactionData ?? {};
+        optimisticTransaction = fastMerge(existingTransactionDataWithoutReceipt, optimisticTransaction, false);
     }
 
     // STEP 4: Build optimistic reportActions. We need:


### PR DESCRIPTION
$ #85150

## Root Cause

When creating a manual/odometer distance expense via QAB, a receipt placeholder briefly flashes on screen before disappearing.

The cause is a `fastMerge` interaction between the draft and optimistic transactions:

1. `setMoneyRequestReceiptState` unconditionally sets `receipt: {state: 'OPEN'}` on the **draft** transaction whenever fields like amount/merchant are modified — including for distance expenses.
2. `buildOptimisticTransaction` correctly sets `receipt: undefined` for manual distance requests (no receipt source).
3. However, `fastMerge` skips `undefined` source values, so the draft's stale `receipt: {state: 'OPEN'}` survived into the merged optimistic transaction.
4. `hasReceipt()` returned `true`, causing `MoneyRequestReceiptView` to render a receipt placeholder until the server responded with the real transaction data (no receipt) — hence the brief flash.

## Changes

Exclude the `receipt` field from `existingTransaction`/`existingTransactionData` **before** passing to `fastMerge` in both `getMoneyRequestInformation` and `getTrackExpenseInformation`.

The optimistic transaction already carries the correct `receipt` value from `buildOptimisticTransaction`:
- For waypoint-based distance requests: `{source: ReceiptGeneric, state: 'OPEN'}` (shows the route map)
- For manual/odometer distance requests: `undefined` (no receipt)

So the draft's stale receipt is never needed in the merge. This follows the existing pattern where `merchant` is already destructured out before `fastMerge` for split expenses to prevent a similar overwrite problem.

## Testing

1. Open a workspace chat
2. Create a manual distance expense via QAB (Quick Add Button)
3. Fill in the distance fields and submit
4. **Before fix:** A receipt placeholder briefly flashes in the chat before disappearing
5. **After fix:** No receipt placeholder flash — the expense renders correctly immediately