### PR TITLE
fix: keyboard doesn't close after PDF password entry

### DIFF
--- a/src/components/PDFView/index.native.tsx
+++ b/src/components/PDFView/index.native.tsx
@@ -1,6 +1,6 @@
 import React, {useCallback, useEffect, useMemo, useState} from 'react';
 import type {StyleProp, ViewStyle} from 'react-native';
-import {Linking, View} from 'react-native';
+import {Keyboard, Linking, View} from 'react-native';
 import PDF from 'react-native-pdf';
 import KeyboardAvoidingView from '@components/KeyboardAvoidingView';
 import LoadingIndicator from '@components/LoadingIndicator';
@@ -114,6 +114,11 @@ function PDFView({onToggleKeyboard, onLoadComplete, fileName, onPress, isFocused
      * @param pdfPassword Password submitted via PDFPasswordForm
      */
     const attemptPDFLoadWithPassword = (pdfPassword: string) => {
+        // Dismiss the keyboard explicitly before loading the PDF. Without this, the keyboard
+        // stays open on Android after the user submits the password (regression in RN 0.83
+        // where unmounting a TextInput no longer implicitly dismisses the keyboard).
+        Keyboard.dismiss();
+
         // Render react-native-pdf/PDF so that it can validate the password.
         // Note that at this point in the password challenge, shouldRequestPassword is true.
         // Thus react-native-pdf/PDF will be rendered - but not visible.


### PR DESCRIPTION
$ #85889

## Root Cause

On Android with React Native 0.83 (staging v9.3.41-0), the keyboard no longer implicitly dismisses when a `TextInput` is unmounted. Previously (RN 0.81), submitting the PDF password would eventually unmount the `PDFPasswordForm` via `finishPDFLoad()` setting `shouldRequestPassword = false`, which would close the keyboard as a side effect.

With RN 0.83, this implicit behavior broke — the keyboard stays open after the user taps "Confirm" on the PDF password form. The `ScrollView` wrapping the form also uses `keyboardShouldPersistTaps="handled"`, which explicitly keeps the keyboard open during button taps.

## Changes

Added an explicit `Keyboard.dismiss()` call at the start of `attemptPDFLoadWithPassword()` in `src/components/PDFView/index.native.tsx`:

- Dismisses the keyboard immediately when the user submits the password
- Placed in the native-specific file — zero impact on the web PDF view
- Follows the same pattern used by `FormWrapper.tsx` and other submission handlers in the codebase
- If the password is incorrect, `initiatePasswordChallenge()` re-renders `PDFPasswordForm` and the existing `useEffect` re-focuses the `TextInput`, naturally reopening the keyboard

## Testing

1. Find or create a password-protected PDF
2. Attach it to an Expensify chat on Android
3. Open the attachment — PDF password form should appear with keyboard open
4. Enter the password and tap "Confirm"
5. **Before fix:** keyboard stays open (regression in RN 0.83)
6. **After fix:** keyboard dismisses immediately when "Confirm" is tapped