### PR TITLE
fix: Fall back to isPolicyAdmin when adminAccess is undefined for domain-level feeds

### DIFF
--- a/src/hooks/useIsAllowedToIssueCompanyCard.ts
+++ b/src/hooks/useIsAllowedToIssueCompanyCard.ts
@@ -21,6 +21,13 @@ function useIsAllowedToIssueCompanyCard({policyID}: {policyID?: string}) {
         return isPolicyAdmin;
     }
 
+    // When adminAccess hasn't been loaded yet (user hasn't visited Domain page),
+    // fall back to isPolicyAdmin to avoid silently blocking the action.
+    // The server validates domain admin access on the actual AssignCompanyCard API call.
+    if (adminAccess === undefined) {
+        return isPolicyAdmin;
+    }
+
     return !!adminAccess;
 }
 


### PR DESCRIPTION
### Explanation of Change

When a workspace admin navigates to **Workspace > Company Cards** and clicks "Assign Card" on a domain-level card feed (e.g., Chase), the action silently fails because `adminAccess` from `SHARED_NVP_PRIVATE_ADMIN_ACCESS` hasn't been loaded into Onyx (it's only populated when the user visits the Domain settings page).

This PR adds a fallback in `useIsAllowedToIssueCompanyCard` — when `adminAccess` is `undefined` (not yet loaded), it falls back to `isPolicyAdmin` instead of treating it as `false`. This is safe because:
1. The `AssignCompanyCard` API call validates admin permissions server-side
2. For legitimate domain admins (the affected users), `isPolicyAdmin` is `true` and the action proceeds correctly
3. Once the admin access data IS loaded, the explicit `true`/`false` value takes over

### Fixed Issues

$ https://github.com/Expensify/App/issues/86277
PROPOSAL: https://github.com/Expensify/App/issues/86277#issuecomment-4121419348

Linked issue: https://github.com/Expensify/Expensify/issues/615675

### Tests

1. Log in as a workspace admin
2. Navigate to **Workspace > Company Cards** for a workspace that has a domain-level card feed (e.g., Chase)
3. Do NOT visit the Domain settings page first
4. Click "Assign Card" on a card from the domain-level feed
5. Verify the assign card flow opens correctly instead of silently failing

- [x] Verify that no errors appear in the JS console

### Offline tests

1. While offline, attempt to assign a card from a domain-level feed
2. Verify the offline modal appears as expected (existing behavior, unchanged by this PR)

### QA Steps

1. Log in as a workspace admin with a domain-level card feed (e.g., Chase)
2. Clear Onyx storage to ensure `SHARED_NVP_PRIVATE_ADMIN_ACCESS` is not cached
3. Navigate directly to **Workspace > Company Cards**
4. Click "Assign Card" on a card from the domain-level feed
5. Verify the assign card flow proceeds correctly

- [x] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).