### PR TITLE
Collect and persist aaguid and transports

### DIFF
--- a/src/components/MultifactorAuthentication/biometrics/usePasskeys.ts
+++ b/src/components/MultifactorAuthentication/biometrics/usePasskeys.ts
@@ -77,7 +77,8 @@ function usePasskeys(): UseBiometricsReturn {
 
         const transports = attestationResponse.getTransports?.().filter(isSupportedTransport);
 
-        // getAuthenticatorData() is a WebAuthn Level 2 method — not available in older browsers
+        // getAuthenticatorData() is a WebAuthn Level 2 method — not available in older browsers.
+        // NOTE: A vvalue of "00000000-0000-0000-0000-000000000000" is expected for Apple iCloud Keychain
         const aaguid = attestationResponse.getAuthenticatorData ? extractAAGUID(attestationResponse.getAuthenticatorData()) : undefined;
 
         addLocalPasskeyCredential({

--- a/src/components/MultifactorAuthentication/biometrics/usePasskeys.ts
+++ b/src/components/MultifactorAuthentication/biometrics/usePasskeys.ts
@@ -8,6 +8,7 @@ import {
     buildPublicKeyCredentialRequestOptions,
     createPasskeyCredential,
     decodeWebAuthnError,
+    extractAAGUID,
     isSupportedTransport,
     isWebAuthnSupported,
     PASSKEY_AUTH_TYPE,
@@ -76,12 +77,16 @@ function usePasskeys(): UseBiometricsReturn {
 
         const transports = attestationResponse.getTransports?.().filter(isSupportedTransport);
 
+        // getAuthenticatorData() is a WebAuthn Level 2 method — not available in older browsers
+        const aaguid = attestationResponse.getAuthenticatorData ? extractAAGUID(attestationResponse.getAuthenticatorData()) : undefined;
+
         addLocalPasskeyCredential({
             userId,
             credential: {
                 id: credentialId,
                 type: CONST.PASSKEY_CREDENTIAL_TYPE,
                 transports,
+                aaguid,
             },
             existingCredentials: localPasskeyCredentials ?? null,
         });
@@ -92,6 +97,8 @@ function usePasskeys(): UseBiometricsReturn {
             keyInfo: {
                 rawId: credentialId,
                 type: CONST.PASSKEY_CREDENTIAL_TYPE,
+                transports,
+                aaguid,
                 response: {
                     clientDataJSON,
                     attestationObject,

--- a/src/components/MultifactorAuthentication/biometrics/usePasskeys.ts
+++ b/src/components/MultifactorAuthentication/biometrics/usePasskeys.ts
@@ -78,7 +78,7 @@ function usePasskeys(): UseBiometricsReturn {
         const transports = attestationResponse.getTransports?.().filter(isSupportedTransport);
 
         // getAuthenticatorData() is a WebAuthn Level 2 method — not available in older browsers.
-        // NOTE: A vvalue of "00000000-0000-0000-0000-000000000000" is expected for Apple iCloud Keychain
+        // NOTE: A value of "00000000-0000-0000-0000-000000000000" is expected for Apple iCloud Keychain
         const aaguid = attestationResponse.getAuthenticatorData ? extractAAGUID(attestationResponse.getAuthenticatorData()) : undefined;
 
         addLocalPasskeyCredential({

--- a/src/libs/MultifactorAuthentication/Passkeys/WebAuthn.ts
+++ b/src/libs/MultifactorAuthentication/Passkeys/WebAuthn.ts
@@ -111,6 +111,20 @@ function buildAllowedCredentialDescriptors(credentials: Array<{id: string; trans
         transports: c.transports?.filter(isSupportedTransport),
     }));
 }
+/**
+ * Extracts the AAGUID (Authenticator Attestation Globally Unique Identifier) from WebAuthn authenticatorData.
+ * The AAGUID occupies bytes 37-52: after rpIdHash (32 bytes), flags (1 byte), and signCount (4 bytes).
+ * Returns a UUID-formatted string, or empty string if authenticatorData is too short.
+ */
+function extractAAGUID(authData: ArrayBuffer): string | undefined {
+    const bytes = new Uint8Array(authData);
+    if (bytes.length < 53) {
+        return undefined;
+    }
+    const aaguidBytes = bytes.slice(37, 53);
+    const hex = Array.from(aaguidBytes, (b) => b.toString(16).padStart(2, '0')).join('');
+    return [hex.slice(0, 8), hex.slice(8, 12), hex.slice(12, 16), hex.slice(16, 20), hex.slice(20, 32)].join('-');
+}
 
 function isWebAuthnReason(name: string): name is MultifactorAuthenticationReason {
     return Object.values<string>(VALUES.REASON.WEBAUTHN).includes(name);
@@ -136,5 +150,6 @@ export {
     authenticateWithPasskey,
     buildAllowedCredentialDescriptors,
     isSupportedTransport,
+    extractAAGUID,
     decodeWebAuthnError,
 };

--- a/src/libs/MultifactorAuthentication/Passkeys/WebAuthn.ts
+++ b/src/libs/MultifactorAuthentication/Passkeys/WebAuthn.ts
@@ -1,4 +1,5 @@
 import type {ValueOf} from 'type-fest';
+import Log from '@libs/Log';
 import type {AuthenticationChallenge, RegistrationChallenge} from '@libs/MultifactorAuthentication/shared/challengeTypes';
 import MARQETA_VALUES from '@libs/MultifactorAuthentication/shared/MarqetaValues';
 import type {MultifactorAuthenticationReason} from '@libs/MultifactorAuthentication/shared/types';
@@ -132,6 +133,7 @@ function isWebAuthnReason(name: string): name is MultifactorAuthenticationReason
 
 /** Decodes WebAuthn DOMException errors and maps them to authentication error reasons. */
 function decodeWebAuthnError(error: unknown): MultifactorAuthenticationReason {
+    Log.info('[Passkey] WebAuthn error', false, {error: error instanceof Error ? error.message : String(error)});
     if (error instanceof DOMException && isWebAuthnReason(error.name)) {
         return error.name;
     }

--- a/src/libs/MultifactorAuthentication/Passkeys/types.ts
+++ b/src/libs/MultifactorAuthentication/Passkeys/types.ts
@@ -4,6 +4,8 @@
 type PasskeyRegistrationKeyInfo = {
     rawId: string;
     type: 'public-key';
+    transports?: string[];
+    aaguid?: string;
     response: {
         clientDataJSON: string;
         attestationObject: string;

--- a/src/libs/MultifactorAuthentication/shared/challengeTypes.ts
+++ b/src/libs/MultifactorAuthentication/shared/challengeTypes.ts
@@ -55,6 +55,7 @@ type AuthenticationChallenge = {
     allowCredentials: Array<{
         type: string;
         id: string;
+        transports?: string[];
     }>;
     userVerification: UserVerificationRequirement;
     timeout: number;

--- a/src/types/onyx/LocalPasskeyCredentialsEntry.ts
+++ b/src/types/onyx/LocalPasskeyCredentialsEntry.ts
@@ -14,6 +14,9 @@ type PasskeyCredential = {
 
     /** Optional array of transport methods that can be used to communicate with the authenticator */
     transports?: PasskeyTransport[];
+
+    /** Authenticator model identifier (UUID). Identifies the authenticator provider (e.g. Apple Passwords, Google Password Manager). */
+    aaguid?: string;
 };
 
 /**

--- a/tests/actions/PasskeyTest.ts
+++ b/tests/actions/PasskeyTest.ts
@@ -64,6 +64,24 @@ describe('actions/Passkey', () => {
             expect(value).toEqual([{id: 'existing', type: CONST.PASSKEY_CREDENTIAL_TYPE, transports: [CONST.PASSKEY_TRANSPORT.INTERNAL]}, credential]);
         });
 
+        it('should store credential with aaguid field', async () => {
+            // Given a credential with an AAGUID
+            const credentialWithAAGUID: PasskeyCredential = {
+                id: 'cred-aaguid',
+                type: CONST.PASSKEY_CREDENTIAL_TYPE,
+                transports: [CONST.PASSKEY_TRANSPORT.INTERNAL],
+                aaguid: 'fbfc3007-154e-4ecc-8c0b-6e020557d7bd',
+            };
+
+            // When adding it to Onyx
+            addLocalPasskeyCredential({userId, credential: credentialWithAAGUID, existingCredentials: null});
+            await waitForBatchedUpdates();
+
+            // Then the AAGUID should be preserved in Onyx storage
+            const value = await getOnyxValue(getPasskeyOnyxKey(userId));
+            expect(value).toEqual([credentialWithAAGUID]);
+        });
+
         it('should throw error when credential with same id already exists', () => {
             // Given an existing entry that already contains a credential with the same id
             const existingCredentials: LocalPasskeyCredentialsEntry = [{id: 'cred-1', type: CONST.PASSKEY_CREDENTIAL_TYPE, transports: [CONST.PASSKEY_TRANSPORT.INTERNAL]}];
@@ -186,6 +204,20 @@ describe('actions/Passkey', () => {
 
             const value = await getOnyxValue(getPasskeyOnyxKey(userId));
             expect(value).toEqual([]);
+        });
+
+        it('should preserve aaguid from local credentials', () => {
+            // Given a local credential with an AAGUID and a backend credential without it
+            const localCredentials: PasskeyCredential[] = [
+                {id: 'cred-1', type: CONST.PASSKEY_CREDENTIAL_TYPE, transports: [CONST.PASSKEY_TRANSPORT.INTERNAL], aaguid: 'fbfc3007-154e-4ecc-8c0b-6e020557d7bd'},
+            ];
+            const backendCredentials: BackendPasskeyCredential[] = [{id: 'cred-1', type: CONST.PASSKEY_CREDENTIAL_TYPE}];
+
+            // When reconciling with backend
+            const result = reconcileLocalPasskeysWithBackend({userId, backendCredentials, localCredentials});
+
+            // Then the local AAGUID should be preserved in the result
+            expect(result).toEqual(localCredentials);
         });
 
         it('should preserve transports from local credentials', () => {

--- a/tests/unit/libs/MultifactorAuthentication/Passkeys/WebAuthn.test.ts
+++ b/tests/unit/libs/MultifactorAuthentication/Passkeys/WebAuthn.test.ts
@@ -1,0 +1,89 @@
+import {extractAAGUID} from '@libs/MultifactorAuthentication/Passkeys/WebAuthn';
+
+describe('MultifactorAuthentication Passkeys WebAuthn', () => {
+    describe('extractAAGUID', () => {
+        it('should return empty string when authenticatorData is too short', () => {
+            // Given authenticatorData shorter than 53 bytes (rpIdHash[32] + flags[1] + signCount[4] + AAGUID[16])
+            const shortData = new Uint8Array(37).buffer;
+
+            // When extracting the AAGUID
+            const result = extractAAGUID(shortData);
+
+            // Then it should return undefined
+            expect(result).toBeUndefined();
+        });
+
+        it('should extract all-zeros AAGUID from authenticatorData with zeroed AAGUID bytes', () => {
+            // Given authenticatorData with all-zero AAGUID at bytes 37-52
+            const authData = new Uint8Array(53);
+
+            // When extracting the AAGUID
+            const result = extractAAGUID(authData.buffer);
+
+            // Then it should return the all-zeros UUID
+            expect(result).toBe('00000000-0000-0000-0000-000000000000');
+        });
+
+        it('should extract Apple Passwords AAGUID correctly', () => {
+            // Given authenticatorData with Apple Passwords AAGUID (fbfc3007-154e-4ecc-8c0b-6e020557d7bd) at bytes 37-52
+            const authData = new Uint8Array(53);
+            const appleAAGUIDBytes = [0xfb, 0xfc, 0x30, 0x07, 0x15, 0x4e, 0x4e, 0xcc, 0x8c, 0x0b, 0x6e, 0x02, 0x05, 0x57, 0xd7, 0xbd];
+            authData.set(appleAAGUIDBytes, 37);
+
+            // When extracting the AAGUID
+            const result = extractAAGUID(authData.buffer);
+
+            // Then it should return the correctly formatted Apple Passwords UUID
+            expect(result).toBe('fbfc3007-154e-4ecc-8c0b-6e020557d7bd');
+        });
+
+        it('should extract Google Password Manager AAGUID correctly', () => {
+            // Given authenticatorData with Google Password Manager AAGUID (ea9b8d66-4d01-1d21-3ce4-b6b48cb575d4)
+            const authData = new Uint8Array(53);
+            const googleAAGUIDBytes = [0xea, 0x9b, 0x8d, 0x66, 0x4d, 0x01, 0x1d, 0x21, 0x3c, 0xe4, 0xb6, 0xb4, 0x8c, 0xb5, 0x75, 0xd4];
+            authData.set(googleAAGUIDBytes, 37);
+
+            // When extracting the AAGUID
+            const result = extractAAGUID(authData.buffer);
+
+            // Then it should return the correctly formatted Google Password Manager UUID
+            expect(result).toBe('ea9b8d66-4d01-1d21-3ce4-b6b48cb575d4');
+        });
+
+        it('should work with authenticatorData longer than 53 bytes', () => {
+            // Given authenticatorData that is much longer than the minimum (e.g., includes attested credential data)
+            const authData = new Uint8Array(200);
+            const aaguidBytes = [0xfb, 0xfc, 0x30, 0x07, 0x15, 0x4e, 0x4e, 0xcc, 0x8c, 0x0b, 0x6e, 0x02, 0x05, 0x57, 0xd7, 0xbd];
+            authData.set(aaguidBytes, 37);
+
+            // When extracting the AAGUID
+            const result = extractAAGUID(authData.buffer);
+
+            // Then it should still correctly extract the AAGUID
+            expect(result).toBe('fbfc3007-154e-4ecc-8c0b-6e020557d7bd');
+        });
+
+        it('should return empty string for exactly 52 bytes (one byte short)', () => {
+            // Given authenticatorData that is exactly one byte too short for AAGUID extraction
+            const authData = new Uint8Array(52).buffer;
+
+            // When extracting the AAGUID
+            const result = extractAAGUID(authData);
+
+            // Then it should return undefined
+            expect(result).toBeUndefined();
+        });
+
+        it('should handle exactly 53 bytes (minimum valid length)', () => {
+            // Given authenticatorData that is exactly 53 bytes (the minimum to contain a full AAGUID)
+            const authData = new Uint8Array(53);
+            authData.set([0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10], 37);
+
+            // When extracting the AAGUID
+            const result = extractAAGUID(authData.buffer);
+
+            // Then it should return the correctly formatted UUID
+            expect(result).toBe('01020304-0506-0708-090a-0b0c0d0e0f10');
+        });
+    });
+});


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change

Collect transports and aaguid from passkeys and send them to Auth. Relates to https://github.com/Expensify/Auth/pull/20649/ but does not need to be held for it, since deploy order does not matter.

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
Part of https://github.com/Expensify/App/issues/86065
PROPOSAL: N/A


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

N/A online only

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->
Same as tests

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.


### Screenshots/Videos


<details>
<summary>MacOS: Chrome / Safari</summary>

There's not much to show in the UI for this, but here you can see the values being sent, persisted in auth, and returned
<img width="1624" height="1060" alt="Screenshot 2026-03-24 at 7 04 06 PM" src="https://github.com/user-attachments/assets/749df8c1-6b84-43b0-816b-33072ad97768" />

<img width="1512" height="949" alt="Screenshot 2026-03-24 at 7 04 35 PM" src="https://github.com/user-attachments/assets/b96e2dae-af03-4a12-a9a9-3948f1fdbe82" />

<img width="1624" height="1060" alt="Screenshot 2026-03-24 at 7 04 21 PM" src="https://github.com/user-attachments/assets/944ffa4e-574b-4794-b319-4388bdf2c4a7" />

</details>