### PR TITLE
fix: reject 0-byte receipt uploads client-side

### DIFF
--- a/src/libs/isFileUploadable/index.ts
+++ b/src/libs/isFileUploadable/index.ts
@@ -1,7 +1,7 @@
 import type {FileObject} from '@src/types/utils/Attachment';
 
 function isFileUploadable(file: FileObject | undefined): boolean {
-    return file instanceof Blob;
+    return file instanceof Blob && file.size > 0;
 }
 
 export default isFileUploadable;


### PR DESCRIPTION
## Fixed Issues
$ https://github.com/Expensify/App/issues/86159

## Tests

1. Open web app
2. Try uploading a 0-byte file as a receipt (e.g. from failed camera capture)
3. Verify the file is rejected client-side instead of producing a server 666 error

## Root Cause

`isFileUploadable()` on web only checked `file instanceof Blob` without verifying the blob has content. This allowed empty (0-byte) blobs to pass through to the API.

## Solution

Added `file.size > 0` guard to `src/libs/isFileUploadable/index.ts` so zero-byte blobs are rejected before the API request is made.

The native implementation already validates `uri` exists and is non-empty, so it's unaffected.

### Offline tests
N/A — this is a client-side validation fix.

### QA Steps
1. Navigate to any expense creation flow on web
2. Attempt to attach a 0-byte file as a receipt
3. Verify the empty file is not sent to the server
4. Verify a normal receipt file still uploads correctly