### PR TITLE
fix: show submitter name instead of "you" for admin viewers in fix-issue next step

### DIFF
--- a/src/libs/NextStepUtils.ts
+++ b/src/libs/NextStepUtils.ts
@@ -325,7 +325,7 @@ function buildOptimisticNextStepForPreventSelfApprovalsEnabled() {
 function buildOptimisticFixIssueNextStep(moneyRequestReport?: OnyxEntry<Report>) {
     const isCurrentUserOwner = isReportOwner(moneyRequestReport);
     const ownerName = moneyRequestReport?.ownerAccountID
-        ? getDisplayNameForParticipant({accountID: moneyRequestReport.ownerAccountID, formatPhoneNumber: formatPhoneNumberPhoneUtils}) ?? 'the submitter'
+        ? getDisplayNameForParticipant({accountID: moneyRequestReport.ownerAccountID, formatPhoneNumber: formatPhoneNumberPhoneUtils}) || 'the submitter'
         : 'the submitter';
 
     const optimisticNextStep: ReportNextStepDeprecated = {

--- a/src/libs/NextStepUtils.ts
+++ b/src/libs/NextStepUtils.ts
@@ -322,7 +322,12 @@ function buildOptimisticNextStepForPreventSelfApprovalsEnabled() {
     return optimisticNextStep;
 }
 
-function buildOptimisticFixIssueNextStep() {
+function buildOptimisticFixIssueNextStep(moneyRequestReport?: OnyxEntry<Report>) {
+    const isCurrentUserOwner = isReportOwner(moneyRequestReport);
+    const ownerName = moneyRequestReport?.ownerAccountID
+        ? getDisplayNameForParticipant({accountID: moneyRequestReport.ownerAccountID, formatPhoneNumber: formatPhoneNumberPhoneUtils}) ?? 'the submitter'
+        : 'the submitter';
+
     const optimisticNextStep: ReportNextStepDeprecated = {
         type: 'neutral',
         icon: CONST.NEXT_STEP.ICONS.HOURGLASS,
@@ -331,7 +336,7 @@ function buildOptimisticFixIssueNextStep() {
                 text: 'Waiting for ',
             },
             {
-                text: `you`,
+                text: isCurrentUserOwner ? 'you' : ownerName,
                 type: 'strong',
             },
             {
@@ -378,7 +383,7 @@ function getReportNextStep(
             (transaction) => !!transaction && hasSubmissionBlockingViolations(transaction, transactionViolations, currentUserEmail, currentUserAccountID, moneyRequestReport, policy),
         )
     ) {
-        return buildOptimisticFixIssueNextStep();
+        return buildOptimisticFixIssueNextStep(moneyRequestReport);
     }
 
     const isSubmitterSameAsNextApprover =


### PR DESCRIPTION
## Fixed Issues
$ #86252

## Root Cause
`buildOptimisticFixIssueNextStep()` always hardcoded `you` in the hourglass message without checking if the current user is the report owner.

When an admin views an expense report with blocking violations, the message incorrectly shows:
> Waiting for **you** to fix the issue(s)

instead of:
> Waiting for **[submitter name]** to fix the issue(s)

## Solution
Updated `buildOptimisticFixIssueNextStep()` to accept the `moneyRequestReport` parameter and check `isReportOwner()`. When the viewer is NOT the report owner (e.g., admin), the submitter's display name is shown instead of `you`.

## Tests
- Admin viewing report with violations → shows submitter's name
- Submitter viewing own report → still shows `you`
- Report without ownerAccountID → gracefully falls back to `the submitter`