### PR TITLE
fix: include segmentType in NetSuite custom segment payload

### DIFF
--- a/src/pages/workspace/accounting/netsuite/import/NetSuiteImportCustomFieldNew/NetSuiteImportAddCustomSegmentContent.tsx
+++ b/src/pages/workspace/accounting/netsuite/import/NetSuiteImportCustomFieldNew/NetSuiteImportAddCustomSegmentContent.tsx
@@ -55,6 +55,7 @@ function NetSuiteImportAddCustomSegmentContent({policy, draftValues}: NetSuiteIm
                     internalID: values[INPUT_IDS.INTERNAL_ID],
                     scriptID: values[INPUT_IDS.SCRIPT_ID],
                     mapping: values[INPUT_IDS.MAPPING] ?? CONST.INTEGRATION_ENTITY_MAP_TYPES.TAG,
+                    segmentType: values[INPUT_IDS.SEGMENT_TYPE],
                 },
             ]);
             updateNetSuiteCustomSegments(

--- a/src/types/onyx/Policy.ts
+++ b/src/types/onyx/Policy.ts
@@ -927,6 +927,9 @@ type NetSuiteCustomSegment = {
 
     /** Whether we import this segment as a report field or tag */
     mapping: NetSuiteCustomFieldMapping;
+
+    /** Whether this is a custom segment or custom record */
+    segmentType?: string;
 };
 
 /** The custom form ID object */


### PR DESCRIPTION
$ #86357

**Root cause:** segmentType (customSegment vs customRecord) was collected in step 0 but never included in the payload sent to backend. Without it, NetSuite API calls fail during sync.

**Fix (2 files, 4 lines):**
1. src/types/onyx/Policy.ts — Added optional segmentType field to NetSuiteCustomSegment type
2. NetSuiteImportAddCustomSegmentContent.tsx — Added segmentType to segment object in handleFinishStep