### PR TITLE
fix: prevent flash of Not Here page on waypoint refresh (mWeb)

### DIFF
--- a/src/pages/iou/request/step/IOURequestStepDistance.tsx
+++ b/src/pages/iou/request/step/IOURequestStepDistance.tsx
@@ -66,6 +66,9 @@ type IOURequestStepDistanceProps = WithCurrentUserPersonalDetailsProps &
     WithWritableReportOrNotFoundProps<typeof SCREENS.MONEY_REQUEST.STEP_DISTANCE | typeof SCREENS.MONEY_REQUEST.CREATE> & {
         /** The transaction object being modified in Onyx */
         transaction: OnyxEntry<Transaction>;
+
+        /** Whether the transaction data is still loading from Onyx */
+        isLoadingTransaction?: boolean;
     };
 
 function IOURequestStepDistance({
@@ -75,6 +78,7 @@ function IOURequestStepDistance({
     },
     transaction,
     currentUserPersonalDetails,
+    isLoadingTransaction,
 }: IOURequestStepDistanceProps) {
     const styles = useThemeStyles();
     const {isOffline} = useNetwork();
@@ -548,7 +552,7 @@ function IOURequestStepDistance({
             headerTitle={translate('common.distance')}
             onBackButtonPress={navigateBack}
             testID="IOURequestStepDistance"
-            shouldShowNotFoundPage={(isEditing && !currentTransaction?.comment?.waypoints) || shouldShowNotFoundPage}
+            shouldShowNotFoundPage={!isLoadingTransaction && ((isEditing && !currentTransaction?.comment?.waypoints) || shouldShowNotFoundPage)}
             shouldShowWrapper={!isCreatingNewRequest}
         >
             <>


### PR DESCRIPTION
$ #86324

**Root cause:** On mWeb refresh, Onyx hasn't hydrated transaction data yet. The condition `isEditing && !currentTransaction?.comment?.waypoints` evaluates true during loading, flashing the FullPageNotFoundView.

**Fix:** Added `!isLoadingTransaction` guard to `shouldShowNotFoundPage` in `IOURequestStepDistance.tsx`. The prop was already passed by `withFullTransactionOrNotFound` HOC — just wasn't being used.