### PR TITLE
fix: skip highlight animation on duplicated expense

### DIFF
--- a/src/ONYXKEYS.ts
+++ b/src/ONYXKEYS.ts
@@ -686,6 +686,9 @@ const ONYXKEYS = {
     /** The transaction IDs to be highlighted when opening the Expenses search route page */
     TRANSACTION_IDS_HIGHLIGHT_ON_SEARCH_ROUTE: 'transactionIdsHighlightOnSearchRoute',
 
+    /** Whether to skip highlighting the next new transaction on the search route (e.g. after duplicating an expense) */
+    SHOULD_SKIP_NEXT_TRANSACTION_HIGHLIGHT: 'shouldSkipNextTransactionHighlight',
+
     /** Collection Keys */
     COLLECTION: {
         ATTACHMENT: 'attachment_',
@@ -1475,6 +1478,7 @@ type OnyxValuesMapping = {
     [ONYXKEYS.IS_OPEN_CONFIRM_NAVIGATE_EXPENSIFY_CLASSIC_MODAL_OPEN]: boolean;
     [ONYXKEYS.PERSONAL_POLICY_ID]: string;
     [ONYXKEYS.TRANSACTION_IDS_HIGHLIGHT_ON_SEARCH_ROUTE]: Record<string, Record<string, boolean>>;
+    [ONYXKEYS.SHOULD_SKIP_NEXT_TRANSACTION_HIGHLIGHT]: boolean;
     [ONYXKEYS.DEVICE_BIOMETRICS]: OnyxTypes.DeviceBiometrics;
 };
 

--- a/src/hooks/useSearchHighlightAndScroll.ts
+++ b/src/hooks/useSearchHighlightAndScroll.ts
@@ -1,6 +1,7 @@
 import {useIsFocused} from '@react-navigation/native';
 import {useCallback, useEffect, useRef, useState} from 'react';
 import {InteractionManager} from 'react-native';
+import Onyx from 'react-native-onyx';
 import type {OnyxCollection, OnyxEntry} from 'react-native-onyx';
 import type {SearchListItem, TransactionGroupListItemType, TransactionListItemType} from '@components/Search/SearchList/ListItem/types';
 import type {SearchQueryJSON} from '@components/Search/types';
@@ -62,6 +63,7 @@ function useSearchHighlightAndScroll({
     const [transactionIDsToHighlight] = useOnyx(ONYXKEYS.TRANSACTION_IDS_HIGHLIGHT_ON_SEARCH_ROUTE, {
         selector: transactionIDsToHighlightSelector,
     });
+    const [shouldSkipNextHighlight] = useOnyx(ONYXKEYS.SHOULD_SKIP_NEXT_TRANSACTION_HIGHLIGHT);
     const searchResultsData = searchResults?.data;
 
     const prevTransactionsIDs = Object.keys(previousTransactions ?? {});
@@ -221,6 +223,12 @@ function useSearchHighlightAndScroll({
                 return;
             }
 
+            // Skip highlight for duplicated expenses
+            if (shouldSkipNextHighlight) {
+                Onyx.set(ONYXKEYS.SHOULD_SKIP_NEXT_TRANSACTION_HIGHLIGHT, false);
+                return;
+            }
+
             const newKeys = new Set<string>();
             for (const id of newTransactionIDs) {
                 const newTransactionKey = `${ONYXKEYS.COLLECTION.TRANSACTION}${id}`;
@@ -229,7 +237,7 @@ function useSearchHighlightAndScroll({
             }
             setNewSearchResultKeys(newKeys);
         }
-    }, [searchResults?.data, previousSearchResults, isChat, transactionIDsToHighlight]);
+    }, [searchResults?.data, previousSearchResults, isChat, transactionIDsToHighlight, shouldSkipNextHighlight]);
 
     // Reset transactionIDsToHighlight after they have been highlighted
     useEffect(() => {

--- a/src/libs/actions/IOU/Duplicate.ts
+++ b/src/libs/actions/IOU/Duplicate.ts
@@ -681,6 +681,9 @@ function duplicateExpenseTransaction({
         return;
     }
 
+    // Skip highlight animation for duplicated transactions on the search route
+    Onyx.set(ONYXKEYS.SHOULD_SKIP_NEXT_TRANSACTION_HIGHLIGHT, true);
+
     const userAccountID = getUserAccountID();
     const currentUserEmail = getCurrentUserEmail();
 
@@ -820,6 +823,9 @@ function duplicateReport({
     if (!targetPolicy || !parentChatReport) {
         return;
     }
+
+    // Skip highlight animation for duplicated transactions on the search route
+    Onyx.set(ONYXKEYS.SHOULD_SKIP_NEXT_TRANSACTION_HIGHLIGHT, true);
 
     const userAccountID = getUserAccountID();
     const currentUserEmailValue = getCurrentUserEmail();


### PR DESCRIPTION
$ #86354

**Root cause:** When duplicating an expense, the new transaction triggers highlight animation in useSearchHighlightAndScroll because it appears as a new transaction.

**Fix:** Added SHOULD_SKIP_NEXT_TRANSACTION_HIGHLIGHT Onyx key. Set to true before duplication in Duplicate.ts, consumed and reset in useSearchHighlightAndScroll.ts to skip the animation.