### PR TITLE
Fix 85553 rbr carousel sorting

### DIFF
--- a/src/components/MoneyRequestReportView/MoneyRequestReportTransactionList.tsx
+++ b/src/components/MoneyRequestReportView/MoneyRequestReportTransactionList.tsx
@@ -55,6 +55,7 @@ import {
     isIOUReport,
 } from '@libs/ReportUtils';
 import {compareValues, getColumnsToShow, getTableMinWidth, isTransactionAmountTooLong, isTransactionTaxAmountTooLong} from '@libs/SearchUIUtils';
+import {transactionHasRBR} from '@libs/TransactionPreviewUtils';
 import {getAmount, getCategory, getCreated, getMerchant, getTag, getTransactionPendingAction, isTransactionPendingDelete, shouldShowExpenseBreakdown} from '@libs/TransactionUtils';
 import shouldShowTransactionYear from '@libs/TransactionUtils/shouldShowTransactionYear';
 import Navigation from '@navigation/Navigation';
@@ -197,6 +198,7 @@ function MoneyRequestReportTransactionList({
     const [reportDetailsColumns] = useOnyx(ONYXKEYS.NVP_REPORT_DETAILS_COLUMNS);
     const [introSelected] = useOnyx(ONYXKEYS.NVP_INTRO_SELECTED);
     const [draftTransactionIDs] = useOnyx(ONYXKEYS.COLLECTION.TRANSACTION_DRAFT, {selector: validTransactionDraftIDsSelector});
+    const [allTransactionViolations] = useOnyx(ONYXKEYS.COLLECTION.TRANSACTION_VIOLATIONS);
 
     const shouldShowGroupedTransactions = isExpenseReport(report) && !isIOUReport(report);
 
@@ -265,10 +267,23 @@ function MoneyRequestReportTransactionList({
     });
 
     const {sortBy, sortOrder} = sortConfig;
+    const isDefaultSort = sortBy === CONST.SEARCH.TABLE_COLUMNS.DATE && sortOrder === CONST.SEARCH.SORT_ORDER.ASC;
 
     const sortedTransactions: TransactionWithOptionalHighlight[] = useMemo(() => {
-        return [...transactions].sort((a, b) => compareValues(getTransactionValue(a, sortBy, report), getTransactionValue(b, sortBy, report), sortOrder, sortBy, localeCompare, true));
-    }, [sortBy, sortOrder, transactions, localeCompare, report]);
+        return [...transactions].sort((a, b) => {
+            // When on default sort (Date/ASC), prioritize RBR-flagged transactions
+            if (isDefaultSort && allTransactionViolations) {
+                const aViolations = allTransactionViolations?.[`${ONYXKEYS.COLLECTION.TRANSACTION_VIOLATIONS}${a.transactionID}`] ?? [];
+                const bViolations = allTransactionViolations?.[`${ONYXKEYS.COLLECTION.TRANSACTION_VIOLATIONS}${b.transactionID}`] ?? [];
+                const aHasRBR = transactionHasRBR(a, aViolations);
+                const bHasRBR = transactionHasRBR(b, bViolations);
+                if (aHasRBR !== bHasRBR) {
+                    return aHasRBR ? -1 : 1;
+                }
+            }
+            return compareValues(getTransactionValue(a, sortBy, report), getTransactionValue(b, sortBy, report), sortOrder, sortBy, localeCompare, true);
+        });
+    }, [sortBy, sortOrder, transactions, localeCompare, report, isDefaultSort, allTransactionViolations]);
 
     const highlightedTransactionIDs = useMemo(() => new Set(newTransactions.map(({transactionID}) => transactionID)), [newTransactions]);
 

--- a/src/components/ReportActionItem/MoneyRequestReportPreview/MoneyRequestReportPreviewContent.tsx
+++ b/src/components/ReportActionItem/MoneyRequestReportPreview/MoneyRequestReportPreviewContent.tsx
@@ -78,6 +78,8 @@ import shouldAdjustScroll from '@libs/shouldAdjustScroll';
 import {startSpan} from '@libs/telemetry/activeSpans';
 import type {SkeletonSpanReasonAttributes} from '@libs/telemetry/useSkeletonSpan';
 import {hasAnyPendingRTERViolation as hasAnyPendingRTERViolationTransactionUtils, hasPendingUI, isManagedCardTransaction, isPending} from '@libs/TransactionUtils';
+import {hasPendingUI, isManagedCardTransaction, isPending} from '@libs/TransactionUtils';
+import {transactionHasRBR} from '@libs/TransactionPreviewUtils';
 import colors from '@styles/theme/colors';
 import variables from '@styles/variables';
 import {approveMoneyRequest, canIOUBePaid as canIOUBePaidIOUActions, payInvoice, payMoneyRequest, submitReport} from '@userActions/IOU';
@@ -497,7 +499,22 @@ function MoneyRequestReportPreviewContent({
         thumbsUpScale.set(isApprovedAnimationRunning ? withDelay(CONST.ANIMATION_THUMBS_UP_DELAY, withSpring(1, {duration: CONST.ANIMATION_THUMBS_UP_DURATION})) : 1);
     }, [isApproved, isApprovedAnimationRunning, thumbsUpScale]);
 
-    const carouselTransactions = useMemo(() => (shouldShowAccessPlaceHolder ? [] : transactions.slice(0, 11)), [shouldShowAccessPlaceHolder, transactions]);
+    const carouselTransactions = useMemo(() => {
+        if (shouldShowAccessPlaceHolder) {
+            return [];
+        }
+        const sorted = [...transactions].sort((a, b) => {
+            const aViolations = transactionViolations?.[`${ONYXKEYS.COLLECTION.TRANSACTION_VIOLATIONS}${a.transactionID}`] ?? [];
+            const bViolations = transactionViolations?.[`${ONYXKEYS.COLLECTION.TRANSACTION_VIOLATIONS}${b.transactionID}`] ?? [];
+            const aHasRBR = transactionHasRBR(a, aViolations);
+            const bHasRBR = transactionHasRBR(b, bViolations);
+            if (aHasRBR === bHasRBR) {
+                return 0;
+            }
+            return aHasRBR ? -1 : 1;
+        });
+        return sorted.slice(0, 11);
+    }, [shouldShowAccessPlaceHolder, transactions, transactionViolations]);
     const prevCarouselTransactionLength = useRef(0);
 
     useEffect(() => {

--- a/src/components/ReportActionItem/MoneyRequestReportPreview/MoneyRequestReportPreviewContent.tsx
+++ b/src/components/ReportActionItem/MoneyRequestReportPreview/MoneyRequestReportPreviewContent.tsx
@@ -1,34 +1,34 @@
-import {useFocusEffect} from '@react-navigation/native';
-import {hasSeenTourSelector} from '@selectors/Onboarding';
-import {FlashList} from '@shopify/flash-list';
-import type {FlashListRef, ListRenderItemInfo} from '@shopify/flash-list';
-import React, {useCallback, useDeferredValue, useEffect, useMemo, useRef, useState} from 'react';
-import {View} from 'react-native';
-import type {ViewToken} from 'react-native';
-import type {OnyxEntry} from 'react-native-onyx';
-import Animated, {useAnimatedStyle, useSharedValue, withDelay, withSpring, withTiming} from 'react-native-reanimated';
+import { useFocusEffect } from '@react-navigation/native';
+import { hasSeenTourSelector } from '@selectors/Onboarding';
+import { FlashList } from '@shopify/flash-list';
+import type { FlashListRef, ListRenderItemInfo } from '@shopify/flash-list';
+import React, { useCallback, useDeferredValue, useEffect, useMemo, useRef, useState } from 'react';
+import { View } from 'react-native';
+import type { ViewToken } from 'react-native';
+import type { OnyxEntry } from 'react-native-onyx';
+import Animated, { useAnimatedStyle, useSharedValue, withDelay, withSpring, withTiming } from 'react-native-reanimated';
 import ActivityIndicator from '@components/ActivityIndicator';
 import AnimatedSubmitButton from '@components/AnimatedSubmitButton';
 import Button from '@components/Button';
-import {getButtonRole} from '@components/Button/utils';
+import { getButtonRole } from '@components/Button/utils';
 import ButtonWithDropdownMenu from '@components/ButtonWithDropdownMenu';
-import {useDelegateNoAccessActions, useDelegateNoAccessState} from '@components/DelegateNoAccessModalProvider';
+import { useDelegateNoAccessActions, useDelegateNoAccessState } from '@components/DelegateNoAccessModalProvider';
 import Icon from '@components/Icon';
 import MoneyReportHeaderStatusBarSkeleton from '@components/MoneyReportHeaderStatusBarSkeleton';
 import OfflineWithFeedback from '@components/OfflineWithFeedback';
-import {PressableWithFeedback} from '@components/Pressable';
+import { PressableWithFeedback } from '@components/Pressable';
 import PressableWithoutFeedback from '@components/Pressable/PressableWithoutFeedback';
 import ProcessMoneyReportHoldMenu from '@components/ProcessMoneyReportHoldMenu';
-import type {ActionHandledType} from '@components/ProcessMoneyReportHoldMenu';
+import type { ActionHandledType } from '@components/ProcessMoneyReportHoldMenu';
 import ExportWithDropdownMenu from '@components/ReportActionItem/ExportWithDropdownMenu';
 import AnimatedSettlementButton from '@components/SettlementButton/AnimatedSettlementButton';
-import type {PaymentActionParams} from '@components/SettlementButton/types';
-import {showContextMenuForReport} from '@components/ShowContextMenuContext';
+import type { PaymentActionParams } from '@components/SettlementButton/types';
+import { showContextMenuForReport } from '@components/ShowContextMenuContext';
 import StatusBadge from '@components/StatusBadge';
 import Text from '@components/Text';
 import useConfirmPendingRTERAndProceed from '@hooks/useConfirmPendingRTERAndProceed';
 import useCurrentUserPersonalDetails from '@hooks/useCurrentUserPersonalDetails';
-import {useMemoizedLazyExpensifyIcons} from '@hooks/useLazyAsset';
+import { useMemoizedLazyExpensifyIcons } from '@hooks/useLazyAsset';
 import useLocalize from '@hooks/useLocalize';
 import useNetwork from '@hooks/useNetwork';
 import useOnyx from '@hooks/useOnyx';
@@ -42,13 +42,13 @@ import useStyleUtils from '@hooks/useStyleUtils';
 import useTheme from '@hooks/useTheme';
 import useThemeStyles from '@hooks/useThemeStyles';
 import ControlSelection from '@libs/ControlSelection';
-import {convertToDisplayString} from '@libs/CurrencyUtils';
-import {canUseTouchScreen} from '@libs/DeviceCapabilities';
-import {getTotalAmountForIOUReportPreviewButton} from '@libs/MoneyRequestReportUtils';
+import { convertToDisplayString } from '@libs/CurrencyUtils';
+import { canUseTouchScreen } from '@libs/DeviceCapabilities';
+import { getTotalAmountForIOUReportPreviewButton } from '@libs/MoneyRequestReportUtils';
 import Navigation from '@libs/Navigation/Navigation';
-import {getConnectedIntegration, hasDynamicExternalWorkflow} from '@libs/PolicyUtils';
-import {hasPendingDEWSubmit} from '@libs/ReportActionsUtils';
-import {getInvoicePayerName, getReportName} from '@libs/ReportNameUtils';
+import { getConnectedIntegration, hasDynamicExternalWorkflow } from '@libs/PolicyUtils';
+import { hasPendingDEWSubmit } from '@libs/ReportActionsUtils';
+import { getInvoicePayerName, getReportName } from '@libs/ReportNameUtils';
 import getReportPreviewAction from '@libs/ReportPreviewActionUtils';
 import {
     areAllRequestsBeingSmartScanned as areAllRequestsBeingSmartScannedReportUtils,
@@ -75,25 +75,24 @@ import {
     isTripRoom as isTripRoomReportUtils,
 } from '@libs/ReportUtils';
 import shouldAdjustScroll from '@libs/shouldAdjustScroll';
-import {startSpan} from '@libs/telemetry/activeSpans';
-import type {SkeletonSpanReasonAttributes} from '@libs/telemetry/useSkeletonSpan';
-import {hasAnyPendingRTERViolation as hasAnyPendingRTERViolationTransactionUtils, hasPendingUI, isManagedCardTransaction, isPending} from '@libs/TransactionUtils';
-import {hasPendingUI, isManagedCardTransaction, isPending} from '@libs/TransactionUtils';
-import {transactionHasRBR} from '@libs/TransactionPreviewUtils';
+import { startSpan } from '@libs/telemetry/activeSpans';
+import type { SkeletonSpanReasonAttributes } from '@libs/telemetry/useSkeletonSpan';
+import { hasAnyPendingRTERViolation as hasAnyPendingRTERViolationTransactionUtils, hasPendingUI, isManagedCardTransaction, isPending } from '@libs/TransactionUtils';
+import { transactionHasRBR } from '@libs/TransactionPreviewUtils';
 import colors from '@styles/theme/colors';
 import variables from '@styles/variables';
-import {approveMoneyRequest, canIOUBePaid as canIOUBePaidIOUActions, payInvoice, payMoneyRequest, submitReport} from '@userActions/IOU';
-import {markPendingRTERTransactionsAsCash} from '@userActions/Transaction';
+import { approveMoneyRequest, canIOUBePaid as canIOUBePaidIOUActions, payInvoice, payMoneyRequest, submitReport } from '@userActions/IOU';
+import { markPendingRTERTransactionsAsCash } from '@userActions/Transaction';
 import CONST from '@src/CONST';
-import type {TranslationPaths} from '@src/languages/types';
+import type { TranslationPaths } from '@src/languages/types';
 import ONYXKEYS from '@src/ONYXKEYS';
 import ROUTES from '@src/ROUTES';
-import {validTransactionDraftIDsSelector} from '@src/selectors/TransactionDraft';
-import type {ReportAttributesDerivedValue, Transaction} from '@src/types/onyx';
-import type {PaymentMethodType} from '@src/types/onyx/OriginalMessage';
+import { validTransactionDraftIDsSelector } from '@src/selectors/TransactionDraft';
+import type { ReportAttributesDerivedValue, Transaction } from '@src/types/onyx';
+import type { PaymentMethodType } from '@src/types/onyx/OriginalMessage';
 import AccessMoneyRequestReportPreviewPlaceHolder from './AccessMoneyRequestReportPreviewPlaceHolder';
 import EmptyMoneyRequestReportPreview from './EmptyMoneyRequestReportPreview';
-import type {MoneyRequestReportPreviewContentProps} from './types';
+import type { MoneyRequestReportPreviewContentProps } from './types';
 
 const MAX_PREVIEWS_NUMBER = 10;
 
@@ -113,7 +112,7 @@ function MoneyRequestReportPreviewContent({
     contextMenuAnchor,
     isHovered = false,
     isWhisper = false,
-    checkIfContextMenuActive = () => {},
+    checkIfContextMenuActive = () => { },
     onPaymentOptionsShow,
     onPaymentOptionsHide,
     chatReport,
@@ -167,16 +166,16 @@ function MoneyRequestReportPreviewContent({
     const theme = useTheme();
     const styles = useThemeStyles();
     const StyleUtils = useStyleUtils();
-    const {translate, formatPhoneNumber} = useLocalize();
-    const {isOffline} = useNetwork();
+    const { translate, formatPhoneNumber } = useLocalize();
+    const { isOffline } = useNetwork();
     // eslint-disable-next-line rulesdir/prefer-shouldUseNarrowLayout-instead-of-isSmallScreenWidth
-    const {shouldUseNarrowLayout, isSmallScreenWidth} = useResponsiveLayout();
+    const { shouldUseNarrowLayout, isSmallScreenWidth } = useResponsiveLayout();
     const currentUserDetails = useCurrentUserPersonalDetails();
     const currentUserAccountID = currentUserDetails.accountID;
     const currentUserEmail = currentUserDetails.email ?? '';
     const expensifyIcons = useMemoizedLazyExpensifyIcons(['ArrowRight', 'BackArrow', 'Location', 'ReceiptPlus']);
 
-    const {areAllRequestsBeingSmartScanned, hasNonReimbursableTransactions} = useMemo(
+    const { areAllRequestsBeingSmartScanned, hasNonReimbursableTransactions } = useMemo(
         () => ({
             areAllRequestsBeingSmartScanned: areAllRequestsBeingSmartScannedReportUtils(iouReportID, action),
             hasOnlyTransactionsWithPendingRoutes: hasOnlyTransactionsWithPendingRoutesReportUtils(iouReportID),
@@ -187,7 +186,7 @@ function MoneyRequestReportPreviewContent({
         [transactions, iouReportID, action],
     );
 
-    const {isPaidAnimationRunning, isApprovedAnimationRunning, isSubmittingAnimationRunning, stopAnimation, startAnimation, startApprovedAnimation, startSubmittingAnimation} =
+    const { isPaidAnimationRunning, isApprovedAnimationRunning, isSubmittingAnimationRunning, stopAnimation, startAnimation, startApprovedAnimation, startSubmittingAnimation } =
         usePaymentAnimations();
     const [isHoldMenuVisible, setIsHoldMenuVisible] = useState(false);
     const [requestType, setRequestType] = useState<ActionHandledType>();
@@ -195,19 +194,19 @@ function MoneyRequestReportPreviewContent({
     const isIouReportArchived = useReportIsArchived(iouReportID);
     const isChatReportArchived = useReportIsArchived(chatReport?.reportID);
     const [introSelected] = useOnyx(ONYXKEYS.NVP_INTRO_SELECTED);
-    const {isBetaEnabled} = usePermissions();
+    const { isBetaEnabled } = usePermissions();
     const [transactionViolations] = useOnyx(ONYXKEYS.COLLECTION.TRANSACTION_VIOLATIONS);
     const [bankAccountList] = useOnyx(ONYXKEYS.BANK_ACCOUNT_LIST);
     const isASAPSubmitBetaEnabled = isBetaEnabled(CONST.BETAS.ASAP_SUBMIT);
     const [betas] = useOnyx(ONYXKEYS.BETAS);
-    const [isSelfTourViewed] = useOnyx(ONYXKEYS.NVP_ONBOARDING, {selector: hasSeenTourSelector});
+    const [isSelfTourViewed] = useOnyx(ONYXKEYS.NVP_ONBOARDING, { selector: hasSeenTourSelector });
     const hasViolations = hasViolationsReportUtils(iouReport?.reportID, transactionViolations, currentUserAccountID, currentUserEmail);
     const hasAnyPendingRTERViolation = useMemo(
         () => hasAnyPendingRTERViolationTransactionUtils(transactions, transactionViolations, currentUserEmail, currentUserAccountID, iouReport, policy),
         [transactions, transactionViolations, currentUserEmail, currentUserAccountID, iouReport, policy],
     );
 
-    const [draftTransactionIDs] = useOnyx(ONYXKEYS.COLLECTION.TRANSACTION_DRAFT, {selector: validTransactionDraftIDsSelector});
+    const [draftTransactionIDs] = useOnyx(ONYXKEYS.COLLECTION.TRANSACTION_DRAFT, { selector: validTransactionDraftIDsSelector });
 
     const getCanIOUBePaid = useCallback(
         (shouldShowOnlyPayElsewhere = false) =>
@@ -219,13 +218,13 @@ function MoneyRequestReportPreviewContent({
     const onlyShowPayElsewhere = useMemo(() => !canIOUBePaid && getCanIOUBePaid(true), [canIOUBePaid, getCanIOUBePaid]);
     const shouldShowPayButton = isPaidAnimationRunning || canIOUBePaid || onlyShowPayElsewhere;
 
-    const {nonHeldAmount, fullAmount, hasValidNonHeldAmount} = getNonHeldAndFullAmount(iouReport, shouldShowPayButton);
+    const { nonHeldAmount, fullAmount, hasValidNonHeldAmount } = getNonHeldAndFullAmount(iouReport, shouldShowPayButton);
     const canIOUBePaidAndApproved = useMemo(() => getCanIOUBePaid(false), [getCanIOUBePaid]);
     const connectedIntegration = getConnectedIntegration(policy);
     const hasOnlyHeldExpenses = hasOnlyHeldExpensesReportUtils(iouReport?.reportID);
 
     const managerID = iouReport?.managerID ?? action.childManagerAccountID ?? CONST.DEFAULT_NUMBER_ID;
-    const {totalDisplaySpend} = getMoneyRequestSpendBreakdown(iouReport);
+    const { totalDisplaySpend } = getMoneyRequestSpendBreakdown(iouReport);
 
     const iouSettled = isSettled(iouReportID) || action?.childStatusNum === CONST.REPORT.STATUS_NUM.REIMBURSED;
     const previewMessageOpacity = useSharedValue(1);
@@ -260,8 +259,8 @@ function MoneyRequestReportPreviewContent({
     const isScanning = hasReceipts && areAllRequestsBeingSmartScanned;
     const existingB2BInvoiceReport = useParticipantsInvoiceReport(activePolicyID, CONST.REPORT.INVOICE_RECEIVER_TYPE.BUSINESS, chatReport?.policyID);
 
-    const {isDelegateAccessRestricted} = useDelegateNoAccessState();
-    const {showDelegateNoAccessModal} = useDelegateNoAccessActions();
+    const { isDelegateAccessRestricted } = useDelegateNoAccessState();
+    const { showDelegateNoAccessModal } = useDelegateNoAccessActions();
     const [reportActions] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${iouReportID}`);
 
     const handleMarkPendingRTERTransactionsAsCash = useCallback(() => {
@@ -278,7 +277,7 @@ function MoneyRequestReportPreviewContent({
     );
 
     const confirmPayment = useCallback(
-        ({paymentType: type, payAsBusiness, methodID, paymentMethod}: PaymentActionParams) => {
+        ({ paymentType: type, payAsBusiness, methodID, paymentMethod }: PaymentActionParams) => {
             if (!type) {
                 return;
             }
@@ -386,7 +385,7 @@ function MoneyRequestReportPreviewContent({
 
         let payerOrApproverName;
         if (isPolicyExpenseChat || isTripRoom) {
-            payerOrApproverName = getPolicyName({report: chatReport, policy});
+            payerOrApproverName = getPolicyName({ report: chatReport, policy });
         } else if (isInvoiceRoom) {
             payerOrApproverName = getInvoicePayerName(chatReport, invoiceReceiverPolicy, invoiceReceiverPersonalDetail);
         } else {
@@ -475,8 +474,8 @@ function MoneyRequestReportPreviewContent({
         }
 
         previewMessageOpacity.set(
-            withTiming(0.75, {duration: CONST.ANIMATION_PAID_DURATION / 2}, () => {
-                previewMessageOpacity.set(withTiming(1, {duration: CONST.ANIMATION_PAID_DURATION / 2}));
+            withTiming(0.75, { duration: CONST.ANIMATION_PAID_DURATION / 2 }, () => {
+                previewMessageOpacity.set(withTiming(1, { duration: CONST.ANIMATION_PAID_DURATION / 2 }));
             }),
         );
         // We only want to animate the text when the text changes
@@ -488,7 +487,7 @@ function MoneyRequestReportPreviewContent({
             return;
         }
 
-        checkMarkScale.set(isPaidAnimationRunning ? withDelay(CONST.ANIMATION_PAID_CHECKMARK_DELAY, withSpring(1, {duration: CONST.ANIMATION_PAID_DURATION})) : 1);
+        checkMarkScale.set(isPaidAnimationRunning ? withDelay(CONST.ANIMATION_PAID_CHECKMARK_DELAY, withSpring(1, { duration: CONST.ANIMATION_PAID_DURATION })) : 1);
     }, [isPaidAnimationRunning, iouSettled, checkMarkScale]);
 
     useEffect(() => {
@@ -496,7 +495,7 @@ function MoneyRequestReportPreviewContent({
             return;
         }
 
-        thumbsUpScale.set(isApprovedAnimationRunning ? withDelay(CONST.ANIMATION_THUMBS_UP_DELAY, withSpring(1, {duration: CONST.ANIMATION_THUMBS_UP_DURATION})) : 1);
+        thumbsUpScale.set(isApprovedAnimationRunning ? withDelay(CONST.ANIMATION_THUMBS_UP_DELAY, withSpring(1, { duration: CONST.ANIMATION_THUMBS_UP_DURATION })) : 1);
     }, [isApproved, isApprovedAnimationRunning, thumbsUpScale]);
 
     const carouselTransactions = useMemo(() => {
@@ -553,7 +552,7 @@ function MoneyRequestReportPreviewContent({
         return Math.floor((currentWidth - 2 * styles.pl2.paddingLeft - lastItemWithGap) / itemWithGap) + 1;
     }, [transactions.length, footerWidth, reportPreviewStyles.transactionPreviewCarouselStyle.width, styles.gap2.gap, styles.pl2.paddingLeft, currentWidth]);
     const viewabilityConfig = useMemo(() => {
-        return {itemVisiblePercentThreshold: 100};
+        return { itemVisiblePercentThreshold: 100 };
     }, []);
 
     const carouselTransactionsRef = useRef(carouselTransactions);
@@ -588,7 +587,7 @@ function MoneyRequestReportPreviewContent({
         }, [newTransactionIDs]),
     );
 
-    const onViewableItemsChanged = useRef(({viewableItems}: {viewableItems: ViewToken[]; changed: ViewToken[]}) => {
+    const onViewableItemsChanged = useRef(({ viewableItems }: { viewableItems: ViewToken[]; changed: ViewToken[] }) => {
         const newIndex = viewableItems.at(0)?.index;
         if (typeof newIndex === 'number') {
             setCurrentIndex(newIndex);
@@ -611,12 +610,12 @@ function MoneyRequestReportPreviewContent({
         }
         if (index < 0) {
             setOptimisticIndex(0);
-            carouselRef.current?.scrollToTop({animated: true});
+            carouselRef.current?.scrollToTop({ animated: true });
             return;
         }
         if (index === carouselTransactions.length - visibleItemsOnEndCount) {
             setOptimisticIndex(index);
-            carouselRef.current?.scrollToEnd({animated: true});
+            carouselRef.current?.scrollToEnd({ animated: true });
             return;
         }
         setOptimisticIndex(index);
@@ -633,7 +632,7 @@ function MoneyRequestReportPreviewContent({
                     style={[styles.p5, styles.justifyContentCenter]}
                     onLayout={(e) => setFooterWidth(e.nativeEvent.layout.width)}
                 >
-                    <Text style={{color: colors.blue600}}>
+                    <Text style={{ color: colors.blue600 }}>
                         +{transactions.length - MAX_PREVIEWS_NUMBER} {translate('common.more').toLowerCase()}
                     </Text>
                 </View>
@@ -645,7 +644,7 @@ function MoneyRequestReportPreviewContent({
     // The button should expand up to transaction width
     const buttonMaxWidth =
         !shouldUseNarrowLayout && reportPreviewStyles.transactionPreviewCarouselStyle.width >= CONST.REPORT.TRANSACTION_PREVIEW.CAROUSEL.MIN_WIDE_WIDTH
-            ? {maxWidth: reportPreviewStyles.transactionPreviewCarouselStyle.width}
+            ? { maxWidth: reportPreviewStyles.transactionPreviewCarouselStyle.width }
             : {};
 
     useEffect(() => {
@@ -848,7 +847,7 @@ function MoneyRequestReportPreviewContent({
 
     const addExpenseAction = (
         <ButtonWithDropdownMenu
-            onPress={() => {}}
+            onPress={() => { }}
             shouldAlwaysShowDropdownMenu
             customText={translate('iou.addExpense')}
             options={addExpenseDropdownOptions}
@@ -986,7 +985,7 @@ function MoneyRequestReportPreviewContent({
                                                         accessibilityRole="button"
                                                         accessible
                                                         accessibilityLabel={translate('common.previous')}
-                                                        style={[styles.reportPreviewArrowButton, {backgroundColor: theme.buttonDefaultBG}]}
+                                                        style={[styles.reportPreviewArrowButton, { backgroundColor: theme.buttonDefaultBG }]}
                                                         onPress={() => handleChange(currentIndex - 1)}
                                                         disabled={optimisticIndex !== undefined ? optimisticIndex === 0 : currentIndex === 0 && currentVisibleItems.at(0) === 0}
                                                         disabledStyle={[styles.cursorDefault, styles.buttonOpacityDisabled]}
@@ -1003,7 +1002,7 @@ function MoneyRequestReportPreviewContent({
                                                         accessibilityRole="button"
                                                         accessible
                                                         accessibilityLabel={translate('common.next')}
-                                                        style={[styles.reportPreviewArrowButton, {backgroundColor: theme.buttonDefaultBG}]}
+                                                        style={[styles.reportPreviewArrowButton, { backgroundColor: theme.buttonDefaultBG }]}
                                                         onPress={() => handleChange(currentIndex + 1)}
                                                         disabled={
                                                             optimisticIndex
@@ -1075,7 +1074,7 @@ function MoneyRequestReportPreviewContent({
                                     <View style={[styles.expenseAndReportPreviewTextContainer]}>
                                         <View style={[totalAmountStyle, styles.justifyContentBetween, styles.gap4, StyleUtils.getMinimumHeight(variables.h28)]}>
                                             {/* height is needed to avoid flickering on animation */}
-                                            <View style={[buttonMaxWidth, styles.flex1, {height: variables.h40}]}>{reportPreviewActionView}</View>
+                                            <View style={[buttonMaxWidth, styles.flex1, { height: variables.h40 }]}>{reportPreviewActionView}</View>
                                             {transactions.length > 1 && !shouldShowAccessPlaceHolder && (
                                                 <View style={[styles.flexRow, shouldUseNarrowLayout ? styles.justifyContentBetween : styles.gap2, styles.alignItemsCenter]}>
                                                     <Text

--- a/src/libs/TransactionPreviewUtils.ts
+++ b/src/libs/TransactionPreviewUtils.ts
@@ -451,6 +451,42 @@ function createTransactionPreviewConditionals({
     };
 }
 
+/**
+ * Lightweight check for whether a transaction has any RBR (Red Brick Road) indicator.
+ * Evaluates transaction-level signals only (violations, hold, missing fields, receipt errors)
+ * without requiring heavy report/policy context.
+ */
+function transactionHasRBR(transaction: OnyxEntry<OnyxTypes.Transaction>, violations: OnyxTypes.TransactionViolations): boolean {
+    if (!transaction) {
+        return false;
+    }
+
+    // Check for violation-type or warning-type violations
+    const hasViolationOrWarning = violations?.some(
+        (v) => v.type === CONST.VIOLATION_TYPES.VIOLATION || v.type === CONST.VIOLATION_TYPES.WARNING,
+    );
+    if (hasViolationOrWarning) {
+        return true;
+    }
+
+    // Check if transaction is on hold
+    if (isOnHold(transaction)) {
+        return true;
+    }
+
+    // Check if transaction has missing required fields (missing merchant/amount)
+    if (isMerchantMissing(transaction) || isAmountMissing(transaction)) {
+        return true;
+    }
+
+    // Check if transaction has receipt error
+    if (hasReceiptError(transaction)) {
+        return true;
+    }
+
+    return false;
+}
+
 export {
     getReviewNavigationRoute,
     getIOUPayerAndReceiver,
@@ -459,5 +495,6 @@ export {
     getViolationTranslatePath,
     getUniqueActionErrorsForTransaction,
     formatLastFourPAN,
+    transactionHasRBR,
 };
 export type {TranslationPathOrText};

--- a/tests/unit/TransactionPreviewUtils.test.ts
+++ b/tests/unit/TransactionPreviewUtils.test.ts
@@ -7,6 +7,7 @@ import {
     getTransactionPreviewTextAndTranslationPaths,
     getUniqueActionErrorsForTransaction,
     getViolationTranslatePath,
+    transactionHasRBR,
 } from '@libs/TransactionPreviewUtils';
 import {buildOptimisticTransaction} from '@libs/TransactionUtils';
 import CONST from '@src/CONST';
@@ -837,6 +838,61 @@ describe('TransactionPreviewUtils', () => {
             } as unknown as ReportActions;
 
             expect(getUniqueActionErrorsForTransaction(actions, undefined)).toEqual(['Error B', 'Error D']);
+        });
+    describe('transactionHasRBR', () => {
+        it('should return false for a clean transaction with no violations', () => {
+            expect(transactionHasRBR(basicProps.transaction, [])).toBe(false);
+        });
+
+        it('should return true for a transaction with violation-type violations', () => {
+            const violations = [
+                {name: CONST.VIOLATIONS.MISSING_CATEGORY, type: CONST.VIOLATION_TYPES.VIOLATION, showInReview: true},
+            ];
+            expect(transactionHasRBR(basicProps.transaction, violations)).toBe(true);
+        });
+
+        it('should return true for a transaction with warning-type violations', () => {
+            const violations = [
+                {name: CONST.VIOLATIONS.CUSTOM_RULES, type: CONST.VIOLATION_TYPES.WARNING, showInReview: true},
+            ];
+            expect(transactionHasRBR(basicProps.transaction, violations)).toBe(true);
+        });
+
+        it('should return true for a transaction on hold', () => {
+            const heldTransaction = {...basicProps.transaction, comment: {hold: 'true'}};
+            expect(transactionHasRBR(heldTransaction, [])).toBe(true);
+        });
+
+        it('should return true for a transaction with missing merchant', () => {
+            const transactionMissingMerchant = {...basicProps.transaction, merchant: '', modifiedMerchant: '', created: '2024-01-01'};
+            expect(transactionHasRBR(transactionMissingMerchant, [])).toBe(true);
+        });
+
+        it('should return true for a transaction with receipt error', () => {
+            const transactionWithReceiptError = {
+                ...basicProps.transaction,
+                errors: {
+                    error1: {
+                        error: CONST.IOU.RECEIPT_ERROR,
+                        source: 'source.com',
+                        filename: 'file_name.png',
+                        action: 'replaceReceipt',
+                        retryParams: {transactionID: basicProps.transaction.transactionID, source: 'source.com', transactionPolicy: undefined},
+                    },
+                },
+            };
+            expect(transactionHasRBR(transactionWithReceiptError, [])).toBe(true);
+        });
+
+        it('should return false for undefined transaction', () => {
+            expect(transactionHasRBR(undefined, [])).toBe(false);
+        });
+
+        it('should return false for notice-type violations only', () => {
+            const violations = [
+                {name: CONST.VIOLATIONS.CUSTOM_RULES, type: CONST.VIOLATION_TYPES.NOTICE, showInReview: true},
+            ];
+            expect(transactionHasRBR(basicProps.transaction, violations)).toBe(false);
         });
     });
 });

--- a/tests/unit/TransactionPreviewUtils.test.ts
+++ b/tests/unit/TransactionPreviewUtils.test.ts
@@ -28,6 +28,7 @@ const basicProps = {
             comment: '',
             attendees: [],
             created: '2024-01-01',
+            merchant: 'Test Merchant',
         },
     }),
     translate: jest.fn().mockImplementation((key: string) => key),
@@ -114,7 +115,7 @@ describe('TransactionPreviewUtils', () => {
         it('returns missing field message when appropriate', () => {
             const functionArgs = {
                 ...basicProps,
-                transaction: {...basicProps.transaction, created: '', amount: 100},
+                transaction: {...basicProps.transaction, created: '', amount: 100, merchant: ''},
                 originalTransaction: undefined,
                 shouldShowRBR: true,
             };
@@ -839,6 +840,8 @@ describe('TransactionPreviewUtils', () => {
 
             expect(getUniqueActionErrorsForTransaction(actions, undefined)).toEqual(['Error B', 'Error D']);
         });
+    });
+
     describe('transactionHasRBR', () => {
         it('should return false for a clean transaction with no violations', () => {
             expect(transactionHasRBR(basicProps.transaction, [])).toBe(false);


### PR DESCRIPTION
### Details
This PR introduces RBR-aware sorting for expense report previews to ensure actionable transactions (violations, holds, missing fields, receipt errors) are surfaced first.

Previously, transactions were displayed in backend insertion order, which could cause RBR-flagged expenses to be buried beyond the first 11 items in the carousel, making them easy to miss.

---

### Fixed Issues
$ #85553

---

### Solution
- Added a reusable helper `transactionHasRBR` in `TransactionPreviewUtils` to determine if a transaction requires user action.
- Updated **MoneyRequestReportPreviewContent**:
  - Transactions are now sorted by RBR status before applying `slice(0, 11)` for the carousel.
- Updated **MoneyRequestReportTransactionList**:
  - RBR-prioritized sorting is applied only under the default sort (Date/ASC).
  - User-selected sorting (e.g., Merchant, Amount) remains unaffected.
- Reused existing logic for:
  - Violations
  - Receipt errors
  - Hold status
  - Missing required fields

---

### Tests
1. Open a report with multiple expenses
2. Ensure at least one expense has an RBR condition:
   - violation / hold / missing field / receipt error
3. Verify in the **carousel**:
   - RBR transaction appears first
4. Verify in the **transaction list**:
   - Default sort → RBR transactions appear first
   - Change sort (e.g., Merchant) → order follows selected sort

---

### Verified
- [x] Reproduced original issue
- [x] RBR transactions now appear first in carousel
- [x] Transaction list applies conditional RBR sorting correctly
- [x] User-selected sorting is preserved
- [x] No regressions observed

---

### Screenshots / Video
1. RBR item buried in carousel (before)
<img width="1920" height="1200" alt="image" src="https://github.com/user-attachments/assets/9d2b4ee0-3bc2-4982-8ef9-cf38cc7ec457" />

2. RBR item appearing first (after)
<img width="1920" height="1200" alt="image" src="https://github.com/user-attachments/assets/113cff4a-3b54-40d2-a4b4-b0c160988bd8" />

-->

---

### QA Steps
1. Navigate to a report with multiple expenses
2. Ensure at least one transaction has an RBR condition:
   - Add a violation, remove receipt, or trigger hold
4. Open the report preview
5. Confirm:
   - RBR transaction appears first in the carousel
6. Open full transaction list:
   - Default sort → RBR prioritized
   - Change sort → RBR prioritization is disabled

---

### PR Author Checklist
- [x] Followed existing codebase patterns
- [x] Kept changes minimal and scoped
- [x] Reused existing utilities where possible
- [x] Added unit tests for new helper logic
- [x] Self-reviewed code
