### PR TITLE
fix: Workspace-RHP does not close after importing members

### DIFF
--- a/src/components/ImportSpreadsheetConfirmModal.tsx
+++ b/src/components/ImportSpreadsheetConfirmModal.tsx
@@ -39,9 +39,10 @@ function ImportSpreadsheetConfirmModal({isVisible, closeImportPageAndModal, onMo
             confirmText: translate('common.buttonConfirm'),
             shouldShowCancelButton: false,
             shouldHandleNavigationBack,
-            onModalHide,
-        }).then(() => {
-            closeImportPageAndModal();
+            onModalHide: () => {
+                closeImportPageAndModal();
+                onModalHide?.();
+            },
         });
     }, [isVisible, titleText, promptText, closeImportPageAndModal, onModalHide, shouldHandleNavigationBack, showConfirmModal, translate, spreadsheet?.importFinalModal]);
 


### PR DESCRIPTION
## Problem
In the spreadsheet import flow, after the user clicks 'Got it' (Confirm) on the final success/failure modal, the modal closes but the underlying import spreadsheet page remains visible.

## Cause
The ImportSpreadsheetConfirmModal was using the .then() handler of showConfirmModal to trigger closeImportPageAndModal(). However, the global modal system used by showConfirmModal resolves the promise immediately when the confirm button is clicked, but the actual modal closing and navigation logic depend on onModalHide. By the time closeImportPageAndModal (which sets isClosing to true) was called, the page might have already attempted to navigate back without the proper cleanup flag.

## Solution
Move the call to closeImportPageAndModal() into the onModalHide callback. This ensures that the import page state is correctly updated to 'closing' exactly when the modal is being hidden, allowing the useCloseImportPage hook to trigger closeImportPage() action during unmount.

## Tests
- Verified that onModalHide is now correctly invoked with the cleanup logic.
- This affects all spreadsheet import flows (Members, Categories, Tags, Per Diem) as they all share this component.

$ https://github.com/Expensify/App/issues/79631