### PR TITLE
fix: Composer - @here suggestion list menu reappears when pressing enter

### DIFF
--- a/src/pages/inbox/report/ReportActionCompose/SuggestionMention.tsx
+++ b/src/pages/inbox/report/ReportActionCompose/SuggestionMention.tsx
@@ -245,6 +245,9 @@ function SuggestionMention({
             const trimmedCommentAfterMention = trimLeadingSpace(commentAfterMention);
             const spacer = !trimmedCommentAfterMention || !CONST.REGEX.STARTS_WITH_PUNCTUATION.test(trimmedCommentAfterMention) ? ' ' : '';
 
+            // We block suggestions from showing up for a moment to prevent the menu from reappearing
+            // immediately after selecting a suggestion due to the comment update triggering the suggestion logic.
+            shouldBlockCalc.current = true;
             updateComment(`${commentBeforeAtSign}${mentionCode}${dotToAppend}${spacer}${trimmedCommentAfterMention}`, true);
             const selectionPosition = suggestionValues.atSignIndex + mentionCode.length + dotToAppend.length + spacer.length;
             setSelection({


### PR DESCRIPTION
## Problem
In the Composer, when a user selects a mention suggestion (like `@here`) by pressing Enter or clicking, the suggestion menu sometimes reappears immediately after the mention is inserted.

## Cause
When a suggestion is selected, `insertSelectedMention` updates the composer comment. This update triggers `calculateMentionSuggestion` via `useEffect`. In some cases (especially with `@here` which matches many prefixes), the logic might still think the cursor is in a position that requires a suggestion menu, causing it to "flicker" back into view after being explicitly closed during the selection process.

## Solution
Use the existing `shouldBlockCalc` ref to explicitly block suggestion calculation immediately before triggering the comment update in `insertSelectedMention`. This ensures that the state update caused by the insertion doesn't unintentionally re-trigger the suggestion menu. The ref is already automatically reset to `false` in the next `calculateMentionSuggestion` call.

## Tests
1. Open any chat.
2. Type `@here`.
3. Press Enter to select the suggestion.
4. Verify the suggestion menu closes and stays closed.
5. Verify no other mention functionality is regressed.

$ https://github.com/Expensify/App/issues/83530
