### PR TITLE
fix: apply finallyData in SequentialQueue on max-retry failure

### DIFF
--- a/src/libs/Network/SequentialQueue.ts
+++ b/src/libs/Network/SequentialQueue.ts
@@ -249,7 +249,7 @@ function process(): Promise<void> {
                         command: requestToProcess.command,
                         errorMessage: error.message,
                     });
-                    Onyx.update(requestToProcess.failureData ?? []);
+                    Onyx.update([...(requestToProcess.failureData ?? []), ...(requestToProcess.finallyData ?? [])]);
                     endPersistedRequestAndRemoveFromQueue(requestToProcess);
                     sequentialQueueRequestThrottle.clear();
                     if (requestToProcess.command === WRITE_COMMANDS.OPEN_APP) {


### PR DESCRIPTION
## Problem
While the original issue reported (page stuck on logo) may have been mitigated by recent reverts, a significant infrastructure bug was identified in `SequentialQueue.ts`. When an API request exhausts its maximum retry attempts, the `finallyData` is silently dropped, and only `failureData` is applied. 

This violates the contract of `finallyData` (which should always run) and can lead to permanent UI hang states for any action that relies on `finallyData` for state cleanup (like dismissing splash screens or resetting loading indicators).

## Cause
In `SequentialQueue.ts`, the `.catch()` block for max-retry failures only called `Onyx.update(requestToProcess.failureData ?? [])`.

## Solution
Update the max-retry failure handler in `SequentialQueue.ts` to apply both `failureData` and `finallyData`, matching the pattern used in the `shouldFailAllRequests` branch.

## Tests
1. Trigger a network request that includes `finallyData`.
2. Simulate a permanent network failure that exhausts all retries.
3. Verify that the state changes specified in `finallyData` are correctly applied to Onyx.

$ https://github.com/Expensify/App/issues/85763
