### PR TITLE
Composer: close suggestions on Enter to prevent reopening (fix #83530)

### DIFF
--- a/patches/issue-713.md
+++ b/patches/issue-713.md
@@ -1,0 +1,1 @@
+force update

--- a/src/pages/inbox/report/ReportActionCompose/ComposerWithSuggestions/ComposerWithSuggestions.tsx
+++ b/src/pages/inbox/report/ReportActionCompose/ComposerWithSuggestions/ComposerWithSuggestions.tsx
@@ -531,6 +531,14 @@ function ComposerWithSuggestions({
             // Submit the form when Enter is pressed
             if (webEvent.key === CONST.KEYBOARD_SHORTCUTS.ENTER.shortcutKey && !webEvent.shiftKey) {
                 webEvent.preventDefault();
+                // If a suggestion element wants to handle the Enter (selecting an item), allow it to do so.
+                const handled = suggestionsRef.current?.triggerHotkeyActions?.(webEvent);
+                if (handled) {
+                    return;
+                }
+                // Otherwise close/reset suggestions before submitting to avoid reopening.
+                suggestionsRef.current?.updateShouldShowSuggestionMenuToFalse?.();
+                suggestionsRef.current?.resetSuggestions?.();
                 onEnterKeyPress();
             }
 


### PR DESCRIPTION
This PR fixes an issue where composer suggestions would reopen after pressing Enter.

Change:
- Prevent reopening suggestions after Enter key submission

This ensures expected behavior when sending messages.