### PR TITLE
decompose ReportScreen 6: extract guards and handlers

### DIFF
--- a/src/pages/inbox/LinkedActionNotFoundGuard.tsx
+++ b/src/pages/inbox/LinkedActionNotFoundGuard.tsx
@@ -60,15 +60,10 @@ function LinkedActionNotFoundGate({reportActionIDFromRoute, children}: LinkedAct
 
     // --- Linked action status ---
     const actionReportID = linkedAction?.reportID ?? reportID;
-    const isLinkedActionDeleted = (() => {
-        if (!linkedAction) {
-            return false;
-        }
-        if (!actionReportID) {
-            return true;
-        }
-        return !isReportActionVisible(linkedAction, actionReportID, canUserPerformWriteAction(report, isReportArchived), visibleReportActionsData);
-    })();
+    const hasNoActionReportID = !!linkedAction && !actionReportID;
+    const isActionHidden =
+        !!linkedAction && !!actionReportID && !isReportActionVisible(linkedAction, actionReportID, canUserPerformWriteAction(report, isReportArchived), visibleReportActionsData);
+    const isLinkedActionDeleted = hasNoActionReportID || isActionHidden;
 
     const prevIsLinkedActionDeleted = usePrevious(linkedAction ? isLinkedActionDeleted : undefined);
     const lastReportActionIDFromRoute = usePrevious(!firstRender ? reportActionIDFromRoute : undefined);

--- a/src/pages/inbox/LinkedActionNotFoundGuard.tsx
+++ b/src/pages/inbox/LinkedActionNotFoundGuard.tsx
@@ -1,0 +1,159 @@
+import {useRoute} from '@react-navigation/native';
+import type {ReactNode} from 'react';
+import React, {useEffect, useState} from 'react';
+import {InteractionManager} from 'react-native';
+import FullPageNotFoundView from '@components/BlockingViews/FullPageNotFoundView';
+import useCurrentUserPersonalDetails from '@hooks/useCurrentUserPersonalDetails';
+import useOnyx from '@hooks/useOnyx';
+import usePaginatedReportActions from '@hooks/usePaginatedReportActions';
+import usePrevious from '@hooks/usePrevious';
+import useReportIsArchived from '@hooks/useReportIsArchived';
+import getNonEmptyStringOnyxID from '@libs/getNonEmptyStringOnyxID';
+import Navigation from '@libs/Navigation/Navigation';
+import {getFilteredReportActionsForReportView, isReportActionVisible, isWhisperAction} from '@libs/ReportActionsUtils';
+import {canUserPerformWriteAction} from '@libs/ReportUtils';
+import ONYXKEYS from '@src/ONYXKEYS';
+
+type LinkedActionNotFoundGuardProps = {
+    children: ReactNode;
+};
+
+// eslint-disable-next-line rulesdir/no-negated-variables
+function LinkedActionNotFoundGuard({children}: LinkedActionNotFoundGuardProps) {
+    const route = useRoute();
+    const routeParams = route.params as {reportActionID?: string} | undefined;
+    const reportActionIDFromRoute = routeParams?.reportActionID;
+
+    if (!reportActionIDFromRoute) {
+        return children;
+    }
+
+    return <LinkedActionNotFoundGate reportActionIDFromRoute={reportActionIDFromRoute}>{children}</LinkedActionNotFoundGate>;
+}
+
+type LinkedActionNotFoundGateProps = {
+    reportActionIDFromRoute: string;
+    children: ReactNode;
+};
+
+// eslint-disable-next-line rulesdir/no-negated-variables
+function LinkedActionNotFoundGate({reportActionIDFromRoute, children}: LinkedActionNotFoundGateProps) {
+    const route = useRoute();
+    const routeParams = route.params as {reportID?: string; reportActionID?: string} | undefined;
+    const reportIDFromRoute = getNonEmptyStringOnyxID(routeParams?.reportID);
+
+    const {accountID: currentUserAccountID} = useCurrentUserPersonalDetails();
+
+    const [isLinkingToMessage, setIsLinkingToMessage] = useState(!!reportActionIDFromRoute);
+    const [isNavigatingToDeletedAction, setIsNavigatingToDeletedAction] = useState(false);
+    const [firstRender, setFirstRender] = useState(true);
+
+    const [report] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT}${reportIDFromRoute}`);
+    const [reportMetadata] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT_METADATA}${reportIDFromRoute}`);
+    const [visibleReportActionsData] = useOnyx(ONYXKEYS.DERIVED.VISIBLE_REPORT_ACTIONS);
+
+    const reportID = report?.reportID;
+    const isReportArchived = useReportIsArchived(report?.reportID);
+
+    const {reportActions: unfilteredReportActions, linkedAction, sortedAllReportActions} = usePaginatedReportActions(reportID, reportActionIDFromRoute);
+    const reportActions = getFilteredReportActionsForReportView(unfilteredReportActions);
+
+    // --- Linked action status ---
+    const actionReportID = linkedAction?.reportID ?? reportID;
+    const isLinkedActionDeleted = (() => {
+        if (!linkedAction) {
+            return false;
+        }
+        if (!actionReportID) {
+            return true;
+        }
+        return !isReportActionVisible(linkedAction, actionReportID, canUserPerformWriteAction(report, isReportArchived), visibleReportActionsData);
+    })();
+
+    const prevIsLinkedActionDeleted = usePrevious(linkedAction ? isLinkedActionDeleted : undefined);
+    const lastReportActionIDFromRoute = usePrevious(!firstRender ? reportActionIDFromRoute : undefined);
+
+    const isLinkedActionInaccessibleWhisper = !!linkedAction && isWhisperAction(linkedAction) && !(linkedAction?.whisperedToAccountIDs ?? []).includes(currentUserAccountID);
+
+    // eslint-disable-next-line rulesdir/no-negated-variables
+    const shouldShowNotFoundLinkedAction =
+        (!isLinkedActionInaccessibleWhisper && isLinkedActionDeleted && isNavigatingToDeletedAction) ||
+        (!reportMetadata?.isLoadingInitialReportActions &&
+            !!reportActionIDFromRoute &&
+            !!sortedAllReportActions &&
+            sortedAllReportActions?.length > 0 &&
+            reportActions.length === 0 &&
+            !isLinkingToMessage);
+
+    // Track firstRender
+    useEffect(() => {
+        // eslint-disable-next-line react-hooks/set-state-in-effect
+        setFirstRender(false);
+    }, []);
+
+    // Reset isLinkingToMessage
+    useEffect(() => {
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
+        InteractionManager.runAfterInteractions(() => {
+            setIsLinkingToMessage(false);
+        });
+    }, [reportMetadata?.isLoadingInitialReportActions]);
+
+    // Handle deleted linked action
+    useEffect(() => {
+        if (!isLinkedActionDeleted) {
+            // eslint-disable-next-line react-hooks/set-state-in-effect
+            setIsNavigatingToDeletedAction(false);
+            return;
+        }
+        if (lastReportActionIDFromRoute !== reportActionIDFromRoute) {
+            // eslint-disable-next-line react-hooks/set-state-in-effect
+            setIsNavigatingToDeletedAction(true);
+            return;
+        }
+        if (!isNavigatingToDeletedAction && prevIsLinkedActionDeleted === false) {
+            Navigation.setParams({reportActionID: ''});
+        }
+    }, [isLinkedActionDeleted, prevIsLinkedActionDeleted, lastReportActionIDFromRoute, reportActionIDFromRoute, isNavigatingToDeletedAction]);
+
+    // Handle inaccessible whisper
+    useEffect(() => {
+        if (!isLinkedActionInaccessibleWhisper) {
+            return;
+        }
+        Navigation.isNavigationReady().then(() => {
+            Navigation.setParams({reportActionID: ''});
+        });
+    }, [isLinkedActionInaccessibleWhisper]);
+
+    const navigateToEndOfReport = () => {
+        Navigation.setParams({reportActionID: ''});
+    };
+
+    const lastRoute = usePrevious(route);
+
+    // Render-time guard: prevent flash while linking state syncs
+    if ((lastRoute !== route || lastReportActionIDFromRoute !== reportActionIDFromRoute) && isLinkingToMessage !== !!reportActionIDFromRoute) {
+        setIsLinkingToMessage(!!reportActionIDFromRoute);
+        return null;
+    }
+
+    return (
+        <FullPageNotFoundView
+            shouldShow={shouldShowNotFoundLinkedAction}
+            subtitleKey="notFound.commentYouLookingForCannotBeFound"
+            onBackButtonPress={navigateToEndOfReport}
+            shouldShowLink
+            linkTranslationKey="notFound.goToChatInstead"
+            subtitleKeyBelowLink="notFound.contactConcierge"
+            onLinkPress={navigateToEndOfReport}
+            shouldDisplaySearchRouter
+        >
+            {children}
+        </FullPageNotFoundView>
+    );
+}
+
+LinkedActionNotFoundGuard.displayName = 'LinkedActionNotFoundGuard';
+
+export default LinkedActionNotFoundGuard;

--- a/src/pages/inbox/ReportFetchController.tsx
+++ b/src/pages/inbox/ReportFetchController.tsx
@@ -47,7 +47,7 @@ const defaultReportMetadata = {
 };
 
 /**
- * Renderless component. Owns all fetch/open-report logic, transaction thread creation,
+ * Component that does not render anything. Owns all fetch/open-report logic, transaction thread creation,
  * leaving events subscriptions, and related effects that were previously in ReportScreen.
  *
  * Self-subscribes to route params via useRoute().

--- a/src/pages/inbox/ReportFetchController.tsx
+++ b/src/pages/inbox/ReportFetchController.tsx
@@ -1,5 +1,5 @@
 import {useIsFocused, useRoute} from '@react-navigation/native';
-import {useCallback, useEffect, useRef} from 'react';
+import {useEffect, useEffectEvent, useRef} from 'react';
 import {InteractionManager} from 'react-native';
 import useCurrentUserPersonalDetails from '@hooks/useCurrentUserPersonalDetails';
 import useIsAnonymousUser from '@hooks/useIsAnonymousUser';
@@ -106,8 +106,8 @@ function ReportFetchController() {
     const isInviteOnboardingComplete = introSelected?.isInviteOnboardingComplete ?? false;
     const isOnboardingCompleted = onboarding?.hasCompletedGuidedSetupFlow ?? false;
 
-    // #1 — fetchReport
-    const fetchReport = useCallback(() => {
+    // #1 — Fetch report
+    const fetchReport = useEffectEvent(() => {
         if (reportMetadata.isOptimisticReport && report?.type === CONST.REPORT.TYPE.CHAT && !isPolicyExpenseChat(report)) {
             return;
         }
@@ -131,26 +131,7 @@ function ReportFetchController() {
         }
 
         openReport({reportID: reportIDFromRoute, introSelected, reportActionID: reportActionIDFromRoute, betas});
-    }, [
-        reportMetadata.isOptimisticReport,
-        report,
-        isOffline,
-        isLoadingApp,
-        introSelected,
-        isOnboardingCompleted,
-        isInviteOnboardingComplete,
-        reportIDFromRoute,
-        reportActionIDFromRoute,
-        betas,
-    ]);
-
-    // #3 — createOneTransactionThreadReport
-    const createOneTransactionThreadReport = () => {
-        const currentReportTransaction = getReportTransactions(reportID).filter((transaction) => transaction.pendingAction !== CONST.RED_BRICK_ROAD_PENDING_ACTION.DELETE);
-        const oneTransactionID = currentReportTransaction.at(0)?.transactionID;
-        const iouAction = getIOUActionForReportID(reportID, oneTransactionID);
-        createTransactionThreadReport(introSelected, currentUserEmail ?? '', currentUserAccountID, betas, report, iouAction, currentReportTransaction.at(0));
-    };
+    });
 
     // #2 — isAnonymousUser tracking
     useEffect(() => {
@@ -160,14 +141,20 @@ function ReportFetchController() {
         prevIsAnonymousUser.current = true;
     }, [isAnonymousUser]);
 
-    // #3 — create transaction thread when transactionThreadReportID === CONST.FAKE_REPORT_ID
+    // #3 — create transaction thread (useEffectEvent reads latest values without triggering the effect)
+    const createOneTransactionThread = useEffectEvent(() => {
+        const currentReportTransaction = getReportTransactions(reportID).filter((transaction) => transaction.pendingAction !== CONST.RED_BRICK_ROAD_PENDING_ACTION.DELETE);
+        const oneTransactionID = currentReportTransaction.at(0)?.transactionID;
+        const iouAction = getIOUActionForReportID(reportID, oneTransactionID);
+        createTransactionThreadReport(introSelected, currentUserEmail ?? '', currentUserAccountID, betas, report, iouAction, currentReportTransaction.at(0));
+    });
+
     useEffect(() => {
         if (transactionThreadReportID !== CONST.FAKE_REPORT_ID || transactionThreadReport?.reportID || (!reportMetadata.hasOnceLoadedReportActions && !reportMetadata?.isOptimisticReport)) {
             return;
         }
 
-        createOneTransactionThreadReport();
-        // eslint-disable-next-line react-hooks/exhaustive-deps -- we don't want to run this useEffect when createOneTransactionThreadReport changes
+        createOneTransactionThread();
     }, [reportMetadata.hasOnceLoadedReportActions, reportMetadata?.isOptimisticReport, transactionThreadReport?.reportID, transactionThreadReportID]);
 
     // #4 — Re-fetch after anonymous-to-signed-in
@@ -178,7 +165,7 @@ function ReportFetchController() {
         // Re-fetch public report data after user signs in and OpenApp API is called to
         // avoid reportActions data being empty for public rooms.
         fetchReport();
-    }, [isLoadingReportData, prevIsLoadingReportData, prevIsAnonymousUser, isAnonymousUser, fetchReport]);
+    }, [isLoadingReportData, prevIsLoadingReportData, prevIsAnonymousUser, isAnonymousUser]);
 
     // #5 — Re-fetch after transaction thread created
     useEffect(() => {
@@ -195,7 +182,7 @@ function ReportFetchController() {
         }
 
         fetchReport();
-    }, [fetchReport, prevTransactionThreadReportID, transactionThreadReportID]);
+    }, [prevTransactionThreadReportID, transactionThreadReportID]);
 
     // #6 — updateLastVisitTime
     useEffect(() => {
@@ -206,6 +193,13 @@ function ReportFetchController() {
     }, [reportID, isFocused, isInSidePanel]);
 
     // #7 — Compose input init + leaving events cleanup
+    const onUnmount = useEffectEvent(() => {
+        if (!didSubscribeToReportLeavingEvents.current) {
+            return;
+        }
+        unsubscribeFromLeavingRoomReportChannel(reportID);
+    });
+
     useEffect(() => {
         // eslint-disable-next-line @typescript-eslint/no-deprecated
         const interactionTask = InteractionManager.runAfterInteractions(() => {
@@ -213,15 +207,8 @@ function ReportFetchController() {
         });
         return () => {
             interactionTask.cancel();
-            if (!didSubscribeToReportLeavingEvents.current) {
-                return;
-            }
-
-            unsubscribeFromLeavingRoomReportChannel(reportID);
+            onUnmount();
         };
-
-        // I'm disabling the warning, as it expects to use exhaustive deps, even though we want this useEffect to run only on the first render.
-        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
 
     // #8 — fetchReport on navigation/linking
@@ -230,7 +217,6 @@ function ReportFetchController() {
         // For each link click, we retrieve the report data again, even though it may already be cached.
         // There should be only one openReport execution per page start or navigating
         fetchReport();
-        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [route, isLinkedMessagePageReady, reportActionIDFromRoute]);
 
     // #9 — Re-fetch when invited to room
@@ -242,20 +228,23 @@ function ReportFetchController() {
             return;
         }
         fetchReport();
-    }, [prevReportActions.length, reportActions, fetchReport]);
+    }, [prevReportActions.length, reportActions]);
 
     // #10 — Thread rejoin on re-focus
     // If a user has chosen to leave a thread, and then returns to it (e.g. with the back button), we need to call `openReport` again in order to allow the user to rejoin and to receive real-time updates
-    useEffect(() => {
-        if (!shouldUseNarrowLayout || !isFocused || prevIsFocused || !isChatThread(report) || !isHiddenForCurrentUser(report) || isTransactionThreadView) {
+    const rejoinThread = useEffectEvent(() => {
+        if (!shouldUseNarrowLayout || !isChatThread(report) || !isHiddenForCurrentUser(report) || isTransactionThreadView) {
             return;
         }
         openReport({reportID, introSelected, betas});
+    });
 
-        // We don't want to run this useEffect every time `report` is changed
-        // Excluding shouldUseNarrowLayout from the dependency list to prevent re-triggering on screen resize events.
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [prevIsFocused, report?.participants, isFocused, isTransactionThreadView, reportID, introSelected, betas]);
+    useEffect(() => {
+        if (!isFocused || prevIsFocused) {
+            return;
+        }
+        rejoinThread();
+    }, [isFocused, prevIsFocused]);
 
     // #11 — Subscribe to leaving events
     useEffect(() => {
@@ -333,6 +322,7 @@ function ReportFetchController() {
         introSelected,
         currentUserEmail,
         currentUserAccountID,
+        betas,
         report,
         visibleTransactions,
         transactionThreadReport,

--- a/src/pages/inbox/ReportFetchController.tsx
+++ b/src/pages/inbox/ReportFetchController.tsx
@@ -1,0 +1,374 @@
+import {useIsFocused, useRoute} from '@react-navigation/native';
+import {useCallback, useEffect, useMemo, useRef} from 'react';
+import {InteractionManager} from 'react-native';
+import useCurrentUserPersonalDetails from '@hooks/useCurrentUserPersonalDetails';
+import useIsAnonymousUser from '@hooks/useIsAnonymousUser';
+import useIsInSidePanel from '@hooks/useIsInSidePanel';
+import useNetwork from '@hooks/useNetwork';
+import useOnyx from '@hooks/useOnyx';
+import usePaginatedReportActions from '@hooks/usePaginatedReportActions';
+import usePrevious from '@hooks/usePrevious';
+import useReportTransactionsCollection from '@hooks/useReportTransactionsCollection';
+import useResponsiveLayout from '@hooks/useResponsiveLayout';
+import getNonEmptyStringOnyxID from '@libs/getNonEmptyStringOnyxID';
+import {getAllNonDeletedTransactions} from '@libs/MoneyRequestReportUtils';
+import Navigation from '@libs/Navigation/Navigation';
+import type {PlatformStackRouteProp} from '@libs/Navigation/PlatformStackNavigation/types';
+import {getFilteredReportActionsForReportView, getIOUActionForReportID, getOneTransactionThreadReportID, isCreatedAction} from '@libs/ReportActionsUtils';
+import {
+    getReportTransactions,
+    isChatThread,
+    isHiddenForCurrentUser,
+    isOneTransactionThread,
+    isPolicyExpenseChat,
+    isReportTransactionThread,
+    isTaskReport,
+    isValidReportIDFromPath,
+} from '@libs/ReportUtils';
+import type {ReportsSplitNavigatorParamList, RightModalNavigatorParamList} from '@navigation/types';
+import {setShouldShowComposeInput} from '@userActions/Composer';
+import {createTransactionThreadReport, openReport, readNewestAction, subscribeToReportLeavingEvents, unsubscribeFromLeavingRoomReportChannel, updateLastVisitTime} from '@userActions/Report';
+import CONST from '@src/CONST';
+import ONYXKEYS from '@src/ONYXKEYS';
+import SCREENS from '@src/SCREENS';
+
+type ReportScreenRoute =
+    | PlatformStackRouteProp<ReportsSplitNavigatorParamList, typeof SCREENS.REPORT>
+    | PlatformStackRouteProp<RightModalNavigatorParamList, typeof SCREENS.RIGHT_MODAL.SEARCH_REPORT>;
+
+const defaultReportMetadata = {
+    hasOnceLoadedReportActions: false,
+    isLoadingInitialReportActions: true,
+    isLoadingOlderReportActions: false,
+    hasLoadingOlderReportActionsError: false,
+    isLoadingNewerReportActions: false,
+    hasLoadingNewerReportActionsError: false,
+    isOptimisticReport: false,
+};
+
+/**
+ * Renderless component. Owns all fetch/open-report logic, transaction thread creation,
+ * leaving events subscriptions, and related effects that were previously in ReportScreen.
+ *
+ * Self-subscribes to route params via useRoute().
+ */
+function ReportFetchController() {
+    const route = useRoute<ReportScreenRoute>();
+    const reportIDFromRoute = getNonEmptyStringOnyxID(route.params?.reportID);
+    const reportActionIDFromRoute = route?.params?.reportActionID;
+
+    const isFocused = useIsFocused();
+    const prevIsFocused = usePrevious(isFocused);
+    const {isOffline} = useNetwork();
+    const {shouldUseNarrowLayout} = useResponsiveLayout();
+    const isInSidePanel = useIsInSidePanel();
+    const {accountID: currentUserAccountID, email: currentUserEmail} = useCurrentUserPersonalDetails();
+    const isAnonymousUser = useIsAnonymousUser();
+    const prevIsAnonymousUser = useRef(false);
+    const hasCreatedLegacyThreadRef = useRef(false);
+    const didSubscribeToReportLeavingEvents = useRef(false);
+
+    const [reportOnyx] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT}${reportIDFromRoute}`);
+    const [chatReport] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT}${reportOnyx?.chatReportID}`);
+    const [reportMetadata = defaultReportMetadata] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT_METADATA}${reportIDFromRoute}`);
+    const [introSelected] = useOnyx(ONYXKEYS.NVP_INTRO_SELECTED);
+    const [betas] = useOnyx(ONYXKEYS.BETAS);
+    const [onboarding] = useOnyx(ONYXKEYS.NVP_ONBOARDING);
+    const [isLoadingApp] = useOnyx(ONYXKEYS.IS_LOADING_APP);
+    const [isLoadingReportData = true] = useOnyx(ONYXKEYS.IS_LOADING_REPORT_DATA);
+    const prevIsLoadingReportData = usePrevious(isLoadingReportData);
+
+    const reportID = reportOnyx?.reportID;
+    const report = reportOnyx;
+
+    const {reportActions: unfilteredReportActions, linkedAction} = usePaginatedReportActions(reportID, reportActionIDFromRoute);
+    const reportActions = useMemo(() => getFilteredReportActionsForReportView(unfilteredReportActions), [unfilteredReportActions]);
+    const prevReportActions = usePrevious(reportActions);
+
+    const [childReport] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT}${linkedAction?.childReportID}`);
+
+    const allReportTransactions = useReportTransactionsCollection(reportIDFromRoute);
+    const reportTransactions = useMemo(() => getAllNonDeletedTransactions(allReportTransactions, reportActions, isOffline, true), [allReportTransactions, reportActions, isOffline]);
+    const visibleTransactions = useMemo(
+        () => reportTransactions?.filter((transaction) => isOffline || transaction.pendingAction !== CONST.RED_BRICK_ROAD_PENDING_ACTION.DELETE),
+        [reportTransactions, isOffline],
+    );
+    const reportTransactionIDs = useMemo(() => visibleTransactions?.map((transaction) => transaction.transactionID), [visibleTransactions]);
+
+    const transactionThreadReportID = getOneTransactionThreadReportID(report, chatReport, reportActions ?? [], isOffline, reportTransactionIDs);
+    const [transactionThreadReport] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT}${transactionThreadReportID}`);
+    const prevTransactionThreadReportID = usePrevious(transactionThreadReportID);
+
+    const isTransactionThreadView = isReportTransactionThread(report);
+
+    const indexOfLinkedMessage = useMemo(
+        (): number => reportActions.findIndex((obj) => reportActionIDFromRoute && String(obj.reportActionID) === String(reportActionIDFromRoute)),
+        [reportActions, reportActionIDFromRoute],
+    );
+    const doesCreatedActionExists = useCallback(() => !!reportActions?.findLast((action) => isCreatedAction(action)), [reportActions]);
+    const isLinkedMessageAvailable = indexOfLinkedMessage > -1;
+    const isLinkedMessagePageReady = isLinkedMessageAvailable && (reportActions.length - indexOfLinkedMessage >= CONST.REPORT.MIN_INITIAL_REPORT_ACTION_COUNT || doesCreatedActionExists());
+
+    const isInviteOnboardingComplete = introSelected?.isInviteOnboardingComplete ?? false;
+    const isOnboardingCompleted = onboarding?.hasCompletedGuidedSetupFlow ?? false;
+
+    // #1 — fetchReport callback
+    const fetchReport = useCallback(() => {
+        if (reportMetadata.isOptimisticReport && report?.type === CONST.REPORT.TYPE.CHAT && !isPolicyExpenseChat(report)) {
+            return;
+        }
+
+        if (report?.errorFields?.notFound && isOffline) {
+            return;
+        }
+
+        // When a user goes through onboarding for the first time, various tasks are created for chatting with Concierge.
+        // If this function is called too early (while the application is still loading), we will not have information about policies,
+        // which means we will not be able to obtain the correct link for one of the tasks.
+        // More information here: https://github.com/Expensify/App/issues/71742
+        if (isLoadingApp && introSelected && !isOnboardingCompleted && !isInviteOnboardingComplete) {
+            const {choice, inviteType} = introSelected;
+            const isInviteIOUorInvoice = inviteType === CONST.ONBOARDING_INVITE_TYPES.IOU || inviteType === CONST.ONBOARDING_INVITE_TYPES.INVOICE;
+            const isInviteChoiceCorrect = choice === CONST.ONBOARDING_CHOICES.ADMIN || choice === CONST.ONBOARDING_CHOICES.SUBMIT || choice === CONST.ONBOARDING_CHOICES.CHAT_SPLIT;
+
+            if (isInviteChoiceCorrect && !isInviteIOUorInvoice) {
+                return;
+            }
+        }
+
+        openReport({reportID: reportIDFromRoute, introSelected, reportActionID: reportActionIDFromRoute, betas});
+    }, [
+        reportMetadata.isOptimisticReport,
+        report,
+        isOffline,
+        isLoadingApp,
+        introSelected,
+        isOnboardingCompleted,
+        isInviteOnboardingComplete,
+        reportIDFromRoute,
+        reportActionIDFromRoute,
+        betas,
+    ]);
+
+    // #3 — createOneTransactionThreadReport callback
+    const createOneTransactionThreadReport = useCallback(() => {
+        const currentReportTransaction = getReportTransactions(reportID).filter((transaction) => transaction.pendingAction !== CONST.RED_BRICK_ROAD_PENDING_ACTION.DELETE);
+        const oneTransactionID = currentReportTransaction.at(0)?.transactionID;
+        const iouAction = getIOUActionForReportID(reportID, oneTransactionID);
+        createTransactionThreadReport(introSelected, currentUserEmail ?? '', currentUserAccountID, betas, report, iouAction, currentReportTransaction.at(0));
+    }, [introSelected, currentUserEmail, currentUserAccountID, betas, report, reportID]);
+
+    // #2 — isAnonymousUser tracking
+    useEffect(() => {
+        if (!isAnonymousUser) {
+            return;
+        }
+        prevIsAnonymousUser.current = true;
+    }, [isAnonymousUser]);
+
+    // #3 — create transaction thread when transactionThreadReportID === CONST.FAKE_REPORT_ID
+    useEffect(() => {
+        if (transactionThreadReportID !== CONST.FAKE_REPORT_ID || transactionThreadReport?.reportID || (!reportMetadata.hasOnceLoadedReportActions && !reportMetadata?.isOptimisticReport)) {
+            return;
+        }
+
+        createOneTransactionThreadReport();
+        // eslint-disable-next-line react-hooks/exhaustive-deps -- we don't want to run this useEffect when createOneTransactionThreadReport changes
+    }, [reportMetadata.hasOnceLoadedReportActions, reportMetadata?.isOptimisticReport, transactionThreadReport?.reportID, transactionThreadReportID]);
+
+    // #4 — Re-fetch after anonymous-to-signed-in
+    useEffect(() => {
+        if (isLoadingReportData || !prevIsLoadingReportData || !prevIsAnonymousUser.current || isAnonymousUser) {
+            return;
+        }
+        // Re-fetch public report data after user signs in and OpenApp API is called to
+        // avoid reportActions data being empty for public rooms.
+        fetchReport();
+    }, [isLoadingReportData, prevIsLoadingReportData, prevIsAnonymousUser, isAnonymousUser, fetchReport]);
+
+    // #5 — Re-fetch after transaction thread created
+    useEffect(() => {
+        // If transactionThreadReportID is undefined or CONST.FAKE_REPORT_ID, we do not call fetchReport.
+        // Only when transactionThreadReportID changes to a valid value, the fetchReport will be called to fetch the data again for the current report.
+        // Since fetchReport is always called once when opening a report,
+        // if that initial call is used to create a transactionThreadReport,
+        // then fetchReport needs to be called again after the transactionThreadReport has been fully created.
+        const prevTransactionThreadReportIDWasValid = !!prevTransactionThreadReportID && prevTransactionThreadReportID !== CONST.FAKE_REPORT_ID;
+        const transactionThreadReportIDUpdatedFromValidToFake = transactionThreadReportID === CONST.FAKE_REPORT_ID && !!prevTransactionThreadReportID;
+
+        if (prevTransactionThreadReportIDWasValid || !transactionThreadReportID || transactionThreadReportIDUpdatedFromValidToFake) {
+            return;
+        }
+
+        fetchReport();
+    }, [fetchReport, prevTransactionThreadReportID, transactionThreadReportID]);
+
+    // #6 — updateLastVisitTime
+    useEffect(() => {
+        if (!reportID || !isFocused || isInSidePanel) {
+            return;
+        }
+        updateLastVisitTime(reportID);
+    }, [reportID, isFocused, isInSidePanel]);
+
+    // #7 — Compose input init + leaving events cleanup
+    useEffect(() => {
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
+        const interactionTask = InteractionManager.runAfterInteractions(() => {
+            setShouldShowComposeInput(true);
+        });
+        return () => {
+            interactionTask.cancel();
+            if (!didSubscribeToReportLeavingEvents.current) {
+                return;
+            }
+
+            unsubscribeFromLeavingRoomReportChannel(reportID);
+        };
+
+        // I'm disabling the warning, as it expects to use exhaustive deps, even though we want this useEffect to run only on the first render.
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
+
+    // #8 — fetchReport on navigation/linking
+    useEffect(() => {
+        // This function is triggered when a user clicks on a link to navigate to a report.
+        // For each link click, we retrieve the report data again, even though it may already be cached.
+        // There should be only one openReport execution per page start or navigating
+        fetchReport();
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [route, isLinkedMessagePageReady, reportActionIDFromRoute]);
+
+    // #9 — Re-fetch when invited to room
+    useEffect(() => {
+        // This function is only triggered when a user is invited to a room after opening the link.
+        // When a user opens a room they are not a member of, and the admin then invites them, only the INVITE_TO_ROOM action is available, so the background will be empty and room description is not available.
+        // See https://github.com/Expensify/App/issues/57769 for more details
+        if (prevReportActions.length !== 0 || reportActions.length !== 1 || reportActions.at(0)?.actionName !== CONST.REPORT.ACTIONS.TYPE.ROOM_CHANGE_LOG.INVITE_TO_ROOM) {
+            return;
+        }
+        fetchReport();
+    }, [prevReportActions.length, reportActions, fetchReport]);
+
+    // #10 — Thread rejoin on re-focus
+    // If a user has chosen to leave a thread, and then returns to it (e.g. with the back button), we need to call `openReport` again in order to allow the user to rejoin and to receive real-time updates
+    useEffect(() => {
+        if (!shouldUseNarrowLayout || !isFocused || prevIsFocused || !isChatThread(report) || !isHiddenForCurrentUser(report) || isTransactionThreadView) {
+            return;
+        }
+        openReport({reportID, introSelected, betas});
+
+        // We don't want to run this useEffect every time `report` is changed
+        // Excluding shouldUseNarrowLayout from the dependency list to prevent re-triggering on screen resize events.
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [prevIsFocused, report?.participants, isFocused, isTransactionThreadView, reportID, introSelected, betas]);
+
+    // #11 — Subscribe to leaving events
+    useEffect(() => {
+        if (!isValidReportIDFromPath(reportIDFromRoute)) {
+            return;
+        }
+        // Ensures the optimistic report is created successfully
+        if (reportIDFromRoute !== report?.reportID || report?.pendingFields?.createChat) {
+            return;
+        }
+        // Ensures subscription event succeeds when the report/workspace room is created optimistically.
+        // Check if the optimistic `OpenReport` or `AddWorkspaceRoom` has succeeded by confirming
+        // any `pendingFields.createChat` or `pendingFields.addWorkspaceRoom` fields are set to null.
+        // Existing reports created will have empty fields for `pendingFields`.
+        const didCreateReportSuccessfully = !report?.pendingFields || (!report?.pendingFields.addWorkspaceRoom && !report?.pendingFields.createChat);
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
+        let interactionTask: ReturnType<typeof InteractionManager.runAfterInteractions> | null = null;
+        if (!didSubscribeToReportLeavingEvents.current && didCreateReportSuccessfully) {
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
+            interactionTask = InteractionManager.runAfterInteractions(() => {
+                subscribeToReportLeavingEvents(reportIDFromRoute, currentUserAccountID);
+                didSubscribeToReportLeavingEvents.current = true;
+            });
+        }
+        return () => {
+            if (!interactionTask) {
+                return;
+            }
+            interactionTask.cancel();
+        };
+    }, [report?.reportID, didSubscribeToReportLeavingEvents, reportIDFromRoute, report?.pendingFields, currentUserAccountID]);
+
+    // #12 — Reset hasCreatedLegacyThreadRef
+    useEffect(() => {
+        hasCreatedLegacyThreadRef.current = false;
+    }, [reportID]);
+
+    // #13 — Legacy transaction thread creation
+    // When opening IOU report for single transaction, we will create IOU action and transaction thread
+    // for legacy transaction that doesn't have IOU action
+    useEffect(() => {
+        // Skip if already created, coming from Search page, or thread already exists
+        if (
+            hasCreatedLegacyThreadRef.current ||
+            route.name === SCREENS.RIGHT_MODAL.SEARCH_REPORT ||
+            transactionThreadReport ||
+            (transactionThreadReportID && transactionThreadReportID !== '0') ||
+            !reportMetadata?.hasOnceLoadedReportActions ||
+            reportActions.length === 0
+        ) {
+            return;
+        }
+
+        // Only handle single transaction expense reports that are fully loaded
+        const transaction = visibleTransactions?.at(0);
+        if (!reportID || visibleTransactions?.length !== 1 || report?.type !== CONST.REPORT.TYPE.EXPENSE || !transaction?.transactionID) {
+            return;
+        }
+
+        // Skip legacy transaction handling if:
+        // - IOU action already exists (not a legacy transaction)
+        // - Transaction is pending addition (new transaction, not legacy)
+        const iouAction = getIOUActionForReportID(reportID, transaction.transactionID);
+        if (iouAction || transaction?.pendingAction === CONST.RED_BRICK_ROAD_PENDING_ACTION.ADD || !!transaction.linkedTrackedExpenseReportAction?.childReportID) {
+            return;
+        }
+
+        // Mark as created BEFORE calling to prevent race conditions
+        hasCreatedLegacyThreadRef.current = true;
+
+        // For legacy transactions, pass undefined as IOU action and the transaction object
+        // It will be created optimistically and in the backend when call openReport
+        createTransactionThreadReport(introSelected, currentUserEmail ?? '', currentUserAccountID, betas, report, undefined, transaction);
+    }, [
+        introSelected,
+        currentUserEmail,
+        currentUserAccountID,
+        report,
+        visibleTransactions,
+        transactionThreadReport,
+        transactionThreadReportID,
+        reportID,
+        route.name,
+        reportMetadata?.hasOnceLoadedReportActions,
+        reportActions.length,
+    ]);
+
+    // #14 — Task report init
+    useEffect(() => {
+        if (!!report?.lastReadTime || !isTaskReport(report)) {
+            return;
+        }
+        // After creating the task report then navigating to task detail we don't have any report actions and the last read time is empty so We need to update the initial last read time when opening the task report detail.
+        readNewestAction(report?.reportID, !!reportMetadata?.hasOnceLoadedReportActions);
+    }, [report, reportMetadata?.hasOnceLoadedReportActions]);
+
+    // #15 — One-transaction-thread redirect
+    useEffect(() => {
+        if (!transactionThreadReportID || !route?.params?.reportActionID || !isOneTransactionThread(childReport, report, linkedAction)) {
+            return;
+        }
+        Navigation.setParams({reportActionID: ''});
+    }, [transactionThreadReportID, route?.params?.reportActionID, linkedAction, reportID, report, childReport]);
+
+    return null;
+}
+
+ReportFetchController.displayName = 'ReportFetchController';
+
+export default ReportFetchController;

--- a/src/pages/inbox/ReportFetchController.tsx
+++ b/src/pages/inbox/ReportFetchController.tsx
@@ -1,5 +1,5 @@
 import {useIsFocused, useRoute} from '@react-navigation/native';
-import {useCallback, useEffect, useMemo, useRef} from 'react';
+import {useCallback, useEffect, useRef} from 'react';
 import {InteractionManager} from 'react-native';
 import useCurrentUserPersonalDetails from '@hooks/useCurrentUserPersonalDetails';
 import useIsAnonymousUser from '@hooks/useIsAnonymousUser';
@@ -82,18 +82,15 @@ function ReportFetchController() {
     const report = reportOnyx;
 
     const {reportActions: unfilteredReportActions, linkedAction} = usePaginatedReportActions(reportID, reportActionIDFromRoute);
-    const reportActions = useMemo(() => getFilteredReportActionsForReportView(unfilteredReportActions), [unfilteredReportActions]);
+    const reportActions = getFilteredReportActionsForReportView(unfilteredReportActions);
     const prevReportActions = usePrevious(reportActions);
 
     const [childReport] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT}${linkedAction?.childReportID}`);
 
     const allReportTransactions = useReportTransactionsCollection(reportIDFromRoute);
-    const reportTransactions = useMemo(() => getAllNonDeletedTransactions(allReportTransactions, reportActions, isOffline, true), [allReportTransactions, reportActions, isOffline]);
-    const visibleTransactions = useMemo(
-        () => reportTransactions?.filter((transaction) => isOffline || transaction.pendingAction !== CONST.RED_BRICK_ROAD_PENDING_ACTION.DELETE),
-        [reportTransactions, isOffline],
-    );
-    const reportTransactionIDs = useMemo(() => visibleTransactions?.map((transaction) => transaction.transactionID), [visibleTransactions]);
+    const reportTransactions = getAllNonDeletedTransactions(allReportTransactions, reportActions, isOffline, true);
+    const visibleTransactions = isOffline ? reportTransactions : reportTransactions?.filter((transaction) => transaction.pendingAction !== CONST.RED_BRICK_ROAD_PENDING_ACTION.DELETE);
+    const reportTransactionIDs = visibleTransactions?.map((transaction) => transaction.transactionID);
 
     const transactionThreadReportID = getOneTransactionThreadReportID(report, chatReport, reportActions ?? [], isOffline, reportTransactionIDs);
     const [transactionThreadReport] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT}${transactionThreadReportID}`);
@@ -101,18 +98,15 @@ function ReportFetchController() {
 
     const isTransactionThreadView = isReportTransactionThread(report);
 
-    const indexOfLinkedMessage = useMemo(
-        (): number => reportActions.findIndex((obj) => reportActionIDFromRoute && String(obj.reportActionID) === String(reportActionIDFromRoute)),
-        [reportActions, reportActionIDFromRoute],
-    );
-    const doesCreatedActionExists = useCallback(() => !!reportActions?.findLast((action) => isCreatedAction(action)), [reportActions]);
+    const indexOfLinkedMessage = reportActionIDFromRoute ? reportActions.findIndex((obj) => String(obj.reportActionID) === String(reportActionIDFromRoute)) : -1;
+    const doesCreatedActionExists = !!reportActions?.findLast((action) => isCreatedAction(action));
     const isLinkedMessageAvailable = indexOfLinkedMessage > -1;
-    const isLinkedMessagePageReady = isLinkedMessageAvailable && (reportActions.length - indexOfLinkedMessage >= CONST.REPORT.MIN_INITIAL_REPORT_ACTION_COUNT || doesCreatedActionExists());
+    const isLinkedMessagePageReady = isLinkedMessageAvailable && (reportActions.length - indexOfLinkedMessage >= CONST.REPORT.MIN_INITIAL_REPORT_ACTION_COUNT || doesCreatedActionExists);
 
     const isInviteOnboardingComplete = introSelected?.isInviteOnboardingComplete ?? false;
     const isOnboardingCompleted = onboarding?.hasCompletedGuidedSetupFlow ?? false;
 
-    // #1 — fetchReport callback
+    // #1 — fetchReport
     const fetchReport = useCallback(() => {
         if (reportMetadata.isOptimisticReport && report?.type === CONST.REPORT.TYPE.CHAT && !isPolicyExpenseChat(report)) {
             return;
@@ -150,13 +144,13 @@ function ReportFetchController() {
         betas,
     ]);
 
-    // #3 — createOneTransactionThreadReport callback
-    const createOneTransactionThreadReport = useCallback(() => {
+    // #3 — createOneTransactionThreadReport
+    const createOneTransactionThreadReport = () => {
         const currentReportTransaction = getReportTransactions(reportID).filter((transaction) => transaction.pendingAction !== CONST.RED_BRICK_ROAD_PENDING_ACTION.DELETE);
         const oneTransactionID = currentReportTransaction.at(0)?.transactionID;
         const iouAction = getIOUActionForReportID(reportID, oneTransactionID);
         createTransactionThreadReport(introSelected, currentUserEmail ?? '', currentUserAccountID, betas, report, iouAction, currentReportTransaction.at(0));
-    }, [introSelected, currentUserEmail, currentUserAccountID, betas, report, reportID]);
+    };
 
     // #2 — isAnonymousUser tracking
     useEffect(() => {

--- a/src/pages/inbox/ReportLifecycleHandler.tsx
+++ b/src/pages/inbox/ReportLifecycleHandler.tsx
@@ -1,0 +1,79 @@
+import {useIsFocused} from '@react-navigation/native';
+import {useEffect} from 'react';
+import {DeviceEventEmitter} from 'react-native';
+import useAppFocusEvent from '@hooks/useAppFocusEvent';
+import useBankAccountUnlockEffect from '@hooks/useBankAccountUnlockEffect';
+import {useCurrentReportIDState} from '@hooks/useCurrentReportID';
+import useOnyx from '@hooks/useOnyx';
+import usePrevious from '@hooks/usePrevious';
+import {hideEmojiPicker} from '@libs/actions/EmojiPickerAction';
+import getNonEmptyStringOnyxID from '@libs/getNonEmptyStringOnyxID';
+import clearReportNotifications from '@libs/Notification/clearReportNotifications';
+import {cancelSpan, cancelSpansByPrefix} from '@libs/telemetry/activeSpans';
+import CONST from '@src/CONST';
+import ONYXKEYS from '@src/ONYXKEYS';
+
+type ReportLifecycleHandlerProps = {
+    reportIDFromRoute: string | undefined;
+};
+
+/**
+ * Renderless component. Handles screen lifecycle side effects:
+ * - Hide emoji picker when screen loses focus
+ * - Clear notifications when report is opened/re-focused
+ * - DeviceEventEmitter listener for switchToPreExistingReport
+ * - Telemetry span cancellation on unmount
+ * - Bank account unlock effect
+ */
+function ReportLifecycleHandler({reportIDFromRoute}: ReportLifecycleHandlerProps) {
+    const reportID = getNonEmptyStringOnyxID(reportIDFromRoute);
+    const isFocused = useIsFocused();
+    const prevIsFocused = usePrevious(isFocused);
+    const {currentReportID: currentReportIDValue} = useCurrentReportIDState();
+    const isTopMostReportId = currentReportIDValue === reportIDFromRoute;
+
+    const [report] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT}${reportID}`);
+    useBankAccountUnlockEffect(report);
+
+    // Hide emoji picker when screen loses focus
+    useEffect(() => {
+        if (!prevIsFocused || isFocused) {
+            return;
+        }
+        hideEmojiPicker(true);
+    }, [prevIsFocused, isFocused]);
+
+    // DeviceEventEmitter listener + telemetry cleanup
+    useEffect(() => {
+        const skipOpenReportListener = DeviceEventEmitter.addListener(`switchToPreExistingReport_${reportID}`, () => {});
+
+        return () => {
+            skipOpenReportListener.remove();
+
+            // Cancel telemetry span when user leaves the screen before full report data is loaded
+            cancelSpan(`${CONST.TELEMETRY.SPAN_OPEN_REPORT}_${reportID}`);
+
+            // Cancel any pending send-message spans to prevent orphaned spans when navigating away
+            cancelSpansByPrefix(CONST.TELEMETRY.SPAN_SEND_MESSAGE);
+        };
+    }, [reportID]);
+
+    // Clear notifications for the current report when it's opened and re-focused
+    const clearNotifications = () => {
+        // Check if this is the top-most ReportScreen since the Navigator preserves multiple at a time
+        if (!isTopMostReportId) {
+            return;
+        }
+
+        clearReportNotifications(reportID);
+    };
+
+    useEffect(clearNotifications, [clearNotifications]);
+    useAppFocusEvent(clearNotifications);
+
+    return null;
+}
+
+ReportLifecycleHandler.displayName = 'ReportLifecycleHandler';
+
+export default ReportLifecycleHandler;

--- a/src/pages/inbox/ReportLifecycleHandler.tsx
+++ b/src/pages/inbox/ReportLifecycleHandler.tsx
@@ -18,7 +18,7 @@ type ReportLifecycleHandlerProps = {
 };
 
 /**
- * Renderless component. Handles screen lifecycle side effects:
+ * Component that does not render anything. Handles screen lifecycle side effects:
  * - Hide emoji picker when screen loses focus
  * - Clear notifications when report is opened/re-focused
  * - DeviceEventEmitter listener for switchToPreExistingReport

--- a/src/pages/inbox/ReportNavigateAwayHandler.tsx
+++ b/src/pages/inbox/ReportNavigateAwayHandler.tsx
@@ -1,0 +1,216 @@
+import {useIsFocused, useRoute} from '@react-navigation/native';
+import {useEffect, useRef} from 'react';
+import type {OnyxEntry} from 'react-native-onyx';
+import {useCurrentReportIDState} from '@hooks/useCurrentReportID';
+import useCurrentUserPersonalDetails from '@hooks/useCurrentUserPersonalDetails';
+import useOnyx from '@hooks/useOnyx';
+import useParentReportAction from '@hooks/useParentReportAction';
+import usePrevious from '@hooks/usePrevious';
+import useResponsiveLayout from '@hooks/useResponsiveLayout';
+import getNonEmptyStringOnyxID from '@libs/getNonEmptyStringOnyxID';
+import Navigation, {navigationRef} from '@libs/Navigation/Navigation';
+import type {PlatformStackRouteProp} from '@libs/Navigation/PlatformStackNavigation/types';
+import {isDeletedParentAction} from '@libs/ReportActionsUtils';
+import {isAdminRoom, isAnnounceRoom, isGroupChat, isMoneyRequest, isMoneyRequestReport, isMoneyRequestReportPendingDeletion, isPolicyExpenseChat} from '@libs/ReportUtils';
+import type {ReportsSplitNavigatorParamList, RightModalNavigatorParamList} from '@navigation/types';
+import {setShouldShowComposeInput} from '@userActions/Composer';
+import {navigateToConciergeChat} from '@userActions/Report';
+import CONST from '@src/CONST';
+import ONYXKEYS from '@src/ONYXKEYS';
+import ROUTES from '@src/ROUTES';
+import SCREENS from '@src/SCREENS';
+import type * as OnyxTypes from '@src/types/onyx';
+import {isEmptyObject} from '@src/types/utils/EmptyObject';
+import useReportWasDeleted from './hooks/useReportWasDeleted';
+
+type ReportScreenRoute =
+    | PlatformStackRouteProp<ReportsSplitNavigatorParamList, typeof SCREENS.REPORT>
+    | PlatformStackRouteProp<RightModalNavigatorParamList, typeof SCREENS.RIGHT_MODAL.SEARCH_REPORT>;
+
+const reportDetailScreens = [
+    ...Object.values(SCREENS.REPORT_DETAILS),
+    ...Object.values(SCREENS.REPORT_SETTINGS),
+    ...Object.values(SCREENS.PRIVATE_NOTES),
+    ...Object.values(SCREENS.REPORT_PARTICIPANTS),
+];
+
+/**
+ * Check is the report is deleted.
+ * We currently use useMemo to memorize every properties of the report
+ * so we can't check using isEmpty.
+ */
+function isEmpty(report: OnyxEntry<OnyxTypes.Report>): boolean {
+    if (isEmptyObject(report)) {
+        return true;
+    }
+    return !Object.values(report).some((value) => value !== undefined && value !== '');
+}
+
+/**
+ * Renderless component. Owns navigate-on-removal and navigate-on-deletion logic
+ * that was previously in ReportScreen.
+ *
+ * Self-subscribes to route params via useRoute().
+ */
+function ReportNavigateAwayHandler() {
+    const route = useRoute<ReportScreenRoute>();
+    const reportIDFromRoute = getNonEmptyStringOnyxID(route.params?.reportID);
+
+    const isFocused = useIsFocused();
+    const {isInNarrowPaneModal} = useResponsiveLayout();
+    const {accountID: currentUserAccountID} = useCurrentUserPersonalDetails();
+    const {currentReportID: currentReportIDValue} = useCurrentReportIDState();
+    const isTopMostReportId = currentReportIDValue === reportIDFromRoute;
+
+    const [reportOnyx] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT}${reportIDFromRoute}`);
+    const [userLeavingStatus = false] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT_USER_IS_LEAVING_ROOM}${reportIDFromRoute}`);
+    const [introSelected] = useOnyx(ONYXKEYS.NVP_INTRO_SELECTED);
+    const [betas] = useOnyx(ONYXKEYS.BETAS);
+    const [onboarding] = useOnyx(ONYXKEYS.NVP_ONBOARDING);
+    const isSelfTourViewed = onboarding?.selfTourViewed;
+    const [conciergeReportID] = useOnyx(ONYXKEYS.CONCIERGE_REPORT_ID);
+
+    const report = reportOnyx;
+
+    const parentReportAction = useParentReportAction(reportOnyx);
+    const deletedParentAction = isDeletedParentAction(parentReportAction);
+    const prevDeletedParentAction = usePrevious(deletedParentAction);
+
+    const prevReport = usePrevious(report);
+    const prevUserLeavingStatus = usePrevious(userLeavingStatus);
+    const lastReportIDFromRoute = usePrevious(reportIDFromRoute);
+
+    const isOptimisticDelete = report?.statusNum === CONST.REPORT.STATUS_NUM.CLOSED;
+    const {wasDeleted: reportWasDeleted, parentReportID: deletedReportParentID} = useReportWasDeleted(reportIDFromRoute, report, isOptimisticDelete, userLeavingStatus);
+
+    const firstRender = useRef(true);
+
+    // Navigate on removal
+    useEffect(() => {
+        // We don't want this effect to run on the first render.
+        if (firstRender.current) {
+            firstRender.current = false;
+            return;
+        }
+
+        const onyxReportID = report?.reportID;
+        const prevOnyxReportID = prevReport?.reportID;
+        const wasReportRemoved = !!prevOnyxReportID && prevOnyxReportID === reportIDFromRoute && !onyxReportID;
+        const isRemovalExpectedForReportType =
+            isEmpty(report) &&
+            (isMoneyRequest(prevReport) ||
+                isMoneyRequestReport(prevReport) ||
+                isPolicyExpenseChat(prevReport) ||
+                isGroupChat(prevReport) ||
+                isAdminRoom(prevReport) ||
+                isAnnounceRoom(prevReport));
+        const didReportClose = wasReportRemoved && prevReport.statusNum === CONST.REPORT.STATUS_NUM.OPEN && report?.statusNum === CONST.REPORT.STATUS_NUM.CLOSED;
+        const isTopLevelPolicyRoomWithNoStatus = !report?.statusNum && !prevReport?.parentReportID && prevReport?.chatType === CONST.REPORT.CHAT_TYPE.POLICY_ROOM;
+        const isClosedTopLevelPolicyRoom = wasReportRemoved && prevReport.statusNum === CONST.REPORT.STATUS_NUM.OPEN && isTopLevelPolicyRoomWithNoStatus;
+        // Navigate to the Concierge chat if the room was removed from another device (e.g. user leaving a room or removed from a room)
+        if (
+            // non-optimistic case
+            (!prevUserLeavingStatus && !!userLeavingStatus) ||
+            didReportClose ||
+            isRemovalExpectedForReportType ||
+            isClosedTopLevelPolicyRoom ||
+            (prevDeletedParentAction && !deletedParentAction)
+        ) {
+            const currentRoute = navigationRef.getCurrentRoute();
+            const topmostReportIDInSearchRHP = Navigation.getTopmostSearchReportID();
+            const isTopmostSearchReportID = reportIDFromRoute === topmostReportIDInSearchRHP;
+            const isHoldScreenOpenInRHP =
+                currentRoute?.name === SCREENS.MONEY_REQUEST.HOLD && (route.name === SCREENS.RIGHT_MODAL.SEARCH_REPORT ? isTopmostSearchReportID : isTopMostReportId);
+            const isReportDetailOpenInRHP =
+                isTopMostReportId &&
+                reportDetailScreens.find((r) => r === currentRoute?.name) &&
+                !!currentRoute?.params &&
+                typeof currentRoute.params === 'object' &&
+                'reportID' in currentRoute.params &&
+                reportIDFromRoute === currentRoute.params.reportID;
+            // Early return if the report we're passing isn't in a focused state. We only want to navigate to Concierge if the user leaves the room from another device or gets removed from the room while the report is in a focused state.
+            // Prevent auto navigation for report in RHP
+            if ((!isFocused && !isHoldScreenOpenInRHP && !isReportDetailOpenInRHP) || (!isHoldScreenOpenInRHP && isInNarrowPaneModal)) {
+                return;
+            }
+            Navigation.dismissModal();
+            if (Navigation.getTopmostReportId() === prevOnyxReportID) {
+                Navigation.isNavigationReady().then(() => {
+                    Navigation.popToSidebar();
+                });
+            }
+            if (prevReport?.parentReportID) {
+                // Prevent navigation to the IOU/Expense Report if it is pending deletion.
+                if (isMoneyRequestReportPendingDeletion(prevReport.parentReportID)) {
+                    return;
+                }
+                Navigation.isNavigationReady().then(() => {
+                    Navigation.navigate(ROUTES.REPORT_WITH_ID.getRoute(prevReport.parentReportID));
+                });
+                return;
+            }
+
+            Navigation.isNavigationReady().then(() => {
+                navigateToConciergeChat(conciergeReportID, introSelected, currentUserAccountID, isSelfTourViewed, betas, false);
+            });
+            return;
+        }
+
+        // If you already have a report open and are deeplinking to a new report on native,
+        // the ReportScreen never actually unmounts and the reportID in the route also doesn't change.
+        // Therefore, we need to compare if the existing reportID is the same as the one in the route
+        // before deciding that we shouldn't call OpenReport.
+        if (reportIDFromRoute === lastReportIDFromRoute && (!onyxReportID || onyxReportID === reportIDFromRoute)) {
+            return;
+        }
+
+        setShouldShowComposeInput(true);
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [
+        route.name,
+        report,
+        prevReport?.reportID,
+        prevUserLeavingStatus,
+        userLeavingStatus,
+        prevReport?.statusNum,
+        prevReport?.parentReportID,
+        prevReport?.chatType,
+        prevReport,
+        reportIDFromRoute,
+        lastReportIDFromRoute,
+        isFocused,
+        deletedParentAction,
+        prevDeletedParentAction,
+    ]);
+
+    // Navigate on deletion
+    useEffect(() => {
+        if (!reportWasDeleted) {
+            return;
+        }
+
+        // Only redirect if focused
+        if (!isFocused) {
+            return;
+        }
+
+        // Try to navigate to parent report if available
+        if (deletedReportParentID && !isMoneyRequestReportPendingDeletion(deletedReportParentID)) {
+            Navigation.isNavigationReady().then(() => {
+                Navigation.navigate(ROUTES.REPORT_WITH_ID.getRoute(deletedReportParentID));
+            });
+            return;
+        }
+
+        // Fallback to Concierge
+        Navigation.isNavigationReady().then(() => {
+            navigateToConciergeChat(conciergeReportID, introSelected, currentUserAccountID, isSelfTourViewed, betas);
+        });
+    }, [reportWasDeleted, isFocused, deletedReportParentID, conciergeReportID, introSelected, currentUserAccountID, isSelfTourViewed, betas]);
+
+    return null;
+}
+
+ReportNavigateAwayHandler.displayName = 'ReportNavigateAwayHandler';
+
+export default ReportNavigateAwayHandler;

--- a/src/pages/inbox/ReportNavigateAwayHandler.tsx
+++ b/src/pages/inbox/ReportNavigateAwayHandler.tsx
@@ -47,7 +47,7 @@ function isEmpty(report: OnyxEntry<OnyxTypes.Report>): boolean {
 }
 
 /**
- * Renderless component. Owns navigate-on-removal and navigate-on-deletion logic
+ * Component that does not render anything. Owns navigate-on-removal and navigate-on-deletion logic
  * that was previously in ReportScreen.
  *
  * Self-subscribes to route params via useRoute().

--- a/src/pages/inbox/ReportNavigateAwayHandler.tsx
+++ b/src/pages/inbox/ReportNavigateAwayHandler.tsx
@@ -1,5 +1,5 @@
 import {useIsFocused, useRoute} from '@react-navigation/native';
-import {useEffect, useRef} from 'react';
+import {useEffect, useEffectEvent, useRef} from 'react';
 import type {OnyxEntry} from 'react-native-onyx';
 import {useCurrentReportIDState} from '@hooks/useCurrentReportID';
 import useCurrentUserPersonalDetails from '@hooks/useCurrentUserPersonalDetails';
@@ -85,6 +85,46 @@ function ReportNavigateAwayHandler() {
 
     const firstRender = useRef(true);
 
+    // Navigation action that reads non-reactive context (concierge params, modal state, etc.)
+    const navigateAwayFromReport = useEffectEvent((prevOnyxReportID: string | undefined, prevParentReportID: string | undefined) => {
+        const currentRoute = navigationRef.getCurrentRoute();
+        const topmostReportIDInSearchRHP = Navigation.getTopmostSearchReportID();
+        const isTopmostSearchReportID = reportIDFromRoute === topmostReportIDInSearchRHP;
+        const isHoldScreenOpenInRHP = currentRoute?.name === SCREENS.MONEY_REQUEST.HOLD && (route.name === SCREENS.RIGHT_MODAL.SEARCH_REPORT ? isTopmostSearchReportID : isTopMostReportId);
+        const isReportDetailOpenInRHP =
+            isTopMostReportId &&
+            reportDetailScreens.find((r) => r === currentRoute?.name) &&
+            !!currentRoute?.params &&
+            typeof currentRoute.params === 'object' &&
+            'reportID' in currentRoute.params &&
+            reportIDFromRoute === currentRoute.params.reportID;
+        // Early return if the report we're passing isn't in a focused state. We only want to navigate to Concierge if the user leaves the room from another device or gets removed from the room while the report is in a focused state.
+        // Prevent auto navigation for report in RHP
+        if ((!isFocused && !isHoldScreenOpenInRHP && !isReportDetailOpenInRHP) || (!isHoldScreenOpenInRHP && isInNarrowPaneModal)) {
+            return;
+        }
+        Navigation.dismissModal();
+        if (Navigation.getTopmostReportId() === prevOnyxReportID) {
+            Navigation.isNavigationReady().then(() => {
+                Navigation.popToSidebar();
+            });
+        }
+        if (prevParentReportID) {
+            // Prevent navigation to the IOU/Expense Report if it is pending deletion.
+            if (isMoneyRequestReportPendingDeletion(prevParentReportID)) {
+                return;
+            }
+            Navigation.isNavigationReady().then(() => {
+                Navigation.navigate(ROUTES.REPORT_WITH_ID.getRoute(prevParentReportID));
+            });
+            return;
+        }
+
+        Navigation.isNavigationReady().then(() => {
+            navigateToConciergeChat(conciergeReportID, introSelected, currentUserAccountID, isSelfTourViewed, betas, false);
+        });
+    });
+
     // Navigate on removal
     useEffect(() => {
         // We don't want this effect to run on the first render.
@@ -116,43 +156,7 @@ function ReportNavigateAwayHandler() {
             isClosedTopLevelPolicyRoom ||
             (prevDeletedParentAction && !deletedParentAction)
         ) {
-            const currentRoute = navigationRef.getCurrentRoute();
-            const topmostReportIDInSearchRHP = Navigation.getTopmostSearchReportID();
-            const isTopmostSearchReportID = reportIDFromRoute === topmostReportIDInSearchRHP;
-            const isHoldScreenOpenInRHP =
-                currentRoute?.name === SCREENS.MONEY_REQUEST.HOLD && (route.name === SCREENS.RIGHT_MODAL.SEARCH_REPORT ? isTopmostSearchReportID : isTopMostReportId);
-            const isReportDetailOpenInRHP =
-                isTopMostReportId &&
-                reportDetailScreens.find((r) => r === currentRoute?.name) &&
-                !!currentRoute?.params &&
-                typeof currentRoute.params === 'object' &&
-                'reportID' in currentRoute.params &&
-                reportIDFromRoute === currentRoute.params.reportID;
-            // Early return if the report we're passing isn't in a focused state. We only want to navigate to Concierge if the user leaves the room from another device or gets removed from the room while the report is in a focused state.
-            // Prevent auto navigation for report in RHP
-            if ((!isFocused && !isHoldScreenOpenInRHP && !isReportDetailOpenInRHP) || (!isHoldScreenOpenInRHP && isInNarrowPaneModal)) {
-                return;
-            }
-            Navigation.dismissModal();
-            if (Navigation.getTopmostReportId() === prevOnyxReportID) {
-                Navigation.isNavigationReady().then(() => {
-                    Navigation.popToSidebar();
-                });
-            }
-            if (prevReport?.parentReportID) {
-                // Prevent navigation to the IOU/Expense Report if it is pending deletion.
-                if (isMoneyRequestReportPendingDeletion(prevReport.parentReportID)) {
-                    return;
-                }
-                Navigation.isNavigationReady().then(() => {
-                    Navigation.navigate(ROUTES.REPORT_WITH_ID.getRoute(prevReport.parentReportID));
-                });
-                return;
-            }
-
-            Navigation.isNavigationReady().then(() => {
-                navigateToConciergeChat(conciergeReportID, introSelected, currentUserAccountID, isSelfTourViewed, betas, false);
-            });
+            navigateAwayFromReport(prevOnyxReportID, prevReport?.parentReportID);
             return;
         }
 
@@ -165,9 +169,7 @@ function ReportNavigateAwayHandler() {
         }
 
         setShouldShowComposeInput(true);
-        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [
-        route.name,
         report,
         prevReport?.reportID,
         prevUserLeavingStatus,

--- a/src/pages/inbox/ReportNotFoundGuard.tsx
+++ b/src/pages/inbox/ReportNotFoundGuard.tsx
@@ -1,0 +1,123 @@
+import {useRoute} from '@react-navigation/native';
+import type {ReactNode} from 'react';
+import React, {useEffect} from 'react';
+import FullPageNotFoundView from '@components/BlockingViews/FullPageNotFoundView';
+import useNetwork from '@hooks/useNetwork';
+import useOnyx from '@hooks/useOnyx';
+import useParentReportAction from '@hooks/useParentReportAction';
+import useResponsiveLayout from '@hooks/useResponsiveLayout';
+import useThemeStyles from '@hooks/useThemeStyles';
+import getNonEmptyStringOnyxID from '@libs/getNonEmptyStringOnyxID';
+import Log from '@libs/Log';
+import Navigation from '@libs/Navigation/Navigation';
+import {isReportTransactionThread, isValidReportIDFromPath} from '@libs/ReportUtils';
+import {getParentReportActionDeletionStatus} from '@libs/TransactionNavigationUtils';
+import CONST from '@src/CONST';
+import ONYXKEYS from '@src/ONYXKEYS';
+
+const defaultReportMetadata = {
+    hasOnceLoadedReportActions: false,
+    isLoadingInitialReportActions: true,
+    isLoadingOlderReportActions: false,
+    hasLoadingOlderReportActionsError: false,
+    isLoadingNewerReportActions: false,
+    hasLoadingNewerReportActionsError: false,
+    isOptimisticReport: false,
+};
+
+type ReportNotFoundGuardProps = {
+    children: ReactNode;
+};
+
+// eslint-disable-next-line rulesdir/no-negated-variables
+function ReportNotFoundGuard({children}: ReportNotFoundGuardProps) {
+    const styles = useThemeStyles();
+    const route = useRoute();
+    const routeParams = route.params as {reportID?: string} | undefined;
+    const reportIDFromRoute = getNonEmptyStringOnyxID(routeParams?.reportID);
+
+    const {isOffline} = useNetwork();
+    const {shouldUseNarrowLayout} = useResponsiveLayout();
+
+    const [report] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT}${reportIDFromRoute}`);
+    const [parentReportMetadata] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT_METADATA}${report?.parentReportID}`);
+    const [userLeavingStatus = false] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT_USER_IS_LEAVING_ROOM}${reportIDFromRoute}`);
+    const [reportMetadata = defaultReportMetadata] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT_METADATA}${reportIDFromRoute}`);
+    const [isLoadingReportData = true] = useOnyx(ONYXKEYS.IS_LOADING_REPORT_DATA);
+    const [isLoadingApp] = useOnyx(ONYXKEYS.IS_LOADING_APP);
+    const [deleteTransactionNavigateBackUrl] = useOnyx(ONYXKEYS.NVP_DELETE_TRANSACTION_NAVIGATE_BACK_URL);
+
+    const parentReportAction = useParentReportAction(report);
+    const reportID = report?.reportID;
+    const isOptimisticDelete = report?.statusNum === CONST.REPORT.STATUS_NUM.CLOSED;
+
+    const {isParentActionMissingAfterLoad, isParentActionDeleted} = getParentReportActionDeletionStatus({
+        parentReportID: report?.parentReportID,
+        parentReportActionID: report?.parentReportActionID,
+        parentReportAction,
+        parentReportMetadata,
+        isOffline,
+    });
+    const isDeletedTransactionThread = isReportTransactionThread(report) && (isParentActionDeleted || isParentActionMissingAfterLoad);
+
+    const currentReportIDFormRoute = (route.params as {reportID?: string} | undefined)?.reportID;
+
+    const isInvalidReportPath = !!currentReportIDFormRoute && !isValidReportIDFromPath(currentReportIDFormRoute);
+    const isLoading = isLoadingApp !== false || isLoadingReportData || (!isOffline && !!reportMetadata?.isLoadingInitialReportActions);
+    const reportExists = !!reportID || (!isDeletedTransactionThread && isOptimisticDelete) || userLeavingStatus;
+
+    // eslint-disable-next-line rulesdir/no-negated-variables
+    const shouldShowNotFoundPage = !deleteTransactionNavigateBackUrl && (isDeletedTransactionThread || isInvalidReportPath || (!isLoading && !reportExists));
+
+    useEffect(() => {
+        if (!shouldShowNotFoundPage) {
+            return;
+        }
+
+        Log.info('[ReportScreen] Displaying NotFound Page', false, {
+            isLoadingApp,
+            isLoadingReportData,
+            isOffline,
+            isLoadingInitialReportActions: reportMetadata?.isLoadingInitialReportActions,
+            reportID,
+            isOptimisticDelete,
+            userLeavingStatus,
+            currentReportIDFormRoute,
+            deleteTransactionNavigateBackUrl,
+            isDeletedTransactionThread,
+            isParentActionDeleted,
+            isParentActionMissingAfterLoad,
+        });
+    }, [
+        shouldShowNotFoundPage,
+        isLoadingApp,
+        isLoadingReportData,
+        isOffline,
+        reportMetadata?.isLoadingInitialReportActions,
+        reportID,
+        isOptimisticDelete,
+        userLeavingStatus,
+        currentReportIDFormRoute,
+        deleteTransactionNavigateBackUrl,
+        isDeletedTransactionThread,
+        isParentActionDeleted,
+        isParentActionMissingAfterLoad,
+    ]);
+
+    return (
+        <FullPageNotFoundView
+            shouldShow={shouldShowNotFoundPage}
+            subtitleKey="notFound.noAccess"
+            subtitleStyle={[styles.textSupporting]}
+            shouldShowBackButton={shouldUseNarrowLayout}
+            onBackButtonPress={Navigation.goBack}
+            shouldDisplaySearchRouter
+        >
+            {children}
+        </FullPageNotFoundView>
+    );
+}
+
+ReportNotFoundGuard.displayName = 'ReportNotFoundGuard';
+
+export default ReportNotFoundGuard;

--- a/src/pages/inbox/ReportRouteParamHandler.tsx
+++ b/src/pages/inbox/ReportRouteParamHandler.tsx
@@ -20,7 +20,7 @@ type ReportRouteParamHandlerProps = {
 };
 
 /**
- * Renderless component. Resolves the reportID route param when missing,
+ * Component that does not render anything. Resolves the reportID route param when missing,
  * and validates the reportActionID param.
  */
 function ReportRouteParamHandler({route, navigation}: ReportRouteParamHandlerProps) {

--- a/src/pages/inbox/ReportRouteParamHandler.tsx
+++ b/src/pages/inbox/ReportRouteParamHandler.tsx
@@ -1,0 +1,64 @@
+import {useFocusEffect} from '@react-navigation/native';
+import useArchivedReportsIdSet from '@hooks/useArchivedReportsIdSet';
+import usePermissions from '@hooks/usePermissions';
+import Log from '@libs/Log';
+import Navigation from '@libs/Navigation/Navigation';
+import type {PlatformStackScreenProps} from '@libs/Navigation/PlatformStackNavigation/types';
+import {findLastAccessedReport} from '@libs/ReportUtils';
+import {isNumeric} from '@libs/ValidationUtils';
+import type {ReportsSplitNavigatorParamList, RightModalNavigatorParamList} from '@navigation/types';
+import CONST from '@src/CONST';
+import type SCREENS from '@src/SCREENS';
+
+type ReportRouteParamHandlerProps = {
+    route:
+        | PlatformStackScreenProps<ReportsSplitNavigatorParamList, typeof SCREENS.REPORT>['route']
+        | PlatformStackScreenProps<RightModalNavigatorParamList, typeof SCREENS.RIGHT_MODAL.SEARCH_REPORT>['route'];
+    navigation:
+        | PlatformStackScreenProps<ReportsSplitNavigatorParamList, typeof SCREENS.REPORT>['navigation']
+        | PlatformStackScreenProps<RightModalNavigatorParamList, typeof SCREENS.RIGHT_MODAL.SEARCH_REPORT>['navigation'];
+};
+
+/**
+ * Renderless component. Resolves the reportID route param when missing,
+ * and validates the reportActionID param.
+ */
+function ReportRouteParamHandler({route, navigation}: ReportRouteParamHandlerProps) {
+    const {isBetaEnabled} = usePermissions();
+    const archivedReportsIdSet = useArchivedReportsIdSet();
+
+    useFocusEffect(() => {
+        // Don't update if there is a reportID in the params already
+        if (route.params.reportID) {
+            const reportActionID = route?.params?.reportActionID;
+            const isValidReportActionID = reportActionID && isNumeric(reportActionID);
+            if (reportActionID && !isValidReportActionID) {
+                Navigation.isNavigationReady().then(() => navigation.setParams({reportActionID: ''}));
+            }
+            return;
+        }
+
+        const lastAccessedReportID = findLastAccessedReport(
+            !isBetaEnabled(CONST.BETAS.DEFAULT_ROOMS),
+            'openOnAdminRoom' in route.params && !!route.params.openOnAdminRoom,
+            undefined,
+            archivedReportsIdSet,
+        )?.reportID;
+
+        // It's possible that reports aren't fully loaded yet
+        // in that case the reportID is undefined
+        if (!lastAccessedReportID) {
+            return;
+        }
+        Navigation.isNavigationReady().then(() => {
+            Log.info(`[ReportScreen] no reportID found in params, setting it to lastAccessedReportID: ${lastAccessedReportID}`);
+            navigation.setParams({reportID: lastAccessedReportID});
+        });
+    });
+
+    return null;
+}
+
+ReportRouteParamHandler.displayName = 'ReportRouteParamHandler';
+
+export default ReportRouteParamHandler;

--- a/src/pages/inbox/ReportScreen.tsx
+++ b/src/pages/inbox/ReportScreen.tsx
@@ -5,7 +5,7 @@ import type {ViewStyle} from 'react-native';
 // We use Animated for all functionality related to wide RHP to make it easier
 // to interact with react-navigation components (e.g., CardContainer, interpolator), which also use Animated.
 // eslint-disable-next-line no-restricted-imports
-import {Animated, DeviceEventEmitter, InteractionManager, View} from 'react-native';
+import {Animated, InteractionManager, View} from 'react-native';
 import type {OnyxEntry} from 'react-native-onyx';
 import FullPageNotFoundView from '@components/BlockingViews/FullPageNotFoundView';
 import DragAndDropProvider from '@components/DragAndDrop/Provider';
@@ -20,8 +20,6 @@ import ScrollView from '@components/ScrollView';
 import useShowWideRHPVersion from '@components/WideRHPContextProvider/useShowWideRHPVersion';
 import WideRHPOverlayWrapper from '@components/WideRHPOverlayWrapper';
 import useActionListContextValue from '@hooks/useActionListContextValue';
-import useAppFocusEvent from '@hooks/useAppFocusEvent';
-import useBankAccountUnlockEffect from '@hooks/useBankAccountUnlockEffect';
 import {useCurrentReportIDState} from '@hooks/useCurrentReportID';
 import useCurrentUserPersonalDetails from '@hooks/useCurrentUserPersonalDetails';
 import useDocumentTitle from '@hooks/useDocumentTitle';
@@ -41,13 +39,11 @@ import useSidePanelActions from '@hooks/useSidePanelActions';
 import useSubmitToDestinationVisible from '@hooks/useSubmitToDestinationVisible';
 import useThemeStyles from '@hooks/useThemeStyles';
 import useViewportOffsetTop from '@hooks/useViewportOffsetTop';
-import {hideEmojiPicker} from '@libs/actions/EmojiPickerAction';
 import getNonEmptyStringOnyxID from '@libs/getNonEmptyStringOnyxID';
 import Log from '@libs/Log';
 import {getAllNonDeletedTransactions, shouldDisplayReportTableView, shouldWaitForTransactions as shouldWaitForTransactionsUtil} from '@libs/MoneyRequestReportUtils';
 import Navigation, {navigationRef} from '@libs/Navigation/Navigation';
 import type {PlatformStackScreenProps} from '@libs/Navigation/PlatformStackNavigation/types';
-import clearReportNotifications from '@libs/Notification/clearReportNotifications';
 import {
     getFilteredReportActionsForReportView,
     getIOUActionForReportID,
@@ -78,7 +74,6 @@ import {
     isTaskReport,
     isValidReportIDFromPath,
 } from '@libs/ReportUtils';
-import {cancelSpan, cancelSpansByPrefix} from '@libs/telemetry/activeSpans';
 import {getParentReportActionDeletionStatus} from '@libs/TransactionNavigationUtils';
 import type {ReportsSplitNavigatorParamList, RightModalNavigatorParamList} from '@navigation/types';
 import {setShouldShowComposeInput} from '@userActions/Composer';
@@ -107,6 +102,7 @@ import useReportWasDeleted from './hooks/useReportWasDeleted';
 import ReactionListWrapper from './ReactionListWrapper';
 import ReportActionsView from './report/ReportActionsView';
 import ReportFooter from './report/ReportFooter';
+import ReportLifecycleHandler from './ReportLifecycleHandler';
 import ReportRouteParamHandler from './ReportRouteParamHandler';
 import {ActionListContext} from './ReportScreenContext';
 
@@ -154,7 +150,6 @@ function ReportScreen({route, navigation}: ReportScreenProps) {
     const isFocused = useIsFocused();
     const prevIsFocused = usePrevious(isFocused);
     const [firstRender, setFirstRender] = useState(true);
-    const isSkippingOpenReport = useRef(false);
     const hasCreatedLegacyThreadRef = useRef(false);
     const {isOffline} = useNetwork();
     const {shouldUseNarrowLayout, isInNarrowPaneModal} = useResponsiveLayout();
@@ -305,15 +300,6 @@ function ReportScreen({route, navigation}: ReportScreenProps) {
     const newTransactions = useNewTransactions(reportMetadata?.hasOnceLoadedReportActions, reportTransactions);
 
     const {closeSidePanel} = useSidePanelActions();
-
-    useBankAccountUnlockEffect(report);
-
-    useEffect(() => {
-        if (!prevIsFocused || isFocused) {
-            return;
-        }
-        hideEmojiPicker(true);
-    }, [prevIsFocused, isFocused]);
 
     const backTo = route?.params?.backTo as string;
     const onBackButtonPress = useCallback(
@@ -610,38 +596,6 @@ function ReportScreen({route, navigation}: ReportScreenProps) {
         }
         updateLastVisitTime(reportID);
     }, [reportID, isFocused, isInSidePanel]);
-
-    useEffect(() => {
-        const skipOpenReportListener = DeviceEventEmitter.addListener(`switchToPreExistingReport_${reportID}`, ({preexistingReportID}: {preexistingReportID: string}) => {
-            if (!preexistingReportID) {
-                return;
-            }
-            isSkippingOpenReport.current = true;
-        });
-
-        return () => {
-            skipOpenReportListener.remove();
-
-            // We need to cancel telemetry span when user leaves the screen before full report data is loaded
-            cancelSpan(`${CONST.TELEMETRY.SPAN_OPEN_REPORT}_${reportID}`);
-
-            // Cancel any pending send-message spans to prevent orphaned spans when navigating away
-            cancelSpansByPrefix(CONST.TELEMETRY.SPAN_SEND_MESSAGE);
-        };
-    }, [reportID]);
-
-    // Clear notifications for the current report when it's opened and re-focused
-    const clearNotifications = useCallback(() => {
-        // Check if this is the top-most ReportScreen since the Navigator preserves multiple at a time
-        if (!isTopMostReportId) {
-            return;
-        }
-
-        clearReportNotifications(reportID);
-    }, [reportID, isTopMostReportId]);
-
-    useEffect(clearNotifications, [clearNotifications]);
-    useAppFocusEvent(clearNotifications);
 
     useEffect(() => {
         // eslint-disable-next-line @typescript-eslint/no-deprecated
@@ -1023,6 +977,7 @@ function ReportScreen({route, navigation}: ReportScreenProps) {
                             shouldDisplaySearchRouter
                         >
                             <DragAndDropProvider isDisabled={isEditingDisabled}>
+                                <ReportLifecycleHandler reportIDFromRoute={reportIDFromRoute} />
                                 <OfflineWithFeedback
                                     pendingAction={reportPendingAction ?? report?.pendingFields?.reimbursed}
                                     errors={reportErrors}

--- a/src/pages/inbox/ReportScreen.tsx
+++ b/src/pages/inbox/ReportScreen.tsx
@@ -1,5 +1,5 @@
 import {PortalHost} from '@gorhom/portal';
-import {useFocusEffect, useIsFocused} from '@react-navigation/native';
+import {useIsFocused} from '@react-navigation/native';
 import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import type {ViewStyle} from 'react-native';
 // We use Animated for all functionality related to wide RHP to make it easier
@@ -21,7 +21,6 @@ import useShowWideRHPVersion from '@components/WideRHPContextProvider/useShowWid
 import WideRHPOverlayWrapper from '@components/WideRHPOverlayWrapper';
 import useActionListContextValue from '@hooks/useActionListContextValue';
 import useAppFocusEvent from '@hooks/useAppFocusEvent';
-import useArchivedReportsIdSet from '@hooks/useArchivedReportsIdSet';
 import useBankAccountUnlockEffect from '@hooks/useBankAccountUnlockEffect';
 import {useCurrentReportIDState} from '@hooks/useCurrentReportID';
 import useCurrentUserPersonalDetails from '@hooks/useCurrentUserPersonalDetails';
@@ -34,7 +33,6 @@ import useNewTransactions from '@hooks/useNewTransactions';
 import useOnyx from '@hooks/useOnyx';
 import usePaginatedReportActions from '@hooks/usePaginatedReportActions';
 import useParentReportAction from '@hooks/useParentReportAction';
-import usePermissions from '@hooks/usePermissions';
 import usePrevious from '@hooks/usePrevious';
 import useReportIsArchived from '@hooks/useReportIsArchived';
 import useReportTransactionsCollection from '@hooks/useReportTransactionsCollection';
@@ -63,7 +61,6 @@ import {
 import {getReportName} from '@libs/ReportNameUtils';
 import {
     canUserPerformWriteAction,
-    findLastAccessedReport,
     getReportOfflinePendingActionAndErrors,
     getReportTransactions,
     isAdminRoom,
@@ -83,7 +80,6 @@ import {
 } from '@libs/ReportUtils';
 import {cancelSpan, cancelSpansByPrefix} from '@libs/telemetry/activeSpans';
 import {getParentReportActionDeletionStatus} from '@libs/TransactionNavigationUtils';
-import {isNumeric} from '@libs/ValidationUtils';
 import type {ReportsSplitNavigatorParamList, RightModalNavigatorParamList} from '@navigation/types';
 import {setShouldShowComposeInput} from '@userActions/Composer';
 import {
@@ -111,6 +107,7 @@ import useReportWasDeleted from './hooks/useReportWasDeleted';
 import ReactionListWrapper from './ReactionListWrapper';
 import ReportActionsView from './report/ReportActionsView';
 import ReportFooter from './report/ReportFooter';
+import ReportRouteParamHandler from './ReportRouteParamHandler';
 import {ActionListContext} from './ReportScreenContext';
 
 type ReportScreenNavigationProps =
@@ -159,7 +156,6 @@ function ReportScreen({route, navigation}: ReportScreenProps) {
     const [firstRender, setFirstRender] = useState(true);
     const isSkippingOpenReport = useRef(false);
     const hasCreatedLegacyThreadRef = useRef(false);
-    const {isBetaEnabled} = usePermissions();
     const {isOffline} = useNetwork();
     const {shouldUseNarrowLayout, isInNarrowPaneModal} = useResponsiveLayout();
     const isInSidePanel = useIsInSidePanel();
@@ -178,8 +174,6 @@ function ReportScreen({route, navigation}: ReportScreenProps) {
     const isSelfTourViewed = onboarding?.selfTourViewed;
     const [conciergeReportID] = useOnyx(ONYXKEYS.CONCIERGE_REPORT_ID);
 
-    const archivedReportsIdSet = useArchivedReportsIdSet();
-
     const parentReportAction = useParentReportAction(reportOnyx);
 
     const deletedParentAction = isDeletedParentAction(parentReportAction);
@@ -189,37 +183,6 @@ function ReportScreen({route, navigation}: ReportScreenProps) {
     const [isLoadingReportData = true] = useOnyx(ONYXKEYS.IS_LOADING_REPORT_DATA);
     const prevIsLoadingReportData = usePrevious(isLoadingReportData);
     const prevIsAnonymousUser = useRef(false);
-
-    useFocusEffect(
-        useCallback(() => {
-            // Don't update if there is a reportID in the params already
-            if (route.params.reportID) {
-                const reportActionID = route?.params?.reportActionID;
-                const isValidReportActionID = reportActionID && isNumeric(reportActionID);
-                if (reportActionID && !isValidReportActionID) {
-                    Navigation.isNavigationReady().then(() => navigation.setParams({reportActionID: ''}));
-                }
-                return;
-            }
-
-            const lastAccessedReportID = findLastAccessedReport(
-                !isBetaEnabled(CONST.BETAS.DEFAULT_ROOMS),
-                'openOnAdminRoom' in route.params && !!route.params.openOnAdminRoom,
-                undefined,
-                archivedReportsIdSet,
-            )?.reportID;
-
-            // It's possible that reports aren't fully loaded yet
-            // in that case the reportID is undefined
-            if (!lastAccessedReportID) {
-                return;
-            }
-            Navigation.isNavigationReady().then(() => {
-                Log.info(`[ReportScreen] no reportID found in params, setting it to lastAccessedReportID: ${lastAccessedReportID}`);
-                navigation.setParams({reportID: lastAccessedReportID});
-            });
-        }, [archivedReportsIdSet, isBetaEnabled, navigation, route.params]),
-    );
 
     /**
      * Create a lightweight Report so as to keep the re-rendering as light as possible by
@@ -1043,6 +1006,10 @@ function ReportScreen({route, navigation}: ReportScreenProps) {
                         testID={`report-screen-${reportID}`}
                     >
                         <DeleteTransactionNavigateBackHandler />
+                        <ReportRouteParamHandler
+                            route={route}
+                            navigation={navigation}
+                        />
                         <FullPageNotFoundView
                             shouldShow={shouldShowNotFoundPage}
                             subtitleKey={shouldShowNotFoundLinkedAction ? 'notFound.commentYouLookingForCannotBeFound' : 'notFound.noAccess'}

--- a/src/pages/inbox/ReportScreen.tsx
+++ b/src/pages/inbox/ReportScreen.tsx
@@ -1,6 +1,5 @@
 import {PortalHost} from '@gorhom/portal';
-import {useIsFocused} from '@react-navigation/native';
-import React, {useCallback, useEffect, useMemo, useState} from 'react';
+import React, {useCallback, useMemo} from 'react';
 import type {ViewStyle} from 'react-native';
 // We use Animated for all functionality related to wide RHP to make it easier
 // to interact with react-navigation components (e.g., CardContainer, interpolator), which also use Animated.
@@ -20,7 +19,6 @@ import useShowWideRHPVersion from '@components/WideRHPContextProvider/useShowWid
 import WideRHPOverlayWrapper from '@components/WideRHPOverlayWrapper';
 import useActionListContextValue from '@hooks/useActionListContextValue';
 import {useCurrentReportIDState} from '@hooks/useCurrentReportID';
-import useCurrentUserPersonalDetails from '@hooks/useCurrentUserPersonalDetails';
 import useDocumentTitle from '@hooks/useDocumentTitle';
 import useIsInSidePanel from '@hooks/useIsInSidePanel';
 import useIsReportReadyToDisplay from '@hooks/useIsReportReadyToDisplay';
@@ -29,7 +27,6 @@ import useNewTransactions from '@hooks/useNewTransactions';
 import useOnyx from '@hooks/useOnyx';
 import usePaginatedReportActions from '@hooks/usePaginatedReportActions';
 import useParentReportAction from '@hooks/useParentReportAction';
-import usePrevious from '@hooks/usePrevious';
 import useReportIsArchived from '@hooks/useReportIsArchived';
 import useReportTransactionsCollection from '@hooks/useReportTransactionsCollection';
 import useResponsiveLayout from '@hooks/useResponsiveLayout';
@@ -39,44 +36,29 @@ import useThemeStyles from '@hooks/useThemeStyles';
 import useViewportOffsetTop from '@hooks/useViewportOffsetTop';
 import getNonEmptyStringOnyxID from '@libs/getNonEmptyStringOnyxID';
 import {getAllNonDeletedTransactions, shouldDisplayReportTableView, shouldWaitForTransactions as shouldWaitForTransactionsUtil} from '@libs/MoneyRequestReportUtils';
-import Navigation, {navigationRef} from '@libs/Navigation/Navigation';
+import Navigation from '@libs/Navigation/Navigation';
 import type {PlatformStackScreenProps} from '@libs/Navigation/PlatformStackNavigation/types';
-import {getFilteredReportActionsForReportView, getOneTransactionThreadReportID, isDeletedParentAction, isTransactionThread} from '@libs/ReportActionsUtils';
+import {getFilteredReportActionsForReportView, getOneTransactionThreadReportID, isTransactionThread} from '@libs/ReportActionsUtils';
 import {getReportName} from '@libs/ReportNameUtils';
-import {
-    getReportOfflinePendingActionAndErrors,
-    isAdminRoom,
-    isAnnounceRoom,
-    isGroupChat,
-    isInvoiceReport,
-    isMoneyRequest,
-    isMoneyRequestReport,
-    isMoneyRequestReportPendingDeletion,
-    isPolicyExpenseChat,
-    isReportTransactionThread,
-} from '@libs/ReportUtils';
+import {getReportOfflinePendingActionAndErrors, isInvoiceReport, isMoneyRequestReport, isReportTransactionThread} from '@libs/ReportUtils';
 import type {ReportsSplitNavigatorParamList, RightModalNavigatorParamList} from '@navigation/types';
-import {setShouldShowComposeInput} from '@userActions/Composer';
-import {navigateToConciergeChat} from '@userActions/Report';
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
 import type {Route} from '@src/ROUTES';
-import ROUTES from '@src/ROUTES';
 import SCREENS from '@src/SCREENS';
 import {reportByIDsSelector} from '@src/selectors/Attributes';
 import type * as OnyxTypes from '@src/types/onyx';
-import {isEmptyObject} from '@src/types/utils/EmptyObject';
 import AccountManagerBanner from './AccountManagerBanner';
 import {AgentZeroStatusProvider} from './AgentZeroStatusContext';
 import DeleteTransactionNavigateBackHandler from './DeleteTransactionNavigateBackHandler';
 import HeaderView from './HeaderView';
-import useReportWasDeleted from './hooks/useReportWasDeleted';
 import LinkedActionNotFoundGuard from './LinkedActionNotFoundGuard';
 import ReactionListWrapper from './ReactionListWrapper';
 import ReportActionsView from './report/ReportActionsView';
 import ReportFooter from './report/ReportFooter';
 import ReportFetchController from './ReportFetchController';
 import ReportLifecycleHandler from './ReportLifecycleHandler';
+import ReportNavigateAwayHandler from './ReportNavigateAwayHandler';
 import ReportNotFoundGuard from './ReportNotFoundGuard';
 import ReportRouteParamHandler from './ReportRouteParamHandler';
 import {ActionListContext} from './ReportScreenContext';
@@ -97,33 +79,10 @@ const defaultReportMetadata = {
     isOptimisticReport: false,
 };
 
-const reportDetailScreens = [
-    ...Object.values(SCREENS.REPORT_DETAILS),
-    ...Object.values(SCREENS.REPORT_SETTINGS),
-    ...Object.values(SCREENS.PRIVATE_NOTES),
-    ...Object.values(SCREENS.REPORT_PARTICIPANTS),
-];
-
-/**
- * Check is the report is deleted.
- * We currently use useMemo to memorize every properties of the report
- * so we can't check using isEmpty.
- *
- * @param report
- */
-function isEmpty(report: OnyxEntry<OnyxTypes.Report>): boolean {
-    if (isEmptyObject(report)) {
-        return true;
-    }
-    return !Object.values(report).some((value) => value !== undefined && value !== '');
-}
-
 function ReportScreen({route, navigation}: ReportScreenProps) {
     const styles = useThemeStyles();
     const reportIDFromRoute = getNonEmptyStringOnyxID(route.params?.reportID);
     const reportActionIDFromRoute = route?.params?.reportActionID;
-    const isFocused = useIsFocused();
-    const [firstRender, setFirstRender] = useState(true);
     const {isOffline} = useNetwork();
     const {isInNarrowPaneModal} = useResponsiveLayout();
     const isInSidePanel = useIsInSidePanel();
@@ -131,20 +90,11 @@ function ReportScreen({route, navigation}: ReportScreenProps) {
     const {currentReportID: currentReportIDValue} = useCurrentReportIDState();
 
     const [reportOnyx] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT}${reportIDFromRoute}`);
-    const [userLeavingStatus = false] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT_USER_IS_LEAVING_ROOM}${reportIDFromRoute}`);
     const [reportNameValuePairsOnyx] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT_NAME_VALUE_PAIRS}${reportIDFromRoute}`);
     const [reportMetadata = defaultReportMetadata] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT_METADATA}${reportIDFromRoute}`);
     const [policy] = useOnyx(`${ONYXKEYS.COLLECTION.POLICY}${getNonEmptyStringOnyxID(reportOnyx?.policyID)}`);
-    const [introSelected] = useOnyx(ONYXKEYS.NVP_INTRO_SELECTED);
-    const [betas] = useOnyx(ONYXKEYS.BETAS);
-    const [onboarding] = useOnyx(ONYXKEYS.NVP_ONBOARDING);
-    const isSelfTourViewed = onboarding?.selfTourViewed;
-    const [conciergeReportID] = useOnyx(ONYXKEYS.CONCIERGE_REPORT_ID);
 
     const parentReportAction = useParentReportAction(reportOnyx);
-
-    const deletedParentAction = isDeletedParentAction(parentReportAction);
-    const prevDeletedParentAction = usePrevious(deletedParentAction);
 
     /**
      * Create a lightweight Report so as to keep the re-rendering as light as possible by
@@ -209,11 +159,6 @@ function ReportScreen({route, navigation}: ReportScreenProps) {
     useDocumentTitle(getReportName(report, reportAttributes));
 
     const [chatReport] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT}${report?.chatReportID}`);
-    const prevReport = usePrevious(report);
-    const prevUserLeavingStatus = usePrevious(userLeavingStatus);
-    const lastReportIDFromRoute = usePrevious(reportIDFromRoute);
-
-    const {accountID: currentUserAccountID} = useCurrentUserPersonalDetails();
 
     const {reportActions: unfilteredReportActions, hasNewerActions, hasOlderActions} = usePaginatedReportActions(reportID, reportActionIDFromRoute);
     // wrapping in useMemo because this is array operation and can cause performance issues
@@ -222,9 +167,6 @@ function ReportScreen({route, navigation}: ReportScreenProps) {
 
     const {reportPendingAction, reportErrors} = getReportOfflinePendingActionAndErrors(report);
     const screenWrapperStyle: ViewStyle[] = [styles.appContent, styles.flex1, {marginTop: viewportOffsetTop}];
-    const isOptimisticDelete = report?.statusNum === CONST.REPORT.STATUS_NUM.CLOSED;
-
-    const {wasDeleted: reportWasDeleted, parentReportID: deletedReportParentID} = useReportWasDeleted(reportIDFromRoute, report, isOptimisticDelete, userLeavingStatus);
 
     const allReportTransactions = useReportTransactionsCollection(reportIDFromRoute);
     const hasPendingDeletionTransaction = Object.values(allReportTransactions ?? {}).some((transaction) => transaction?.pendingAction === CONST.RED_BRICK_ROAD_PENDING_ACTION.DELETE);
@@ -308,127 +250,6 @@ function ReportScreen({route, navigation}: ReportScreenProps) {
     const isReportArchived = useReportIsArchived(report?.reportID);
     const {isEditingDisabled} = useIsReportReadyToDisplay(report, reportIDFromRoute, isReportArchived);
 
-    useEffect(() => {
-        // We don't want this effect to run on the first render.
-        if (firstRender) {
-            setFirstRender(false);
-            return;
-        }
-
-        const onyxReportID = report?.reportID;
-        const prevOnyxReportID = prevReport?.reportID;
-        const wasReportRemoved = !!prevOnyxReportID && prevOnyxReportID === reportIDFromRoute && !onyxReportID;
-        const isRemovalExpectedForReportType =
-            isEmpty(report) &&
-            (isMoneyRequest(prevReport) ||
-                isMoneyRequestReport(prevReport) ||
-                isPolicyExpenseChat(prevReport) ||
-                isGroupChat(prevReport) ||
-                isAdminRoom(prevReport) ||
-                isAnnounceRoom(prevReport));
-        const didReportClose = wasReportRemoved && prevReport.statusNum === CONST.REPORT.STATUS_NUM.OPEN && report?.statusNum === CONST.REPORT.STATUS_NUM.CLOSED;
-        const isTopLevelPolicyRoomWithNoStatus = !report?.statusNum && !prevReport?.parentReportID && prevReport?.chatType === CONST.REPORT.CHAT_TYPE.POLICY_ROOM;
-        const isClosedTopLevelPolicyRoom = wasReportRemoved && prevReport.statusNum === CONST.REPORT.STATUS_NUM.OPEN && isTopLevelPolicyRoomWithNoStatus;
-        // Navigate to the Concierge chat if the room was removed from another device (e.g. user leaving a room or removed from a room)
-        if (
-            // non-optimistic case
-            (!prevUserLeavingStatus && !!userLeavingStatus) ||
-            didReportClose ||
-            isRemovalExpectedForReportType ||
-            isClosedTopLevelPolicyRoom ||
-            (prevDeletedParentAction && !deletedParentAction)
-        ) {
-            const currentRoute = navigationRef.getCurrentRoute();
-            const topmostReportIDInSearchRHP = Navigation.getTopmostSearchReportID();
-            const isTopmostSearchReportID = reportIDFromRoute === topmostReportIDInSearchRHP;
-            const isHoldScreenOpenInRHP =
-                currentRoute?.name === SCREENS.MONEY_REQUEST.HOLD && (route.name === SCREENS.RIGHT_MODAL.SEARCH_REPORT ? isTopmostSearchReportID : isTopMostReportId);
-            const isReportDetailOpenInRHP =
-                isTopMostReportId &&
-                reportDetailScreens.find((r) => r === currentRoute?.name) &&
-                !!currentRoute?.params &&
-                typeof currentRoute.params === 'object' &&
-                'reportID' in currentRoute.params &&
-                reportIDFromRoute === currentRoute.params.reportID;
-            // Early return if the report we're passing isn't in a focused state. We only want to navigate to Concierge if the user leaves the room from another device or gets removed from the room while the report is in a focused state.
-            // Prevent auto navigation for report in RHP
-            if ((!isFocused && !isHoldScreenOpenInRHP && !isReportDetailOpenInRHP) || (!isHoldScreenOpenInRHP && isInNarrowPaneModal)) {
-                return;
-            }
-            Navigation.dismissModal();
-            if (Navigation.getTopmostReportId() === prevOnyxReportID) {
-                Navigation.isNavigationReady().then(() => {
-                    Navigation.popToSidebar();
-                });
-            }
-            if (prevReport?.parentReportID) {
-                // Prevent navigation to the IOU/Expense Report if it is pending deletion.
-                if (isMoneyRequestReportPendingDeletion(prevReport.parentReportID)) {
-                    return;
-                }
-                Navigation.isNavigationReady().then(() => {
-                    Navigation.navigate(ROUTES.REPORT_WITH_ID.getRoute(prevReport.parentReportID));
-                });
-                return;
-            }
-
-            Navigation.isNavigationReady().then(() => {
-                navigateToConciergeChat(conciergeReportID, introSelected, currentUserAccountID, isSelfTourViewed, betas, false);
-            });
-            return;
-        }
-
-        // If you already have a report open and are deeplinking to a new report on native,
-        // the ReportScreen never actually unmounts and the reportID in the route also doesn't change.
-        // Therefore, we need to compare if the existing reportID is the same as the one in the route
-        // before deciding that we shouldn't call OpenReport.
-        if (reportIDFromRoute === lastReportIDFromRoute && (!onyxReportID || onyxReportID === reportIDFromRoute)) {
-            return;
-        }
-
-        setShouldShowComposeInput(true);
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [
-        route.name,
-        report,
-        prevReport?.reportID,
-        prevUserLeavingStatus,
-        userLeavingStatus,
-        prevReport?.statusNum,
-        prevReport?.parentReportID,
-        prevReport?.chatType,
-        prevReport,
-        reportIDFromRoute,
-        lastReportIDFromRoute,
-        isFocused,
-        deletedParentAction,
-        prevDeletedParentAction,
-    ]);
-
-    useEffect(() => {
-        if (!reportWasDeleted) {
-            return;
-        }
-
-        // Only redirect if focused
-        if (!isFocused) {
-            return;
-        }
-
-        // Try to navigate to parent report if available
-        if (deletedReportParentID && !isMoneyRequestReportPendingDeletion(deletedReportParentID)) {
-            Navigation.isNavigationReady().then(() => {
-                Navigation.navigate(ROUTES.REPORT_WITH_ID.getRoute(deletedReportParentID));
-            });
-            return;
-        }
-
-        // Fallback to Concierge
-        Navigation.isNavigationReady().then(() => {
-            navigateToConciergeChat(conciergeReportID, introSelected, currentUserAccountID, isSelfTourViewed, betas);
-        });
-    }, [reportWasDeleted, isFocused, deletedReportParentID, conciergeReportID, introSelected, currentUserAccountID, isSelfTourViewed, betas]);
-
     const actionListValue = useActionListContextValue();
 
     // wrapping into useMemo to stabilize children re-renders as reportMetadata is changed frequently
@@ -481,6 +302,7 @@ function ReportScreen({route, navigation}: ReportScreenProps) {
                             navigation={navigation}
                         />
                         <ReportFetchController />
+                        <ReportNavigateAwayHandler />
                         <ReportNotFoundGuard>
                             <LinkedActionNotFoundGuard>
                                 <DragAndDropProvider isDisabled={isEditingDisabled}>

--- a/src/pages/inbox/ReportScreen.tsx
+++ b/src/pages/inbox/ReportScreen.tsx
@@ -5,9 +5,8 @@ import type {ViewStyle} from 'react-native';
 // We use Animated for all functionality related to wide RHP to make it easier
 // to interact with react-navigation components (e.g., CardContainer, interpolator), which also use Animated.
 // eslint-disable-next-line no-restricted-imports
-import {Animated, InteractionManager, View} from 'react-native';
+import {Animated, View} from 'react-native';
 import type {OnyxEntry} from 'react-native-onyx';
-import FullPageNotFoundView from '@components/BlockingViews/FullPageNotFoundView';
 import DragAndDropProvider from '@components/DragAndDrop/Provider';
 import MoneyReportHeader from '@components/MoneyReportHeader';
 import MoneyRequestHeader from '@components/MoneyRequestHeader';
@@ -39,21 +38,12 @@ import useSubmitToDestinationVisible from '@hooks/useSubmitToDestinationVisible'
 import useThemeStyles from '@hooks/useThemeStyles';
 import useViewportOffsetTop from '@hooks/useViewportOffsetTop';
 import getNonEmptyStringOnyxID from '@libs/getNonEmptyStringOnyxID';
-import Log from '@libs/Log';
 import {getAllNonDeletedTransactions, shouldDisplayReportTableView, shouldWaitForTransactions as shouldWaitForTransactionsUtil} from '@libs/MoneyRequestReportUtils';
 import Navigation, {navigationRef} from '@libs/Navigation/Navigation';
 import type {PlatformStackScreenProps} from '@libs/Navigation/PlatformStackNavigation/types';
-import {
-    getFilteredReportActionsForReportView,
-    getOneTransactionThreadReportID,
-    isDeletedParentAction,
-    isReportActionVisible,
-    isTransactionThread,
-    isWhisperAction,
-} from '@libs/ReportActionsUtils';
+import {getFilteredReportActionsForReportView, getOneTransactionThreadReportID, isDeletedParentAction, isTransactionThread} from '@libs/ReportActionsUtils';
 import {getReportName} from '@libs/ReportNameUtils';
 import {
-    canUserPerformWriteAction,
     getReportOfflinePendingActionAndErrors,
     isAdminRoom,
     isAnnounceRoom,
@@ -64,9 +54,7 @@ import {
     isMoneyRequestReportPendingDeletion,
     isPolicyExpenseChat,
     isReportTransactionThread,
-    isValidReportIDFromPath,
 } from '@libs/ReportUtils';
-import {getParentReportActionDeletionStatus} from '@libs/TransactionNavigationUtils';
 import type {ReportsSplitNavigatorParamList, RightModalNavigatorParamList} from '@navigation/types';
 import {setShouldShowComposeInput} from '@userActions/Composer';
 import {navigateToConciergeChat} from '@userActions/Report';
@@ -83,11 +71,13 @@ import {AgentZeroStatusProvider} from './AgentZeroStatusContext';
 import DeleteTransactionNavigateBackHandler from './DeleteTransactionNavigateBackHandler';
 import HeaderView from './HeaderView';
 import useReportWasDeleted from './hooks/useReportWasDeleted';
+import LinkedActionNotFoundGuard from './LinkedActionNotFoundGuard';
 import ReactionListWrapper from './ReactionListWrapper';
 import ReportActionsView from './report/ReportActionsView';
 import ReportFooter from './report/ReportFooter';
 import ReportFetchController from './ReportFetchController';
 import ReportLifecycleHandler from './ReportLifecycleHandler';
+import ReportNotFoundGuard from './ReportNotFoundGuard';
 import ReportRouteParamHandler from './ReportRouteParamHandler';
 import {ActionListContext} from './ReportScreenContext';
 
@@ -135,13 +125,12 @@ function ReportScreen({route, navigation}: ReportScreenProps) {
     const isFocused = useIsFocused();
     const [firstRender, setFirstRender] = useState(true);
     const {isOffline} = useNetwork();
-    const {shouldUseNarrowLayout, isInNarrowPaneModal} = useResponsiveLayout();
+    const {isInNarrowPaneModal} = useResponsiveLayout();
     const isInSidePanel = useIsInSidePanel();
 
     const {currentReportID: currentReportIDValue} = useCurrentReportIDState();
 
     const [reportOnyx] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT}${reportIDFromRoute}`);
-    const [parentReportMetadata] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT_METADATA}${reportOnyx?.parentReportID}`);
     const [userLeavingStatus = false] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT_USER_IS_LEAVING_ROOM}${reportIDFromRoute}`);
     const [reportNameValuePairsOnyx] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT_NAME_VALUE_PAIRS}${reportIDFromRoute}`);
     const [reportMetadata = defaultReportMetadata] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT_METADATA}${reportIDFromRoute}`);
@@ -156,8 +145,6 @@ function ReportScreen({route, navigation}: ReportScreenProps) {
 
     const deletedParentAction = isDeletedParentAction(parentReportAction);
     const prevDeletedParentAction = usePrevious(deletedParentAction);
-
-    const [isLoadingReportData = true] = useOnyx(ONYXKEYS.IS_LOADING_REPORT_DATA);
 
     /**
      * Create a lightweight Report so as to keep the re-rendering as light as possible by
@@ -225,13 +212,10 @@ function ReportScreen({route, navigation}: ReportScreenProps) {
     const prevReport = usePrevious(report);
     const prevUserLeavingStatus = usePrevious(userLeavingStatus);
     const lastReportIDFromRoute = usePrevious(reportIDFromRoute);
-    const [isLinkingToMessage, setIsLinkingToMessage] = useState(!!reportActionIDFromRoute);
 
     const {accountID: currentUserAccountID} = useCurrentUserPersonalDetails();
 
-    const [isLoadingApp] = useOnyx(ONYXKEYS.IS_LOADING_APP);
-    const [visibleReportActionsData] = useOnyx(ONYXKEYS.DERIVED.VISIBLE_REPORT_ACTIONS);
-    const {reportActions: unfilteredReportActions, linkedAction, sortedAllReportActions, hasNewerActions, hasOlderActions} = usePaginatedReportActions(reportID, reportActionIDFromRoute);
+    const {reportActions: unfilteredReportActions, hasNewerActions, hasOlderActions} = usePaginatedReportActions(reportID, reportActionIDFromRoute);
     // wrapping in useMemo because this is array operation and can cause performance issues
     const reportActions = useMemo(() => getFilteredReportActionsForReportView(unfilteredReportActions), [unfilteredReportActions]);
     const viewportOffsetTop = useViewportOffsetTop();
@@ -323,141 +307,6 @@ function ReportScreen({route, navigation}: ReportScreenProps) {
 
     const isReportArchived = useReportIsArchived(report?.reportID);
     const {isEditingDisabled} = useIsReportReadyToDisplay(report, reportIDFromRoute, isReportArchived);
-
-    const isLinkedActionDeleted = useMemo(() => {
-        if (!linkedAction) {
-            return false;
-        }
-        const actionReportID = linkedAction.reportID ?? reportID;
-        if (!actionReportID) {
-            return true;
-        }
-        return !isReportActionVisible(linkedAction, actionReportID, canUserPerformWriteAction(report, isReportArchived), visibleReportActionsData);
-    }, [linkedAction, report, isReportArchived, reportID, visibleReportActionsData]);
-
-    const prevIsLinkedActionDeleted = usePrevious(linkedAction ? isLinkedActionDeleted : undefined);
-
-    const lastReportActionIDFromRoute = usePrevious(!firstRender ? reportActionIDFromRoute : undefined);
-
-    const [isNavigatingToDeletedAction, setIsNavigatingToDeletedAction] = useState(false);
-
-    const isLinkedActionInaccessibleWhisper = useMemo(
-        () => !!linkedAction && isWhisperAction(linkedAction) && !(linkedAction?.whisperedToAccountIDs ?? []).includes(currentUserAccountID),
-        [currentUserAccountID, linkedAction],
-    );
-    const {isParentActionMissingAfterLoad, isParentActionDeleted} = getParentReportActionDeletionStatus({
-        parentReportID: report?.parentReportID,
-        parentReportActionID: report?.parentReportActionID,
-        parentReportAction,
-        parentReportMetadata,
-        isOffline,
-    });
-    const isDeletedTransactionThread = isReportTransactionThread(report) && (isParentActionDeleted || isParentActionMissingAfterLoad);
-    const [deleteTransactionNavigateBackUrl] = useOnyx(ONYXKEYS.NVP_DELETE_TRANSACTION_NAVIGATE_BACK_URL);
-    // eslint-disable-next-line rulesdir/no-negated-variables
-    const shouldShowNotFoundLinkedAction =
-        (!isLinkedActionInaccessibleWhisper && isLinkedActionDeleted && isNavigatingToDeletedAction) ||
-        (!reportMetadata?.isLoadingInitialReportActions &&
-            !!reportActionIDFromRoute &&
-            !!sortedAllReportActions &&
-            sortedAllReportActions?.length > 0 &&
-            reportActions.length === 0 &&
-            !isLinkingToMessage);
-
-    const currentReportIDFormRoute = route.params?.reportID;
-
-    // eslint-disable-next-line rulesdir/no-negated-variables
-    const shouldShowNotFoundPage = useMemo((): boolean => {
-        const isInvalidReportPath = !!currentReportIDFormRoute && !isValidReportIDFromPath(currentReportIDFormRoute);
-        const isLoading = isLoadingApp !== false || isLoadingReportData || (!isOffline && !!reportMetadata?.isLoadingInitialReportActions);
-        const reportExists = !!reportID || (!isDeletedTransactionThread && isOptimisticDelete) || userLeavingStatus;
-
-        if (shouldShowNotFoundLinkedAction) {
-            return true;
-        }
-
-        if (deleteTransactionNavigateBackUrl) {
-            return false;
-        }
-
-        if (isDeletedTransactionThread) {
-            return true;
-        }
-
-        if (isInvalidReportPath) {
-            return true;
-        }
-
-        if (isLoading) {
-            return false;
-        }
-
-        if (firstRender) {
-            return false;
-        }
-
-        return !reportExists;
-    }, [
-        shouldShowNotFoundLinkedAction,
-        isLoadingApp,
-        isLoadingReportData,
-        isOffline,
-        reportMetadata?.isLoadingInitialReportActions,
-        reportID,
-        isOptimisticDelete,
-        userLeavingStatus,
-        currentReportIDFormRoute,
-        firstRender,
-        deleteTransactionNavigateBackUrl,
-        isDeletedTransactionThread,
-    ]);
-
-    useEffect(() => {
-        if (!shouldShowNotFoundPage) {
-            return;
-        }
-
-        Log.info('[ReportScreen] Displaying NotFound Page', false, {
-            shouldShowNotFoundLinkedAction,
-            isLoadingApp,
-            isLoadingReportData,
-            isOffline,
-            isLoadingInitialReportActions: reportMetadata?.isLoadingInitialReportActions,
-            reportID,
-            isOptimisticDelete,
-            userLeavingStatus,
-            currentReportIDFormRoute,
-            firstRender,
-            deleteTransactionNavigateBackUrl,
-            isDeletedTransactionThread,
-            isParentActionDeleted,
-            isParentActionMissingAfterLoad,
-            isNavigatingToDeletedAction,
-            isLinkedActionInaccessibleWhisper,
-            isLinkedActionDeleted,
-            isLinkingToMessage,
-        });
-    }, [
-        shouldShowNotFoundPage,
-        shouldShowNotFoundLinkedAction,
-        isLoadingApp,
-        isLoadingReportData,
-        isOffline,
-        reportMetadata?.isLoadingInitialReportActions,
-        reportID,
-        isOptimisticDelete,
-        userLeavingStatus,
-        currentReportIDFormRoute,
-        firstRender,
-        deleteTransactionNavigateBackUrl,
-        isDeletedTransactionThread,
-        isParentActionDeleted,
-        isParentActionMissingAfterLoad,
-        isNavigatingToDeletedAction,
-        isLinkedActionInaccessibleWhisper,
-        isLinkedActionDeleted,
-        isLinkingToMessage,
-    ]);
 
     useEffect(() => {
         // We don't want this effect to run on the first render.
@@ -582,50 +431,6 @@ function ReportScreen({route, navigation}: ReportScreenProps) {
 
     const actionListValue = useActionListContextValue();
 
-    // This helps in tracking from the moment 'route' triggers useMemo until isLoadingInitialReportActions becomes true. It prevents blinking when loading reportActions from cache.
-    useEffect(() => {
-        // eslint-disable-next-line @typescript-eslint/no-deprecated
-        InteractionManager.runAfterInteractions(() => {
-            setIsLinkingToMessage(false);
-        });
-    }, [reportMetadata?.isLoadingInitialReportActions]);
-
-    const navigateToEndOfReport = useCallback(() => {
-        Navigation.setParams({reportActionID: ''});
-    }, []);
-
-    useEffect(() => {
-        // Only handle deletion cases when there's a deleted action
-        if (!isLinkedActionDeleted) {
-            setIsNavigatingToDeletedAction(false);
-            return;
-        }
-
-        // we want to do this distinguish between normal navigation and delete behavior
-        if (lastReportActionIDFromRoute !== reportActionIDFromRoute) {
-            setIsNavigatingToDeletedAction(true);
-            return;
-        }
-
-        // Clear params when action gets deleted while highlighting
-        if (!isNavigatingToDeletedAction && prevIsLinkedActionDeleted === false) {
-            Navigation.setParams({reportActionID: ''});
-        }
-    }, [isLinkedActionDeleted, prevIsLinkedActionDeleted, lastReportActionIDFromRoute, reportActionIDFromRoute, isNavigatingToDeletedAction]);
-
-    // If user redirects to an inaccessible whisper via a deeplink, on a report they have access to,
-    // then we set reportActionID as empty string, so we display them the report and not the "Not found page".
-    useEffect(() => {
-        if (!isLinkedActionInaccessibleWhisper) {
-            return;
-        }
-        Navigation.isNavigationReady().then(() => {
-            Navigation.setParams({reportActionID: ''});
-        });
-    }, [isLinkedActionInaccessibleWhisper]);
-
-    const lastRoute = usePrevious(route);
-
     // wrapping into useMemo to stabilize children re-renders as reportMetadata is changed frequently
     const showReportActionsLoadingState = useMemo(
         () => reportMetadata?.isLoadingInitialReportActions && !reportMetadata?.hasOnceLoadedReportActions,
@@ -659,14 +464,6 @@ function ReportScreen({route, navigation}: ReportScreenProps) {
         CONST.TELEMETRY.SUBMIT_TO_DESTINATION_VISIBLE_TRIGGER.FOCUS,
     );
 
-    // Define here because reportActions are recalculated before mount, allowing data to display faster than useEffect can trigger.
-    // If we have cached reportActions, they will be shown immediately.
-    // We aim to display a loader first, then fetch relevant reportActions, and finally show them.
-    if ((lastRoute !== route || lastReportActionIDFromRoute !== reportActionIDFromRoute) && isLinkingToMessage !== !!reportActionIDFromRoute) {
-        setIsLinkingToMessage(!!reportActionIDFromRoute);
-        return null;
-    }
-
     return (
         // Wide RHP overlays should be rendered only for the report screen displayed in RHP
         <WideRHPOverlayWrapper shouldWrap={route.name === SCREENS.RIGHT_MODAL.SEARCH_REPORT}>
@@ -684,72 +481,63 @@ function ReportScreen({route, navigation}: ReportScreenProps) {
                             navigation={navigation}
                         />
                         <ReportFetchController />
-                        <FullPageNotFoundView
-                            shouldShow={shouldShowNotFoundPage}
-                            subtitleKey={shouldShowNotFoundLinkedAction ? 'notFound.commentYouLookingForCannotBeFound' : 'notFound.noAccess'}
-                            subtitleStyle={[styles.textSupporting]}
-                            shouldShowBackButton={shouldUseNarrowLayout}
-                            onBackButtonPress={shouldShowNotFoundLinkedAction ? navigateToEndOfReport : Navigation.goBack}
-                            shouldShowLink={shouldShowNotFoundLinkedAction}
-                            linkTranslationKey="notFound.goToChatInstead"
-                            subtitleKeyBelowLink={shouldShowNotFoundLinkedAction ? 'notFound.contactConcierge' : ''}
-                            onLinkPress={navigateToEndOfReport}
-                            shouldDisplaySearchRouter
-                        >
-                            <DragAndDropProvider isDisabled={isEditingDisabled}>
-                                <ReportLifecycleHandler reportIDFromRoute={reportIDFromRoute} />
-                                <OfflineWithFeedback
-                                    pendingAction={reportPendingAction ?? report?.pendingFields?.reimbursed}
-                                    errors={reportErrors}
-                                    shouldShowErrorMessages={false}
-                                    needsOffscreenAlphaCompositing
-                                >
-                                    {headerView}
-                                </OfflineWithFeedback>
-                                <AccountManagerBanner reportID={reportIDFromRoute} />
-                                <View style={[styles.flex1, styles.flexRow]}>
-                                    {shouldShowWideRHP && (
-                                        <Animated.View style={styles.wideRHPMoneyRequestReceiptViewContainer}>
-                                            <ScrollView contentContainerStyle={styles.wideRHPMoneyRequestReceiptViewScrollViewContainer}>
-                                                <MoneyRequestReceiptView
-                                                    report={transactionThreadReport ?? report}
-                                                    fillSpace
-                                                    isDisplayedInWideRHP
-                                                />
-                                            </ScrollView>
-                                        </Animated.View>
-                                    )}
-                                    <AgentZeroStatusProvider
-                                        reportID={reportIDFromRoute}
-                                        chatType={report?.chatType}
+                        <ReportNotFoundGuard>
+                            <LinkedActionNotFoundGuard>
+                                <DragAndDropProvider isDisabled={isEditingDisabled}>
+                                    <ReportLifecycleHandler reportIDFromRoute={reportIDFromRoute} />
+                                    <OfflineWithFeedback
+                                        pendingAction={reportPendingAction ?? report?.pendingFields?.reimbursed}
+                                        errors={reportErrors}
+                                        shouldShowErrorMessages={false}
+                                        needsOffscreenAlphaCompositing
                                     >
-                                        <View
-                                            style={[styles.flex1, styles.justifyContentEnd, styles.overflowHidden]}
-                                            testID="report-actions-view-wrapper"
+                                        {headerView}
+                                    </OfflineWithFeedback>
+                                    <AccountManagerBanner reportID={reportIDFromRoute} />
+                                    <View style={[styles.flex1, styles.flexRow]}>
+                                        {shouldShowWideRHP && (
+                                            <Animated.View style={styles.wideRHPMoneyRequestReceiptViewContainer}>
+                                                <ScrollView contentContainerStyle={styles.wideRHPMoneyRequestReceiptViewScrollViewContainer}>
+                                                    <MoneyRequestReceiptView
+                                                        report={transactionThreadReport ?? report}
+                                                        fillSpace
+                                                        isDisplayedInWideRHP
+                                                    />
+                                                </ScrollView>
+                                            </Animated.View>
+                                        )}
+                                        <AgentZeroStatusProvider
+                                            reportID={reportIDFromRoute}
+                                            chatType={report?.chatType}
                                         >
-                                            {(!report || shouldWaitForTransactions) && <ReportActionsSkeletonView />}
-                                            {!!report && !shouldDisplayMoneyRequestActionsList && !shouldWaitForTransactions ? <ReportActionsView reportID={report.reportID} /> : null}
-                                            {!!report && shouldDisplayMoneyRequestActionsList && !shouldWaitForTransactions ? (
-                                                <MoneyRequestReportActionsList
-                                                    report={report}
-                                                    hasPendingDeletionTransaction={hasPendingDeletionTransaction}
-                                                    policy={policy}
-                                                    reportActions={reportActions}
-                                                    transactions={visibleTransactions}
-                                                    newTransactions={newTransactions}
-                                                    hasOlderActions={hasOlderActions}
-                                                    hasNewerActions={hasNewerActions}
-                                                    showReportActionsLoadingState={showReportActionsLoadingState}
-                                                    reportPendingAction={reportPendingAction}
-                                                />
-                                            ) : null}
-                                            <ReportFooter />
-                                        </View>
-                                    </AgentZeroStatusProvider>
-                                </View>
-                                <PortalHost name="suggestions" />
-                            </DragAndDropProvider>
-                        </FullPageNotFoundView>
+                                            <View
+                                                style={[styles.flex1, styles.justifyContentEnd, styles.overflowHidden]}
+                                                testID="report-actions-view-wrapper"
+                                            >
+                                                {(!report || shouldWaitForTransactions) && <ReportActionsSkeletonView />}
+                                                {!!report && !shouldDisplayMoneyRequestActionsList && !shouldWaitForTransactions ? <ReportActionsView reportID={report.reportID} /> : null}
+                                                {!!report && shouldDisplayMoneyRequestActionsList && !shouldWaitForTransactions ? (
+                                                    <MoneyRequestReportActionsList
+                                                        report={report}
+                                                        hasPendingDeletionTransaction={hasPendingDeletionTransaction}
+                                                        policy={policy}
+                                                        reportActions={reportActions}
+                                                        transactions={visibleTransactions}
+                                                        newTransactions={newTransactions}
+                                                        hasOlderActions={hasOlderActions}
+                                                        hasNewerActions={hasNewerActions}
+                                                        showReportActionsLoadingState={showReportActionsLoadingState}
+                                                        reportPendingAction={reportPendingAction}
+                                                    />
+                                                ) : null}
+                                                <ReportFooter />
+                                            </View>
+                                        </AgentZeroStatusProvider>
+                                    </View>
+                                    <PortalHost name="suggestions" />
+                                </DragAndDropProvider>
+                            </LinkedActionNotFoundGuard>
+                        </ReportNotFoundGuard>
                     </ScreenWrapper>
                 </ReactionListWrapper>
             </ActionListContext.Provider>

--- a/src/pages/inbox/ReportScreen.tsx
+++ b/src/pages/inbox/ReportScreen.tsx
@@ -1,6 +1,6 @@
 import {PortalHost} from '@gorhom/portal';
 import {useIsFocused} from '@react-navigation/native';
-import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react';
+import React, {useCallback, useEffect, useMemo, useState} from 'react';
 import type {ViewStyle} from 'react-native';
 // We use Animated for all functionality related to wide RHP to make it easier
 // to interact with react-navigation components (e.g., CardContainer, interpolator), which also use Animated.
@@ -23,7 +23,6 @@ import useActionListContextValue from '@hooks/useActionListContextValue';
 import {useCurrentReportIDState} from '@hooks/useCurrentReportID';
 import useCurrentUserPersonalDetails from '@hooks/useCurrentUserPersonalDetails';
 import useDocumentTitle from '@hooks/useDocumentTitle';
-import useIsAnonymousUser from '@hooks/useIsAnonymousUser';
 import useIsInSidePanel from '@hooks/useIsInSidePanel';
 import useIsReportReadyToDisplay from '@hooks/useIsReportReadyToDisplay';
 import useNetwork from '@hooks/useNetwork';
@@ -46,9 +45,7 @@ import Navigation, {navigationRef} from '@libs/Navigation/Navigation';
 import type {PlatformStackScreenProps} from '@libs/Navigation/PlatformStackNavigation/types';
 import {
     getFilteredReportActionsForReportView,
-    getIOUActionForReportID,
     getOneTransactionThreadReportID,
-    isCreatedAction,
     isDeletedParentAction,
     isReportActionVisible,
     isTransactionThread,
@@ -58,34 +55,21 @@ import {getReportName} from '@libs/ReportNameUtils';
 import {
     canUserPerformWriteAction,
     getReportOfflinePendingActionAndErrors,
-    getReportTransactions,
     isAdminRoom,
     isAnnounceRoom,
-    isChatThread,
     isGroupChat,
-    isHiddenForCurrentUser,
     isInvoiceReport,
     isMoneyRequest,
     isMoneyRequestReport,
     isMoneyRequestReportPendingDeletion,
-    isOneTransactionThread,
     isPolicyExpenseChat,
     isReportTransactionThread,
-    isTaskReport,
     isValidReportIDFromPath,
 } from '@libs/ReportUtils';
 import {getParentReportActionDeletionStatus} from '@libs/TransactionNavigationUtils';
 import type {ReportsSplitNavigatorParamList, RightModalNavigatorParamList} from '@navigation/types';
 import {setShouldShowComposeInput} from '@userActions/Composer';
-import {
-    createTransactionThreadReport,
-    navigateToConciergeChat,
-    openReport,
-    readNewestAction,
-    subscribeToReportLeavingEvents,
-    unsubscribeFromLeavingRoomReportChannel,
-    updateLastVisitTime,
-} from '@userActions/Report';
+import {navigateToConciergeChat} from '@userActions/Report';
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
 import type {Route} from '@src/ROUTES';
@@ -102,6 +86,7 @@ import useReportWasDeleted from './hooks/useReportWasDeleted';
 import ReactionListWrapper from './ReactionListWrapper';
 import ReportActionsView from './report/ReportActionsView';
 import ReportFooter from './report/ReportFooter';
+import ReportFetchController from './ReportFetchController';
 import ReportLifecycleHandler from './ReportLifecycleHandler';
 import ReportRouteParamHandler from './ReportRouteParamHandler';
 import {ActionListContext} from './ReportScreenContext';
@@ -148,9 +133,7 @@ function ReportScreen({route, navigation}: ReportScreenProps) {
     const reportIDFromRoute = getNonEmptyStringOnyxID(route.params?.reportID);
     const reportActionIDFromRoute = route?.params?.reportActionID;
     const isFocused = useIsFocused();
-    const prevIsFocused = usePrevious(isFocused);
     const [firstRender, setFirstRender] = useState(true);
-    const hasCreatedLegacyThreadRef = useRef(false);
     const {isOffline} = useNetwork();
     const {shouldUseNarrowLayout, isInNarrowPaneModal} = useResponsiveLayout();
     const isInSidePanel = useIsInSidePanel();
@@ -174,10 +157,7 @@ function ReportScreen({route, navigation}: ReportScreenProps) {
     const deletedParentAction = isDeletedParentAction(parentReportAction);
     const prevDeletedParentAction = usePrevious(deletedParentAction);
 
-    const isAnonymousUser = useIsAnonymousUser();
     const [isLoadingReportData = true] = useOnyx(ONYXKEYS.IS_LOADING_REPORT_DATA);
-    const prevIsLoadingReportData = usePrevious(isLoadingReportData);
-    const prevIsAnonymousUser = useRef(false);
 
     /**
      * Create a lightweight Report so as to keep the re-rendering as light as possible by
@@ -247,15 +227,13 @@ function ReportScreen({route, navigation}: ReportScreenProps) {
     const lastReportIDFromRoute = usePrevious(reportIDFromRoute);
     const [isLinkingToMessage, setIsLinkingToMessage] = useState(!!reportActionIDFromRoute);
 
-    const {accountID: currentUserAccountID, email: currentUserEmail} = useCurrentUserPersonalDetails();
+    const {accountID: currentUserAccountID} = useCurrentUserPersonalDetails();
 
     const [isLoadingApp] = useOnyx(ONYXKEYS.IS_LOADING_APP);
     const [visibleReportActionsData] = useOnyx(ONYXKEYS.DERIVED.VISIBLE_REPORT_ACTIONS);
     const {reportActions: unfilteredReportActions, linkedAction, sortedAllReportActions, hasNewerActions, hasOlderActions} = usePaginatedReportActions(reportID, reportActionIDFromRoute);
     // wrapping in useMemo because this is array operation and can cause performance issues
     const reportActions = useMemo(() => getFilteredReportActionsForReportView(unfilteredReportActions), [unfilteredReportActions]);
-    const [childReport] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT}${linkedAction?.childReportID}`);
-
     const viewportOffsetTop = useViewportOffsetTop();
 
     const {reportPendingAction, reportErrors} = getReportOfflinePendingActionAndErrors(report);
@@ -264,18 +242,6 @@ function ReportScreen({route, navigation}: ReportScreenProps) {
 
     const {wasDeleted: reportWasDeleted, parentReportID: deletedReportParentID} = useReportWasDeleted(reportIDFromRoute, report, isOptimisticDelete, userLeavingStatus);
 
-    const indexOfLinkedMessage = useMemo(
-        (): number => reportActions.findIndex((obj) => reportActionIDFromRoute && String(obj.reportActionID) === String(reportActionIDFromRoute)),
-        [reportActions, reportActionIDFromRoute],
-    );
-
-    const doesCreatedActionExists = useCallback(() => !!reportActions?.findLast((action) => isCreatedAction(action)), [reportActions]);
-    const isLinkedMessageAvailable = indexOfLinkedMessage > -1;
-
-    // The linked report actions should have at least 15 messages (counting as 1 page) above them to fill the screen.
-    // If the count is too high (equal to or exceeds the web pagination size / 50) and there are no cached messages in the report,
-    // OpenReport will be called each time the user scrolls up the report a bit, clicks on report preview, and then goes back.
-    const isLinkedMessagePageReady = isLinkedMessageAvailable && (reportActions.length - indexOfLinkedMessage >= CONST.REPORT.MIN_INITIAL_REPORT_ACTION_COUNT || doesCreatedActionExists());
     const allReportTransactions = useReportTransactionsCollection(reportIDFromRoute);
     const hasPendingDeletionTransaction = Object.values(allReportTransactions ?? {}).some((transaction) => transaction?.pendingAction === CONST.RED_BRICK_ROAD_PENDING_ACTION.DELETE);
 
@@ -290,7 +256,6 @@ function ReportScreen({route, navigation}: ReportScreenProps) {
     const transactionThreadReportID = getOneTransactionThreadReportID(report, chatReport, reportActions ?? [], isOffline, reportTransactionIDs);
     const [transactionThreadReport] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT}${transactionThreadReportID}`);
     const isTopMostReportId = currentReportIDValue === reportIDFromRoute;
-    const didSubscribeToReportLeavingEvents = useRef(false);
     const isTransactionThreadView = isReportTransactionThread(report);
     const isMoneyRequestOrInvoiceReport = isMoneyRequestReport(report) || isInvoiceReport(report);
     // Prevent the empty state flash by ensuring transaction data is fully loaded before deciding which view to render
@@ -355,13 +320,6 @@ function ReportScreen({route, navigation}: ReportScreenProps) {
             />
         );
     }, [isTransactionThreadView, isMoneyRequestOrInvoiceReport, onBackButtonPress, reportIDFromRoute]);
-
-    useEffect(() => {
-        if (!transactionThreadReportID || !route?.params?.reportActionID || !isOneTransactionThread(childReport, report, linkedAction)) {
-            return;
-        }
-        navigation.setParams({reportActionID: ''});
-    }, [transactionThreadReportID, route?.params?.reportActionID, linkedAction, reportID, navigation, report, childReport]);
 
     const isReportArchived = useReportIsArchived(report?.reportID);
     const {isEditingDisabled} = useIsReportReadyToDisplay(report, reportIDFromRoute, isReportArchived);
@@ -501,151 +459,6 @@ function ReportScreen({route, navigation}: ReportScreenProps) {
         isLinkingToMessage,
     ]);
 
-    const createOneTransactionThreadReport = useCallback(() => {
-        const currentReportTransaction = getReportTransactions(reportID).filter((transaction) => transaction.pendingAction !== CONST.RED_BRICK_ROAD_PENDING_ACTION.DELETE);
-        const oneTransactionID = currentReportTransaction.at(0)?.transactionID;
-        const iouAction = getIOUActionForReportID(reportID, oneTransactionID);
-        createTransactionThreadReport(introSelected, currentUserEmail ?? '', currentUserAccountID, betas, report, iouAction, currentReportTransaction.at(0));
-    }, [introSelected, currentUserEmail, currentUserAccountID, betas, report, reportID]);
-
-    const isInviteOnboardingComplete = introSelected?.isInviteOnboardingComplete ?? false;
-    const isOnboardingCompleted = onboarding?.hasCompletedGuidedSetupFlow ?? false;
-
-    const fetchReport = useCallback(() => {
-        if (reportMetadata.isOptimisticReport && report?.type === CONST.REPORT.TYPE.CHAT && !isPolicyExpenseChat(report)) {
-            return;
-        }
-
-        if (report?.errorFields?.notFound && isOffline) {
-            return;
-        }
-
-        // When a user goes through onboarding for the first time, various tasks are created for chatting with Concierge.
-        // If this function is called too early (while the application is still loading), we will not have information about policies,
-        // which means we will not be able to obtain the correct link for one of the tasks.
-        // More information here: https://github.com/Expensify/App/issues/71742
-        if (isLoadingApp && introSelected && !isOnboardingCompleted && !isInviteOnboardingComplete) {
-            const {choice, inviteType} = introSelected;
-            const isInviteIOUorInvoice = inviteType === CONST.ONBOARDING_INVITE_TYPES.IOU || inviteType === CONST.ONBOARDING_INVITE_TYPES.INVOICE;
-            const isInviteChoiceCorrect = choice === CONST.ONBOARDING_CHOICES.ADMIN || choice === CONST.ONBOARDING_CHOICES.SUBMIT || choice === CONST.ONBOARDING_CHOICES.CHAT_SPLIT;
-
-            if (isInviteChoiceCorrect && !isInviteIOUorInvoice) {
-                return;
-            }
-        }
-
-        openReport({reportID: reportIDFromRoute, introSelected, reportActionID: reportActionIDFromRoute, betas});
-    }, [
-        reportMetadata.isOptimisticReport,
-        report,
-        isOffline,
-        isLoadingApp,
-        introSelected,
-        isOnboardingCompleted,
-        isInviteOnboardingComplete,
-        reportIDFromRoute,
-        reportActionIDFromRoute,
-        betas,
-    ]);
-
-    useEffect(() => {
-        if (!isAnonymousUser) {
-            return;
-        }
-        prevIsAnonymousUser.current = true;
-    }, [isAnonymousUser]);
-
-    useEffect(() => {
-        if (transactionThreadReportID !== CONST.FAKE_REPORT_ID || transactionThreadReport?.reportID || (!reportMetadata.hasOnceLoadedReportActions && !reportMetadata?.isOptimisticReport)) {
-            return;
-        }
-
-        createOneTransactionThreadReport();
-        // eslint-disable-next-line react-hooks/exhaustive-deps -- we don't want to run this useEffect when createOneTransactionThreadReport changes
-    }, [reportMetadata.hasOnceLoadedReportActions, reportMetadata?.isOptimisticReport, transactionThreadReport?.reportID, transactionThreadReportID]);
-
-    useEffect(() => {
-        if (isLoadingReportData || !prevIsLoadingReportData || !prevIsAnonymousUser.current || isAnonymousUser) {
-            return;
-        }
-        // Re-fetch public report data after user signs in and OpenApp API is called to
-        // avoid reportActions data being empty for public rooms.
-        fetchReport();
-    }, [isLoadingReportData, prevIsLoadingReportData, prevIsAnonymousUser, isAnonymousUser, fetchReport]);
-
-    const prevTransactionThreadReportID = usePrevious(transactionThreadReportID);
-    useEffect(() => {
-        // If transactionThreadReportID is undefined or CONST.FAKE_REPORT_ID, we do not call fetchReport.
-        // Only when transactionThreadReportID changes to a valid value, the fetchReport will be called to fetch the data again for the current report.
-        // Since fetchReport is always called once when opening a report,
-        // if that initial call is used to create a transactionThreadReport,
-        // then fetchReport needs to be called again after the transactionThreadReport has been fully created.
-        const prevTransactionThreadReportIDWasValid = !!prevTransactionThreadReportID && prevTransactionThreadReportID !== CONST.FAKE_REPORT_ID;
-        const transactionThreadReportIDUpdatedFromValidToFake = transactionThreadReportID === CONST.FAKE_REPORT_ID && !!prevTransactionThreadReportID;
-
-        if (prevTransactionThreadReportIDWasValid || !transactionThreadReportID || transactionThreadReportIDUpdatedFromValidToFake) {
-            return;
-        }
-
-        fetchReport();
-    }, [fetchReport, prevTransactionThreadReportID, transactionThreadReportID]);
-
-    useEffect(() => {
-        if (!reportID || !isFocused || isInSidePanel) {
-            return;
-        }
-        updateLastVisitTime(reportID);
-    }, [reportID, isFocused, isInSidePanel]);
-
-    useEffect(() => {
-        // eslint-disable-next-line @typescript-eslint/no-deprecated
-        const interactionTask = InteractionManager.runAfterInteractions(() => {
-            setShouldShowComposeInput(true);
-        });
-        return () => {
-            interactionTask.cancel();
-            if (!didSubscribeToReportLeavingEvents.current) {
-                return;
-            }
-
-            unsubscribeFromLeavingRoomReportChannel(reportID);
-        };
-
-        // I'm disabling the warning, as it expects to use exhaustive deps, even though we want this useEffect to run only on the first render.
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, []);
-
-    useEffect(() => {
-        // This function is triggered when a user clicks on a link to navigate to a report.
-        // For each link click, we retrieve the report data again, even though it may already be cached.
-        // There should be only one openReport execution per page start or navigating
-        fetchReport();
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [route, isLinkedMessagePageReady, reportActionIDFromRoute]);
-
-    const prevReportActions = usePrevious(reportActions);
-    useEffect(() => {
-        // This function is only triggered when a user is invited to a room after opening the link.
-        // When a user opens a room they are not a member of, and the admin then invites them, only the INVITE_TO_ROOM action is available, so the background will be empty and room description is not available.
-        // See https://github.com/Expensify/App/issues/57769 for more details
-        if (prevReportActions.length !== 0 || reportActions.length !== 1 || reportActions.at(0)?.actionName !== CONST.REPORT.ACTIONS.TYPE.ROOM_CHANGE_LOG.INVITE_TO_ROOM) {
-            return;
-        }
-        fetchReport();
-    }, [prevReportActions.length, reportActions, fetchReport]);
-
-    // If a user has chosen to leave a thread, and then returns to it (e.g. with the back button), we need to call `openReport` again in order to allow the user to rejoin and to receive real-time updates
-    useEffect(() => {
-        if (!shouldUseNarrowLayout || !isFocused || prevIsFocused || !isChatThread(report) || !isHiddenForCurrentUser(report) || isTransactionThreadView) {
-            return;
-        }
-        openReport({reportID, introSelected, betas});
-
-        // We don't want to run this useEffect every time `report` is changed
-        // Excluding shouldUseNarrowLayout from the dependency list to prevent re-triggering on screen resize events.
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [prevIsFocused, report?.participants, isFocused, isTransactionThreadView, reportID, introSelected, betas]);
-
     useEffect(() => {
         // We don't want this effect to run on the first render.
         if (firstRender) {
@@ -767,36 +580,6 @@ function ReportScreen({route, navigation}: ReportScreenProps) {
         });
     }, [reportWasDeleted, isFocused, deletedReportParentID, conciergeReportID, introSelected, currentUserAccountID, isSelfTourViewed, betas]);
 
-    useEffect(() => {
-        if (!isValidReportIDFromPath(reportIDFromRoute)) {
-            return;
-        }
-        // Ensures the optimistic report is created successfully
-        if (reportIDFromRoute !== report?.reportID || report?.pendingFields?.createChat) {
-            return;
-        }
-        // Ensures subscription event succeeds when the report/workspace room is created optimistically.
-        // Check if the optimistic `OpenReport` or `AddWorkspaceRoom` has succeeded by confirming
-        // any `pendingFields.createChat` or `pendingFields.addWorkspaceRoom` fields are set to null.
-        // Existing reports created will have empty fields for `pendingFields`.
-        const didCreateReportSuccessfully = !report?.pendingFields || (!report?.pendingFields.addWorkspaceRoom && !report?.pendingFields.createChat);
-        // eslint-disable-next-line @typescript-eslint/no-deprecated
-        let interactionTask: ReturnType<typeof InteractionManager.runAfterInteractions> | null = null;
-        if (!didSubscribeToReportLeavingEvents.current && didCreateReportSuccessfully) {
-            // eslint-disable-next-line @typescript-eslint/no-deprecated
-            interactionTask = InteractionManager.runAfterInteractions(() => {
-                subscribeToReportLeavingEvents(reportIDFromRoute, currentUserAccountID);
-                didSubscribeToReportLeavingEvents.current = true;
-            });
-        }
-        return () => {
-            if (!interactionTask) {
-                return;
-            }
-            interactionTask.cancel();
-        };
-    }, [report?.reportID, didSubscribeToReportLeavingEvents, reportIDFromRoute, report?.pendingFields, currentUserAccountID]);
-
     const actionListValue = useActionListContextValue();
 
     // This helps in tracking from the moment 'route' triggers useMemo until isLoadingInitialReportActions becomes true. It prevents blinking when loading reportActions from cache.
@@ -809,8 +592,7 @@ function ReportScreen({route, navigation}: ReportScreenProps) {
 
     const navigateToEndOfReport = useCallback(() => {
         Navigation.setParams({reportActionID: ''});
-        fetchReport();
-    }, [fetchReport]);
+    }, []);
 
     useEffect(() => {
         // Only handle deletion cases when there's a deleted action
@@ -841,69 +623,6 @@ function ReportScreen({route, navigation}: ReportScreenProps) {
             Navigation.setParams({reportActionID: ''});
         });
     }, [isLinkedActionInaccessibleWhisper]);
-
-    useEffect(() => {
-        if (!!report?.lastReadTime || !isTaskReport(report)) {
-            return;
-        }
-        // After creating the task report then navigating to task detail we don't have any report actions and the last read time is empty so We need to update the initial last read time when opening the task report detail.
-        readNewestAction(report?.reportID, !!reportMetadata?.hasOnceLoadedReportActions);
-    }, [report, reportMetadata?.hasOnceLoadedReportActions]);
-
-    // Reset the ref when navigating to a different report
-    useEffect(() => {
-        hasCreatedLegacyThreadRef.current = false;
-    }, [reportID]);
-
-    // When opening IOU report for single transaction, we will create IOU action and transaction thread
-    // for legacy transaction that doesn't have IOU action
-    useEffect(() => {
-        // Skip if already created, coming from Search page, or thread already exists
-        if (
-            hasCreatedLegacyThreadRef.current ||
-            route.name === SCREENS.RIGHT_MODAL.SEARCH_REPORT ||
-            transactionThreadReport ||
-            (transactionThreadReportID && transactionThreadReportID !== '0') ||
-            !reportMetadata?.hasOnceLoadedReportActions ||
-            reportActions.length === 0
-        ) {
-            return;
-        }
-
-        // Only handle single transaction expense reports that are fully loaded
-        const transaction = visibleTransactions?.at(0);
-        if (!reportID || visibleTransactions?.length !== 1 || report?.type !== CONST.REPORT.TYPE.EXPENSE || !transaction?.transactionID) {
-            return;
-        }
-
-        // Skip legacy transaction handling if:
-        // - IOU action already exists (not a legacy transaction)
-        // - Transaction is pending addition (new transaction, not legacy)
-        const iouAction = getIOUActionForReportID(reportID, transaction.transactionID);
-        if (iouAction || transaction?.pendingAction === CONST.RED_BRICK_ROAD_PENDING_ACTION.ADD || !!transaction.linkedTrackedExpenseReportAction?.childReportID) {
-            return;
-        }
-
-        // Mark as created BEFORE calling to prevent race conditions
-        hasCreatedLegacyThreadRef.current = true;
-
-        // For legacy transactions, pass undefined as IOU action and the transaction object
-        // It will be created optimistically and in the backend when call openReport
-        createTransactionThreadReport(introSelected, currentUserEmail ?? '', currentUserAccountID, betas, report, undefined, transaction);
-    }, [
-        introSelected,
-        currentUserEmail,
-        currentUserAccountID,
-        betas,
-        report,
-        visibleTransactions,
-        transactionThreadReport,
-        transactionThreadReportID,
-        reportID,
-        route.name,
-        reportMetadata?.hasOnceLoadedReportActions,
-        reportActions.length,
-    ]);
 
     const lastRoute = usePrevious(route);
 
@@ -964,6 +683,7 @@ function ReportScreen({route, navigation}: ReportScreenProps) {
                             route={route}
                             navigation={navigation}
                         />
+                        <ReportFetchController />
                         <FullPageNotFoundView
                             shouldShow={shouldShowNotFoundPage}
                             subtitleKey={shouldShowNotFoundLinkedAction ? 'notFound.commentYouLookingForCannotBeFound' : 'notFound.noAccess'}


### PR DESCRIPTION
### Explanation of Change
@rlinoz @TMisiukiewicz 

PR 6 in the [ReportScreen decomposition series](https://github.com/Expensify/App/issues/84895).

Extracts 6 non-rendering behavioral components (guards & handlers) from `ReportScreen.tsx`, reducing it from ~1117 lines to ~370 lines:

- **`ReportRouteParamHandler`** — validates/resolves route params when missing
- **`ReportLifecycleHandler`** — emoji picker hide, notifications, telemetry cleanup, bank account unlock
- **`ReportFetchController`** — `openReport()`, transaction thread creation, re-fetch logic, leaving events
- **`ReportNotFoundGuard`** — report-level not-found → `FullPageNotFoundView` or children
- **`LinkedActionNotFoundGuard`** — two-level gate for linked report action not-found (cheap outer + heavy inner)
- **`ReportNavigateAwayHandler`** — navigates away on report removal/deletion/leaving

### Fixed Issues

$ https://github.com/Expensify/App/issues/84895

### Tests

**Route param resolution (ReportRouteParamHandler)**
1. Navigate to the app root URL without a reportID in the path — verify you land on the last accessed report
2. Navigate to a report with an invalid (non-numeric) `reportActionID` in the URL — verify the param is cleared and the report loads normally

**Lifecycle effects (ReportLifecycleHandler)**
1. Open a report, open the emoji picker, then navigate to a different report — verify the emoji picker closes
2. Send yourself a notification-triggering message from another device, then open that report — verify the notification clears

**Data fetching (ReportFetchController)**
1. Open any chat report — verify messages load
2. Open a one-transaction expense report — verify the transaction thread is created and visible
3. Navigate away from a report and back — verify data reloads correctly
4. Open a thread you previously left (narrow layout) — verify you rejoin and see messages

**Report not-found (ReportNotFoundGuard)**
1. Navigate to `/r/999999999999` (non-existent report) — verify "not found" page with "you don't have access" message
2. Navigate to `/r/abc` (invalid path) — verify "not found" page appears
3. While online, have another user delete an expense report you're viewing — verify you're not stuck on a blank screen

**Linked action not-found (LinkedActionNotFoundGuard)**
1. Navigate to a report with a valid `reportActionID` — verify the message is highlighted/scrolled to
2. Navigate to a report with a `reportActionID` that doesn't exist — verify "not found" page with "comment you're looking for" message and "Go to chat instead" link
3. Click "Go to chat instead" — verify it navigates to the report without the linked action

**Navigate away (ReportNavigateAwayHandler)**
1. Open a workspace room, then have an admin remove you — verify you're navigated to Concierge
2. Open an expense report, then delete it from another device — verify you navigate to the parent report (or Concierge if no parent)
3. Leave a room via the room settings — verify you're navigated away

### Offline tests

1. Open a report while online, go offline — verify the report stays visible
2. Navigate between cached reports while offline — verify no "not found" flashes
3. Go back online — verify reports refresh

### QA Steps

Same as tests.

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>