### PR TITLE
Fix shared DOB constraints and add 18+ boundary tests

### DIFF
--- a/src/pages/settings/Profile/PersonalDetails/DateOfBirthPage.tsx
+++ b/src/pages/settings/Profile/PersonalDetails/DateOfBirthPage.tsx
@@ -33,7 +33,7 @@ function DateOfBirthPage() {
             const requiredFields = ['dob' as const];
             const errors = getFieldRequiredErrors(values, requiredFields, translate);
 
-            const minimumAge = CONST.DATE_BIRTH.MIN_AGE;
+            const minimumAge = CONST.DATE_BIRTH.MIN_AGE_FOR_PAYMENT;
             const maximumAge = CONST.DATE_BIRTH.MAX_AGE;
             const dateError = getAgeRequirementError(translate, values.dob ?? '', minimumAge, maximumAge);
 
@@ -77,7 +77,7 @@ function DateOfBirthPage() {
                             label={translate('common.date')}
                             defaultValue={privatePersonalDetails?.dob ?? ''}
                             minDate={subYears(new Date(), CONST.DATE_BIRTH.MAX_AGE)}
-                            maxDate={subYears(new Date(), CONST.DATE_BIRTH.MIN_AGE)}
+                            maxDate={subYears(new Date(), CONST.DATE_BIRTH.MIN_AGE_FOR_PAYMENT)}
                             autoFocus
                             autoComplete="birthdate-full"
                         />

--- a/tests/ui/DateOfBirthPageTest.tsx
+++ b/tests/ui/DateOfBirthPageTest.tsx
@@ -1,0 +1,96 @@
+import {PortalProvider} from '@gorhom/portal';
+import {NavigationContainer} from '@react-navigation/native';
+import {act, render, screen} from '@testing-library/react-native';
+import {format, subYears} from 'date-fns';
+import Onyx from 'react-native-onyx';
+import ComposeProviders from '@components/ComposeProviders';
+import {LocaleContextProvider} from '@components/LocaleContextProvider';
+import OnyxListItemProvider from '@components/OnyxListItemProvider';
+import {CurrentReportIDContextProvider} from '@hooks/useCurrentReportID';
+import createPlatformStackNavigator from '@libs/Navigation/PlatformStackNavigation/createPlatformStackNavigator';
+import type {SettingsNavigatorParamList} from '@libs/Navigation/types';
+import DateOfBirthPage from '@pages/settings/Profile/PersonalDetails/DateOfBirthPage';
+import type {DateInputWithPickerProps} from '@src/components/DatePicker/types';
+import CONST from '@src/CONST';
+import ONYXKEYS from '@src/ONYXKEYS';
+import SCREENS from '@src/SCREENS';
+import * as TestHelper from '../utils/TestHelper';
+import waitForBatchedUpdatesWithAct from '../utils/waitForBatchedUpdatesWithAct';
+
+const mockDatePicker = jest.fn<null, [DateInputWithPickerProps]>(() => null);
+
+jest.mock(
+    '@components/DatePicker',
+    () =>
+        function MockDatePicker(props: DateInputWithPickerProps) {
+            mockDatePicker(props);
+            return null;
+        },
+);
+
+const Stack = createPlatformStackNavigator<SettingsNavigatorParamList>();
+
+function renderPage() {
+    return render(
+        <ComposeProviders components={[OnyxListItemProvider, LocaleContextProvider, CurrentReportIDContextProvider]}>
+            <PortalProvider>
+                <NavigationContainer>
+                    <Stack.Navigator initialRouteName={SCREENS.SETTINGS.PROFILE.DATE_OF_BIRTH}>
+                        <Stack.Screen
+                            name={SCREENS.SETTINGS.PROFILE.DATE_OF_BIRTH}
+                            component={DateOfBirthPage}
+                        />
+                    </Stack.Navigator>
+                </NavigationContainer>
+            </PortalProvider>
+        </ComposeProviders>,
+    );
+}
+
+describe('DateOfBirthPage', () => {
+    beforeAll(async () => {
+        Onyx.init({
+            keys: ONYXKEYS,
+        });
+
+        await act(async () => {
+            await Onyx.set(ONYXKEYS.NVP_PREFERRED_LOCALE, CONST.LOCALES.EN);
+        });
+        await waitForBatchedUpdatesWithAct();
+    });
+
+    beforeEach(() => {
+        mockDatePicker.mockClear();
+    });
+
+    it('should reuse the shared 18 plus DOB constraint for the profile date picker', async () => {
+        const expectedDOB = '2000-01-01';
+        const expectedMinDate = format(subYears(new Date(), CONST.DATE_BIRTH.MAX_AGE), CONST.DATE.FNS_FORMAT_STRING);
+        const expectedMaxDate = format(subYears(new Date(), CONST.DATE_BIRTH.MIN_AGE_FOR_PAYMENT), CONST.DATE.FNS_FORMAT_STRING);
+
+        await TestHelper.signInWithTestUser();
+
+        // Given the private details page is opened for a user with an existing DOB
+        await act(async () => {
+            await Onyx.merge(ONYXKEYS.PRIVATE_PERSONAL_DETAILS, {dob: expectedDOB});
+            await Onyx.merge(ONYXKEYS.IS_LOADING_APP, false);
+        });
+        await waitForBatchedUpdatesWithAct();
+
+        renderPage();
+
+        // When the page renders the DOB input
+        await waitForBatchedUpdatesWithAct();
+        expect(screen.getByTestId('DateOfBirthPage')).toBeOnTheScreen();
+
+        // Then the page should pass the shared 18+ DOB range into the picker instead of allowing dates up to today
+        const lastCall = mockDatePicker.mock.lastCall?.[0];
+        expect(lastCall).toBeDefined();
+        expect(lastCall?.value ?? lastCall?.defaultValue).toBe(expectedDOB);
+        if (!lastCall?.minDate || !lastCall?.maxDate) {
+            throw new Error('Expected DateOfBirthPage to pass minDate and maxDate to DatePicker');
+        }
+        expect(format(lastCall.minDate, CONST.DATE.FNS_FORMAT_STRING)).toBe(expectedMinDate);
+        expect(format(lastCall.maxDate, CONST.DATE.FNS_FORMAT_STRING)).toBe(expectedMaxDate);
+    });
+});

--- a/tests/unit/ValidationUtilsTest.ts
+++ b/tests/unit/ValidationUtilsTest.ts
@@ -184,6 +184,18 @@ describe('ValidationUtils', () => {
             expect(meetsRequirement).toBe(true);
         });
 
+        test('Should return true for a date that is exactly on the 18 year boundary', () => {
+            const validDate = '2006-01-15';
+            const meetsRequirement = meetsMinimumAgeRequirement(validDate);
+            expect(meetsRequirement).toBe(true);
+        });
+
+        test('Should return false for a date that is one day younger than 18 years old', () => {
+            const invalidDate = '2006-01-16';
+            const meetsRequirement = meetsMinimumAgeRequirement(invalidDate);
+            expect(meetsRequirement).toBe(false);
+        });
+
         test('Should return false for a date that does not meet the minimum age requirement', () => {
             const invalidDate = format(subYears(new Date(), 17), CONST.DATE.FNS_FORMAT_STRING); // Date of birth 17 years ago
             const meetsRequirement = meetsMinimumAgeRequirement(invalidDate);
@@ -222,6 +234,18 @@ describe('ValidationUtils', () => {
             const validDate: string = format(subYears(new Date(), 30), CONST.DATE.FNS_FORMAT_STRING); // Date of birth 30 years ago
             const error = getAgeRequirementError(translateLocal, validDate, 18, 150);
             expect(error).toBe('');
+        });
+
+        test('Should return an empty string for a date exactly on the 18 year boundary', () => {
+            const validDate = '2006-01-15';
+            const error = getAgeRequirementError(translateLocal, validDate, 18, 150);
+            expect(error).toBe('');
+        });
+
+        test('Should return an error message for a date that is one day younger than 18 years old', () => {
+            const invalidDate = '2006-01-16';
+            const error = getAgeRequirementError(translateLocal, invalidDate, 18, 150);
+            expect(error).toEqual(translateLocal('privatePersonalDetails.error.dateShouldBeBefore', '2006-01-15'));
         });
 
         test('Should return an error message for a date before the minimum age requirement', () => {


### PR DESCRIPTION
## Summary
- reuse the shared 18+ DOB constraint on the Profile > Private DOB page so validation and picker bounds match the other DOB flows
- add exact 18th-birthday boundary coverage in `ValidationUtilsTest` for the inclusive cutoff and the one-day-too-young case
- add a `DateOfBirthPage` regression test that verifies the page passes the shared DOB bounds into `DatePicker`

## Testing
- `npx eslint src/pages/settings/Profile/PersonalDetails/DateOfBirthPage.tsx tests/ui/DateOfBirthPageTest.tsx tests/unit/ValidationUtilsTest.ts --max-warnings=0`
- `npm run typecheck-tsgo`
- `npm test -- --runInBand tests/unit/ValidationUtilsTest.ts tests/ui/DateOfBirthPageTest.tsx`