### PR TITLE
Persist search date filter draft state between subpages

### DIFF
--- a/src/components/Search/SearchDatePresetFilterBasePage.tsx
+++ b/src/components/Search/SearchDatePresetFilterBasePage.tsx
@@ -1,6 +1,7 @@
 import {useRoute} from '@react-navigation/native';
 import React, {useCallback} from 'react';
 import ScreenWrapper from '@components/ScreenWrapper';
+import type {SearchDateValues} from '@components/Search/FilterComponents/DatePresetFilterBase';
 import useLocalize from '@hooks/useLocalize';
 import useOnyx from '@hooks/useOnyx';
 import useThemeStyles from '@hooks/useThemeStyles';
@@ -102,6 +103,17 @@ function SearchDatePresetFilterBasePage({dateKey, titleKey}: SearchDatePresetFil
     const defaultDateValues = getDefaultDateValues();
     const presets = getPresets();
 
+    const updateDraftDateValues = useCallback(
+        (values: SearchDateValues) => {
+            updateAdvancedFilters({
+                [dateOnKey]: values[CONST.SEARCH.DATE_MODIFIERS.ON] ?? null,
+                [dateBeforeKey]: values[CONST.SEARCH.DATE_MODIFIERS.BEFORE] ?? null,
+                [dateAfterKey]: values[CONST.SEARCH.DATE_MODIFIERS.AFTER] ?? null,
+            });
+        },
+        [dateAfterKey, dateBeforeKey, dateOnKey],
+    );
+
     return (
         <ScreenWrapper
             testID="SearchDatePresetFilterBasePage"
@@ -116,14 +128,11 @@ function SearchDatePresetFilterBasePage({dateKey, titleKey}: SearchDatePresetFil
                 presets={presets}
                 isSearchAdvancedFiltersFormLoading={isSearchAdvancedFiltersFormLoading}
                 onBackButtonPress={goBack}
+                onDateValuesChange={updateDraftDateValues}
                 selectedDateModifier={selectedDateModifier}
                 onSelectDateModifier={selectDateModifier}
                 onSubmit={(values) => {
-                    updateAdvancedFilters({
-                        [dateOnKey]: values[CONST.SEARCH.DATE_MODIFIERS.ON] ?? null,
-                        [dateBeforeKey]: values[CONST.SEARCH.DATE_MODIFIERS.BEFORE] ?? null,
-                        [dateAfterKey]: values[CONST.SEARCH.DATE_MODIFIERS.AFTER] ?? null,
-                    });
+                    updateDraftDateValues(values);
                     Navigation.goBack(ROUTES.SEARCH_ADVANCED_FILTERS.getRoute());
                 }}
             />

--- a/tests/unit/components/Search/SearchDatePresetFilterBasePage.test.tsx
+++ b/tests/unit/components/Search/SearchDatePresetFilterBasePage.test.tsx
@@ -1,0 +1,109 @@
+import {render} from '@testing-library/react-native';
+import type {ComponentProps} from 'react';
+import React from 'react';
+import SearchDatePresetFilterBasePage from '@components/Search/SearchDatePresetFilterBasePage';
+import type DateFilterBase from '@components/Search/FilterComponents/DateFilterBase';
+import {updateAdvancedFilters} from '@libs/actions/Search';
+import Navigation from '@libs/Navigation/Navigation';
+import CONST from '@src/CONST';
+
+let mockRouteParams: {subPage?: string} | undefined;
+let mockSearchAdvancedFiltersForm: Record<string, string | null | undefined> | undefined;
+let lastDateFilterBaseProps: ComponentProps<typeof DateFilterBase> | undefined;
+
+jest.mock('@components/ScreenWrapper', () => {
+    return function ScreenWrapper({children}: {children: React.ReactNode}) {
+        return children;
+    };
+});
+
+jest.mock('@components/Search/FilterComponents/DateFilterBase', () => {
+    return function MockDateFilterBase(props: ComponentProps<typeof DateFilterBase>) {
+        lastDateFilterBaseProps = props;
+        return null;
+    };
+});
+
+jest.mock('@hooks/useLocalize', () => () => ({
+    translate: (key: string) => key,
+}));
+
+jest.mock('@hooks/useOnyx', () => ({
+    __esModule: true,
+    default: () => [mockSearchAdvancedFiltersForm, undefined],
+}));
+
+jest.mock('@hooks/useThemeStyles', () => () => ({}));
+
+jest.mock('@libs/actions/Search', () => ({
+    updateAdvancedFilters: jest.fn(),
+}));
+
+jest.mock('@libs/Navigation/Navigation', () => ({
+    goBack: jest.fn(),
+    navigate: jest.fn(),
+}));
+
+jest.mock('@libs/SearchUIUtils', () => ({
+    getDatePresets: jest.fn(() => []),
+}));
+
+jest.mock('@react-navigation/native', () => ({
+    useRoute: () => ({params: mockRouteParams}),
+}));
+
+jest.mock('@src/types/utils/isLoadingOnyxValue', () => jest.fn(() => false));
+
+describe('SearchDatePresetFilterBasePage', () => {
+    beforeEach(() => {
+        mockRouteParams = undefined;
+        mockSearchAdvancedFiltersForm = {};
+        lastDateFilterBaseProps = undefined;
+        jest.clearAllMocks();
+    });
+
+    it('persists withdrawn draft values when the date subpage saves', () => {
+        render(
+            <SearchDatePresetFilterBasePage
+                dateKey={CONST.SEARCH.SYNTAX_FILTER_KEYS.WITHDRAWN}
+                titleKey="search.filters.withdrawn"
+            />,
+        );
+
+        expect(lastDateFilterBaseProps?.onDateValuesChange).toBeDefined();
+
+        lastDateFilterBaseProps?.onDateValuesChange?.({
+            [CONST.SEARCH.DATE_MODIFIERS.ON]: '2026-03-27',
+            [CONST.SEARCH.DATE_MODIFIERS.AFTER]: undefined,
+            [CONST.SEARCH.DATE_MODIFIERS.BEFORE]: undefined,
+        });
+
+        expect(updateAdvancedFilters).toHaveBeenCalledWith({
+            withdrawnOn: '2026-03-27',
+            withdrawnAfter: null,
+            withdrawnBefore: null,
+        });
+    });
+
+    it('still saves and returns to advanced filters on submit', () => {
+        render(
+            <SearchDatePresetFilterBasePage
+                dateKey={CONST.SEARCH.SYNTAX_FILTER_KEYS.WITHDRAWN}
+                titleKey="search.filters.withdrawn"
+            />,
+        );
+
+        lastDateFilterBaseProps?.onSubmit({
+            [CONST.SEARCH.DATE_MODIFIERS.ON]: '2026-03-27',
+            [CONST.SEARCH.DATE_MODIFIERS.AFTER]: undefined,
+            [CONST.SEARCH.DATE_MODIFIERS.BEFORE]: undefined,
+        });
+
+        expect(updateAdvancedFilters).toHaveBeenCalledWith({
+            withdrawnOn: '2026-03-27',
+            withdrawnAfter: null,
+            withdrawnBefore: null,
+        });
+        expect(Navigation.goBack).toHaveBeenCalled();
+    });
+});


### PR DESCRIPTION
## Summary
- persist advanced-search date filter draft values when a date subpage is saved so route transitions cannot drop the selected withdrawn/date value before the parent filter page rehydrates
- keep the final apply behavior unchanged by writing only to the advanced-filters Onyx draft, then reusing the same mapping on submit
- add a regression test around `SearchDatePresetFilterBasePage` to cover the withdrawn date draft sync path

## Validation
- Added `tests/unit/components/Search/SearchDatePresetFilterBasePage.test.tsx`
- Passed: `TZ=utc NODE_OPTIONS='--experimental-vm-modules --max_old_space_size=8192' node ./node_modules/jest/bin/jest.js tests/unit/components/Search/SearchDatePresetFilterBasePage.test.tsx --runInBand`
- `lsp_diagnostics` for changed files were clean
- `tsgo` still reports existing repo-wide type errors in unrelated files on this clone; none were introduced by this change

## Why this approach
- The issue reproduces because the selected date can be lost between the date subpage and the parent advanced filters page
- This fix treats `SEARCH_ADVANCED_FILTERS_FORM` as the shared draft source of truth, so the selected filter state survives navigation/remounts and the subtitle can rebuild from the same draft values
- This keeps the scope narrow and avoids changing the final query-apply boundary

## Cross-platform verification idea
- Web / iOS / Android: open `Reports > Expenses > Filters > Withdrawn > On`, select a date, save, and confirm the chosen subtitle is still visible when returning to the Withdrawn page and the main Advanced Filters list
- Repeat for `After` / `Before` and for reset/clear to confirm sibling date modifiers are cleared correctly
- Confirm final Apply still updates the actual search results, not just the subtitle

$ #86540