### PR TITLE
feat: enable scrolling in ThreeDotsMenu popover

### DIFF
--- a/src/components/ThreeDotsMenu/index.tsx
+++ b/src/components/ThreeDotsMenu/index.tsx
@@ -179,6 +179,7 @@ function ThreeDotsMenu({
                 anchorRef={buttonRef}
                 shouldEnableNewFocusManagement
                 restoreFocusType={restoreFocusType}
+                shouldUseScrollView
             />
         </>
     );


### PR DESCRIPTION
### Explanation of Change
This PR fixes the issue where the "More" options bottom sheet (and other menus using `ThreeDotsMenu`) would not scroll when the content exceeded the available screen height. 

I passed `shouldUseScrollView={true}` to the underlying `PopoverMenu` component in `ThreeDotsMenu.tsx`. This ensures that any menu triggered via the three-dots icon supports vertical scrolling out of the box, which is particularly critical for the Expenses view on smaller screens or mWeb.

### Fixed Issues
$ https://github.com/Expensify/App/issues/86593

### Tests
1. Open any Expense or Transaction details page.
2. Tap the "Three Dots" (More) menu icon in the header.
3. Ensure the menu items are scrollable if they exceed the screen height.
4. Verify that the menu position remains correct across different screen sizes.

- [x] Verify that no errors appear in the JS console

### Offline tests
1. Open the app in offline mode.
2. Trigger the "More" menu.
3. Verify the menu still renders correctly and allows scrolling.

### QA Steps
1. Go to an expense report.
2. Open the "More" options menu via the three-dots button.
3. On a mobile device or using web inspector (small screen), verify that you can scroll through the menu items.

### PR Author Checklist
- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
- [x] I followed proper code patterns
- [x] I verified all code is DRY

### Screenshots/Videos
<details>
<summary>Web / mWeb</summary>
Verified scroll behavior in browser inspector.
</details>

## Payment Information
- SOL Address: `6eUdVwsPArTxwVqEARYGCh4S2qwW2zCs7jSEDRpxydnv`