### PR TITLE
[No QA] Add CLEAN-REACT-PATTERNS-6: guard wrappers for conditional subtrees

### DIFF
--- a/.claude/skills/coding-standards/SKILL.md
+++ b/.claude/skills/coding-standards/SKILL.md
@@ -50,6 +50,7 @@ Coding standards for the Expensify App. Each standard is a standalone file in `r
 - [CLEAN-REACT-PATTERNS-3](rules/clean-react-3-context-free-contracts.md) — Context-free component contracts
 - [CLEAN-REACT-PATTERNS-4](rules/clean-react-4-no-side-effect-spaghetti.md) — No side-effect spaghetti
 - [CLEAN-REACT-PATTERNS-5](rules/clean-react-5-narrow-state.md) — Keep state narrow
+- [CLEAN-REACT-PATTERNS-6](rules/clean-react-6-guard-wrappers.md) — Guard wrappers for conditional subtrees
 
 ## Usage
 

--- a/.claude/skills/coding-standards/rules/clean-react-6-guard-wrappers.md
+++ b/.claude/skills/coding-standards/rules/clean-react-6-guard-wrappers.md
@@ -1,0 +1,321 @@
+---
+ruleId: CLEAN-REACT-PATTERNS-6
+title: Use guard wrappers to bypass feature subtrees
+---
+
+## [CLEAN-REACT-PATTERNS-6] Use guard wrappers to bypass feature subtrees
+
+### Reasoning
+
+When a feature only applies to a subset of users or scenarios, every component in the feature's subtree still mounts, subscribes, and runs effects — even when the feature is irrelevant. This wastes resources and scatters the "does this feature apply?" check across multiple components.
+
+A guard wrapper centralizes the decision at the subtree root: one cheap check determines whether to activate the entire feature or bypass it completely. When bypassed, nothing below the guard mounts — no providers, no subscriptions, no effects, no Pusher connections. The JSX tree itself becomes the feature flag.
+
+This pattern has two forms:
+
+1. **Single-level guard** — a wrapper that checks a condition and either returns children unchanged or wraps them with a provider/feature component. Use when the condition check and the feature logic are both simple enough to live in one component.
+2. **Two-level guard** — an outer wrapper does a cheap scalar check (e.g., one Onyx key comparison or a route param check), and an inner component owns all the heavy logic. The outer guard short-circuits before the inner component ever mounts. Use when the feature logic is heavy (multiple subscriptions, Pusher, complex state).
+
+**Distinction from CLEAN-REACT-PATTERNS-2**: PATTERNS-2 addresses who owns data — components should fetch their own data rather than receiving it from a parent. This rule addresses whether components should mount at all — entire subtrees should be skipped when the feature they serve doesn't apply.
+
+**Distinction from CLEAN-REACT-PATTERNS-5**: PATTERNS-5 addresses how state is structured within a provider (keep it cohesive). This rule addresses whether the provider should mount in the first place.
+
+### Incorrect
+
+#### Incorrect (unconditional provider — all reports pay the cost)
+
+- Provider mounts for every report, even though only Concierge chats need AgentZero status
+- Pusher subscription, Onyx subscription, and state management run unconditionally
+- Consumers check `isProcessing` to decide whether to render — but the provider shouldn't have mounted at all
+
+```tsx
+function ReportScreen({reportID}: {reportID: string}) {
+    return (
+        <AgentZeroStatusProvider reportID={reportID}>
+            <ReportActionsView reportID={reportID} />
+            <ReportFooter reportID={reportID} />
+        </AgentZeroStatusProvider>
+    );
+}
+
+// ❌ Always subscribes to Pusher, always runs effects, even for the 99% of reports
+// that aren't Concierge chats
+function AgentZeroStatusProvider({reportID, children}: PropsWithChildren<{reportID: string}>) {
+    const [reportNVP] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT_NAME_VALUE_PAIRS}${reportID}`, {
+        selector: agentZeroProcessingIndicatorSelector,
+    });
+
+    useEffect(() => {
+        const channel = getReportChannelName(reportID);
+        const listener = Pusher.subscribe(channel, Pusher.TYPE.CONCIERGE_REASONING, handleReasoning);
+        return () => listener.unsubscribe();
+    }, [reportID]);
+
+    const [reasoningHistory, setReasoningHistory] = useState<ReasoningEntry[]>([]);
+    const [displayedLabel, setDisplayedLabel] = useState('');
+    // ... more state and effects ...
+
+    return (
+        <AgentZeroStatusContext.Provider value={stateValue}>
+            {children}
+        </AgentZeroStatusContext.Provider>
+    );
+}
+```
+
+#### Incorrect (scattered condition checks across the subtree)
+
+- Multiple components independently check whether a linked action exists
+- Each component subscribes and computes even when there's no linked action (the common case)
+
+```tsx
+function ReportScreen({reportID}: {reportID: string}) {
+    const reportActionIDFromRoute = useRoute().params?.reportActionID;
+
+    // ❌ All these components mount and subscribe even when there's no linked action
+    return (
+        <View>
+            <LinkedActionBanner reportID={reportID} reportActionID={reportActionIDFromRoute} />
+            <ReportActionsList reportID={reportID} reportActionID={reportActionIDFromRoute} />
+            <LinkedActionNotFoundView reportID={reportID} reportActionID={reportActionIDFromRoute} />
+        </View>
+    );
+}
+
+// ❌ Each component independently checks the same condition
+function LinkedActionBanner({reportActionID}: {reportActionID?: string}) {
+    const [linkedAction] = useOnyx(/* ... */);
+    if (!reportActionID) return null;  // Redundant — shouldn't have mounted
+    // ...
+}
+```
+
+#### Incorrect (prop drilling through uninvolved components)
+
+- Feature state is fetched high in the tree and drilled through components that don't use it
+- Intermediate components re-render when the feature state changes, even though they just pass it through
+
+```tsx
+function ReportScreen({reportID}: {reportID: string}) {
+    const [conciergeStatus] = useOnyx(/* ... */);
+    const [reasoningHistory, setReasoningHistory] = useState([]);
+
+    return (
+        <ReportActionsView
+            reportID={reportID}
+            conciergeStatus={conciergeStatus}        // ❌ pass-through
+            reasoningHistory={reasoningHistory}       // ❌ pass-through
+        />
+    );
+}
+
+function ReportActionsView({reportID, conciergeStatus, reasoningHistory}) {
+    return (
+        <ReportActionsList
+            reportID={reportID}
+            conciergeStatus={conciergeStatus}        // ❌ pass-through
+            reasoningHistory={reasoningHistory}       // ❌ pass-through
+        />
+    );
+}
+
+function ReportActionsList({conciergeStatus, reasoningHistory}) {
+    // Finally used here, 3 levels down
+    return conciergeStatus.isProcessing
+        ? <ConciergeThinkingMessage history={reasoningHistory} />
+        : null;
+}
+```
+
+### Correct
+
+#### Correct (two-level guard — cheap outer check, heavy inner logic)
+
+From PR #85535 — `AgentZeroStatusProvider` guards the entire AgentZero feature:
+
+- Outer guard does one scalar Onyx check (`CONCIERGE_REPORT_ID`)
+- For non-Concierge reports (the common case), returns children with zero overhead
+- Inner gate only mounts for Concierge chats, owning Pusher, state, and all heavy logic
+
+```tsx
+// Outer guard — one cheap Onyx subscription, scalar comparison
+function AgentZeroStatusProvider({
+    reportID,
+    chatType,
+    children,
+}: PropsWithChildren<{reportID: string | undefined; chatType: string | undefined}>) {
+    const [conciergeReportID] = useOnyx(ONYXKEYS.CONCIERGE_REPORT_ID);
+    const isConciergeChat = reportID === conciergeReportID;
+    const isAdmin = chatType === CONST.REPORT.CHAT_TYPE.POLICY_ADMINS;
+    const isAgentZeroChat = isConciergeChat || isAdmin;
+
+    if (!reportID || !isAgentZeroChat) {
+        return children;  // ✅ Zero cost — no providers, no Pusher, no state
+    }
+
+    return (
+        <AgentZeroStatusGate key={reportID} reportID={reportID}>
+            {children}
+        </AgentZeroStatusGate>
+    );
+}
+
+// Inner gate — all heavy logic, only mounts for AgentZero chats
+function AgentZeroStatusGate({reportID, children}: PropsWithChildren<{reportID: string}>) {
+    const [serverLabel] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT_NAME_VALUE_PAIRS}${reportID}`, {
+        selector: agentZeroProcessingIndicatorSelector,
+    });
+    const [reasoningHistory, setReasoningHistory] = useState<ReasoningEntry[]>([]);
+
+    useEffect(() => {
+        const channel = getReportChannelName(reportID);
+        const listener = Pusher.subscribe(channel, Pusher.TYPE.CONCIERGE_REASONING, handleReasoning);
+        return () => listener.unsubscribe();
+    }, [reportID]);
+
+    // ... state management, debouncing, etc. ...
+
+    return (
+        <AgentZeroStatusContext.Provider value={stateValue}>
+            {children}
+        </AgentZeroStatusContext.Provider>
+    );
+}
+```
+
+#### Correct (two-level guard — linked action not-found)
+
+From PR #86543 — `LinkedActionNotFoundGuard` only activates when a `reportActionID` route param exists:
+
+- Outer guard checks one route param — no Onyx subscriptions at all
+- Inner gate owns 6 Onyx subscriptions, pagination hooks, and multiple effects
+- Most report views have no linked action, so the inner gate never mounts
+
+```tsx
+// Outer guard — route param check, zero subscriptions
+function LinkedActionNotFoundGuard({children}: {children: ReactNode}) {
+    const route = useRoute();
+    const reportActionIDFromRoute = (route.params as {reportActionID?: string})?.reportActionID;
+
+    if (!reportActionIDFromRoute) {
+        return children;  // ✅ No linked action → bypass entirely
+    }
+
+    return (
+        <LinkedActionNotFoundGate reportActionIDFromRoute={reportActionIDFromRoute}>
+            {children}
+        </LinkedActionNotFoundGate>
+    );
+}
+
+// Inner gate — 6 Onyx subs, pagination hook, multiple effects
+// Only mounts when navigating to a specific linked report action
+function LinkedActionNotFoundGate({reportActionIDFromRoute, children}: {reportActionIDFromRoute: string; children: ReactNode}) {
+    const [report] = useOnyx(/* ... */);
+    const [reportMetadata] = useOnyx(/* ... */);
+    const [visibleReportActionsData] = useOnyx(/* ... */);
+    const {reportActions, linkedAction, sortedAllReportActions} = usePaginatedReportActions(reportID, reportActionIDFromRoute);
+    // ... linked action status computation, effects ...
+
+    if (shouldShowNotFoundLinkedAction) {
+        return <FullPageNotFoundView />;
+    }
+
+    return children;
+}
+```
+
+#### Correct (single-level guard — report not-found)
+
+From PR #86543 — `ReportNotFoundGuard` validates report existence:
+
+- Checks if the report exists and handles loading/error states
+- If the report doesn't exist, shows a not-found view
+- If it does, renders children
+
+```tsx
+function ReportNotFoundGuard({children}: {children: ReactNode}) {
+    const route = useRoute();
+    const reportIDFromRoute = getNonEmptyStringOnyxID((route.params as {reportID?: string})?.reportID);
+
+    const [report] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT}${reportIDFromRoute}`);
+    const [reportMetadata] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT_METADATA}${reportIDFromRoute}`);
+    const [isLoadingReportData] = useOnyx(ONYXKEYS.IS_LOADING_REPORT_DATA);
+    // ... existence checks ...
+
+    if (shouldShowNotFoundPage) {
+        return (
+            <FullPageNotFoundView
+                shouldShow
+                shouldShowBackButton={shouldUseNarrowLayout}
+            />
+        );
+    }
+
+    return children;
+}
+```
+
+#### Correct (single-level guard — onboarding feature gate)
+
+- Onboarding tooltips only apply to users who haven't completed setup
+- Guard checks one Onyx key with a selector that returns a boolean
+
+```tsx
+function OnboardingGuard({children}: PropsWithChildren) {
+    const [isOnboardingCompleted] = useOnyx(ONYXKEYS.NVP_ONBOARDING, {
+        selector: (onboarding) => onboarding?.hasCompletedGuidedSetupFlow ?? true,
+    });
+
+    if (isOnboardingCompleted) {
+        return children;  // ✅ No tooltip logic mounts
+    }
+
+    return (
+        <OnboardingTooltipProvider>
+            {children}
+        </OnboardingTooltipProvider>
+    );
+}
+```
+
+---
+
+### Review Metadata
+
+#### Condition
+
+Flag when ALL of these are true:
+
+1. A feature or behavior only applies to a subset of scenarios (specific report types, user roles, feature flags, onboarding states, presence of a route param)
+2. AND the feature's logic (subscriptions, effects, providers, state) is mounted unconditionally or the condition is checked redundantly across multiple components
+
+**Signs of violation:**
+- A provider wraps children unconditionally but its consumers immediately check `if (!relevant) return null` — the provider shouldn't have mounted
+- Multiple components in a subtree independently check the same condition (e.g., `isConciergeChat`, `isAdmin`, `hasFeature`) before using feature-specific data
+- Pusher subscriptions, Onyx subscriptions, or effects that only matter for a specific scenario run for all scenarios
+- Feature state is prop-drilled through components that don't use it, just to reach the one component that needs it — a guard wrapper + context eliminates the pass-through chain
+- A route param (e.g., `reportActionID`) triggers additional logic in multiple components, each checking for its presence independently
+
+**Signs of a good guard:**
+- The guard's condition check is cheap (scalar comparison, boolean flag, single Onyx key, route param presence)
+- The bypass path returns `children` unchanged — zero additional overhead
+- The activation path mounts all feature-specific logic in one place (or delegates to a focused inner gate)
+- Consumers below the guard don't need to re-check the condition
+
+**Two-level guard indicators:**
+- The feature logic requires multiple Onyx subscriptions, Pusher connections, or complex state management — too heavy for the outer guard
+- The condition check is cheap but the feature logic is expensive — splitting them ensures the common bypass path pays only for the check
+
+**DO NOT flag if:**
+- The feature applies to all or most scenarios — a guard that almost never bypasses adds overhead for no benefit
+- The condition check itself is expensive (requires multiple Onyx subscriptions, API calls, or complex computation) — this defeats the purpose of a cheap gate
+- A single component with a simple early return already handles the bypass — wrapping it in a guard wrapper adds unnecessary indirection
+- The feature's logic is trivial (no subscriptions, no effects, no providers) — a guard wrapper is overkill for a conditional `<Text>` element
+
+**Search Patterns** (hints for reviewers):
+- `useOnyx` inside a provider that wraps children unconditionally — check if all consumers actually need the data
+- `Pusher.subscribe` in components that mount for all scenarios — check if the subscription is scenario-specific
+- `if (!isX) return null` appearing in multiple sibling or child components checking the same condition
+- Props drilled through 2+ levels where intermediate components don't use them
+- `reportActionID` or other route params checked independently in multiple components


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change

Adds a new coding standard rule `CLEAN-REACT-PATTERNS-6` — "Use guard wrappers to bypass feature subtrees".

The rule describes a pattern where a cheap guard component sits at the root of a feature subtree and decides whether to activate the feature or bypass it entirely. When bypassed, nothing below the guard mounts — no providers, no Onyx subscriptions, no Pusher connections, no effects. When activated, all feature logic is owned in one place (or a focused inner gate).

Two variants are documented:
- **Single-level guard**: condition check and feature logic in one component. Use for simple features.
- **Two-level guard**: cheap outer check short-circuits before a heavy inner gate ever mounts. Use when feature logic involves multiple subscriptions, Pusher, or complex state.

The rule includes real examples from PRs #85535 (AgentZeroStatusProvider) and #86543 (LinkedActionNotFoundGuard, ReportNotFoundGuard), wrong patterns (unconditional providers, scattered condition checks, prop drilling), review metadata, and "DO NOT flag if" guardrails to avoid over-applying the pattern.

Also updates the coding-standards `SKILL.md` index to list the new rule.

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$
PROPOSAL:


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

N/A

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->

Same as tests

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>