### PR TITLE
Implement correct path handling in navigation state

### DIFF
--- a/src/libs/Navigation/helpers/dynamicRoutesUtils/getDynamicRouteQueryParams.ts
+++ b/src/libs/Navigation/helpers/dynamicRoutesUtils/getDynamicRouteQueryParams.ts
@@ -1,0 +1,24 @@
+import {DYNAMIC_ROUTES} from '@src/ROUTES';
+
+/**
+ * Returns the query parameter names that belong to a dynamic route suffix and should be
+ * stripped when removing that suffix from the path. Looks up the matching DYNAMIC_ROUTES
+ * config and returns its `queryParams` array if defined.
+ *
+ * @param dynamicSuffix - The dynamic route path segment (e.g., 'country')
+ * @returns The list of query param keys to strip, or undefined if no match or no queryParams config
+ */
+function getDynamicRouteQueryParams(dynamicSuffix: string): readonly string[] | undefined {
+    const keys = Object.keys(DYNAMIC_ROUTES) as Array<keyof typeof DYNAMIC_ROUTES>;
+    const match = keys.find((key) => DYNAMIC_ROUTES[key].path === dynamicSuffix);
+    if (!match) {
+        return undefined;
+    }
+    const config = DYNAMIC_ROUTES[match];
+    if (!('queryParams' in config)) {
+        return undefined;
+    }
+    return config.queryParams;
+}
+
+export default getDynamicRouteQueryParams;

--- a/src/libs/Navigation/helpers/dynamicRoutesUtils/getPathWithoutDynamicSuffix.ts
+++ b/src/libs/Navigation/helpers/dynamicRoutesUtils/getPathWithoutDynamicSuffix.ts
@@ -1,29 +1,6 @@
 import type {Route} from '@src/ROUTES';
-import {DYNAMIC_ROUTES} from '@src/ROUTES';
+import getDynamicRouteQueryParams from './getDynamicRouteQueryParams';
 import splitPathAndQuery from './splitPathAndQuery';
-
-/**
- * Returns the query parameter names that belong to a dynamic route suffix and should be
- * stripped when removing that suffix from the path. Looks up the matching DYNAMIC_ROUTES
- * config and returns its `queryParams` array if defined.
- *
- * @param dynamicSuffix - The dynamic route path segment (e.g., 'country')
- * @returns The list of query param keys to strip, or undefined if no match or no queryParams config
- *
- * @private - Internal helper. Do not export or use outside this file.
- */
-function getQueryParamsToStrip(dynamicSuffix: string): readonly string[] | undefined {
-    const keys = Object.keys(DYNAMIC_ROUTES) as Array<keyof typeof DYNAMIC_ROUTES>;
-    const match = keys.find((key) => DYNAMIC_ROUTES[key].path === dynamicSuffix);
-    if (!match) {
-        return undefined;
-    }
-    const config = DYNAMIC_ROUTES[match];
-    if (!('queryParams' in config)) {
-        return undefined;
-    }
-    return config.queryParams;
-}
 
 /**
  * Returns the path without a dynamic route suffix, stripping suffix-specific query parameters
@@ -41,7 +18,7 @@ function getPathWithoutDynamicSuffix(fullPath: string, dynamicSuffix: string): R
         return '';
     }
 
-    const paramsToStrip = getQueryParamsToStrip(dynamicSuffix);
+    const paramsToStrip = getDynamicRouteQueryParams(dynamicSuffix);
     let filteredQuery = query;
     if (paramsToStrip?.length && query) {
         const params = new URLSearchParams(query);

--- a/src/libs/Navigation/helpers/getPathFromState.ts
+++ b/src/libs/Navigation/helpers/getPathFromState.ts
@@ -89,30 +89,54 @@ function buildSuffixFromPattern(pattern: string, params: Record<string, unknown>
  * @private - Internal helper. Do not export or use outside this file.
  */
 function popFocusedRoute(state: State): State | undefined {
-    const index = state.index ?? state.routes.length - 1;
-    const focusedRoute = state.routes[index];
+    const ancestors: Array<{state: State; index: number}> = [];
+    let current: State = state;
+    let index = current.index ?? current.routes.length - 1;
+    let focusedRoute = current.routes[index];
 
-    if (!focusedRoute) {
-        return undefined;
+    // Descend to the deepest focused route, recording each ancestor level
+    while (focusedRoute?.state) {
+        ancestors.push({state: current, index});
+        current = focusedRoute.state as State;
+        index = current.index ?? current.routes.length - 1;
+        focusedRoute = current.routes[index];
     }
 
-    if (focusedRoute.state) {
-        const nestedResult = popFocusedRoute(focusedRoute.state as State);
+    // Remove the leaf route or mark the state as empty
+    let result: State | undefined;
+    if (!focusedRoute) {
+        result = undefined;
+    } else if (current.routes.length > 1) {
+        const newRoutes = current.routes.filter((_, i) => i !== index);
+        result = {...current, routes: newRoutes, index: newRoutes.length - 1} as State;
+    } else {
+        result = undefined;
+    }
 
-        if (nestedResult) {
-            const newRoutes = [...state.routes] as typeof state.routes;
-            // @ts-expect-error -- we're rebuilding a structurally identical route with updated nested state
-            newRoutes[index] = {...focusedRoute, state: nestedResult};
-            return {...state, routes: newRoutes, index} as State;
+    // Rebuild the state tree bottom-up, propagating the removal through ancestors
+    for (let i = ancestors.length - 1; i >= 0; i--) {
+        const ancestor = ancestors.at(i);
+        if (!ancestor) {
+            continue;
+        }
+
+        const {state: ancestorState, index: ancestorIndex} = ancestor;
+        const route = ancestorState.routes[ancestorIndex];
+
+        if (result !== undefined) {
+            const newRoutes = [...ancestorState.routes] as typeof ancestorState.routes;
+            // @ts-expect-error -- rebuilding a structurally identical route with updated nested state
+            newRoutes[ancestorIndex] = {...route, state: result};
+            result = {...ancestorState, routes: newRoutes, index: ancestorIndex} as State;
+        } else if (ancestorState.routes.length > 1) {
+            const newRoutes = ancestorState.routes.filter((_, j) => j !== ancestorIndex);
+            result = {...ancestorState, routes: newRoutes, index: newRoutes.length - 1} as State;
+        } else {
+            result = undefined;
         }
     }
 
-    if (state.routes.length > 1) {
-        const newRoutes = state.routes.filter((_, i) => i !== index);
-        return {...state, routes: newRoutes, index: newRoutes.length - 1} as State;
-    }
-
-    return undefined;
+    return result;
 }
 
 /**

--- a/src/libs/Navigation/helpers/getPathFromState.ts
+++ b/src/libs/Navigation/helpers/getPathFromState.ts
@@ -129,9 +129,17 @@ function getPathForDynamicRoute(state: State): string {
     }
 
     const basePath = getPathFromState(reducedState);
-    const [basePathWithoutQuery] = splitPathAndQuery(basePath);
+    const [basePathWithoutQuery, baseQuery] = splitPathAndQuery(basePath);
+    const [suffixPath, suffixQuery] = splitPathAndQuery(actualSuffix);
 
-    return `${basePathWithoutQuery}/${actualSuffix}`;
+    const mergedParams = new URLSearchParams(baseQuery ?? '');
+    const suffixParams = new URLSearchParams(suffixQuery ?? '');
+    for (const [key, value] of suffixParams) {
+        mergedParams.set(key, value);
+    }
+    const queryString = mergedParams.toString();
+
+    return `${basePathWithoutQuery}/${suffixPath}${queryString ? `?${queryString}` : ''}`;
 }
 
 function getPathFromState(state: State): string {

--- a/src/libs/Navigation/helpers/getPathFromState.ts
+++ b/src/libs/Navigation/helpers/getPathFromState.ts
@@ -88,54 +88,35 @@ function buildSuffixFromPattern(pattern: string, params: Record<string, unknown>
  * @private - Internal helper. Do not export or use outside this file.
  */
 function popFocusedRoute(state: State): State | undefined {
-    const ancestors: Array<{state: State; index: number}> = [];
-    let current: State = state;
-    let index = current.index ?? current.routes.length - 1;
-    let focusedRoute = current.routes[index];
+    const index = state.index ?? state.routes.length - 1;
+    const focusedRoute = state.routes[index];
 
-    // Descend to the deepest focused route, recording each ancestor level
-    while (focusedRoute?.state) {
-        ancestors.push({state: current, index});
-        current = focusedRoute.state as State;
-        index = current.index ?? current.routes.length - 1;
-        focusedRoute = current.routes[index];
-    }
-
-    // Remove the leaf route or mark the state as empty
-    let result: State | undefined;
+    // no focused route exists at this level - nothing to pop.
     if (!focusedRoute) {
-        result = undefined;
-    } else if (current.routes.length > 1) {
-        const newRoutes = current.routes.filter((_, i) => i !== index);
-        result = {...current, routes: newRoutes, index: newRoutes.length - 1} as State;
-    } else {
-        result = undefined;
+        return undefined;
     }
 
-    // Rebuild the state tree bottom-up, propagating the removal through ancestors
-    for (let i = ancestors.length - 1; i >= 0; i--) {
-        const ancestor = ancestors.at(i);
-        if (!ancestor) {
-            continue;
-        }
+    // the focused route has nested state — try to pop from deeper levels first.
+    if (focusedRoute.state) {
+        const nestedResult = popFocusedRoute(focusedRoute.state as State);
 
-        const {state: ancestorState, index: ancestorIndex} = ancestor;
-        const route = ancestorState.routes[ancestorIndex];
-
-        if (result !== undefined) {
-            const newRoutes = [...ancestorState.routes] as typeof ancestorState.routes;
-            // @ts-expect-error -- rebuilding a structurally identical route with updated nested state
-            newRoutes[ancestorIndex] = {...route, state: result};
-            result = {...ancestorState, routes: newRoutes, index: ancestorIndex} as State;
-        } else if (ancestorState.routes.length > 1) {
-            const newRoutes = ancestorState.routes.filter((_, j) => j !== ancestorIndex);
-            result = {...ancestorState, routes: newRoutes, index: newRoutes.length - 1} as State;
-        } else {
-            result = undefined;
+        // A deeper route was successfully popped - rebuild the current level with the updated nested state.
+        if (nestedResult) {
+            const newRoutes = [...state.routes] as typeof state.routes;
+            // @ts-expect-error -- we're rebuilding a structurally identical route with updated nested state
+            newRoutes[index] = {...focusedRoute, state: nestedResult};
+            return {...state, routes: newRoutes, index} as State;
         }
     }
 
-    return result;
+    // remove the focused route itself if siblings remain.
+    if (state.routes.length > 1) {
+        const newRoutes = state.routes.filter((_, i) => i !== index);
+        return {...state, routes: newRoutes, index: newRoutes.length - 1} as State;
+    }
+
+    // Only one route at this level and nothing deeper to pop — signal the parent to remove this level entirely.
+    return undefined;
 }
 
 /**

--- a/src/libs/Navigation/helpers/getPathFromState.ts
+++ b/src/libs/Navigation/helpers/getPathFromState.ts
@@ -24,6 +24,27 @@ function isDynamicRouteScreen(screenName: Screen): boolean {
 }
 
 /**
+ * Resolves a single path segment: if it's a `:param` placeholder, replaces it
+ * with the URL-encoded value from `params`; otherwise returns the segment as-is.
+ * Returns an empty string when a param value is missing or not a string/number.
+ *
+ * @private - Internal helper. Do not export or use outside this file.
+ */
+function resolveSegment(segment: string, params: Record<string, unknown> | undefined): string {
+    if (segment.startsWith(':')) {
+        const paramName = segment.endsWith('?') ? segment.slice(1, -1) : segment.slice(1);
+        const value = params?.[paramName];
+
+        if (typeof value === 'string' || typeof value === 'number') {
+            return encodeURIComponent(String(value));
+        }
+
+        return '';
+    }
+    return segment;
+}
+
+/**
  * Builds a concrete URL suffix from a dynamic route pattern by replacing `:param`
  * placeholders with actual values and appending configured query parameters.
  *
@@ -36,17 +57,8 @@ function isDynamicRouteScreen(screenName: Screen): boolean {
 function buildSuffixFromPattern(pattern: string, params: Record<string, unknown> | undefined): string {
     const pathPart = pattern
         .split('/')
-        .map((segment) => {
-            if (segment.startsWith(':')) {
-                const paramName = segment.endsWith('?') ? segment.slice(1, -1) : segment.slice(1);
-                const value = params?.[paramName];
-                if (typeof value === 'string' || typeof value === 'number') {
-                    return encodeURIComponent(String(value));
-                }
-                return '';
-            }
-            return segment;
-        })
+        .map((segment) => resolveSegment(segment, params))
+        // filter(Boolean) is used to remove empty segments
         .filter(Boolean)
         .join('/');
 
@@ -112,7 +124,7 @@ function popFocusedRoute(state: State): State | undefined {
  *
  * @private - Internal helper. Do not export or use outside this file.
  */
-function getPathForDynamicRoute(state: State): string {
+function getPathFromStateWithDynamicRoute(state: State): string {
     const focusedRoute = findFocusedRoute(state);
     const screenName = focusedRoute?.name ?? '';
     const suffixPattern = normalizedConfigs[screenName as Screen]?.path;
@@ -147,10 +159,7 @@ function getPathFromState(state: State): string {
     const screenName = focusedRoute?.name ?? '';
 
     if (isDynamicRouteScreen(screenName as Screen)) {
-        if (focusedRoute?.path) {
-            return focusedRoute.path;
-        }
-        return getPathForDynamicRoute(state);
+        return focusedRoute?.path ?? getPathFromStateWithDynamicRoute(state);
     }
 
     return RNGetPathFromState(state, linkingConfig.config);

--- a/src/libs/Navigation/helpers/getPathFromState.ts
+++ b/src/libs/Navigation/helpers/getPathFromState.ts
@@ -3,8 +3,10 @@ import type {NavigationState, PartialState} from '@react-navigation/routers';
 import {linkingConfig} from '@libs/Navigation/linkingConfig';
 import {normalizedConfigs} from '@libs/Navigation/linkingConfig/config';
 import type {DynamicRouteSuffix} from '@src/ROUTES';
+import {DYNAMIC_ROUTES} from '@src/ROUTES';
 import type {Screen} from '@src/SCREENS';
 import {dynamicRoutePaths} from './dynamicRoutesUtils/isDynamicRouteSuffix';
+import splitPathAndQuery from './dynamicRoutesUtils/splitPathAndQuery';
 
 type State = NavigationState | Omit<PartialState<NavigationState>, 'stale'>;
 
@@ -21,19 +23,131 @@ function isDynamicRouteScreen(screenName: Screen): boolean {
     return dynamicRoutePaths.has(screenPath as DynamicRouteSuffix);
 }
 
-const getPathFromState = (state: State): string => {
+function findQueryParamsForPattern(pattern: string): readonly string[] | undefined {
+    for (const entry of Object.values(DYNAMIC_ROUTES)) {
+        if (entry.path === pattern && 'queryParams' in entry) {
+            return entry.queryParams as readonly string[];
+        }
+    }
+    return undefined;
+}
+
+/**
+ * Reconstructs the actual URL suffix from a dynamic route pattern and route params.
+ * Fills :param placeholders with values from params, and appends query params
+ * based on the DYNAMIC_ROUTES[].queryParams config.
+ *
+ * Example: pattern 'flag/:reportID/:reportActionID' + params {reportID: '456', reportActionID: 'abc'}
+ *          --> 'flag/456/abc'
+ * Example: pattern 'country' + params {country: 'US'} + queryParams config ['country']
+ *          --> 'country?country=US'
+ */
+function buildSuffixFromPattern(pattern: string, params: Record<string, unknown> | undefined): string {
+    const pathPart = pattern
+        .split('/')
+        .map((segment) => {
+            if (segment.startsWith(':')) {
+                const paramName = segment.endsWith('?') ? segment.slice(1, -1) : segment.slice(1);
+                const value = params?.[paramName];
+                if (typeof value === 'string' || typeof value === 'number') {
+                    return encodeURIComponent(String(value));
+                }
+                return '';
+            }
+            return segment;
+        })
+        .join('/');
+
+    const queryParamKeys = findQueryParamsForPattern(pattern);
+    if (queryParamKeys && queryParamKeys.length > 0 && params) {
+        const queryParts: string[] = [];
+        for (const key of queryParamKeys) {
+            const value = params[key];
+            if ((typeof value === 'string' || typeof value === 'number') && value !== '') {
+                queryParts.push(`${encodeURIComponent(key)}=${encodeURIComponent(String(value))}`);
+            }
+        }
+        if (queryParts.length > 0) {
+            return `${pathPart}?${queryParts.join('&')}`;
+        }
+    }
+
+    return pathPart;
+}
+
+/**
+ * Removes the deepest focused route from the state tree.
+ * Descends through routes[index] at each level until reaching a leaf route,
+ * then removes it. If removing the route empties the navigator, cascades
+ * removal upward by returning undefined to the parent.
+ */
+function popFocusedRoute(state: State): State | undefined {
+    const index = state.index ?? state.routes.length - 1;
+    const focusedRoute = state.routes[index];
+
+    if (!focusedRoute) {
+        return undefined;
+    }
+
+    if (focusedRoute.state) {
+        const nestedResult = popFocusedRoute(focusedRoute.state as State);
+
+        if (nestedResult) {
+            const newRoutes = [...state.routes] as typeof state.routes;
+            // @ts-expect-error -- we're rebuilding a structurally identical route with updated nested state
+            newRoutes[index] = {...focusedRoute, state: nestedResult};
+            return {...state, routes: newRoutes, index} as State;
+        }
+    }
+
+    if (state.routes.length > 1) {
+        const newRoutes = state.routes.filter((_, i) => i !== index);
+        return {...state, routes: newRoutes, index: newRoutes.length - 1} as State;
+    }
+
+    return undefined;
+}
+
+/**
+ * Fallback path builder for dynamic route screens that lack a `path` property.
+ * Peels off the dynamic suffix from the focused route, pops it from the state,
+ * and recursively calls getPathFromState on the reduced state. This naturally
+ * handles stacked dynamic routes (each recursion peels off one suffix).
+ */
+function getPathForDynamicRoute(state: State): string {
+    const focusedRoute = findFocusedRoute(state);
+    const screenName = focusedRoute?.name ?? '';
+    const suffixPattern = normalizedConfigs[screenName as Screen]?.path;
+
+    if (!suffixPattern) {
+        return RNGetPathFromState(state, linkingConfig.config);
+    }
+
+    const actualSuffix = buildSuffixFromPattern(suffixPattern, focusedRoute?.params as Record<string, unknown> | undefined);
+    const reducedState = popFocusedRoute(state);
+
+    if (!reducedState) {
+        return `/${actualSuffix}`;
+    }
+
+    const basePath = getPathFromState(reducedState);
+    const [basePathWithoutQuery] = splitPathAndQuery(basePath);
+
+    return `${basePathWithoutQuery}/${actualSuffix}`;
+}
+
+function getPathFromState(state: State): string {
     const focusedRoute = findFocusedRoute(state);
     const screenName = focusedRoute?.name ?? '';
 
-    // Handle dynamic route screens that require special path that is placed in state
-    if (isDynamicRouteScreen(screenName as Screen) && focusedRoute?.path) {
-        return focusedRoute.path;
+    if (isDynamicRouteScreen(screenName as Screen)) {
+        if (focusedRoute?.path) {
+            return focusedRoute.path;
+        }
+        return getPathForDynamicRoute(state);
     }
 
-    // For regular routes, use React Navigation's default path generation
-    const path = RNGetPathFromState(state, linkingConfig.config);
-
-    return path;
-};
+    return RNGetPathFromState(state, linkingConfig.config);
+}
 
 export default getPathFromState;

--- a/src/libs/Navigation/helpers/getPathFromState.ts
+++ b/src/libs/Navigation/helpers/getPathFromState.ts
@@ -1,7 +1,6 @@
 import {findFocusedRoute, getPathFromState as RNGetPathFromState} from '@react-navigation/native';
 import type {NavigationState, PartialState} from '@react-navigation/routers';
-import {linkingConfig} from '@libs/Navigation/linkingConfig';
-import {normalizedConfigs} from '@libs/Navigation/linkingConfig/config';
+import {config, normalizedConfigs} from '@libs/Navigation/linkingConfig/config';
 import type {DynamicRouteSuffix} from '@src/ROUTES';
 import type {Screen} from '@src/SCREENS';
 import getDynamicRouteQueryParams from './dynamicRoutesUtils/getDynamicRouteQueryParams';
@@ -154,7 +153,7 @@ function getPathFromStateWithDynamicRoute(state: State): string {
     const suffixPattern = normalizedConfigs[screenName as Screen]?.path;
 
     if (!suffixPattern) {
-        return RNGetPathFromState(state, linkingConfig.config);
+        return RNGetPathFromState(state, config);
     }
 
     const actualSuffix = buildSuffixFromPattern(suffixPattern, focusedRoute?.params as Record<string, unknown> | undefined);
@@ -186,7 +185,7 @@ function getPathFromState(state: State): string {
         return focusedRoute?.path ?? getPathFromStateWithDynamicRoute(state);
     }
 
-    return RNGetPathFromState(state, linkingConfig.config);
+    return RNGetPathFromState(state, config);
 }
 
 export default getPathFromState;

--- a/src/libs/Navigation/helpers/getPathFromState.ts
+++ b/src/libs/Navigation/helpers/getPathFromState.ts
@@ -3,8 +3,8 @@ import type {NavigationState, PartialState} from '@react-navigation/routers';
 import {linkingConfig} from '@libs/Navigation/linkingConfig';
 import {normalizedConfigs} from '@libs/Navigation/linkingConfig/config';
 import type {DynamicRouteSuffix} from '@src/ROUTES';
-import {DYNAMIC_ROUTES} from '@src/ROUTES';
 import type {Screen} from '@src/SCREENS';
+import getDynamicRouteQueryParams from './dynamicRoutesUtils/getDynamicRouteQueryParams';
 import {dynamicRoutePaths} from './dynamicRoutesUtils/isDynamicRouteSuffix';
 import splitPathAndQuery from './dynamicRoutesUtils/splitPathAndQuery';
 
@@ -23,24 +23,15 @@ function isDynamicRouteScreen(screenName: Screen): boolean {
     return dynamicRoutePaths.has(screenPath as DynamicRouteSuffix);
 }
 
-function findQueryParamsForPattern(pattern: string): readonly string[] | undefined {
-    for (const entry of Object.values(DYNAMIC_ROUTES)) {
-        if (entry.path === pattern && 'queryParams' in entry) {
-            return entry.queryParams as readonly string[];
-        }
-    }
-    return undefined;
-}
-
 /**
- * Reconstructs the actual URL suffix from a dynamic route pattern and route params.
- * Fills :param placeholders with values from params, and appends query params
- * based on the DYNAMIC_ROUTES[].queryParams config.
+ * Builds a concrete URL suffix from a dynamic route pattern by replacing `:param`
+ * placeholders with actual values and appending configured query parameters.
  *
- * Example: pattern 'flag/:reportID/:reportActionID' + params {reportID: '456', reportActionID: 'abc'}
- *          --> 'flag/456/abc'
- * Example: pattern 'country' + params {country: 'US'} + queryParams config ['country']
- *          --> 'country?country=US'
+ * @param pattern - The route path pattern (e.g., 'flag/:reportID/:reportActionID' or 'country')
+ * @param params - Route params to fill placeholders and query values from
+ * @returns The resolved suffix string (e.g., 'flag/456/abc' or 'country?country=US')
+ *
+ * @private - Internal helper. Do not export or use outside this file.
  */
 function buildSuffixFromPattern(pattern: string, params: Record<string, unknown> | undefined): string {
     const pathPart = pattern
@@ -56,9 +47,10 @@ function buildSuffixFromPattern(pattern: string, params: Record<string, unknown>
             }
             return segment;
         })
+        .filter(Boolean)
         .join('/');
 
-    const queryParamKeys = findQueryParamsForPattern(pattern);
+    const queryParamKeys = getDynamicRouteQueryParams(pattern);
     if (queryParamKeys && queryParamKeys.length > 0 && params) {
         const queryParts: string[] = [];
         for (const key of queryParamKeys) {
@@ -76,10 +68,13 @@ function buildSuffixFromPattern(pattern: string, params: Record<string, unknown>
 }
 
 /**
- * Removes the deepest focused route from the state tree.
- * Descends through routes[index] at each level until reaching a leaf route,
- * then removes it. If removing the route empties the navigator, cascades
- * removal upward by returning undefined to the parent.
+ * Pops the deepest focused route from a navigation state tree.
+ * Returns the reduced state, or undefined if the tree becomes empty.
+ *
+ * @param state - The navigation state tree to pop from
+ * @returns The reduced state, or undefined if the tree becomes empty
+ *
+ * @private - Internal helper. Do not export or use outside this file.
  */
 function popFocusedRoute(state: State): State | undefined {
     const index = state.index ?? state.routes.length - 1;
@@ -109,10 +104,13 @@ function popFocusedRoute(state: State): State | undefined {
 }
 
 /**
- * Fallback path builder for dynamic route screens that lack a `path` property.
- * Peels off the dynamic suffix from the focused route, pops it from the state,
- * and recursively calls getPathFromState on the reduced state. This naturally
- * handles stacked dynamic routes (each recursion peels off one suffix).
+ * Builds a URL path for a dynamic route screen that has no `path` in state.
+ * Recursively peels off dynamic suffixes and resolves the base path underneath.
+ *
+ * @param state - The navigation state tree to build the path from
+ * @returns The resolved path for the focused dynamic route screen
+ *
+ * @private - Internal helper. Do not export or use outside this file.
  */
 function getPathForDynamicRoute(state: State): string {
     const focusedRoute = findFocusedRoute(state);

--- a/src/libs/Navigation/helpers/linkTo/index.ts
+++ b/src/libs/Navigation/helpers/linkTo/index.ts
@@ -1,7 +1,6 @@
 import {getActionFromState} from '@react-navigation/core';
 import type {NavigationContainerRef, NavigationState, PartialState} from '@react-navigation/native';
 import {findFocusedRoute, StackActions} from '@react-navigation/native';
-import findMatchingDynamicSuffix from '@libs/Navigation/helpers/dynamicRoutesUtils/findMatchingDynamicSuffix';
 import {getMatchingFullScreenRoute, isFullScreenName} from '@libs/Navigation/helpers/getAdaptedStateFromPath';
 import getStateFromPath from '@libs/Navigation/helpers/getStateFromPath';
 import normalizePath from '@libs/Navigation/helpers/normalizePath';
@@ -152,12 +151,10 @@ export default function linkTo(navigation: NavigationContainerRef<RootNavigatorP
     // If not, it will be replaced. This way, navigating between one attachment screen and another won't be added to the browser history.
     // Report screen - Also a special case. If we are navigating to the report with same reportID we want to replace it (navigate will do that).
     // This covers the case when we open a specific message in report (reportActionID).
-    // Dynamic routes - Keep NAVIGATE so that StackRouter preserves `path` on the route (PUSH explicitly sets path to undefined).
     else if (
         action.type === CONST.NAVIGATION.ACTION_TYPE.NAVIGATE &&
         !isNavigatingToAttachmentScreen(focusedRouteFromPath?.name) &&
-        !isNavigatingToReportWithSameReportID(currentFocusedRoute, focusedRouteFromPath) &&
-        !findMatchingDynamicSuffix(normalizedPath)
+        !isNavigatingToReportWithSameReportID(currentFocusedRoute, focusedRouteFromPath)
     ) {
         // We want to PUSH by default to add entries to the browser history.
         action.type = CONST.NAVIGATION.ACTION_TYPE.PUSH;

--- a/src/libs/Navigation/linkingConfig/index.ts
+++ b/src/libs/Navigation/linkingConfig/index.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/naming-convention */
 import type {LinkingOptions} from '@react-navigation/native';
 import getAdaptedStateFromPath from '@libs/Navigation/helpers/getAdaptedStateFromPath';
+import getPathFromState from '@libs/Navigation/helpers/getPathFromState';
 import type {RootNavigatorParamList} from '@libs/Navigation/types';
 import {config} from './config';
 import prefixes from './prefixes';
@@ -8,6 +9,7 @@ import subscribe from './subscribe';
 
 const linkingConfig: LinkingOptions<RootNavigatorParamList> = {
     getStateFromPath: getAdaptedStateFromPath,
+    getPathFromState: (state) => getPathFromState(state),
     prefixes,
     config,
     subscribe,

--- a/src/libs/Navigation/linkingConfig/index.ts
+++ b/src/libs/Navigation/linkingConfig/index.ts
@@ -9,7 +9,7 @@ import subscribe from './subscribe';
 
 const linkingConfig: LinkingOptions<RootNavigatorParamList> = {
     getStateFromPath: getAdaptedStateFromPath,
-    getPathFromState: (state) => getPathFromState(state),
+    getPathFromState,
     prefixes,
     config,
     subscribe,

--- a/tests/navigation/getPathFromStateTests.ts
+++ b/tests/navigation/getPathFromStateTests.ts
@@ -15,6 +15,24 @@ jest.mock('@libs/Navigation/linkingConfig/config', () => ({
         StandardScreen: {
             path: 'standard',
         },
+        VerifyAccountScreen: {
+            path: 'verify-account',
+        },
+        CountryScreen: {
+            path: 'country',
+        },
+        FlagScreen: {
+            path: 'flag/:reportID/:reportActionID',
+        },
+        ConstantPickerScreen: {
+            path: 'constant-picker',
+        },
+        WalletScreen: {
+            path: 'settings/wallet',
+        },
+        ReportScreen: {
+            path: 'r/:reportID',
+        },
     },
 }));
 
@@ -29,8 +47,54 @@ jest.mock('@src/ROUTES', () => ({
         TEST_DYNAMIC: {
             path: 'test-dynamic',
         },
+        VERIFY_ACCOUNT: {
+            path: 'verify-account',
+        },
+        ADDRESS_COUNTRY: {
+            path: 'country',
+            queryParams: ['country'],
+        },
+        FLAG: {
+            path: 'flag/:reportID/:reportActionID',
+        },
+        CONSTANT_PICKER: {
+            path: 'constant-picker',
+            queryParams: ['formType', 'fieldName', 'fieldValue'],
+        },
     },
 }));
+
+type RouteEntry = {
+    name: string;
+    params?: Record<string, unknown>;
+    path?: string;
+    state?: {routes: RouteEntry[]; index: number};
+};
+
+type TestState = {
+    routes: RouteEntry[];
+    index: number;
+};
+
+function buildState(routes: RouteEntry[], index?: number): TestState {
+    return {
+        routes,
+        index: index ?? routes.length - 1,
+    } as TestState;
+}
+
+function realFindFocusedRoute(state: TestState | RouteEntry['state']): RouteEntry | undefined {
+    let current: TestState | RouteEntry['state'] = state;
+    while (current?.routes?.[current.index ?? 0]?.state != null) {
+        current = current.routes[current.index ?? 0].state;
+    }
+    return current?.routes?.[current?.index ?? 0];
+}
+
+const staticBasePaths: Record<string, (params?: Record<string, unknown>) => string> = {
+    WalletScreen: () => '/settings/wallet',
+    ReportScreen: (params) => `/r/${(params?.reportID as string) ?? ''}`,
+};
 
 describe('getPathFromState', () => {
     const mockFindFocusedRoute = findFocusedRoute as jest.Mock;
@@ -55,19 +119,15 @@ describe('getPathFromState', () => {
         expect(mockRNGetPathFromState).not.toHaveBeenCalled();
     });
 
-    it('should fall back to RN getPathFromState for dynamic screens when path is MISSING', () => {
-        const state = {} as PartialState<NavigationState>;
-        const expectedPath = '/generated/path';
+    it('should use custom fallback for dynamic screens when path is MISSING', () => {
+        const state = buildState([{name: 'StandardScreen'}, {name: 'TestDynamicScreen'}]);
 
-        mockFindFocusedRoute.mockReturnValue({
-            name: 'TestDynamicScreen',
-        });
-        mockRNGetPathFromState.mockReturnValue(expectedPath);
+        mockFindFocusedRoute.mockImplementation(realFindFocusedRoute);
+        mockRNGetPathFromState.mockReturnValue('/standard');
 
-        const result = getPathFromState(state);
+        const result = getPathFromState(state as PartialState<NavigationState>);
 
-        expect(result).toBe(expectedPath);
-        expect(mockRNGetPathFromState).toHaveBeenCalledWith(state, expect.anything());
+        expect(result).toBe('/standard/test-dynamic');
     });
 
     it('should use RN getPathFromState for standard screens', () => {
@@ -94,5 +154,168 @@ describe('getPathFromState', () => {
 
         expect(result).toBe('/fallback');
         expect(mockRNGetPathFromState).toHaveBeenCalled();
+    });
+
+    describe('dynamic route fallback (no path in state)', () => {
+        beforeEach(() => {
+            mockFindFocusedRoute.mockImplementation(realFindFocusedRoute);
+
+            mockRNGetPathFromState.mockImplementation((s: TestState) => {
+                const route = realFindFocusedRoute(s);
+                const builder = staticBasePaths[route?.name ?? ''];
+                return builder ? builder(route?.params) : '/unknown';
+            });
+        });
+
+        it('1a: simple suffix (no path/query params)', () => {
+            const state = buildState([{name: 'WalletScreen'}, {name: 'VerifyAccountScreen'}]);
+
+            expect(getPathFromState(state as PartialState<NavigationState>)).toBe('/settings/wallet/verify-account');
+        });
+
+        it('1b: suffix with path params', () => {
+            const state = buildState([
+                {name: 'ReportScreen', params: {reportID: '123'}},
+                {name: 'FlagScreen', params: {reportID: '456', reportActionID: 'abc'}},
+            ]);
+
+            expect(getPathFromState(state as PartialState<NavigationState>)).toBe('/r/123/flag/456/abc');
+        });
+
+        it('1c: suffix with query params', () => {
+            const state = buildState([{name: 'WalletScreen'}, {name: 'CountryScreen', params: {country: 'PL'}}]);
+
+            expect(getPathFromState(state as PartialState<NavigationState>)).toBe('/settings/wallet/country?country=PL');
+        });
+
+        it('1d: suffix with multiple query params', () => {
+            const state = buildState([
+                {name: 'ReportScreen', params: {reportID: '123'}},
+                {name: 'ConstantPickerScreen', params: {formType: 'report', fieldName: 'status', fieldValue: 'open'}},
+            ]);
+
+            expect(getPathFromState(state as PartialState<NavigationState>)).toBe('/r/123/constant-picker?formType=report&fieldName=status&fieldValue=open');
+        });
+
+        it('1e: suffix with query params config but params missing', () => {
+            const state = buildState([{name: 'WalletScreen'}, {name: 'CountryScreen', params: {}}]);
+
+            expect(getPathFromState(state as PartialState<NavigationState>)).toBe('/settings/wallet/country');
+        });
+
+        it('1f: suffix with partial query params (some present, some missing)', () => {
+            const state = buildState([
+                {name: 'ReportScreen', params: {reportID: '123'}},
+                {name: 'ConstantPickerScreen', params: {formType: 'report', fieldName: 'status'}},
+            ]);
+
+            expect(getPathFromState(state as PartialState<NavigationState>)).toBe('/r/123/constant-picker?formType=report&fieldName=status');
+        });
+
+        it('2a: inner has path, outer has query params', () => {
+            const state = buildState([{name: 'WalletScreen'}, {name: 'VerifyAccountScreen', path: '/settings/wallet/verify-account'}, {name: 'CountryScreen', params: {country: 'US'}}]);
+
+            expect(getPathFromState(state as PartialState<NavigationState>)).toBe('/settings/wallet/verify-account/country?country=US');
+        });
+
+        it('2b: inner has path with path params, outer is simple', () => {
+            const state = buildState([{name: 'ReportScreen', params: {reportID: '123'}}, {name: 'FlagScreen', path: '/r/123/flag/456/abc'}, {name: 'VerifyAccountScreen'}]);
+
+            expect(getPathFromState(state as PartialState<NavigationState>)).toBe('/r/123/flag/456/abc/verify-account');
+        });
+
+        it('2c: inner has path WITH query params, outer appends suffix (inner query params stripped)', () => {
+            const state = buildState([
+                {name: 'WalletScreen'},
+                {name: 'CountryScreen', path: '/settings/wallet/country?country=US'},
+                {name: 'ConstantPickerScreen', params: {formType: 'report', fieldName: 'status', fieldValue: 'open'}},
+            ]);
+
+            expect(getPathFromState(state as PartialState<NavigationState>)).toBe('/settings/wallet/country/constant-picker?formType=report&fieldName=status&fieldValue=open');
+        });
+
+        it('3a: two simple dynamic suffixes, no params on first', () => {
+            const state = buildState([{name: 'WalletScreen'}, {name: 'VerifyAccountScreen'}, {name: 'CountryScreen', params: {country: 'US'}}]);
+
+            expect(getPathFromState(state as PartialState<NavigationState>)).toBe('/settings/wallet/verify-account/country?country=US');
+        });
+
+        it('3b: path params + query params stacking', () => {
+            const state = buildState([
+                {name: 'ReportScreen', params: {reportID: '123'}},
+                {name: 'FlagScreen', params: {reportID: '456', reportActionID: 'abc'}},
+                {name: 'CountryScreen', params: {country: 'US'}},
+            ]);
+
+            expect(getPathFromState(state as PartialState<NavigationState>)).toBe('/r/123/flag/456/abc/country?country=US');
+        });
+
+        it('3c: three stacked dynamic suffixes, none with path', () => {
+            const state = buildState([
+                {name: 'WalletScreen'},
+                {name: 'VerifyAccountScreen'},
+                {name: 'CountryScreen', params: {country: 'US'}},
+                {name: 'ConstantPickerScreen', params: {formType: 'report', fieldName: 'x'}},
+            ]);
+
+            expect(getPathFromState(state as PartialState<NavigationState>)).toBe('/settings/wallet/verify-account/country/constant-picker?formType=report&fieldName=x');
+        });
+
+        it('4a: dynamic screen inside a nested navigator', () => {
+            const state = buildState([
+                {
+                    name: 'RHPNavigator',
+                    state: buildState([{name: 'WalletScreen'}, {name: 'VerifyAccountScreen'}]),
+                },
+            ]);
+
+            expect(getPathFromState(state as PartialState<NavigationState>)).toBe('/settings/wallet/verify-account');
+        });
+
+        it('4b: two dynamic suffixes inside nested navigator', () => {
+            const state = buildState([
+                {
+                    name: 'RHPNavigator',
+                    state: buildState([{name: 'WalletScreen'}, {name: 'VerifyAccountScreen'}, {name: 'CountryScreen', params: {country: 'PL'}}]),
+                },
+            ]);
+
+            expect(getPathFromState(state as PartialState<NavigationState>)).toBe('/settings/wallet/verify-account/country?country=PL');
+        });
+
+        it('5a: only dynamic route, no base (state has single route)', () => {
+            const state = buildState([{name: 'VerifyAccountScreen'}]);
+
+            expect(getPathFromState(state as PartialState<NavigationState>)).toBe('/verify-account');
+        });
+
+        it('5b: trailing slash normalization from base path', () => {
+            mockRNGetPathFromState.mockReturnValue('/settings/wallet/');
+
+            const state = buildState([{name: 'WalletScreen'}, {name: 'VerifyAccountScreen'}]);
+
+            expect(getPathFromState(state as PartialState<NavigationState>)).toBe('/settings/wallet/verify-account');
+        });
+
+        it('5c: path params with special characters are encoded', () => {
+            const state = buildState([
+                {name: 'ReportScreen', params: {reportID: '123'}},
+                {name: 'FlagScreen', params: {reportID: 'a/b', reportActionID: 'c&d'}},
+            ]);
+
+            expect(getPathFromState(state as PartialState<NavigationState>)).toBe('/r/123/flag/a%2Fb/c%26d');
+        });
+
+        it('5d: query param values with special characters are encoded', () => {
+            const state = buildState([{name: 'WalletScreen'}, {name: 'CountryScreen', params: {country: 'a&b=c'}}]);
+
+            expect(getPathFromState(state as PartialState<NavigationState>)).toBe('/settings/wallet/country?country=a%26b%3Dc');
+        });
+
+        it('5e: dynamic route with no params at all (params undefined)', () => {
+            const state = buildState([{name: 'WalletScreen'}, {name: 'CountryScreen'}]);
+
+            expect(getPathFromState(state as PartialState<NavigationState>)).toBe('/settings/wallet/country');
+        });
     });
 });

--- a/tests/navigation/getPathFromStateTests.ts
+++ b/tests/navigation/getPathFromStateTests.ts
@@ -119,17 +119,6 @@ describe('getPathFromState', () => {
         expect(mockRNGetPathFromState).not.toHaveBeenCalled();
     });
 
-    it('should use custom fallback for dynamic screens when path is MISSING', () => {
-        const state = buildState([{name: 'StandardScreen'}, {name: 'TestDynamicScreen'}]);
-
-        mockFindFocusedRoute.mockImplementation(realFindFocusedRoute);
-        mockRNGetPathFromState.mockReturnValue('/standard');
-
-        const result = getPathFromState(state as PartialState<NavigationState>);
-
-        expect(result).toBe('/standard/test-dynamic');
-    });
-
     it('should use RN getPathFromState for standard screens', () => {
         const state = {} as PartialState<NavigationState>;
         const expectedPath = '/standard/path';
@@ -167,13 +156,13 @@ describe('getPathFromState', () => {
             });
         });
 
-        it('1a: simple suffix (no path/query params)', () => {
+        it('simple suffix (no path/query params)', () => {
             const state = buildState([{name: 'WalletScreen'}, {name: 'VerifyAccountScreen'}]);
 
             expect(getPathFromState(state as PartialState<NavigationState>)).toBe('/settings/wallet/verify-account');
         });
 
-        it('1b: suffix with path params', () => {
+        it('suffix with path params', () => {
             const state = buildState([
                 {name: 'ReportScreen', params: {reportID: '123'}},
                 {name: 'FlagScreen', params: {reportID: '456', reportActionID: 'abc'}},
@@ -182,28 +171,28 @@ describe('getPathFromState', () => {
             expect(getPathFromState(state as PartialState<NavigationState>)).toBe('/r/123/flag/456/abc');
         });
 
-        it('1c: suffix with query params', () => {
+        it('suffix with query params', () => {
             const state = buildState([{name: 'WalletScreen'}, {name: 'CountryScreen', params: {country: 'PL'}}]);
 
             expect(getPathFromState(state as PartialState<NavigationState>)).toBe('/settings/wallet/country?country=PL');
         });
 
-        it('1d: suffix with multiple query params', () => {
+        it('suffix with multiple query params', () => {
             const state = buildState([
                 {name: 'ReportScreen', params: {reportID: '123'}},
-                {name: 'ConstantPickerScreen', params: {formType: 'report', fieldName: 'status', fieldValue: 'open'}},
+                {name: 'ConstantPickerScreen', params: {formType: 'report', fieldName: 'status', fieldValue: 'open', reportID: '123'}},
             ]);
 
             expect(getPathFromState(state as PartialState<NavigationState>)).toBe('/r/123/constant-picker?formType=report&fieldName=status&fieldValue=open');
         });
 
-        it('1e: suffix with query params config but params missing', () => {
+        it('suffix with query params config but params missing', () => {
             const state = buildState([{name: 'WalletScreen'}, {name: 'CountryScreen', params: {}}]);
 
             expect(getPathFromState(state as PartialState<NavigationState>)).toBe('/settings/wallet/country');
         });
 
-        it('1f: suffix with partial query params (some present, some missing)', () => {
+        it('suffix with partial query params (some present, some missing)', () => {
             const state = buildState([
                 {name: 'ReportScreen', params: {reportID: '123'}},
                 {name: 'ConstantPickerScreen', params: {formType: 'report', fieldName: 'status'}},
@@ -212,35 +201,36 @@ describe('getPathFromState', () => {
             expect(getPathFromState(state as PartialState<NavigationState>)).toBe('/r/123/constant-picker?formType=report&fieldName=status');
         });
 
-        it('2a: inner has path, outer has query params', () => {
+        it('inner dynamic suffix has path, outer has query params', () => {
             const state = buildState([{name: 'WalletScreen'}, {name: 'VerifyAccountScreen', path: '/settings/wallet/verify-account'}, {name: 'CountryScreen', params: {country: 'US'}}]);
 
             expect(getPathFromState(state as PartialState<NavigationState>)).toBe('/settings/wallet/verify-account/country?country=US');
         });
 
-        it('2b: inner has path with path params, outer is simple', () => {
+        it('inner dynamic suffix has path with path params, outer is simple', () => {
             const state = buildState([{name: 'ReportScreen', params: {reportID: '123'}}, {name: 'FlagScreen', path: '/r/123/flag/456/abc'}, {name: 'VerifyAccountScreen'}]);
 
             expect(getPathFromState(state as PartialState<NavigationState>)).toBe('/r/123/flag/456/abc/verify-account');
         });
 
-        it('2c: inner has path WITH query params, outer appends suffix (inner query params stripped)', () => {
+        it('inner dynamic suffix has path with query params, outer appends suffix (inner query params stripped)', () => {
             const state = buildState([
                 {name: 'WalletScreen'},
                 {name: 'CountryScreen', path: '/settings/wallet/country?country=US'},
                 {name: 'ConstantPickerScreen', params: {formType: 'report', fieldName: 'status', fieldValue: 'open'}},
             ]);
 
-            expect(getPathFromState(state as PartialState<NavigationState>)).toBe('/settings/wallet/country/constant-picker?formType=report&fieldName=status&fieldValue=open');
+            expect(getPathFromState(state as PartialState<NavigationState>)).toBe('/settings/wallet/country/constant-picker?country=US&formType=report&fieldName=status&fieldValue=open');
         });
+        // no
 
-        it('3a: two simple dynamic suffixes, no params on first', () => {
+        it('two simple dynamic suffixes, no params on first', () => {
             const state = buildState([{name: 'WalletScreen'}, {name: 'VerifyAccountScreen'}, {name: 'CountryScreen', params: {country: 'US'}}]);
 
             expect(getPathFromState(state as PartialState<NavigationState>)).toBe('/settings/wallet/verify-account/country?country=US');
         });
 
-        it('3b: path params + query params stacking', () => {
+        it('path params + query params stacking', () => {
             const state = buildState([
                 {name: 'ReportScreen', params: {reportID: '123'}},
                 {name: 'FlagScreen', params: {reportID: '456', reportActionID: 'abc'}},
@@ -250,7 +240,7 @@ describe('getPathFromState', () => {
             expect(getPathFromState(state as PartialState<NavigationState>)).toBe('/r/123/flag/456/abc/country?country=US');
         });
 
-        it('3c: three stacked dynamic suffixes, none with path', () => {
+        it('three stacked dynamic suffixes, none with path', () => {
             const state = buildState([
                 {name: 'WalletScreen'},
                 {name: 'VerifyAccountScreen'},
@@ -258,10 +248,10 @@ describe('getPathFromState', () => {
                 {name: 'ConstantPickerScreen', params: {formType: 'report', fieldName: 'x'}},
             ]);
 
-            expect(getPathFromState(state as PartialState<NavigationState>)).toBe('/settings/wallet/verify-account/country/constant-picker?formType=report&fieldName=x');
+            expect(getPathFromState(state as PartialState<NavigationState>)).toBe('/settings/wallet/verify-account/country/constant-picker?country=US&formType=report&fieldName=x');
         });
 
-        it('4a: dynamic screen inside a nested navigator', () => {
+        it('dynamic screen inside a nested navigator', () => {
             const state = buildState([
                 {
                     name: 'RHPNavigator',
@@ -272,7 +262,7 @@ describe('getPathFromState', () => {
             expect(getPathFromState(state as PartialState<NavigationState>)).toBe('/settings/wallet/verify-account');
         });
 
-        it('4b: two dynamic suffixes inside nested navigator', () => {
+        it('two dynamic suffixes inside nested navigator', () => {
             const state = buildState([
                 {
                     name: 'RHPNavigator',
@@ -283,13 +273,13 @@ describe('getPathFromState', () => {
             expect(getPathFromState(state as PartialState<NavigationState>)).toBe('/settings/wallet/verify-account/country?country=PL');
         });
 
-        it('5a: only dynamic route, no base (state has single route)', () => {
+        it('only dynamic route, no base (state has single route)', () => {
             const state = buildState([{name: 'VerifyAccountScreen'}]);
 
             expect(getPathFromState(state as PartialState<NavigationState>)).toBe('/verify-account');
         });
 
-        it('5b: trailing slash normalization from base path', () => {
+        it('trailing slash normalization from base path', () => {
             mockRNGetPathFromState.mockReturnValue('/settings/wallet/');
 
             const state = buildState([{name: 'WalletScreen'}, {name: 'VerifyAccountScreen'}]);
@@ -297,7 +287,7 @@ describe('getPathFromState', () => {
             expect(getPathFromState(state as PartialState<NavigationState>)).toBe('/settings/wallet/verify-account');
         });
 
-        it('5c: path params with special characters are encoded', () => {
+        it('path params with special characters are encoded', () => {
             const state = buildState([
                 {name: 'ReportScreen', params: {reportID: '123'}},
                 {name: 'FlagScreen', params: {reportID: 'a/b', reportActionID: 'c&d'}},
@@ -306,13 +296,13 @@ describe('getPathFromState', () => {
             expect(getPathFromState(state as PartialState<NavigationState>)).toBe('/r/123/flag/a%2Fb/c%26d');
         });
 
-        it('5d: query param values with special characters are encoded', () => {
+        it('query param values with special characters are encoded', () => {
             const state = buildState([{name: 'WalletScreen'}, {name: 'CountryScreen', params: {country: 'a&b=c'}}]);
 
             expect(getPathFromState(state as PartialState<NavigationState>)).toBe('/settings/wallet/country?country=a%26b%3Dc');
         });
 
-        it('5e: dynamic route with no params at all (params undefined)', () => {
+        it('dynamic route with no params at all (params undefined)', () => {
             const state = buildState([{name: 'WalletScreen'}, {name: 'CountryScreen'}]);
 
             expect(getPathFromState(state as PartialState<NavigationState>)).toBe('/settings/wallet/country');

--- a/tests/navigation/getPathFromStateTests.ts
+++ b/tests/navigation/getPathFromStateTests.ts
@@ -222,7 +222,6 @@ describe('getPathFromState', () => {
 
             expect(getPathFromState(state as PartialState<NavigationState>)).toBe('/settings/wallet/country/constant-picker?country=US&formType=report&fieldName=status&fieldValue=open');
         });
-        // no
 
         it('two simple dynamic suffixes, no params on first', () => {
             const state = buildState([{name: 'WalletScreen'}, {name: 'VerifyAccountScreen'}, {name: 'CountryScreen', params: {country: 'US'}}]);

--- a/tests/navigation/getPathFromStateTests.ts
+++ b/tests/navigation/getPathFromStateTests.ts
@@ -8,6 +8,7 @@ jest.mock('@react-navigation/native', () => ({
 }));
 
 jest.mock('@libs/Navigation/linkingConfig/config', () => ({
+    config: {},
     normalizedConfigs: {
         TestDynamicScreen: {
             path: 'test-dynamic',


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
<!-- Explain what your change does and how it addresses the linked issue -->

Rewrote `getPathFromState` to properly build URL paths for dynamic route screens when `path` is missing from navigation state. Instead of relying on `focusedRoute.path`, the new logic recursively peels off dynamic suffixes, resolves the base path via `popFocusedRoute`, and merges query parameters. Extracted `getDynamicRouteQueryParams` into its own module.

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/86518


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

1. Navigate to Settings > Profile > address and open the dynamic `country` route 
2. Select a country 
3. Verify that the browser URL updates to `/settings/profile/address/country?country=<countryName>` (the country value appears as a query parameter)
4. Copy the URL from the address bar, open a new tab, and paste it
5. Verify the app deep-links correctly and the country selector opens with `PL` pre-selected
6. Click back button, then navigate to the country selector again
7. Refresh the page and verify that the country selector opens correctly

- [x] Verify that no errors appear in the JS console

### Offline tests

N/A

### QA Steps

Same as tests

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

https://github.com/user-attachments/assets/358ef429-1408-49ff-90de-2b9a9777c5ff


<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/d1c5bfd3-6a71-4fa4-922f-3af7e5042884


</details>
