### PR TITLE
[No QA] Migrate off actions-ecosystem PR helpers; bump actions/checkout to v6

### DIFF
--- a/.github/actions/composite/getMergedPullRequest/action.yml
+++ b/.github/actions/composite/getMergedPullRequest/action.yml
@@ -1,0 +1,65 @@
+name: Get merged pull request
+description: >
+  Given the current push event's commit SHA, finds the pull request that was merged to produce it.
+  Uses the GitHub "list pull requests associated with a commit" API, which is more reliable than
+  scanning the most-recent closed PRs list.
+
+inputs:
+  github_token:
+    description: GitHub token used to call the API
+    required: true
+
+outputs:
+  number:
+    description: The PR number
+    value: ${{ steps.getMergedPR.outputs.number }}
+  title:
+    description: The PR title
+    value: ${{ steps.getMergedPR.outputs.title }}
+  body:
+    description: The PR body
+    value: ${{ steps.getMergedPR.outputs.body }}
+  labels:
+    description: Newline-separated label names
+    value: ${{ steps.getMergedPR.outputs.labels }}
+  assignees:
+    description: Newline-separated assignee logins
+    value: ${{ steps.getMergedPR.outputs.assignees }}
+
+runs:
+  using: composite
+  steps:
+    - name: Find merged pull request for this commit
+      id: getMergedPR
+      shell: bash
+      run: |
+        RESP=$(gh api -H "Accept: application/vnd.github+json" "/repos/${GITHUB_REPOSITORY}/commits/${GITHUB_SHA}/pulls")
+
+        # Prefer the PR whose merge_commit_sha matches exactly (parity with the old action)
+        PR=$(echo "$RESP" | jq -c "first(.[] | select(.merge_commit_sha == \"${GITHUB_SHA}\"))" 2>/dev/null)
+
+        # Fall back to the first merged PR associated with this commit
+        if [[ -z "$PR" || "$PR" == "null" ]]; then
+          PR=$(echo "$RESP" | jq -c 'first(.[] | select(.merged_at != null))' 2>/dev/null)
+        fi
+
+        if [[ -z "$PR" || "$PR" == "null" ]]; then
+          echo "::warning::No merged pull request found for commit ${GITHUB_SHA}"
+          exit 0
+        fi
+
+        {
+          echo "number=$(echo "$PR" | jq -r '.number')"
+          echo "title=$(echo "$PR" | jq -r '.title')"
+          echo "body<<GETMPR_EOF"
+          echo "$PR" | jq -r '.body // ""'
+          echo "GETMPR_EOF"
+          echo "labels<<GETMPR_LABELS_EOF"
+          echo "$PR" | jq -r '[.labels[].name] | join("\n")'
+          echo "GETMPR_LABELS_EOF"
+          echo "assignees<<GETMPR_ASSIGNEES_EOF"
+          echo "$PR" | jq -r '[.assignees[].login] | join("\n")'
+          echo "GETMPR_ASSIGNEES_EOF"
+        } >> "$GITHUB_OUTPUT"
+      env:
+        GITHUB_TOKEN: ${{ inputs.github_token }}

--- a/.github/actions/composite/getMergedPullRequest/action.yml
+++ b/.github/actions/composite/getMergedPullRequest/action.yml
@@ -1,8 +1,5 @@
 name: Get merged pull request
-description: >
-  Given the current push event's commit SHA, finds the pull request that was merged to produce it.
-  Uses the GitHub "list pull requests associated with a commit" API, which is more reliable than
-  scanning the most-recent closed PRs list.
+description: Given the current push event's commit SHA, finds the pull request that was merged to produce it.
 
 inputs:
   github_token:
@@ -51,15 +48,19 @@ runs:
         {
           echo "number=$(echo "$PR" | jq -r '.number')"
           echo "title=$(echo "$PR" | jq -r '.title')"
+
           echo "body<<GETMPR_EOF"
           echo "$PR" | jq -r '.body // ""'
           echo "GETMPR_EOF"
+
           echo "labels<<GETMPR_LABELS_EOF"
           echo "$PR" | jq -r '[.labels[].name] | join("\n")'
           echo "GETMPR_LABELS_EOF"
+
           echo "assignees<<GETMPR_ASSIGNEES_EOF"
           echo "$PR" | jq -r '[.assignees[].login] | join("\n")'
           echo "GETMPR_ASSIGNEES_EOF"
+
         } >> "$GITHUB_OUTPUT"
       env:
         GITHUB_TOKEN: ${{ inputs.github_token }}

--- a/.github/workflows/androidBump.yml
+++ b/.github/workflows/androidBump.yml
@@ -10,7 +10,7 @@ jobs:
   android_bump:
     runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
-      - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup Node
         uses: ./.github/actions/composite/setupNode

--- a/.github/workflows/authorChecklist.yml
+++ b/.github/workflows/authorChecklist.yml
@@ -27,8 +27,8 @@ jobs:
       && github.actor != 'imgbot[bot]'
     steps:
       - name: Checkout
-        # v4
-        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608
+        # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: authorChecklist.ts
         uses: ./.github/actions/javascript/authorChecklist

--- a/.github/workflows/checkSVGCompression.yml
+++ b/.github/workflows/checkSVGCompression.yml
@@ -21,8 +21,8 @@ jobs:
     runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
       - name: Checkout
-        # v4
-        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608
+        # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Setup Node
         uses: ./.github/actions/composite/setupNode

--- a/.github/workflows/cherryPick.yml
+++ b/.github/workflows/cherryPick.yml
@@ -74,7 +74,8 @@ jobs:
 
         # v4
       - name: Checkout target branch
-        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608
+        # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           ref: ${{ inputs.TARGET }}
           token: ${{ secrets.OS_BOTIFY_TOKEN }}

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -31,7 +31,7 @@ jobs:
       PR_NUMBER: ${{ github.event.pull_request.number }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 1
 

--- a/.github/workflows/createDeployChecklist.yml
+++ b/.github/workflows/createDeployChecklist.yml
@@ -9,8 +9,8 @@ jobs:
     runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
       - name: Checkout
-        # v4
-        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608
+        # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Setup Node
         uses: ./.github/actions/composite/setupNode

--- a/.github/workflows/createNewVersion.yml
+++ b/.github/workflows/createNewVersion.yml
@@ -53,8 +53,8 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
 
       - name: Check out
-        # v4
-        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608
+        # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           ref: main
           submodules: true

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,8 +25,8 @@ jobs:
       IOS_VERSION: ${{ steps.getIOSVersion.outputs.IOS_VERSION }}
     steps:
       - name: Checkout
-        # v4
-        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608
+        # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           token: ${{ secrets.OS_BOTIFY_TOKEN }}
           submodules: true
@@ -641,8 +641,8 @@ jobs:
     needs: [androidBuild, androidUploadGooglePlay, androidUploadBrowserStack, androidUploadApplause, androidSubmit, iosBuild, iosUploadTestflight, iosUploadBrowserStack, iosUploadApplause, iosSubmit, webBuild, webDeploy]
     steps:
       - name: Checkout
-        # v4
-        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608
+        # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Post Slack message on failure
         uses: ./.github/actions/composite/announceFailedWorkflowInSlack

--- a/.github/workflows/deployBlocker.yml
+++ b/.github/workflows/deployBlocker.yml
@@ -16,8 +16,8 @@ jobs:
     runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
       - name: Checkout
-        # v4
-        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608
+        # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Give the issue/PR the Hourly, Engineering labels
         run: gh issue edit ${{ github.event.issue.number }} --add-label 'Engineering,Hourly' --remove-label 'Daily,Weekly,Monthly'

--- a/.github/workflows/deployBlockerInvestigation.yml
+++ b/.github/workflows/deployBlockerInvestigation.yml
@@ -28,7 +28,7 @@ jobs:
       ISSUE_URL: ${{ github.event.issue.html_url || inputs.ISSUE_URL }}
     steps:
       - name: Checkout App repository
-        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 1
 

--- a/.github/workflows/deployExpensifyHelp.yml
+++ b/.github/workflows/deployExpensifyHelp.yml
@@ -32,8 +32,8 @@ jobs:
     continue-on-error: true
     steps:
       - name: Checkout
-        # v4
-        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608
+        # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           fetch-depth: 0
 

--- a/.github/workflows/deployNewHelp.yml
+++ b/.github/workflows/deployNewHelp.yml
@@ -42,8 +42,8 @@ jobs:
       # We start by checking out the entire repo into a clean build environment within
       # the Github Action
       - name: Checkout code
-        # v4
-        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608
+        # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       # Set up Ruby and run bundle install inside the /help directory
       - name: Set up Ruby
@@ -97,7 +97,7 @@ jobs:
       - name: Get merged pull request
         if: ${{ github.event_name == 'push' }}
         id: getMergedPullRequest
-        uses: actions-ecosystem/action-get-merged-pull-request@59afe90821bb0b555082ce8ff1e36b03f91553d9
+        uses: ./.github/actions/composite/getMergedPullRequest
         with:
           github_token: ${{ github.token }}
 

--- a/.github/workflows/failureNotifier.yml
+++ b/.github/workflows/failureNotifier.yml
@@ -16,8 +16,8 @@ jobs:
     if: ${{ github.event.workflow_run.conclusion == 'failure' }}
     steps:
       - name: Checkout
-        # v4
-        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608
+        # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Process Failed Jobs
         uses: ./.github/actions/javascript/failureNotifier

--- a/.github/workflows/finishReleaseCycle.yml
+++ b/.github/workflows/finishReleaseCycle.yml
@@ -13,8 +13,8 @@ jobs:
       isValid: ${{ fromJSON(steps.isDeployer.outputs.IS_DEPLOYER) && !fromJSON(steps.checkDeployBlockers.outputs.HAS_DEPLOY_BLOCKERS) }}
     steps:
       - name: Checkout
-        # v4
-        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608
+        # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           ref: main
           token: ${{ secrets.OS_BOTIFY_TOKEN }}

--- a/.github/workflows/formatCodeCovComment.yml
+++ b/.github/workflows/formatCodeCovComment.yml
@@ -13,8 +13,8 @@ jobs:
     if: github.event.issue.pull_request && github.event.comment.user.login == 'codecov[bot]'
     steps:
       - name: Checkout
-      # v4
-        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 
+      # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd 
       - name: Format CodeCov Comment
         uses: ./.github/actions/javascript/formatCodeCovComment
         with:

--- a/.github/workflows/generateTranslations.yml
+++ b/.github/workflows/generateTranslations.yml
@@ -41,9 +41,9 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
 
-      # v4
+      # v6
       - name: Checkout
-        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           ref: ${{ steps.pr-data.outputs.HEAD_SHA }}
 

--- a/.github/workflows/lint-changed.yml
+++ b/.github/workflows/lint-changed.yml
@@ -47,8 +47,8 @@ jobs:
           REPO: ${{ github.repository }}
           
       - name: Checkout
-        # v4
-        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608
+        # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           fetch-depth: ${{ fromJSON(steps.count.outputs.count) }}
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,8 +18,8 @@ jobs:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - name: Checkout
-        # v4
-        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608
+        # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Setup Node
         uses: ./.github/actions/composite/setupNode

--- a/.github/workflows/lockDeploys.yml
+++ b/.github/workflows/lockDeploys.yml
@@ -10,8 +10,8 @@ jobs:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - name: Checkout
-        # v4
-        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608
+        # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Wait for staging deploys to finish
         uses: ./.github/actions/javascript/awaitStagingDeploys

--- a/.github/workflows/postDeployComments.yml
+++ b/.github/workflows/postDeployComments.yml
@@ -89,8 +89,8 @@ jobs:
     runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
       - name: Checkout
-        # v4
-        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608
+        # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Setup Node
         uses: ./.github/actions/composite/setupNode

--- a/.github/workflows/preDeploy.yml
+++ b/.github/workflows/preDeploy.yml
@@ -26,7 +26,7 @@ jobs:
     if: ${{ always() }}
 
     steps:
-      - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Exit failed workflow
         if: ${{ needs.typecheck.result == 'failure' || needs.lint.result == 'failure' || needs.test.result == 'failure' }}
@@ -42,11 +42,11 @@ jobs:
       SHOULD_DEPLOY: ${{ fromJSON(steps.shouldDeploy.outputs.SHOULD_DEPLOY) }}
 
     steps:
-      - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Get merged pull request
         id: getMergedPullRequest
-        uses: actions-ecosystem/action-get-merged-pull-request@59afe90821bb0b555082ce8ff1e36b03f91553d9
+        uses: ./.github/actions/composite/getMergedPullRequest
         with:
           github_token: ${{ github.token }}
 
@@ -73,12 +73,13 @@ jobs:
     if: ${{ !fromJSON(needs.chooseDeployActions.outputs.SHOULD_DEPLOY) && github.actor != 'OSBotify' }}
     steps:
       - name: Comment on deferred PR
-        uses: actions-ecosystem/action-create-comment@cd098164398331c50e7dfdd0dfa1b564a1873fac
-        with:
-          github_token: ${{ secrets.OS_BOTIFY_TOKEN }}
-          number: ${{ needs.chooseDeployActions.outputs.MERGED_PR }}
-          body: |
-            :hand: This PR was not deployed to staging yet because QA is ongoing. It will be automatically deployed to staging after the next production release.
+        run: |
+          gh pr comment ${{ needs.chooseDeployActions.outputs.MERGED_PR }} --body "$(cat <<'EOF'
+          :hand: This PR was not deployed to staging yet because QA is ongoing. It will be automatically deployed to staging after the next production release.
+          EOF
+          )"
+        env:
+          GITHUB_TOKEN: ${{ secrets.OS_BOTIFY_TOKEN }}
 
   createNewVersion:
     needs: chooseDeployActions

--- a/.github/workflows/preDeploy.yml
+++ b/.github/workflows/preDeploy.yml
@@ -74,7 +74,7 @@ jobs:
     steps:
       - name: Comment on deferred PR
         run: |
-          gh pr comment ${{ needs.chooseDeployActions.outputs.MERGED_PR }} --body "$(cat <<'EOF'
+          gh pr comment ${{ needs.chooseDeployActions.outputs.MERGED_PR }} --repo ${{ github.repository }} --body "$(cat <<'EOF'
           :hand: This PR was not deployed to staging yet because QA is ongoing. It will be automatically deployed to staging after the next production release.
           EOF
           )"

--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -18,8 +18,8 @@ jobs:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - name: Checkout
-        # v4
-        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608
+        # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Setup Node
         uses: ./.github/actions/composite/setupNode

--- a/.github/workflows/proposalPolice.yml
+++ b/.github/workflows/proposalPolice.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     if: "!contains(fromJSON('[\"OSBotify\", \"imgbot[bot]\", \"melvin-bot[bot]\", \"codecov[bot]\"]'), github.actor)"
     steps:
-      - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       # Checks if the comment is created and follows the template OR
       # if the comment is edited and if proposal template is followed.

--- a/.github/workflows/publishReactNativeAndroidArtifacts.yml
+++ b/.github/workflows/publishReactNativeAndroidArtifacts.yml
@@ -32,7 +32,8 @@ jobs:
       standalone_patches_hash: ${{ steps.getNewPatchesHash.outputs.STANDALONE_APP_HASH }}
     steps:
       - name: Checkout
-        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608
+        # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           submodules: true
           ref: ${{ github.event.before || 'main' }}
@@ -138,7 +139,8 @@ jobs:
       cancel-in-progress: true
     steps:
       - name: Checkout Code
-        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608
+        # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           submodules: ${{ matrix.is_hybrid }}
           token: ${{ secrets.OS_BOTIFY_TOKEN }}

--- a/.github/workflows/react-compiler-compliance.yml
+++ b/.github/workflows/react-compiler-compliance.yml
@@ -17,9 +17,9 @@ jobs:
     runs-on: blacksmith-4vcpu-ubuntu-2404
 
     steps:
-      # v4
+      # v6
       - name: Checkout
-        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Setup Node
         uses: ./.github/actions/composite/setupNode

--- a/.github/workflows/reassurePerformanceTests.yml
+++ b/.github/workflows/reassurePerformanceTests.yml
@@ -12,8 +12,8 @@ jobs:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - name: Checkout
-        # v4
-        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608
+        # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           fetch-depth: 0
 

--- a/.github/workflows/remote-build-android.yml
+++ b/.github/workflows/remote-build-android.yml
@@ -30,8 +30,8 @@ jobs:
             is_hybrid_build: true
     steps:
       - name: Checkout
-        # v4
-        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608
+        # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           submodules: ${{ matrix.is_hybrid_build || false }}
           token: ${{ secrets.OS_BOTIFY_TOKEN }}

--- a/.github/workflows/remote-build-ios.yml
+++ b/.github/workflows/remote-build-ios.yml
@@ -34,8 +34,8 @@ jobs:
             is_hybrid_build: true
     steps:
       - name: Checkout
-        # v4
-        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608
+        # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           submodules: ${{ matrix.is_hybrid_build || false }}
           token: ${{ secrets.OS_BOTIFY_TOKEN }}

--- a/.github/workflows/reviewerChecklist.yml
+++ b/.github/workflows/reviewerChecklist.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     if: github.actor != 'OSBotify' && github.actor != 'imgbot[bot]'
     steps:
-      - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Filter paths
         uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2

--- a/.github/workflows/sendReassurePerfData.yml
+++ b/.github/workflows/sendReassurePerfData.yml
@@ -11,8 +11,8 @@ jobs:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - name: Checkout
-        # v4
-        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608
+        # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           fetch-depth: 0
 
@@ -30,7 +30,7 @@ jobs:
 
       - name: Get merged pull request
         id: getMergedPullRequest
-        uses: actions-ecosystem/action-get-merged-pull-request@59afe90821bb0b555082ce8ff1e36b03f91553d9
+        uses: ./.github/actions/composite/getMergedPullRequest
         with:
           github_token: ${{ github.token }}
 

--- a/.github/workflows/shellCheck.yml
+++ b/.github/workflows/shellCheck.yml
@@ -13,8 +13,8 @@ jobs:
     runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
       - name: Checkout
-        # v4
-        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608
+        # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Lint shell scripts with ShellCheck
         run: npm run shellcheck

--- a/.github/workflows/syncVersions.yml
+++ b/.github/workflows/syncVersions.yml
@@ -13,8 +13,8 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Check out
-        # v4
-        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608
+        # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           ref: main
           submodules: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,8 +25,8 @@ jobs:
     name: test (job ${{ fromJSON(matrix.chunk) }})
     steps:
       - name: Checkout
-        # v4
-        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608
+        # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Setup Node
         uses: ./.github/actions/composite/setupNode
@@ -88,7 +88,7 @@ jobs:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     name: Storybook tests
     steps:
-      - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - uses: ./.github/actions/composite/setupNode
 

--- a/.github/workflows/translationDryRun.yml
+++ b/.github/workflows/translationDryRun.yml
@@ -13,9 +13,9 @@ jobs:
   dryRun:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
-      # v4
+      # v6
       - name: Checkout
-        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Setup Node
         uses: ./.github/actions/composite/setupNode

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -16,7 +16,7 @@ jobs:
     if: ${{ github.actor != 'OSBotify' || github.event_name == 'workflow_call' }}
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
-      - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - uses: ./.github/actions/composite/setupNode
 

--- a/.github/workflows/unused-styles.yml
+++ b/.github/workflows/unused-styles.yml
@@ -18,8 +18,8 @@ jobs:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - name: Checkout
-        # v4
-        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608
+        # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Setup Node
         uses: ./.github/actions/composite/setupNode

--- a/.github/workflows/updateHelpDotRedirects.yml
+++ b/.github/workflows/updateHelpDotRedirects.yml
@@ -22,8 +22,8 @@ jobs:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - name: Checkout
-        # v4
-        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608
+        # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Create help dot redirect
         env:

--- a/.github/workflows/updateProtectedBranch.yml
+++ b/.github/workflows/updateProtectedBranch.yml
@@ -28,8 +28,8 @@ jobs:
           fi
 
       - name: Checkout source branch
-        # v4
-        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608
+        # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           ref: ${{ steps.getSourceBranch.outputs.SOURCE_BRANCH }}
           token: ${{ secrets.OS_BOTIFY_TOKEN }}

--- a/.github/workflows/validateDocsRoutes.yml
+++ b/.github/workflows/validateDocsRoutes.yml
@@ -11,7 +11,7 @@ jobs:
     if: github.actor != 'OSBotify' && github.actor != 'imgbot[bot]'
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
-      - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - uses: ./.github/actions/composite/setupNode
 

--- a/.github/workflows/validateGithubActions.yml
+++ b/.github/workflows/validateGithubActions.yml
@@ -12,8 +12,8 @@ jobs:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - name: Checkout
-        # v4
-        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608
+        # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Setup Node
         uses: ./.github/actions/composite/setupNode

--- a/.github/workflows/validatePatches.yml
+++ b/.github/workflows/validatePatches.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - name: Checkout
-        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Fetch main branch
         run: git fetch origin --depth=1 main

--- a/.github/workflows/verifyParserFiles.yml
+++ b/.github/workflows/verifyParserFiles.yml
@@ -13,8 +13,8 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Checkout
-        # v4
-        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608
+        # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Setup Node
         uses: ./.github/actions/composite/setupNode

--- a/.github/workflows/verifyPodfile.yml
+++ b/.github/workflows/verifyPodfile.yml
@@ -15,8 +15,8 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Checkout
-        # v4
-        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608
+        # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Setup Node
         uses: ./.github/actions/composite/setupNode

--- a/.github/workflows/verifySignedCommits.yml
+++ b/.github/workflows/verifySignedCommits.yml
@@ -9,7 +9,7 @@ jobs:
   verifySignedCommits:
     runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
-      - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Verify signed commits
         uses: ./.github/actions/javascript/verifySignedCommits

--- a/.github/workflows/welcome.yml
+++ b/.github/workflows/welcome.yml
@@ -10,8 +10,8 @@ jobs:
     if: ${{ github.actor != 'OSBotify' && github.actor != 'imgbot[bot]' }}
     steps:
       - name: Checkout
-        # v4
-        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608
+        # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Get merged pull request
         id: getMergedPullRequest


### PR DESCRIPTION
### Explanation of Change

This PR removes two deprecated `actions-ecosystem` GitHub Actions that trigger Node.js 20 deprecation warnings, and bumps all remaining `actions/checkout` pins from v4 to v6 across the repository. Node.js 20 warnings will stop working in September if not migrated before then.

**1. Replace `actions-ecosystem/action-get-merged-pull-request`**

The upstream action lists the 100 most-recently-updated closed PRs and scans for a `merge_commit_sha` match — which can miss the target PR if the window is exceeded. This PR replaces it with a new composite action (`.github/actions/composite/getMergedPullRequest`) that calls the more reliable `GET /repos/{owner}/{repo}/commits/{sha}/pulls` REST endpoint via `gh api` + `jq`. This API is already used in `testBuildOnPush.yml`. The composite action exposes the same outputs (`number`, `title`, `body`, `labels`, `assignees`) for drop-in compatibility.

Affected workflows: `preDeploy.yml`, `sendReassurePerfData.yml`, `deployNewHelp.yml`.

**2. Replace `actions-ecosystem/action-create-comment`**

The `skipDeploy` job in `preDeploy.yml` used this deprecated action to post a "deferred staging deploy" comment. Replaced with a `gh pr comment` run step using the same `OS_BOTIFY_TOKEN`, matching the existing pattern in `deployNewHelp.yml`.

**3. Bump `actions/checkout` from v4 to v6**

Every remaining `actions/checkout@8ade135...` (v4) pin across the repository is updated to `actions/checkout@de0fac2...` (v6), clearing the Node 20 deprecation warning repo-wide.

### Fixed Issues
$ https://github.com/Expensify/App/issues/86670

### Tests

- [x] Verify that no errors appear in the JS console

1. After merging, observe a `push` to `main` from a merged PR
2. Verify the `preDeploy` workflow still populates `MERGED_PR` correctly and subsequent jobs (deploy or skip-deploy comment) function as before
3. Verify `sendReassurePerfData` still passes the PR number to `getGraphiteString`
4. Verify `deployNewHelp` still posts the production deploy comment on the merged PR
5. When deploy is skipped (non-deployer or checklist locked), verify the deferred-deploy comment still appears on the merged PR

### Offline tests

N/A — CI-only changes, no app behavior affected.

### QA Steps

[No QA] — these changes affect GitHub Actions workflows only. They don't modify any application code or user-facing behavior.

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I verified there are no new alerts related to the `canBeMissing` param for `useOnyx`
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

N/A — CI-only changes

</details>

<details>
<summary>Android: mWeb Chrome</summary>

N/A — CI-only changes

</details>

<details>
<summary>iOS: Native</summary>

N/A — CI-only changes

</details>

<details>
<summary>iOS: mWeb Safari</summary>

N/A — CI-only changes

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

N/A — CI-only changes

</details>