### PR TITLE
decompose ReportScreen 6a: extract route param + lifecycle handlers

### DIFF
--- a/src/pages/inbox/ReportLifecycleHandler.tsx
+++ b/src/pages/inbox/ReportLifecycleHandler.tsx
@@ -14,7 +14,7 @@ import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
 
 type ReportLifecycleHandlerProps = {
-    reportIDFromRoute: string | undefined;
+    reportID: string | undefined;
 };
 
 /**
@@ -25,14 +25,14 @@ type ReportLifecycleHandlerProps = {
  * - Telemetry span cancellation on unmount
  * - Bank account unlock effect
  */
-function ReportLifecycleHandler({reportIDFromRoute}: ReportLifecycleHandlerProps) {
-    const reportID = getNonEmptyStringOnyxID(reportIDFromRoute);
+function ReportLifecycleHandler({reportID}: ReportLifecycleHandlerProps) {
+    const onyxReportID = getNonEmptyStringOnyxID(reportID);
     const isFocused = useIsFocused();
     const prevIsFocused = usePrevious(isFocused);
     const {currentReportID: currentReportIDValue} = useCurrentReportIDState();
-    const isTopMostReportId = currentReportIDValue === reportIDFromRoute;
+    const isTopMostReportId = currentReportIDValue === reportID;
 
-    const [report] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT}${reportID}`);
+    const [report] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT}${onyxReportID}`);
     useBankAccountUnlockEffect(report);
 
     // Hide emoji picker when screen loses focus
@@ -45,18 +45,18 @@ function ReportLifecycleHandler({reportIDFromRoute}: ReportLifecycleHandlerProps
 
     // DeviceEventEmitter listener + telemetry cleanup
     useEffect(() => {
-        const skipOpenReportListener = DeviceEventEmitter.addListener(`switchToPreExistingReport_${reportID}`, () => {});
+        const skipOpenReportListener = DeviceEventEmitter.addListener(`switchToPreExistingReport_${onyxReportID}`, () => {});
 
         return () => {
             skipOpenReportListener.remove();
 
             // Cancel telemetry span when user leaves the screen before full report data is loaded
-            cancelSpan(`${CONST.TELEMETRY.SPAN_OPEN_REPORT}_${reportID}`);
+            cancelSpan(`${CONST.TELEMETRY.SPAN_OPEN_REPORT}_${onyxReportID}`);
 
             // Cancel any pending send-message spans to prevent orphaned spans when navigating away
             cancelSpansByPrefix(CONST.TELEMETRY.SPAN_SEND_MESSAGE);
         };
-    }, [reportID]);
+    }, [onyxReportID]);
 
     // Clear notifications for the current report when it's opened and re-focused
     const clearNotifications = () => {
@@ -65,7 +65,7 @@ function ReportLifecycleHandler({reportIDFromRoute}: ReportLifecycleHandlerProps
             return;
         }
 
-        clearReportNotifications(reportID);
+        clearReportNotifications(onyxReportID);
     };
 
     useEffect(clearNotifications, [clearNotifications]);

--- a/src/pages/inbox/ReportLifecycleHandler.tsx
+++ b/src/pages/inbox/ReportLifecycleHandler.tsx
@@ -1,6 +1,5 @@
 import {useIsFocused} from '@react-navigation/native';
 import {useEffect} from 'react';
-import {DeviceEventEmitter} from 'react-native';
 import useAppFocusEvent from '@hooks/useAppFocusEvent';
 import useBankAccountUnlockEffect from '@hooks/useBankAccountUnlockEffect';
 import {useCurrentReportIDState} from '@hooks/useCurrentReportID';
@@ -21,7 +20,6 @@ type ReportLifecycleHandlerProps = {
  * Component that does not render anything. Handles screen lifecycle side effects:
  * - Hide emoji picker when screen loses focus
  * - Clear notifications when report is opened/re-focused
- * - DeviceEventEmitter listener for switchToPreExistingReport
  * - Telemetry span cancellation on unmount
  * - Bank account unlock effect
  */
@@ -43,13 +41,9 @@ function ReportLifecycleHandler({reportID}: ReportLifecycleHandlerProps) {
         hideEmojiPicker(true);
     }, [prevIsFocused, isFocused]);
 
-    // DeviceEventEmitter listener + telemetry cleanup
+    // Telemetry cleanup
     useEffect(() => {
-        const skipOpenReportListener = DeviceEventEmitter.addListener(`switchToPreExistingReport_${onyxReportID}`, () => {});
-
         return () => {
-            skipOpenReportListener.remove();
-
             // Cancel telemetry span when user leaves the screen before full report data is loaded
             cancelSpan(`${CONST.TELEMETRY.SPAN_OPEN_REPORT}_${onyxReportID}`);
 

--- a/src/pages/inbox/ReportLifecycleHandler.tsx
+++ b/src/pages/inbox/ReportLifecycleHandler.tsx
@@ -1,0 +1,79 @@
+import {useIsFocused} from '@react-navigation/native';
+import {useEffect} from 'react';
+import {DeviceEventEmitter} from 'react-native';
+import useAppFocusEvent from '@hooks/useAppFocusEvent';
+import useBankAccountUnlockEffect from '@hooks/useBankAccountUnlockEffect';
+import {useCurrentReportIDState} from '@hooks/useCurrentReportID';
+import useOnyx from '@hooks/useOnyx';
+import usePrevious from '@hooks/usePrevious';
+import {hideEmojiPicker} from '@libs/actions/EmojiPickerAction';
+import getNonEmptyStringOnyxID from '@libs/getNonEmptyStringOnyxID';
+import clearReportNotifications from '@libs/Notification/clearReportNotifications';
+import {cancelSpan, cancelSpansByPrefix} from '@libs/telemetry/activeSpans';
+import CONST from '@src/CONST';
+import ONYXKEYS from '@src/ONYXKEYS';
+
+type ReportLifecycleHandlerProps = {
+    reportIDFromRoute: string | undefined;
+};
+
+/**
+ * Component that does not render anything. Handles screen lifecycle side effects:
+ * - Hide emoji picker when screen loses focus
+ * - Clear notifications when report is opened/re-focused
+ * - DeviceEventEmitter listener for switchToPreExistingReport
+ * - Telemetry span cancellation on unmount
+ * - Bank account unlock effect
+ */
+function ReportLifecycleHandler({reportIDFromRoute}: ReportLifecycleHandlerProps) {
+    const reportID = getNonEmptyStringOnyxID(reportIDFromRoute);
+    const isFocused = useIsFocused();
+    const prevIsFocused = usePrevious(isFocused);
+    const {currentReportID: currentReportIDValue} = useCurrentReportIDState();
+    const isTopMostReportId = currentReportIDValue === reportIDFromRoute;
+
+    const [report] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT}${reportID}`);
+    useBankAccountUnlockEffect(report);
+
+    // Hide emoji picker when screen loses focus
+    useEffect(() => {
+        if (!prevIsFocused || isFocused) {
+            return;
+        }
+        hideEmojiPicker(true);
+    }, [prevIsFocused, isFocused]);
+
+    // DeviceEventEmitter listener + telemetry cleanup
+    useEffect(() => {
+        const skipOpenReportListener = DeviceEventEmitter.addListener(`switchToPreExistingReport_${reportID}`, () => {});
+
+        return () => {
+            skipOpenReportListener.remove();
+
+            // Cancel telemetry span when user leaves the screen before full report data is loaded
+            cancelSpan(`${CONST.TELEMETRY.SPAN_OPEN_REPORT}_${reportID}`);
+
+            // Cancel any pending send-message spans to prevent orphaned spans when navigating away
+            cancelSpansByPrefix(CONST.TELEMETRY.SPAN_SEND_MESSAGE);
+        };
+    }, [reportID]);
+
+    // Clear notifications for the current report when it's opened and re-focused
+    const clearNotifications = () => {
+        // Check if this is the top-most ReportScreen since the Navigator preserves multiple at a time
+        if (!isTopMostReportId) {
+            return;
+        }
+
+        clearReportNotifications(reportID);
+    };
+
+    useEffect(clearNotifications, [clearNotifications]);
+    useAppFocusEvent(clearNotifications);
+
+    return null;
+}
+
+ReportLifecycleHandler.displayName = 'ReportLifecycleHandler';
+
+export default ReportLifecycleHandler;

--- a/src/pages/inbox/ReportRouteParamHandler.tsx
+++ b/src/pages/inbox/ReportRouteParamHandler.tsx
@@ -20,7 +20,7 @@ type ReportRouteParamHandlerProps = {
 };
 
 /**
- * Renderless component. Resolves the reportID route param when missing,
+ * Component that does not render anything. Resolves the reportID route param when missing,
  * and validates the reportActionID param.
  */
 function ReportRouteParamHandler({route, navigation}: ReportRouteParamHandlerProps) {

--- a/src/pages/inbox/ReportRouteParamHandler.tsx
+++ b/src/pages/inbox/ReportRouteParamHandler.tsx
@@ -1,0 +1,64 @@
+import {useFocusEffect} from '@react-navigation/native';
+import useArchivedReportsIdSet from '@hooks/useArchivedReportsIdSet';
+import usePermissions from '@hooks/usePermissions';
+import Log from '@libs/Log';
+import Navigation from '@libs/Navigation/Navigation';
+import type {PlatformStackScreenProps} from '@libs/Navigation/PlatformStackNavigation/types';
+import {findLastAccessedReport} from '@libs/ReportUtils';
+import {isNumeric} from '@libs/ValidationUtils';
+import type {ReportsSplitNavigatorParamList, RightModalNavigatorParamList} from '@navigation/types';
+import CONST from '@src/CONST';
+import type SCREENS from '@src/SCREENS';
+
+type ReportRouteParamHandlerProps = {
+    route:
+        | PlatformStackScreenProps<ReportsSplitNavigatorParamList, typeof SCREENS.REPORT>['route']
+        | PlatformStackScreenProps<RightModalNavigatorParamList, typeof SCREENS.RIGHT_MODAL.SEARCH_REPORT>['route'];
+    navigation:
+        | PlatformStackScreenProps<ReportsSplitNavigatorParamList, typeof SCREENS.REPORT>['navigation']
+        | PlatformStackScreenProps<RightModalNavigatorParamList, typeof SCREENS.RIGHT_MODAL.SEARCH_REPORT>['navigation'];
+};
+
+/**
+ * Renderless component. Resolves the reportID route param when missing,
+ * and validates the reportActionID param.
+ */
+function ReportRouteParamHandler({route, navigation}: ReportRouteParamHandlerProps) {
+    const {isBetaEnabled} = usePermissions();
+    const archivedReportsIdSet = useArchivedReportsIdSet();
+
+    useFocusEffect(() => {
+        // Don't update if there is a reportID in the params already
+        if (route.params.reportID) {
+            const reportActionID = route?.params?.reportActionID;
+            const isValidReportActionID = reportActionID && isNumeric(reportActionID);
+            if (reportActionID && !isValidReportActionID) {
+                Navigation.isNavigationReady().then(() => navigation.setParams({reportActionID: ''}));
+            }
+            return;
+        }
+
+        const lastAccessedReportID = findLastAccessedReport(
+            !isBetaEnabled(CONST.BETAS.DEFAULT_ROOMS),
+            'openOnAdminRoom' in route.params && !!route.params.openOnAdminRoom,
+            undefined,
+            archivedReportsIdSet,
+        )?.reportID;
+
+        // It's possible that reports aren't fully loaded yet
+        // in that case the reportID is undefined
+        if (!lastAccessedReportID) {
+            return;
+        }
+        Navigation.isNavigationReady().then(() => {
+            Log.info(`[ReportScreen] no reportID found in params, setting it to lastAccessedReportID: ${lastAccessedReportID}`);
+            navigation.setParams({reportID: lastAccessedReportID});
+        });
+    });
+
+    return null;
+}
+
+ReportRouteParamHandler.displayName = 'ReportRouteParamHandler';
+
+export default ReportRouteParamHandler;

--- a/src/pages/inbox/ReportScreen.tsx
+++ b/src/pages/inbox/ReportScreen.tsx
@@ -5,7 +5,7 @@ import type {ViewStyle} from 'react-native';
 // We use Animated for all functionality related to wide RHP to make it easier
 // to interact with react-navigation components (e.g., CardContainer, interpolator), which also use Animated.
 // eslint-disable-next-line no-restricted-imports
-import {Animated, DeviceEventEmitter, InteractionManager, View} from 'react-native';
+import {Animated, InteractionManager, View} from 'react-native';
 import type {OnyxEntry} from 'react-native-onyx';
 import FullPageNotFoundView from '@components/BlockingViews/FullPageNotFoundView';
 import DragAndDropProvider from '@components/DragAndDrop/Provider';
@@ -20,8 +20,6 @@ import ScrollView from '@components/ScrollView';
 import useShowWideRHPVersion from '@components/WideRHPContextProvider/useShowWideRHPVersion';
 import WideRHPOverlayWrapper from '@components/WideRHPOverlayWrapper';
 import useActionListContextValue from '@hooks/useActionListContextValue';
-import useAppFocusEvent from '@hooks/useAppFocusEvent';
-import useBankAccountUnlockEffect from '@hooks/useBankAccountUnlockEffect';
 import {useCurrentReportIDState} from '@hooks/useCurrentReportID';
 import useCurrentUserPersonalDetails from '@hooks/useCurrentUserPersonalDetails';
 import useDocumentTitle from '@hooks/useDocumentTitle';
@@ -41,13 +39,11 @@ import useSidePanelActions from '@hooks/useSidePanelActions';
 import useSubmitToDestinationVisible from '@hooks/useSubmitToDestinationVisible';
 import useThemeStyles from '@hooks/useThemeStyles';
 import useViewportOffsetTop from '@hooks/useViewportOffsetTop';
-import {hideEmojiPicker} from '@libs/actions/EmojiPickerAction';
 import getNonEmptyStringOnyxID from '@libs/getNonEmptyStringOnyxID';
 import Log from '@libs/Log';
 import {getAllNonDeletedTransactions, shouldDisplayReportTableView, shouldWaitForTransactions as shouldWaitForTransactionsUtil} from '@libs/MoneyRequestReportUtils';
 import Navigation, {navigationRef} from '@libs/Navigation/Navigation';
 import type {PlatformStackScreenProps} from '@libs/Navigation/PlatformStackNavigation/types';
-import clearReportNotifications from '@libs/Notification/clearReportNotifications';
 import {
     getFilteredReportActionsForReportView,
     getIOUActionForReportID,
@@ -78,7 +74,6 @@ import {
     isTaskReport,
     isValidReportIDFromPath,
 } from '@libs/ReportUtils';
-import {cancelSpan, cancelSpansByPrefix} from '@libs/telemetry/activeSpans';
 import {getParentReportActionDeletionStatus} from '@libs/TransactionNavigationUtils';
 import type {ReportsSplitNavigatorParamList, RightModalNavigatorParamList} from '@navigation/types';
 import {setShouldShowComposeInput} from '@userActions/Composer';
@@ -107,6 +102,7 @@ import useReportWasDeleted from './hooks/useReportWasDeleted';
 import ReactionListWrapper from './ReactionListWrapper';
 import ReportActionsView from './report/ReportActionsView';
 import ReportFooter from './report/ReportFooter';
+import ReportLifecycleHandler from './ReportLifecycleHandler';
 import ReportRouteParamHandler from './ReportRouteParamHandler';
 import {ActionListContext} from './ReportScreenContext';
 
@@ -154,7 +150,6 @@ function ReportScreen({route, navigation}: ReportScreenProps) {
     const isFocused = useIsFocused();
     const prevIsFocused = usePrevious(isFocused);
     const [firstRender, setFirstRender] = useState(true);
-    const isSkippingOpenReport = useRef(false);
     const hasCreatedLegacyThreadRef = useRef(false);
     const {isOffline} = useNetwork();
     const {shouldUseNarrowLayout, isInNarrowPaneModal} = useResponsiveLayout();
@@ -305,15 +300,6 @@ function ReportScreen({route, navigation}: ReportScreenProps) {
     const newTransactions = useNewTransactions(reportMetadata?.hasOnceLoadedReportActions, reportTransactions);
 
     const {closeSidePanel} = useSidePanelActions();
-
-    useBankAccountUnlockEffect(report);
-
-    useEffect(() => {
-        if (!prevIsFocused || isFocused) {
-            return;
-        }
-        hideEmojiPicker(true);
-    }, [prevIsFocused, isFocused]);
 
     const backTo = route?.params?.backTo as string;
     const onBackButtonPress = useCallback(
@@ -610,38 +596,6 @@ function ReportScreen({route, navigation}: ReportScreenProps) {
         }
         updateLastVisitTime(reportID);
     }, [reportID, isFocused, isInSidePanel]);
-
-    useEffect(() => {
-        const skipOpenReportListener = DeviceEventEmitter.addListener(`switchToPreExistingReport_${reportID}`, ({preexistingReportID}: {preexistingReportID: string}) => {
-            if (!preexistingReportID) {
-                return;
-            }
-            isSkippingOpenReport.current = true;
-        });
-
-        return () => {
-            skipOpenReportListener.remove();
-
-            // We need to cancel telemetry span when user leaves the screen before full report data is loaded
-            cancelSpan(`${CONST.TELEMETRY.SPAN_OPEN_REPORT}_${reportID}`);
-
-            // Cancel any pending send-message spans to prevent orphaned spans when navigating away
-            cancelSpansByPrefix(CONST.TELEMETRY.SPAN_SEND_MESSAGE);
-        };
-    }, [reportID]);
-
-    // Clear notifications for the current report when it's opened and re-focused
-    const clearNotifications = useCallback(() => {
-        // Check if this is the top-most ReportScreen since the Navigator preserves multiple at a time
-        if (!isTopMostReportId) {
-            return;
-        }
-
-        clearReportNotifications(reportID);
-    }, [reportID, isTopMostReportId]);
-
-    useEffect(clearNotifications, [clearNotifications]);
-    useAppFocusEvent(clearNotifications);
 
     useEffect(() => {
         // eslint-disable-next-line @typescript-eslint/no-deprecated
@@ -1023,6 +977,7 @@ function ReportScreen({route, navigation}: ReportScreenProps) {
                             shouldDisplaySearchRouter
                         >
                             <DragAndDropProvider isDisabled={isEditingDisabled}>
+                                <ReportLifecycleHandler reportIDFromRoute={reportIDFromRoute} />
                                 <OfflineWithFeedback
                                     pendingAction={reportPendingAction ?? report?.pendingFields?.reimbursed}
                                     errors={reportErrors}

--- a/src/pages/inbox/ReportScreen.tsx
+++ b/src/pages/inbox/ReportScreen.tsx
@@ -1,5 +1,5 @@
 import {PortalHost} from '@gorhom/portal';
-import {useFocusEffect, useIsFocused} from '@react-navigation/native';
+import {useIsFocused} from '@react-navigation/native';
 import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import type {ViewStyle} from 'react-native';
 // We use Animated for all functionality related to wide RHP to make it easier
@@ -21,7 +21,6 @@ import useShowWideRHPVersion from '@components/WideRHPContextProvider/useShowWid
 import WideRHPOverlayWrapper from '@components/WideRHPOverlayWrapper';
 import useActionListContextValue from '@hooks/useActionListContextValue';
 import useAppFocusEvent from '@hooks/useAppFocusEvent';
-import useArchivedReportsIdSet from '@hooks/useArchivedReportsIdSet';
 import useBankAccountUnlockEffect from '@hooks/useBankAccountUnlockEffect';
 import {useCurrentReportIDState} from '@hooks/useCurrentReportID';
 import useCurrentUserPersonalDetails from '@hooks/useCurrentUserPersonalDetails';
@@ -34,7 +33,6 @@ import useNewTransactions from '@hooks/useNewTransactions';
 import useOnyx from '@hooks/useOnyx';
 import usePaginatedReportActions from '@hooks/usePaginatedReportActions';
 import useParentReportAction from '@hooks/useParentReportAction';
-import usePermissions from '@hooks/usePermissions';
 import usePrevious from '@hooks/usePrevious';
 import useReportIsArchived from '@hooks/useReportIsArchived';
 import useReportTransactionsCollection from '@hooks/useReportTransactionsCollection';
@@ -63,7 +61,6 @@ import {
 import {getReportName} from '@libs/ReportNameUtils';
 import {
     canUserPerformWriteAction,
-    findLastAccessedReport,
     getReportOfflinePendingActionAndErrors,
     getReportTransactions,
     isAdminRoom,
@@ -83,7 +80,6 @@ import {
 } from '@libs/ReportUtils';
 import {cancelSpan, cancelSpansByPrefix} from '@libs/telemetry/activeSpans';
 import {getParentReportActionDeletionStatus} from '@libs/TransactionNavigationUtils';
-import {isNumeric} from '@libs/ValidationUtils';
 import type {ReportsSplitNavigatorParamList, RightModalNavigatorParamList} from '@navigation/types';
 import {setShouldShowComposeInput} from '@userActions/Composer';
 import {
@@ -111,6 +107,7 @@ import useReportWasDeleted from './hooks/useReportWasDeleted';
 import ReactionListWrapper from './ReactionListWrapper';
 import ReportActionsView from './report/ReportActionsView';
 import ReportFooter from './report/ReportFooter';
+import ReportRouteParamHandler from './ReportRouteParamHandler';
 import {ActionListContext} from './ReportScreenContext';
 
 type ReportScreenNavigationProps =
@@ -159,7 +156,6 @@ function ReportScreen({route, navigation}: ReportScreenProps) {
     const [firstRender, setFirstRender] = useState(true);
     const isSkippingOpenReport = useRef(false);
     const hasCreatedLegacyThreadRef = useRef(false);
-    const {isBetaEnabled} = usePermissions();
     const {isOffline} = useNetwork();
     const {shouldUseNarrowLayout, isInNarrowPaneModal} = useResponsiveLayout();
     const isInSidePanel = useIsInSidePanel();
@@ -178,8 +174,6 @@ function ReportScreen({route, navigation}: ReportScreenProps) {
     const isSelfTourViewed = onboarding?.selfTourViewed;
     const [conciergeReportID] = useOnyx(ONYXKEYS.CONCIERGE_REPORT_ID);
 
-    const archivedReportsIdSet = useArchivedReportsIdSet();
-
     const parentReportAction = useParentReportAction(reportOnyx);
 
     const deletedParentAction = isDeletedParentAction(parentReportAction);
@@ -189,37 +183,6 @@ function ReportScreen({route, navigation}: ReportScreenProps) {
     const [isLoadingReportData = true] = useOnyx(ONYXKEYS.IS_LOADING_REPORT_DATA);
     const prevIsLoadingReportData = usePrevious(isLoadingReportData);
     const prevIsAnonymousUser = useRef(false);
-
-    useFocusEffect(
-        useCallback(() => {
-            // Don't update if there is a reportID in the params already
-            if (route.params.reportID) {
-                const reportActionID = route?.params?.reportActionID;
-                const isValidReportActionID = reportActionID && isNumeric(reportActionID);
-                if (reportActionID && !isValidReportActionID) {
-                    Navigation.isNavigationReady().then(() => navigation.setParams({reportActionID: ''}));
-                }
-                return;
-            }
-
-            const lastAccessedReportID = findLastAccessedReport(
-                !isBetaEnabled(CONST.BETAS.DEFAULT_ROOMS),
-                'openOnAdminRoom' in route.params && !!route.params.openOnAdminRoom,
-                undefined,
-                archivedReportsIdSet,
-            )?.reportID;
-
-            // It's possible that reports aren't fully loaded yet
-            // in that case the reportID is undefined
-            if (!lastAccessedReportID) {
-                return;
-            }
-            Navigation.isNavigationReady().then(() => {
-                Log.info(`[ReportScreen] no reportID found in params, setting it to lastAccessedReportID: ${lastAccessedReportID}`);
-                navigation.setParams({reportID: lastAccessedReportID});
-            });
-        }, [archivedReportsIdSet, isBetaEnabled, navigation, route.params]),
-    );
 
     /**
      * Create a lightweight Report so as to keep the re-rendering as light as possible by
@@ -1043,6 +1006,10 @@ function ReportScreen({route, navigation}: ReportScreenProps) {
                         testID={`report-screen-${reportID}`}
                     >
                         <DeleteTransactionNavigateBackHandler />
+                        <ReportRouteParamHandler
+                            route={route}
+                            navigation={navigation}
+                        />
                         <FullPageNotFoundView
                             shouldShow={shouldShowNotFoundPage}
                             subtitleKey={shouldShowNotFoundLinkedAction ? 'notFound.commentYouLookingForCannotBeFound' : 'notFound.noAccess'}

--- a/src/pages/inbox/ReportScreen.tsx
+++ b/src/pages/inbox/ReportScreen.tsx
@@ -977,7 +977,7 @@ function ReportScreen({route, navigation}: ReportScreenProps) {
                             shouldDisplaySearchRouter
                         >
                             <DragAndDropProvider isDisabled={isEditingDisabled}>
-                                <ReportLifecycleHandler reportIDFromRoute={reportIDFromRoute} />
+                                <ReportLifecycleHandler reportID={reportIDFromRoute} />
                                 <OfflineWithFeedback
                                     pendingAction={reportPendingAction ?? report?.pendingFields?.reimbursed}
                                     errors={reportErrors}


### PR DESCRIPTION
### Explanation of Change

PR 6a in the [ReportScreen decomposition series](https://github.com/Expensify/App/issues/84895) (**6a** → 6b → 6c → 6d).

Extracts 2 non-rendering behavioral components from `ReportScreen.tsx`:

- **`ReportRouteParamHandler`** — validates/resolves route params when missing (finds last accessed report if no reportID, clears non-numeric reportActionID)
- **`ReportLifecycleHandler`** — emoji picker hide, notification clearing, telemetry span cancellation, bank account unlock

Both return `null` and are rendered as siblings inside `ReportScreen`. Pure extraction — no behavior change.

### Fixed Issues

$ https://github.com/Expensify/App/issues/84895

PROPOSAL:

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

**Route param resolution (ReportRouteParamHandler)**
1. Navigate to the app root URL without a reportID in the path — verify you land on the last accessed report
2. Navigate to a report with an invalid (non-numeric) `reportActionID` in the URL — verify the param is cleared and the report loads normally

**Lifecycle effects (ReportLifecycleHandler)**
1. Open a report, open the emoji picker, then navigate to a different report — verify the emoji picker closes
2. Send yourself a notification-triggering message from another device, then open that report — verify the notification clears

**General regression**
1. Open any chat report — verify it loads normally with no blank state
2. Verify no JS console errors on any platform

- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

1. Open a report while online, go offline — verify the report stays visible
2. Navigate between cached reports while offline — verify no "not found" flashes
3. Go back online — verify reports refresh

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->

Same as tests.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>