### PR TITLE
decompose ReportScreen 6c: extract not-found guards

### DIFF
--- a/src/pages/inbox/LinkedActionNotFoundGuard.tsx
+++ b/src/pages/inbox/LinkedActionNotFoundGuard.tsx
@@ -1,18 +1,19 @@
 import {useRoute} from '@react-navigation/native';
 import type {ReactNode} from 'react';
-import React, {useEffect} from 'react';
+import React, {useEffect, useState} from 'react';
+import type {OnyxEntry} from 'react-native-onyx';
 import FullPageNotFoundView from '@components/BlockingViews/FullPageNotFoundView';
 import useCurrentUserPersonalDetails from '@hooks/useCurrentUserPersonalDetails';
 import useOnyx from '@hooks/useOnyx';
-import usePaginatedReportActions from '@hooks/usePaginatedReportActions';
-import usePrevious from '@hooks/usePrevious';
 import useReportIsArchived from '@hooks/useReportIsArchived';
 import getNonEmptyStringOnyxID from '@libs/getNonEmptyStringOnyxID';
 import Navigation from '@libs/Navigation/Navigation';
-import {getFilteredReportActionsForReportView, isReportActionVisible, isWhisperAction} from '@libs/ReportActionsUtils';
+import {isReportActionVisible, isWhisperAction} from '@libs/ReportActionsUtils';
 import {canUserPerformWriteAction} from '@libs/ReportUtils';
 import ONYXKEYS from '@src/ONYXKEYS';
+import {getReportActionByIDSelector} from '@src/selectors/ReportAction';
 import {isLoadingInitialReportActionsSelector} from '@src/selectors/ReportMetaData';
+import type {ReportActions} from '@src/types/onyx';
 
 type LinkedActionNotFoundGuardProps = {
     children: ReactNode;
@@ -55,39 +56,49 @@ function LinkedActionNotFoundGate({reportActionIDFromRoute, children}: LinkedAct
     const [isLoadingInitialReportActions] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT_METADATA}${reportIDFromRoute}`, {
         selector: isLoadingInitialReportActionsSelector,
     });
+    const [linkedAction] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${reportIDFromRoute}`, {
+        selector: (actions: OnyxEntry<ReportActions>) => getReportActionByIDSelector(actions, reportActionIDFromRoute),
+    });
     const [visibleReportActionsData] = useOnyx(ONYXKEYS.DERIVED.VISIBLE_REPORT_ACTIONS);
 
-    const reportID = report?.reportID;
-    const isReportArchived = useReportIsArchived(report?.reportID);
-
-    const {reportActions: unfilteredReportActions, linkedAction, sortedAllReportActions} = usePaginatedReportActions(reportID, reportActionIDFromRoute);
-    const reportActions = getFilteredReportActionsForReportView(unfilteredReportActions);
+    const isReportArchived = useReportIsArchived(reportIDFromRoute);
 
     // --- Linked action status ---
-    const actionReportID = linkedAction?.reportID ?? reportID;
+    const actionReportID = linkedAction?.reportID ?? reportIDFromRoute;
     const hasNoActionReportID = !!linkedAction && !actionReportID;
     const isActionHidden =
         !!linkedAction && !!actionReportID && !isReportActionVisible(linkedAction, actionReportID, canUserPerformWriteAction(report, isReportArchived), visibleReportActionsData);
     const isLinkedActionDeleted = hasNoActionReportID || isActionHidden;
 
-    const prevIsLinkedActionDeleted = usePrevious(linkedAction ? isLinkedActionDeleted : undefined);
-
     const isLinkedActionInaccessibleWhisper = !!linkedAction && isWhisperAction(linkedAction) && !(linkedAction?.whisperedToAccountIDs ?? []).includes(currentUserAccountID);
 
-    const isNavigatedToDeletedAction = isLinkedActionDeleted && prevIsLinkedActionDeleted !== false;
+    // Track whether the linked action was ever loaded and visible during this mount.
+    // Set during render (React-supported pattern for adjusting state based on props).
+    // The key={reportActionIDFromRoute} on the gate ensures this resets on navigation to a different action.
+    const [wasEverVisible, setWasEverVisible] = useState(false);
+    if (linkedAction && !isLinkedActionDeleted && !wasEverVisible) {
+        setWasEverVisible(true);
+    }
 
+    // Show "comment not found" when:
+    // 1. The linked action doesn't exist in the report's actions collection (after loading completes)
+    // 2. The linked action exists but is deleted/hidden, and was never visible during this mount
+    //    (if it gets deleted while viewing, the effect below navigates away instead)
+    // Note: the inaccessible whisper case is handled separately by the whisper effect.
+    //
+    // This intentionally does NOT guard against "report actions exist but the filtered/paginated
+    // view is empty" — that's a report view concern, not a linked-action-not-found concern.
+    // Showing "comment not found" for an action that exists in the collection is incorrect.
     // eslint-disable-next-line rulesdir/no-negated-variables
-    const shouldShowNotFoundLinkedAction =
-        (!isLinkedActionInaccessibleWhisper && isNavigatedToDeletedAction) ||
-        (!isLoadingInitialReportActions && !!reportActionIDFromRoute && !!sortedAllReportActions && sortedAllReportActions?.length > 0 && reportActions.length === 0);
+    const shouldShowNotFoundLinkedAction = (!isLinkedActionInaccessibleWhisper && isLinkedActionDeleted && !wasEverVisible) || (!isLoadingInitialReportActions && !linkedAction);
 
     // Action was deleted while we were viewing it — navigate away
     useEffect(() => {
-        if (!isLinkedActionDeleted || prevIsLinkedActionDeleted !== false) {
+        if (!isLinkedActionDeleted || !wasEverVisible) {
             return;
         }
         Navigation.setParams({reportActionID: ''});
-    }, [isLinkedActionDeleted, prevIsLinkedActionDeleted]);
+    }, [isLinkedActionDeleted, wasEverVisible]);
 
     // Handle inaccessible whisper
     useEffect(() => {

--- a/src/pages/inbox/LinkedActionNotFoundGuard.tsx
+++ b/src/pages/inbox/LinkedActionNotFoundGuard.tsx
@@ -82,6 +82,14 @@ function LinkedActionNotFoundGate({reportActionIDFromRoute, children}: LinkedAct
         setWasEverVisible(true);
     }
 
+    // Track whether isLoadingInitialReportActions has been true at least once during this mount.
+    // For previously loaded reports, stale metadata may already have isLoadingInitialReportActions: false
+    // before openReport() fires its optimistic update — without this guard we'd flash "not found".
+    const [hasSeenLoadingCycle, setHasSeenLoadingCycle] = useState(false);
+    if (isLoadingInitialReportActions && !hasSeenLoadingCycle) {
+        setHasSeenLoadingCycle(true);
+    }
+
     // Show "comment not found" when:
     // 1. The linked action doesn't exist in the report's actions collection (after loading completes)
     // 2. The linked action exists but is deleted/hidden, and was never visible during this mount
@@ -92,7 +100,8 @@ function LinkedActionNotFoundGate({reportActionIDFromRoute, children}: LinkedAct
     // view is empty" — that's a report view concern, not a linked-action-not-found concern.
     // Showing "comment not found" for an action that exists in the collection is incorrect.
     // eslint-disable-next-line rulesdir/no-negated-variables
-    const shouldShowNotFoundLinkedAction = (!isLinkedActionInaccessibleWhisper && isLinkedActionDeleted && !wasEverVisible) || (!isLoadingInitialReportActions && !linkedAction);
+    const shouldShowNotFoundLinkedAction =
+        (!isLinkedActionInaccessibleWhisper && isLinkedActionDeleted && !wasEverVisible) || (hasSeenLoadingCycle && !isLoadingInitialReportActions && !linkedAction);
 
     // Action was deleted while we were viewing it — navigate away
     useEffect(() => {

--- a/src/pages/inbox/LinkedActionNotFoundGuard.tsx
+++ b/src/pages/inbox/LinkedActionNotFoundGuard.tsx
@@ -6,6 +6,7 @@ import FullPageNotFoundView from '@components/BlockingViews/FullPageNotFoundView
 import useCurrentUserPersonalDetails from '@hooks/useCurrentUserPersonalDetails';
 import useOnyx from '@hooks/useOnyx';
 import useReportIsArchived from '@hooks/useReportIsArchived';
+import useResponsiveLayout from '@hooks/useResponsiveLayout';
 import getNonEmptyStringOnyxID from '@libs/getNonEmptyStringOnyxID';
 import Navigation from '@libs/Navigation/Navigation';
 import {isReportActionVisible, isWhisperAction} from '@libs/ReportActionsUtils';
@@ -51,6 +52,7 @@ function LinkedActionNotFoundGate({reportActionIDFromRoute, children}: LinkedAct
     const reportIDFromRoute = getNonEmptyStringOnyxID(routeParams?.reportID);
 
     const {accountID: currentUserAccountID} = useCurrentUserPersonalDetails();
+    const {shouldUseNarrowLayout} = useResponsiveLayout();
 
     const [report] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT}${reportIDFromRoute}`);
     const [isLoadingInitialReportActions] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT_METADATA}${reportIDFromRoute}`, {
@@ -125,6 +127,7 @@ function LinkedActionNotFoundGate({reportActionIDFromRoute, children}: LinkedAct
         <FullPageNotFoundView
             shouldShow={shouldShowNotFoundLinkedAction}
             subtitleKey="notFound.commentYouLookingForCannotBeFound"
+            shouldShowBackButton={shouldUseNarrowLayout}
             onBackButtonPress={navigateToEndOfReport}
             shouldShowLink
             linkTranslationKey="notFound.goToChatInstead"

--- a/src/pages/inbox/LinkedActionNotFoundGuard.tsx
+++ b/src/pages/inbox/LinkedActionNotFoundGuard.tsx
@@ -9,6 +9,7 @@ import useReportIsArchived from '@hooks/useReportIsArchived';
 import useResponsiveLayout from '@hooks/useResponsiveLayout';
 import useThemeStyles from '@hooks/useThemeStyles';
 import getNonEmptyStringOnyxID from '@libs/getNonEmptyStringOnyxID';
+import Log from '@libs/Log';
 import Navigation from '@libs/Navigation/Navigation';
 import {isReportActionVisible, isWhisperAction} from '@libs/ReportActionsUtils';
 import {canUserPerformWriteAction} from '@libs/ReportUtils';
@@ -104,6 +105,33 @@ function LinkedActionNotFoundGate({reportActionIDFromRoute, children}: LinkedAct
     // eslint-disable-next-line rulesdir/no-negated-variables
     const shouldShowNotFoundLinkedAction =
         (!isLinkedActionInaccessibleWhisper && isLinkedActionDeleted && !wasEverVisible) || (hasSeenLoadingCycle && !isLoadingInitialReportActions && !linkedAction);
+
+    useEffect(() => {
+        if (!shouldShowNotFoundLinkedAction) {
+            return;
+        }
+
+        Log.info('[ReportScreen] Displaying NotFound Page for linked action', false, {
+            reportIDFromRoute,
+            reportActionIDFromRoute,
+            isLoadingInitialReportActions,
+            hasSeenLoadingCycle,
+            isLinkedActionDeleted,
+            isLinkedActionInaccessibleWhisper,
+            wasEverVisible,
+            linkedActionExists: !!linkedAction,
+        });
+    }, [
+        shouldShowNotFoundLinkedAction,
+        reportIDFromRoute,
+        reportActionIDFromRoute,
+        isLoadingInitialReportActions,
+        hasSeenLoadingCycle,
+        isLinkedActionDeleted,
+        isLinkedActionInaccessibleWhisper,
+        wasEverVisible,
+        linkedAction,
+    ]);
 
     // Action was deleted while we were viewing it — navigate away
     useEffect(() => {

--- a/src/pages/inbox/LinkedActionNotFoundGuard.tsx
+++ b/src/pages/inbox/LinkedActionNotFoundGuard.tsx
@@ -55,7 +55,7 @@ function LinkedActionNotFoundGate({reportActionIDFromRoute, children}: LinkedAct
     const {shouldUseNarrowLayout} = useResponsiveLayout();
 
     const [report] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT}${reportIDFromRoute}`);
-    const [isLoadingInitialReportActions] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT_METADATA}${reportIDFromRoute}`, {
+    const [isLoadingInitialReportActions = true] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT_METADATA}${reportIDFromRoute}`, {
         selector: isLoadingInitialReportActionsSelector,
     });
     const [linkedAction] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT_ACTIONS}${reportIDFromRoute}`, {

--- a/src/pages/inbox/LinkedActionNotFoundGuard.tsx
+++ b/src/pages/inbox/LinkedActionNotFoundGuard.tsx
@@ -7,6 +7,7 @@ import useCurrentUserPersonalDetails from '@hooks/useCurrentUserPersonalDetails'
 import useOnyx from '@hooks/useOnyx';
 import useReportIsArchived from '@hooks/useReportIsArchived';
 import useResponsiveLayout from '@hooks/useResponsiveLayout';
+import useThemeStyles from '@hooks/useThemeStyles';
 import getNonEmptyStringOnyxID from '@libs/getNonEmptyStringOnyxID';
 import Navigation from '@libs/Navigation/Navigation';
 import {isReportActionVisible, isWhisperAction} from '@libs/ReportActionsUtils';
@@ -51,6 +52,7 @@ function LinkedActionNotFoundGate({reportActionIDFromRoute, children}: LinkedAct
     const routeParams = route.params as {reportID?: string; reportActionID?: string} | undefined;
     const reportIDFromRoute = getNonEmptyStringOnyxID(routeParams?.reportID);
 
+    const styles = useThemeStyles();
     const {accountID: currentUserAccountID} = useCurrentUserPersonalDetails();
     const {shouldUseNarrowLayout} = useResponsiveLayout();
 
@@ -136,6 +138,7 @@ function LinkedActionNotFoundGate({reportActionIDFromRoute, children}: LinkedAct
         <FullPageNotFoundView
             shouldShow={shouldShowNotFoundLinkedAction}
             subtitleKey="notFound.commentYouLookingForCannotBeFound"
+            subtitleStyle={[styles.textSupporting]}
             shouldShowBackButton={shouldUseNarrowLayout}
             onBackButtonPress={navigateToEndOfReport}
             shouldShowLink

--- a/src/pages/inbox/LinkedActionNotFoundGuard.tsx
+++ b/src/pages/inbox/LinkedActionNotFoundGuard.tsx
@@ -1,7 +1,6 @@
 import {useRoute} from '@react-navigation/native';
 import type {ReactNode} from 'react';
-import React, {useEffect, useState} from 'react';
-import {InteractionManager} from 'react-native';
+import React, {useEffect} from 'react';
 import FullPageNotFoundView from '@components/BlockingViews/FullPageNotFoundView';
 import useCurrentUserPersonalDetails from '@hooks/useCurrentUserPersonalDetails';
 import useOnyx from '@hooks/useOnyx';
@@ -13,6 +12,7 @@ import Navigation from '@libs/Navigation/Navigation';
 import {getFilteredReportActionsForReportView, isReportActionVisible, isWhisperAction} from '@libs/ReportActionsUtils';
 import {canUserPerformWriteAction} from '@libs/ReportUtils';
 import ONYXKEYS from '@src/ONYXKEYS';
+import {isLoadingInitialReportActionsSelector} from '@src/selectors/ReportMetaData';
 
 type LinkedActionNotFoundGuardProps = {
     children: ReactNode;
@@ -28,7 +28,14 @@ function LinkedActionNotFoundGuard({children}: LinkedActionNotFoundGuardProps) {
         return children;
     }
 
-    return <LinkedActionNotFoundGate reportActionIDFromRoute={reportActionIDFromRoute}>{children}</LinkedActionNotFoundGate>;
+    return (
+        <LinkedActionNotFoundGate
+            key={reportActionIDFromRoute}
+            reportActionIDFromRoute={reportActionIDFromRoute}
+        >
+            {children}
+        </LinkedActionNotFoundGate>
+    );
 }
 
 type LinkedActionNotFoundGateProps = {
@@ -44,12 +51,10 @@ function LinkedActionNotFoundGate({reportActionIDFromRoute, children}: LinkedAct
 
     const {accountID: currentUserAccountID} = useCurrentUserPersonalDetails();
 
-    const [isLinkingToMessage, setIsLinkingToMessage] = useState(!!reportActionIDFromRoute);
-    const [isNavigatingToDeletedAction, setIsNavigatingToDeletedAction] = useState(false);
-    const [firstRender, setFirstRender] = useState(true);
-
     const [report] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT}${reportIDFromRoute}`);
-    const [reportMetadata] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT_METADATA}${reportIDFromRoute}`);
+    const [isLoadingInitialReportActions] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT_METADATA}${reportIDFromRoute}`, {
+        selector: isLoadingInitialReportActionsSelector,
+    });
     const [visibleReportActionsData] = useOnyx(ONYXKEYS.DERIVED.VISIBLE_REPORT_ACTIONS);
 
     const reportID = report?.reportID;
@@ -66,72 +71,44 @@ function LinkedActionNotFoundGate({reportActionIDFromRoute, children}: LinkedAct
     const isLinkedActionDeleted = hasNoActionReportID || isActionHidden;
 
     const prevIsLinkedActionDeleted = usePrevious(linkedAction ? isLinkedActionDeleted : undefined);
-    const lastReportActionIDFromRoute = usePrevious(!firstRender ? reportActionIDFromRoute : undefined);
 
     const isLinkedActionInaccessibleWhisper = !!linkedAction && isWhisperAction(linkedAction) && !(linkedAction?.whisperedToAccountIDs ?? []).includes(currentUserAccountID);
 
+    const isNavigatedToDeletedAction = isLinkedActionDeleted && prevIsLinkedActionDeleted !== false;
+
     // eslint-disable-next-line rulesdir/no-negated-variables
     const shouldShowNotFoundLinkedAction =
-        (!isLinkedActionInaccessibleWhisper && isLinkedActionDeleted && isNavigatingToDeletedAction) ||
-        (!reportMetadata?.isLoadingInitialReportActions &&
-            !!reportActionIDFromRoute &&
-            !!sortedAllReportActions &&
-            sortedAllReportActions?.length > 0 &&
-            reportActions.length === 0 &&
-            !isLinkingToMessage);
+        (!isLinkedActionInaccessibleWhisper && isNavigatedToDeletedAction) ||
+        (!isLoadingInitialReportActions && !!reportActionIDFromRoute && !!sortedAllReportActions && sortedAllReportActions?.length > 0 && reportActions.length === 0);
 
-    // Track firstRender
+    // Action was deleted while we were viewing it — navigate away
     useEffect(() => {
-        // eslint-disable-next-line react-hooks/set-state-in-effect
-        setFirstRender(false);
-    }, []);
-
-    // Reset isLinkingToMessage
-    useEffect(() => {
-        // eslint-disable-next-line @typescript-eslint/no-deprecated
-        InteractionManager.runAfterInteractions(() => {
-            setIsLinkingToMessage(false);
-        });
-    }, [reportMetadata?.isLoadingInitialReportActions]);
-
-    // Handle deleted linked action
-    useEffect(() => {
-        if (!isLinkedActionDeleted) {
-            // eslint-disable-next-line react-hooks/set-state-in-effect
-            setIsNavigatingToDeletedAction(false);
+        if (!isLinkedActionDeleted || prevIsLinkedActionDeleted !== false) {
             return;
         }
-        if (lastReportActionIDFromRoute !== reportActionIDFromRoute) {
-            // eslint-disable-next-line react-hooks/set-state-in-effect
-            setIsNavigatingToDeletedAction(true);
-            return;
-        }
-        if (!isNavigatingToDeletedAction && prevIsLinkedActionDeleted === false) {
-            Navigation.setParams({reportActionID: ''});
-        }
-    }, [isLinkedActionDeleted, prevIsLinkedActionDeleted, lastReportActionIDFromRoute, reportActionIDFromRoute, isNavigatingToDeletedAction]);
+        Navigation.setParams({reportActionID: ''});
+    }, [isLinkedActionDeleted, prevIsLinkedActionDeleted]);
 
     // Handle inaccessible whisper
     useEffect(() => {
         if (!isLinkedActionInaccessibleWhisper) {
             return;
         }
+        let ignore = false;
         Navigation.isNavigationReady().then(() => {
+            if (ignore) {
+                return;
+            }
             Navigation.setParams({reportActionID: ''});
         });
+        return () => {
+            ignore = true;
+        };
     }, [isLinkedActionInaccessibleWhisper]);
 
     const navigateToEndOfReport = () => {
         Navigation.setParams({reportActionID: ''});
     };
-
-    const lastRoute = usePrevious(route);
-
-    // Render-time guard: prevent flash while linking state syncs
-    if ((lastRoute !== route || lastReportActionIDFromRoute !== reportActionIDFromRoute) && isLinkingToMessage !== !!reportActionIDFromRoute) {
-        setIsLinkingToMessage(!!reportActionIDFromRoute);
-        return null;
-    }
 
     return (
         <FullPageNotFoundView

--- a/src/pages/inbox/LinkedActionNotFoundGuard.tsx
+++ b/src/pages/inbox/LinkedActionNotFoundGuard.tsx
@@ -1,0 +1,154 @@
+import {useRoute} from '@react-navigation/native';
+import type {ReactNode} from 'react';
+import React, {useEffect, useState} from 'react';
+import {InteractionManager} from 'react-native';
+import FullPageNotFoundView from '@components/BlockingViews/FullPageNotFoundView';
+import useCurrentUserPersonalDetails from '@hooks/useCurrentUserPersonalDetails';
+import useOnyx from '@hooks/useOnyx';
+import usePaginatedReportActions from '@hooks/usePaginatedReportActions';
+import usePrevious from '@hooks/usePrevious';
+import useReportIsArchived from '@hooks/useReportIsArchived';
+import getNonEmptyStringOnyxID from '@libs/getNonEmptyStringOnyxID';
+import Navigation from '@libs/Navigation/Navigation';
+import {getFilteredReportActionsForReportView, isReportActionVisible, isWhisperAction} from '@libs/ReportActionsUtils';
+import {canUserPerformWriteAction} from '@libs/ReportUtils';
+import ONYXKEYS from '@src/ONYXKEYS';
+
+type LinkedActionNotFoundGuardProps = {
+    children: ReactNode;
+};
+
+// eslint-disable-next-line rulesdir/no-negated-variables
+function LinkedActionNotFoundGuard({children}: LinkedActionNotFoundGuardProps) {
+    const route = useRoute();
+    const routeParams = route.params as {reportActionID?: string} | undefined;
+    const reportActionIDFromRoute = routeParams?.reportActionID;
+
+    if (!reportActionIDFromRoute) {
+        return children;
+    }
+
+    return <LinkedActionNotFoundGate reportActionIDFromRoute={reportActionIDFromRoute}>{children}</LinkedActionNotFoundGate>;
+}
+
+type LinkedActionNotFoundGateProps = {
+    reportActionIDFromRoute: string;
+    children: ReactNode;
+};
+
+// eslint-disable-next-line rulesdir/no-negated-variables
+function LinkedActionNotFoundGate({reportActionIDFromRoute, children}: LinkedActionNotFoundGateProps) {
+    const route = useRoute();
+    const routeParams = route.params as {reportID?: string; reportActionID?: string} | undefined;
+    const reportIDFromRoute = getNonEmptyStringOnyxID(routeParams?.reportID);
+
+    const {accountID: currentUserAccountID} = useCurrentUserPersonalDetails();
+
+    const [isLinkingToMessage, setIsLinkingToMessage] = useState(!!reportActionIDFromRoute);
+    const [isNavigatingToDeletedAction, setIsNavigatingToDeletedAction] = useState(false);
+    const [firstRender, setFirstRender] = useState(true);
+
+    const [report] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT}${reportIDFromRoute}`);
+    const [reportMetadata] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT_METADATA}${reportIDFromRoute}`);
+    const [visibleReportActionsData] = useOnyx(ONYXKEYS.DERIVED.VISIBLE_REPORT_ACTIONS);
+
+    const reportID = report?.reportID;
+    const isReportArchived = useReportIsArchived(report?.reportID);
+
+    const {reportActions: unfilteredReportActions, linkedAction, sortedAllReportActions} = usePaginatedReportActions(reportID, reportActionIDFromRoute);
+    const reportActions = getFilteredReportActionsForReportView(unfilteredReportActions);
+
+    // --- Linked action status ---
+    const actionReportID = linkedAction?.reportID ?? reportID;
+    const hasNoActionReportID = !!linkedAction && !actionReportID;
+    const isActionHidden =
+        !!linkedAction && !!actionReportID && !isReportActionVisible(linkedAction, actionReportID, canUserPerformWriteAction(report, isReportArchived), visibleReportActionsData);
+    const isLinkedActionDeleted = hasNoActionReportID || isActionHidden;
+
+    const prevIsLinkedActionDeleted = usePrevious(linkedAction ? isLinkedActionDeleted : undefined);
+    const lastReportActionIDFromRoute = usePrevious(!firstRender ? reportActionIDFromRoute : undefined);
+
+    const isLinkedActionInaccessibleWhisper = !!linkedAction && isWhisperAction(linkedAction) && !(linkedAction?.whisperedToAccountIDs ?? []).includes(currentUserAccountID);
+
+    // eslint-disable-next-line rulesdir/no-negated-variables
+    const shouldShowNotFoundLinkedAction =
+        (!isLinkedActionInaccessibleWhisper && isLinkedActionDeleted && isNavigatingToDeletedAction) ||
+        (!reportMetadata?.isLoadingInitialReportActions &&
+            !!reportActionIDFromRoute &&
+            !!sortedAllReportActions &&
+            sortedAllReportActions?.length > 0 &&
+            reportActions.length === 0 &&
+            !isLinkingToMessage);
+
+    // Track firstRender
+    useEffect(() => {
+        // eslint-disable-next-line react-hooks/set-state-in-effect
+        setFirstRender(false);
+    }, []);
+
+    // Reset isLinkingToMessage
+    useEffect(() => {
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
+        InteractionManager.runAfterInteractions(() => {
+            setIsLinkingToMessage(false);
+        });
+    }, [reportMetadata?.isLoadingInitialReportActions]);
+
+    // Handle deleted linked action
+    useEffect(() => {
+        if (!isLinkedActionDeleted) {
+            // eslint-disable-next-line react-hooks/set-state-in-effect
+            setIsNavigatingToDeletedAction(false);
+            return;
+        }
+        if (lastReportActionIDFromRoute !== reportActionIDFromRoute) {
+            // eslint-disable-next-line react-hooks/set-state-in-effect
+            setIsNavigatingToDeletedAction(true);
+            return;
+        }
+        if (!isNavigatingToDeletedAction && prevIsLinkedActionDeleted === false) {
+            Navigation.setParams({reportActionID: ''});
+        }
+    }, [isLinkedActionDeleted, prevIsLinkedActionDeleted, lastReportActionIDFromRoute, reportActionIDFromRoute, isNavigatingToDeletedAction]);
+
+    // Handle inaccessible whisper
+    useEffect(() => {
+        if (!isLinkedActionInaccessibleWhisper) {
+            return;
+        }
+        Navigation.isNavigationReady().then(() => {
+            Navigation.setParams({reportActionID: ''});
+        });
+    }, [isLinkedActionInaccessibleWhisper]);
+
+    const navigateToEndOfReport = () => {
+        Navigation.setParams({reportActionID: ''});
+    };
+
+    const lastRoute = usePrevious(route);
+
+    // Render-time guard: prevent flash while linking state syncs
+    if ((lastRoute !== route || lastReportActionIDFromRoute !== reportActionIDFromRoute) && isLinkingToMessage !== !!reportActionIDFromRoute) {
+        setIsLinkingToMessage(!!reportActionIDFromRoute);
+        return null;
+    }
+
+    return (
+        <FullPageNotFoundView
+            shouldShow={shouldShowNotFoundLinkedAction}
+            subtitleKey="notFound.commentYouLookingForCannotBeFound"
+            onBackButtonPress={navigateToEndOfReport}
+            shouldShowLink
+            linkTranslationKey="notFound.goToChatInstead"
+            subtitleKeyBelowLink="notFound.contactConcierge"
+            onLinkPress={navigateToEndOfReport}
+            shouldDisplaySearchRouter
+        >
+            {children}
+        </FullPageNotFoundView>
+    );
+}
+
+LinkedActionNotFoundGuard.displayName = 'LinkedActionNotFoundGuard';
+
+export default LinkedActionNotFoundGuard;

--- a/src/pages/inbox/ReportNotFoundGuard.tsx
+++ b/src/pages/inbox/ReportNotFoundGuard.tsx
@@ -102,6 +102,7 @@ function ReportNotFoundGuard({children}: ReportNotFoundGuardProps) {
             subtitleStyle={[styles.textSupporting]}
             shouldShowBackButton={shouldUseNarrowLayout}
             onBackButtonPress={Navigation.goBack}
+            shouldShowLink={false}
             shouldDisplaySearchRouter
         >
             {children}

--- a/src/pages/inbox/ReportNotFoundGuard.tsx
+++ b/src/pages/inbox/ReportNotFoundGuard.tsx
@@ -14,16 +14,7 @@ import {isReportTransactionThread, isValidReportIDFromPath} from '@libs/ReportUt
 import {getParentReportActionDeletionStatus} from '@libs/TransactionNavigationUtils';
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
-
-const defaultReportMetadata = {
-    hasOnceLoadedReportActions: false,
-    isLoadingInitialReportActions: true,
-    isLoadingOlderReportActions: false,
-    hasLoadingOlderReportActionsError: false,
-    isLoadingNewerReportActions: false,
-    hasLoadingNewerReportActionsError: false,
-    isOptimisticReport: false,
-};
+import {isLoadingInitialReportActionsSelector} from '@src/selectors/ReportMetaData';
 
 type ReportNotFoundGuardProps = {
     children: ReactNode;
@@ -42,7 +33,9 @@ function ReportNotFoundGuard({children}: ReportNotFoundGuardProps) {
     const [report] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT}${reportIDFromRoute}`);
     const [parentReportMetadata] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT_METADATA}${report?.parentReportID}`);
     const [userLeavingStatus = false] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT_USER_IS_LEAVING_ROOM}${reportIDFromRoute}`);
-    const [reportMetadata = defaultReportMetadata] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT_METADATA}${reportIDFromRoute}`);
+    const [isLoadingInitialReportActions = true] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT_METADATA}${reportIDFromRoute}`, {
+        selector: isLoadingInitialReportActionsSelector,
+    });
     const [isLoadingReportData = true] = useOnyx(ONYXKEYS.IS_LOADING_REPORT_DATA);
     const [isLoadingApp] = useOnyx(ONYXKEYS.IS_LOADING_APP);
     const [deleteTransactionNavigateBackUrl] = useOnyx(ONYXKEYS.NVP_DELETE_TRANSACTION_NAVIGATE_BACK_URL);
@@ -60,10 +53,8 @@ function ReportNotFoundGuard({children}: ReportNotFoundGuardProps) {
     });
     const isDeletedTransactionThread = isReportTransactionThread(report) && (isParentActionDeleted || isParentActionMissingAfterLoad);
 
-    const currentReportIDFormRoute = (route.params as {reportID?: string} | undefined)?.reportID;
-
-    const isInvalidReportPath = !!currentReportIDFormRoute && !isValidReportIDFromPath(currentReportIDFormRoute);
-    const isLoading = isLoadingApp !== false || isLoadingReportData || (!isOffline && !!reportMetadata?.isLoadingInitialReportActions);
+    const isInvalidReportPath = !!routeParams?.reportID && !isValidReportIDFromPath(routeParams.reportID);
+    const isLoading = isLoadingApp !== false || isLoadingReportData || (!isOffline && !!isLoadingInitialReportActions);
     const reportExists = !!reportID || (!isDeletedTransactionThread && isOptimisticDelete) || userLeavingStatus;
 
     // eslint-disable-next-line rulesdir/no-negated-variables
@@ -78,11 +69,11 @@ function ReportNotFoundGuard({children}: ReportNotFoundGuardProps) {
             isLoadingApp,
             isLoadingReportData,
             isOffline,
-            isLoadingInitialReportActions: reportMetadata?.isLoadingInitialReportActions,
+            isLoadingInitialReportActions,
             reportID,
             isOptimisticDelete,
             userLeavingStatus,
-            currentReportIDFormRoute,
+            reportIDFromPath: routeParams?.reportID,
             deleteTransactionNavigateBackUrl,
             isDeletedTransactionThread,
             isParentActionDeleted,
@@ -93,11 +84,11 @@ function ReportNotFoundGuard({children}: ReportNotFoundGuardProps) {
         isLoadingApp,
         isLoadingReportData,
         isOffline,
-        reportMetadata?.isLoadingInitialReportActions,
+        isLoadingInitialReportActions,
         reportID,
         isOptimisticDelete,
         userLeavingStatus,
-        currentReportIDFormRoute,
+        routeParams?.reportID,
         deleteTransactionNavigateBackUrl,
         isDeletedTransactionThread,
         isParentActionDeleted,

--- a/src/pages/inbox/ReportNotFoundGuard.tsx
+++ b/src/pages/inbox/ReportNotFoundGuard.tsx
@@ -1,0 +1,123 @@
+import {useRoute} from '@react-navigation/native';
+import type {ReactNode} from 'react';
+import React, {useEffect} from 'react';
+import FullPageNotFoundView from '@components/BlockingViews/FullPageNotFoundView';
+import useNetwork from '@hooks/useNetwork';
+import useOnyx from '@hooks/useOnyx';
+import useParentReportAction from '@hooks/useParentReportAction';
+import useResponsiveLayout from '@hooks/useResponsiveLayout';
+import useThemeStyles from '@hooks/useThemeStyles';
+import getNonEmptyStringOnyxID from '@libs/getNonEmptyStringOnyxID';
+import Log from '@libs/Log';
+import Navigation from '@libs/Navigation/Navigation';
+import {isReportTransactionThread, isValidReportIDFromPath} from '@libs/ReportUtils';
+import {getParentReportActionDeletionStatus} from '@libs/TransactionNavigationUtils';
+import CONST from '@src/CONST';
+import ONYXKEYS from '@src/ONYXKEYS';
+
+const defaultReportMetadata = {
+    hasOnceLoadedReportActions: false,
+    isLoadingInitialReportActions: true,
+    isLoadingOlderReportActions: false,
+    hasLoadingOlderReportActionsError: false,
+    isLoadingNewerReportActions: false,
+    hasLoadingNewerReportActionsError: false,
+    isOptimisticReport: false,
+};
+
+type ReportNotFoundGuardProps = {
+    children: ReactNode;
+};
+
+// eslint-disable-next-line rulesdir/no-negated-variables
+function ReportNotFoundGuard({children}: ReportNotFoundGuardProps) {
+    const styles = useThemeStyles();
+    const route = useRoute();
+    const routeParams = route.params as {reportID?: string} | undefined;
+    const reportIDFromRoute = getNonEmptyStringOnyxID(routeParams?.reportID);
+
+    const {isOffline} = useNetwork();
+    const {shouldUseNarrowLayout} = useResponsiveLayout();
+
+    const [report] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT}${reportIDFromRoute}`);
+    const [parentReportMetadata] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT_METADATA}${report?.parentReportID}`);
+    const [userLeavingStatus = false] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT_USER_IS_LEAVING_ROOM}${reportIDFromRoute}`);
+    const [reportMetadata = defaultReportMetadata] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT_METADATA}${reportIDFromRoute}`);
+    const [isLoadingReportData = true] = useOnyx(ONYXKEYS.IS_LOADING_REPORT_DATA);
+    const [isLoadingApp] = useOnyx(ONYXKEYS.IS_LOADING_APP);
+    const [deleteTransactionNavigateBackUrl] = useOnyx(ONYXKEYS.NVP_DELETE_TRANSACTION_NAVIGATE_BACK_URL);
+
+    const parentReportAction = useParentReportAction(report);
+    const reportID = report?.reportID;
+    const isOptimisticDelete = report?.statusNum === CONST.REPORT.STATUS_NUM.CLOSED;
+
+    const {isParentActionMissingAfterLoad, isParentActionDeleted} = getParentReportActionDeletionStatus({
+        parentReportID: report?.parentReportID,
+        parentReportActionID: report?.parentReportActionID,
+        parentReportAction,
+        parentReportMetadata,
+        isOffline,
+    });
+    const isDeletedTransactionThread = isReportTransactionThread(report) && (isParentActionDeleted || isParentActionMissingAfterLoad);
+
+    const currentReportIDFormRoute = (route.params as {reportID?: string} | undefined)?.reportID;
+
+    const isInvalidReportPath = !!currentReportIDFormRoute && !isValidReportIDFromPath(currentReportIDFormRoute);
+    const isLoading = isLoadingApp !== false || isLoadingReportData || (!isOffline && !!reportMetadata?.isLoadingInitialReportActions);
+    const reportExists = !!reportID || (!isDeletedTransactionThread && isOptimisticDelete) || userLeavingStatus;
+
+    // eslint-disable-next-line rulesdir/no-negated-variables
+    const shouldShowNotFoundPage = !deleteTransactionNavigateBackUrl && (isDeletedTransactionThread || isInvalidReportPath || (!isLoading && !reportExists));
+
+    useEffect(() => {
+        if (!shouldShowNotFoundPage) {
+            return;
+        }
+
+        Log.info('[ReportScreen] Displaying NotFound Page', false, {
+            isLoadingApp,
+            isLoadingReportData,
+            isOffline,
+            isLoadingInitialReportActions: reportMetadata?.isLoadingInitialReportActions,
+            reportID,
+            isOptimisticDelete,
+            userLeavingStatus,
+            currentReportIDFormRoute,
+            deleteTransactionNavigateBackUrl,
+            isDeletedTransactionThread,
+            isParentActionDeleted,
+            isParentActionMissingAfterLoad,
+        });
+    }, [
+        shouldShowNotFoundPage,
+        isLoadingApp,
+        isLoadingReportData,
+        isOffline,
+        reportMetadata?.isLoadingInitialReportActions,
+        reportID,
+        isOptimisticDelete,
+        userLeavingStatus,
+        currentReportIDFormRoute,
+        deleteTransactionNavigateBackUrl,
+        isDeletedTransactionThread,
+        isParentActionDeleted,
+        isParentActionMissingAfterLoad,
+    ]);
+
+    return (
+        <FullPageNotFoundView
+            shouldShow={shouldShowNotFoundPage}
+            subtitleKey="notFound.noAccess"
+            subtitleStyle={[styles.textSupporting]}
+            shouldShowBackButton={shouldUseNarrowLayout}
+            onBackButtonPress={Navigation.goBack}
+            shouldDisplaySearchRouter
+        >
+            {children}
+        </FullPageNotFoundView>
+    );
+}
+
+ReportNotFoundGuard.displayName = 'ReportNotFoundGuard';
+
+export default ReportNotFoundGuard;

--- a/src/pages/inbox/ReportScreen.tsx
+++ b/src/pages/inbox/ReportScreen.tsx
@@ -5,9 +5,8 @@ import type {ViewStyle} from 'react-native';
 // We use Animated for all functionality related to wide RHP to make it easier
 // to interact with react-navigation components (e.g., CardContainer, interpolator), which also use Animated.
 // eslint-disable-next-line no-restricted-imports
-import {Animated, InteractionManager, View} from 'react-native';
+import {Animated, View} from 'react-native';
 import type {OnyxEntry} from 'react-native-onyx';
-import FullPageNotFoundView from '@components/BlockingViews/FullPageNotFoundView';
 import DragAndDropProvider from '@components/DragAndDrop/Provider';
 import MoneyReportHeader from '@components/MoneyReportHeader';
 import MoneyRequestHeader from '@components/MoneyRequestHeader';
@@ -39,21 +38,12 @@ import useSubmitToDestinationVisible from '@hooks/useSubmitToDestinationVisible'
 import useThemeStyles from '@hooks/useThemeStyles';
 import useViewportOffsetTop from '@hooks/useViewportOffsetTop';
 import getNonEmptyStringOnyxID from '@libs/getNonEmptyStringOnyxID';
-import Log from '@libs/Log';
 import {getAllNonDeletedTransactions, shouldDisplayReportTableView, shouldWaitForTransactions as shouldWaitForTransactionsUtil} from '@libs/MoneyRequestReportUtils';
 import Navigation, {navigationRef} from '@libs/Navigation/Navigation';
 import type {PlatformStackScreenProps} from '@libs/Navigation/PlatformStackNavigation/types';
-import {
-    getFilteredReportActionsForReportView,
-    getOneTransactionThreadReportID,
-    isDeletedParentAction,
-    isReportActionVisible,
-    isTransactionThread,
-    isWhisperAction,
-} from '@libs/ReportActionsUtils';
+import {getFilteredReportActionsForReportView, getOneTransactionThreadReportID, isDeletedParentAction, isTransactionThread} from '@libs/ReportActionsUtils';
 import {getReportName} from '@libs/ReportNameUtils';
 import {
-    canUserPerformWriteAction,
     getReportOfflinePendingActionAndErrors,
     isAdminRoom,
     isAnnounceRoom,
@@ -64,9 +54,7 @@ import {
     isMoneyRequestReportPendingDeletion,
     isPolicyExpenseChat,
     isReportTransactionThread,
-    isValidReportIDFromPath,
 } from '@libs/ReportUtils';
-import {getParentReportActionDeletionStatus} from '@libs/TransactionNavigationUtils';
 import type {ReportsSplitNavigatorParamList, RightModalNavigatorParamList} from '@navigation/types';
 import {setShouldShowComposeInput} from '@userActions/Composer';
 import {navigateToConciergeChat} from '@userActions/Report';
@@ -83,11 +71,13 @@ import {AgentZeroStatusProvider} from './AgentZeroStatusContext';
 import DeleteTransactionNavigateBackHandler from './DeleteTransactionNavigateBackHandler';
 import HeaderView from './HeaderView';
 import useReportWasDeleted from './hooks/useReportWasDeleted';
+import LinkedActionNotFoundGuard from './LinkedActionNotFoundGuard';
 import ReactionListWrapper from './ReactionListWrapper';
 import ReportActionsView from './report/ReportActionsView';
 import ReportFooter from './report/ReportFooter';
 import ReportFetchHandler from './ReportFetchHandler';
 import ReportLifecycleHandler from './ReportLifecycleHandler';
+import ReportNotFoundGuard from './ReportNotFoundGuard';
 import ReportRouteParamHandler from './ReportRouteParamHandler';
 import {ActionListContext} from './ReportScreenContext';
 
@@ -135,13 +125,12 @@ function ReportScreen({route, navigation}: ReportScreenProps) {
     const isFocused = useIsFocused();
     const [firstRender, setFirstRender] = useState(true);
     const {isOffline} = useNetwork();
-    const {shouldUseNarrowLayout, isInNarrowPaneModal} = useResponsiveLayout();
+    const {isInNarrowPaneModal} = useResponsiveLayout();
     const isInSidePanel = useIsInSidePanel();
 
     const {currentReportID: currentReportIDValue} = useCurrentReportIDState();
 
     const [reportOnyx] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT}${reportIDFromRoute}`);
-    const [parentReportMetadata] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT_METADATA}${reportOnyx?.parentReportID}`);
     const [userLeavingStatus = false] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT_USER_IS_LEAVING_ROOM}${reportIDFromRoute}`);
     const [reportNameValuePairsOnyx] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT_NAME_VALUE_PAIRS}${reportIDFromRoute}`);
     const [reportMetadata = defaultReportMetadata] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT_METADATA}${reportIDFromRoute}`);
@@ -156,8 +145,6 @@ function ReportScreen({route, navigation}: ReportScreenProps) {
 
     const deletedParentAction = isDeletedParentAction(parentReportAction);
     const prevDeletedParentAction = usePrevious(deletedParentAction);
-
-    const [isLoadingReportData = true] = useOnyx(ONYXKEYS.IS_LOADING_REPORT_DATA);
 
     /**
      * Create a lightweight Report so as to keep the re-rendering as light as possible by
@@ -225,13 +212,10 @@ function ReportScreen({route, navigation}: ReportScreenProps) {
     const prevReport = usePrevious(report);
     const prevUserLeavingStatus = usePrevious(userLeavingStatus);
     const lastReportIDFromRoute = usePrevious(reportIDFromRoute);
-    const [isLinkingToMessage, setIsLinkingToMessage] = useState(!!reportActionIDFromRoute);
 
     const {accountID: currentUserAccountID} = useCurrentUserPersonalDetails();
 
-    const [isLoadingApp] = useOnyx(ONYXKEYS.IS_LOADING_APP);
-    const [visibleReportActionsData] = useOnyx(ONYXKEYS.DERIVED.VISIBLE_REPORT_ACTIONS);
-    const {reportActions: unfilteredReportActions, linkedAction, sortedAllReportActions, hasNewerActions, hasOlderActions} = usePaginatedReportActions(reportID, reportActionIDFromRoute);
+    const {reportActions: unfilteredReportActions, hasNewerActions, hasOlderActions} = usePaginatedReportActions(reportID, reportActionIDFromRoute);
     // wrapping in useMemo because this is array operation and can cause performance issues
     const reportActions = useMemo(() => getFilteredReportActionsForReportView(unfilteredReportActions), [unfilteredReportActions]);
     const viewportOffsetTop = useViewportOffsetTop();
@@ -323,141 +307,6 @@ function ReportScreen({route, navigation}: ReportScreenProps) {
 
     const isReportArchived = useReportIsArchived(report?.reportID);
     const {isEditingDisabled} = useIsReportReadyToDisplay(report, reportIDFromRoute, isReportArchived);
-
-    const isLinkedActionDeleted = useMemo(() => {
-        if (!linkedAction) {
-            return false;
-        }
-        const actionReportID = linkedAction.reportID ?? reportID;
-        if (!actionReportID) {
-            return true;
-        }
-        return !isReportActionVisible(linkedAction, actionReportID, canUserPerformWriteAction(report, isReportArchived), visibleReportActionsData);
-    }, [linkedAction, report, isReportArchived, reportID, visibleReportActionsData]);
-
-    const prevIsLinkedActionDeleted = usePrevious(linkedAction ? isLinkedActionDeleted : undefined);
-
-    const lastReportActionIDFromRoute = usePrevious(!firstRender ? reportActionIDFromRoute : undefined);
-
-    const [isNavigatingToDeletedAction, setIsNavigatingToDeletedAction] = useState(false);
-
-    const isLinkedActionInaccessibleWhisper = useMemo(
-        () => !!linkedAction && isWhisperAction(linkedAction) && !(linkedAction?.whisperedToAccountIDs ?? []).includes(currentUserAccountID),
-        [currentUserAccountID, linkedAction],
-    );
-    const {isParentActionMissingAfterLoad, isParentActionDeleted} = getParentReportActionDeletionStatus({
-        parentReportID: report?.parentReportID,
-        parentReportActionID: report?.parentReportActionID,
-        parentReportAction,
-        parentReportMetadata,
-        isOffline,
-    });
-    const isDeletedTransactionThread = isReportTransactionThread(report) && (isParentActionDeleted || isParentActionMissingAfterLoad);
-    const [deleteTransactionNavigateBackUrl] = useOnyx(ONYXKEYS.NVP_DELETE_TRANSACTION_NAVIGATE_BACK_URL);
-    // eslint-disable-next-line rulesdir/no-negated-variables
-    const shouldShowNotFoundLinkedAction =
-        (!isLinkedActionInaccessibleWhisper && isLinkedActionDeleted && isNavigatingToDeletedAction) ||
-        (!reportMetadata?.isLoadingInitialReportActions &&
-            !!reportActionIDFromRoute &&
-            !!sortedAllReportActions &&
-            sortedAllReportActions?.length > 0 &&
-            reportActions.length === 0 &&
-            !isLinkingToMessage);
-
-    const currentReportIDFormRoute = route.params?.reportID;
-
-    // eslint-disable-next-line rulesdir/no-negated-variables
-    const shouldShowNotFoundPage = useMemo((): boolean => {
-        const isInvalidReportPath = !!currentReportIDFormRoute && !isValidReportIDFromPath(currentReportIDFormRoute);
-        const isLoading = isLoadingApp !== false || isLoadingReportData || (!isOffline && !!reportMetadata?.isLoadingInitialReportActions);
-        const reportExists = !!reportID || (!isDeletedTransactionThread && isOptimisticDelete) || userLeavingStatus;
-
-        if (shouldShowNotFoundLinkedAction) {
-            return true;
-        }
-
-        if (deleteTransactionNavigateBackUrl) {
-            return false;
-        }
-
-        if (isDeletedTransactionThread) {
-            return true;
-        }
-
-        if (isInvalidReportPath) {
-            return true;
-        }
-
-        if (isLoading) {
-            return false;
-        }
-
-        if (firstRender) {
-            return false;
-        }
-
-        return !reportExists;
-    }, [
-        shouldShowNotFoundLinkedAction,
-        isLoadingApp,
-        isLoadingReportData,
-        isOffline,
-        reportMetadata?.isLoadingInitialReportActions,
-        reportID,
-        isOptimisticDelete,
-        userLeavingStatus,
-        currentReportIDFormRoute,
-        firstRender,
-        deleteTransactionNavigateBackUrl,
-        isDeletedTransactionThread,
-    ]);
-
-    useEffect(() => {
-        if (!shouldShowNotFoundPage) {
-            return;
-        }
-
-        Log.info('[ReportScreen] Displaying NotFound Page', false, {
-            shouldShowNotFoundLinkedAction,
-            isLoadingApp,
-            isLoadingReportData,
-            isOffline,
-            isLoadingInitialReportActions: reportMetadata?.isLoadingInitialReportActions,
-            reportID,
-            isOptimisticDelete,
-            userLeavingStatus,
-            currentReportIDFormRoute,
-            firstRender,
-            deleteTransactionNavigateBackUrl,
-            isDeletedTransactionThread,
-            isParentActionDeleted,
-            isParentActionMissingAfterLoad,
-            isNavigatingToDeletedAction,
-            isLinkedActionInaccessibleWhisper,
-            isLinkedActionDeleted,
-            isLinkingToMessage,
-        });
-    }, [
-        shouldShowNotFoundPage,
-        shouldShowNotFoundLinkedAction,
-        isLoadingApp,
-        isLoadingReportData,
-        isOffline,
-        reportMetadata?.isLoadingInitialReportActions,
-        reportID,
-        isOptimisticDelete,
-        userLeavingStatus,
-        currentReportIDFormRoute,
-        firstRender,
-        deleteTransactionNavigateBackUrl,
-        isDeletedTransactionThread,
-        isParentActionDeleted,
-        isParentActionMissingAfterLoad,
-        isNavigatingToDeletedAction,
-        isLinkedActionInaccessibleWhisper,
-        isLinkedActionDeleted,
-        isLinkingToMessage,
-    ]);
 
     useEffect(() => {
         // We don't want this effect to run on the first render.
@@ -582,50 +431,6 @@ function ReportScreen({route, navigation}: ReportScreenProps) {
 
     const actionListValue = useActionListContextValue();
 
-    // This helps in tracking from the moment 'route' triggers useMemo until isLoadingInitialReportActions becomes true. It prevents blinking when loading reportActions from cache.
-    useEffect(() => {
-        // eslint-disable-next-line @typescript-eslint/no-deprecated
-        InteractionManager.runAfterInteractions(() => {
-            setIsLinkingToMessage(false);
-        });
-    }, [reportMetadata?.isLoadingInitialReportActions]);
-
-    const navigateToEndOfReport = useCallback(() => {
-        Navigation.setParams({reportActionID: ''});
-    }, []);
-
-    useEffect(() => {
-        // Only handle deletion cases when there's a deleted action
-        if (!isLinkedActionDeleted) {
-            setIsNavigatingToDeletedAction(false);
-            return;
-        }
-
-        // we want to do this distinguish between normal navigation and delete behavior
-        if (lastReportActionIDFromRoute !== reportActionIDFromRoute) {
-            setIsNavigatingToDeletedAction(true);
-            return;
-        }
-
-        // Clear params when action gets deleted while highlighting
-        if (!isNavigatingToDeletedAction && prevIsLinkedActionDeleted === false) {
-            Navigation.setParams({reportActionID: ''});
-        }
-    }, [isLinkedActionDeleted, prevIsLinkedActionDeleted, lastReportActionIDFromRoute, reportActionIDFromRoute, isNavigatingToDeletedAction]);
-
-    // If user redirects to an inaccessible whisper via a deeplink, on a report they have access to,
-    // then we set reportActionID as empty string, so we display them the report and not the "Not found page".
-    useEffect(() => {
-        if (!isLinkedActionInaccessibleWhisper) {
-            return;
-        }
-        Navigation.isNavigationReady().then(() => {
-            Navigation.setParams({reportActionID: ''});
-        });
-    }, [isLinkedActionInaccessibleWhisper]);
-
-    const lastRoute = usePrevious(route);
-
     // wrapping into useMemo to stabilize children re-renders as reportMetadata is changed frequently
     const showReportActionsLoadingState = useMemo(
         () => reportMetadata?.isLoadingInitialReportActions && !reportMetadata?.hasOnceLoadedReportActions,
@@ -659,14 +464,6 @@ function ReportScreen({route, navigation}: ReportScreenProps) {
         CONST.TELEMETRY.SUBMIT_TO_DESTINATION_VISIBLE_TRIGGER.FOCUS,
     );
 
-    // Define here because reportActions are recalculated before mount, allowing data to display faster than useEffect can trigger.
-    // If we have cached reportActions, they will be shown immediately.
-    // We aim to display a loader first, then fetch relevant reportActions, and finally show them.
-    if ((lastRoute !== route || lastReportActionIDFromRoute !== reportActionIDFromRoute) && isLinkingToMessage !== !!reportActionIDFromRoute) {
-        setIsLinkingToMessage(!!reportActionIDFromRoute);
-        return null;
-    }
-
     return (
         // Wide RHP overlays should be rendered only for the report screen displayed in RHP
         <WideRHPOverlayWrapper shouldWrap={route.name === SCREENS.RIGHT_MODAL.SEARCH_REPORT}>
@@ -681,72 +478,63 @@ function ReportScreen({route, navigation}: ReportScreenProps) {
                         <DeleteTransactionNavigateBackHandler />
                         <ReportRouteParamHandler />
                         <ReportFetchHandler />
-                        <FullPageNotFoundView
-                            shouldShow={shouldShowNotFoundPage}
-                            subtitleKey={shouldShowNotFoundLinkedAction ? 'notFound.commentYouLookingForCannotBeFound' : 'notFound.noAccess'}
-                            subtitleStyle={[styles.textSupporting]}
-                            shouldShowBackButton={shouldUseNarrowLayout}
-                            onBackButtonPress={shouldShowNotFoundLinkedAction ? navigateToEndOfReport : Navigation.goBack}
-                            shouldShowLink={shouldShowNotFoundLinkedAction}
-                            linkTranslationKey="notFound.goToChatInstead"
-                            subtitleKeyBelowLink={shouldShowNotFoundLinkedAction ? 'notFound.contactConcierge' : ''}
-                            onLinkPress={navigateToEndOfReport}
-                            shouldDisplaySearchRouter
-                        >
-                            <DragAndDropProvider isDisabled={isEditingDisabled}>
-                                <ReportLifecycleHandler reportID={reportIDFromRoute} />
-                                <OfflineWithFeedback
-                                    pendingAction={reportPendingAction ?? report?.pendingFields?.reimbursed}
-                                    errors={reportErrors}
-                                    shouldShowErrorMessages={false}
-                                    needsOffscreenAlphaCompositing
-                                >
-                                    {headerView}
-                                </OfflineWithFeedback>
-                                <AccountManagerBanner reportID={reportIDFromRoute} />
-                                <View style={[styles.flex1, styles.flexRow]}>
-                                    {shouldShowWideRHP && (
-                                        <Animated.View style={styles.wideRHPMoneyRequestReceiptViewContainer}>
-                                            <ScrollView contentContainerStyle={styles.wideRHPMoneyRequestReceiptViewScrollViewContainer}>
-                                                <MoneyRequestReceiptView
-                                                    report={transactionThreadReport ?? report}
-                                                    fillSpace
-                                                    isDisplayedInWideRHP
-                                                />
-                                            </ScrollView>
-                                        </Animated.View>
-                                    )}
-                                    <AgentZeroStatusProvider
-                                        reportID={reportIDFromRoute}
-                                        chatType={report?.chatType}
+                        <ReportNotFoundGuard>
+                            <LinkedActionNotFoundGuard>
+                                <DragAndDropProvider isDisabled={isEditingDisabled}>
+                                    <ReportLifecycleHandler reportID={reportIDFromRoute} />
+                                    <OfflineWithFeedback
+                                        pendingAction={reportPendingAction ?? report?.pendingFields?.reimbursed}
+                                        errors={reportErrors}
+                                        shouldShowErrorMessages={false}
+                                        needsOffscreenAlphaCompositing
                                     >
-                                        <View
-                                            style={[styles.flex1, styles.justifyContentEnd, styles.overflowHidden]}
-                                            testID="report-actions-view-wrapper"
+                                        {headerView}
+                                    </OfflineWithFeedback>
+                                    <AccountManagerBanner reportID={reportIDFromRoute} />
+                                    <View style={[styles.flex1, styles.flexRow]}>
+                                        {shouldShowWideRHP && (
+                                            <Animated.View style={styles.wideRHPMoneyRequestReceiptViewContainer}>
+                                                <ScrollView contentContainerStyle={styles.wideRHPMoneyRequestReceiptViewScrollViewContainer}>
+                                                    <MoneyRequestReceiptView
+                                                        report={transactionThreadReport ?? report}
+                                                        fillSpace
+                                                        isDisplayedInWideRHP
+                                                    />
+                                                </ScrollView>
+                                            </Animated.View>
+                                        )}
+                                        <AgentZeroStatusProvider
+                                            reportID={reportIDFromRoute}
+                                            chatType={report?.chatType}
                                         >
-                                            {(!report || shouldWaitForTransactions) && <ReportActionsSkeletonView />}
-                                            {!!report && !shouldDisplayMoneyRequestActionsList && !shouldWaitForTransactions ? <ReportActionsView reportID={report.reportID} /> : null}
-                                            {!!report && shouldDisplayMoneyRequestActionsList && !shouldWaitForTransactions ? (
-                                                <MoneyRequestReportActionsList
-                                                    report={report}
-                                                    hasPendingDeletionTransaction={hasPendingDeletionTransaction}
-                                                    policy={policy}
-                                                    reportActions={reportActions}
-                                                    transactions={visibleTransactions}
-                                                    newTransactions={newTransactions}
-                                                    hasOlderActions={hasOlderActions}
-                                                    hasNewerActions={hasNewerActions}
-                                                    showReportActionsLoadingState={showReportActionsLoadingState}
-                                                    reportPendingAction={reportPendingAction}
-                                                />
-                                            ) : null}
-                                            <ReportFooter />
-                                        </View>
-                                    </AgentZeroStatusProvider>
-                                </View>
-                                <PortalHost name="suggestions" />
-                            </DragAndDropProvider>
-                        </FullPageNotFoundView>
+                                            <View
+                                                style={[styles.flex1, styles.justifyContentEnd, styles.overflowHidden]}
+                                                testID="report-actions-view-wrapper"
+                                            >
+                                                {(!report || shouldWaitForTransactions) && <ReportActionsSkeletonView />}
+                                                {!!report && !shouldDisplayMoneyRequestActionsList && !shouldWaitForTransactions ? <ReportActionsView reportID={report.reportID} /> : null}
+                                                {!!report && shouldDisplayMoneyRequestActionsList && !shouldWaitForTransactions ? (
+                                                    <MoneyRequestReportActionsList
+                                                        report={report}
+                                                        hasPendingDeletionTransaction={hasPendingDeletionTransaction}
+                                                        policy={policy}
+                                                        reportActions={reportActions}
+                                                        transactions={visibleTransactions}
+                                                        newTransactions={newTransactions}
+                                                        hasOlderActions={hasOlderActions}
+                                                        hasNewerActions={hasNewerActions}
+                                                        showReportActionsLoadingState={showReportActionsLoadingState}
+                                                        reportPendingAction={reportPendingAction}
+                                                    />
+                                                ) : null}
+                                                <ReportFooter />
+                                            </View>
+                                        </AgentZeroStatusProvider>
+                                    </View>
+                                    <PortalHost name="suggestions" />
+                                </DragAndDropProvider>
+                            </LinkedActionNotFoundGuard>
+                        </ReportNotFoundGuard>
                     </ScreenWrapper>
                 </ReactionListWrapper>
             </ActionListContext.Provider>

--- a/src/pages/inbox/report/ReportFooter.tsx
+++ b/src/pages/inbox/report/ReportFooter.tsx
@@ -29,12 +29,12 @@ import {
 } from '@libs/ReportUtils';
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
+import {isLoadingInitialReportActionsSelector} from '@src/selectors/ReportMetaData';
 import type * as OnyxTypes from '@src/types/onyx';
 import ReportActionCompose from './ReportActionCompose/ReportActionCompose';
 import SystemChatReportFooterMessage from './SystemChatReportFooterMessage';
 
 const policyRoleSelector = (policy: OnyxEntry<OnyxTypes.Policy>) => policy?.role;
-const isLoadingInitialReportActionsSelector = (reportMetadata: OnyxEntry<OnyxTypes.ReportMetadata>) => reportMetadata?.isLoadingInitialReportActions;
 
 /**
  * Footer component that decides between the composer and

--- a/src/selectors/ReportAction.ts
+++ b/src/selectors/ReportAction.ts
@@ -48,4 +48,11 @@ function getReportActionsForReportIDs(allReportActions: OnyxCollection<ReportAct
     return filteredReportActions;
 }
 
-export {getParentReportActionSelector, getLastClosedReportAction, getReportActionsForReportIDs};
+function getReportActionByIDSelector(reportActions: OnyxEntry<ReportActions>, reportActionID?: string): OnyxEntry<ReportAction> {
+    if (!reportActions || !reportActionID) {
+        return;
+    }
+    return reportActions[reportActionID];
+}
+
+export {getParentReportActionSelector, getLastClosedReportAction, getReportActionsForReportIDs, getReportActionByIDSelector};

--- a/src/selectors/ReportMetaData.ts
+++ b/src/selectors/ReportMetaData.ts
@@ -5,7 +5,9 @@ const isActionLoadingSelector = (reportMetadata: OnyxEntry<ReportMetadata>) => r
 
 const hasOnceLoadedReportActionsSelector = (reportMetadata: OnyxEntry<ReportMetadata>) => reportMetadata?.hasOnceLoadedReportActions;
 
+const isLoadingInitialReportActionsSelector = (reportMetadata: OnyxEntry<ReportMetadata>) => reportMetadata?.isLoadingInitialReportActions;
+
 const pendingChatMembersSelector = (reportMetadata: OnyxEntry<ReportMetadata>): OnyxEntry<ReportMetadata> =>
     reportMetadata ? {pendingChatMembers: reportMetadata.pendingChatMembers} : undefined;
 
-export {isActionLoadingSelector, hasOnceLoadedReportActionsSelector, pendingChatMembersSelector};
+export {isActionLoadingSelector, hasOnceLoadedReportActionsSelector, isLoadingInitialReportActionsSelector, pendingChatMembersSelector};


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
<!-- Explain what your change does and how it addresses the linked issue -->

PR 6c in the [ReportScreen decomposition series](https://github.com/Expensify/App/issues/84895) (6a → 6b → **6c** → 6d).

Extracts two guard wrapper components from `ReportScreen.tsx` and simplifies them:

- **`ReportNotFoundGuard`** — report-level not-found logic, wraps children in `FullPageNotFoundView` when the report does not exist or is inaccessible. Uses shared `isLoadingInitialReportActionsSelector` instead of subscribing to the full `reportMetadata` object. Deduplicates route param extraction.

- **`LinkedActionNotFoundGuard`** — linked action not-found with a cheap outer gate (skips the heavy check when no `reportActionID` is in the route) and a heavy inner gate (verifies the linked action actually exists in the report). Simplified with:
  - **`key={reportActionIDFromRoute}`** on the inner gate — React-idiomatic remount per linked action, replacing the manual `firstRender` state + `lastReportActionIDFromRoute` tracking
  - **Removed `isLinkingToMessage`** state, its `InteractionManager` effect, and its render-time guard — vestigial since the outer gate already ensures the inner gate only mounts when `reportActionIDFromRoute` is truthy, and `!isLoadingInitialReportActions` already suppresses not-found during loading
  - **Removed `isNavigatingToDeletedAction`** state — replaced with `wasEverVisible`, a one-way flag set during render (React-supported pattern for adjusting state based on props)
  - **Removed `usePrevious`** — replaced by `wasEverVisible` which tracks the same semantic ("was the action ever loaded and visible during this mount?") without reading refs during render
  - **Replaced `usePaginatedReportActions`** (pagination, sorting, continuous-chain computation) with a direct `useOnyx` selector that looks up the linked action by ID — the guard only needs the action itself, not the full paginated view
  - **Replaced branch 2** (`sortedAllReportActions.length > 0 && reportActions.length === 0`) with a direct `!linkedAction` null check — the old check incorrectly showed "comment not found" for existing, visible actions when the filtered paginated window happened to be empty (a pagination artifact, not a linked-action-not-found concern)
  - **Added PERF-15 async cleanup** to the whisper effect

**UX differences from main:**
1. Not-found shows slightly faster after loading (no InteractionManager delay) — the action data arrives in the same Onyx batch as `isLoadingInitialReportActions: false`, so the delay was unnecessary
2. No longer shows "comment not found" for actions that exist in the collection but have an empty paginated/filtered view (pagination artifact fix)
3. Now correctly shows "comment not found" when the linked action genuinely doesn't exist in the collection (which main could miss if other actions made the filtered view non-empty)

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/84895
PROPOSAL:


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

**General regression — report loads normally**
1. Open the app and navigate to any existing report.
2. Verify the report loads and renders correctly with no console errors.
3. Send a message and verify it appears in the thread.

**Report not-found — invalid report ID**
1. In the browser address bar (or via deep link), navigate to a report URL with a non-existent report ID (e.g. `/r/000000000`).
2. Verify the "Not found" full-page view is shown.
3. Verify no crash or blank screen occurs.

**Report not-found — deleted/inaccessible report**
1. Have a second account create a private report that your account has no access to.
2. Navigate to that report URL directly.
3. Verify the "Not found" full-page view is shown.

**Linked action not-found — deleted comment**
1. Open a report that has a linked action in the URL (e.g. a deep link to a specific comment: `/r/<reportID>/<reportActionID>`).
2. Delete the comment from another session or device so the action no longer exists.
3. Reload the page with the original deep link URL still in the address bar.
4. Verify the "Not found" view for the linked action is shown (not a crash or blank screen).

**Linked action not-found — inaccessible whisper**
1. Open a report where a whisper was sent to a different user (one your account cannot see).
2. Construct a deep link URL pointing to that whisper's `reportActionID`.
3. Navigate to the URL.
4. Verify the "Not found" view for the linked action is shown.

**Linked action not-found — no `reportActionID` in route (cheap gate)**
1. Navigate to a report URL without any `reportActionID` query param.
2. Verify the report loads normally — the heavy linked-action check is skipped entirely, and no "Not found" view is shown.

**Offline behavior**
1. Open a report while online and confirm it loads.
2. Disconnect from the network.
3. Navigate away and back to the same report.
4. Verify the report still renders from cache with no "Not found" flicker or crash.
5. Reconnect and verify the report is still intact.

- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

N/A

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->

Same as tests

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>