### PR TITLE
Remove overridden search filter when clicking chart data point

### DIFF
--- a/src/components/Search/SearchChartView.tsx
+++ b/src/components/Search/SearchChartView.tsx
@@ -45,11 +45,11 @@ const CHART_VIEW_TO_COMPONENT: Record<ChartView, React.ComponentType<SearchChart
 function SearchChartView({queryJSON, view, groupBy, data, isLoading}: SearchChartViewProps) {
     const {preferredLocale} = useLocalize();
 
-    const {getLabel, getFilterQuery} = CHART_GROUP_BY_CONFIG[groupBy];
+    const {getLabel, getFilterQuery, filterKey} = CHART_GROUP_BY_CONFIG[groupBy];
     const ChartComponent = CHART_VIEW_TO_COMPONENT[view];
 
     const handleItemPress = (filterQuery: string) => {
-        const currentQueryString = buildSearchQueryString(queryJSON);
+        const currentQueryString = buildSearchQueryString({...queryJSON, flatFilters: queryJSON.flatFilters.filter((filter) => filter.key !== filterKey)});
         const newQueryJSON = buildSearchQueryJSON(`${currentQueryString} ${filterQuery}`);
 
         if (!newQueryJSON) {

--- a/src/components/Search/chartGroupByConfig.ts
+++ b/src/components/Search/chartGroupByConfig.ts
@@ -16,8 +16,8 @@ import type {GroupedItem, SearchFilterKey, SearchGroupBy} from './types';
 
 type ChartGroupByConfig = {
     titleIconName: 'Users' | 'CreditCard' | 'Send' | 'Folder' | 'Basket' | 'Tag' | 'Calendar';
-    filterKey: SearchFilterKey;
     getLabel: (item: GroupedItem) => string;
+    filterKey: SearchFilterKey;
     getFilterQuery: (item: GroupedItem) => string;
 };
 
@@ -28,45 +28,45 @@ type ChartGroupByConfig = {
 const CHART_GROUP_BY_CONFIG: Record<SearchGroupBy, ChartGroupByConfig> = {
     [CONST.SEARCH.GROUP_BY.FROM]: {
         titleIconName: 'Users',
-        filterKey: CONST.SEARCH.SYNTAX_FILTER_KEYS.FROM,
         getLabel: (item: GroupedItem) => (item as TransactionMemberGroupListItemType).formattedFrom ?? '',
+        filterKey: CONST.SEARCH.SYNTAX_FILTER_KEYS.FROM,
         getFilterQuery: (item: GroupedItem) => `from:${(item as TransactionMemberGroupListItemType).accountID}`,
     },
     [CONST.SEARCH.GROUP_BY.CARD]: {
         titleIconName: 'CreditCard',
-        filterKey: CONST.SEARCH.SYNTAX_FILTER_KEYS.CARD_ID,
         getLabel: (item: GroupedItem) => (item as TransactionCardGroupListItemType).formattedCardName ?? '',
+        filterKey: CONST.SEARCH.SYNTAX_FILTER_KEYS.CARD_ID,
         getFilterQuery: (item: GroupedItem) => `cardID:${(item as TransactionCardGroupListItemType).cardID}`,
     },
     [CONST.SEARCH.GROUP_BY.WITHDRAWAL_ID]: {
         titleIconName: 'Send',
-        filterKey: CONST.SEARCH.SYNTAX_FILTER_KEYS.WITHDRAWAL_ID,
         // eslint-disable-next-line rulesdir/no-default-id-values -- formattedWithdrawalID is a display label, not an Onyx ID
         getLabel: (item: GroupedItem) => (item as TransactionWithdrawalIDGroupListItemType).formattedWithdrawalID ?? '',
+        filterKey: CONST.SEARCH.SYNTAX_FILTER_KEYS.WITHDRAWAL_ID,
         getFilterQuery: (item: GroupedItem) => `withdrawalID:${(item as TransactionWithdrawalIDGroupListItemType).entryID}`,
     },
     [CONST.SEARCH.GROUP_BY.CATEGORY]: {
         titleIconName: 'Folder',
-        filterKey: CONST.SEARCH.SYNTAX_FILTER_KEYS.CATEGORY,
         getLabel: (item: GroupedItem) => (item as TransactionCategoryGroupListItemType).formattedCategory ?? '',
+        filterKey: CONST.SEARCH.SYNTAX_FILTER_KEYS.CATEGORY,
         getFilterQuery: (item: GroupedItem) => `category:"${(item as TransactionCategoryGroupListItemType).category}"`,
     },
     [CONST.SEARCH.GROUP_BY.MERCHANT]: {
         titleIconName: 'Basket',
-        filterKey: CONST.SEARCH.SYNTAX_FILTER_KEYS.MERCHANT,
         getLabel: (item: GroupedItem) => (item as TransactionMerchantGroupListItemType).formattedMerchant ?? '',
+        filterKey: CONST.SEARCH.SYNTAX_FILTER_KEYS.MERCHANT,
         getFilterQuery: (item: GroupedItem) => `merchant:"${(item as TransactionMerchantGroupListItemType).merchant}"`,
     },
     [CONST.SEARCH.GROUP_BY.TAG]: {
         titleIconName: 'Tag',
-        filterKey: CONST.SEARCH.SYNTAX_FILTER_KEYS.TAG,
         getLabel: (item: GroupedItem) => (item as TransactionTagGroupListItemType).formattedTag ?? '',
+        filterKey: CONST.SEARCH.SYNTAX_FILTER_KEYS.TAG,
         getFilterQuery: (item: GroupedItem) => `tag:"${(item as TransactionTagGroupListItemType).tag}"`,
     },
     [CONST.SEARCH.GROUP_BY.MONTH]: {
         titleIconName: 'Calendar',
-        filterKey: CONST.SEARCH.SYNTAX_FILTER_KEYS.DATE,
         getLabel: (item: GroupedItem) => (item as TransactionMonthGroupListItemType).formattedMonth ?? '',
+        filterKey: CONST.SEARCH.SYNTAX_FILTER_KEYS.DATE,
         getFilterQuery: (item: GroupedItem) => {
             const monthItem = item as TransactionMonthGroupListItemType;
             const {start, end} = DateUtils.getMonthDateRange(monthItem.year, monthItem.month);
@@ -75,8 +75,8 @@ const CHART_GROUP_BY_CONFIG: Record<SearchGroupBy, ChartGroupByConfig> = {
     },
     [CONST.SEARCH.GROUP_BY.WEEK]: {
         titleIconName: 'Calendar',
-        filterKey: CONST.SEARCH.SYNTAX_FILTER_KEYS.DATE,
         getLabel: (item: GroupedItem) => (item as TransactionWeekGroupListItemType).formattedWeek ?? '',
+        filterKey: CONST.SEARCH.SYNTAX_FILTER_KEYS.DATE,
         getFilterQuery: (item: GroupedItem) => {
             const weekItem = item as TransactionWeekGroupListItemType;
             const {start, end} = DateUtils.getWeekDateRange(weekItem.week);

--- a/src/components/Search/chartGroupByConfig.ts
+++ b/src/components/Search/chartGroupByConfig.ts
@@ -17,7 +17,11 @@ import type {GroupedItem, SearchFilterKey, SearchGroupBy} from './types';
 type ChartGroupByConfig = {
     titleIconName: 'Users' | 'CreditCard' | 'Send' | 'Folder' | 'Basket' | 'Tag' | 'Calendar';
     getLabel: (item: GroupedItem) => string;
+
+    /** The search filter key used to detect conflicting filters when a chart data point is clicked. */
     filterKey: SearchFilterKey;
+
+    /** Builds the query string fragment appended to the main query when a chart data point is clicked. */
     getFilterQuery: (item: GroupedItem) => string;
 };
 

--- a/src/components/Search/chartGroupByConfig.ts
+++ b/src/components/Search/chartGroupByConfig.ts
@@ -12,10 +12,11 @@ import type {
     TransactionWithdrawalIDGroupListItemType,
     TransactionYearGroupListItemType,
 } from './SearchList/ListItem/types';
-import type {GroupedItem, SearchGroupBy} from './types';
+import type {GroupedItem, SearchFilterKey, SearchGroupBy} from './types';
 
 type ChartGroupByConfig = {
     titleIconName: 'Users' | 'CreditCard' | 'Send' | 'Folder' | 'Basket' | 'Tag' | 'Calendar';
+    filterKey: SearchFilterKey;
     getLabel: (item: GroupedItem) => string;
     getFilterQuery: (item: GroupedItem) => string;
 };
@@ -27,37 +28,44 @@ type ChartGroupByConfig = {
 const CHART_GROUP_BY_CONFIG: Record<SearchGroupBy, ChartGroupByConfig> = {
     [CONST.SEARCH.GROUP_BY.FROM]: {
         titleIconName: 'Users',
+        filterKey: CONST.SEARCH.SYNTAX_FILTER_KEYS.FROM,
         getLabel: (item: GroupedItem) => (item as TransactionMemberGroupListItemType).formattedFrom ?? '',
         getFilterQuery: (item: GroupedItem) => `from:${(item as TransactionMemberGroupListItemType).accountID}`,
     },
     [CONST.SEARCH.GROUP_BY.CARD]: {
         titleIconName: 'CreditCard',
+        filterKey: CONST.SEARCH.SYNTAX_FILTER_KEYS.CARD_ID,
         getLabel: (item: GroupedItem) => (item as TransactionCardGroupListItemType).formattedCardName ?? '',
         getFilterQuery: (item: GroupedItem) => `cardID:${(item as TransactionCardGroupListItemType).cardID}`,
     },
     [CONST.SEARCH.GROUP_BY.WITHDRAWAL_ID]: {
         titleIconName: 'Send',
+        filterKey: CONST.SEARCH.SYNTAX_FILTER_KEYS.WITHDRAWAL_ID,
         // eslint-disable-next-line rulesdir/no-default-id-values -- formattedWithdrawalID is a display label, not an Onyx ID
         getLabel: (item: GroupedItem) => (item as TransactionWithdrawalIDGroupListItemType).formattedWithdrawalID ?? '',
         getFilterQuery: (item: GroupedItem) => `withdrawalID:${(item as TransactionWithdrawalIDGroupListItemType).entryID}`,
     },
     [CONST.SEARCH.GROUP_BY.CATEGORY]: {
         titleIconName: 'Folder',
+        filterKey: CONST.SEARCH.SYNTAX_FILTER_KEYS.CATEGORY,
         getLabel: (item: GroupedItem) => (item as TransactionCategoryGroupListItemType).formattedCategory ?? '',
         getFilterQuery: (item: GroupedItem) => `category:"${(item as TransactionCategoryGroupListItemType).category}"`,
     },
     [CONST.SEARCH.GROUP_BY.MERCHANT]: {
         titleIconName: 'Basket',
+        filterKey: CONST.SEARCH.SYNTAX_FILTER_KEYS.MERCHANT,
         getLabel: (item: GroupedItem) => (item as TransactionMerchantGroupListItemType).formattedMerchant ?? '',
         getFilterQuery: (item: GroupedItem) => `merchant:"${(item as TransactionMerchantGroupListItemType).merchant}"`,
     },
     [CONST.SEARCH.GROUP_BY.TAG]: {
         titleIconName: 'Tag',
+        filterKey: CONST.SEARCH.SYNTAX_FILTER_KEYS.TAG,
         getLabel: (item: GroupedItem) => (item as TransactionTagGroupListItemType).formattedTag ?? '',
         getFilterQuery: (item: GroupedItem) => `tag:"${(item as TransactionTagGroupListItemType).tag}"`,
     },
     [CONST.SEARCH.GROUP_BY.MONTH]: {
         titleIconName: 'Calendar',
+        filterKey: CONST.SEARCH.SYNTAX_FILTER_KEYS.DATE,
         getLabel: (item: GroupedItem) => (item as TransactionMonthGroupListItemType).formattedMonth ?? '',
         getFilterQuery: (item: GroupedItem) => {
             const monthItem = item as TransactionMonthGroupListItemType;
@@ -67,6 +75,7 @@ const CHART_GROUP_BY_CONFIG: Record<SearchGroupBy, ChartGroupByConfig> = {
     },
     [CONST.SEARCH.GROUP_BY.WEEK]: {
         titleIconName: 'Calendar',
+        filterKey: CONST.SEARCH.SYNTAX_FILTER_KEYS.DATE,
         getLabel: (item: GroupedItem) => (item as TransactionWeekGroupListItemType).formattedWeek ?? '',
         getFilterQuery: (item: GroupedItem) => {
             const weekItem = item as TransactionWeekGroupListItemType;
@@ -77,6 +86,7 @@ const CHART_GROUP_BY_CONFIG: Record<SearchGroupBy, ChartGroupByConfig> = {
     [CONST.SEARCH.GROUP_BY.YEAR]: {
         titleIconName: 'Calendar',
         getLabel: (item: GroupedItem) => (item as TransactionYearGroupListItemType).formattedYear ?? '',
+        filterKey: CONST.SEARCH.SYNTAX_FILTER_KEYS.DATE,
         getFilterQuery: (item: GroupedItem) => {
             const yearItem = item as TransactionYearGroupListItemType;
             const {start, end} = DateUtils.getYearDateRange(yearItem.year);
@@ -86,6 +96,7 @@ const CHART_GROUP_BY_CONFIG: Record<SearchGroupBy, ChartGroupByConfig> = {
     [CONST.SEARCH.GROUP_BY.QUARTER]: {
         titleIconName: 'Calendar',
         getLabel: (item: GroupedItem) => (item as TransactionQuarterGroupListItemType).formattedQuarter ?? '',
+        filterKey: CONST.SEARCH.SYNTAX_FILTER_KEYS.DATE,
         getFilterQuery: (item: GroupedItem) => {
             const quarterItem = item as TransactionQuarterGroupListItemType;
             const {start, end} = DateUtils.getQuarterDateRange(quarterItem.year, quarterItem.quarter);


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
<!-- Explain what your change does and how it addresses the linked issue -->

When clicking on a chart data point, we now first remove the filter key that is being overridden from the query we navigate to, so there are no conflicting options in the query. For example when clicking on March on the Spend Over Time line chart instead of `date:last-12-months date>=2026-03-01 date<=2026-03-31` it should be just `date>=2026-03-01 date<=2026-03-31`.

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/86452
PROPOSAL: N/A

<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

1. Open the Spend Over Time chart (on Home page or in Reports tab, visible to workspace admins/auditors/approvers only).
2. Click on a point.
3. Check if the search we navigate to has only data>= and date<= options in the query, no date:last-12-months (in the url, web only). Also "Last 12 months" in the Date filter dropdown button/advanced filters should not be selected (all platforms).

also:
1. Open the Reports tab
2. Search for:`date:last-12-months group-by:year view:pie`
3. Click on a slice.
4. Verify there is no `date:last-12-months` in the query, but `date>=... date<=...` instead.

also:
1. Open the Reports tab
2. Search for: `category:<some category> group-by:category view:bar`.
3. Click on a bar in the chart.
4. Verify there is only one category filter in the query.

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

N/A

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
5. Upload an image via copy paste
6. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->

Same as tests.

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

https://github.com/user-attachments/assets/df3d3a70-4159-4f96-8d98-699b8f6bd0cd

</details>

<details>
<summary>Android: mWeb Chrome</summary>

https://github.com/user-attachments/assets/a5af02f0-04c3-4fee-a006-c6e68451b8d9

</details>

<details>
<summary>iOS: Native</summary>

https://github.com/user-attachments/assets/2fc53734-6557-480f-9627-717619c54505

</details>

<details>
<summary>iOS: mWeb Safari</summary>

https://github.com/user-attachments/assets/4ec5a89b-618a-4e40-99fb-abb13aab13b6

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

https://github.com/user-attachments/assets/c6ab4aca-0d05-4aef-b755-bb78ea63caab

</details>