### PR TITLE
fix: prevent document title flicker during navigation (#86679)

### DIFF
--- a/src/libs/UnreadIndicatorUpdater/updateUnread/index.ts
+++ b/src/libs/UnreadIndicatorUpdater/updateUnread/index.ts
@@ -25,13 +25,14 @@ function updateDocumentTitle() {
     // This setTimeout is required because due to how react rendering messes with the DOM, the document title can't be modified synchronously, and we must wait until all JS is done
     // running before setting the title.
     setTimeout(() => {
-        // There is a Chrome browser bug that causes the title to revert back to the previous when we are navigating back. Setting the title to an empty string
-        // seems to improve this issue.
-        document.title = '';
-
         // Use page-specific title if available, otherwise use the default SITE_TITLE
         const baseTitle = currentPageTitle || CONFIG.SITE_TITLE;
-        document.title = hasUnread ? `(${unreadTotalCount}) ${baseTitle}` : baseTitle;
+        const newTitle = hasUnread ? `(${unreadTotalCount}) ${baseTitle}` : baseTitle;
+
+        // Only update if the title actually changed to avoid flicker during navigation
+        if (document.title !== newTitle) {
+            document.title = newTitle;
+        }
 
         const favicon = document.getElementById('favicon');
         if (favicon instanceof HTMLLinkElement) {
@@ -49,6 +50,9 @@ const updateUnread: UpdateUnread = (totalCount) => {
 };
 
 window.addEventListener('popstate', () => {
+    // Workaround for Chrome bug: briefly clear title on back navigation
+    // so the browser doesn't show the stale title from history
+    document.title = '';
     updateUnread(unreadTotalCount);
 });
 


### PR DESCRIPTION
## Problem
During navigation, `updateDocumentTitle()` was setting `document.title = ""` before every title update as a Chrome back-navigation workaround. This caused visible flicker when navigating between pages because multiple triggers would each blank the title briefly.

## Fix
1. Remove the blanket `document.title = ""` from `updateDocumentTitle()`
2. Add a check: only update `document.title` when the new title actually differs
3. Keep the Chrome back-navigation workaround only for `popstate` events where it's actually needed

$ #86679