### PR TITLE
fix: debounce updateDocumentTitle to eliminate browser tab title flicker

### DIFF
--- a/src/libs/UnreadIndicatorUpdater/updateUnread/index.ts
+++ b/src/libs/UnreadIndicatorUpdater/updateUnread/index.ts
@@ -6,6 +6,7 @@ import type UpdateUnread from './types';
 
 let unreadTotalCount = 0;
 let currentPageTitle = '';
+let pendingTitleUpdate: ReturnType<typeof setTimeout> | null = null;
 
 /**
  * Set the current page-specific title (called by useDocumentTitle hook)
@@ -18,13 +19,25 @@ function setPageTitle(title: string) {
 }
 
 /**
- * Update the actual document title and favicon
+ * Update the actual document title and favicon.
+ *
+ * Debounced so that only the last call in a burst (popstate + navigation
+ * state listener + useFocusEffect) actually runs.  This prevents the
+ * visible blank-title flash that occurred when multiple calls each
+ * executed `document.title = ''` followed by the real title in separate
+ * setTimeout(0) callbacks.
  */
 function updateDocumentTitle() {
-    const hasUnread = unreadTotalCount !== 0;
+    if (pendingTitleUpdate !== null) {
+        clearTimeout(pendingTitleUpdate);
+    }
+
     // This setTimeout is required because due to how react rendering messes with the DOM, the document title can't be modified synchronously, and we must wait until all JS is done
     // running before setting the title.
-    setTimeout(() => {
+    pendingTitleUpdate = setTimeout(() => {
+        pendingTitleUpdate = null;
+        const hasUnread = unreadTotalCount !== 0;
+
         // There is a Chrome browser bug that causes the title to revert back to the previous when we are navigating back. Setting the title to an empty string
         // seems to improve this issue.
         document.title = '';


### PR DESCRIPTION
## Root Cause

`updateDocumentTitle()` schedules a `setTimeout(0)` each time it is called. During a single navigation, multiple callers fire in quick succession — the `popstate` listener, the debounced navigation-state listener, and `useFocusEffect` via `setPageTitle`. Each one queues its own callback, and each callback sets `document.title = ''` before setting the real title. The browser can paint a frame with the empty title between these callbacks, producing the visible flicker.

## Fix

Add a `pendingTitleUpdate` ref that cancels the previous `setTimeout` before scheduling a new one. Only the last call in any burst executes — so `document.title = ''` runs exactly once per navigation, immediately followed by the real title. The Chrome back-navigation workaround is preserved.

## Test

1. Open the app in Chrome.
2. Open an expense report via Search.
3. Click another page (e.g. Inbox).
4. Observe the browser tab title — no blank flash.

Before this fix the title briefly showed blank or "New Expensify" during step 3.

## Platforms
- [x] Windows: Chrome

$ #86679
