### PR TITLE
[50] Fix crash when attendee has undefined email in getPersonalDetailByEmail

### DIFF
--- a/src/libs/PersonalDetailsUtils.ts
+++ b/src/libs/PersonalDetailsUtils.ts
@@ -141,6 +141,9 @@ function getPersonalDetailsByIDs({
 }
 
 function getPersonalDetailByEmail(email: string): PersonalDetails | undefined {
+    if (!email) {
+        return undefined;
+    }
     return emailToPersonalDetailsCache[email.toLowerCase()];
 }
 


### PR DESCRIPTION
## Details

$ #86781

## Root Cause
`getPersonalDetailByEmail` calls `email.toLowerCase()` without guarding against `undefined`. When legacy data (e.g., from OldDot where only `displayName` was required) has attendees with no `email` key, the app crashes with `TypeError: Cannot read properties of undefined (reading 'toLowerCase')`.

## Fix
Added a defensive null/undefined check at the top of `getPersonalDetailByEmail`:

```typescript
function getPersonalDetailByEmail(email: string): PersonalDetails | undefined {
    if (!email) {
        return undefined;
    }
    return emailToPersonalDetailsCache[email.toLowerCase()];
}
```

This single guard protects all 50+ callers across the codebase, including the vulnerable attendee-related call sites in:
- `useReportPreviewSenderID.ts:72-77`
- `MoneyRequestAttendeeSelector.tsx:91`
- `OptionsListUtils/index.ts:2864`

## Tests
- [x] Verify existing tests pass
- [x] Verify no TypeScript errors