### PR TITLE
[$250] Fix crash when attendee has undefined email in getPersonalDetailByEmail

### DIFF
--- a/src/libs/PersonalDetailsUtils.ts
+++ b/src/libs/PersonalDetailsUtils.ts
@@ -141,6 +141,9 @@ function getPersonalDetailsByIDs({
 }
 
 function getPersonalDetailByEmail(email: string): PersonalDetails | undefined {
+    if (!email) {
+        return undefined;
+    }
     return emailToPersonalDetailsCache[email.toLowerCase()];
 }
 


### PR DESCRIPTION
## Details

Fixes the crash described in #86781.

### Problem
When a transaction attendee has `email: undefined` (e.g., legacy data from OldDot where only `displayName` was required), calling `getPersonalDetailByEmail(att.email)` throws a `TypeError: Cannot read properties of undefined (reading 'toLowerCase')`, causing the app to crash.

### Root Cause
`getPersonalDetailByEmail()` in `src/libs/PersonalDetailsUtils.ts:143` calls `email.toLowerCase()` without guarding against `undefined` or `null`.

### Fix
Added a guard clause at the top of `getPersonalDetailByEmail` that returns `undefined` early when `email` is falsy. This is a defensive fix at the source function level that protects all callers simultaneously.

```typescript
function getPersonalDetailByEmail(email: string): PersonalDetails | undefined {
    if (!email) {
        return undefined;
    }
    return emailToPersonalDetailsCache[email.toLowerCase()];
}
```

### Why this approach
- Fixes the crash at the source rather than patching individual callers
- All callers already use optional chaining (`?.`) so they handle `undefined` gracefully
- Minimal change with no side effects
- Handles both `undefined` and empty string cases

## Related Issues
Expensify/Expensify#618370