### PR TITLE
[$250] Fix crash when attendee has undefined email in getPersonalDetailByEmail

### DIFF
--- a/src/libs/PersonalDetailsUtils.ts
+++ b/src/libs/PersonalDetailsUtils.ts
@@ -141,6 +141,9 @@ function getPersonalDetailsByIDs({
 }
 
 function getPersonalDetailByEmail(email: string): PersonalDetails | undefined {
+    if (!email) {
+        return undefined;
+    }
     return emailToPersonalDetailsCache[email.toLowerCase()];
 }
 


### PR DESCRIPTION
## Details

Fixes the crash described in #86781.

### Problem
When a transaction attendee has `email: undefined` (e.g., legacy data from OldDot where only `displayName` was required), calling `getPersonalDetailByEmail(att.email)` throws a `TypeError: Cannot read properties of undefined (reading 'toLowerCase')`.

### Root Cause
The `getPersonalDetailByEmail` function in `src/libs/PersonalDetailsUtils.ts` calls `email.toLowerCase()` directly without defending against undefined/null input. While the TS type says `string`, runtime data from Onyx can include undefined values from OldDot.

### Solution
Add a simple null/undefined guard at the top of the function:
```typescript
if (!email) {
    return undefined;
}
```

### Why this approach?
- Minimal code change (3 lines) — low merge risk
- Defensive at the source — protects all 50+ callers
- No behavior change for valid inputs
- Returns `undefined` (same as when email not found in cache)

### Tests
- [x] Verified no new console errors
- [x] No regressions for valid email inputs
- [x] Handles undefined/null email gracefully without crash

### Offline tests
N/A — pure function change

### QA Steps
1. Create a transaction with an attendee whose email is undefined
2. Verify the app does not crash when rendering the report preview
3. Verify the attendee is simply omitted from the personal details lookup