### PR TITLE
Fix: Show pending indicator for bulk-edited transactions in search list

### DIFF
--- a/src/components/Search/SearchList/ListItem/TransactionListItem.tsx
+++ b/src/components/Search/SearchList/ListItem/TransactionListItem.tsx
@@ -92,6 +92,12 @@ function TransactionListItem<TItem extends ListItem>({
         transactionItem,
     ]);
     const currentUserDetails = useCurrentUserPersonalDetails();
+
+    // When bulk-editing transactions, `pendingFields` are set optimistically on the live Onyx
+    // transaction object. The search list items rely on snapshot data, so they would not see
+    // these pending edits without this live-Onyx fallback.
+    const hasPendingTransaction = !!transaction?.pendingFields && Object.keys(transaction.pendingFields).length > 0;
+
     const transactionPreviewData: TransactionPreviewData = {
         hasParentReport: !!parentReport,
         hasTransaction: !!transaction,
@@ -177,7 +183,9 @@ function TransactionListItem<TItem extends ListItem>({
     useSyncFocus(pressableRef, !!isFocused, shouldSyncFocus);
 
     return (
-        <OfflineWithFeedback pendingAction={item.pendingAction}>
+        <OfflineWithFeedback
+            pendingAction={item.pendingAction ?? (hasPendingTransaction ? CONST.RED_BRICK_ROAD_PENDING_ACTION.UPDATE : undefined)}
+        >
             <PressableWithFeedback
                 ref={pressableRef}
                 onLongPress={() => onLongPressRow?.(item)}


### PR DESCRIPTION
## Fixed Issue
#86841

## Details
When bulk-editing multiple expenses, `pendingFields` are set optimistically on the live Onyx transaction object via \`updateMultipleMoneyRequests\`. However, the Search list items rely on snapshot data from the search results, which does not include these optimistic updates.

As a result, expenses that were just edited via bulk edit show no pending indicator, even though the optimistic update is in progress.

## Solution
The \`TransactionListItem\` component already fetches live Onyx transaction data via \`originalUseOnyx\`. This change reads the \`pendingFields\` from the live transaction and applies a \`RED_BRICK_ROAD_PENDING_ACTION.UPDATE\` to the \`OfflineWithFeedback\` wrapper, so bulk-edited transactions immediately show the pending indicator.

## Tests
1. Navigate to Search
2. Select 2+ expenses
3. Bulk edit merchant or other fields
4. Verify the edited expenses show a pending indicator (offline feedback styling)
5. Verify the indicator clears once the server response arrives