### PR TITLE
fix: prevent Concierge redirect and LHN disappearance when vacation delegate splits expense

### DIFF
--- a/src/hooks/useIsOwnWorkspaceChatRef.ts
+++ b/src/hooks/useIsOwnWorkspaceChatRef.ts
@@ -1,0 +1,30 @@
+import {useRef} from 'react';
+import type {OnyxEntry} from 'react-native-onyx';
+import type * as OnyxTypes from '@src/types/onyx';
+
+/**
+ * Returns a ref that tracks whether the currently-open report is an own workspace chat.
+ *
+ * Must be updated synchronously during render — after a vacation delegate splits an expense
+ * the server sends an Onyx SET that wipes the report object. By the time any useEffect fires,
+ * `report` is already undefined, so live state and usePrevious both fail. The ref persists
+ * the last known value through that wipe window so navigation guards and re-fetch effects
+ * can still make the correct decision. See issue #84248.
+ */
+function useIsOwnWorkspaceChatRef(report: OnyxEntry<OnyxTypes.Report> | undefined, reportIDFromRoute: string | undefined) {
+    const isOwnWorkspaceChatRef = useRef(false);
+
+    if (report?.reportID && report.reportID === reportIDFromRoute) {
+        // Valid, matching report — update the ref.
+        isOwnWorkspaceChatRef.current = !!report.isOwnPolicyExpenseChat;
+    } else if (!report?.reportID) {
+        // Report wiped by Onyx SET — intentionally keep the last known value.
+    } else {
+        // Different report loaded — reset.
+        isOwnWorkspaceChatRef.current = false;
+    }
+
+    return isOwnWorkspaceChatRef;
+}
+
+export default useIsOwnWorkspaceChatRef;

--- a/src/pages/inbox/ReportFetchHandler.tsx
+++ b/src/pages/inbox/ReportFetchHandler.tsx
@@ -4,6 +4,7 @@ import {InteractionManager} from 'react-native';
 import useCurrentUserPersonalDetails from '@hooks/useCurrentUserPersonalDetails';
 import useIsAnonymousUser from '@hooks/useIsAnonymousUser';
 import useIsInSidePanel from '@hooks/useIsInSidePanel';
+import useIsOwnWorkspaceChatRef from '@hooks/useIsOwnWorkspaceChatRef';
 import useNetwork from '@hooks/useNetwork';
 import useOnyx from '@hooks/useOnyx';
 import usePaginatedReportActions from '@hooks/usePaginatedReportActions';
@@ -91,6 +92,9 @@ function ReportFetchHandler() {
 
     const isTransactionThreadView = isReportTransactionThread(report);
 
+    // Track whether the current route is an own workspace chat. See issue #84248.
+    const isCurrentRouteOwnWorkspaceChatRef = useIsOwnWorkspaceChatRef(report, reportIDFromRoute);
+
     const indexOfLinkedMessage = reportActionIDFromRoute ? reportActions.findIndex((obj) => String(obj.reportActionID) === String(reportActionIDFromRoute)) : -1;
     const doesCreatedActionExists = !!reportActions?.findLast((action) => isCreatedAction(action));
     const isLinkedMessageAvailable = indexOfLinkedMessage > -1;
@@ -150,6 +154,21 @@ function ReportFetchHandler() {
     });
 
     // Effect order below matches the original declaration order in ReportScreen.tsx.
+
+    // When a delegate splits an expense the server sends a temporary Onyx SET that wipes the
+    // workspace chat. The navigation guards in ReportScreen block any redirect, but the report
+    // stays blank until something re-fetches it. This effect detects the wipe and re-fetches.
+    // See issue #84248.
+    const prevReportID = usePrevious(report?.reportID);
+    useEffect(() => {
+        const wasJustWiped = !!prevReportID && prevReportID === reportIDFromRoute && !report?.reportID;
+        if (!wasJustWiped || !isCurrentRouteOwnWorkspaceChatRef.current) {
+            return;
+        }
+        fetchReport();
+        // fetchReport is a stable useEffectEvent callback and does not need to be listed as a dependency.
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [report?.reportID, prevReportID, reportIDFromRoute]);
 
     useEffect(() => {
         if (!transactionThreadReportID || !route?.params?.reportActionID || !isOneTransactionThread(childReport, report, linkedAction)) {

--- a/src/pages/inbox/ReportNavigateAwayHandler.tsx
+++ b/src/pages/inbox/ReportNavigateAwayHandler.tsx
@@ -3,6 +3,7 @@ import {useEffect, useEffectEvent, useRef} from 'react';
 import type {OnyxEntry} from 'react-native-onyx';
 import {useCurrentReportIDState} from '@hooks/useCurrentReportID';
 import useCurrentUserPersonalDetails from '@hooks/useCurrentUserPersonalDetails';
+import useIsOwnWorkspaceChatRef from '@hooks/useIsOwnWorkspaceChatRef';
 import useOnyx from '@hooks/useOnyx';
 import useParentReportAction from '@hooks/useParentReportAction';
 import usePrevious from '@hooks/usePrevious';
@@ -81,6 +82,11 @@ function ReportNavigateAwayHandler() {
     const isOptimisticDelete = report?.statusNum === CONST.REPORT.STATUS_NUM.CLOSED;
     const {wasDeleted: reportWasDeleted, parentReportID: deletedReportParentID} = useReportWasDeleted(reportIDFromRoute, report, isOptimisticDelete, userLeavingStatus);
 
+    // Track whether the current route is an own workspace chat. A vacation delegate split sends
+    // a temporary Onyx SET that wipes the report; by the time effects fire, report is undefined
+    // so we must persist the value in a ref updated synchronously during render. See issue #84248.
+    const isCurrentRouteOwnWorkspaceChatRef = useIsOwnWorkspaceChatRef(report, reportIDFromRoute);
+
     const firstRender = useRef(true);
 
     // Navigation action that reads non-reactive context (concierge params, modal state, etc.)
@@ -138,7 +144,10 @@ function ReportNavigateAwayHandler() {
             isEmpty(report) &&
             (isMoneyRequest(prevReport) ||
                 isMoneyRequestReport(prevReport) ||
-                isPolicyExpenseChat(prevReport) ||
+                // Own workspace chats are excluded: a vacation delegate split sends a temporary
+                // Onyx SET that wipes the report — the chat was never intentionally removed.
+                // See issue #84248.
+                (isPolicyExpenseChat(prevReport) && !prevReport?.isOwnPolicyExpenseChat) ||
                 isGroupChat(prevReport) ||
                 isAdminRoom(prevReport) ||
                 isAnnounceRoom(prevReport));
@@ -191,6 +200,17 @@ function ReportNavigateAwayHandler() {
 
         // Only redirect if focused
         if (!isFocused) {
+            return;
+        }
+
+        // For own workspace chats, a vacation delegate split sends a temporary Onyx SET that
+        // silently wipes the report from Onyx — triggering this effect. We skip navigation here
+        // entirely: the re-fetch effect in ReportFetchHandler restores the data, which causes
+        // useReportWasDeleted to reset wasDeleted → false, and this effect exits early on the
+        // next run. Genuine workspace deletions (e.g. user removed, workspace closed) always
+        // trigger the "navigate on removal" effect above via userLeavingStatus / didReportClose,
+        // never via this path alone. See issue #84248.
+        if (isCurrentRouteOwnWorkspaceChatRef.current) {
             return;
         }
 


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change

When a vacation delegate (Account C) splits a submitted expense, the server sends an Onyx `SET` update that temporarily wipes the workspace chat report on the submitter's (Account D) client. This triggered two navigation effects in `ReportScreen.tsx` before the data recovered:

- **Effect 1** (`isRemovalExpectedForReportType`) incorrectly flagged the workspace chat as removed and initiated navigation away
- **Effect 2** (`reportWasDeleted` effect) navigated to Concierge, and caused an infinite loop if the screen remained in the navigation stack (pressing Back re-triggered the effect)

On mobile (narrow layout), the LHN didn't recover because `useSidebarOrderedReports` skips force-inclusion of the focused report on narrow layouts. On web (wide layout), the sidebar force-includes it so it reappeared after ~2 seconds.

**Three targeted fixes across three files:**

`ReportScreen.tsx`
- Added `isCurrentRouteOwnWorkspaceChatRef` — a `useRef` set synchronously during render that survives the Onyx wipe window (by the time navigation effects fire, `prevReport` is already `undefined` so `usePrevious` cannot be used)
- **Effect 1 guard**: changed `isPolicyExpenseChat(prevReport)` → `(isPolicyExpenseChat(prevReport) && !prevReport?.isOwnPolicyExpenseChat)` to exclude own workspace chats from triggering the Concierge redirect
- **Effect 2 guard**: added early return using the ref to block navigation for own workspace chats; added `Navigation.dismissModal()` + `Navigation.popToSidebar()` stack cleanup before genuine Concierge redirects to prevent the infinite loop

`ReportFetchHandler.tsx`
- Same `isCurrentRouteOwnWorkspaceChatRef` ref pattern to survive the Onyx wipe window
- New `useEffect` that detects the wipe (`prevReportID === reportIDFromRoute && !report?.reportID`) and calls `fetchReport()` to restore data — without this, the screen stays as a blank loading skeleton after the wipe

`useSidebarOrderedReports.tsx`
- Added `isCurrentReportOwnWorkspaceChatRef` ref with synchronous render update
- Added `|| isCurrentReportOwnWorkspaceChatRef.current` to the narrow-layout force-inclusion condition so the workspace chat stays visible in the LHN on mobile during the wipe window

**Known limitation**: A ~2 second visual flicker on web LHN still occurs as an artifact of the Onyx `SET` timing. A full fix requires the server to switch from `SET` to `MERGE` for this update (backend change outside scope of this PR).

### Fixed Issues
$ https://github.com/Expensify/App/issues/84248
PROPOSAL: https://github.com/Expensify/App/issues/84248#issuecomment-4107204858

### Tests

**Preconditions — set up 4 accounts:**
1. As workspace owner: invite Account B (Approver), Account C (Vacation delegate), Account D (Submitter). Set Account B as approver in Workflows.
2. As Account B: set Account C as Vacation delegate in Profile → Status.

**Test steps:**
1. Sign in as Account D. Navigate to the workspace chat.
2. Create an expense in the workspace chat and tap Submit. Stay in the workspace chat.
3. On a second device, sign in as Account C. Open the submitted expense.
4. As Account C: tap More → Split, split the expense into two equal parts.
5. On Account D's device verify:
   - Account D is **not** navigated away to Concierge chat
   - The workspace chat remains visible in the LHN on mobile
   - The workspace chat content loads correctly (no blank loading skeleton)
   - No infinite navigation loop when pressing Back
6. Delete a different report and verify genuine deletions **still** navigate to Concierge correctly (regression check)
- [x] Verify that no errors appear in the JS console

### Offline tests
1. Follow preconditions above.
2. On Account D's device, disable network after submitting the expense (step 2).
3. Re-enable network and have Account C perform the split.
4. Verify the workspace chat remains visible in the LHN after reconnecting.
- [x] Verify that no errors appear in the JS console

### QA Steps

Same as Tests section above.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

https://github.com/user-attachments/assets/c93c62f5-be1c-42ab-882f-c731de47d42d

</details>

<details>
<summary>Android: mWeb Chrome</summary>

https://github.com/user-attachments/assets/738000f1-6611-44db-806c-a15f3ce567ae

</details>

<details>
<summary>iOS: Native</summary>

https://github.com/user-attachments/assets/f7cd6206-e0d0-4c9a-9c28-200756d9360d

</details>

<details>
<summary>iOS: mWeb Safari</summary>

https://github.com/user-attachments/assets/4c515643-3327-401a-a5c1-cfdb02f0180c

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

https://github.com/user-attachments/assets/05632dc4-aecc-4f5b-8606-ca39e5c21ffb 

</details>