### PR TITLE
[50] Fix crash when attendee has undefined email in getPersonalDetailByEmail

### DIFF
--- a/src/libs/PersonalDetailsUtils.ts
+++ b/src/libs/PersonalDetailsUtils.ts
@@ -141,6 +141,9 @@ function getPersonalDetailsByIDs({
 }
 
 function getPersonalDetailByEmail(email: string): PersonalDetails | undefined {
+    if (!email) {
+        return undefined;
+    }
     return emailToPersonalDetailsCache[email.toLowerCase()];
 }
 


### PR DESCRIPTION
## Description

This PR fixes a crash that occurs when an attendee's email is `undefined`, causing `getPersonalDetailByEmail` to fail on `email.toLowerCase()`.

## Problem

When an attendee has an `undefined` email value, calling `email.toLowerCase()` in `getPersonalDetailByEmail` throws an error, resulting in the "Uh-oh, something went wrong!" error page.

## Solution

Added a null/empty guard at the beginning of `getPersonalDetailByEmail` to return `undefined` early if the email parameter is falsy.

```typescript
function getPersonalDetailByEmail(email: string): PersonalDetails | undefined {
    if (!email) {
        return undefined;
    }
    return emailToPersonalDetailsCache[email.toLowerCase()];
}
```

## Related Issues

$ #86781

## Tests

- [x] Verify the app no longer crashes when an attendee has an undefined email
- [x] Verify existing functionality is preserved