### PR TITLE
Manual expense flow UI refactor r2

### DIFF
--- a/src/components/MoneyRequestConfirmationList.tsx
+++ b/src/components/MoneyRequestConfirmationList.tsx
@@ -1065,7 +1065,6 @@ function MoneyRequestConfirmationList({
             }
 
             const merchantValue = iouMerchant ?? '';
-            const trimmedMerchant = merchantValue.trim();
             const {isValid: isMerchantLengthValid} = isValidInputLength(merchantValue, CONST.MERCHANT_NAME_MAX_BYTES);
 
             if (!isMerchantLengthValid) {
@@ -1078,10 +1077,6 @@ function MoneyRequestConfirmationList({
                 return;
             }
 
-            if (!isEditingSplitBill && trimmedMerchant && isInvalidMerchantValue(trimmedMerchant)) {
-                setFormError('iou.error.invalidMerchant');
-                return;
-            }
             if (iouCategory.length > CONST.API_TRANSACTION_CATEGORY_MAX_LENGTH) {
                 setFormError('iou.error.invalidCategoryLength');
                 return;

--- a/src/components/MoneyRequestConfirmationList.tsx
+++ b/src/components/MoneyRequestConfirmationList.tsx
@@ -663,12 +663,15 @@ function MoneyRequestConfirmationList({
             if (iouAmount !== 0 && !isNewManualExpenseFlowEnabled) {
                 text = translate('iou.createExpenseWithAmount', {amount: formattedAmount});
             }
+        } else if (isTypeSplit) {
+            text = translate('iou.splitAmount', formattedAmount);
+            if (isNewManualExpenseFlowEnabled) {
+                text = translate('iou.splitExpense');
+            }
         } else if (iouAmount === 0) {
             text = translate('iou.createExpense');
         } else if (isNewManualExpenseFlowEnabled) {
             text = translate('iou.createExpense');
-        } else if (isTypeSplit) {
-            text = translate('iou.splitAmount', formattedAmount);
         } else {
             text = translate('iou.createExpenseWithAmount', {amount: formattedAmount});
         }

--- a/src/components/MoneyRequestConfirmationList.tsx
+++ b/src/components/MoneyRequestConfirmationList.tsx
@@ -58,6 +58,7 @@ import {
     isScanning,
     isScanRequest as isScanRequestUtil,
 } from '@libs/TransactionUtils';
+import {isInvalidMerchantValue, isValidInputLength} from '@libs/ValidationUtils';
 import {getIsViolationFixed} from '@libs/Violations/ViolationsUtils';
 import {hasInvoicingDetails} from '@userActions/Policy/Policy';
 import type {IOUAction, IOUType} from '@src/CONST';
@@ -472,6 +473,21 @@ function MoneyRequestConfirmationList({
 
     const isMerchantEmpty = useMemo(() => !iouMerchant || isMerchantMissing(transaction), [transaction, iouMerchant]);
     const isMerchantRequired = isPolicyExpenseChat && (!isScanRequest || isEditingSplitBill) && shouldShowMerchant;
+    const isMerchantFieldValid = useMemo(() => {
+        const merchantValue = iouMerchant ?? '';
+        const trimmedMerchant = merchantValue.trim();
+        const {isValid} = isValidInputLength(merchantValue, CONST.MERCHANT_NAME_MAX_BYTES);
+
+        if (!isValid) {
+            return false;
+        }
+
+        if (!trimmedMerchant) {
+            return !isMerchantRequired;
+        }
+
+        return !isInvalidMerchantValue(trimmedMerchant);
+    }, [iouMerchant, isMerchantRequired]);
 
     const isCategoryRequired = !!policy?.requiresCategory && !isTypeInvoice;
 
@@ -503,6 +519,10 @@ function MoneyRequestConfirmationList({
             setFormError('iou.receiptScanningFailed');
             return;
         }
+        if (formError === 'iou.error.invalidMerchant' && isMerchantFieldValid) {
+            setFormError('');
+            return;
+        }
         // Check 1: If formError does NOT start with "violations.", clear it and return
         // Reset the form error whenever the screen gains or loses focus
         // but preserve violation-related errors since those represent real validation issues
@@ -517,7 +537,7 @@ function MoneyRequestConfirmationList({
             setFormError('');
         }
         // eslint-disable-next-line react-hooks/exhaustive-deps -- we don't want this effect to run if it's just setFormError that changes
-    }, [isFocused, shouldDisplayFieldError, hasSmartScanFailed, didConfirmSplit, isViolationFixed]);
+    }, [isFocused, shouldDisplayFieldError, hasSmartScanFailed, didConfirmSplit, isViolationFixed, isMerchantFieldValid]);
 
     const prevPolicy = usePrevious(policy);
 
@@ -1041,7 +1061,21 @@ function MoneyRequestConfirmationList({
                 return;
             }
 
+            const merchantValue = iouMerchant ?? '';
+            const trimmedMerchant = merchantValue.trim();
+            const {isValid: isMerchantLengthValid} = isValidInputLength(merchantValue, CONST.MERCHANT_NAME_MAX_BYTES);
+
+            if (!isMerchantLengthValid) {
+                setFormError('iou.error.invalidMerchant');
+                return;
+            }
+
             if (!isEditingSplitBill && isMerchantRequired && (isMerchantEmpty || (shouldDisplayFieldError && isMerchantMissing(transaction)))) {
+                setFormError('iou.error.invalidMerchant');
+                return;
+            }
+
+            if (!isEditingSplitBill && trimmedMerchant && isInvalidMerchantValue(trimmedMerchant)) {
                 setFormError('iou.error.invalidMerchant');
                 return;
             }
@@ -1158,6 +1192,7 @@ function MoneyRequestConfirmationList({
             isEditingSplitBill,
             isMerchantRequired,
             isMerchantEmpty,
+            iouMerchant,
             shouldDisplayFieldError,
             shouldShowTax,
             transaction,

--- a/src/components/MoneyRequestConfirmationList.tsx
+++ b/src/components/MoneyRequestConfirmationList.tsx
@@ -663,12 +663,12 @@ function MoneyRequestConfirmationList({
             if (iouAmount !== 0 && !isNewManualExpenseFlowEnabled) {
                 text = translate('iou.createExpenseWithAmount', {amount: formattedAmount});
             }
-        } else if (isTypeSplit) {
-            text = translate('iou.splitAmount', formattedAmount);
         } else if (iouAmount === 0) {
             text = translate('iou.createExpense');
         } else if (isNewManualExpenseFlowEnabled) {
             text = translate('iou.createExpense');
+        } else if (isTypeSplit) {
+            text = translate('iou.splitAmount', formattedAmount);
         } else {
             text = translate('iou.createExpenseWithAmount', {amount: formattedAmount});
         }
@@ -1395,6 +1395,7 @@ function MoneyRequestConfirmationList({
                 isMerchantRequired={isMerchantRequired}
                 isPolicyExpenseChat={isPolicyExpenseChat}
                 isReadOnly={isReadOnly}
+                isEditingSplitBill={isEditingSplitBill}
                 isTypeInvoice={isTypeInvoice}
                 onToggleBillable={onToggleBillable}
                 policy={policy}

--- a/src/components/MoneyRequestConfirmationList.tsx
+++ b/src/components/MoneyRequestConfirmationList.tsx
@@ -1216,6 +1216,7 @@ function MoneyRequestConfirmationList({
             currentUserPersonalDetails,
             isTimeRequest,
             getCurrencyDecimals,
+            isNewManualExpenseFlowEnabled,
         ],
     );
 

--- a/src/components/MoneyRequestConfirmationListFooter.tsx
+++ b/src/components/MoneyRequestConfirmationListFooter.tsx
@@ -176,6 +176,9 @@ type MoneyRequestConfirmationListFooterProps = {
     /** Flag indicating if it is read-only */
     isReadOnly: boolean;
 
+    /** Whether we're editing a split expense */
+    isEditingSplitBill?: boolean;
+
     /** Flag indicating if it is an invoice type */
     isTypeInvoice: boolean;
 
@@ -305,6 +308,7 @@ function MoneyRequestConfirmationListFooter({
     isMerchantRequired,
     isPolicyExpenseChat,
     isReadOnly,
+    isEditingSplitBill = false,
     isTypeInvoice,
     onToggleBillable,
     policy,
@@ -354,6 +358,7 @@ function MoneyRequestConfirmationListFooter({
 
     const [allPolicies] = useOnyx(ONYXKEYS.COLLECTION.POLICY);
     const [allReports] = useOnyx(ONYXKEYS.COLLECTION.REPORT);
+    const [splitDraftTransaction] = useOnyx(`${ONYXKEYS.COLLECTION.SPLIT_TRANSACTION_DRAFT}${transactionID}`);
 
     const reportAttributes = useReportAttributes();
     const [reportNameValuePairs] = useOnyx(ONYXKEYS.COLLECTION.REPORT_NAME_VALUE_PAIRS);
@@ -361,6 +366,9 @@ function MoneyRequestConfirmationListFooter({
     const {policyForMovingExpensesID, policyForMovingExpenses, shouldSelectPolicy} = usePolicyForMovingExpenses();
 
     const [currentUserLogin] = useOnyx(ONYXKEYS.SESSION, {selector: emailSelector});
+    const [currentUserAccountID] = useOnyx(ONYXKEYS.SESSION, {
+        selector: (session) => session?.accountID ?? CONST.DEFAULT_NUMBER_ID,
+    });
     const isUnreported = transaction?.reportID === CONST.REPORT.UNREPORTED_REPORT_ID;
     const isCreatingTrackExpense = action === CONST.IOU.ACTION.CREATE && iouType === CONST.IOU.TYPE.TRACK;
 
@@ -609,9 +617,42 @@ function MoneyRequestConfirmationListFooter({
             }
 
             const parsedAmount = getBackendAmountFromInput(transactionAmount);
-            setMoneyRequestAmount(transactionID, parsedAmount ?? amount, value);
+            const updatedAmount = parsedAmount ?? amount;
+
+            if (isEditingSplitBill) {
+                const splitShares = splitDraftTransaction?.splitShares ?? transaction?.splitShares;
+                const accountID = currentUserAccountID ?? CONST.DEFAULT_NUMBER_ID;
+                const newAccountIDs = Object.keys(splitShares ?? {}).map((key) => Number(key));
+                const oldAccountIDs = Object.keys(transaction?.splitShares ?? {}).map((key) => Number(key));
+                const accountIDs = [...new Set<number>([accountID, ...newAccountIDs, ...oldAccountIDs])];
+
+                const updatedSplitShares = accountIDs.reduce<NonNullable<OnyxTypes.Transaction['splitShares']>>((acc, splitShareAccountID) => {
+                    if (!newAccountIDs.includes(splitShareAccountID) && splitShareAccountID !== accountID) {
+                        acc[splitShareAccountID] = null;
+                        return acc;
+                    }
+
+                    const isPayer = splitShareAccountID === accountID;
+                    const participantsLength = newAccountIDs.includes(accountID) ? newAccountIDs.length - 1 : newAccountIDs.length;
+
+                    acc[splitShareAccountID] = {
+                        amount: calculateAmount(participantsLength, updatedAmount, value, isPayer),
+                        isModified: false,
+                    };
+                    return acc;
+                }, {});
+
+                setDraftSplitTransaction(transactionID, splitDraftTransaction, {
+                    amount: updatedAmount,
+                    currency: value,
+                    ...(accountIDs.length > 0 ? {splitShares: updatedSplitShares} : {}),
+                });
+                return;
+            }
+
+            setMoneyRequestAmount(transactionID, updatedAmount, value);
         },
-        [hideCurrencyPicker, transactionID, getBackendAmountFromInput, transactionAmount, amount],
+        [hideCurrencyPicker, transactionID, getBackendAmountFromInput, transactionAmount, amount, isEditingSplitBill, splitDraftTransaction, transaction?.splitShares, currentUserAccountID],
     );
 
     /**
@@ -628,10 +669,45 @@ function MoneyRequestConfirmationListFooter({
             if (parsedAmount === null) {
                 return;
             }
+            // Edits to the amount from the splits page should reset the split shares.
+            if (transaction?.splitShares) {
+                resetSplitShares(transaction, parsedAmount);
+            }
+
+            if (isEditingSplitBill) {
+                const splitShares = splitDraftTransaction?.splitShares ?? transaction?.splitShares;
+                const accountID = currentUserAccountID ?? CONST.DEFAULT_NUMBER_ID;
+                const newAccountIDs = Object.keys(splitShares ?? {}).map((key) => Number(key));
+                const oldAccountIDs = Object.keys(transaction?.splitShares ?? {}).map((key) => Number(key));
+                const accountIDs = [...new Set<number>([accountID, ...newAccountIDs, ...oldAccountIDs])];
+
+                const updatedSplitShares = accountIDs.reduce<NonNullable<OnyxTypes.Transaction['splitShares']>>((acc, splitShareAccountID) => {
+                    if (!newAccountIDs.includes(splitShareAccountID) && splitShareAccountID !== accountID) {
+                        acc[splitShareAccountID] = null;
+                        return acc;
+                    }
+
+                    const isPayer = splitShareAccountID === accountID;
+                    const participantsLength = newAccountIDs.includes(accountID) ? newAccountIDs.length - 1 : newAccountIDs.length;
+
+                    acc[splitShareAccountID] = {
+                        amount: calculateAmount(participantsLength, parsedAmount, currency, isPayer),
+                        isModified: false,
+                    };
+                    return acc;
+                }, {});
+
+                setDraftSplitTransaction(transactionID, splitDraftTransaction, {
+                    amount: parsedAmount,
+                    currency,
+                    ...(accountIDs.length > 0 ? {splitShares: updatedSplitShares} : {}),
+                });
+                return;
+            }
 
             setMoneyRequestAmount(transactionID, parsedAmount, currency);
         },
-        [transactionID, getBackendAmountFromInput, currency],
+        [transactionID, getBackendAmountFromInput, isEditingSplitBill, splitDraftTransaction, transaction?.splitShares, currentUserAccountID, currency],
     );
 
     const shouldShowAmountRequiredError = useMemo(() => {
@@ -646,7 +722,7 @@ function MoneyRequestConfirmationListFooter({
         {
             item:
                 isNewManualExpenseFlowEnabled && !isAmountFieldDisabled ? (
-                    <View style={[styles.mh4, styles.mb2]}>
+                    <View style={[styles.mh4, styles.mv2]}>
                         <NumberWithSymbolForm
                             displayAsTextInput
                             value={transactionAmount}

--- a/src/components/MoneyRequestConfirmationListFooter.tsx
+++ b/src/components/MoneyRequestConfirmationListFooter.tsx
@@ -377,10 +377,16 @@ function MoneyRequestConfirmationListFooter({
                 return;
             }
 
-            const merchantToSave = newMerchant;
-            setMoneyRequestMerchant(transactionID, merchantToSave, true, hasReceipt(transaction));
+            // When editing a split expense, persist directly to the split draft so that
+            // SplitBillDetailsPage and completeSplitBill read the latest value.
+            if (isEditingSplitBill) {
+                setDraftSplitTransaction(transactionID, splitDraftTransaction, {merchant: newMerchant});
+                return;
+            }
+
+            setMoneyRequestMerchant(transactionID, newMerchant, true, hasReceipt(transaction));
         },
-        [transactionID, transaction],
+        [transactionID, transaction, isEditingSplitBill, splitDraftTransaction],
     );
 
     const handleDescriptionInputChange = useCallback(
@@ -389,9 +395,18 @@ function MoneyRequestConfirmationListFooter({
                 return;
             }
 
-            setMoneyRequestDescription(transactionID, newDescription.trim(), true, hasReceipt(transaction));
+            // When editing a split expense, persist directly to the split draft so that
+            // SplitBillDetailsPage and completeSplitBill read the latest value.
+            // Trimming is deferred to submission time, not during keystrokes, to avoid
+            // silently stripping trailing spaces as the user types.
+            if (isEditingSplitBill) {
+                setDraftSplitTransaction(transactionID, splitDraftTransaction, {comment: newDescription});
+                return;
+            }
+
+            setMoneyRequestDescription(transactionID, newDescription, true, hasReceipt(transaction));
         },
-        [transactionID, transaction],
+        [transactionID, transaction, isEditingSplitBill, splitDraftTransaction],
     );
 
     const decodedCategoryName = useMemo(() => getDecodedCategoryName(iouCategory), [iouCategory]);
@@ -491,12 +506,14 @@ function MoneyRequestConfirmationListFooter({
             return translate('common.error.characterLimitExceedCounter', byteLength, CONST.MERCHANT_NAME_MAX_BYTES);
         }
 
-        if ((shouldDisplayFieldError || formError === 'iou.error.invalidMerchant') && isMerchantRequired) {
+        // Guard with isMerchantEmpty to avoid showing a "field required" error when the merchant
+        // is already filled in — matching the original shouldDisplayMerchantError condition.
+        if ((shouldDisplayFieldError || formError === 'iou.error.invalidMerchant') && isMerchantRequired && isMerchantEmpty) {
             return translate('common.error.fieldRequired');
         }
 
         return '';
-    }, [formError, iouMerchant, isMerchantRequired, shouldDisplayFieldError, translate]);
+    }, [formError, iouMerchant, isMerchantRequired, isMerchantEmpty, shouldDisplayFieldError, translate]);
 
     // Determine if the merchant error should be displayed
     const shouldDisplayMerchantError = !!merchantErrorText;
@@ -599,6 +616,48 @@ function MoneyRequestConfirmationListFooter({
     }, []);
 
     /**
+     * Shared helper that recalculates split shares for a given amount + currency and persists
+     * the result to the split draft.  Extracted to avoid duplicating the logic between
+     * updateCurrency and handleAmountChange.
+     */
+    const buildAndSaveSplitShares = useCallback(
+        (updatedAmount: number, updatedCurrency: string) => {
+            if (!transactionID) {
+                return;
+            }
+
+            const splitShares = splitDraftTransaction?.splitShares ?? transaction?.splitShares;
+            const accountID = currentUserAccountID ?? CONST.DEFAULT_NUMBER_ID;
+            const newAccountIDs = Object.keys(splitShares ?? {}).map((key) => Number(key));
+            const oldAccountIDs = Object.keys(transaction?.splitShares ?? {}).map((key) => Number(key));
+            const accountIDs = [...new Set<number>([accountID, ...newAccountIDs, ...oldAccountIDs])];
+
+            const participantsLength = newAccountIDs.includes(accountID) ? newAccountIDs.length - 1 : newAccountIDs.length;
+
+            const updatedSplitShares = accountIDs.reduce<NonNullable<OnyxTypes.Transaction['splitShares']>>((acc, splitShareAccountID) => {
+                if (!newAccountIDs.includes(splitShareAccountID) && splitShareAccountID !== accountID) {
+                    acc[splitShareAccountID] = null;
+                    return acc;
+                }
+
+                const isPayer = splitShareAccountID === accountID;
+                acc[splitShareAccountID] = {
+                    amount: calculateAmount(participantsLength, updatedAmount, updatedCurrency, isPayer),
+                    isModified: false,
+                };
+                return acc;
+            }, {});
+
+            setDraftSplitTransaction(transactionID, splitDraftTransaction, {
+                amount: updatedAmount,
+                currency: updatedCurrency,
+                ...(accountIDs.length > 0 ? {splitShares: updatedSplitShares} : {}),
+            });
+        },
+        [transactionID, splitDraftTransaction, transaction?.splitShares, currentUserAccountID],
+    );
+
+    /**
      * Updates the selected currency for the transaction.
      * Updates local display state and persists the value to draft transaction.
      */
@@ -614,39 +673,13 @@ function MoneyRequestConfirmationListFooter({
             const updatedAmount = parsedAmount ?? amount;
 
             if (isEditingSplitBill) {
-                const splitShares = splitDraftTransaction?.splitShares ?? transaction?.splitShares;
-                const accountID = currentUserAccountID ?? CONST.DEFAULT_NUMBER_ID;
-                const newAccountIDs = Object.keys(splitShares ?? {}).map((key) => Number(key));
-                const oldAccountIDs = Object.keys(transaction?.splitShares ?? {}).map((key) => Number(key));
-                const accountIDs = [...new Set<number>([accountID, ...newAccountIDs, ...oldAccountIDs])];
-
-                const updatedSplitShares = accountIDs.reduce<NonNullable<OnyxTypes.Transaction['splitShares']>>((acc, splitShareAccountID) => {
-                    if (!newAccountIDs.includes(splitShareAccountID) && splitShareAccountID !== accountID) {
-                        acc[splitShareAccountID] = null;
-                        return acc;
-                    }
-
-                    const isPayer = splitShareAccountID === accountID;
-                    const participantsLength = newAccountIDs.includes(accountID) ? newAccountIDs.length - 1 : newAccountIDs.length;
-
-                    acc[splitShareAccountID] = {
-                        amount: calculateAmount(participantsLength, updatedAmount, value, isPayer),
-                        isModified: false,
-                    };
-                    return acc;
-                }, {});
-
-                setDraftSplitTransaction(transactionID, splitDraftTransaction, {
-                    amount: updatedAmount,
-                    currency: value,
-                    ...(accountIDs.length > 0 ? {splitShares: updatedSplitShares} : {}),
-                });
+                buildAndSaveSplitShares(updatedAmount, value);
                 return;
             }
 
             setMoneyRequestAmount(transactionID, updatedAmount, value);
         },
-        [hideCurrencyPicker, transactionID, getBackendAmountFromInput, transactionAmount, amount, isEditingSplitBill, splitDraftTransaction, transaction?.splitShares, currentUserAccountID],
+        [hideCurrencyPicker, transactionID, getBackendAmountFromInput, transactionAmount, amount, isEditingSplitBill, buildAndSaveSplitShares],
     );
 
     /**
@@ -669,39 +702,13 @@ function MoneyRequestConfirmationListFooter({
             }
 
             if (isEditingSplitBill) {
-                const splitShares = splitDraftTransaction?.splitShares ?? transaction?.splitShares;
-                const accountID = currentUserAccountID ?? CONST.DEFAULT_NUMBER_ID;
-                const newAccountIDs = Object.keys(splitShares ?? {}).map((key) => Number(key));
-                const oldAccountIDs = Object.keys(transaction?.splitShares ?? {}).map((key) => Number(key));
-                const accountIDs = [...new Set<number>([accountID, ...newAccountIDs, ...oldAccountIDs])];
-
-                const updatedSplitShares = accountIDs.reduce<NonNullable<OnyxTypes.Transaction['splitShares']>>((acc, splitShareAccountID) => {
-                    if (!newAccountIDs.includes(splitShareAccountID) && splitShareAccountID !== accountID) {
-                        acc[splitShareAccountID] = null;
-                        return acc;
-                    }
-
-                    const isPayer = splitShareAccountID === accountID;
-                    const participantsLength = newAccountIDs.includes(accountID) ? newAccountIDs.length - 1 : newAccountIDs.length;
-
-                    acc[splitShareAccountID] = {
-                        amount: calculateAmount(participantsLength, parsedAmount, currency, isPayer),
-                        isModified: false,
-                    };
-                    return acc;
-                }, {});
-
-                setDraftSplitTransaction(transactionID, splitDraftTransaction, {
-                    amount: parsedAmount,
-                    currency,
-                    ...(accountIDs.length > 0 ? {splitShares: updatedSplitShares} : {}),
-                });
+                buildAndSaveSplitShares(parsedAmount, currency);
                 return;
             }
 
             setMoneyRequestAmount(transactionID, parsedAmount, currency);
         },
-        [transactionID, getBackendAmountFromInput, isEditingSplitBill, splitDraftTransaction, transaction, currentUserAccountID, currency],
+        [transactionID, getBackendAmountFromInput, isEditingSplitBill, transaction, buildAndSaveSplitShares, currency],
     );
 
     const shouldShowAmountRequiredError = useMemo(() => {

--- a/src/components/MoneyRequestConfirmationListFooter.tsx
+++ b/src/components/MoneyRequestConfirmationListFooter.tsx
@@ -21,10 +21,11 @@ import useTheme from '@hooks/useTheme';
 import useThemeStyles from '@hooks/useThemeStyles';
 import useWindowDimensions from '@hooks/useWindowDimensions';
 import {setMoneyRequestAmount} from '@libs/actions/IOU';
+import {setMoneyRequestDescription, setMoneyRequestMerchant} from '@libs/actions/IOU';
 import {getDecodedCategoryName} from '@libs/CategoryUtils';
 import {convertToBackendAmount, convertToDisplayString, convertToFrontendAmountAsString, getCurrencyDecimals, getLocalizedCurrencySymbol} from '@libs/CurrencyUtils';
 import DistanceRequestUtils from '@libs/DistanceRequestUtils';
-import {isMovingTransactionFromTrackExpense, shouldShowReceiptEmptyState} from '@libs/IOUUtils';
+import {calculateAmount, isMovingTransactionFromTrackExpense, shouldShowReceiptEmptyState} from '@libs/IOUUtils';
 import Navigation from '@libs/Navigation/Navigation';
 import {getDestinationForDisplay, getSubratesFields, getSubratesForDisplay, getTimeDifferenceIntervals, getTimeForDisplay} from '@libs/PerDiemRequestUtils';
 import {canSendInvoice, getPerDiemCustomUnit} from '@libs/PolicyUtils';
@@ -38,6 +39,7 @@ import {
     getTagForDisplay,
     getTaxAmount,
     getTaxRateTitle,
+    hasReceipt,
     isAmountMissing,
     isCreatedMissing,
     isFetchingWaypointsFromServer,
@@ -47,9 +49,11 @@ import {
     willFieldBeAutomaticallyFilled,
 } from '@libs/TransactionUtils';
 import tryResolveUrlFromApiRoot from '@libs/tryResolveUrlFromApiRoot';
+import {isInvalidMerchantValue, isValidInputLength} from '@libs/ValidationUtils';
 import IOURequestStepCurrencyModal from '@pages/iou/request/step/IOURequestStepCurrencyModal';
 import ToggleSettingOptionRow from '@pages/workspace/workflows/ToggleSettingsOptionRow';
 import variables from '@styles/variables';
+import {resetSplitShares, setDraftSplitTransaction} from '@userActions/IOU/Split';
 import CONST from '@src/CONST';
 import type {IOUAction, IOUType} from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
@@ -76,6 +80,7 @@ import ReceiptEmptyState from './ReceiptEmptyState';
 import ReceiptImage from './ReceiptImage';
 import {ShowContextMenuActionsContext, ShowContextMenuStateContext} from './ShowContextMenuContext';
 import Text from './Text';
+import TextInput from './TextInput';
 
 type MoneyRequestConfirmationListFooterProps = {
     /** The action to perform */
@@ -359,6 +364,29 @@ function MoneyRequestConfirmationListFooter({
     const isUnreported = transaction?.reportID === CONST.REPORT.UNREPORTED_REPORT_ID;
     const isCreatingTrackExpense = action === CONST.IOU.ACTION.CREATE && iouType === CONST.IOU.TYPE.TRACK;
 
+    const handleMerchantInputChange = useCallback(
+        (newMerchant: string) => {
+            if (!transactionID) {
+                return;
+            }
+
+            const merchantToSave = newMerchant;
+            setMoneyRequestMerchant(transactionID, merchantToSave, true, hasReceipt(transaction));
+        },
+        [transactionID, transaction],
+    );
+
+    const handleDescriptionInputChange = useCallback(
+        (newDescription: string) => {
+            if (!transactionID) {
+                return;
+            }
+
+            setMoneyRequestDescription(transactionID, newDescription.trim(), true, hasReceipt(transaction));
+        },
+        [transactionID, transaction],
+    );
+
     const decodedCategoryName = useMemo(() => getDecodedCategoryName(iouCategory), [iouCategory]);
     const isScan = isScanRequest(transaction);
 
@@ -448,8 +476,28 @@ function MoneyRequestConfirmationListFooter({
     // Get the tax rate title based on the policy and transaction
     const taxRateTitle = getTaxRateTitle(policy, transaction, isMovingCurrentTransactionFromTrackExpense, policyForMovingExpenses);
 
+    const merchantErrorText = useMemo(() => {
+        const merchantValue = iouMerchant ?? '';
+        const trimmedMerchant = merchantValue.trim();
+        const {isValid, byteLength} = isValidInputLength(merchantValue, CONST.MERCHANT_NAME_MAX_BYTES);
+
+        if (!isValid) {
+            return translate('common.error.characterLimitExceedCounter', byteLength, CONST.MERCHANT_NAME_MAX_BYTES);
+        }
+
+        if ((shouldDisplayFieldError || formError === 'iou.error.invalidMerchant') && isMerchantRequired && !trimmedMerchant) {
+            return translate('common.error.fieldRequired');
+        }
+
+        if ((shouldDisplayFieldError || formError === 'iou.error.invalidMerchant') && trimmedMerchant && isInvalidMerchantValue(trimmedMerchant)) {
+            return translate('iou.error.invalidMerchant');
+        }
+
+        return '';
+    }, [formError, iouMerchant, isMerchantRequired, shouldDisplayFieldError, translate]);
+
     // Determine if the merchant error should be displayed
-    const shouldDisplayMerchantError = isMerchantRequired && (shouldDisplayFieldError || formError === 'iou.error.invalidMerchant') && isMerchantEmpty;
+    const shouldDisplayMerchantError = !!merchantErrorText;
     const shouldDisplayDistanceRateError = formError === 'iou.error.invalidRate';
     const shouldDisplayTagError = formError === 'violations.tagOutOfPolicy';
     const shouldDisplayTaxRateError = formError === 'violations.taxOutOfPolicy';
@@ -657,6 +705,20 @@ function MoneyRequestConfirmationListFooter({
                     <ShowContextMenuStateContext.Provider value={contextMenuStateValue}>
                         <ShowContextMenuActionsContext.Provider value={contextMenuActionsValue}>
                             <MentionReportContext.Provider value={mentionReportContextValue}>
+                                {isNewManualExpenseFlowEnabled && !didConfirm && !isReadOnly ? (
+                                    <View style={[styles.mh4, styles.mv2]}>
+                                        <TextInput
+                                            value={iouComment ?? ''}
+                                            onChangeText={handleDescriptionInputChange}
+                                            label={translate('common.description')}
+                                            accessibilityLabel={translate('common.description')}
+                                            autoGrowHeight
+                                            maxAutoGrowHeight={variables.textInputAutoGrowMaxHeight}
+                                            type="markdown"
+                                            excludedMarkdownStyles={!policy ? ['mentionReport'] : []}
+                                        />
+                                    </View>
+                                ) : (
                                 <MenuItemWithTopDescription
                                     shouldShowRightIcon={!isReadOnly}
                                     shouldParseTitle
@@ -680,6 +742,7 @@ function MoneyRequestConfirmationListFooter({
                                     rightLabel={isDescriptionRequired ? translate('common.required') : ''}
                                     sentryLabel={CONST.SENTRY_LABEL.REQUEST_CONFIRMATION_LIST.DESCRIPTION_FIELD}
                                 />
+                                )}
                             </MentionReportContext.Provider>
                         </ShowContextMenuActionsContext.Provider>
                     </ShowContextMenuStateContext.Provider>
@@ -764,7 +827,18 @@ function MoneyRequestConfirmationListFooter({
             shouldShowAboveShowMore: false,
         },
         {
-            item: (
+            item:
+                isNewManualExpenseFlowEnabled && !isReadOnly ? (
+                    <View style={[styles.mh4, styles.mv2]}>
+                        <TextInput
+                            value={isMerchantEmpty ? '' : (iouMerchant ?? '')}
+                            onChangeText={handleMerchantInputChange}
+                            label={translate('common.merchant')}
+                            accessibilityLabel={translate('common.merchant')}
+                            errorText={merchantErrorText}
+                        />
+                    </View>
+                ) : (
                 <MenuItemWithTopDescription
                     key={translate('common.merchant')}
                     shouldShowRightIcon={!isReadOnly}

--- a/src/components/MoneyRequestConfirmationListFooter.tsx
+++ b/src/components/MoneyRequestConfirmationListFooter.tsx
@@ -492,7 +492,7 @@ function MoneyRequestConfirmationListFooter({
             return translate('common.error.characterLimitExceedCounter', byteLength, CONST.MERCHANT_NAME_MAX_BYTES);
         }
 
-        if ((shouldDisplayFieldError || formError === 'iou.error.invalidMerchant') && isMerchantRequired && !trimmedMerchant) {
+        if ((shouldDisplayFieldError || formError === 'iou.error.invalidMerchant') && isMerchantRequired) {
             return translate('common.error.fieldRequired');
         }
 
@@ -903,6 +903,7 @@ function MoneyRequestConfirmationListFooter({
                     <View style={[styles.mh4, styles.mv2]}>
                         <TextInput
                             value={isMerchantEmpty ? '' : (iouMerchant ?? '')}
+                            readOnly={didConfirm}
                             onChangeText={handleMerchantInputChange}
                             label={translate('common.merchant')}
                             accessibilityLabel={translate('common.merchant')}

--- a/src/components/MoneyRequestConfirmationListFooter.tsx
+++ b/src/components/MoneyRequestConfirmationListFooter.tsx
@@ -48,7 +48,7 @@ import {
     willFieldBeAutomaticallyFilled,
 } from '@libs/TransactionUtils';
 import tryResolveUrlFromApiRoot from '@libs/tryResolveUrlFromApiRoot';
-import {isInvalidMerchantValue, isValidInputLength} from '@libs/ValidationUtils';
+import {isValidInputLength} from '@libs/ValidationUtils';
 import IOURequestStepCurrencyModal from '@pages/iou/request/step/IOURequestStepCurrencyModal';
 import ToggleSettingOptionRow from '@pages/workspace/workflows/ToggleSettingsOptionRow';
 import variables from '@styles/variables';
@@ -494,10 +494,6 @@ function MoneyRequestConfirmationListFooter({
 
         if ((shouldDisplayFieldError || formError === 'iou.error.invalidMerchant') && isMerchantRequired && !trimmedMerchant) {
             return translate('common.error.fieldRequired');
-        }
-
-        if ((shouldDisplayFieldError || formError === 'iou.error.invalidMerchant') && trimmedMerchant && isInvalidMerchantValue(trimmedMerchant)) {
-            return translate('iou.error.invalidMerchant');
         }
 
         return '';

--- a/src/components/MoneyRequestConfirmationListFooter.tsx
+++ b/src/components/MoneyRequestConfirmationListFooter.tsx
@@ -795,29 +795,29 @@ function MoneyRequestConfirmationListFooter({
                                         />
                                     </View>
                                 ) : (
-                                <MenuItemWithTopDescription
-                                    shouldShowRightIcon={!isReadOnly}
-                                    shouldParseTitle
-                                    excludedMarkdownRules={!policy ? ['reportMentions'] : []}
-                                    title={iouComment}
-                                    description={translate('common.description')}
-                                    onPress={() => {
-                                        if (!transactionID) {
-                                            return;
-                                        }
+                                    <MenuItemWithTopDescription
+                                        shouldShowRightIcon={!isReadOnly}
+                                        shouldParseTitle
+                                        excludedMarkdownRules={!policy ? ['reportMentions'] : []}
+                                        title={iouComment}
+                                        description={translate('common.description')}
+                                        onPress={() => {
+                                            if (!transactionID) {
+                                                return;
+                                            }
 
-                                        Navigation.navigate(
-                                            ROUTES.MONEY_REQUEST_STEP_DESCRIPTION.getRoute(action, iouType, transactionID, reportID, Navigation.getActiveRoute(), reportActionID),
-                                        );
-                                    }}
-                                    style={[styles.moneyRequestMenuItem]}
-                                    titleStyle={styles.flex1}
-                                    disabled={didConfirm}
-                                    interactive={!isReadOnly}
-                                    numberOfLinesTitle={2}
-                                    rightLabel={isDescriptionRequired ? translate('common.required') : ''}
-                                    sentryLabel={CONST.SENTRY_LABEL.REQUEST_CONFIRMATION_LIST.DESCRIPTION_FIELD}
-                                />
+                                            Navigation.navigate(
+                                                ROUTES.MONEY_REQUEST_STEP_DESCRIPTION.getRoute(action, iouType, transactionID, reportID, Navigation.getActiveRoute(), reportActionID),
+                                            );
+                                        }}
+                                        style={[styles.moneyRequestMenuItem]}
+                                        titleStyle={styles.flex1}
+                                        disabled={didConfirm}
+                                        interactive={!isReadOnly}
+                                        numberOfLinesTitle={2}
+                                        rightLabel={isDescriptionRequired ? translate('common.required') : ''}
+                                        sentryLabel={CONST.SENTRY_LABEL.REQUEST_CONFIRMATION_LIST.DESCRIPTION_FIELD}
+                                    />
                                 )}
                             </MentionReportContext.Provider>
                         </ShowContextMenuActionsContext.Provider>
@@ -915,29 +915,29 @@ function MoneyRequestConfirmationListFooter({
                         />
                     </View>
                 ) : (
-                <MenuItemWithTopDescription
-                    key={translate('common.merchant')}
-                    shouldShowRightIcon={!isReadOnly}
-                    title={isMerchantEmpty ? '' : iouMerchant}
-                    description={translate('common.merchant')}
-                    style={[styles.moneyRequestMenuItem]}
-                    titleStyle={styles.flex1}
-                    onPress={() => {
-                        if (!transactionID) {
-                            return;
-                        }
+                    <MenuItemWithTopDescription
+                        key={translate('common.merchant')}
+                        shouldShowRightIcon={!isReadOnly}
+                        title={isMerchantEmpty ? '' : iouMerchant}
+                        description={translate('common.merchant')}
+                        style={[styles.moneyRequestMenuItem]}
+                        titleStyle={styles.flex1}
+                        onPress={() => {
+                            if (!transactionID) {
+                                return;
+                            }
 
-                        Navigation.navigate(ROUTES.MONEY_REQUEST_STEP_MERCHANT.getRoute(action, iouType, transactionID, reportID, Navigation.getActiveRoute(), reportActionID));
-                    }}
-                    disabled={didConfirm}
-                    interactive={!isReadOnly}
-                    brickRoadIndicator={shouldDisplayMerchantError ? CONST.BRICK_ROAD_INDICATOR_STATUS.ERROR : undefined}
-                    errorText={shouldDisplayMerchantError ? translate('common.error.fieldRequired') : ''}
-                    rightLabel={isMerchantRequired && !shouldDisplayMerchantError ? translate('common.required') : ''}
-                    numberOfLinesTitle={2}
-                    sentryLabel={CONST.SENTRY_LABEL.REQUEST_CONFIRMATION_LIST.MERCHANT_FIELD}
-                />
-            ),
+                            Navigation.navigate(ROUTES.MONEY_REQUEST_STEP_MERCHANT.getRoute(action, iouType, transactionID, reportID, Navigation.getActiveRoute(), reportActionID));
+                        }}
+                        disabled={didConfirm}
+                        interactive={!isReadOnly}
+                        brickRoadIndicator={shouldDisplayMerchantError ? CONST.BRICK_ROAD_INDICATOR_STATUS.ERROR : undefined}
+                        errorText={shouldDisplayMerchantError ? translate('common.error.fieldRequired') : ''}
+                        rightLabel={isMerchantRequired && !shouldDisplayMerchantError ? translate('common.required') : ''}
+                        numberOfLinesTitle={2}
+                        sentryLabel={CONST.SENTRY_LABEL.REQUEST_CONFIRMATION_LIST.MERCHANT_FIELD}
+                    />
+                ),
             shouldShow: shouldShowMerchant,
             shouldShowAboveShowMore: false,
         },

--- a/src/components/MoneyRequestConfirmationListFooter.tsx
+++ b/src/components/MoneyRequestConfirmationListFooter.tsx
@@ -485,7 +485,6 @@ function MoneyRequestConfirmationListFooter({
 
     const merchantErrorText = useMemo(() => {
         const merchantValue = iouMerchant ?? '';
-        const trimmedMerchant = merchantValue.trim();
         const {isValid, byteLength} = isValidInputLength(merchantValue, CONST.MERCHANT_NAME_MAX_BYTES);
 
         if (!isValid) {

--- a/src/components/MoneyRequestConfirmationListFooter.tsx
+++ b/src/components/MoneyRequestConfirmationListFooter.tsx
@@ -776,10 +776,11 @@ function MoneyRequestConfirmationListFooter({
                     <ShowContextMenuStateContext.Provider value={contextMenuStateValue}>
                         <ShowContextMenuActionsContext.Provider value={contextMenuActionsValue}>
                             <MentionReportContext.Provider value={mentionReportContextValue}>
-                                {isNewManualExpenseFlowEnabled && !didConfirm && !isReadOnly ? (
+                                {isNewManualExpenseFlowEnabled && !isReadOnly ? (
                                     <View style={[styles.mh4, styles.mv2]}>
                                         <TextInput
                                             value={iouComment ?? ''}
+                                            readOnly={didConfirm}
                                             onChangeText={handleDescriptionInputChange}
                                             label={translate('common.description')}
                                             accessibilityLabel={translate('common.description')}

--- a/src/components/MoneyRequestConfirmationListFooter.tsx
+++ b/src/components/MoneyRequestConfirmationListFooter.tsx
@@ -20,8 +20,7 @@ import useReportAttributes from '@hooks/useReportAttributes';
 import useTheme from '@hooks/useTheme';
 import useThemeStyles from '@hooks/useThemeStyles';
 import useWindowDimensions from '@hooks/useWindowDimensions';
-import {setMoneyRequestAmount} from '@libs/actions/IOU';
-import {setMoneyRequestDescription, setMoneyRequestMerchant} from '@libs/actions/IOU';
+import {setMoneyRequestAmount, setMoneyRequestDescription, setMoneyRequestMerchant} from '@libs/actions/IOU';
 import {getDecodedCategoryName} from '@libs/CategoryUtils';
 import {convertToBackendAmount, convertToDisplayString, convertToFrontendAmountAsString, getCurrencyDecimals, getLocalizedCurrencySymbol} from '@libs/CurrencyUtils';
 import DistanceRequestUtils from '@libs/DistanceRequestUtils';
@@ -707,7 +706,7 @@ function MoneyRequestConfirmationListFooter({
 
             setMoneyRequestAmount(transactionID, parsedAmount, currency);
         },
-        [transactionID, getBackendAmountFromInput, isEditingSplitBill, splitDraftTransaction, transaction?.splitShares, currentUserAccountID, currency],
+        [transactionID, getBackendAmountFromInput, isEditingSplitBill, splitDraftTransaction, transaction, currentUserAccountID, currency],
     );
 
     const shouldShowAmountRequiredError = useMemo(() => {

--- a/src/components/NumberWithSymbolForm.tsx
+++ b/src/components/NumberWithSymbolForm.tsx
@@ -444,7 +444,7 @@ function NumberWithSymbolForm({
                 )}
             </View>
         );
-    }, [shouldShowFlipButton, shouldShowCurrencyButton, styles, icons, handleFlipPress, onCurrencyButtonPress, currency, translate]);
+    }, [shouldShowFlipButton, allowNegativeInput, disabled, shouldShowCurrencyButton, styles, icons, handleFlipPress, onCurrencyButtonPress, currency, translate]);
 
     if (displayAsTextInput) {
         return (

--- a/src/components/NumberWithSymbolForm.tsx
+++ b/src/components/NumberWithSymbolForm.tsx
@@ -419,7 +419,7 @@ function NumberWithSymbolForm({
     const textInputRightHandSideComponent = useMemo(() => {
         return (
             <View style={[styles.flexRow, styles.gap2, styles.alignItemsCenter]}>
-                {shouldShowFlipButton && canUseTouchScreen && (
+                {shouldShowFlipButton && allowNegativeInput && canUseTouchScreen && (
                     <Button
                         small
                         icon={icons.PlusMinus}

--- a/tests/ui/TimeExpenseConfirmationTest.tsx
+++ b/tests/ui/TimeExpenseConfirmationTest.tsx
@@ -270,8 +270,15 @@ describe('TimeExpenseConfirmationTest', () => {
             renderConfirmation(CONST.IOU.ACTION.SUBMIT);
             await waitForBatchedUpdatesWithAct();
 
-            // Merchant is shown for non-CREATE actions
-            expect(screen.getByTestId('menu-item-Merchant')).toBeDefined();
+            const merchantRow = screen.queryByTestId('menu-item-Merchant');
+
+            // In the new manual expense flow, merchant is rendered as a text input instead of a menu item.
+            if (merchantRow) {
+                expect(merchantRow).toBeDefined();
+            } else {
+                const merchantInput = screen.getByLabelText('Merchant');
+                expect(merchantInput).toBeDefined();
+            }
 
             // Hours and Rate are only shown during CREATE
             expect(screen.queryByTestId('menu-item-Hours')).toBeNull();


### PR DESCRIPTION
### Explanation of Change
This PR is 2nd release of UI improvements for Expense/IOU creation flow, which aims to replace a few push row inputs with inline inputs to improve UX for migrate users.

The new flow is walled behind `newManualExpenseFlow`.
Current PR refactored Fields `Merchant` and `Description` to be inline input along with addressing previous blockers listed below.

Previous blockers:
https://github.com/Expensify/App/issues/86342
https://github.com/Expensify/App/issues/86394
https://github.com/Expensify/App/issues/86351

### Fixed Issues

$ https://github.com/Expensify/App/issues/82586
PROPOSAL: NA




### Tests

Test 1

1. Open the App.
2. Go to workspace expense room
3. Click `+` from composer -> Create expense   -> Manual.
4. Complete the steps to reach the confirmation page.
5. Verify confirmation page has inline text input for the field `Merchant` and `Description`.
6. Verify `Merchant` and `Description` fields are editable.
7. Clear the Merchant field and click `create expense` button.
8. Verify `Field Required` error pops up for merchant field.
9. Enter a valid merchant value and description value.
10. Click `create expense` button.
11. Verify expense is created successfully.

Test 2

1. Open the App.
2. Go to 1:1 Dm with any user
3. Click `+` from composer -> Create expense   -> Manual.
4. Complete the steps to reach the confirmation page.
5. Verify confirmation page has inline text input for the field `Merchant` and `Description`.
6. Verify `Merchant` and `Description` fields are editable.
7. Clear the Merchant field and click `create expense` button.
8. Verify expense could be created with empty `Merchant` and `Description` values.
9. Repeat step 3-4.
10. Enter valid merchant and description values.
11. Click `create expense` button.
12. Verify expense is created successfully.
13. Click `+` from composer -> Split expense -> Manual.
14. Repeat step 4-12.

- [x] Verify that no errors appear in the JS console

### Offline tests

Same as tests.

### QA Steps

// TODO: These must be filled out, or the issue title must include "[No QA]."


> [!NOTE]
> Following is the list of known bugs, which should be ignored while QA.
> 1. Expense could be created with empty amount field
> 2. Merchant value vanishes for input values (none) and Expense
> 3. Merchant field is allowing empty spaces

Precondition: Log in with Expensifail account.

Test 1

1. Open the App.
2. Go to workspace expense room
3. Click `+` from composer -> Create expense   -> Manual.
4. Complete the steps to reach the confirmation page.
5. Verify confirmation page has inline text input for the field `Merchant` and `Description`.
6. Verify `Merchant` and `Description` fields are editable.
7. Clear the Merchant field and click `create expense` button.
8. Verify `Field Required` error pops up for merchant field.
9. Enter a valid merchant value and description value.
10. Click `create expense` button.
11. Verify expense is created successfully.

Test 2

1. Open the App.
2. Go to 1:1 Dm with any user
3. Click `+` from composer -> Create expense   -> Manual.
4. Complete the steps to reach the confirmation page.
5. Verify confirmation page has inline text input for the field `Merchant` and `Description`.
6. Verify `Merchant` and `Description` fields are editable.
7. Clear the Merchant field and click `create expense` button.
8. Verify expense could be created with empty `Merchant` and `Description` values.
9. Repeat step 3-4.
10. Enter valid merchant and description values.
11. Click `create expense` button.
12. Verify expense is created successfully.
13. Click `+` from composer -> Split expense -> Manual.
14. Repeat step 4-12.


Previous Blocker : https://github.com/Expensify/App/issues/86342
1. Go to staging.new.expensify.com
2. Go to workspace chat.
3. Click + > Create expense > Manual.
4. Enter amount > Next -> Create button does not show amount on confirm page.
5. Open 1:1 DM with any user.
15. Click + > Split expense > Manual.
16. Enter amount > Next.
17. Verify footer button does not include the amount.

Previous Blocker: https://github.com/Expensify/App/issues/86394
Note: Mobile device only test
1. Launch Expensify app.
2. Open 1:1 DM with any user.
3. Tap + > Create expense > Manual.
4. Enter amount > Next.
5. Verify amount field does not show flip button

Previous Blocker: https://github.com/Expensify/App/issues/86351

1. Go to staging.new.expensify.com
2. Open 1:1 DM with any user.
3. Click + > Split expense > Scan.
4. Create a split scan expense.
5. Click on the split preview.
6. Click Show more.
7. On amount field, enter amount.
8. Enter merchant.
18. Click Split expense.
19. Verify split expense is created successfully.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>


https://github.com/user-attachments/assets/c9f07408-7de2-4274-a168-90c677685a49


</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>


https://github.com/user-attachments/assets/2edfedaf-3c83-443f-b7f3-ceb07c2fc07a



</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>


https://github.com/user-attachments/assets/b571d792-d07f-4a55-9a0a-cafccfe0b62f


</details>