### PR TITLE
[No QA] refactor: Extract LHNEmptyState from LHNOptionsList

### DIFF
--- a/src/components/LHNOptionsList/LHNEmptyState.tsx
+++ b/src/components/LHNOptionsList/LHNEmptyState.tsx
@@ -1,0 +1,68 @@
+import React from 'react';
+import {View} from 'react-native';
+import type {BlockingViewProps} from '@components/BlockingViews/BlockingView';
+import BlockingView from '@components/BlockingViews/BlockingView';
+import Icon from '@components/Icon';
+import TextBlock from '@components/TextBlock';
+import {useMemoizedLazyExpensifyIcons} from '@hooks/useLazyAsset';
+import useLocalize from '@hooks/useLocalize';
+import useTheme from '@hooks/useTheme';
+import useThemeStyles from '@hooks/useThemeStyles';
+import variables from '@styles/variables';
+import useEmptyLHNIllustration from './useEmptyLHNIllustration';
+
+function LHNEmptyState() {
+    const theme = useTheme();
+    const styles = useThemeStyles();
+    const {translate} = useLocalize();
+    const expensifyIcons = useMemoizedLazyExpensifyIcons(['MagnifyingGlass', 'Plus']);
+    const emptyLHNIllustration = useEmptyLHNIllustration();
+
+    const subtitle = (
+        <View style={[styles.alignItemsCenter, styles.flexRow, styles.justifyContentCenter, styles.flexWrap, styles.textAlignCenter]}>
+            <TextBlock
+                color={theme.textSupporting}
+                textStyles={[styles.textAlignCenter, styles.textNormal]}
+                text={translate('common.emptyLHN.subtitleText1')}
+            />
+            <Icon
+                src={expensifyIcons.MagnifyingGlass}
+                width={variables.emptyLHNIconWidth}
+                height={variables.emptyLHNIconHeight}
+                fill={theme.icon}
+                small
+                additionalStyles={styles.mh1}
+            />
+            <TextBlock
+                color={theme.textSupporting}
+                textStyles={[styles.textAlignCenter, styles.textNormal]}
+                text={translate('common.emptyLHN.subtitleText2')}
+            />
+            <Icon
+                src={expensifyIcons.Plus}
+                width={variables.emptyLHNIconWidth}
+                height={variables.emptyLHNIconHeight}
+                fill={theme.icon}
+                small
+                additionalStyles={styles.mh1}
+            />
+            <TextBlock
+                color={theme.textSupporting}
+                textStyles={[styles.textAlignCenter, styles.textNormal]}
+                text={translate('common.emptyLHN.subtitleText3')}
+            />
+        </View>
+    );
+
+    return (
+        <BlockingView
+            // eslint-disable-next-line react/jsx-props-no-spreading
+            {...(emptyLHNIllustration as BlockingViewProps)}
+            title={translate('common.emptyLHN.title')}
+            CustomSubtitle={subtitle}
+            accessibilityLabel={translate('common.emptyLHN.title')}
+        />
+    );
+}
+
+export default LHNEmptyState;

--- a/src/components/LHNOptionsList/LHNEmptyState.tsx
+++ b/src/components/LHNOptionsList/LHNEmptyState.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {useEffect} from 'react';
 import {View} from 'react-native';
 import type {BlockingViewProps} from '@components/BlockingViews/BlockingView';
 import BlockingView from '@components/BlockingViews/BlockingView';
@@ -6,9 +6,12 @@ import Icon from '@components/Icon';
 import TextBlock from '@components/TextBlock';
 import {useMemoizedLazyExpensifyIcons} from '@hooks/useLazyAsset';
 import useLocalize from '@hooks/useLocalize';
+import useOnyx from '@hooks/useOnyx';
 import useTheme from '@hooks/useTheme';
 import useThemeStyles from '@hooks/useThemeStyles';
+import Log from '@libs/Log';
 import variables from '@styles/variables';
+import ONYXKEYS from '@src/ONYXKEYS';
 import useEmptyLHNIllustration from './useEmptyLHNIllustration';
 
 function LHNEmptyState() {
@@ -17,6 +20,17 @@ function LHNEmptyState() {
     const {translate} = useLocalize();
     const expensifyIcons = useMemoizedLazyExpensifyIcons(['MagnifyingGlass', 'Plus']);
     const emptyLHNIllustration = useEmptyLHNIllustration();
+    const [reports] = useOnyx(ONYXKEYS.COLLECTION.REPORT);
+    const [policy] = useOnyx(ONYXKEYS.COLLECTION.POLICY);
+    const [personalDetails] = useOnyx(ONYXKEYS.PERSONAL_DETAILS_LIST);
+
+    useEffect(() => {
+        Log.info('Woohoo! All caught up. Was rendered', false, {
+            reportsCount: Object.keys(reports ?? {}).length,
+            policyCount: Object.keys(policy ?? {}).length,
+            personalDetailsCount: Object.keys(personalDetails ?? {}).length,
+        });
+    }, [reports, policy, personalDetails]);
 
     const subtitle = (
         <View style={[styles.alignItemsCenter, styles.flexRow, styles.justifyContentCenter, styles.flexWrap, styles.textAlignCenter]}>

--- a/src/components/LHNOptionsList/LHNOptionsList.tsx
+++ b/src/components/LHNOptionsList/LHNOptionsList.tsx
@@ -16,7 +16,6 @@ import useRootNavigationState from '@hooks/useRootNavigationState';
 import useScrollEventEmitter from '@hooks/useScrollEventEmitter';
 import useThemeStyles from '@hooks/useThemeStyles';
 import getPlatform from '@libs/getPlatform';
-import Log from '@libs/Log';
 import variables from '@styles/variables';
 import CONST from '@src/CONST';
 import NAVIGATORS from '@src/NAVIGATORS';
@@ -195,18 +194,6 @@ function LHNOptionsList({style, contentContainerStyles, data, onSelectRow, optio
             flashListRef.current.scrollToOffset({offset});
         });
     }, [getScrollOffset, route]);
-
-    // eslint-disable-next-line rulesdir/prefer-early-return
-    useEffect(() => {
-        if (data.length === 0) {
-            Log.info('Woohoo! All caught up. Was rendered', false, {
-                reportsCount: Object.keys(reports ?? {}).length,
-                policyCount: Object.keys(policy ?? {}).length,
-                personalDetailsCount: Object.keys(personalDetails ?? {}).length,
-                reportsIDsFromUseReportsCount: data.length,
-            });
-        }
-    }, [data.length, reports, policy, personalDetails]);
 
     return (
         <View style={style ?? styles.flex1}>

--- a/src/components/LHNOptionsList/LHNOptionsList.tsx
+++ b/src/components/LHNOptionsList/LHNOptionsList.tsx
@@ -5,13 +5,8 @@ import {FlashList} from '@shopify/flash-list';
 import type {ReactElement} from 'react';
 import React, {memo, useCallback, useContext, useEffect, useMemo, useRef} from 'react';
 import {StyleSheet, View} from 'react-native';
-import type {BlockingViewProps} from '@components/BlockingViews/BlockingView';
-import BlockingView from '@components/BlockingViews/BlockingView';
-import Icon from '@components/Icon';
 import {ScrollOffsetContext} from '@components/ScrollOffsetContextProvider';
-import TextBlock from '@components/TextBlock';
 import useCurrentUserPersonalDetails from '@hooks/useCurrentUserPersonalDetails';
-import {useMemoizedLazyExpensifyIcons} from '@hooks/useLazyAsset';
 import useLocalize from '@hooks/useLocalize';
 import useNetwork from '@hooks/useNetwork';
 import useOnyx from '@hooks/useOnyx';
@@ -19,7 +14,6 @@ import usePrevious from '@hooks/usePrevious';
 import useReportAttributes from '@hooks/useReportAttributes';
 import useRootNavigationState from '@hooks/useRootNavigationState';
 import useScrollEventEmitter from '@hooks/useScrollEventEmitter';
-import useTheme from '@hooks/useTheme';
 import useThemeStyles from '@hooks/useThemeStyles';
 import getPlatform from '@libs/getPlatform';
 import Log from '@libs/Log';
@@ -32,7 +26,6 @@ import {isEmptyObject} from '@src/types/utils/EmptyObject';
 import OptionRowLHNData from './OptionRowLHNData';
 import OptionRowRendererComponent from './OptionRowRendererComponent';
 import type {LHNOptionsListProps, RenderItemProps} from './types';
-import useEmptyLHNIllustration from './useEmptyLHNIllustration';
 
 const keyExtractor = (item: Report) => `report_${item.reportID}`;
 const platform = getPlatform();
@@ -44,8 +37,6 @@ function LHNOptionsList({style, contentContainerStyles, data, onSelectRow, optio
     const flashListRef = useRef<FlashListRef<Report>>(null);
     const route = useRoute();
     const isScreenFocused = useIsFocused();
-    const expensifyIcons = useMemoizedLazyExpensifyIcons(['MagnifyingGlass', 'Plus']);
-
     const [reports] = useOnyx(ONYXKEYS.COLLECTION.REPORT);
     const reportAttributes = useReportAttributes();
     const [policy] = useOnyx(ONYXKEYS.COLLECTION.POLICY);
@@ -55,13 +46,10 @@ function LHNOptionsList({style, contentContainerStyles, data, onSelectRow, optio
     const [isFullscreenVisible] = useOnyx(ONYXKEYS.FULLSCREEN_VISIBILITY);
     const {accountID: currentUserAccountID} = useCurrentUserPersonalDetails();
 
-    const theme = useTheme();
     const styles = useThemeStyles();
     const {translate, localeCompare} = useLocalize();
     const isReportsSplitNavigatorLast = useRootNavigationState((state) => state?.routes?.at(-1)?.name === NAVIGATORS.REPORTS_SPLIT_NAVIGATOR);
-    const shouldShowEmptyLHN = data.length === 0;
     const estimatedItemSize = optionMode === CONST.OPTION_MODE.COMPACT ? variables.optionRowHeightCompact : variables.optionRowHeight;
-    const emptyLHNIllustration = useEmptyLHNIllustration();
 
     const firstReportIDWithGBRorRBR = useMemo(() => {
         const firstReportWithGBRorRBR = data.find((report) => {
@@ -89,58 +77,6 @@ function LHNOptionsList({style, contentContainerStyles, data, onSelectRow, optio
     // Controls the visibility of the educational tooltip based on user scrolling.
     // Hides the tooltip when the user is scrolling and displays it once scrolling stops.
     const triggerScrollEvent = useScrollEventEmitter();
-
-    const emptyLHNSubtitle = useMemo(
-        () => (
-            <View style={[styles.alignItemsCenter, styles.flexRow, styles.justifyContentCenter, styles.flexWrap, styles.textAlignCenter]}>
-                <TextBlock
-                    color={theme.textSupporting}
-                    textStyles={[styles.textAlignCenter, styles.textNormal]}
-                    text={translate('common.emptyLHN.subtitleText1')}
-                />
-                <Icon
-                    src={expensifyIcons.MagnifyingGlass}
-                    width={variables.emptyLHNIconWidth}
-                    height={variables.emptyLHNIconHeight}
-                    fill={theme.icon}
-                    small
-                    additionalStyles={styles.mh1}
-                />
-                <TextBlock
-                    color={theme.textSupporting}
-                    textStyles={[styles.textAlignCenter, styles.textNormal]}
-                    text={translate('common.emptyLHN.subtitleText2')}
-                />
-                <Icon
-                    src={expensifyIcons.Plus}
-                    width={variables.emptyLHNIconWidth}
-                    height={variables.emptyLHNIconHeight}
-                    fill={theme.icon}
-                    small
-                    additionalStyles={styles.mh1}
-                />
-                <TextBlock
-                    color={theme.textSupporting}
-                    textStyles={[styles.textAlignCenter, styles.textNormal]}
-                    text={translate('common.emptyLHN.subtitleText3')}
-                />
-            </View>
-        ),
-        [
-            styles.alignItemsCenter,
-            styles.flexRow,
-            styles.justifyContentCenter,
-            styles.flexWrap,
-            styles.textAlignCenter,
-            styles.mh1,
-            theme.icon,
-            theme.textSupporting,
-            styles.textNormal,
-            translate,
-            expensifyIcons.MagnifyingGlass,
-            expensifyIcons.Plus,
-        ],
-    );
 
     /**
      * Function which renders a row in the list
@@ -262,7 +198,7 @@ function LHNOptionsList({style, contentContainerStyles, data, onSelectRow, optio
 
     // eslint-disable-next-line rulesdir/prefer-early-return
     useEffect(() => {
-        if (shouldShowEmptyLHN) {
+        if (data.length === 0) {
             Log.info('Woohoo! All caught up. Was rendered', false, {
                 reportsCount: Object.keys(reports ?? {}).length,
                 policyCount: Object.keys(policy ?? {}).length,
@@ -270,39 +206,29 @@ function LHNOptionsList({style, contentContainerStyles, data, onSelectRow, optio
                 reportsIDsFromUseReportsCount: data.length,
             });
         }
-    }, [data.length, shouldShowEmptyLHN, reports, policy, personalDetails]);
+    }, [data.length, reports, policy, personalDetails]);
 
     return (
-        <View style={[style ?? styles.flex1, shouldShowEmptyLHN ? styles.emptyLHNWrapper : undefined]}>
-            {shouldShowEmptyLHN ? (
-                <BlockingView
-                    // eslint-disable-next-line react/jsx-props-no-spreading
-                    {...(emptyLHNIllustration as BlockingViewProps)}
-                    title={translate('common.emptyLHN.title')}
-                    CustomSubtitle={emptyLHNSubtitle}
-                    accessibilityLabel={translate('common.emptyLHN.title')}
-                />
-            ) : (
-                <FlashList
-                    ref={flashListRef}
-                    indicatorStyle="white"
-                    keyboardShouldPersistTaps="always"
-                    CellRendererComponent={OptionRowRendererComponent}
-                    contentContainerStyle={StyleSheet.flatten(contentContainerStyles)}
-                    data={data}
-                    testID="lhn-options-list"
-                    keyExtractor={keyExtractor}
-                    renderItem={renderItem}
-                    extraData={extraData}
-                    showsVerticalScrollIndicator={false}
-                    onLayout={onLayout}
-                    onScroll={onScroll}
-                    initialScrollIndex={isWeb ? getScrollIndex(route) : undefined}
-                    maintainVisibleContentPosition={{disabled: true}}
-                    drawDistance={250}
-                    removeClippedSubviews
-                />
-            )}
+        <View style={style ?? styles.flex1}>
+            <FlashList
+                ref={flashListRef}
+                indicatorStyle="white"
+                keyboardShouldPersistTaps="always"
+                CellRendererComponent={OptionRowRendererComponent}
+                contentContainerStyle={StyleSheet.flatten(contentContainerStyles)}
+                data={data}
+                testID="lhn-options-list"
+                keyExtractor={keyExtractor}
+                renderItem={renderItem}
+                extraData={extraData}
+                showsVerticalScrollIndicator={false}
+                onLayout={onLayout}
+                onScroll={onScroll}
+                initialScrollIndex={isWeb ? getScrollIndex(route) : undefined}
+                maintainVisibleContentPosition={{disabled: true}}
+                drawDistance={250}
+                removeClippedSubviews
+            />
         </View>
     );
 }

--- a/src/pages/inbox/sidebar/SidebarLinks.tsx
+++ b/src/pages/inbox/sidebar/SidebarLinks.tsx
@@ -3,8 +3,10 @@ import {StyleSheet, View} from 'react-native';
 import type {OnyxEntry} from 'react-native-onyx';
 import type {EdgeInsets} from 'react-native-safe-area-context';
 import type {ValueOf} from 'type-fest';
+import LHNEmptyState from '@components/LHNOptionsList/LHNEmptyState';
 import LHNOptionsList from '@components/LHNOptionsList/LHNOptionsList';
 import OptionsListSkeletonView from '@components/OptionsListSkeletonView';
+import useConfirmReadyToOpenApp from '@hooks/useConfirmReadyToOpenApp';
 import useOnyx from '@hooks/useOnyx';
 import useResponsiveLayout from '@hooks/useResponsiveLayout';
 import useStyleUtils from '@hooks/useStyleUtils';
@@ -39,6 +41,8 @@ function SidebarLinks({insets, optionListItems, priorityMode = CONST.PRIORITY_MO
     const StyleUtils = useStyleUtils();
     const {shouldUseNarrowLayout} = useResponsiveLayout();
     const [isLoadingReportData = true] = useOnyx(ONYXKEYS.IS_LOADING_REPORT_DATA);
+
+    useConfirmReadyToOpenApp();
 
     useEffect(() => {
         ReportActionContextMenu.hideContextMenu(false);
@@ -84,18 +88,26 @@ function SidebarLinks({insets, optionListItems, priorityMode = CONST.PRIORITY_MO
     // eslint-disable-next-line react-hooks/exhaustive-deps
     const contentContainerStyles = useMemo(() => StyleSheet.flatten([styles.pt2, {paddingBottom: StyleUtils.getSafeAreaMargins(insets).marginBottom}]), [insets]);
 
+    const shouldShowEmptyLHN = optionListItems.length === 0 && !isLoadingReportData;
+
     return (
         <View style={[styles.flex1, styles.h100]}>
             <View style={[styles.pRelative, styles.flex1]}>
-                <LHNOptionsList
-                    style={styles.flex1}
-                    contentContainerStyles={contentContainerStyles}
-                    data={optionListItems}
-                    onSelectRow={showReportPage}
-                    shouldDisableFocusOptions={shouldUseNarrowLayout}
-                    optionMode={viewMode}
-                    onFirstItemRendered={setSidebarLoaded}
-                />
+                {shouldShowEmptyLHN ? (
+                    <View style={[styles.flex1, styles.emptyLHNWrapper]}>
+                        <LHNEmptyState />
+                    </View>
+                ) : (
+                    <LHNOptionsList
+                        style={styles.flex1}
+                        contentContainerStyles={contentContainerStyles}
+                        data={optionListItems}
+                        onSelectRow={showReportPage}
+                        shouldDisableFocusOptions={shouldUseNarrowLayout}
+                        optionMode={viewMode}
+                        onFirstItemRendered={setSidebarLoaded}
+                    />
+                )}
                 {isLoadingReportData && optionListItems?.length === 0 && (
                     <View style={[StyleSheet.absoluteFill, styles.appBG, styles.mt3]}>
                         <OptionsListSkeletonView

--- a/src/pages/inbox/sidebar/SidebarLinks.tsx
+++ b/src/pages/inbox/sidebar/SidebarLinks.tsx
@@ -6,7 +6,6 @@ import type {ValueOf} from 'type-fest';
 import LHNEmptyState from '@components/LHNOptionsList/LHNEmptyState';
 import LHNOptionsList from '@components/LHNOptionsList/LHNOptionsList';
 import OptionsListSkeletonView from '@components/OptionsListSkeletonView';
-import useConfirmReadyToOpenApp from '@hooks/useConfirmReadyToOpenApp';
 import useOnyx from '@hooks/useOnyx';
 import useResponsiveLayout from '@hooks/useResponsiveLayout';
 import useStyleUtils from '@hooks/useStyleUtils';
@@ -41,8 +40,6 @@ function SidebarLinks({insets, optionListItems, priorityMode = CONST.PRIORITY_MO
     const StyleUtils = useStyleUtils();
     const {shouldUseNarrowLayout} = useResponsiveLayout();
     const [isLoadingReportData = true] = useOnyx(ONYXKEYS.IS_LOADING_REPORT_DATA);
-
-    useConfirmReadyToOpenApp();
 
     useEffect(() => {
         ReportActionContextMenu.hideContextMenu(false);

--- a/src/pages/inbox/sidebar/SidebarLinks.tsx
+++ b/src/pages/inbox/sidebar/SidebarLinks.tsx
@@ -85,7 +85,7 @@ function SidebarLinks({insets, optionListItems, priorityMode = CONST.PRIORITY_MO
     // eslint-disable-next-line react-hooks/exhaustive-deps
     const contentContainerStyles = useMemo(() => StyleSheet.flatten([styles.pt2, {paddingBottom: StyleUtils.getSafeAreaMargins(insets).marginBottom}]), [insets]);
 
-    const shouldShowEmptyLHN = optionListItems.length === 0 && !isLoadingReportData;
+    const shouldShowEmptyLHN = optionListItems.length === 0;
 
     return (
         <View style={[styles.flex1, styles.h100]}>


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
<!-- Explain what your change does and how it addresses the linked issue -->
`LHNOptionsList` previously owned the entire empty-inbox UI inline: three hooks (`useTheme`, `useMemoizedLazyExpensifyIcons`, `useEmptyLHNIllustration`), one `useMemo` for subtitle JSX construction, and a conditional `BlockingView` render. These ran on every mount of `LHNOptionsList`, including the 99%+ of renders where `data.length > 0` and the empty state is never shown.

This PR:

1. **Extracts** the empty state UI into a new `LHNEmptyState` component that only mounts when the inbox is actually empty
2. **Moves the conditional** to `SidebarLinks` (parent level), so `LHNOptionsList` never mounts with empty data
3. **Removes dead code** from `LHNOptionsList`: 3 hook calls, `emptyLHNSubtitle` useMemo (12 deps), conditional `BlockingView` render, and 7 unused imports. The "Woohoo! All caught up" logging useEffect has been relocated to `LHNEmptyState` where it actually fires.

**ManualNavigateToInboxTab span benchmark** (10 runs each, iOS Simulator, same session):

| Metric | main | branch |
|--------|------|--------|
| Avg | 675ms | 622ms |
| Min | 615ms | 558ms |
| Max | 761ms | 724ms |

Delta: -53ms (-7.8%). Perf-neutral to marginally better.

Validated against Onyx rules, React Compiler rules, React Native best practices, and Expensify coding standards. UI is identical between main and branch (verified via accessibility tree diff and visual screenshot comparison).

### Fixed Issues
$ https://github.com/Expensify/App/issues/87080
PROPOSAL:

### Tests

- [x] Verify that no errors appear in the JS console

### Offline tests

N/A

### QA Steps

Same as tests

- [x] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>