### PR TITLE
Add personal card - "Something not working?" modal appears briefly, then disappears

### DIFF
--- a/src/pages/settings/Wallet/PersonalCards/AddNewCardPage.tsx
+++ b/src/pages/settings/Wallet/PersonalCards/AddNewCardPage.tsx
@@ -6,6 +6,7 @@ import useCurrentUserPersonalDetails from '@hooks/useCurrentUserPersonalDetails'
 import useLocalize from '@hooks/useLocalize';
 import useOnyx from '@hooks/useOnyx';
 import useThemeStyles from '@hooks/useThemeStyles';
+import {setAddNewPersonalCardStepAndData} from '@libs/actions/PersonalCards';
 import {navigateToConciergeChat} from '@libs/actions/Report';
 import type {SkeletonSpanReasonAttributes} from '@libs/telemetry/useSkeletonSpan';
 import {clearAddNewPersonalCardFlow} from '@userActions/PersonalCards';
@@ -68,6 +69,17 @@ function AddPersonalNewCardPage() {
             break;
     }
 
+    const onActionPress = (isConfirm?: boolean) => {
+        setIsModalVisible(false);
+        const isUSCountry = addNewPersonalCardFeed?.data?.selectedCountry === CONST.COUNTRY.US;
+        setAddNewPersonalCardStepAndData({
+            step: isUSCountry ? CONST.PERSONAL_CARDS.STEP.SELECT_BANK : CONST.PERSONAL_CARDS.STEP.SELECT_COUNTRY,
+        });
+        if (!isConfirm) {
+            navigateToConciergeChat(conciergeReportID, introSelected, currentUserAccountID, false, betas);
+        }
+    };
+
     return (
         <>
             <View style={styles.flex1}>{CurrentStep}</View>
@@ -78,11 +90,8 @@ function AddPersonalNewCardPage() {
                 confirmText={translate('workspace.companyCards.addNewCard.exitModal.confirmText')}
                 cancelText={translate('workspace.companyCards.addNewCard.exitModal.cancelText')}
                 prompt={translate('workspace.companyCards.addNewCard.exitModal.prompt')}
-                onCancel={() => setIsModalVisible(false)}
-                onConfirm={() => {
-                    setIsModalVisible(false);
-                    navigateToConciergeChat(conciergeReportID, introSelected, currentUserAccountID, false, betas);
-                }}
+                onCancel={onActionPress}
+                onConfirm={() => onActionPress(true)}
             />
         </>
     );

--- a/src/pages/settings/Wallet/PersonalCards/AddNewCardPage.tsx
+++ b/src/pages/settings/Wallet/PersonalCards/AddNewCardPage.tsx
@@ -6,7 +6,6 @@ import useCurrentUserPersonalDetails from '@hooks/useCurrentUserPersonalDetails'
 import useLocalize from '@hooks/useLocalize';
 import useOnyx from '@hooks/useOnyx';
 import useThemeStyles from '@hooks/useThemeStyles';
-import {setAddNewPersonalCardStepAndData} from '@libs/actions/PersonalCards';
 import {navigateToConciergeChat} from '@libs/actions/Report';
 import type {SkeletonSpanReasonAttributes} from '@libs/telemetry/useSkeletonSpan';
 import {clearAddNewPersonalCardFlow} from '@userActions/PersonalCards';
@@ -65,26 +64,9 @@ function AddPersonalNewCardPage() {
             CurrentStep = <PlaidConnectionStep onExit={() => setIsModalVisible(true)} />;
             break;
         default:
-            CurrentStep = <SelectCountryStep />;
+            CurrentStep = <SelectCountryStep disableAutoFocus={isModalVisible} />;
             break;
     }
-
-    const exitPlaidFlowToPreviousStep = () => {
-        setIsModalVisible(false);
-        const isUSCountry = addNewPersonalCardFeed?.data?.selectedCountry === CONST.COUNTRY.US;
-        setAddNewPersonalCardStepAndData({
-            step: isUSCountry ? CONST.PERSONAL_CARDS.STEP.SELECT_BANK : CONST.PERSONAL_CARDS.STEP.SELECT_COUNTRY,
-        });
-    };
-
-    const handleExitModalSkip = () => {
-        exitPlaidFlowToPreviousStep();
-    };
-
-    const handleExitModalReportIssue = () => {
-        exitPlaidFlowToPreviousStep();
-        navigateToConciergeChat(conciergeReportID, introSelected, currentUserAccountID, false, betas);
-    };
 
     return (
         <>
@@ -96,8 +78,11 @@ function AddPersonalNewCardPage() {
                 confirmText={translate('workspace.companyCards.addNewCard.exitModal.confirmText')}
                 cancelText={translate('workspace.companyCards.addNewCard.exitModal.cancelText')}
                 prompt={translate('workspace.companyCards.addNewCard.exitModal.prompt')}
-                onCancel={handleExitModalSkip}
-                onConfirm={handleExitModalReportIssue}
+                onCancel={() => setIsModalVisible(false)}
+                onConfirm={() => {
+                    setIsModalVisible(false);
+                    navigateToConciergeChat(conciergeReportID, introSelected, currentUserAccountID, false, betas);
+                }}
             />
         </>
     );

--- a/src/pages/settings/Wallet/PersonalCards/AddNewCardPage.tsx
+++ b/src/pages/settings/Wallet/PersonalCards/AddNewCardPage.tsx
@@ -69,15 +69,21 @@ function AddPersonalNewCardPage() {
             break;
     }
 
-    const onActionPress = (isConfirm?: boolean) => {
+    const exitPlaidFlowToPreviousStep = () => {
         setIsModalVisible(false);
         const isUSCountry = addNewPersonalCardFeed?.data?.selectedCountry === CONST.COUNTRY.US;
         setAddNewPersonalCardStepAndData({
             step: isUSCountry ? CONST.PERSONAL_CARDS.STEP.SELECT_BANK : CONST.PERSONAL_CARDS.STEP.SELECT_COUNTRY,
         });
-        if (!isConfirm) {
-            navigateToConciergeChat(conciergeReportID, introSelected, currentUserAccountID, false, betas);
-        }
+    };
+
+    const handleExitModalSkip = () => {
+        exitPlaidFlowToPreviousStep();
+    };
+
+    const handleExitModalReportIssue = () => {
+        exitPlaidFlowToPreviousStep();
+        navigateToConciergeChat(conciergeReportID, introSelected, currentUserAccountID, false, betas);
     };
 
     return (
@@ -90,8 +96,8 @@ function AddPersonalNewCardPage() {
                 confirmText={translate('workspace.companyCards.addNewCard.exitModal.confirmText')}
                 cancelText={translate('workspace.companyCards.addNewCard.exitModal.cancelText')}
                 prompt={translate('workspace.companyCards.addNewCard.exitModal.prompt')}
-                onCancel={onActionPress}
-                onConfirm={() => onActionPress(true)}
+                onCancel={handleExitModalSkip}
+                onConfirm={handleExitModalReportIssue}
             />
         </>
     );

--- a/src/pages/settings/Wallet/PersonalCards/steps/PlaidConnectionStep.tsx
+++ b/src/pages/settings/Wallet/PersonalCards/steps/PlaidConnectionStep.tsx
@@ -1,4 +1,4 @@
-import React, {useEffect, useRef, useState} from 'react';
+import React, {useEffect, useRef} from 'react';
 import {View} from 'react-native';
 import type {LinkSuccessMetadata} from 'react-native-plaid-link-sdk';
 import type {PlaidLinkOnSuccessMetadata} from 'react-plaid-link/src/types';
@@ -80,7 +80,6 @@ function PlaidConnectionStep({feed, onExit}: {feed?: CompanyCardFeedWithDomainID
     const plaidErrors = plaidData?.errors;
     const subscribedKeyboardShortcuts = useRef<Array<() => void>>([]);
     const previousNetworkState = useRef<boolean | undefined>(undefined);
-    const [hasExitedPlaidAwaitingConfirmation, setHasExitedPlaidAwaitingConfirmation] = useState(false);
     const plaidDataErrorMessage = !isEmptyObject(plaidErrors) && Object.values(plaidErrors) ? (Object.values(plaidErrors).at(0) ?? '') : '';
     const {isOffline} = useNetwork();
     const isAuthenticatedWithPlaid = !!plaidData?.bankAccounts?.length || !isEmptyObject(plaidData?.errors);
@@ -132,11 +131,11 @@ function PlaidConnectionStep({feed, onExit}: {feed?: CompanyCardFeedWithDomainID
     useEffect(() => {
         // If we are coming back from offline and we haven't authenticated with Plaid yet, we need to re-run our call to kick off Plaid
         // previousNetworkState.current also makes sure that this doesn't run on the first render.
-        if (previousNetworkState.current && !isOffline && !isAuthenticatedWithPlaid && addNewPersonalCard?.data?.selectedCountry && !hasExitedPlaidAwaitingConfirmation) {
+        if (previousNetworkState.current && !isOffline && !isAuthenticatedWithPlaid && addNewPersonalCard?.data?.selectedCountry) {
             openPlaidCompanyCardLogin(addNewPersonalCard.data.selectedCountry, '', feed, true);
         }
         previousNetworkState.current = isOffline;
-    }, [addNewPersonalCard?.data?.selectedCountry, feed, hasExitedPlaidAwaitingConfirmation, isAuthenticatedWithPlaid, isOffline]);
+    }, [addNewPersonalCard?.data?.selectedCountry, feed, isAuthenticatedWithPlaid, isOffline]);
 
     const handleBackButtonPress = () => {
         if (feed) {
@@ -176,8 +175,8 @@ function PlaidConnectionStep({feed, onExit}: {feed?: CompanyCardFeedWithDomainID
     };
 
     const handlePlaidLinkExit = () => {
-        setHasExitedPlaidAwaitingConfirmation(true);
         onExit?.();
+        handleBackButtonPress();
     };
 
     return (
@@ -196,7 +195,7 @@ function PlaidConnectionStep({feed, onExit}: {feed?: CompanyCardFeedWithDomainID
             ) : (
                 <FullPageOfflineBlockingView>
                     <PlaidLinkContent
-                        plaidLinkToken={hasExitedPlaidAwaitingConfirmation ? undefined : plaidLinkToken}
+                        plaidLinkToken={plaidLinkToken}
                         plaidDataErrorMessage={plaidDataErrorMessage}
                         plaidData={plaidData}
                         onSuccess={handlePlaidLinkSuccess}

--- a/src/pages/settings/Wallet/PersonalCards/steps/PlaidConnectionStep.tsx
+++ b/src/pages/settings/Wallet/PersonalCards/steps/PlaidConnectionStep.tsx
@@ -1,4 +1,4 @@
-import React, {useEffect, useRef} from 'react';
+import React, {useEffect, useRef, useState} from 'react';
 import {View} from 'react-native';
 import type {LinkSuccessMetadata} from 'react-native-plaid-link-sdk';
 import type {PlaidLinkOnSuccessMetadata} from 'react-plaid-link/src/types';
@@ -80,6 +80,7 @@ function PlaidConnectionStep({feed, onExit}: {feed?: CompanyCardFeedWithDomainID
     const plaidErrors = plaidData?.errors;
     const subscribedKeyboardShortcuts = useRef<Array<() => void>>([]);
     const previousNetworkState = useRef<boolean | undefined>(undefined);
+    const [hasExitedPlaidAwaitingConfirmation, setHasExitedPlaidAwaitingConfirmation] = useState(false);
     const plaidDataErrorMessage = !isEmptyObject(plaidErrors) && Object.values(plaidErrors) ? (Object.values(plaidErrors).at(0) ?? '') : '';
     const {isOffline} = useNetwork();
     const isAuthenticatedWithPlaid = !!plaidData?.bankAccounts?.length || !isEmptyObject(plaidData?.errors);
@@ -125,16 +126,17 @@ function PlaidConnectionStep({feed, onExit}: {feed?: CompanyCardFeedWithDomainID
         }
 
         // disabling this rule, as we want this to run only on the first render
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
 
     useEffect(() => {
         // If we are coming back from offline and we haven't authenticated with Plaid yet, we need to re-run our call to kick off Plaid
         // previousNetworkState.current also makes sure that this doesn't run on the first render.
-        if (previousNetworkState.current && !isOffline && !isAuthenticatedWithPlaid && addNewPersonalCard?.data?.selectedCountry) {
+        if (previousNetworkState.current && !isOffline && !isAuthenticatedWithPlaid && addNewPersonalCard?.data?.selectedCountry && !hasExitedPlaidAwaitingConfirmation) {
             openPlaidCompanyCardLogin(addNewPersonalCard.data.selectedCountry, '', feed, true);
         }
         previousNetworkState.current = isOffline;
-    }, [addNewPersonalCard?.data?.selectedCountry, feed, isAuthenticatedWithPlaid, isOffline]);
+    }, [addNewPersonalCard?.data?.selectedCountry, feed, hasExitedPlaidAwaitingConfirmation, isAuthenticatedWithPlaid, isOffline]);
 
     const handleBackButtonPress = () => {
         if (feed) {
@@ -174,8 +176,8 @@ function PlaidConnectionStep({feed, onExit}: {feed?: CompanyCardFeedWithDomainID
     };
 
     const handlePlaidLinkExit = () => {
+        setHasExitedPlaidAwaitingConfirmation(true);
         onExit?.();
-        handleBackButtonPress();
     };
 
     return (
@@ -194,7 +196,7 @@ function PlaidConnectionStep({feed, onExit}: {feed?: CompanyCardFeedWithDomainID
             ) : (
                 <FullPageOfflineBlockingView>
                     <PlaidLinkContent
-                        plaidLinkToken={plaidLinkToken}
+                        plaidLinkToken={hasExitedPlaidAwaitingConfirmation ? undefined : plaidLinkToken}
                         plaidDataErrorMessage={plaidDataErrorMessage}
                         plaidData={plaidData}
                         onSuccess={handlePlaidLinkSuccess}

--- a/src/pages/settings/Wallet/PersonalCards/steps/SelectCountryStep.tsx
+++ b/src/pages/settings/Wallet/PersonalCards/steps/SelectCountryStep.tsx
@@ -22,7 +22,7 @@ import CONST from '@src/CONST';
 import type {TranslationPaths} from '@src/languages/types';
 import ONYXKEYS from '@src/ONYXKEYS';
 
-function SelectCountryStep() {
+function SelectCountryStep({disableAutoFocus}: {disableAutoFocus?: boolean}) {
     const {translate, localeCompare} = useLocalize();
     const styles = useThemeStyles();
     const {currencyList} = useCurrencyListState();
@@ -112,6 +112,7 @@ function SelectCountryStep() {
                     value: searchValue,
                     label: translate('common.search'),
                     onChangeText: setSearchValue,
+                    disableAutoFocus,
                 }}
                 confirmButtonOptions={{
                     onConfirm: submit,


### PR DESCRIPTION
### Explanation of Change
"Something not working?" modal appears briefly, then it disappears, and the keyboard opens

### Fixed Issues

$ https://github.com/Expensify/App/issues/86600
PROPOSAL:


### Tests

1. Sign in to ND with a new expensifail account
2. Navigate to the Account tab, open Wallet page
3. Tap Add personal card
4. Select a country other, than US (Poland, for example), then tap Next
5. On the Plaid modal tap "x" button in the top right corner, then "Yes, exit"
6. "Something not working?" modal appears with "Report issue" and "Skip" buttons

- [x] Verify that no errors appear in the JS console

### Offline tests
N/A

### QA Steps

1. Sign in to ND with a new expensifail account
2. Navigate to the Account tab, open Wallet page
3. Tap Add personal card
4. Select a country other, than US (Poland, for example), then tap Next
5. On the Plaid modal tap "x" button in the top right corner, then "Yes, exit"
6. "Something not working?" modal appears with "Report issue" and "Skip" buttons

- [x] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x]  The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>


https://github.com/user-attachments/assets/d1282c63-dfe4-4eaf-b889-731c5242aa81


</details>

<details>
<summary>Android: mWeb Chrome</summary>


</details>

<details>
<summary>iOS: Native</summary>


https://github.com/user-attachments/assets/913a7828-c564-47b4-850d-e17b4ab07c83


</details>

<details>
<summary>iOS: mWeb Safari</summary>


https://github.com/user-attachments/assets/f73fdec0-aaa1-463d-a307-b7fd5c34943e


</details>

<details>
<summary>MacOS: Chrome / Safari</summary>


https://github.com/user-attachments/assets/ff9d09c9-3ac6-4fa5-a5cd-c2f596c1aa76


</details>