### PR TITLE
Fix receipt thumbnail disappearing after rotate/crop

### DIFF
--- a/src/components/ReportActionItem/ReportActionItemImage.tsx
+++ b/src/components/ReportActionItem/ReportActionItemImage.tsx
@@ -137,7 +137,7 @@ function ReportActionItemImage({
     const localSource = transaction?.receipt?.localSource;
     const effectiveIsLocalFile = isLocalFile || !!localSource;
     const effectiveThumbnail = localSource ?? thumbnail;
-    const effectiveImage = localSource !== undefined && typeof image === 'string' ? localSource : image;
+    const effectiveImage = localSource != null && typeof image === 'string' ? localSource : image;
 
     const originalImageSource = tryResolveUrlFromApiRoot(effectiveImage ?? '');
     const thumbnailSource = tryResolveUrlFromApiRoot(effectiveThumbnail ?? '');

--- a/src/libs/actions/IOU/index.ts
+++ b/src/libs/actions/IOU/index.ts
@@ -11685,6 +11685,7 @@ function replaceReceipt({transactionID, file, source, state, transactionPolicy, 
     const oldReceipt = transaction?.receipt ?? {};
     const receiptOptimistic = {
         source,
+        localSource: null,
         state: state ?? CONST.IOU.RECEIPT_STATE.OPEN,
         filename: file.name,
     };

--- a/src/types/onyx/Transaction.ts
+++ b/src/types/onyx/Transaction.ts
@@ -219,7 +219,7 @@ type Receipt = {
     source?: ReceiptSource;
 
     /** Local file URI preserved on the creating device so the remote source from the server does not cause a reload */
-    localSource?: string;
+    localSource?: string | null;
 
     /** Name of receipt file */
     filename?: string;


### PR DESCRIPTION
### Explanation of Change

PR #86512 introduced `localSource` on `transaction.receipt` to preserve the local file URI during SmartScan, preventing the server's remote URL from causing an unnecessary image reload. `ReportActionItemImage` uses `localSource` in priority over `thumbnail`/`image` when rendering.

However, `replaceReceipt` (used by both the Replace button and the Rotate/Crop flow) only merges `source`, `state`, and `filename` into `receiptOptimistic` — Onyx merge doesn't remove keys absent from the update, so the old `localSource` persists. `ReportActionItemImage` then renders the stale local URI instead of the new receipt. The full-receipt modal reads `receipt.source` directly, which is why the correct image shows there but not in expense list/detail thumbnail views.

This PR has two fixes:

**1. `IOU/index.ts` — clear `localSource` on replace (`localSource: null`)**

Adding `localSource: null` to `receiptOptimistic` explicitly clears the stale URI via Onyx merge. This fixes both deploy blockers: the old receipt no longer persists after a Replace, and thumbnails update correctly after Rotate/Crop.

**2. `ReportActionItemImage.tsx` — fix the `effectiveImage` null guard**

Without this fix, setting `localSource: null` introduces a new regression: the image goes blank during the optimistic update. The existing guard uses `!== undefined`:

```js
// before: null !== undefined → true → effectiveImage = null → blank receipt during optimistic update
const effectiveImage = localSource !== undefined && typeof image === 'string' ? localSource : image;
```

`null` passes this strict check, so `effectiveImage` is assigned `null` instead of the correct `image` value, producing an empty image source until the server responds.

```js
// after: null != null → false → correctly falls back to image
const effectiveImage = localSource != null && typeof image === 'string' ? localSource : image;
```

`!= null` (loose equality) treats both `null` and `undefined` as "no local source".

**3. `Transaction.ts` — widen `localSource` type to `string | null`**

Reflects that `localSource` can be explicitly cleared.

### Fixed Issues
$ https://github.com/Expensify/App/issues/87029
$ https://github.com/Expensify/App/issues/87051
PROPOSAL:

### Tests

**Scenario A — Replace receipt ($ #87029: old receipt persists after replace)**

1. Open the Expensify app on any platform
2. Go to a workspace chat and create a scan expense
3. Navigate to the expense details page
4. Tap the receipt thumbnail to open it
5. Tap the **Replace** button and upload a different image
6. Navigate away (tap the back arrow) and return to the expense detail
7. Verify the new receipt thumbnail is shown everywhere — expense list, expense details, report preview
8. Tap the receipt to open the full modal and verify it also shows the new receipt

**Scenario B — Rotate/Crop receipt ($ #87051: thumbnail not updated after rotate/crop)**

1. Open a scan expense with a receipt
2. Tap the receipt preview
3. Tap **Rotate** or **Crop**, make a change, and save
4. Navigate back and verify the updated receipt thumbnail is displayed immediately on all screens: expense detail, expense list row, and report preview — not just in the full receipt modal

**Scenario C — No blank image during optimistic update (fixes Codex-identified regression)**

1. Set your device to a throttled/slow network connection (or enable airplane mode briefly after tapping save)
2. Perform a Rotate or Crop on a receipt and save
3. Verify the receipt image does **not** go blank during the moment between saving and the server response arriving — the UI should continue showing an image throughout

### Offline tests

1. Go offline (airplane mode)
2. Perform a Replace, Rotate, or Crop on a scan expense receipt
3. Verify the updated receipt thumbnail is visible immediately after saving — no blank/missing image — and that the correct image is shown when you come back online

### QA Steps

**Deploy blocker #87029 — Replace receipt:**
1. On staging, create a scan expense in a workspace chat
2. Open the expense, tap the receipt, tap Replace, and upload a new image
3. Navigate away and back
4. Verify the new receipt shows in the expense thumbnail — not the old one

**Deploy blocker #87051 — Rotate/Crop thumbnail:**
1. On staging, open a scan expense with a receipt
2. Tap the receipt preview, tap Rotate or Crop, save
3. Navigate back through the expense detail and report preview
4. Verify the updated thumbnail appears immediately on all screens

**Regression check — no blank image:**
1. On a slow connection, perform a Rotate or Crop and save
2. Verify the receipt image does not go blank between saving and the server response

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>