### PR TITLE
Fix #87093: Preserve line breaks in room header for multi-line descriptions

### DIFF
--- a/src/components/DisplayNames/index.native.tsx
+++ b/src/components/DisplayNames/index.native.tsx
@@ -13,8 +13,11 @@ function DisplayNames({accessibilityLabel, fullTitle, textStyles = [], numberOfL
     const titleContainsTextAndCustomEmoji = useMemo(() => containsCustomEmoji(fullTitle) && !containsOnlyCustomEmoji(fullTitle), [fullTitle]);
     const title = useMemo(() => {
         const processedTitle = shouldParseFullTitle ? Parser.htmlToText(fullTitle) : fullTitle;
-        return StringUtils.lineBreaksToSpaces(processedTitle) || translate('common.hidden');
-    }, [fullTitle, shouldParseFullTitle, translate]);
+        // Only convert line breaks to spaces when numberOfLines is exactly 1 (single-line mode).
+        // For multi-line (numberOfLines > 1) or unlimited (numberOfLines === 0) we preserve line breaks.
+        const finalTitle = numberOfLines === 1 ? StringUtils.lineBreaksToSpaces(processedTitle) : processedTitle;
+        return finalTitle || translate('common.hidden');
+    }, [fullTitle, shouldParseFullTitle, numberOfLines, translate]);
 
     return (
         <Text

--- a/src/components/DisplayNames/index.tsx
+++ b/src/components/DisplayNames/index.tsx
@@ -21,8 +21,11 @@ function DisplayNames({
     const {translate} = useLocalize();
     const title = useMemo(() => {
         const processedTitle = shouldParseFullTitle ? Parser.htmlToText(fullTitle) : fullTitle;
-        return StringUtils.lineBreaksToSpaces(processedTitle) || translate('common.hidden');
-    }, [fullTitle, shouldParseFullTitle, translate]);
+        // Only convert line breaks to spaces when numberOfLines is exactly 1 (single-line mode).
+        // For multi-line (numberOfLines > 1) or unlimited (numberOfLines === 0) we preserve line breaks.
+        const finalTitle = numberOfLines === 1 ? StringUtils.lineBreaksToSpaces(processedTitle) : processedTitle;
+        return finalTitle || translate('common.hidden');
+    }, [fullTitle, shouldParseFullTitle, numberOfLines, translate]);
 
     if (!tooltipEnabled) {
         return (

--- a/src/pages/ReportDetailsPage.tsx
+++ b/src/pages/ReportDetailsPage.tsx
@@ -818,7 +818,7 @@ function ReportDetailsPage({policy, report, route, reportMetadata}: ReportDetail
                 <MenuItemWithTopDescription
                     shouldShowRightIcon={!shouldDisableRename}
                     interactive={!shouldDisableRename}
-                    title={StringUtils.lineBreaksToSpaces(reportName)}
+                    title={reportName}
                     titleStyle={styles.newKansasLarge}
                     titleContainerStyle={shouldDisableRename && styles.alignItemsCenter}
                     shouldCheckActionAllowedOnPress={false}


### PR DESCRIPTION
## Summary

$ https://github.com/Expensify/App/issues/87093

The room header was inconsistently displaying two-line descriptions across platforms:
- **iOS**: showed only the first line
- **Android**: showed "..."
- **Web**: collapsed everything to a single line

### Root Cause

`StringUtils.lineBreaksToSpaces()` was unconditionally called on the display title in the `DisplayNames` component, converting all newlines to spaces regardless of whether the component was in single-line or multi-line mode.

### Fix

- **DisplayNames (web + native)**: Only apply `lineBreaksToSpaces` when `numberOfLines === 1` (single-line mode). For multi-line (`numberOfLines > 1`) or unlimited (`numberOfLines === 0`), preserve line breaks so the native text component handles wrapping naturally.
- **ReportDetailsPage**: Remove `lineBreaksToSpaces` call on room name title, allowing multi-line display.

### Changed Files
- `src/components/DisplayNames/index.tsx`
- `src/components/DisplayNames/index.native.tsx`
- `src/pages/ReportDetailsPage.tsx`

## Test Plan

- [ ] Create a room with a 2-line description
- [ ] Verify the header displays both lines consistently on iOS, Android, and Web
- [ ] Verify single-line contexts (like LHN) still collapse line breaks to spaces
- [ ] Verify room details page shows full multi-line description