### PR TITLE
Fix Safari iOS swipe-back gesture causing screen flicker

### DIFF
--- a/patches/react-navigation/@react-navigation+stack+7.8.5+001+edge-drag-gesture.patch
+++ b/patches/react-navigation/@react-navigation+stack+7.8.5+001+edge-drag-gesture.patch
@@ -1,26 +1,20 @@
 diff --git a/node_modules/@react-navigation/stack/lib/module/utils/edgeDragGestureMonitor.js b/node_modules/@react-navigation/stack/lib/module/utils/edgeDragGestureMonitor.js
 new file mode 100644
-index 0000000..f6edb80
+index 0000000..de3a4e8
 --- /dev/null
 +++ b/node_modules/@react-navigation/stack/lib/module/utils/edgeDragGestureMonitor.js
-@@ -0,0 +1,46 @@
+@@ -0,0 +1,38 @@
 +"use strict";
 +
 +let isInitialized = false;
 +let justFinishedEdgeGestureFromLeft = false;
-+let expectingTouchend = false;
++let touchStartPositionX = 0;
 +
 +/// This returns information if the user just performed edge gesture on iOS safari to navigate in the browser history.
 +export const getIsEdgeDragGesture = () => {
-+  return expectingTouchend || justFinishedEdgeGestureFromLeft;
++  return justFinishedEdgeGestureFromLeft;
 +};
 +
-+// We need to manualy reset this flag after deciding if there should be animation for navigation.
-+export const resetExpectingTouchendWithDelay = () => {
-+  setTimeout(() => {
-+    expectingTouchend = false;
-+  }, 100);
-+};
 +export const maybeInitializeEdgeDragGestureMonitor = () => {
 +  if (isInitialized) {
 +    return;
@@ -28,23 +22,20 @@ index 0000000..f6edb80
 +  isInitialized = true;
 +  let timer;
 +
-+  // Gestures that would trigger navigation forward are broken on iOS safari.
-+  // They don't have touchend event fired so we can look at expectingTouchEnd flag to detect if we should run animation.
-+  const handleTouchStart = () => {
-+    expectingTouchend = true;
++  const handleTouchStart = e => {
++    touchStartPositionX = e.changedTouches[0].pageX;
 +  };
 +  const handleTouchEnd = e => {
 +    let changedTouches;
 +    const pageX = (changedTouches = e.changedTouches[0]) === null || changedTouches === void 0 ? void 0 : changedTouches.pageX;
-+    // PageX for gesture that would trigger navigation back is negative.
-+    if (pageX < 0) {
++    // A left-to-right swipe with sufficient travel distance triggers browser back navigation on iOS Safari.
++    if ((pageX - touchStartPositionX) > 20) {
 +      if (timer) {
 +        clearTimeout(timer);
 +      }
 +      justFinishedEdgeGestureFromLeft = true;
 +      timer = setTimeout(() => justFinishedEdgeGestureFromLeft = false, 100);
 +    }
-+    expectingTouchend = false;
 +  };
 +  document.addEventListener('touchstart', handleTouchStart);
 +  document.addEventListener('touchend', handleTouchEnd);
@@ -53,16 +44,15 @@ index 0000000..f6edb80
 \ No newline at end of file
 diff --git a/node_modules/@react-navigation/stack/lib/module/utils/edgeDragGestureMonitor.native.js b/node_modules/@react-navigation/stack/lib/module/utils/edgeDragGestureMonitor.native.js
 new file mode 100644
-index 0000000..9c7b703
+index 0000000..5a2bb2d
 --- /dev/null
 +++ b/node_modules/@react-navigation/stack/lib/module/utils/edgeDragGestureMonitor.native.js
-@@ -0,0 +1,8 @@
+@@ -0,0 +1,6 @@
 +"use strict";
 +
 +// We don't need edgeDragGestureMonitor for native platforms.
 +
 +export const getIsEdgeDragGesture = () => false;
-+export const resetExpectingTouchendWithDelay = () => {};
 +export const maybeInitializeEdgeDragGestureMonitor = () => {};
 +//# sourceMappingURL=edgeDragGestureMonitor.native.js.map
 \ No newline at end of file
@@ -74,31 +64,31 @@ index 0000000..0000000 100644
  import useLatestCallback from 'use-latest-callback';
  import { CardAnimationContext } from "../../utils/CardAnimationContext.js";
  import { gestureActivationCriteria } from "../../utils/gestureActivationCriteria.js";
-+import { getIsEdgeDragGesture, resetExpectingTouchendWithDelay } from '../../utils/edgeDragGestureMonitor';
++import { getIsEdgeDragGesture } from '../../utils/edgeDragGestureMonitor';
  import { getDistanceForDirection } from "../../utils/getDistanceForDirection.js";
  import { getInvertedMultiplier } from "../../utils/getInvertedMultiplier.js";
  import { getShadowStyle } from "../../utils/getShadowStyle.js";
-@@ -134,7 +135,9 @@ export function Card({
+@@ -111,7 +112,10 @@ export function Card({
+     lastToValueRef.current = toValue;
+     isClosing.setValue(isClosingParam ? TRUE : FALSE);
+     const spec = isClosingParam ? transitionSpec.close : transitionSpec.open;
+-    const animation = spec.animation === 'spring' ? Animated.spring : Animated.timing;
++    const isEdgeDragGesture = getIsEdgeDragGesture();
++    // Switch to timing animation when an edge gesture is detected, as spring animations ignore the duration config.
++    const animation = spec.animation === 'spring' && !isEdgeDragGesture ? Animated.spring : Animated.timing;
+     clearTimeout(pendingGestureCallbackRef.current);
+     if (animationHandleRef.current !== undefined) {
+       cancelAnimationFrame(animationHandleRef.current);
+@@ -134,7 +138,8 @@ export function Card({
      if (animated) {
        onStartInteraction();
        animation(gesture, {
          ...spec.config,
 +        // Detecting if the user used swipe gesture on iOS safari to trigger navigation in the browser history.
-+        duration: getIsEdgeDragGesture() ? 0 : spec.config && 'duration' in spec.config ? spec.config.duration : undefined,
++        duration: isEdgeDragGesture ? 0 : spec.config && 'duration' in spec.config ? spec.config.duration : undefined,
          velocity,
          toValue,
          useNativeDriver,
-@@ -143,7 +145,10 @@ export function Card({
-         finished
-       }) => {
-         onEndInteraction();
-         clearTimeout(pendingGestureCallbackRef.current);
-+
-+        // We need to reset edgeDragGestureMonitor manually because of broken events on iOS safari.
-+        resetExpectingTouchendWithDelay();
-         if (finished) {
-           onFinish();
-         }
 diff --git a/node_modules/@react-navigation/stack/lib/module/views/Stack/CardStack.js b/node_modules/@react-navigation/stack/lib/module/views/Stack/CardStack.js
 index 0000000..0000000 100644
 --- a/node_modules/@react-navigation/stack/lib/module/views/Stack/CardStack.js


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change

Refines the `edgeDragGestureMonitor` patch for `@react-navigation/stack` to more reliably detect iOS Safari swipe-back gestures.

**Root cause**: When a user swipes from the left edge in Safari iOS to navigate back in browser history, the React Navigation spring animation briefly renders the previous screen before completing, causing a visible flicker.

**Previous approach**: Detected the gesture by checking if `touchend.pageX < 0` (negative x coordinate). This was unreliable on newer Safari versions where the coordinate is not negative.

**New approach**: Records `touchStartPositionX` on `touchstart`, then compares against `touchend.pageX`. A left-to-right swipe with > 20px travel is classified as an edge gesture. When detected, the animation switches from spring to timing with `duration: 0`, making the transition instant and eliminating the flicker.

This also removes the `resetExpectingTouchendWithDelay` function and the `expectingTouchend` state variable, simplifying the implementation.

### Fixed Issues

$ https://github.com/Expensify/App/issues/75905
PROPOSAL:

### Tests

1. Open the app on iOS Safari (or use a Safari iOS simulator)
2. Navigate to any chat or screen
3. Perform a swipe-back gesture from the left edge of the screen
4. Verify that the previous screen does NOT flicker/briefly appear — navigation should be smooth
5. Verify normal in-app back button navigation still works correctly

- [ ] Verify that no errors appear in the JS console

### Offline tests

This change only affects navigation animations. Offline behavior is unaffected — navigation still works the same way offline.

### QA Steps

1. Sign in to the app on iOS Safari (mobile web)
2. Navigate to any chat or report
3. Use the swipe-back gesture from the left edge of the screen
4. Verify the previous screen does not flicker or briefly appear during the transition
5. Verify that navigating back via the in-app back button still works correctly on all platforms

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

N/A - this fix is specific to iOS Safari (mWeb)

</details>

<details>
<summary>Android: mWeb Chrome</summary>

N/A - this fix is specific to iOS Safari (mWeb)

</details>

<details>
<summary>iOS: Native</summary>

N/A - this fix is specific to iOS Safari (mWeb)

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- Before: swipe-back gesture briefly shows previous screen (flicker) -->
<!-- After: swipe-back gesture navigates smoothly with no flicker -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

N/A - this fix is specific to iOS Safari touch gestures

</details>