### PR TITLE
Deferring Trie Build

### DIFF
--- a/src/components/LocaleContextProvider.tsx
+++ b/src/components/LocaleContextProvider.tsx
@@ -1,6 +1,5 @@
 import {format as formatDate} from 'date-fns';
 import React, {createContext, useEffect, useState} from 'react';
-import {importEmojiLocale} from '@assets/emojis';
 import useCurrentUserPersonalDetails from '@hooks/useCurrentUserPersonalDetails';
 import useOnyx from '@hooks/useOnyx';
 import DateUtils from '@libs/DateUtils';
@@ -8,10 +7,9 @@ import {fromLocaleDigit as fromLocaleDigitLocaleDigitUtils, toLocaleDigit as toL
 import {formatPhoneNumberWithCountryCode} from '@libs/LocalePhoneNumber';
 import {getDevicePreferredLocale, translate as translateLocalize} from '@libs/Localize';
 import {format} from '@libs/NumberFormatUtils';
-import {endSpan, getSpan, startSpan} from '@libs/telemetry/activeSpans';
 import {setLocale} from '@userActions/App';
 import CONST from '@src/CONST';
-import {isFullySupportedLocale, isSupportedLocale} from '@src/CONST/LOCALES';
+import {isSupportedLocale} from '@src/CONST/LOCALES';
 import IntlStore from '@src/languages/IntlStore';
 import type {TranslationParameters, TranslationPaths} from '@src/languages/types';
 import ONYXKEYS from '@src/ONYXKEYS';
@@ -106,19 +104,6 @@ function LocaleContextProvider({children}: LocaleContextProviderProps) {
 
         IntlStore.load(localeToApply);
         setLocale(localeToApply, nvpPreferredLocale);
-
-        // For locales without emoji support, fallback on English
-        const normalizedLocale = isFullySupportedLocale(localeToApply) ? localeToApply : CONST.LOCALES.DEFAULT;
-
-        startSpan(CONST.TELEMETRY.SPAN_LOCALE.EMOJI_IMPORT, {
-            name: CONST.TELEMETRY.SPAN_LOCALE.EMOJI_IMPORT,
-            op: CONST.TELEMETRY.SPAN_LOCALE.EMOJI_IMPORT,
-            parentSpan: getSpan(CONST.TELEMETRY.SPAN_LOCALE.ROOT),
-        });
-
-        importEmojiLocale(normalizedLocale).then(() => {
-            endSpan(CONST.TELEMETRY.SPAN_LOCALE.EMOJI_IMPORT);
-        });
     }, [localeToApply, nvpPreferredLocale]);
 
     // Sync currentLocale from IntlStore after translations finish loading.

--- a/src/components/LocaleContextProvider.tsx
+++ b/src/components/LocaleContextProvider.tsx
@@ -4,7 +4,6 @@ import {importEmojiLocale} from '@assets/emojis';
 import useCurrentUserPersonalDetails from '@hooks/useCurrentUserPersonalDetails';
 import useOnyx from '@hooks/useOnyx';
 import DateUtils from '@libs/DateUtils';
-import {buildEmojisTrie} from '@libs/EmojiTrie';
 import {fromLocaleDigit as fromLocaleDigitLocaleDigitUtils, toLocaleDigit as toLocaleDigitLocaleDigitUtils, toLocaleOrdinal as toLocaleOrdinalLocaleDigitUtils} from '@libs/LocaleDigitUtils';
 import {formatPhoneNumberWithCountryCode} from '@libs/LocalePhoneNumber';
 import {getDevicePreferredLocale, translate as translateLocalize} from '@libs/Localize';
@@ -119,14 +118,6 @@ function LocaleContextProvider({children}: LocaleContextProviderProps) {
 
         importEmojiLocale(normalizedLocale).then(() => {
             endSpan(CONST.TELEMETRY.SPAN_LOCALE.EMOJI_IMPORT);
-
-            startSpan(CONST.TELEMETRY.SPAN_LOCALE.EMOJI_TRIE_BUILD, {
-                name: CONST.TELEMETRY.SPAN_LOCALE.EMOJI_TRIE_BUILD,
-                op: CONST.TELEMETRY.SPAN_LOCALE.EMOJI_TRIE_BUILD,
-                parentSpan: getSpan(CONST.TELEMETRY.SPAN_APP_STARTUP),
-            });
-            buildEmojisTrie(normalizedLocale);
-            endSpan(CONST.TELEMETRY.SPAN_LOCALE.EMOJI_TRIE_BUILD);
         });
     }, [localeToApply, nvpPreferredLocale]);
 

--- a/src/libs/EmojiTrie.ts
+++ b/src/libs/EmojiTrie.ts
@@ -4,6 +4,7 @@ import CONST from '@src/CONST';
 import {FULLY_SUPPORTED_LOCALES} from '@src/CONST/LOCALES';
 import type {FullySupportedLocale} from '@src/CONST/LOCALES';
 import StringUtils from './StringUtils';
+import {endSpan, startSpan} from './telemetry/activeSpans';
 import Trie from './Trie';
 
 type EmojiMetaData = {
@@ -121,7 +122,12 @@ const buildEmojisTrie = (locale: FullySupportedLocale) => {
     if (emojiTrieForLocale[locale]) {
         return; // Return early if the trie is already built
     }
+    startSpan(CONST.TELEMETRY.SPAN_LOCALE.EMOJI_TRIE_BUILD, {
+        name: CONST.TELEMETRY.SPAN_LOCALE.EMOJI_TRIE_BUILD,
+        op: CONST.TELEMETRY.SPAN_LOCALE.EMOJI_TRIE_BUILD,
+    });
     emojiTrieForLocale[locale] = createTrie(locale);
+    endSpan(CONST.TELEMETRY.SPAN_LOCALE.EMOJI_TRIE_BUILD);
 };
 
 /**

--- a/src/libs/EmojiTrie.ts
+++ b/src/libs/EmojiTrie.ts
@@ -122,6 +122,11 @@ const buildEmojisTrie = (locale: FullySupportedLocale) => {
     if (emojiTrieForLocale[locale]) {
         return; // Return early if the trie is already built
     }
+    // Don't build and cache the trie if locale emoji data hasn't been loaded yet,
+    // otherwise we'd permanently cache a trie with only English fallback names.
+    if (locale !== CONST.LOCALES.DEFAULT && !localeEmojis[locale]) {
+        return;
+    }
     startSpan(CONST.TELEMETRY.SPAN_LOCALE.EMOJI_TRIE_BUILD, {
         name: CONST.TELEMETRY.SPAN_LOCALE.EMOJI_TRIE_BUILD,
         op: CONST.TELEMETRY.SPAN_LOCALE.EMOJI_TRIE_BUILD,

--- a/src/libs/EmojiTrie.ts
+++ b/src/libs/EmojiTrie.ts
@@ -119,10 +119,18 @@ const emojiTrieForLocale: EmojiTrieForLocale = Object.values(FULLY_SUPPORTED_LOC
 
 const buildEmojisTrie = (locale: FullySupportedLocale) => {
     if (emojiTrieForLocale[locale]) {
-        return; // Return early if the locale is not supported or the trie is already built
+        return; // Return early if the trie is already built
     }
     emojiTrieForLocale[locale] = createTrie(locale);
 };
 
+/**
+ * Returns the trie for the given locale, building it lazily on first access.
+ */
+const getEmojiTrie = (locale: FullySupportedLocale): Trie<EmojiMetaData> | undefined => {
+    buildEmojisTrie(locale);
+    return emojiTrieForLocale[locale];
+};
+
 export default emojiTrieForLocale;
-export {buildEmojisTrie};
+export {buildEmojisTrie, getEmojiTrie};

--- a/src/libs/EmojiTrie.ts
+++ b/src/libs/EmojiTrie.ts
@@ -1,4 +1,4 @@
-import emojis, {localeEmojis} from '@assets/emojis';
+import emojis, {importEmojiLocale, localeEmojis} from '@assets/emojis';
 import type {Emoji, HeaderEmoji} from '@assets/emojis/types';
 import CONST from '@src/CONST';
 import {FULLY_SUPPORTED_LOCALES} from '@src/CONST/LOCALES';
@@ -124,7 +124,14 @@ const buildEmojisTrie = (locale: FullySupportedLocale) => {
     }
     // Don't build and cache the trie if locale emoji data hasn't been loaded yet,
     // otherwise we'd permanently cache a trie with only English fallback names.
-    if (locale !== CONST.LOCALES.DEFAULT && !localeEmojis[locale]) {
+    if (!localeEmojis[locale]) {
+        startSpan(CONST.TELEMETRY.SPAN_LOCALE.EMOJI_IMPORT, {
+            name: CONST.TELEMETRY.SPAN_LOCALE.EMOJI_IMPORT,
+            op: CONST.TELEMETRY.SPAN_LOCALE.EMOJI_IMPORT,
+        });
+        importEmojiLocale(locale).then(() => {
+            endSpan(CONST.TELEMETRY.SPAN_LOCALE.EMOJI_IMPORT);
+        });
         return;
     }
     startSpan(CONST.TELEMETRY.SPAN_LOCALE.EMOJI_TRIE_BUILD, {

--- a/src/libs/EmojiUtils.tsx
+++ b/src/libs/EmojiUtils.tsx
@@ -14,7 +14,7 @@ import type {FrequentlyUsedEmoji, Locale} from '@src/types/onyx';
 import type {ReportActionReaction, UsersReactions} from '@src/types/onyx/ReportActionReactions';
 import type IconAsset from '@src/types/utils/IconAsset';
 import {isSafari} from './Browser';
-import type EmojiTrie from './EmojiTrie';
+import type {getEmojiTrie as getEmojiTrieType} from './EmojiTrie';
 import memoize from './memoize';
 
 type HeaderIndices = {code: string; index: number; icon: IconAsset};
@@ -22,7 +22,7 @@ type EmojiSpacer = {code: string; spacer: boolean};
 type EmojiPickerListItem = EmojiSpacer | Emoji | HeaderEmoji;
 type EmojiPickerList = EmojiPickerListItem[];
 type ReplacedEmoji = {text: string; emojis: Emoji[]; cursorPosition?: number};
-type EmojiTrieModule = {default: typeof EmojiTrie};
+type EmojiTrieModule = {getEmojiTrie: typeof getEmojiTrieType};
 type TextWithEmoji = {
     text: string;
     isEmoji: boolean;
@@ -391,11 +391,10 @@ function getAddedEmojis(currentEmojis: Emoji[], formerEmojis: Emoji[]): Emoji[] 
  * If we're on mobile, we also add a space after the emoji granted there's no text after it.
  */
 function replaceEmojis(text: string, preferredSkinTone: OnyxEntry<number | string> = CONST.EMOJI_DEFAULT_SKIN_TONE, locale: Locale = CONST.LOCALES.DEFAULT): ReplacedEmoji {
-    // emojisTrie is importing the emoji JSON file on the app starting and we want to avoid it
-    const emojisTrie = require<EmojiTrieModule>('./EmojiTrie').default;
+    const {getEmojiTrie} = require<EmojiTrieModule>('./EmojiTrie');
 
     const normalizedLocale = locale && isFullySupportedLocale(locale) ? locale : CONST.LOCALES.EN;
-    const trie = emojisTrie[normalizedLocale];
+    const trie = getEmojiTrie(normalizedLocale);
     if (!trie) {
         return {text, emojis: []};
     }
@@ -410,7 +409,7 @@ function replaceEmojis(text: string, preferredSkinTone: OnyxEntry<number | strin
     const codeBlockRanges = parseExpensiMark(text);
     const replacements: Array<{position: number; shortcode: string; replacement: string; name: string}> = [];
     const shortcodeSearchPositions: Record<string, number> = {};
-    const englishTrie = normalizedLocale !== CONST.LOCALES.DEFAULT ? emojisTrie[CONST.LOCALES.DEFAULT] : null;
+    const englishTrie = normalizedLocale !== CONST.LOCALES.DEFAULT ? getEmojiTrie(CONST.LOCALES.DEFAULT) : null;
 
     for (const emoji of emojiData) {
         const name = emoji.slice(1, -1);
@@ -492,11 +491,10 @@ function replaceAndExtractEmojis(text: string, preferredSkinTone: OnyxEntry<numb
  * @param [limit] - matching emojis limit
  */
 function suggestEmojis(text: string, locale: Locale = CONST.LOCALES.DEFAULT, limit: number = CONST.AUTO_COMPLETE_SUGGESTER.MAX_AMOUNT_OF_SUGGESTIONS): Emoji[] | undefined {
-    // emojisTrie is importing the emoji JSON file on the app starting and we want to avoid it
-    const emojisTrie = require<EmojiTrieModule>('./EmojiTrie').default;
+    const {getEmojiTrie} = require<EmojiTrieModule>('./EmojiTrie');
 
     const normalizedLocale = locale && isFullySupportedLocale(locale) ? locale : CONST.LOCALES.EN;
-    const trie = emojisTrie[normalizedLocale];
+    const trie = getEmojiTrie(normalizedLocale);
     if (!trie) {
         return [];
     }


### PR DESCRIPTION
### Explanation of Change

Defers the emoji Trie build from app startup to first use. Previously, `LocaleContextProvider` eagerly called `buildEmojisTrie` right after importing the emoji locale data, adding to startup time.

Now, the trie is built lazily via `getEmojiTrie()` on the first call to `replaceEmojis` or `suggestEmojis` in `EmojiUtils`—i.e., when the user actually interacts with emoji shortcodes.

---

### Fixed Issues

* [https://github.com/Expensify/App/issues/86759](https://github.com/Expensify/App/issues/86759)

---

### Tests

1. Open the app and verify it loads without errors
2. Open any chat and type `:smile` to trigger emoji suggestions
3. Verify emoji suggestions appear correctly
4. Send a message with `:thumbsup:` and verify it gets replaced with the emoji
5. Switch locale to Spanish and repeat steps 2–4

* Verify that no errors appear in the JS console

---

### Offline Tests

N/A — This change only affects when the emoji trie is built (deferred from startup to first use). No network dependency.

---

### QA Steps

[No QA] — Performance-only change that defers emoji trie construction. No user-facing behavior change.

* Verify that no errors appear in the JS console

---

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>