### PR TITLE
Fix SettlementButton: Remove else-if that overwrites EXPENSIFY to ELSEWHERE

### DIFF
--- a/src/components/SettlementButton/index.tsx
+++ b/src/components/SettlementButton/index.tsx
@@ -457,8 +457,6 @@ function SettlementButton({
                 let invoiceDefaultValue = lastPaymentMethod ?? CONST.IOU.PAYMENT_TYPE.ELSEWHERE;
                 if (showPayViaExpensifyOptions && (hasIntentToPay || lastPaymentMethod === CONST.IOU.PAYMENT_TYPE.EXPENSIFY)) {
                     invoiceDefaultValue = CONST.IOU.PAYMENT_TYPE.EXPENSIFY;
-                } else if (lastPaymentMethod === CONST.IOU.PAYMENT_TYPE.EXPENSIFY) {
-                    invoiceDefaultValue = CONST.IOU.PAYMENT_TYPE.ELSEWHERE;
                 }
                 buttonOptions.push({
                     text: translate('iou.settlePersonal', formattedAmount),


### PR DESCRIPTION
## Context
Fixes $ https://github.com/Expensify/App/issues/78241

## Changes
Removed the else-if block at lines 460-461 that incorrectly changed paymentType from EXPENSIFY to ELSEWHERE when lastPaymentMethod was EXPENSIFY.

## Test Plan
1. Go to an invoice room
2. Verify that users who previously paid via Expensify see EXPENSIFY as the default payment option
3. Verify that new users still see ELSEWHERE as the default