### PR TITLE
fix: prevent paymentType overwrite for invoice payments

### DIFF
--- a/src/components/SettlementButton/index.tsx
+++ b/src/components/SettlementButton/index.tsx
@@ -457,8 +457,6 @@ function SettlementButton({
                 let invoiceDefaultValue = lastPaymentMethod ?? CONST.IOU.PAYMENT_TYPE.ELSEWHERE;
                 if (showPayViaExpensifyOptions && (hasIntentToPay || lastPaymentMethod === CONST.IOU.PAYMENT_TYPE.EXPENSIFY)) {
                     invoiceDefaultValue = CONST.IOU.PAYMENT_TYPE.EXPENSIFY;
-                } else if (lastPaymentMethod === CONST.IOU.PAYMENT_TYPE.EXPENSIFY) {
-                    invoiceDefaultValue = CONST.IOU.PAYMENT_TYPE.ELSEWHERE;
                 }
                 buttonOptions.push({
                     text: translate('iou.settlePersonal', formattedAmount),


### PR DESCRIPTION
## Release Note
Fixed an issue where invoice payment showed 'waiting for bank account' error despite VBBA being verified.

## Related Issues
- $ https://github.com/Expensify/App/issues/78241

## Root Cause
In `src/components/SettlementButton/index.tsx`, the `else if` block at lines 460-461 incorrectly reverted `paymentType` from `EXPENSIFY` to `ELSEWHERE` after it was correctly set.

## The Fix
Removed the buggy `else if` block:
```typescript
// REMOVED (was causing bug):
} else if (lastPaymentMethod === CONST.IOU.PAYMENT_TYPE.EXPENSIFY) {
    invoiceDefaultValue = CONST.IOU.PAYMENT_TYPE.ELSEWHERE;
}
```

## Test Steps
1. Go to an invoice conversation
2. Attempt to pay via Expensify
3. Verify payment type is correctly set to EXPENSIFY (not ELSEWHERE)
