### PR TITLE
[No QA] Drop in better target icon, reduce threatening auras

### DIFF
--- a/assets/images/simple-illustrations/simple-illustration__target.svg
+++ b/assets/images/simple-illustrations/simple-illustration__target.svg
@@ -1,1 +1,11 @@
-<svg xmlns="http://www.w3.org/2000/svg" id="Layer_1" viewBox="0 0 68 68"><defs><style>.st0{fill:#f25730}.st1{fill:#fffaf0}.st2{fill:#0164bf}.st3{fill:none;stroke:#002140;stroke-linecap:round;stroke-linejoin:round;stroke-width:1px}</style></defs><path d="M34.228 60.012c14.118 0 25.563-11.445 25.563-25.563S48.346 8.886 34.228 8.886 8.665 20.331 8.665 34.449 20.11 60.012 34.228 60.012" class="st1"/><path d="M34.285 51.822c9.531 0 17.257-7.726 17.257-17.257s-7.726-17.257-17.257-17.257-17.257 7.726-17.257 17.257 7.726 17.257 17.257 17.257" class="st2"/><path d="M34.028 41.883a7.234 7.234 0 1 0 0-14.469 7.234 7.234 0 0 0 0 14.469" class="st0"/><path d="M34.097 52.022c9.699 0 17.562-7.863 17.562-17.562s-7.863-17.562-17.562-17.562-17.562 7.863-17.562 17.562 7.863 17.562 17.562 17.562" class="st3"/><path d="M34.097 42.13a7.67 7.67 0 1 0 0-15.34 7.67 7.67 0 0 0 0 15.34" class="st3"/><path d="M34.096 60.364C48.402 60.364 60 48.766 60 34.46S48.402 8.556 34.096 8.556 8.192 20.154 8.192 34.46 19.79 60.364 34.096 60.364" class="st3"/></svg>
+<?xml version="1.0" encoding="UTF-8"?>
+<svg id="Layer_1" xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0 0 68 68">
+  <!-- Generator: Adobe Illustrator 30.3.0, SVG Export Plug-In . SVG Version: 2.1.3 Build 182)  -->
+  <circle cx="34.1" cy="34.46" r="28.5" fill="#fffaf0" stroke="#002140"/>
+  <circle cx="34.1" cy="34.46" r="20.5" fill="#0676de" stroke="#002140"/>
+  <circle cx="34.1" cy="34.46" r="12.5" fill="#bf3013" stroke="#002140"/>
+  <circle cx="34.1" cy="34.46" r="4.5" fill="#e4bc07" stroke="#002140"/>
+  <path d="M62.91,7.71l-28.06,28.06-.28-.08c-.87-.25-1.5-.88-1.75-1.75l-.08-.28L60.79,5.59l2.12,2.12Z" fill="#d18000" stroke="#002140"/>
+  <path d="M61.5,1v6l-7,7v-6l7-7Z" fill="#e4bc07" stroke="#002140" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M67.5,7h-6l-7,7h6l7-7Z" fill="#e4bc07" stroke="#002140" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/assets/images/simple-illustrations/simple-illustration__target.svg
+++ b/assets/images/simple-illustrations/simple-illustration__target.svg
@@ -1,11 +1,1 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<svg id="Layer_1" xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0 0 68 68">
-  <!-- Generator: Adobe Illustrator 30.3.0, SVG Export Plug-In . SVG Version: 2.1.3 Build 182)  -->
-  <circle cx="34.1" cy="34.46" r="28.5" fill="#fffaf0" stroke="#002140"/>
-  <circle cx="34.1" cy="34.46" r="20.5" fill="#0676de" stroke="#002140"/>
-  <circle cx="34.1" cy="34.46" r="12.5" fill="#bf3013" stroke="#002140"/>
-  <circle cx="34.1" cy="34.46" r="4.5" fill="#e4bc07" stroke="#002140"/>
-  <path d="M62.91,7.71l-28.06,28.06-.28-.08c-.87-.25-1.5-.88-1.75-1.75l-.08-.28L60.79,5.59l2.12,2.12Z" fill="#d18000" stroke="#002140"/>
-  <path d="M61.5,1v6l-7,7v-6l7-7Z" fill="#e4bc07" stroke="#002140" stroke-linecap="round" stroke-linejoin="round"/>
-  <path d="M67.5,7h-6l-7,7h6l7-7Z" fill="#e4bc07" stroke="#002140" stroke-linecap="round" stroke-linejoin="round"/>
-</svg>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 68 68"><circle cx="34.1" cy="34.46" r="28.5" fill="#fffaf0" stroke="#002140"/><circle cx="34.1" cy="34.46" r="20.5" fill="#0676de" stroke="#002140"/><circle cx="34.1" cy="34.46" r="12.5" fill="#bf3013" stroke="#002140"/><circle cx="34.1" cy="34.46" r="4.5" fill="#e4bc07" stroke="#002140"/><path fill="#d18000" stroke="#002140" d="M62.91 7.71 34.85 35.77l-.28-.08c-.87-.25-1.5-.88-1.75-1.75l-.08-.28L60.79 5.59z"/><path fill="#e4bc07" stroke="#002140" stroke-linecap="round" stroke-linejoin="round" d="M61.5 1v6l-7 7V8z"/><path fill="#e4bc07" stroke="#002140" stroke-linecap="round" stroke-linejoin="round" d="M67.5 7h-6l-7 7h6z"/></svg>


### PR DESCRIPTION
### Explanation of Change
Replacing the target icon with a better one!

### Fixed Issues
$ n/a - https://expensify.slack.com/archives/C03TME82F/p1775610315597649

### Tests
None.

- [x] Verify that no errors appear in the JS console

### Offline tests
n/a

### QA Steps
None.

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I verified there are no new alerts related to the `canBeMissing` param for `useOnyx`
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<img width="1490" height="909" alt="image" src="https://github.com/user-attachments/assets/e28b9ae2-1aec-49eb-b13e-49e5a755e2d2" />