### PR TITLE
Fix Unable to scroll down group confirm page and member details page

### DIFF
--- a/src/pages/NewChatConfirmPage.tsx
+++ b/src/pages/NewChatConfirmPage.tsx
@@ -1,3 +1,4 @@
+import type {RefObject} from 'react';
 import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import {View} from 'react-native';
 import AvatarWithImagePicker from '@components/AvatarWithImagePicker';
@@ -37,8 +38,12 @@ function navigateToEditChatName() {
     Navigation.navigate(ROUTES.NEW_CHAT_EDIT_NAME);
 }
 
-function AvatarAndGroupNameSection({setAvatarFile}: {setAvatarFile: (avatarFile: File | CustomRNImageManipulatorResult | undefined) => void}) {
-    const optimisticReportID = useRef<string>(generateReportID());
+type AvatarAndGroupNameSectionProps = {
+    setAvatarFile: (avatarFile: File | CustomRNImageManipulatorResult | undefined) => void;
+    optimisticReportID: RefObject<string>;
+};
+
+function AvatarAndGroupNameSection({setAvatarFile, optimisticReportID}: AvatarAndGroupNameSectionProps) {
     const {translate, formatPhoneNumber} = useLocalize();
     const styles = useThemeStyles();
     const [newGroupDraft, newGroupDraftMetaData] = useOnyx(ONYXKEYS.NEW_GROUP_CHAT_DRAFT);
@@ -189,7 +194,12 @@ function NewChatConfirmPage() {
                 onBackButtonPress={navigateBack}
             />
 
-            {!isInLandscapeMode && <AvatarAndGroupNameSection setAvatarFile={setAvatarFile} />}
+            {!isInLandscapeMode && (
+                <AvatarAndGroupNameSection
+                    setAvatarFile={setAvatarFile}
+                    optimisticReportID={optimisticReportID}
+                />
+            )}
 
             <View style={[styles.flex1, styles.mt3]}>
                 <SelectionList
@@ -205,7 +215,12 @@ function NewChatConfirmPage() {
                     shouldHeaderBeInsideList={isInLandscapeMode}
                     customListHeader={
                         <>
-                            {isInLandscapeMode && <AvatarAndGroupNameSection setAvatarFile={setAvatarFile} />}
+                            {isInLandscapeMode && (
+                                <AvatarAndGroupNameSection
+                                    setAvatarFile={setAvatarFile}
+                                    optimisticReportID={optimisticReportID}
+                                />
+                            )}
                             <View style={[styles.mt8, styles.mb4, styles.justifyContentCenter]}>
                                 <Text style={[styles.ph5, styles.textLabelSupporting]}>{translate('common.members')}</Text>
                             </View>

--- a/src/pages/NewChatConfirmPage.tsx
+++ b/src/pages/NewChatConfirmPage.tsx
@@ -121,54 +121,43 @@ function NewChatConfirmPage() {
     const [isSelfTourViewed] = useOnyx(ONYXKEYS.NVP_ONBOARDING, {selector: hasSeenTourSelector});
     const [newGroupDraft] = useOnyx(ONYXKEYS.NEW_GROUP_CHAT_DRAFT);
 
-    const selectedOptions = useMemo((): Participant[] => {
-        if (!newGroupDraft?.participants) {
-            return [];
-        }
-        const options: Participant[] = newGroupDraft.participants.map((participant) =>
-            getParticipantsOption({accountID: participant.accountID, login: participant?.login, reportID: ''}, allPersonalDetails),
-        );
-        return options;
-    }, [allPersonalDetails, newGroupDraft]);
+    const participants = newGroupDraft?.participants ?? [];
 
-    const selectedParticipants: ListItem[] = useMemo(
-        () =>
-            selectedOptions
-                .map((selectedOption: Participant) => {
-                    const accountID = selectedOption.accountID;
-                    const isAdmin = personalData.accountID === accountID;
-                    const section: ListItem = {
-                        login: selectedOption?.login ?? '',
-                        text: selectedOption?.text ?? '',
-                        keyForList: selectedOption?.keyForList ?? '',
-                        isSelected: !isAdmin,
-                        isDisabled: isAdmin,
-                        accountID,
-                        icons: selectedOption?.icons,
-                        alternateText: selectedOption?.login ?? '',
-                        rightElement: isAdmin ? <Badge text={translate('common.admin')} /> : undefined,
-                    };
-                    return section;
-                })
-                .sort((a, b) => localeCompare(a.text?.toLowerCase() ?? '', b.text?.toLowerCase() ?? '')),
-        [selectedOptions, personalData.accountID, translate, localeCompare],
+    const selectedOptions: Participant[] = participants.map((participant) =>
+        getParticipantsOption({accountID: participant.accountID, login: participant?.login, reportID: ''}, allPersonalDetails),
     );
+
+    const selectedParticipants: ListItem[] = selectedOptions
+        .map((selectedOption: Participant) => {
+            const accountID = selectedOption.accountID;
+            const isAdmin = personalData.accountID === accountID;
+            const section: ListItem = {
+                login: selectedOption?.login ?? '',
+                text: selectedOption?.text ?? '',
+                keyForList: selectedOption?.keyForList ?? '',
+                isSelected: !isAdmin,
+                isDisabled: isAdmin,
+                accountID,
+                icons: selectedOption?.icons,
+                alternateText: selectedOption?.login ?? '',
+                rightElement: isAdmin ? <Badge text={translate('common.admin')} /> : undefined,
+            };
+            return section;
+        })
+        .sort((a, b) => localeCompare(a.text?.toLowerCase() ?? '', b.text?.toLowerCase() ?? ''));
 
     /**
      * Removes a selected option from list if already selected.
      */
-    const unselectOption = useCallback(
-        (option: ListItem) => {
-            if (!newGroupDraft) {
-                return;
-            }
-            const newSelectedParticipants = (newGroupDraft.participants ?? []).filter((participant) => participant?.login !== option.login);
-            setGroupDraft({participants: newSelectedParticipants});
-        },
-        [newGroupDraft],
-    );
+    const unselectOption = (option: ListItem) => {
+        if (!newGroupDraft) {
+            return;
+        }
+        const newSelectedParticipants = (newGroupDraft.participants ?? []).filter((participant) => participant?.login !== option.login);
+        setGroupDraft({participants: newSelectedParticipants});
+    };
 
-    const createGroup = useCallback(() => {
+    const createGroup = () => {
         if (!newGroupDraft) {
             return;
         }
@@ -185,7 +174,7 @@ function NewChatConfirmPage() {
             newGroupDraft.avatarUri ?? '',
             avatarFile,
         );
-    }, [newGroupDraft, avatarFile, personalData.login, introSelected, betas, isSelfTourViewed]);
+    };
 
     return (
         <ScreenWrapper testID="NewChatConfirmPage">

--- a/src/pages/NewChatConfirmPage.tsx
+++ b/src/pages/NewChatConfirmPage.tsx
@@ -1,5 +1,5 @@
 import type {RefObject} from 'react';
-import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react';
+import React, {useEffect, useRef, useState} from 'react';
 import {View} from 'react-native';
 import AvatarWithImagePicker from '@components/AvatarWithImagePicker';
 import Badge from '@components/Badge';

--- a/src/pages/NewChatConfirmPage.tsx
+++ b/src/pages/NewChatConfirmPage.tsx
@@ -10,6 +10,7 @@ import InviteMemberListItem from '@components/SelectionList/ListItem/InviteMembe
 import type {ListItem} from '@components/SelectionList/types';
 import Text from '@components/Text';
 import useCurrentUserPersonalDetails from '@hooks/useCurrentUserPersonalDetails';
+import useIsInLandscapeMode from '@hooks/useIsInLandscapeMode';
 import {useMemoizedLazyExpensifyIcons} from '@hooks/useLazyAsset';
 import useLocalize from '@hooks/useLocalize';
 import useOnyx from '@hooks/useOnyx';
@@ -36,19 +37,84 @@ function navigateToEditChatName() {
     Navigation.navigate(ROUTES.NEW_CHAT_EDIT_NAME);
 }
 
+function AvatarAndGroupNameSection({setAvatarFile}: {setAvatarFile: (avatarFile: File | CustomRNImageManipulatorResult | undefined) => void}) {
+    const optimisticReportID = useRef<string>(generateReportID());
+    const {translate, formatPhoneNumber} = useLocalize();
+    const styles = useThemeStyles();
+    const [newGroupDraft, newGroupDraftMetaData] = useOnyx(ONYXKEYS.NEW_GROUP_CHAT_DRAFT);
+
+    const icons = useMemoizedLazyExpensifyIcons(['Camera']);
+    const groupName = newGroupDraft?.reportName ? newGroupDraft?.reportName : getGroupChatName(formatPhoneNumber, newGroupDraft?.participants);
+
+    const stashedLocalAvatarImage = newGroupDraft?.avatarUri;
+
+    useEffect(() => {
+        if (!stashedLocalAvatarImage || isLoadingOnyxValue(newGroupDraftMetaData)) {
+            return;
+        }
+
+        const onSuccess = (file: File) => {
+            setAvatarFile(file);
+        };
+
+        const onFailure = () => {
+            setAvatarFile(undefined);
+            setGroupDraft({avatarUri: null, avatarFileName: null, avatarFileType: null});
+        };
+
+        // If the user navigates back to the member selection page and then returns to the confirmation page, the component will re-mount, causing avatarFile to be null.
+        // To handle this, we re-read the avatar image file from disk whenever the component re-mounts.
+        readFileAsync(stashedLocalAvatarImage, newGroupDraft?.avatarFileName ?? '', onSuccess, onFailure, newGroupDraft?.avatarFileType ?? '');
+
+        // we only need to run this when the component re-mounted and when the onyx is loaded completely
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [newGroupDraftMetaData]);
+
+    return (
+        <>
+            <View style={styles.avatarSectionWrapper}>
+                <AvatarWithImagePicker
+                    isUsingDefaultAvatar={!stashedLocalAvatarImage}
+                    source={stashedLocalAvatarImage ?? getDefaultGroupAvatar(optimisticReportID.current)}
+                    onImageSelected={(image) => {
+                        setAvatarFile(image);
+                        setGroupDraft({avatarUri: image.uri ?? '', avatarFileName: image.name ?? '', avatarFileType: image.type});
+                    }}
+                    onImageRemoved={() => {
+                        setAvatarFile(undefined);
+                        setGroupDraft({avatarUri: null, avatarFileName: null, avatarFileType: null});
+                    }}
+                    size={CONST.AVATAR_SIZE.X_LARGE}
+                    avatarStyle={styles.avatarXLarge}
+                    editIcon={icons.Camera}
+                    editIconStyle={styles.smallEditIconAccount}
+                    style={styles.w100}
+                />
+            </View>
+            <MenuItemWithTopDescription
+                title={groupName}
+                onPress={navigateToEditChatName}
+                shouldShowRightIcon
+                shouldCheckActionAllowedOnPress={false}
+                description={translate('newRoomPage.groupName')}
+                wrapperStyle={[styles.ph4]}
+            />
+        </>
+    );
+}
+
 function NewChatConfirmPage() {
+    const isInLandscapeMode = useIsInLandscapeMode();
     const optimisticReportID = useRef<string>(generateReportID());
     const [avatarFile, setAvatarFile] = useState<File | CustomRNImageManipulatorResult | undefined>();
-    const {translate, localeCompare, formatPhoneNumber} = useLocalize();
+    const {translate, localeCompare} = useLocalize();
     const styles = useThemeStyles();
     const personalData = useCurrentUserPersonalDetails();
-    const [newGroupDraft, newGroupDraftMetaData] = useOnyx(ONYXKEYS.NEW_GROUP_CHAT_DRAFT);
     const [allPersonalDetails] = useOnyx(ONYXKEYS.PERSONAL_DETAILS_LIST);
     const [introSelected] = useOnyx(ONYXKEYS.NVP_INTRO_SELECTED);
     const [betas] = useOnyx(ONYXKEYS.BETAS);
     const [isSelfTourViewed] = useOnyx(ONYXKEYS.NVP_ONBOARDING, {selector: hasSeenTourSelector});
-
-    const icons = useMemoizedLazyExpensifyIcons(['Camera']);
+    const [newGroupDraft] = useOnyx(ONYXKEYS.NEW_GROUP_CHAT_DRAFT);
 
     const selectedOptions = useMemo((): Participant[] => {
         if (!newGroupDraft?.participants) {
@@ -58,9 +124,8 @@ function NewChatConfirmPage() {
             getParticipantsOption({accountID: participant.accountID, login: participant?.login, reportID: ''}, allPersonalDetails),
         );
         return options;
-    }, [allPersonalDetails, newGroupDraft?.participants]);
+    }, [allPersonalDetails, newGroupDraft]);
 
-    const groupName = newGroupDraft?.reportName ? newGroupDraft?.reportName : getGroupChatName(formatPhoneNumber, newGroupDraft?.participants);
     const selectedParticipants: ListItem[] = useMemo(
         () =>
             selectedOptions
@@ -117,63 +182,15 @@ function NewChatConfirmPage() {
         );
     }, [newGroupDraft, avatarFile, personalData.login, introSelected, betas, isSelfTourViewed]);
 
-    const stashedLocalAvatarImage = newGroupDraft?.avatarUri;
-
-    useEffect(() => {
-        if (!stashedLocalAvatarImage || isLoadingOnyxValue(newGroupDraftMetaData)) {
-            return;
-        }
-
-        const onSuccess = (file: File) => {
-            setAvatarFile(file);
-        };
-
-        const onFailure = () => {
-            setAvatarFile(undefined);
-            setGroupDraft({avatarUri: null, avatarFileName: null, avatarFileType: null});
-        };
-
-        // If the user navigates back to the member selection page and then returns to the confirmation page, the component will re-mount, causing avatarFile to be null.
-        // To handle this, we re-read the avatar image file from disk whenever the component re-mounts.
-        readFileAsync(stashedLocalAvatarImage, newGroupDraft?.avatarFileName ?? '', onSuccess, onFailure, newGroupDraft?.avatarFileType ?? '');
-
-        // we only need to run this when the component re-mounted and when the onyx is loaded completely
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [newGroupDraftMetaData]);
-
     return (
         <ScreenWrapper testID="NewChatConfirmPage">
             <HeaderWithBackButton
                 title={translate('common.group')}
                 onBackButtonPress={navigateBack}
             />
-            <View style={styles.avatarSectionWrapper}>
-                <AvatarWithImagePicker
-                    isUsingDefaultAvatar={!stashedLocalAvatarImage}
-                    source={stashedLocalAvatarImage ?? getDefaultGroupAvatar(optimisticReportID.current)}
-                    onImageSelected={(image) => {
-                        setAvatarFile(image);
-                        setGroupDraft({avatarUri: image.uri ?? '', avatarFileName: image.name ?? '', avatarFileType: image.type});
-                    }}
-                    onImageRemoved={() => {
-                        setAvatarFile(undefined);
-                        setGroupDraft({avatarUri: null, avatarFileName: null, avatarFileType: null});
-                    }}
-                    size={CONST.AVATAR_SIZE.X_LARGE}
-                    avatarStyle={styles.avatarXLarge}
-                    editIcon={icons.Camera}
-                    editIconStyle={styles.smallEditIconAccount}
-                    style={styles.w100}
-                />
-            </View>
-            <MenuItemWithTopDescription
-                title={groupName}
-                onPress={navigateToEditChatName}
-                shouldShowRightIcon
-                shouldCheckActionAllowedOnPress={false}
-                description={translate('newRoomPage.groupName')}
-                wrapperStyle={[styles.ph4]}
-            />
+
+            {!isInLandscapeMode && <AvatarAndGroupNameSection setAvatarFile={setAvatarFile} />}
+
             <View style={[styles.flex1, styles.mt3]}>
                 <SelectionList
                     data={selectedParticipants}
@@ -185,10 +202,14 @@ function NewChatConfirmPage() {
                         text: translate('newChatPage.startGroup'),
                         onConfirm: createGroup,
                     }}
+                    shouldHeaderBeInsideList={isInLandscapeMode}
                     customListHeader={
-                        <View style={[styles.mt8, styles.mb4, styles.justifyContentCenter]}>
-                            <Text style={[styles.ph5, styles.textLabelSupporting]}>{translate('common.members')}</Text>
-                        </View>
+                        <>
+                            {isInLandscapeMode && <AvatarAndGroupNameSection setAvatarFile={setAvatarFile} />}
+                            <View style={[styles.mt8, styles.mb4, styles.justifyContentCenter]}>
+                                <Text style={[styles.ph5, styles.textLabelSupporting]}>{translate('common.members')}</Text>
+                            </View>
+                        </>
                     }
                 />
             </View>

--- a/src/pages/ReportParticipantDetailsPage.tsx
+++ b/src/pages/ReportParticipantDetailsPage.tsx
@@ -8,8 +8,10 @@ import MenuItem from '@components/MenuItem';
 import MenuItemWithTopDescription from '@components/MenuItemWithTopDescription';
 import OfflineWithFeedback from '@components/OfflineWithFeedback';
 import ScreenWrapper from '@components/ScreenWrapper';
+import ScrollView from '@components/ScrollView';
 import Text from '@components/Text';
 import useCurrentUserPersonalDetails from '@hooks/useCurrentUserPersonalDetails';
+import useIsInLandscapeMode from '@hooks/useIsInLandscapeMode';
 import {useMemoizedLazyExpensifyIcons} from '@hooks/useLazyAsset';
 import useLocalize from '@hooks/useLocalize';
 import useOnyx from '@hooks/useOnyx';
@@ -34,6 +36,7 @@ type ReportParticipantDetailsPageProps = WithReportOrNotFoundProps & PlatformSta
 
 function ReportParticipantDetails({report, route}: ReportParticipantDetailsPageProps) {
     const icons = useMemoizedLazyExpensifyIcons(['RemoveMembers', 'Info']);
+    const isInLandscapeMode = useIsInLandscapeMode();
     const styles = useThemeStyles();
     const {formatPhoneNumber, translate} = useLocalize();
     const StyleUtils = useStyleUtils();
@@ -75,7 +78,7 @@ function ReportParticipantDetails({report, route}: ReportParticipantDetailsPageP
                 title={displayName}
                 onBackButtonPress={() => Navigation.goBack(backTo)}
             />
-            <View style={[styles.containerWithSpaceBetween, styles.pointerEventsBoxNone, styles.justifyContentStart]}>
+            <ScrollView contentContainerStyle={[!isInLandscapeMode && [styles.containerWithSpaceBetween, styles.justifyContentStart], styles.pointerEventsBoxNone]}>
                 <View style={[styles.avatarSectionWrapper, styles.pb0]}>
                     <Avatar
                         containerStyles={[styles.avatarXLarge, styles.mv5, styles.noOutline]}
@@ -136,7 +139,7 @@ function ReportParticipantDetails({report, route}: ReportParticipantDetailsPageP
                         shouldShowRightIcon
                     />
                 </View>
-            </View>
+            </ScrollView>
         </ScreenWrapper>
     );
 }


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change

Fixing NewChatConfirmPage and ReportParticipantDetailsPage layouts to make them scrollable to let user see full content in the landscape mode.

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/87306
PROPOSAL: N/A


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

1. Launch Expensify app in landscape mode.
2. Tap FAB > Start chat.
3. Tap Add to group on any user > Next.
4. Verify that the confirm page content is scrollable.
5. Tap Start group.
6. Tap on the chat header > Members.
7. Tap on the invited member.
8. Verify that the member details page is scrollable



- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

N/A 

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
4. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->

Same as **Tests** 

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

https://github.com/user-attachments/assets/16ae6a15-8ff9-419a-ad40-4f1670727000






<!-- add screenshots or videos here -->

</details>



<details>
<summary>iOS: Native</summary>


https://github.com/user-attachments/assets/c448c4dd-1bae-43c3-9030-8cf7d26b6195




<!-- add screenshots or videos here -->

</details>
