### PR TITLE
[Performance] Pre-render Search under RHP for instant post-submit navigation on mobile

### DIFF
--- a/src/CONST/index.ts
+++ b/src/CONST/index.ts
@@ -8746,6 +8746,7 @@ const CONST = {
     MODAL_EVENTS: {
         CLOSED: 'modalClosed',
         DISABLE_RHP_ANIMATION: 'disableRHPAnimation',
+        RESTORE_RHP_ANIMATION: 'restoreRHPAnimation',
     },
 
     LIST_BEHAVIOR: {

--- a/src/CONST/index.ts
+++ b/src/CONST/index.ts
@@ -271,6 +271,12 @@ const CONST = {
     ANIMATION_PAID_BUTTON_HIDE_DELAY: 300,
     BACKGROUND_IMAGE_TRANSITION_DURATION: 1000,
     SCREEN_TRANSITION_END_TIMEOUT: 1000,
+
+    // Delay before pre-inserting the Search fullscreen route under the RHP on the confirmation screen.
+    // Chosen to be long enough for the RHP entrance animation to complete (~250ms) and avoid jank
+    // from concurrent navigation state mutations, but short enough to finish well before most users
+    // tap submit. If the user submits before this fires, the fallback (non-pre-insert) path is used.
+    PRE_INSERT_FULLSCREEN_DELAY: 300,
     LIMIT_TIMEOUT: 2147483647,
     ARROW_HIDE_DELAY: 3000,
     MAX_IMAGE_CANVAS_AREA: 16777216,
@@ -6322,6 +6328,7 @@ const CONST = {
             /** These action types are custom for RootNavigator */
             DISMISS_MODAL: 'DISMISS_MODAL',
             REPLACE_FULLSCREEN_UNDER_RHP: 'REPLACE_FULLSCREEN_UNDER_RHP',
+            REMOVE_FULLSCREEN_UNDER_RHP: 'REMOVE_FULLSCREEN_UNDER_RHP',
             OPEN_WORKSPACE_SPLIT: 'OPEN_WORKSPACE_SPLIT',
             OPEN_DOMAIN_SPLIT: 'OPEN_DOMAIN_SPLIT',
             PUSH_PARAMS: 'PUSH_PARAMS',
@@ -8738,6 +8745,7 @@ const CONST = {
 
     MODAL_EVENTS: {
         CLOSED: 'modalClosed',
+        DISABLE_RHP_ANIMATION: 'disableRHPAnimation',
     },
 
     LIST_BEHAVIOR: {

--- a/src/components/Search/SearchStaticList.tsx
+++ b/src/components/Search/SearchStaticList.tsx
@@ -9,7 +9,8 @@
  *  • This component intentionally avoids expensive hooks and Onyx reads.
  *    Do NOT add new subscriptions unless absolutely necessary for correctness.
  */
-import React, {useRef, useState} from 'react';
+import {useFocusEffect} from '@react-navigation/native';
+import React, {useCallback, useRef, useState} from 'react';
 import {FlatList, View} from 'react-native';
 import type {ListRenderItemInfo, StyleProp, ViewStyle} from 'react-native';
 import Button from '@components/Button';
@@ -72,7 +73,23 @@ function SearchStaticList({searchResults, queryJSON, contentContainerStyle, onLa
     const accountID = session?.accountID ?? CONST.DEFAULT_NUMBER_ID;
     const email = session?.email;
 
-    const [showPendingExpensePlaceholder] = useState(() => hasDeferredWrite(CONST.DEFERRED_LAYOUT_WRITE_KEYS.SEARCH));
+    const [showPendingExpensePlaceholder, setShowPendingExpensePlaceholder] = useState(() => hasDeferredWrite(CONST.DEFERRED_LAYOUT_WRITE_KEYS.SEARCH));
+
+    // When pre-inserted behind the RHP, the static list mounts before any submit
+    // action (showPendingExpensePlaceholder = false). On focus (after RHP dismiss),
+    // check for a pending submit-to-search action and show the placeholder row so
+    // the user sees immediate feedback while the Search component mounts.
+    // On subsequent re-focus without a pending action, clear the stale placeholder.
+    useFocusEffect(
+        useCallback(() => {
+            const hasPendingAction = getPendingSubmitFollowUpAction()?.followUpAction === CONST.TELEMETRY.SUBMIT_FOLLOW_UP_ACTION.NAVIGATE_TO_SEARCH;
+            if (!showPendingExpensePlaceholder && hasPendingAction) {
+                setShowPendingExpensePlaceholder(true);
+            } else if (showPendingExpensePlaceholder && !hasPendingAction) {
+                setShowPendingExpensePlaceholder(false);
+            }
+        }, [showPendingExpensePlaceholder]),
+    );
 
     const {type, status, sortBy, sortOrder, groupBy} = queryJSON;
     const validGroupBy = getValidGroupBy(groupBy);

--- a/src/components/Search/SearchStaticList.tsx
+++ b/src/components/Search/SearchStaticList.tsx
@@ -25,7 +25,7 @@ import {hasDeferredWrite} from '@libs/deferredLayoutWrite';
 import Navigation from '@libs/Navigation/Navigation';
 import {isOneTransactionReport} from '@libs/ReportUtils';
 import {createAndOpenSearchTransactionThread, getSections, getSortedSections, getValidGroupBy, isCorrectSearchUserName} from '@libs/SearchUIUtils';
-import {endSubmitFollowUpActionSpan, getPendingSubmitFollowUpAction} from '@libs/telemetry/submitFollowUpAction';
+import {getPendingSubmitFollowUpAction} from '@libs/telemetry/submitFollowUpAction';
 import variables from '@styles/variables';
 import CONST from '@src/CONST';
 import ROUTES from '@src/ROUTES';
@@ -43,6 +43,7 @@ type SearchStaticListProps = {
     queryJSON: SearchQueryJSON;
     contentContainerStyle?: StyleProp<ViewStyle>;
     onLayout?: () => void;
+    onDestinationVisible?: (wasListEmpty: boolean, source: 'focus' | 'layout') => void;
 };
 
 function StaticActionButton({action}: {action: SearchTransactionAction | undefined}) {
@@ -65,7 +66,7 @@ function StaticActionButton({action}: {action: SearchTransactionAction | undefin
     );
 }
 
-function SearchStaticList({searchResults, queryJSON, contentContainerStyle, onLayout: onLayoutProp}: SearchStaticListProps) {
+function SearchStaticList({searchResults, queryJSON, contentContainerStyle, onLayout: onLayoutProp, onDestinationVisible}: SearchStaticListProps) {
     const styles = useThemeStyles();
     const theme = useTheme();
     const {translate, localeCompare, formatPhoneNumber} = useLocalize();
@@ -73,22 +74,8 @@ function SearchStaticList({searchResults, queryJSON, contentContainerStyle, onLa
     const accountID = session?.accountID ?? CONST.DEFAULT_NUMBER_ID;
     const email = session?.email;
 
-    const [showPendingExpensePlaceholder, setShowPendingExpensePlaceholder] = useState(() => hasDeferredWrite(CONST.DEFERRED_LAYOUT_WRITE_KEYS.SEARCH));
-
-    // When pre-inserted behind the RHP, the static list mounts before any submit
-    // action (showPendingExpensePlaceholder = false). On focus (after RHP dismiss),
-    // check for a pending submit-to-search action and show the placeholder row so
-    // the user sees immediate feedback while the Search component mounts.
-    // On subsequent re-focus without a pending action, clear the stale placeholder.
-    useFocusEffect(
-        useCallback(() => {
-            const hasPendingAction = getPendingSubmitFollowUpAction()?.followUpAction === CONST.TELEMETRY.SUBMIT_FOLLOW_UP_ACTION.NAVIGATE_TO_SEARCH;
-            if (!showPendingExpensePlaceholder && hasPendingAction) {
-                setShowPendingExpensePlaceholder(true);
-            } else if (showPendingExpensePlaceholder && !hasPendingAction) {
-                setShowPendingExpensePlaceholder(false);
-            }
-        }, [showPendingExpensePlaceholder]),
+    const [showPendingExpensePlaceholder, setShowPendingExpensePlaceholder] = useState(
+        () => hasDeferredWrite(CONST.DEFERRED_LAYOUT_WRITE_KEYS.SEARCH) || Navigation.getIsFullscreenPreInsertedUnderRHP(),
     );
 
     const {type, status, sortBy, sortOrder, groupBy} = queryJSON;
@@ -113,9 +100,26 @@ function SearchStaticList({searchResults, queryJSON, contentContainerStyle, onLa
         });
 
         return getSortedSections(type, status, filteredData, localeCompare, translate, sortBy, sortOrder, validGroupBy)
-            .filter((item): item is TransactionListItemType => 'transactionID' in item)
+            .filter((item): item is TransactionListItemType => 'transactionID' in item && item.pendingAction !== CONST.RED_BRICK_ROAD_PENDING_ACTION.DELETE)
             .slice(0, STATIC_LIST_MAX_ITEMS);
     })();
+
+    // Sync the pending-expense placeholder on focus and notify the parent that
+    // the destination is visible (focus signal for the dual-gate span ending).
+    useFocusEffect(
+        useCallback(() => {
+            const hasPendingAction = getPendingSubmitFollowUpAction()?.followUpAction === CONST.TELEMETRY.SUBMIT_FOLLOW_UP_ACTION.NAVIGATE_TO_SEARCH;
+            if (!showPendingExpensePlaceholder && hasPendingAction) {
+                setShowPendingExpensePlaceholder(true);
+            } else if (showPendingExpensePlaceholder && !hasPendingAction && sortedData.length > 0) {
+                // Only clear the placeholder once real data is available to avoid
+                // a blank flash when the stale snapshot has been filtered empty.
+                setShowPendingExpensePlaceholder(false);
+            }
+
+            onDestinationVisible?.(sortedData.length === 0, 'focus');
+        }, [showPendingExpensePlaceholder, sortedData.length, onDestinationVisible]),
+    );
 
     const onPressItem = (item: TransactionListItemType) => {
         const backTo = Navigation.getActiveRoute();
@@ -214,14 +218,7 @@ function SearchStaticList({searchResults, queryJSON, contentContainerStyle, onLa
         }
         hasEndedSpanRef.current = true;
 
-        const pending = getPendingSubmitFollowUpAction();
-        if (pending && pending.followUpAction !== CONST.TELEMETRY.SUBMIT_FOLLOW_UP_ACTION.DISMISS_MODAL_AND_OPEN_REPORT) {
-            endSubmitFollowUpActionSpan(pending.followUpAction, undefined, {
-                [CONST.TELEMETRY.ATTRIBUTE_IS_WARM]: true,
-                [CONST.TELEMETRY.ATTRIBUTE_WAS_LIST_EMPTY]: sortedData.length === 0,
-            });
-        }
-
+        onDestinationVisible?.(sortedData.length === 0, 'layout');
         onLayoutProp?.();
     };
 
@@ -281,5 +278,6 @@ export default React.memo(
         prev.searchResults?.data === next.searchResults?.data &&
         prev.queryJSON === next.queryJSON &&
         prev.contentContainerStyle === next.contentContainerStyle &&
-        prev.onLayout === next.onLayout,
+        prev.onLayout === next.onLayout &&
+        prev.onDestinationVisible === next.onDestinationVisible,
 );

--- a/src/components/Search/index.tsx
+++ b/src/components/Search/index.tsx
@@ -55,7 +55,7 @@ import {
     shouldShowYear as shouldShowYearUtil,
 } from '@libs/SearchUIUtils';
 import {cancelSpan, endSpanWithAttributes, getSpan, startSpan} from '@libs/telemetry/activeSpans';
-import {cancelSubmitFollowUpActionSpan, endSubmitFollowUpActionSpan, getPendingSubmitFollowUpAction} from '@libs/telemetry/submitFollowUpAction';
+import {cancelSubmitFollowUpActionSpan, getPendingSubmitFollowUpAction} from '@libs/telemetry/submitFollowUpAction';
 import type {SkeletonSpanReasonAttributes} from '@libs/telemetry/useSkeletonSpan';
 import {getOriginalTransactionWithSplitInfo, hasValidModifiedAmount, isOnHold, isTransactionPendingDelete} from '@libs/TransactionUtils';
 import Navigation, {navigationRef} from '@navigation/Navigation';
@@ -93,6 +93,10 @@ type SearchProps = {
 
     /** Pre-rendered content shown on the first frame while hooks initialize and heavy work is deferred. */
     initialContent?: React.ReactNode;
+
+    /** Callback from the parent (SearchPageNarrow) to end submit-expense navigation spans.
+     *  Consolidates span-ending logic in one place. Accepts `wasListEmpty` for telemetry attributes. */
+    onDestinationVisible?: (wasListEmpty: boolean, source: 'focus' | 'layout') => void;
 };
 
 // Max time (ms) to keep the optimistic item cache/skeleton alive before
@@ -220,6 +224,7 @@ function Search({
     searchRequestResponseStatusCode,
     onContentReady,
     initialContent,
+    onDestinationVisible,
 }: SearchProps) {
     const {type, status, sortBy, sortOrder, hash, similarSearchHash, groupBy, view} = queryJSON;
     // Deferred write: API.write() is postponed so the skeleton renders instantly.
@@ -462,8 +467,6 @@ function Search({
                 return;
             }
 
-            // Re-applying the defer only on the submit-return path keeps the optimization scoped to
-            // the transition we care about instead of slowing every search refocus.
             return deferHeavySearchWork(true);
         }, [deferHeavySearchWork]),
     );
@@ -1398,18 +1401,12 @@ function Search({
 
     const onLayout = useCallback(() => {
         hasHadFirstLayout.current = true;
+        onDestinationVisible?.(isSearchResultsEmptyRef.current, 'layout');
         endSpanWithAttributes(CONST.TELEMETRY.SPAN_NAVIGATE_TO_REPORTS, {[CONST.TELEMETRY.ATTRIBUTE_IS_WARM]: true});
-        const pending = getPendingSubmitFollowUpAction();
-        if (pending && pending.followUpAction !== CONST.TELEMETRY.SUBMIT_FOLLOW_UP_ACTION.DISMISS_MODAL_AND_OPEN_REPORT) {
-            endSubmitFollowUpActionSpan(pending.followUpAction, undefined, {
-                [CONST.TELEMETRY.ATTRIBUTE_IS_WARM]: true,
-                [CONST.TELEMETRY.ATTRIBUTE_WAS_LIST_EMPTY]: isSearchResultsEmptyRef.current,
-            });
-        }
         handleSelectionListScroll(stableSortedData, searchListRef.current);
         flushDeferredWrite(CONST.DEFERRED_LAYOUT_WRITE_KEYS.SEARCH);
         onContentReady?.();
-    }, [handleSelectionListScroll, stableSortedData, onContentReady]);
+    }, [handleSelectionListScroll, stableSortedData, onContentReady, onDestinationVisible]);
 
     // Must be a ref, not state: cancelNavigationSpans is called during render
     // (inside conditional returns), so using setState would trigger infinite re-renders.
@@ -1448,19 +1445,13 @@ function Search({
             if (!hasHadFirstLayout.current) {
                 return;
             }
-            const pending = getPendingSubmitFollowUpAction();
-            if (pending && pending.followUpAction !== CONST.TELEMETRY.SUBMIT_FOLLOW_UP_ACTION.DISMISS_MODAL_AND_OPEN_REPORT) {
-                endSubmitFollowUpActionSpan(pending.followUpAction, undefined, {
-                    [CONST.TELEMETRY.ATTRIBUTE_IS_WARM]: !shouldShowLoadingState,
-                    [CONST.TELEMETRY.ATTRIBUTE_WAS_LIST_EMPTY]: isSearchResultsEmptyRef.current,
-                });
-            }
+            onDestinationVisible?.(isSearchResultsEmptyRef.current, 'focus');
             endSpanWithAttributes(CONST.TELEMETRY.SPAN_NAVIGATE_TO_REPORTS, {
                 [CONST.TELEMETRY.ATTRIBUTE_IS_WARM]: !shouldShowLoadingState,
             });
             // On re-focus (e.g. DISMISS_MODAL_ONLY) onLayout won't re-fire — flush here.
             flushDeferredWrite(CONST.DEFERRED_LAYOUT_WRITE_KEYS.SEARCH);
-        }, [shouldShowLoadingState]),
+        }, [shouldShowLoadingState, onDestinationVisible]),
     );
 
     // Reset before conditional returns. Only cancelNavigationSpans (error/empty paths)
@@ -1513,9 +1504,6 @@ function Search({
     // The SearchPage skeleton (useSearchLoadingState) doesn't cover this case because
     // Search must mount for its onLayout to flush the deferred CreateMoneyRequest API write, which would block the JS thread causing a slowdown on post expense creation navigation
     if (shouldShowRowSkeleton) {
-        // When initialContent is provided (submit-expense flow), render it instead of the skeleton.
-        // This avoids a jarring "data, skeleton, data" flash. The user sees the same
-        // static list continuously until the FlashList is ready to take over.
         if (initialContent) {
             return (
                 <View

--- a/src/components/Search/index.tsx
+++ b/src/components/Search/index.tsx
@@ -91,9 +91,6 @@ type SearchProps = {
     searchRequestResponseStatusCode?: number | null;
     onContentReady?: () => void;
 
-    /** Pre-rendered content shown on the first frame while hooks initialize and heavy work is deferred. */
-    initialContent?: React.ReactNode;
-
     /** Callback from the parent (SearchPageNarrow) to end submit-expense navigation spans.
      *  Consolidates span-ending logic in one place. Accepts `wasListEmpty` for telemetry attributes. */
     onDestinationVisible?: (wasListEmpty: boolean, source: 'focus' | 'layout') => void;
@@ -223,7 +220,6 @@ function Search({
     onSortPressedCallback,
     searchRequestResponseStatusCode,
     onContentReady,
-    initialContent,
     onDestinationVisible,
 }: SearchProps) {
     const {type, status, sortBy, sortOrder, hash, similarSearchHash, groupBy, view} = queryJSON;
@@ -1418,7 +1414,8 @@ function Search({
             cancelSubmitFollowUpActionSpan();
         }
         didBailToFallbackState.current = true;
-    }, []);
+        onContentReady?.();
+    }, [onContentReady]);
 
     // When the render bails to an error/empty state, the SelectionList never mounts
     // so its onLayout callback (the primary flush site) never fires. This effect
@@ -1504,16 +1501,6 @@ function Search({
     // The SearchPage skeleton (useSearchLoadingState) doesn't cover this case because
     // Search must mount for its onLayout to flush the deferred CreateMoneyRequest API write, which would block the JS thread causing a slowdown on post expense creation navigation
     if (shouldShowRowSkeleton) {
-        if (initialContent) {
-            return (
-                <View
-                    style={styles.flex1}
-                    onLayout={onSkeletonLayout}
-                >
-                    {initialContent}
-                </View>
-            );
-        }
         return (
             <SearchRowSkeleton
                 shouldAnimate

--- a/src/components/Search/index.tsx
+++ b/src/components/Search/index.tsx
@@ -231,7 +231,7 @@ function Search({
     const skipDeferralOnFocusRef = useRef(isSearchDataLoaded(searchResults, queryJSON) && !hasPendingWriteOnMountRef.current);
 
     const [shouldDeferHeavySearchWork, setShouldDeferHeavySearchWork] = useState(() => !isSearchDataLoaded(searchResults, queryJSON) || hasPendingWriteOnMountRef.current);
-    const [showPendingExpensePlaceholder, setShowPendingExpensePlaceholder] = useState(() => hasPendingWriteOnMountRef.current && optimisticWatchKeyRef.current != null);
+    const [showPendingExpensePlaceholder, setShowPendingExpensePlaceholder] = useState(() => hasPendingWriteOnMountRef.current);
     // Caches the optimistic list item once it first appears in sortedData.
     // Used by stableSortedData to re-inject the row if a stale snapshot temporarily removes it.
     // Cleared once the server-confirmed (non-optimistic) version arrives.
@@ -259,7 +259,7 @@ function Search({
     // stays visible at its sorted position until server-confirmed data arrives;
     // clearOptimisticTracking handles that cleanup when pendingAction !== ADD.
     useEffect(() => {
-        if (!hasPendingWriteOnMountRef.current || !optimisticWatchKeyRef.current) {
+        if (!hasPendingWriteOnMountRef.current) {
             return;
         }
         const id = setTimeout(() => setShowPendingExpensePlaceholder(false), OPTIMISTIC_TRACKING_TIMEOUT_MS);
@@ -650,6 +650,15 @@ function Search({
 
         const comingBackOnlineWithNoResults = prevIsOffline && !isOffline && isEmptyObject(searchResults?.data);
         if (!comingBackOnlineWithNoResults && ((!isFocused && !isMigratedModalDisplayed) || isOffline)) {
+            return;
+        }
+
+        // When mounting after the pre-insert fast path, the deferred write hasn't
+        // been flushed yet. Triggering a search now would race with the CREATE
+        // API call and return stale results that overwrite the optimistic row.
+        // Skip this call; the optimistic data from flushDeferredWrite will populate
+        // the list, and the next user-driven search will refresh from the server.
+        if (hasPendingWriteOnMountRef.current && hasDeferredWrite(CONST.DEFERRED_LAYOUT_WRITE_KEYS.SEARCH)) {
             return;
         }
 
@@ -1239,9 +1248,26 @@ function Search({
     // Server confirmed (pendingAction !== ADD) -> clear all tracking.
     // Disappeared after caching (rollback) -> schedule cleanup after grace period.
     useEffect(() => {
-        if (!optimisticWatchKeyRef.current) {
+        if (!hasPendingWriteOnMountRef.current || optimisticTrackingCleanedUpRef.current) {
             return;
         }
+
+        // The watch key may not be available at mount when the deferred write channel
+        // was only reserved (fast path: rAF hasn't fired yet). Try to resolve it lazily
+        // on each sortedData change. If data arrives before we ever get a key (e.g. the
+        // channel was flushed between renders), clear tracking since the list is populated.
+        if (!optimisticWatchKeyRef.current) {
+            const latestKey = getOptimisticWatchKey(CONST.DEFERRED_LAYOUT_WRITE_KEYS.SEARCH);
+            if (latestKey) {
+                optimisticWatchKeyRef.current = latestKey;
+            } else if (sortedData.length > 0) {
+                clearOptimisticTracking();
+                return;
+            } else {
+                return;
+            }
+        }
+
         const optimisticItem = sortedData.find(
             (item): item is TransactionListItemType => 'transactionID' in item && `${ONYXKEYS.COLLECTION.TRANSACTION}${item.transactionID}` === optimisticWatchKeyRef.current,
         );

--- a/src/libs/Navigation/AppNavigator/Navigators/RightModalNavigator.tsx
+++ b/src/libs/Navigation/AppNavigator/Navigators/RightModalNavigator.tsx
@@ -115,13 +115,19 @@ function RightModalNavigator({navigation, route}: RightModalNavigatorProps) {
     const {sidePanelOffset} = useSidePanelState();
 
     // When a fullscreen route is pre-inserted under the RHP, disable the slide-out animation
-    // so the dismiss reveals the destination instantly. No restore is needed because the
-    // entire RightModalNavigator unmounts on dismiss; the next RHP open creates a fresh instance.
+    // so the dismiss reveals the destination instantly. If the pre-insert is later cleaned up
+    // (user backs out without submitting), restore the default animation for that session.
     useEffect(() => {
-        const subscription = DeviceEventEmitter.addListener(CONST.MODAL_EVENTS.DISABLE_RHP_ANIMATION, () => {
+        const disableSub = DeviceEventEmitter.addListener(CONST.MODAL_EVENTS.DISABLE_RHP_ANIMATION, () => {
             navigation.setOptions({animation: Animations.NONE});
         });
-        return () => subscription.remove();
+        const restoreSub = DeviceEventEmitter.addListener(CONST.MODAL_EVENTS.RESTORE_RHP_ANIMATION, () => {
+            navigation.setOptions({animation: Animations.SLIDE_FROM_RIGHT});
+        });
+        return () => {
+            disableSub.remove();
+            restoreSub.remove();
+        };
     }, [navigation]);
 
     // Animation should be disabled when we open the wide rhp from the narrow one.

--- a/src/libs/Navigation/AppNavigator/Navigators/RightModalNavigator.tsx
+++ b/src/libs/Navigation/AppNavigator/Navigators/RightModalNavigator.tsx
@@ -114,6 +114,16 @@ function RightModalNavigator({navigation, route}: RightModalNavigatorProps) {
     const styles = useThemeStyles();
     const {sidePanelOffset} = useSidePanelState();
 
+    // When a fullscreen route is pre-inserted under the RHP, disable the slide-out animation
+    // so the dismiss reveals the destination instantly. No restore is needed because the
+    // entire RightModalNavigator unmounts on dismiss; the next RHP open creates a fresh instance.
+    useEffect(() => {
+        const subscription = DeviceEventEmitter.addListener(CONST.MODAL_EVENTS.DISABLE_RHP_ANIMATION, () => {
+            navigation.setOptions({animation: Animations.NONE});
+        });
+        return () => subscription.remove();
+    }, [navigation]);
+
     // Animation should be disabled when we open the wide rhp from the narrow one.
     // When the wide rhp page is opened as first one, it will be animated with the entire RightModalNavigator.
     const animationEnabledOnSearchReport = superWideRHPRouteKeys.length > 0 || isSmallScreenWidth;

--- a/src/libs/Navigation/AppNavigator/createRootStackNavigator/GetStateForActionHandlers.ts
+++ b/src/libs/Navigation/AppNavigator/createRootStackNavigator/GetStateForActionHandlers.ts
@@ -16,6 +16,7 @@ import type {
     OpenDomainSplitActionType,
     OpenWorkspaceSplitActionType,
     PushActionType,
+    RemoveFullscreenUnderRHPActionType,
     ReplaceActionType,
     ReplaceFullscreenUnderRHPActionType,
     ToggleSidePanelWithHistoryActionType,
@@ -269,6 +270,42 @@ function handleReplaceFullscreenUnderRHP(
 }
 
 /**
+ * Reverses handleReplaceFullscreenUnderRHP by removing the fullscreen route that
+ * was pre-inserted underneath the currently open modal.
+ *
+ * State transition: [Home, Search, RHP] -> [Home, RHP]
+ *
+ * Used when the user backs out of the expense confirmation screen without submitting,
+ * so the pre-inserted destination route is cleaned up.
+ */
+function handleRemoveFullscreenUnderRHP(
+    state: StackNavigationState<ParamListBase>,
+    action: RemoveFullscreenUnderRHPActionType,
+    configOptions: RouterConfigOptions,
+    stackRouter: Router<StackNavigationState<ParamListBase>, CommonActions.Action | StackActionType>,
+) {
+    const rhpRoute = state.routes.at(-1);
+    if (rhpRoute?.name !== NAVIGATORS.RIGHT_MODAL_NAVIGATOR) {
+        return null;
+    }
+
+    const routesWithoutRHP = state.routes.slice(0, -1);
+    if (routesWithoutRHP.length < 2) {
+        return null;
+    }
+
+    const preInsertedRoute = routesWithoutRHP.at(-1);
+    if (!preInsertedRoute || !isFullScreenName(preInsertedRoute.name) || preInsertedRoute.name !== action.payload.expectedRouteName) {
+        return null;
+    }
+
+    const routesWithoutPreInserted = routesWithoutRHP.slice(0, -1);
+    const newRoutes = [...routesWithoutPreInserted, rhpRoute];
+    const rehydratedState = stackRouter.getRehydratedState({...state, routes: newRoutes, index: newRoutes.length - 1}, configOptions);
+    return rehydratedState;
+}
+
+/**
  * Handles the DISMISS_MODAL action.
  * If the last route is a modal route, it has to be popped from the navigation stack.
  */
@@ -328,6 +365,7 @@ export {
     handleOpenDomainSplitAction,
     handlePushFullscreenAction,
     handleReplaceFullscreenUnderRHP,
+    handleRemoveFullscreenUnderRHP,
     handleReplaceReportsSplitNavigatorAction,
     screensWithEnteringAnimation,
     handleToggleSidePanelWithHistoryAction,

--- a/src/libs/Navigation/AppNavigator/createRootStackNavigator/RootStackRouter.ts
+++ b/src/libs/Navigation/AppNavigator/createRootStackNavigator/RootStackRouter.ts
@@ -14,6 +14,7 @@ import {
     handleOpenDomainSplitAction,
     handleOpenWorkspaceSplitAction,
     handlePushFullscreenAction,
+    handleRemoveFullscreenUnderRHP,
     handleReplaceFullscreenUnderRHP,
     handleReplaceReportsSplitNavigatorAction,
     handleToggleSidePanelWithHistoryAction,
@@ -25,6 +26,7 @@ import type {
     OpenWorkspaceSplitActionType,
     PreloadActionType,
     PushActionType,
+    RemoveFullscreenUnderRHPActionType,
     ReplaceActionType,
     ReplaceFullscreenUnderRHPActionType,
     RootStackNavigatorAction,
@@ -54,6 +56,10 @@ function isDismissModalAction(action: RootStackNavigatorAction): action is Dismi
 
 function isReplaceFullscreenUnderRHPAction(action: RootStackNavigatorAction): action is ReplaceFullscreenUnderRHPActionType {
     return action.type === CONST.NAVIGATION.ACTION_TYPE.REPLACE_FULLSCREEN_UNDER_RHP;
+}
+
+function isRemoveFullscreenUnderRHPAction(action: RootStackNavigatorAction): action is RemoveFullscreenUnderRHPActionType {
+    return action.type === CONST.NAVIGATION.ACTION_TYPE.REMOVE_FULLSCREEN_UNDER_RHP;
 }
 
 function isToggleSidePanelWithHistoryAction(action: RootStackNavigatorAction): action is ToggleSidePanelWithHistoryActionType {
@@ -153,6 +159,10 @@ function RootStackRouter(options: RootStackNavigatorRouterOptions) {
 
             if (isReplaceFullscreenUnderRHPAction(action)) {
                 return handleReplaceFullscreenUnderRHP(state, action, configOptions, stackRouter);
+            }
+
+            if (isRemoveFullscreenUnderRHPAction(action)) {
+                return handleRemoveFullscreenUnderRHP(state, action, configOptions, stackRouter);
             }
 
             if (isReplaceAction(action) && action.payload.name === NAVIGATORS.REPORTS_SPLIT_NAVIGATOR) {

--- a/src/libs/Navigation/AppNavigator/createRootStackNavigator/types.ts
+++ b/src/libs/Navigation/AppNavigator/createRootStackNavigator/types.ts
@@ -18,6 +18,10 @@ type RootStackNavigatorActionType =
           payload: {route: Route};
       }
     | {
+          type: typeof CONST.NAVIGATION.ACTION_TYPE.REMOVE_FULLSCREEN_UNDER_RHP;
+          payload: {expectedRouteName: string};
+      }
+    | {
           type: typeof CONST.NAVIGATION.ACTION_TYPE.OPEN_WORKSPACE_SPLIT;
           payload: {
               policyID: string;
@@ -69,6 +73,11 @@ type ReplaceFullscreenUnderRHPActionType = RootStackNavigatorActionType & {
     payload: {route: Route};
 };
 
+type RemoveFullscreenUnderRHPActionType = RootStackNavigatorActionType & {
+    type: typeof CONST.NAVIGATION.ACTION_TYPE.REMOVE_FULLSCREEN_UNDER_RHP;
+    payload: {expectedRouteName: string};
+};
+
 type RootStackNavigatorRouterOptions = StackRouterOptions;
 
 type RootStackNavigatorAction = CommonActions.Action | StackActionType | RootStackNavigatorActionType;
@@ -81,6 +90,7 @@ export type {
     DismissModalActionType,
     PreloadActionType,
     ReplaceFullscreenUnderRHPActionType,
+    RemoveFullscreenUnderRHPActionType,
     RootStackNavigatorAction,
     RootStackNavigatorRouterOptions,
     ToggleSidePanelWithHistoryActionType,

--- a/src/libs/Navigation/AppNavigator/routerExtensions/addRootHistoryRouterExtension.ts
+++ b/src/libs/Navigation/AppNavigator/routerExtensions/addRootHistoryRouterExtension.ts
@@ -1,11 +1,15 @@
 import type {CommonActions, ParamListBase, PartialState, Router, RouterConfigOptions, StackActionType} from '@react-navigation/native';
-import type {ReplaceFullscreenUnderRHPActionType, RootStackNavigatorAction} from '@libs/Navigation/AppNavigator/createRootStackNavigator/types';
+import type {RemoveFullscreenUnderRHPActionType, ReplaceFullscreenUnderRHPActionType, RootStackNavigatorAction} from '@libs/Navigation/AppNavigator/createRootStackNavigator/types';
 import type {PlatformStackNavigationState, PlatformStackRouterFactory, PlatformStackRouterOptions} from '@libs/Navigation/PlatformStackNavigation/types';
 import CONST from '@src/CONST';
 import {enhanceStateWithHistory} from './utils';
 
 function isReplaceFullscreenUnderRHPAction(action: RootStackNavigatorAction): action is ReplaceFullscreenUnderRHPActionType {
     return action.type === CONST.NAVIGATION.ACTION_TYPE.REPLACE_FULLSCREEN_UNDER_RHP;
+}
+
+function isRemoveFullscreenUnderRHPAction(action: RootStackNavigatorAction): action is RemoveFullscreenUnderRHPActionType {
+    return action.type === CONST.NAVIGATION.ACTION_TYPE.REMOVE_FULLSCREEN_UNDER_RHP;
 }
 
 /**
@@ -17,10 +21,10 @@ function isReplaceFullscreenUnderRHPAction(action: RootStackNavigatorAction): ac
  * 1. **Side panel** – preserves the CUSTOM_HISTORY_ENTRY_SIDE_PANEL entry through
  *    rehydration so the side panel open/close state survives navigation state rebuilds.
  *
- * 2. **REPLACE_FULLSCREEN_UNDER_RHP** – freezes the history array for this action so
- *    that useLinking sees historyDelta=0 and does NOT push/pop any browser history
- *    entries for this intermediate state change. The correct browser history update
- *    happens later when DISMISS_MODAL pops the RHP in the next animation frame.
+ * 2. **REPLACE/REMOVE_FULLSCREEN_UNDER_RHP** - freezes the history array for these
+ *    actions so that useLinking sees historyDelta=0 and does NOT push/pop any browser
+ *    history entries for these intermediate state changes. The correct browser history
+ *    update happens later when DISMISS_MODAL pops the RHP in the next animation frame.
  */
 function addRootHistoryRouterExtension<RouterOptions extends PlatformStackRouterOptions = PlatformStackRouterOptions>(
     originalRouter: PlatformStackRouterFactory<ParamListBase, RouterOptions>,
@@ -52,11 +56,10 @@ function addRootHistoryRouterExtension<RouterOptions extends PlatformStackRouter
                 return null;
             }
 
-            // For REPLACE_FULLSCREEN_UNDER_RHP we intentionally preserve the original history
-            // array so that useLinking sees historyDelta=0 and does NOT push/pop any browser
-            // history entries for this intermediate state change. The correct browser history
-            // update happens later when DISMISS_MODAL pops the RHP in the next animation frame.
-            if (isReplaceFullscreenUnderRHPAction(action) && state.history) {
+            // For REPLACE/REMOVE_FULLSCREEN_UNDER_RHP we intentionally preserve the original
+            // history array so that useLinking sees historyDelta=0 and does NOT push/pop any
+            // browser history entries for these intermediate state changes.
+            if ((isReplaceFullscreenUnderRHPAction(action) || isRemoveFullscreenUnderRHPAction(action)) && state.history) {
                 // @ts-expect-error newState can be partial but getRehydratedState handles it correctly.
                 const rehydrated = getRehydratedState(newState, configOptions);
                 return {...rehydrated, history: state.history};

--- a/src/libs/Navigation/Navigation.ts
+++ b/src/libs/Navigation/Navigation.ts
@@ -552,6 +552,8 @@ function popToSidebar() {
  * Reset the navigation state to Home page.
  */
 function resetToHome() {
+    clearFullscreenPreInsertedFlag();
+
     const isNarrowLayout = getIsNarrowLayout();
     const rootState = navigationRef.getRootState();
     navigationRef.dispatch({...StackActions.popToTop(), target: rootState.key});
@@ -997,10 +999,21 @@ function preInsertFullscreenUnderRHP(route: Route) {
     const stateFromPath = getStateFromPath(route);
     const targetRouteName = stateFromPath?.routes.findLast((r) => isFullScreenName(r.name))?.name;
 
+    const stateBefore = navigationRef.current.getRootState();
+    const routeCountBefore = stateBefore.routes.length;
+    const lastKeyBefore = stateBefore.routes.at(-1)?.key;
+
     navigationRef.current.dispatch({
         type: CONST.NAVIGATION.ACTION_TYPE.REPLACE_FULLSCREEN_UNDER_RHP,
         payload: {route},
     });
+
+    const stateAfter = navigationRef.current.getRootState();
+    if (stateAfter.routes.length === routeCountBefore && stateAfter.routes.at(-1)?.key === lastKeyBefore) {
+        Log.hmmm(`[Navigation] preInsertFullscreenUnderRHP dispatch was ignored`, {route});
+        return;
+    }
+
     isFullscreenPreInsertedUnderRHP = true;
     preInsertedFullscreenRouteName = targetRouteName;
 
@@ -1032,6 +1045,8 @@ function removePreInsertedFullscreenIfNeeded() {
     isFullscreenPreInsertedUnderRHP = false;
     preInsertedFullscreenRouteName = undefined;
 
+    DeviceEventEmitter.emit(CONST.MODAL_EVENTS.RESTORE_RHP_ANIMATION);
+
     const rootState = navigationRef.getRootState();
     if (!rootState) {
         return;
@@ -1050,10 +1065,12 @@ function removePreInsertedFullscreenIfNeeded() {
 
     // RHP already dismissed - the pre-inserted fullscreen is now the topmost route; pop it.
     // Deferred to the next frame to avoid dispatching during a React commit.
+    // Capture the route key now so the rAF callback can match on identity, not just name.
+    const targetRouteKey = rootState.routes.at(-1)?.key;
     requestAnimationFrame(() => {
         const currentState = navigationRef.getRootState();
         const topmostRoute = currentState?.routes.at(-1);
-        if (!topmostRoute || !isFullScreenName(topmostRoute.name) || topmostRoute.name !== routeNameToRemove) {
+        if (!topmostRoute || topmostRoute.key !== targetRouteKey || topmostRoute.name !== routeNameToRemove) {
             return;
         }
         if (!navigationRef.current?.canGoBack()) {

--- a/src/libs/Navigation/Navigation.ts
+++ b/src/libs/Navigation/Navigation.ts
@@ -963,6 +963,106 @@ function revealRouteBeforeDismissingModal(route: Route) {
     });
 }
 
+// Module-level state tracking the pre-inserted fullscreen route. This follows the same
+// pattern as other module-level navigation state in this file (e.g. pendingRoute).
+// It is only mutated from preInsertFullscreenUnderRHP / clearFullscreenPreInsertedFlag /
+// removePreInsertedFullscreenIfNeeded, which are always called from the JS thread.
+let isFullscreenPreInsertedUnderRHP = false;
+let preInsertedFullscreenRouteName: string | undefined;
+
+/**
+ * Pre-inserts a fullscreen route (e.g. Search) underneath the currently open RHP on narrow layout.
+ * The route renders behind the fullscreen RHP so that when the user later submits,
+ * we can simply dismiss the RHP to reveal the already-mounted screen.
+ *
+ * This is the mobile counterpart of revealRouteBeforeDismissingModal; the difference
+ * is that the insert happens eagerly (on confirmation screen mount) rather than at
+ * submission time, giving React time to mount the destination component tree while
+ * the user is still filling in details.
+ */
+function preInsertFullscreenUnderRHP(route: Route) {
+    if (!getIsNarrowLayout()) {
+        return;
+    }
+
+    if (isFullscreenPreInsertedUnderRHP) {
+        return;
+    }
+
+    if (!canNavigate('preInsertFullscreenUnderRHP', {route}) || !navigationRef.current) {
+        Log.hmmm(`[Navigation] Unable to pre-insert fullscreen under RHP. Can't navigate.`, {route});
+        return;
+    }
+
+    const stateFromPath = getStateFromPath(route);
+    const targetRouteName = stateFromPath?.routes.findLast((r) => isFullScreenName(r.name))?.name;
+
+    navigationRef.current.dispatch({
+        type: CONST.NAVIGATION.ACTION_TYPE.REPLACE_FULLSCREEN_UNDER_RHP,
+        payload: {route},
+    });
+    isFullscreenPreInsertedUnderRHP = true;
+    preInsertedFullscreenRouteName = targetRouteName;
+
+    DeviceEventEmitter.emit(CONST.MODAL_EVENTS.DISABLE_RHP_ANIMATION);
+}
+
+function getIsFullscreenPreInsertedUnderRHP() {
+    return isFullscreenPreInsertedUnderRHP;
+}
+
+function clearFullscreenPreInsertedFlag() {
+    isFullscreenPreInsertedUnderRHP = false;
+    preInsertedFullscreenRouteName = undefined;
+}
+
+/**
+ * Removes a pre-inserted fullscreen route when the user backs out without submitting.
+ * If the RHP is still on top, the pre-inserted route is popped from under it.
+ * If the RHP is already gone (back-dismissed), the pre-inserted route is the topmost
+ * fullscreen and is popped directly.
+ */
+function removePreInsertedFullscreenIfNeeded() {
+    if (!isFullscreenPreInsertedUnderRHP) {
+        return;
+    }
+
+    const routeNameToRemove = preInsertedFullscreenRouteName;
+
+    isFullscreenPreInsertedUnderRHP = false;
+    preInsertedFullscreenRouteName = undefined;
+
+    const rootState = navigationRef.getRootState();
+    if (!rootState) {
+        return;
+    }
+
+    const topRoute = rootState.routes.at(-1);
+    const isRHPStillOnTop = topRoute?.name === NAVIGATORS.RIGHT_MODAL_NAVIGATOR;
+
+    if (isRHPStillOnTop && routeNameToRemove) {
+        navigationRef.current?.dispatch({
+            type: CONST.NAVIGATION.ACTION_TYPE.REMOVE_FULLSCREEN_UNDER_RHP,
+            payload: {expectedRouteName: routeNameToRemove},
+        });
+        return;
+    }
+
+    // RHP already dismissed - the pre-inserted fullscreen is now the topmost route; pop it.
+    // Deferred to the next frame to avoid dispatching during a React commit.
+    requestAnimationFrame(() => {
+        const currentState = navigationRef.getRootState();
+        const topmostRoute = currentState?.routes.at(-1);
+        if (!topmostRoute || !isFullScreenName(topmostRoute.name) || topmostRoute.name !== routeNameToRemove) {
+            return;
+        }
+        if (!navigationRef.current?.canGoBack()) {
+            return;
+        }
+        navigationRef.current.goBack();
+    });
+}
+
 function getTopmostSearchReportRouteParams(state = navigationRef.getRootState()): RightModalNavigatorParamList[typeof SCREENS.RIGHT_MODAL.SEARCH_REPORT] | undefined {
     if (!state) {
         return undefined;
@@ -1021,6 +1121,10 @@ export default {
     dismissToPreviousRHP,
     dismissToSuperWideRHP,
     revealRouteBeforeDismissingModal,
+    preInsertFullscreenUnderRHP,
+    getIsFullscreenPreInsertedUnderRHP,
+    clearFullscreenPreInsertedFlag,
+    removePreInsertedFullscreenIfNeeded,
     getTopmostSearchReportID,
     getTopmostSuperWideRHPReportParams,
     getTopmostSuperWideRHPReportID,

--- a/src/libs/actions/IOU/index.ts
+++ b/src/libs/actions/IOU/index.ts
@@ -985,10 +985,11 @@ function handleNavigateAfterExpenseCreate({
             Navigation.clearFullscreenPreInsertedFlag();
             Navigation.dismissModal();
         } else if (getIsNarrowLayout()) {
-            // Skip navigation if we're already on the correct Search page (e.g. after the
-            // pre-insert fast path dismissed the RHP and revealed the pre-mounted Search).
-            if (!alreadyOnSearchRoot || !isSameSearchType) {
+            const isRHPStillOnTop = navigationRef.getRootState()?.routes?.at(-1)?.name === NAVIGATORS.RIGHT_MODAL_NAVIGATOR;
+            if (!alreadyOnSearchRoot || !isSameSearchType || isRHPStillOnTop) {
                 Navigation.navigate(ROUTES.SEARCH_ROOT.getRoute({query: queryString}), {forceReplace: true});
+            } else {
+                Log.info('[IOU] navigateToSearch: already on matching Search root with RHP dismissed — no-op');
             }
         } else {
             Navigation.revealRouteBeforeDismissingModal(ROUTES.SEARCH_ROOT.getRoute({query: queryString}));

--- a/src/libs/actions/IOU/index.ts
+++ b/src/libs/actions/IOU/index.ts
@@ -978,8 +978,18 @@ function handleNavigateAfterExpenseCreate({
     );
     const queryString = buildCannedSearchQuery({type});
     const navigateToSearch = () => {
-        if (getIsNarrowLayout()) {
-            Navigation.navigate(ROUTES.SEARCH_ROOT.getRoute({query: queryString}), {forceReplace: true});
+        // On the fast path, onConfirm already cleared the flag and dismissed the modal,
+        // so this branch is only reached on the slow path (user submitted before the
+        // 300ms pre-insert timer fired).
+        if (getIsNarrowLayout() && Navigation.getIsFullscreenPreInsertedUnderRHP()) {
+            Navigation.clearFullscreenPreInsertedFlag();
+            Navigation.dismissModal();
+        } else if (getIsNarrowLayout()) {
+            // Skip navigation if we're already on the correct Search page (e.g. after the
+            // pre-insert fast path dismissed the RHP and revealed the pre-mounted Search).
+            if (!alreadyOnSearchRoot || !isSameSearchType) {
+                Navigation.navigate(ROUTES.SEARCH_ROOT.getRoute({query: queryString}), {forceReplace: true});
+            }
         } else {
             Navigation.revealRouteBeforeDismissingModal(ROUTES.SEARCH_ROOT.getRoute({query: queryString}));
         }

--- a/src/libs/deferredLayoutWrite.ts
+++ b/src/libs/deferredLayoutWrite.ts
@@ -148,6 +148,8 @@ function reserveDeferredWriteChannel(key: string) {
         return;
     }
 
+    flushedWatchKeys.delete(key);
+
     const safetyTimeoutId = setTimeout(() => {
         Log.warn(`[DeferredLayoutWrite] Safety timeout fired for reserved channel "${key}" - the real write was never registered`);
         channels.delete(key);

--- a/src/libs/deferredLayoutWrite.ts
+++ b/src/libs/deferredLayoutWrite.ts
@@ -33,6 +33,9 @@ type DeferredChannel = {
      * when the optimistic updates have been applied.
      */
     optimisticWatchKey?: OnyxKey;
+
+    /** True when the channel was created by reserveDeferredWriteChannel. */
+    isReserved?: boolean;
 };
 
 const channels = new Map<string, DeferredChannel>();
@@ -56,8 +59,13 @@ function registerDeferredWrite(key: string, callback: () => void, options: Defer
 
     const existing = channels.get(key);
     if (existing) {
-        Log.warn(`[DeferredLayoutWrite] Overwriting unflushed deferred write for key "${key}" - flushing the pending one first`);
-        flushDeferredWrite(key);
+        if (existing.isReserved) {
+            clearChannelTimeout(existing);
+            channels.delete(key);
+        } else {
+            Log.warn(`[DeferredLayoutWrite] Overwriting unflushed deferred write for key "${key}" - flushing the pending one first`);
+            flushDeferredWrite(key);
+        }
     }
 
     const safetyTimeoutId = setTimeout(() => {
@@ -96,6 +104,25 @@ function cancelDeferredWrite(key: string) {
     channels.delete(key);
 }
 
+/**
+ * Pre-create a channel so that hasDeferredWrite(key) returns true immediately.
+ * The real callback will be registered later via registerDeferredWrite, which
+ * silently replaces the reservation. A safety timeout is still set in case
+ * the real registration never arrives.
+ */
+function reserveDeferredWriteChannel(key: string) {
+    if (channels.has(key)) {
+        return;
+    }
+
+    const safetyTimeoutId = setTimeout(() => {
+        Log.warn(`[DeferredLayoutWrite] Safety timeout fired for reserved channel "${key}" - the real write was never registered`);
+        channels.delete(key);
+    }, DEFAULT_SAFETY_TIMEOUT_MS);
+
+    channels.set(key, {write: () => {}, safetyTimeoutId, isReserved: true});
+}
+
 function hasDeferredWrite(key: string): boolean {
     return channels.has(key);
 }
@@ -122,4 +149,4 @@ AppState.addEventListener('change', (nextState) => {
     }
 });
 
-export {registerDeferredWrite, flushDeferredWrite, cancelDeferredWrite, hasDeferredWrite, getOptimisticWatchKey};
+export {registerDeferredWrite, reserveDeferredWriteChannel, flushDeferredWrite, cancelDeferredWrite, hasDeferredWrite, getOptimisticWatchKey};

--- a/src/libs/deferredLayoutWrite.ts
+++ b/src/libs/deferredLayoutWrite.ts
@@ -36,9 +36,23 @@ type DeferredChannel = {
 
     /** True when the channel was created by reserveDeferredWriteChannel. */
     isReserved?: boolean;
+
+    /**
+     * Set when flushDeferredWrite is called while the channel is still reserved.
+     * Signals that the target component already laid out and tried to flush,
+     * so registerDeferredWrite should execute the real callback immediately
+     * instead of creating a new deferred channel.
+     */
+    flushRequested?: boolean;
 };
 
 const channels = new Map<string, DeferredChannel>();
+
+// Watch keys that outlive their channel. When a reserved channel is flushed
+// immediately (flushRequested path), the channel is deleted but the watch key
+// must remain accessible so Search's lazy getOptimisticWatchKey() resolution
+// can still find it.
+const flushedWatchKeys = new Map<string, OnyxKey>();
 
 function clearChannelTimeout(channel: DeferredChannel) {
     clearTimeout(channel.safetyTimeoutId);
@@ -61,7 +75,16 @@ function registerDeferredWrite(key: string, callback: () => void, options: Defer
     if (existing) {
         if (existing.isReserved) {
             clearChannelTimeout(existing);
+            const shouldFlushImmediately = existing.flushRequested;
             channels.delete(key);
+
+            if (shouldFlushImmediately) {
+                if (optimisticWatchKey) {
+                    flushedWatchKeys.set(key, optimisticWatchKey);
+                }
+                callback();
+                return;
+            }
         } else {
             Log.warn(`[DeferredLayoutWrite] Overwriting unflushed deferred write for key "${key}" - flushing the pending one first`);
             flushDeferredWrite(key);
@@ -79,10 +102,20 @@ function registerDeferredWrite(key: string, callback: () => void, options: Defer
 /**
  * Execute and clear the pending deferred write for the given key.
  * Called by the target component when actual content (not skeleton) lays out.
+ *
+ * If the channel is still reserved (real callback not yet registered), the
+ * flush is deferred: the channel is marked `flushRequested` so that
+ * registerDeferredWrite will execute the real callback immediately when it
+ * arrives, instead of creating a new channel that nobody would flush.
  */
 function flushDeferredWrite(key: string) {
     const channel = channels.get(key);
     if (!channel) {
+        return;
+    }
+
+    if (channel.isReserved) {
+        channel.flushRequested = true;
         return;
     }
 
@@ -133,7 +166,7 @@ function hasDeferredWrite(key: string): boolean {
  * or the channel was registered without a watch key.
  */
 function getOptimisticWatchKey(key: string): OnyxKey | undefined {
-    return channels.get(key)?.optimisticWatchKey;
+    return channels.get(key)?.optimisticWatchKey ?? flushedWatchKeys.get(key);
 }
 
 // Flush every pending deferred write when the app moves to background so

--- a/src/libs/telemetry/submitFollowUpAction.ts
+++ b/src/libs/telemetry/submitFollowUpAction.ts
@@ -49,11 +49,21 @@ function setPendingSubmitFollowUpAction(followUpAction: SubmitFollowUpAction, re
     const pending = pendingSubmitFollowUpAction;
 
     if (pending !== null && span && isSameFlowUpdate(pending, followUpAction, reportID)) {
-        // Same flow: update in place instead of cancelling (e.g. dismissModalAndOpenReportInInboxTab sets pending, then onBeforeNavigate refines it).
-        pendingSubmitFollowUpAction = {followUpAction, reportID};
-        span.setAttribute(CONST.TELEMETRY.ATTRIBUTE_SUBMIT_FOLLOW_UP_ACTION, followUpAction);
-        if (reportID !== undefined) {
-            span.setAttribute(CONST.TELEMETRY.ATTRIBUTE_REPORT_ID, reportID);
+        // Same flow: only update when the new action is a genuine refinement (e.g.
+        // DISMISS_MODAL_ONLY -> DISMISS_MODAL_AND_OPEN_REPORT). When the fast path set
+        // NAVIGATE_TO_SEARCH and handleNavigateAfterExpenseCreate later calls with
+        // DISMISS_MODAL_ONLY (because Search is already on top), preserve the original
+        // action so telemetry correctly reflects the pre-insert path.
+        const isRefinement =
+            pending.followUpAction !== followUpAction &&
+            !(pending.followUpAction === CONST.TELEMETRY.SUBMIT_FOLLOW_UP_ACTION.NAVIGATE_TO_SEARCH && followUpAction === CONST.TELEMETRY.SUBMIT_FOLLOW_UP_ACTION.DISMISS_MODAL_ONLY);
+
+        if (isRefinement) {
+            pendingSubmitFollowUpAction = {followUpAction, reportID};
+            span.setAttribute(CONST.TELEMETRY.ATTRIBUTE_SUBMIT_FOLLOW_UP_ACTION, followUpAction);
+            if (reportID !== undefined) {
+                span.setAttribute(CONST.TELEMETRY.ATTRIBUTE_REPORT_ID, reportID);
+            }
         }
         return;
     }
@@ -62,15 +72,20 @@ function setPendingSubmitFollowUpAction(followUpAction: SubmitFollowUpAction, re
         cancelSpan(CONST.TELEMETRY.SPAN_SUBMIT_TO_DESTINATION_VISIBLE);
         pendingSubmitFollowUpAction = null;
     }
-    pendingSubmitFollowUpAction = {followUpAction, reportID};
-    // Set the attribute on the span immediately so it is present when the transaction is serialized.
-    // When navigating away (e.g. to Search), the confirmation transaction can end and the SDK may cancel our span before the destination screen mounts to call endSubmitFollowUpActionSpan.
+
+    // Only set pending when the span is still active. On the fast path the span
+    // may have already been ended by SearchStaticList before createTransaction's
+    // rAF fires. Setting pending without a span leaves stale state that would
+    // cancel the next flow's span in the conflict check above.
     const spanAfter = getSpan(CONST.TELEMETRY.SPAN_SUBMIT_TO_DESTINATION_VISIBLE);
-    if (spanAfter) {
-        spanAfter.setAttribute(CONST.TELEMETRY.ATTRIBUTE_SUBMIT_FOLLOW_UP_ACTION, followUpAction);
-        if (reportID !== undefined) {
-            spanAfter.setAttribute(CONST.TELEMETRY.ATTRIBUTE_REPORT_ID, reportID);
-        }
+    if (!spanAfter) {
+        return;
+    }
+
+    pendingSubmitFollowUpAction = {followUpAction, reportID};
+    spanAfter.setAttribute(CONST.TELEMETRY.ATTRIBUTE_SUBMIT_FOLLOW_UP_ACTION, followUpAction);
+    if (reportID !== undefined) {
+        spanAfter.setAttribute(CONST.TELEMETRY.ATTRIBUTE_REPORT_ID, reportID);
     }
 }
 

--- a/src/libs/telemetry/submitFollowUpAction.ts
+++ b/src/libs/telemetry/submitFollowUpAction.ts
@@ -29,7 +29,13 @@ function isSameFlowUpdate(pending: NonNullable<PendingSubmitFollowUpAction>, fol
         return true;
     }
     // Refinement: we first set DISMISS_MODAL_ONLY, then dismissModalWithReport's onBeforeNavigate refines it to DISMISS_MODAL_AND_OPEN_REPORT when the report will open. Same flow — update in place instead of cancelling.
-    return pending.followUpAction === CONST.TELEMETRY.SUBMIT_FOLLOW_UP_ACTION.DISMISS_MODAL_ONLY && followUpAction === CONST.TELEMETRY.SUBMIT_FOLLOW_UP_ACTION.DISMISS_MODAL_AND_OPEN_REPORT;
+    if (pending.followUpAction === CONST.TELEMETRY.SUBMIT_FOLLOW_UP_ACTION.DISMISS_MODAL_ONLY && followUpAction === CONST.TELEMETRY.SUBMIT_FOLLOW_UP_ACTION.DISMISS_MODAL_AND_OPEN_REPORT) {
+        return true;
+    }
+    // The fast path (pre-insert) sets NAVIGATE_TO_SEARCH before createTransaction runs.
+    // handleNavigateAfterExpenseCreate may later call with DISMISS_MODAL_ONLY because it
+    // sees the Search page as already on top. Treat this as same-flow - keep the original.
+    return pending.followUpAction === CONST.TELEMETRY.SUBMIT_FOLLOW_UP_ACTION.NAVIGATE_TO_SEARCH && followUpAction === CONST.TELEMETRY.SUBMIT_FOLLOW_UP_ACTION.DISMISS_MODAL_ONLY;
 }
 
 /**

--- a/src/pages/Search/SearchPageNarrow/index.tsx
+++ b/src/pages/Search/SearchPageNarrow/index.tsx
@@ -1,6 +1,6 @@
 import {useFocusEffect, useNavigation, useRoute} from '@react-navigation/native';
 import React, {useCallback, useContext, useEffect, useRef, useState, useTransition} from 'react';
-import {View} from 'react-native';
+import {StyleSheet, View} from 'react-native';
 import Animated, {clamp, useAnimatedScrollHandler, useAnimatedStyle, useSharedValue, withTiming} from 'react-native-reanimated';
 import {scheduleOnRN} from 'react-native-worklets';
 import FullPageNotFoundView from '@components/BlockingViews/FullPageNotFoundView';
@@ -166,6 +166,7 @@ function SearchPageNarrow({queryJSON, searchResults, isMobileSelectionModeEnable
     });
     const [isInteractive, setIsInteractive] = useState(!useStaticRendering);
     const [isHeaderInteractive, setIsHeaderInteractive] = useState(!useStaticRendering);
+    const [isSearchReady, setIsSearchReady] = useState(!useStaticRendering);
     const isHeaderInteractiveRef = useRef(isHeaderInteractive);
     const [, startTransition] = useTransition();
     useEffect(() => {
@@ -179,6 +180,10 @@ function SearchPageNarrow({queryJSON, searchResults, isMobileSelectionModeEnable
             setIsHeaderInteractive(true);
         });
     }, [startTransition]);
+
+    const onSearchContentReady = useCallback(() => {
+        setIsSearchReady(true);
+    }, []);
 
     const hadFocusRef = useRef(false);
     const hadLayoutRef = useRef(false);
@@ -246,40 +251,41 @@ function SearchPageNarrow({queryJSON, searchResults, isMobileSelectionModeEnable
     const shouldShowLoadingState = !isOffline && (!isDataLoaded || !!metadata?.isLoading);
     const contentContainerStyle = !isMobileSelectionModeEnabled ? styles.searchListContentContainerStyles : undefined;
 
-    // Single element used in both phases so React.memo sees stable props.
-    // Phase 1: Rendered directly for fast perceived performance.
-    // Phase 2: Passed as initialContent to Search (onLayout is a no-op via the ref guard).
-    // Phase 3: Search transitions to the full FlashList once deferred work completes.
-    const staticListContent = (
-        <SearchStaticList
-            searchResults={searchResults}
-            queryJSON={queryJSON}
-            contentContainerStyle={contentContainerStyle}
-            onLayout={onSearchLayout}
-            onDestinationVisible={endSubmitNavigationSpans}
-        />
+    // Overlay pattern: SearchStaticList renders as an absolute-fill sibling on
+    // top of Search, so its native views are never unmounted by a tree-structure
+    // swap. Search mounts behind the overlay when isInteractive flips, and once
+    // Search signals readiness (onContentReady -> onLayout), the overlay is removed.
+    const showStaticOverlay = useStaticRendering && !isSearchReady;
+
+    const renderStaticSearchList = () => (
+        <>
+            {isInteractive && (
+                <Search
+                    searchResults={searchResults}
+                    queryJSON={queryJSON}
+                    key={queryJSON.hash}
+                    contentContainerStyle={contentContainerStyle}
+                    handleSearch={handleSearchAction}
+                    isMobileSelectionModeEnabled={isMobileSelectionModeEnabled}
+                    onSearchListScroll={scrollHandler}
+                    searchRequestResponseStatusCode={searchRequestResponseStatusCode}
+                    onDestinationVisible={endSubmitNavigationSpans}
+                    onContentReady={onSearchContentReady}
+                />
+            )}
+            {showStaticOverlay && (
+                <View style={[StyleSheet.absoluteFill, styles.appBG]}>
+                    <SearchStaticList
+                        searchResults={searchResults}
+                        queryJSON={queryJSON}
+                        contentContainerStyle={contentContainerStyle}
+                        onLayout={onSearchLayout}
+                        onDestinationVisible={endSubmitNavigationSpans}
+                    />
+                </View>
+            )}
+        </>
     );
-
-    const renderStaticSearchList = () => {
-        if (!isInteractive) {
-            return staticListContent;
-        }
-
-        return (
-            <Search
-                searchResults={searchResults}
-                queryJSON={queryJSON}
-                key={queryJSON.hash}
-                contentContainerStyle={contentContainerStyle}
-                handleSearch={handleSearchAction}
-                isMobileSelectionModeEnabled={isMobileSelectionModeEnabled}
-                onSearchListScroll={scrollHandler}
-                searchRequestResponseStatusCode={searchRequestResponseStatusCode}
-                initialContent={staticListContent}
-                onDestinationVisible={endSubmitNavigationSpans}
-            />
-        );
-    };
 
     const renderDynamicSearchList = () => {
         if (shouldShowLoadingSkeleton) {

--- a/src/pages/Search/SearchPageNarrow/index.tsx
+++ b/src/pages/Search/SearchPageNarrow/index.tsx
@@ -1,4 +1,4 @@
-import {useRoute} from '@react-navigation/native';
+import {useFocusEffect, useNavigation, useRoute} from '@react-navigation/native';
 import React, {useCallback, useContext, useEffect, useRef, useState, useTransition} from 'react';
 import {View} from 'react-native';
 import Animated, {clamp, useAnimatedScrollHandler, useAnimatedStyle, useSharedValue, withTiming} from 'react-native-reanimated';
@@ -152,7 +152,18 @@ function SearchPageNarrow({queryJSON, searchResults, isMobileSelectionModeEnable
         return () => removeRouteKey(route.key);
     }, [addRouteKey, removeRouteKey, route.key, searchRouterListVisible]);
 
-    const [useStaticRendering] = useState(() => getPendingSubmitFollowUpAction()?.followUpAction === CONST.TELEMETRY.SUBMIT_FOLLOW_UP_ACTION.NAVIGATE_TO_SEARCH);
+    const navigation = useNavigation();
+    // When pre-inserted behind the RHP (not focused), always start in static rendering
+    // mode so we stay at the lightweight static list until focus arrives. This avoids
+    // mounting the heavy Search component while hidden and ensures the deferred write
+    // mechanism works correctly: createTransaction registers the write in the next rAF,
+    // and the full Search component flushes it when it mounts after focus-driven phase transition.
+    const [useStaticRendering] = useState(() => {
+        if (!navigation.isFocused()) {
+            return true;
+        }
+        return getPendingSubmitFollowUpAction()?.followUpAction === CONST.TELEMETRY.SUBMIT_FOLLOW_UP_ACTION.NAVIGATE_TO_SEARCH;
+    });
     const [isInteractive, setIsInteractive] = useState(!useStaticRendering);
     const [isHeaderInteractive, setIsHeaderInteractive] = useState(!useStaticRendering);
     const isHeaderInteractiveRef = useRef(isHeaderInteractive);
@@ -168,14 +179,20 @@ function SearchPageNarrow({queryJSON, searchResults, isMobileSelectionModeEnable
             setIsHeaderInteractive(true);
         });
     }, [startTransition]);
-    useEffect(() => {
-        if (!isHeaderInteractive || isInteractive) {
-            return;
-        }
-        startTransition(() => {
-            setIsInteractive(true);
-        });
-    }, [isHeaderInteractive, isInteractive, startTransition]);
+    // Wait for focus before transitioning to the full interactive Search component.
+    // When pre-inserted behind the RHP, this keeps the page at the lightweight static
+    // list phase until it is actually visible, avoiding wasted work and premature span endings.
+    // useFocusEffect avoids the extra re-renders that useIsFocused causes on every focus change.
+    useFocusEffect(
+        useCallback(() => {
+            if (!isHeaderInteractive || isInteractive) {
+                return;
+            }
+            startTransition(() => {
+                setIsInteractive(true);
+            });
+        }, [isHeaderInteractive, isInteractive, startTransition]),
+    );
 
     if (!queryJSON) {
         return (

--- a/src/pages/Search/SearchPageNarrow/index.tsx
+++ b/src/pages/Search/SearchPageNarrow/index.tsx
@@ -33,7 +33,7 @@ import {turnOffMobileSelectionMode} from '@libs/actions/MobileSelectionMode';
 import Navigation from '@libs/Navigation/Navigation';
 import {buildCannedSearchQuery} from '@libs/SearchQueryUtils';
 import {isSearchDataLoaded} from '@libs/SearchUIUtils';
-import {getPendingSubmitFollowUpAction} from '@libs/telemetry/submitFollowUpAction';
+import {endSubmitFollowUpActionSpan, getPendingSubmitFollowUpAction} from '@libs/telemetry/submitFollowUpAction';
 import variables from '@styles/variables';
 import {searchInServer} from '@userActions/Report';
 import {search} from '@userActions/Search';
@@ -179,6 +179,37 @@ function SearchPageNarrow({queryJSON, searchResults, isMobileSelectionModeEnable
             setIsHeaderInteractive(true);
         });
     }, [startTransition]);
+
+    const hadFocusRef = useRef(false);
+    const hadLayoutRef = useRef(false);
+
+    // Single callback for ending submit-expense navigation spans. Passed down
+    // to SearchStaticList and Search so the logic lives in one place.
+    // Requires both focus and layout signals before ending — prevents 0ms spans
+    // on subsequent flows where useFocusEffect fires before the content re-renders.
+    const endSubmitNavigationSpans = useCallback((wasListEmpty: boolean, source: 'focus' | 'layout') => {
+        if (source === 'focus') {
+            hadFocusRef.current = true;
+        } else {
+            hadLayoutRef.current = true;
+        }
+
+        if (!hadFocusRef.current || !hadLayoutRef.current) {
+            return;
+        }
+
+        hadFocusRef.current = false;
+        hadLayoutRef.current = false;
+
+        const pending = getPendingSubmitFollowUpAction();
+        if (pending && pending.followUpAction !== CONST.TELEMETRY.SUBMIT_FOLLOW_UP_ACTION.DISMISS_MODAL_AND_OPEN_REPORT) {
+            endSubmitFollowUpActionSpan(pending.followUpAction, undefined, {
+                [CONST.TELEMETRY.ATTRIBUTE_IS_WARM]: true,
+                [CONST.TELEMETRY.ATTRIBUTE_WAS_LIST_EMPTY]: wasListEmpty,
+            });
+        }
+    }, []);
+
     // Wait for focus before transitioning to the full interactive Search component.
     // When pre-inserted behind the RHP, this keeps the page at the lightweight static
     // list phase until it is actually visible, avoiding wasted work and premature span endings.
@@ -225,6 +256,7 @@ function SearchPageNarrow({queryJSON, searchResults, isMobileSelectionModeEnable
             queryJSON={queryJSON}
             contentContainerStyle={contentContainerStyle}
             onLayout={onSearchLayout}
+            onDestinationVisible={endSubmitNavigationSpans}
         />
     );
 
@@ -244,6 +276,7 @@ function SearchPageNarrow({queryJSON, searchResults, isMobileSelectionModeEnable
                 onSearchListScroll={scrollHandler}
                 searchRequestResponseStatusCode={searchRequestResponseStatusCode}
                 initialContent={staticListContent}
+                onDestinationVisible={endSubmitNavigationSpans}
             />
         );
     };
@@ -277,6 +310,7 @@ function SearchPageNarrow({queryJSON, searchResults, isMobileSelectionModeEnable
                 handleSearch={handleSearchAction}
                 isMobileSelectionModeEnabled={isMobileSelectionModeEnabled}
                 searchRequestResponseStatusCode={searchRequestResponseStatusCode}
+                onDestinationVisible={endSubmitNavigationSpans}
             />
         );
     };

--- a/src/pages/Search/SearchPageWide.tsx
+++ b/src/pages/Search/SearchPageWide.tsx
@@ -20,7 +20,9 @@ import type {PlatformStackRouteProp} from '@libs/Navigation/PlatformStackNavigat
 import type {SearchFullscreenNavigatorParamList} from '@libs/Navigation/types';
 import {buildCannedSearchQuery} from '@libs/SearchQueryUtils';
 import {isSearchDataLoaded} from '@libs/SearchUIUtils';
+import {endSubmitFollowUpActionSpan, getPendingSubmitFollowUpAction} from '@libs/telemetry/submitFollowUpAction';
 import Navigation from '@navigation/Navigation';
+import CONST from '@src/CONST';
 import ROUTES from '@src/ROUTES';
 import type SCREENS from '@src/SCREENS';
 import type {SearchResults} from '@src/types/onyx';
@@ -58,6 +60,19 @@ function SearchPageWide({
     const {shouldUseLiveData} = useSearchStateContext();
     const {saveScrollOffset} = useContext(ScrollOffsetContext);
     const receiptDropTargetRef = useRef<View>(null);
+
+    // Wide layout doesn't need the focus+layout dual-gate (pre-insert is narrow-only),
+    // but the callback signature must match onDestinationVisible's type.
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const endSubmitNavigationSpans = useCallback((wasListEmpty: boolean, _source: 'focus' | 'layout') => {
+        const pending = getPendingSubmitFollowUpAction();
+        if (pending && pending.followUpAction !== CONST.TELEMETRY.SUBMIT_FOLLOW_UP_ACTION.DISMISS_MODAL_AND_OPEN_REPORT) {
+            endSubmitFollowUpActionSpan(pending.followUpAction, undefined, {
+                [CONST.TELEMETRY.ATTRIBUTE_IS_WARM]: true,
+                [CONST.TELEMETRY.ATTRIBUTE_WAS_LIST_EMPTY]: wasListEmpty,
+            });
+        }
+    }, []);
 
     const scrollHandler = useCallback(
         (e: NativeSyntheticEvent<NativeScrollEvent>) => {
@@ -132,6 +147,7 @@ function SearchPageWide({
                                     onSearchListScroll={scrollHandler}
                                     onSortPressedCallback={onSortPressedCallback}
                                     searchRequestResponseStatusCode={searchRequestResponseStatusCode}
+                                    onDestinationVisible={endSubmitNavigationSpans}
                                 />
                             )}
                             {shouldShowFooter && (

--- a/src/pages/iou/request/step/IOURequestStepConfirmation.tsx
+++ b/src/pages/iou/request/step/IOURequestStepConfirmation.tsx
@@ -53,6 +53,7 @@ import {
 } from '@libs/IOUUtils';
 import Log from '@libs/Log';
 import isReportTopmostSplitNavigator from '@libs/Navigation/helpers/isReportTopmostSplitNavigator';
+import isSearchTopmostFullScreenRoute from '@libs/Navigation/helpers/isSearchTopmostFullScreenRoute';
 import navigateAfterInteraction from '@libs/Navigation/navigateAfterInteraction';
 import Navigation from '@libs/Navigation/Navigation';
 import {rand64, roundToTwoDecimalPlaces} from '@libs/NumberUtils';
@@ -377,10 +378,29 @@ function IOURequestStepConfirmation({
     const odometerStartImage = transaction?.comment?.odometerStartImage;
     const odometerEndImage = transaction?.comment?.odometerEndImage;
 
+    // Pre-insert is only useful for flows whose submit ends in handleNavigateAfterExpenseCreate
+    // (which navigates to Search). Flows that use dismissModalAndOpenReportInInboxTab (PAY,
+    // SPLIT-from-global-create, per-diem self-DM track) navigate to a specific report instead,
+    // so pre-inserting Search would leave a stale route in the stack.
+    const canPreInsertSearch = iouType !== CONST.IOU.TYPE.PAY && iouType !== CONST.IOU.TYPE.SPLIT && !(isPerDiemRequest && iouType === CONST.IOU.TYPE.TRACK);
+
+    const hasPreInsertFired = useRef(false);
+    const isTransactionReady = !!transaction;
+
     useEffect(() => {
-        if (!transaction || !getIsNarrowLayout() || !isFromGlobalCreate || isReportTopmostSplitNavigator()) {
+        if (
+            hasPreInsertFired.current ||
+            !isTransactionReady ||
+            !getIsNarrowLayout() ||
+            !isFromGlobalCreate ||
+            !canPreInsertSearch ||
+            isReportTopmostSplitNavigator() ||
+            isSearchTopmostFullScreenRoute()
+        ) {
             return;
         }
+
+        hasPreInsertFired.current = true;
 
         const type = iouType === CONST.IOU.TYPE.INVOICE ? CONST.SEARCH.DATA_TYPES.INVOICE : CONST.SEARCH.DATA_TYPES.EXPENSE;
         const queryString = buildCannedSearchQuery({type});
@@ -399,10 +419,11 @@ function IOURequestStepConfirmation({
 
             Navigation.removePreInsertedFullscreenIfNeeded();
         };
-        // isFromGlobalCreate and iouType are stable for the lifetime of this screen instance
-        // since they derive from route params / Onyx and don't change while the confirmation screen is open.
-        // eslint-disable-next-line react-hooks/exhaustive-deps -- Pre-insertion is a one-time side effect on mount.
-    }, []);
+        // isFromGlobalCreate, iouType, and canPreInsertSearch are stable for the lifetime of
+        // this screen instance. isTransactionReady may flip from false to true once, which
+        // re-triggers the effect so the pre-insert fires even when the transaction loads late.
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [isTransactionReady]);
 
     const navigateBack = useCallback(() => {
         if (backTo) {
@@ -947,45 +968,6 @@ function IOURequestStepConfirmation({
 
             formHasBeenSubmitted.current = true;
 
-            const hasReceiptFiles = Object.values(receiptFiles).some((receipt) => !!receipt);
-            const isFromGlobalCreateForTelemetry = !!(transaction?.isFromGlobalCreate ?? transaction?.isFromFloatingActionButton);
-
-            const scenario = getSubmitExpenseScenario({
-                iouType,
-                isDistanceRequest,
-                isMovingTransactionFromTrackExpense,
-                isUnreported,
-                isCategorizingTrackExpense,
-                isSharingTrackExpense,
-                isPerDiemRequest,
-                isFromGlobalCreate: isFromGlobalCreateForTelemetry,
-                hasReceiptFiles,
-            });
-
-            const submitSpanAttributes = {
-                [CONST.TELEMETRY.ATTRIBUTE_SCENARIO]: scenario,
-                [CONST.TELEMETRY.ATTRIBUTE_HAS_RECEIPT]: hasReceiptFiles,
-                [CONST.TELEMETRY.ATTRIBUTE_IS_FROM_GLOBAL_CREATE]: isFromGlobalCreateForTelemetry,
-                [CONST.TELEMETRY.ATTRIBUTE_IOU_TYPE]: iouType,
-                [CONST.TELEMETRY.ATTRIBUTE_IOU_REQUEST_TYPE]: requestType ?? 'unknown',
-            };
-
-            startSpan(CONST.TELEMETRY.SPAN_SUBMIT_EXPENSE, {
-                name: 'submit-expense',
-                op: CONST.TELEMETRY.SPAN_SUBMIT_EXPENSE,
-                attributes: submitSpanAttributes,
-            });
-
-            startSpan(CONST.TELEMETRY.SPAN_SUBMIT_TO_DESTINATION_VISIBLE, {
-                name: 'submit-to-destination-visible',
-                op: CONST.TELEMETRY.SPAN_SUBMIT_TO_DESTINATION_VISIBLE,
-                attributes: submitSpanAttributes,
-            });
-
-            // IMPORTANT: Every branch below must call markSubmitExpenseEnd() after dispatching the expense action.
-            // The submit follow-up action span above is ended by the target screen (ReportScreen, Search, etc.) or by runAfterInteractions for dismiss_modal_only.
-            // This ensures the telemetry span started above is always closed, including inside async getCurrentPosition callbacks.
-            // If missed, the impact is benign (an orphaned Sentry span), but it pollutes telemetry data.
             if (iouType !== CONST.IOU.TYPE.TRACK && isDistanceRequest && !isMovingTransactionFromTrackExpense && !isUnreported) {
                 createDistanceRequest(iouType === CONST.IOU.TYPE.SPLIT ? splitParticipants : selectedParticipants, trimmedComment);
                 markSubmitExpenseEnd();
@@ -1225,7 +1207,6 @@ function IOURequestStepConfirmation({
             submitPerDiemExpense,
             policyRecentlyUsedCurrencies,
             reportID,
-            requestType,
             betas,
             participantsPolicyTags,
             personalDetails,
@@ -1311,6 +1292,40 @@ function IOURequestStepConfirmation({
     // To prevent the component from rendering with the wrong currency, we show a loading indicator until the correct currency is set.
     const isLoading = !!transaction?.originalCurrency;
 
+    const startSubmitSpans = () => {
+        const hasReceiptFiles = Object.values(receiptFiles).some((receipt) => !!receipt);
+        // Re-derive from transaction inside the callback so telemetry captures the value
+        // at submission time, not at render time (transaction is mutable Onyx state).
+        const isFromGlobalCreateForTelemetry = !!(transaction?.isFromGlobalCreate ?? transaction?.isFromFloatingActionButton);
+        const scenario = getSubmitExpenseScenario({
+            iouType,
+            isDistanceRequest,
+            isMovingTransactionFromTrackExpense,
+            isUnreported,
+            isCategorizingTrackExpense,
+            isSharingTrackExpense,
+            isPerDiemRequest,
+            isFromGlobalCreate: isFromGlobalCreateForTelemetry,
+            hasReceiptFiles,
+        });
+        const submitSpanAttributes = {
+            [CONST.TELEMETRY.ATTRIBUTE_SCENARIO]: scenario,
+            [CONST.TELEMETRY.ATTRIBUTE_HAS_RECEIPT]: hasReceiptFiles,
+            [CONST.TELEMETRY.ATTRIBUTE_IS_FROM_GLOBAL_CREATE]: isFromGlobalCreateForTelemetry,
+            [CONST.TELEMETRY.ATTRIBUTE_IOU_TYPE]: iouType,
+            [CONST.TELEMETRY.ATTRIBUTE_IOU_REQUEST_TYPE]: requestType ?? 'unknown',
+        };
+
+        startSpan(CONST.TELEMETRY.SPAN_SUBMIT_EXPENSE, {
+            name: 'submit-expense',
+            op: CONST.TELEMETRY.SPAN_SUBMIT_EXPENSE,
+        })?.setAttributes(submitSpanAttributes);
+        startSpan(CONST.TELEMETRY.SPAN_SUBMIT_TO_DESTINATION_VISIBLE, {
+            name: 'submit-to-destination-visible',
+            op: CONST.TELEMETRY.SPAN_SUBMIT_TO_DESTINATION_VISIBLE,
+        })?.setAttributes(submitSpanAttributes);
+    };
+
     const onConfirm = (listOfParticipants: Participant[]) => {
         setIsConfirming(true);
         setSelectedParticipantList(listOfParticipants);
@@ -1326,6 +1341,8 @@ function IOURequestStepConfirmation({
                 return;
             }
         }
+
+        startSubmitSpans();
 
         // Fast path: the Search page was pre-inserted under the RHP (see useEffect above).
         // Dismiss the RHP immediately so the user sees the Search page, then run the
@@ -1526,11 +1543,13 @@ function IOURequestStepConfirmation({
                             startPermissionFlow={startLocationPermissionFlow}
                             resetPermissionFlow={() => setStartLocationPermissionFlow(false)}
                             onGrant={() => {
+                                startSubmitSpans();
                                 navigateAfterInteraction(() => {
                                     createTransaction(selectedParticipantList, true);
                                 });
                             }}
                             onDeny={() => {
+                                startSubmitSpans();
                                 updateLastLocationPermissionPrompt();
                                 navigateAfterInteraction(() => {
                                     createTransaction(selectedParticipantList, false);

--- a/src/pages/iou/request/step/IOURequestStepConfirmation.tsx
+++ b/src/pages/iou/request/step/IOURequestStepConfirmation.tsx
@@ -37,9 +37,11 @@ import {completeTestDriveTask} from '@libs/actions/Task';
 import {isMobileSafari} from '@libs/Browser';
 import {getCurrencySymbol} from '@libs/CurrencyUtils';
 import DateUtils from '@libs/DateUtils';
+import {reserveDeferredWriteChannel} from '@libs/deferredLayoutWrite';
 import {canUseTouchScreen} from '@libs/DeviceCapabilities';
 import DistanceRequestUtils from '@libs/DistanceRequestUtils';
 import getCurrentPosition from '@libs/getCurrentPosition';
+import getIsNarrowLayout from '@libs/getIsNarrowLayout';
 import getNonEmptyStringOnyxID from '@libs/getNonEmptyStringOnyxID';
 import {getGPSCoordinates} from '@libs/GPSDraftDetailsUtils';
 import {
@@ -50,6 +52,7 @@ import {
     shouldUseTransactionDraft,
 } from '@libs/IOUUtils';
 import Log from '@libs/Log';
+import isReportTopmostSplitNavigator from '@libs/Navigation/helpers/isReportTopmostSplitNavigator';
 import navigateAfterInteraction from '@libs/Navigation/navigateAfterInteraction';
 import Navigation from '@libs/Navigation/Navigation';
 import {rand64, roundToTwoDecimalPlaces} from '@libs/NumberUtils';
@@ -64,9 +67,11 @@ import {
     isReportOutstanding,
     isSelectedManagerMcTest,
 } from '@libs/ReportUtils';
+import {buildCannedSearchQuery} from '@libs/SearchQueryUtils';
 import {endSpan, getSpan, startSpan} from '@libs/telemetry/activeSpans';
 import getSubmitExpenseScenario from '@libs/telemetry/getSubmitExpenseScenario';
 import markSubmitExpenseEnd from '@libs/telemetry/markSubmitExpenseEnd';
+import {setPendingSubmitFollowUpAction} from '@libs/telemetry/submitFollowUpAction';
 import type {SkeletonSpanReasonAttributes} from '@libs/telemetry/useSkeletonSpan';
 import {
     getDefaultTaxCode,
@@ -359,6 +364,7 @@ function IOURequestStepConfirmation({
     const isPolicyExpenseChat = useMemo(() => participants?.some((participant) => participant.isPolicyExpenseChat), [participants]);
     const shouldGenerateTransactionThreadReport = !isBetaEnabled(CONST.BETAS.NO_OPTIMISTIC_TRANSACTION_THREADS);
     const formHasBeenSubmitted = useRef(false);
+    const isFromGlobalCreate = !!(transaction?.isFromGlobalCreate ?? transaction?.isFromFloatingActionButton);
 
     const isASAPSubmitBetaEnabled = isBetaEnabled(CONST.BETAS.ASAP_SUBMIT);
 
@@ -370,6 +376,33 @@ function IOURequestStepConfirmation({
 
     const odometerStartImage = transaction?.comment?.odometerStartImage;
     const odometerEndImage = transaction?.comment?.odometerEndImage;
+
+    useEffect(() => {
+        if (!transaction || !getIsNarrowLayout() || !isFromGlobalCreate || isReportTopmostSplitNavigator()) {
+            return;
+        }
+
+        const type = iouType === CONST.IOU.TYPE.INVOICE ? CONST.SEARCH.DATA_TYPES.INVOICE : CONST.SEARCH.DATA_TYPES.EXPENSE;
+        const queryString = buildCannedSearchQuery({type});
+        const searchRoute = ROUTES.SEARCH_ROOT.getRoute({query: queryString});
+
+        const timer = setTimeout(() => {
+            Navigation.preInsertFullscreenUnderRHP(searchRoute);
+        }, CONST.PRE_INSERT_FULLSCREEN_DELAY);
+
+        return () => {
+            clearTimeout(timer);
+
+            if (!Navigation.getIsFullscreenPreInsertedUnderRHP() || formHasBeenSubmitted.current) {
+                return;
+            }
+
+            Navigation.removePreInsertedFullscreenIfNeeded();
+        };
+        // isFromGlobalCreate and iouType are stable for the lifetime of this screen instance
+        // since they derive from route params / Onyx and don't change while the confirmation screen is open.
+        // eslint-disable-next-line react-hooks/exhaustive-deps -- Pre-insertion is a one-time side effect on mount.
+    }, []);
 
     const navigateBack = useCallback(() => {
         if (backTo) {
@@ -915,7 +948,7 @@ function IOURequestStepConfirmation({
             formHasBeenSubmitted.current = true;
 
             const hasReceiptFiles = Object.values(receiptFiles).some((receipt) => !!receipt);
-            const isFromGlobalCreate = transaction?.isFromGlobalCreate ?? transaction?.isFromFloatingActionButton ?? false;
+            const isFromGlobalCreateForTelemetry = !!(transaction?.isFromGlobalCreate ?? transaction?.isFromFloatingActionButton);
 
             const scenario = getSubmitExpenseScenario({
                 iouType,
@@ -925,14 +958,14 @@ function IOURequestStepConfirmation({
                 isCategorizingTrackExpense,
                 isSharingTrackExpense,
                 isPerDiemRequest,
-                isFromGlobalCreate,
+                isFromGlobalCreate: isFromGlobalCreateForTelemetry,
                 hasReceiptFiles,
             });
 
             const submitSpanAttributes = {
                 [CONST.TELEMETRY.ATTRIBUTE_SCENARIO]: scenario,
                 [CONST.TELEMETRY.ATTRIBUTE_HAS_RECEIPT]: hasReceiptFiles,
-                [CONST.TELEMETRY.ATTRIBUTE_IS_FROM_GLOBAL_CREATE]: isFromGlobalCreate,
+                [CONST.TELEMETRY.ATTRIBUTE_IS_FROM_GLOBAL_CREATE]: isFromGlobalCreateForTelemetry,
                 [CONST.TELEMETRY.ATTRIBUTE_IOU_TYPE]: iouType,
                 [CONST.TELEMETRY.ATTRIBUTE_IOU_REQUEST_TYPE]: requestType ?? 'unknown',
             };
@@ -1294,13 +1327,29 @@ function IOURequestStepConfirmation({
             }
         }
 
-        requestAnimationFrame(() => {
-            createTransaction(listOfParticipants);
-            // Keep the pre-submit loading state visible for one more paint so the spinner appears before navigation work starts.
+        // Fast path: the Search page was pre-inserted under the RHP (see useEffect above).
+        // Dismiss the RHP immediately so the user sees the Search page, then run the
+        // heavy createTransaction work in the next frame - "dismiss first, compute later".
+        // Reserve the deferred write channel synchronously so that the Search component
+        // always sees hasDeferredWrite=true on mount (on iOS, rAF fires after
+        // startTransition resolves, so without the reservation Search would mount first).
+        if (Navigation.getIsFullscreenPreInsertedUnderRHP()) {
+            setPendingSubmitFollowUpAction(CONST.TELEMETRY.SUBMIT_FOLLOW_UP_ACTION.NAVIGATE_TO_SEARCH);
+            Navigation.clearFullscreenPreInsertedFlag();
+            reserveDeferredWriteChannel(CONST.DEFERRED_LAYOUT_WRITE_KEYS.SEARCH);
+            Navigation.dismissModal();
             requestAnimationFrame(() => {
+                createTransaction(listOfParticipants);
                 setIsConfirming(false);
             });
-        });
+        } else {
+            requestAnimationFrame(() => {
+                createTransaction(listOfParticipants);
+                requestAnimationFrame(() => {
+                    setIsConfirming(false);
+                });
+            });
+        }
     };
 
     /**

--- a/tests/actions/IOUTest.ts
+++ b/tests/actions/IOUTest.ts
@@ -145,6 +145,9 @@ jest.mock('@src/libs/Navigation/Navigation', () => ({
     getReportRouteByID: jest.fn(),
     getActiveRouteWithoutParams: jest.fn(),
     getActiveRoute: jest.fn(),
+    getIsFullscreenPreInsertedUnderRHP: jest.fn(() => false),
+    clearFullscreenPreInsertedFlag: jest.fn(),
+    revealRouteBeforeDismissingModal: jest.fn(),
     navigationRef: {
         getRootState: jest.fn(),
         isReady: jest.fn(() => true),

--- a/tests/ui/SearchPageTest.tsx
+++ b/tests/ui/SearchPageTest.tsx
@@ -27,7 +27,7 @@ jest.mock('@hooks/useResponsiveLayout', () => jest.fn());
 
 jest.mock('@react-navigation/core', () => ({
     ...jest.requireActual<typeof CoreNavigation>('@react-navigation/core'),
-    useNavigation: jest.fn(() => ({getState: jest.fn(() => undefined)})),
+    useNavigation: jest.fn(() => ({getState: jest.fn(() => undefined), isFocused: jest.fn(() => true)})),
 }));
 
 jest.mock('@react-navigation/native', () => ({

--- a/tests/ui/TimeExpenseConfirmationTest.tsx
+++ b/tests/ui/TimeExpenseConfirmationTest.tsx
@@ -80,7 +80,11 @@ jest.mock('@libs/Navigation/Navigation', () => {
     return {
         navigate: jest.fn(),
         goBack: jest.fn(),
+        dismissModal: jest.fn(),
         dismissModalWithReport: jest.fn(),
+        getIsFullscreenPreInsertedUnderRHP: jest.fn(() => false),
+        clearFullscreenPreInsertedFlag: jest.fn(),
+        revealRouteBeforeDismissingModal: jest.fn(),
         navigationRef: mockRef,
     };
 });

--- a/tests/ui/components/IOURequestStepConfirmationPageTest.tsx
+++ b/tests/ui/components/IOURequestStepConfirmationPageTest.tsx
@@ -101,12 +101,17 @@ jest.mock('@libs/Navigation/Navigation', () => {
             params: {},
         })),
         getState: jest.fn(() => ({})),
+        getRootState: jest.fn(() => ({routes: []})),
     };
     return {
         navigate: jest.fn(),
         goBack: jest.fn(),
+        dismissModal: jest.fn(),
         dismissModalWithReport: jest.fn(),
         setNavigationActionToMicrotaskQueue: jest.fn((callback: () => void) => callback()),
+        getIsFullscreenPreInsertedUnderRHP: jest.fn(() => false),
+        clearFullscreenPreInsertedFlag: jest.fn(),
+        revealRouteBeforeDismissingModal: jest.fn(),
         navigationRef: mockRef,
     };
 });

--- a/tests/unit/deferredLayoutWriteTest.ts
+++ b/tests/unit/deferredLayoutWriteTest.ts
@@ -1,5 +1,5 @@
 import {AppState} from 'react-native';
-import {cancelDeferredWrite, flushDeferredWrite, getOptimisticWatchKey, hasDeferredWrite, registerDeferredWrite} from '@libs/deferredLayoutWrite';
+import {cancelDeferredWrite, flushDeferredWrite, getOptimisticWatchKey, hasDeferredWrite, registerDeferredWrite, reserveDeferredWriteChannel} from '@libs/deferredLayoutWrite';
 
 beforeEach(() => {
     jest.useFakeTimers();
@@ -119,5 +119,50 @@ describe('deferredLayoutWrite', () => {
         expect(hasDeferredWrite('test')).toBe(true);
 
         flushDeferredWrite('test');
+    });
+
+    it('marks a reserved channel as flushRequested instead of consuming it', () => {
+        reserveDeferredWriteChannel('test');
+        expect(hasDeferredWrite('test')).toBe(true);
+
+        flushDeferredWrite('test');
+
+        expect(hasDeferredWrite('test')).toBe(true);
+    });
+
+    it('executes the real callback immediately when registering on a flush-requested reservation', () => {
+        reserveDeferredWriteChannel('test');
+        flushDeferredWrite('test');
+
+        const callback = jest.fn();
+        registerDeferredWrite('test', callback);
+
+        expect(callback).toHaveBeenCalledTimes(1);
+        expect(hasDeferredWrite('test')).toBe(false);
+    });
+
+    it('preserves optimisticWatchKey when flush-requested reservation is consumed', () => {
+        reserveDeferredWriteChannel('test');
+        flushDeferredWrite('test');
+
+        const callback = jest.fn();
+        registerDeferredWrite('test', callback, {optimisticWatchKey: 'transactions_123'});
+
+        expect(callback).toHaveBeenCalledTimes(1);
+        expect(hasDeferredWrite('test')).toBe(false);
+        expect(getOptimisticWatchKey('test')).toBe('transactions_123');
+    });
+
+    it('defers the real callback normally when registering on a reservation that was not flushed', () => {
+        reserveDeferredWriteChannel('test');
+
+        const callback = jest.fn();
+        registerDeferredWrite('test', callback);
+
+        expect(callback).not.toHaveBeenCalled();
+        expect(hasDeferredWrite('test')).toBe(true);
+
+        flushDeferredWrite('test');
+        expect(callback).toHaveBeenCalledTimes(1);
     });
 });


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
On narrow layout (mobile), pre-renders the Search page behind the RHP while the user is on the expense confirmation screen, so post-submit navigation is instant.

#### How it works

| Phase | What happens |
|---|---|
| **Mount** (confirmation screen) | After a 300ms delay, the Search fullscreen route is inserted underneath the RHP via `REPLACE_FULLSCREEN_UNDER_RHP`. The Search page mounts in the background while the user fills in details. |
| **Submit** (fast path) | If the pre-insert fired, the RHP is dismissed instantly to reveal the already-mounted Search. `createTransaction` runs in the next frame - "dismiss first, compute later". |
| **Submit** (slow path) | If the user taps submit before the 300ms timer fires, the existing non-pre-insert navigation path is used as a fallback. |
| **Back out** (cleanup) | If the user leaves without submitting, the pre-inserted route is removed via the new `REMOVE_FULLSCREEN_UNDER_RHP` action. |

#### Supporting changes
- **`reserveDeferredWriteChannel`** - pre-creates the deferred write channel so Search always sees `hasDeferredWrite=true` on mount; clears stale `flushedWatchKeys` on new reservations so repeated fast-path submits track the correct optimistic item
- **`SearchPageNarrow`** - gates phase transitions on focus (`useFocusEffect`) to avoid wasted work while hidden behind the RHP; uses an overlay pattern for the static-to-interactive transition (SearchStaticList renders as an `absoluteFill` sibling on top of Search, removed once Search signals readiness) to prevent blank frame flashes from React tree-structure swaps
- **`Search`** - removed `initialContent` prop (no longer needed with the overlay pattern); `cancelNavigationSpans` calls `onContentReady` so the overlay is removed even on error/empty bail-out paths
- **`SearchStaticList`** - shows the pending expense placeholder on focus when a submit action is pending
- **`RightModalNavigator`** - disables slide-out animation when a pre-insert is active so the dismiss reveals the destination instantly


**Performance gains (`ManualSubmitToDestinationVisible` (`navigate_to_search`) span):**

| Platform | `main` avg (ms) | This branch avg (ms) | Improvement |
|----------|-----------------|----------------------|-------------|
| Android  | 615             | 197                  | **-418 ms (68%)** |
| iOS      | 1118            | 222                 | **-896 ms (80.1%)** |

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/88295
PROPOSAL: N/A


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

1. **Fast-path submit (pre-insert fires before user taps submit)**
   1. Open the app on a narrow-layout device (mobile or narrow browser window) and do not navigate to inbox/search
   2. Tap the FAB (+) button and start creating a new expense (e.g. Manual -> enter amount -> select participant)
   3. On the confirmation screen, wait at least 300ms (the pre-insert delay)
   4. Tap **Submit** / **Create**
   5. Verify that the Search page appears instantly without a visible navigation transition - the RHP dismisses to reveal the already-mounted Search screen with a pending expense placeholder row

2. **Slow-path submit (user taps submit before 300ms pre-insert fires)**
   1. Open the app on a narrow-layout device and do not navigate to inbox/search
   2. Tap the FAB (+) and quickly go through the expense creation flow
   3. On the confirmation screen, tap **Submit** immediately (within ~300ms of the screen appearing)
   4. Verify that the app still navigates to the Search page correctly (via the existing non-pre-insert path) and no errors appear

3. **Back-out cleanup (user leaves confirmation without submitting)**
   1. Open the app on a narrow-layout device and do not navigate to inbox/search
   2. Start creating an expense and reach the confirmation screen
   3. Wait at least 300ms for the pre-insert to fire
   4. Press the back button or swipe to go back without submitting
   5. Verify that the pre-inserted Search route is removed - you should return to the previous screen (not the Search page), and no stale Search route remains in the navigation stack

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

1. Enable airplane mode / disable network on the device
2. Tap the FAB (+) and create a new expense through the confirmation screen while being outside of inbox/search
3. Wait 300ms, then tap Submit
4. Verify the Search page appears with the optimistic pending expense placeholder row
5. Re-enable network and verify the expense syncs and the placeholder is replaced with the confirmed row

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->

Same as tests

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/81965088-c523-4716-952b-8fa8be36cc78

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/e40eaf6e-fff8-4b22-bf16-39334607c2fb

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>
