### PR TITLE
Fix: Android react-native-pdf scanner - event coalescing

### DIFF
--- a/patches/react-native-pdf/details.md
+++ b/patches/react-native-pdf/details.md
@@ -41,6 +41,7 @@
     react-native-pdf sends loadComplete and pageChanged through the same topChange event name. Under Fabric, TopChangeEvent inherited React Native's default coalescing behavior, so pageChanged could replace loadComplete for the same PDF view before JS received it. That broke the onLoadComplete contract for hidden PDF validation renders. Marking the event as non-coalescible preserves both native callbacks in JS without adding an app-level success fallback.
     ```
 
-- Upstream PR/issue: N/A
+- Upstream PR/issue: https://github.com/wonday/react-native-pdf/issues/1009
+- Upstream draft PR: https://github.com/wonday/react-native-pdf/pull/1010
 - E/App issue: https://github.com/Expensify/App/issues/81225
-- PR introducing patch: TBD
+- PR introducing patch: https://github.com/Expensify/App/pull/87416

--- a/patches/react-native-pdf/details.md
+++ b/patches/react-native-pdf/details.md
@@ -41,7 +41,6 @@
     react-native-pdf sends loadComplete and pageChanged through the same topChange event name. Under Fabric, TopChangeEvent inherited React Native's default coalescing behavior, so pageChanged could replace loadComplete for the same PDF view before JS received it. That broke the onLoadComplete contract for hidden PDF validation renders. Marking the event as non-coalescible preserves both native callbacks in JS without adding an app-level success fallback.
     ```
 
-- Upstream PR/issue: https://github.com/wonday/react-native-pdf/issues/1009
-- Upstream PR: https://github.com/wonday/react-native-pdf/pull/1011
+- Upstream PR/issue: https://github.com/wonday/react-native-pdf/issues/1009, https://github.com/wonday/react-native-pdf/pull/1011
 - E/App issue: https://github.com/Expensify/App/issues/81225
 - PR introducing patch: https://github.com/Expensify/App/pull/87416

--- a/patches/react-native-pdf/details.md
+++ b/patches/react-native-pdf/details.md
@@ -3,7 +3,7 @@
 ### [react-native-pdf+7.0.2+001+fix-onPressLink-android.patch](react-native-pdf+7.0.2+001+fix-onPressLink-android.patch)
 
 - Reason:
-  
+
     ```
     This patch fixes the onPressLink callback not working on Android by upgrading the pdfiumandroid library from version 1.0.32 to 1.0.35.
     
@@ -19,7 +19,7 @@
 ### [react-native-pdf+7.0.2+002+fix-pdf-crash-already-closed-android.patch](react-native-pdf+7.0.2+002+fix-pdf-crash-already-closed-android.patch)
 
 - Reason:
-  
+
     ```
     This patch fixes a fatal Android crash (java.lang.IllegalStateException: Already closed) that occurs when users navigate away from a PDF while it's still rendering.
 
@@ -29,3 +29,18 @@
 - Upstream PR/issue: https://github.com/wonday/react-native-pdf/issues/976, https://github.com/wonday/react-native-pdf/issues/882, https://github.com/wonday/react-native-pdf/issues/830, https://github.com/wonday/react-native-pdf/pull/999
 - E/App issue: https://github.com/Expensify/App/issues/82570
 - PR introducing patch: https://github.com/Expensify/App/pull/82628
+
+
+### [react-native-pdf+7.0.2+003+disable-topchange-coalescing-android.patch](react-native-pdf+7.0.2+003+disable-topchange-coalescing-android.patch)
+
+- Reason:
+
+    ```
+    This patch prevents Android Fabric from coalescing react-native-pdf's shared topChange events.
+
+    react-native-pdf sends loadComplete and pageChanged through the same topChange event name. Under Fabric, TopChangeEvent inherited React Native's default coalescing behavior, so pageChanged could replace loadComplete for the same PDF view before JS received it. That broke the onLoadComplete contract for hidden PDF validation renders. Marking the event as non-coalescible preserves both native callbacks in JS without adding an app-level success fallback.
+    ```
+
+- Upstream PR/issue: N/A
+- E/App issue: https://github.com/Expensify/App/issues/81225
+- PR introducing patch: TBD

--- a/patches/react-native-pdf/details.md
+++ b/patches/react-native-pdf/details.md
@@ -42,6 +42,6 @@
     ```
 
 - Upstream PR/issue: https://github.com/wonday/react-native-pdf/issues/1009
-- Upstream draft PR: https://github.com/wonday/react-native-pdf/pull/1010
+- Upstream PR: https://github.com/wonday/react-native-pdf/pull/1011
 - E/App issue: https://github.com/Expensify/App/issues/81225
 - PR introducing patch: https://github.com/Expensify/App/pull/87416

--- a/patches/react-native-pdf/react-native-pdf+7.0.2+003+disable-topchange-coalescing-android.patch
+++ b/patches/react-native-pdf/react-native-pdf+7.0.2+003+disable-topchange-coalescing-android.patch
@@ -1,0 +1,16 @@
+diff --git a/node_modules/react-native-pdf/android/src/main/java/org/wonday/pdf/events/TopChangeEvent.java b/node_modules/react-native-pdf/android/src/main/java/org/wonday/pdf/events/TopChangeEvent.java
+index 6feb97d..aab7738 100644
+--- a/node_modules/react-native-pdf/android/src/main/java/org/wonday/pdf/events/TopChangeEvent.java
++++ b/node_modules/react-native-pdf/android/src/main/java/org/wonday/pdf/events/TopChangeEvent.java
+@@ -17,6 +17,11 @@ public class TopChangeEvent extends Event<TopChangeEvent> {
+         return "topChange";
+     }
+
++    @Override
++    public boolean canCoalesce() {
++        return false;
++    }
++
+     @Nullable
+     @Override
+     protected WritableMap getEventData() {

--- a/src/components/PDFThumbnail/index.native.tsx
+++ b/src/components/PDFThumbnail/index.native.tsx
@@ -1,4 +1,4 @@
-import React, {useState} from 'react';
+import React, {useCallback, useRef, useState} from 'react';
 import {View} from 'react-native';
 import Pdf from 'react-native-pdf';
 import LoadingIndicator from '@components/LoadingIndicator';
@@ -13,6 +13,16 @@ function PDFThumbnail({previewSourceURL, style, enabled = true, fitPolicy = 0, o
     const styles = useThemeStyles();
     const sizeStyles = [styles.w100, styles.h100];
     const [failedToLoad, setFailedToLoad] = useState(false);
+    const lastReportedLoadSuccessSource = useRef<string | undefined>(undefined);
+
+    const reportLoadSuccess = useCallback(() => {
+        if (!onLoadSuccess || lastReportedLoadSuccessSource.current === previewSourceURL) {
+            return;
+        }
+
+        lastReportedLoadSuccessSource.current = previewSourceURL;
+        onLoadSuccess();
+    }, [onLoadSuccess, previewSourceURL]);
 
     return (
         <View style={[style, styles.overflowHidden]}>
@@ -35,12 +45,7 @@ function PDFThumbnail({previewSourceURL, style, enabled = true, fitPolicy = 0, o
                             }
                             setFailedToLoad(true);
                         }}
-                        onLoadComplete={() => {
-                            if (!onLoadSuccess) {
-                                return;
-                            }
-                            onLoadSuccess();
-                        }}
+                        onLoadComplete={reportLoadSuccess}
                     />
                 )}
                 {failedToLoad && <PDFThumbnailError />}

--- a/src/components/PDFThumbnail/index.native.tsx
+++ b/src/components/PDFThumbnail/index.native.tsx
@@ -1,4 +1,4 @@
-import React, {useCallback, useRef, useState} from 'react';
+import React, {useState} from 'react';
 import {View} from 'react-native';
 import Pdf from 'react-native-pdf';
 import LoadingIndicator from '@components/LoadingIndicator';
@@ -13,16 +13,6 @@ function PDFThumbnail({previewSourceURL, style, enabled = true, fitPolicy = 0, o
     const styles = useThemeStyles();
     const sizeStyles = [styles.w100, styles.h100];
     const [failedToLoad, setFailedToLoad] = useState(false);
-    const lastReportedLoadSuccessSource = useRef<string | undefined>(undefined);
-
-    const reportLoadSuccess = useCallback(() => {
-        if (!onLoadSuccess || lastReportedLoadSuccessSource.current === previewSourceURL) {
-            return;
-        }
-
-        lastReportedLoadSuccessSource.current = previewSourceURL;
-        onLoadSuccess();
-    }, [onLoadSuccess, previewSourceURL]);
 
     return (
         <View style={[style, styles.overflowHidden]}>
@@ -45,7 +35,12 @@ function PDFThumbnail({previewSourceURL, style, enabled = true, fitPolicy = 0, o
                             }
                             setFailedToLoad(true);
                         }}
-                        onLoadComplete={reportLoadSuccess}
+                        onLoadComplete={() => {
+                            if (!onLoadSuccess) {
+                                return;
+                            }
+                            onLoadSuccess();
+                        }}
                     />
                 )}
                 {failedToLoad && <PDFThumbnailError />}


### PR DESCRIPTION
### Explanation of Change

- This PR fixes the Android issue where selecting a local PDF receipt can immediately bounce the user back to the camera view instead of attaching the receipt and continuing to `Confirm details`.

**Root Cause:**

- On Android/Fabric, `react-native-pdf` emits both `loadComplete` and `pageChanged` through the same native event path (`TopChangeEvent` / `topChange`).
- `TopChangeEvent` inherited React Native's default coalescing behavior, so Fabric could coalesce those events for the same PDF view.
- In practice, `pageChanged` could replace `loadComplete` before JS received it.
- That meant native Android successfully loaded the PDF, but JS sometimes never received `onLoadComplete`, so receipt validation failed and the flow jumped back instead of attaching the PDF.

**Solution:**

- Add a `react-native-pdf` patch that makes `TopChangeEvent` non-coalescible by returning `false` from `canCoalesce()`.
- Keep the app-side success path tied to `onLoadComplete` in `PDFThumbnail` instead of relying on `onPageChanged` as a fallback.
- This fixes the library-level event loss itself instead of introducing another workaround.

**Validation evidence:**

- Before the fix, native emitted both `loadComplete` and `pageChanged`, but JS only received `pageChanged`.
- After the fix, JS received `loadComplete` and then `pageChanged`, and the Android receipt flow reached `Confirm details` without the old `onPageChanged` success fallback.

### Fixed Issues

$ https://github.com/Expensify/App/issues/81225
PROPOSAL: https://github.com/Expensify/App/issues/81225#issuecomment-4193954509

### Tests

**Prerequisites:**

- Android app build from this branch
- A local PDF file available on the Android device/emulator

**Primary Test (original issue):**

1. Open the Android app
2. Tap FAB `+`
3. Tap `Create expense`
4. Tap the photo icon
5. Tap `Choose file`
6. Select a local PDF from device storage
7. Verify the app does not jump back to the camera view
8. Verify the flow continues to `Confirm details` with the PDF receipt attached


**Repeatability / regression check:**

9. From `Confirm details`, go back to the scan step
10. Select another local PDF
11. Verify the flow again continues to `Confirm details`

- [x] Verify that no errors appear in the JS console during the Android validation flow

### Offline tests

N/A -
### QA Steps

1. Open the Android app
2. Tap FAB `+`
3. Tap `Create expense`
4. Tap the photo icon
5. Tap `Choose file`
6. Select a local PDF from device storage
7. Verify the app does not jump back to the camera view
8. Verify the flow continues to `Confirm details` with the PDF receipt attached


### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] Windows: Chrome
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I verified there are no new alerts related to the `canBeMissing` param for `useOnyx`
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.



### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/c10c6c15-8c1d-479d-86c8-d7d72e401ef0



</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->



https://github.com/user-attachments/assets/8482cdd2-c85a-4b71-bced-f2be015a05fb




</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->



https://github.com/user-attachments/assets/29528222-c6f7-4e83-b200-d13750f0ae3a





</details>

<details>
<summary>iOS: mWeb Safari</summary>



https://github.com/user-attachments/assets/d7cba862-06b2-4032-9760-d441cff10317




</details>

<details>
<summary>MacOS: Chrome / Safari</summary>


https://github.com/user-attachments/assets/6aea87fb-1c69-4d85-b84d-832fac5b8c28






</details>



