### PR TITLE
[WIP] refactor: Onyx cleanup in AccountManagerBanner and ReportNotFoundGuard

### DIFF
--- a/src/pages/inbox/AccountManagerBanner.tsx
+++ b/src/pages/inbox/AccountManagerBanner.tsx
@@ -6,7 +6,6 @@ import useOnyx from '@hooks/useOnyx';
 import useThemeStyles from '@hooks/useThemeStyles';
 import getNonEmptyStringOnyxID from '@libs/getNonEmptyStringOnyxID';
 import Navigation from '@libs/Navigation/Navigation';
-import {getPersonalDetailsForAccountIDs} from '@libs/OptionsListUtils';
 import {getDisplayNameOrDefault} from '@libs/PersonalDetailsUtils';
 import {getParticipantsAccountIDsForDisplay, isConciergeChatReport} from '@libs/ReportUtils';
 import ONYXKEYS from '@src/ONYXKEYS';
@@ -23,16 +22,15 @@ function AccountManagerBanner({reportID}: AccountManagerBannerProps) {
     const [report] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT}${getNonEmptyStringOnyxID(reportID)}`);
     const [accountManagerReportID] = useOnyx(ONYXKEYS.ACCOUNT_MANAGER_REPORT_ID);
     const [accountManagerReport] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT}${getNonEmptyStringOnyxID(accountManagerReportID)}`);
-    const [personalDetails] = useOnyx(ONYXKEYS.PERSONAL_DETAILS_LIST);
+    const accountManagerAccountID = getParticipantsAccountIDsForDisplay(accountManagerReport, false, true)?.at(0) ?? -1;
+    const [participantPersonalDetail] = useOnyx(ONYXKEYS.PERSONAL_DETAILS_LIST, {
+        selector: (details) => details?.[accountManagerAccountID],
+    });
     const [isBannerVisible, setIsBannerVisible] = useState(true);
 
     if (!accountManagerReportID || !isConciergeChatReport(report) || !isBannerVisible) {
         return null;
     }
-
-    const participants = getParticipantsAccountIDsForDisplay(accountManagerReport, false, true);
-    const participantPersonalDetails = getPersonalDetailsForAccountIDs([participants?.at(0) ?? -1], personalDetails);
-    const participantPersonalDetail = Object.values(participantPersonalDetails).at(0);
     const displayName = getDisplayNameOrDefault(participantPersonalDetail);
     const login = participantPersonalDetail?.login;
     const chatWithAccountManagerText = displayName && login ? translate('common.chatWithAccountManager', `${displayName} (${login})`) : '';

--- a/src/pages/inbox/ReportNotFoundGuard.tsx
+++ b/src/pages/inbox/ReportNotFoundGuard.tsx
@@ -1,6 +1,7 @@
 import {useRoute} from '@react-navigation/native';
 import type {ReactNode} from 'react';
 import React, {useEffect} from 'react';
+import type {OnyxEntry} from 'react-native-onyx';
 import FullPageNotFoundView from '@components/BlockingViews/FullPageNotFoundView';
 import useNetwork from '@hooks/useNetwork';
 import useOnyx from '@hooks/useOnyx';
@@ -15,23 +16,31 @@ import {getParentReportActionDeletionStatus} from '@libs/TransactionNavigationUt
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
 import {isLoadingInitialReportActionsSelector} from '@src/selectors/ReportMetaData';
+import type * as OnyxTypes from '@src/types/onyx';
 
 type ReportNotFoundGuardProps = {
     children: ReactNode;
 };
 
+/**
+ * Two-level gate: the outer guard subscribes to lightweight keys to determine
+ * whether the report clearly exists. When it does (and the report is not a
+ * transaction thread), children render directly without the cost of
+ * parentReportMetadata / useParentReportAction subscriptions.
+ *
+ * The inner gate mounts only when the "not found" path is plausible:
+ * the report is missing, the path is invalid, or the report is a transaction
+ * thread whose parent action may have been deleted.
+ */
 // eslint-disable-next-line rulesdir/no-negated-variables
 function ReportNotFoundGuard({children}: ReportNotFoundGuardProps) {
-    const styles = useThemeStyles();
     const route = useRoute();
     const routeParams = route.params as {reportID?: string} | undefined;
     const reportIDFromRoute = getNonEmptyStringOnyxID(routeParams?.reportID);
 
     const {isOffline} = useNetwork();
-    const {shouldUseNarrowLayout} = useResponsiveLayout();
 
     const [report] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT}${reportIDFromRoute}`);
-    const [parentReportMetadata] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT_METADATA}${report?.parentReportID}`);
     const [userLeavingStatus = false] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT_USER_IS_LEAVING_ROOM}${reportIDFromRoute}`);
     const [isLoadingInitialReportActions = true] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT_METADATA}${reportIDFromRoute}`, {
         selector: isLoadingInitialReportActionsSelector,
@@ -40,9 +49,81 @@ function ReportNotFoundGuard({children}: ReportNotFoundGuardProps) {
     const [isLoadingApp] = useOnyx(ONYXKEYS.IS_LOADING_APP);
     const [deleteTransactionNavigateBackUrl] = useOnyx(ONYXKEYS.NVP_DELETE_TRANSACTION_NAVIGATE_BACK_URL);
 
-    const parentReportAction = useParentReportAction(report);
     const reportID = report?.reportID;
     const isOptimisticDelete = report?.statusNum === CONST.REPORT.STATUS_NUM.CLOSED;
+    const isInvalidReportPath = !!routeParams?.reportID && !isValidReportIDFromPath(routeParams.reportID);
+    const isLoading = isLoadingApp !== false || isLoadingReportData || (!isOffline && !!isLoadingInitialReportActions);
+    const mayBeTransactionThread = isReportTransactionThread(report);
+
+    // Fast path: skip the expensive inner guard (parentReportMetadata, useParentReportAction)
+    // when we can determine shouldShowNotFoundPage is definitely false.
+    //
+    // shouldShowNotFoundPage is false when:
+    //  - deleteTransactionNavigateBackUrl is set (always suppresses not-found), OR
+    //  - path is valid AND report is not a transaction thread AND (still loading OR report exists)
+    const reportClearlyExists = !!reportID || isOptimisticDelete || userLeavingStatus;
+    const canSkipInnerGuard = !!deleteTransactionNavigateBackUrl || (!isInvalidReportPath && !mayBeTransactionThread && (isLoading || reportClearlyExists));
+    if (canSkipInnerGuard) {
+        return children;
+    }
+
+    return (
+        <ReportNotFoundInnerGuard
+            report={report}
+            reportIDFromPath={routeParams?.reportID}
+            reportID={reportID}
+            isOptimisticDelete={isOptimisticDelete}
+            isInvalidReportPath={isInvalidReportPath}
+            isLoading={isLoading}
+            isLoadingApp={isLoadingApp}
+            isLoadingReportData={isLoadingReportData}
+            isLoadingInitialReportActions={isLoadingInitialReportActions}
+            isOffline={isOffline}
+            userLeavingStatus={userLeavingStatus}
+            deleteTransactionNavigateBackUrl={deleteTransactionNavigateBackUrl}
+        >
+            {children}
+        </ReportNotFoundInnerGuard>
+    );
+}
+
+type ReportNotFoundInnerGuardProps = {
+    report: OnyxEntry<OnyxTypes.Report>;
+    reportIDFromPath: string | undefined;
+    reportID: string | undefined;
+    isOptimisticDelete: boolean;
+    isInvalidReportPath: boolean;
+    isLoading: boolean;
+    isLoadingApp: OnyxEntry<boolean>;
+    isLoadingReportData: boolean;
+    isLoadingInitialReportActions: boolean;
+    isOffline: boolean;
+    userLeavingStatus: boolean;
+    deleteTransactionNavigateBackUrl: OnyxEntry<string>;
+    children: ReactNode;
+};
+
+// eslint-disable-next-line rulesdir/no-negated-variables
+function ReportNotFoundInnerGuard({
+    report,
+    reportIDFromPath,
+    reportID,
+    isOptimisticDelete,
+    isInvalidReportPath,
+    isLoading,
+    isLoadingApp,
+    isLoadingReportData,
+    isLoadingInitialReportActions,
+    isOffline,
+    userLeavingStatus,
+    deleteTransactionNavigateBackUrl,
+    children,
+}: ReportNotFoundInnerGuardProps) {
+    const styles = useThemeStyles();
+    const {shouldUseNarrowLayout} = useResponsiveLayout();
+
+    const [parentReportMetadata] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT_METADATA}${report?.parentReportID}`);
+    const parentReportAction = useParentReportAction(report);
 
     const {isParentActionMissingAfterLoad, isParentActionDeleted} = getParentReportActionDeletionStatus({
         parentReportID: report?.parentReportID,
@@ -53,8 +134,6 @@ function ReportNotFoundGuard({children}: ReportNotFoundGuardProps) {
     });
     const isDeletedTransactionThread = isReportTransactionThread(report) && (isParentActionDeleted || isParentActionMissingAfterLoad);
 
-    const isInvalidReportPath = !!routeParams?.reportID && !isValidReportIDFromPath(routeParams.reportID);
-    const isLoading = isLoadingApp !== false || isLoadingReportData || (!isOffline && !!isLoadingInitialReportActions);
     const reportExists = !!reportID || (!isDeletedTransactionThread && isOptimisticDelete) || userLeavingStatus;
 
     // eslint-disable-next-line rulesdir/no-negated-variables
@@ -73,7 +152,7 @@ function ReportNotFoundGuard({children}: ReportNotFoundGuardProps) {
             reportID,
             isOptimisticDelete,
             userLeavingStatus,
-            reportIDFromPath: routeParams?.reportID,
+            reportIDFromPath,
             deleteTransactionNavigateBackUrl,
             isDeletedTransactionThread,
             isParentActionDeleted,
@@ -88,7 +167,7 @@ function ReportNotFoundGuard({children}: ReportNotFoundGuardProps) {
         reportID,
         isOptimisticDelete,
         userLeavingStatus,
-        routeParams?.reportID,
+        reportIDFromPath,
         deleteTransactionNavigateBackUrl,
         isDeletedTransactionThread,
         isParentActionDeleted,


### PR DESCRIPTION
### Explanation of Change

Two Onyx hygiene improvements in the Inbox screen:

1. **AccountManagerBanner**: replaced full `PERSONAL_DETAILS_LIST` subscription with a selector that extracts only the account manager's personal details (W-1: no selector on heavy key)

2. **ReportNotFoundGuard**: introduced a two-level gate pattern (matching `LinkedActionNotFoundGuard`). The outer guard uses lightweight subscriptions to determine if the report clearly exists. The inner guard (with expensive `parentReportMetadata` and `useParentReportAction`) only mounts when the "not found" path is plausible (missing report, invalid path, or transaction thread with deleted parent).

### Fixed Issues

$

PROPOSAL:

### Tests

1. Open a concierge chat where AccountManagerBanner is visible
2. Verify the banner still shows the correct account manager name and login
3. Click "Chat with account manager" and verify navigation works
4. Open 5+ regular chats (not transaction threads), verify no "not found" page appears
5. Open a transaction thread whose parent action was deleted, verify the "not found" page still appears correctly
6. Navigate rapidly between reports, verify no flicker or regressions

- [ ] Verify that no errors appear in the JS console

### Offline tests

1. Go offline
2. Navigate between reports, verify no "not found" page appears for previously loaded reports
3. Verify AccountManagerBanner still renders correctly with cached data

### QA Steps

1. Open a concierge chat, verify AccountManagerBanner displays correctly
2. Navigate between 5+ different report types (DM, group, expense, workspace chat)
3. Verify no "not found" page appears incorrectly
4. Open a deleted transaction thread, verify "not found" page appears

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist

- [ ] I linked the correct issue in the `### Fixed Issues` section above
- [ ] I wrote clear testing steps that cover the changes made in this PR
    - [ ] I added steps for local testing in the `Tests` section
    - [ ] I added steps for the expected offline behavior in the `Offline steps` section
    - [ ] I added steps for Staging and/or Production testing in the `QA steps` section
    - [ ] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [ ] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [ ] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [ ] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [ ] I ran the tests on **all platforms** & verified they passed on:
    - [ ] Android: Native
    - [ ] Android: mWeb Chrome
    - [ ] iOS: Native
    - [ ] iOS: mWeb Safari
    - [ ] MacOS: Chrome / Safari
- [ ] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [ ] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [ ] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [ ] I verified that comments were added to code that is not self explanatory
    - [ ] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [ ] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [ ] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [ ] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [ ] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [ ] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [ ] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [ ] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [ ] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [ ] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [ ] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [ ] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [ ] I verified that if a function's arguments changed that all usages have also been updated correctly
- [ ] If any new file was added I verified that:
    - [ ] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [ ] If a new CSS style is added I verified that:
    - [ ] A similar style doesn't already exist
    - [ ] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [ ] If new assets were added or existing ones were modified, I verified that:
    - [ ] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [ ] The assets load correctly across all supported platforms.
- [ ] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [ ] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [ ] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [ ] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [ ] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [ ] I verified that all the inputs inside a form are aligned with each other.
    - [ ] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [ ] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [ ] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [ ] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>