### PR TITLE
fix: route Home report creation through Reports tab

### DIFF
--- a/src/components/Navigation/QuickCreationActionsBar/index.tsx
+++ b/src/components/Navigation/QuickCreationActionsBar/index.tsx
@@ -20,6 +20,8 @@ import {startDistanceRequest, startMoneyRequest} from '@libs/actions/IOU';
 import {openOldDotLink} from '@libs/actions/Link';
 import {createNewReport} from '@libs/actions/Report';
 import interceptAnonymousUser from '@libs/interceptAnonymousUser';
+import getCreateReportRoute, {getDefaultReportsPageRoute} from '@libs/Navigation/helpers/getCreateReportRoute';
+import isHomeTopmostFullScreenRoute from '@libs/Navigation/helpers/isHomeTopmostFullScreenRoute';
 import isSearchTopmostFullScreenRoute from '@libs/Navigation/helpers/isSearchTopmostFullScreenRoute';
 import Navigation from '@libs/Navigation/Navigation';
 import {openTravelDotLink} from '@libs/openTravelDotLink';
@@ -120,10 +122,15 @@ function QuickCreationActionsBar() {
                 shouldDismissEmptyReportsConfirmation,
             );
             Navigation.setNavigationActionToMicrotaskQueue(() => {
+                const activeRoute = Navigation.getActiveRoute();
                 Navigation.navigate(
-                    isSearchTopmostFullScreenRoute()
-                        ? ROUTES.SEARCH_MONEY_REQUEST_REPORT.getRoute({reportID: createdReportID, backTo: Navigation.getActiveRoute()})
-                        : ROUTES.REPORT_WITH_ID.getRoute(createdReportID, undefined, undefined, Navigation.getActiveRoute()),
+                    getCreateReportRoute({
+                        reportID: createdReportID,
+                        searchBackTo: activeRoute,
+                        fallbackBackTo: activeRoute,
+                        shouldOpenInReports: isHomeTopmostFullScreenRoute(),
+                        shouldOpenInSearch: isSearchTopmostFullScreenRoute(),
+                    }),
                 );
             });
         },
@@ -134,6 +141,7 @@ function QuickCreationActionsBar() {
         policyID: defaultChatEnabledPolicyID,
         policyName: defaultChatEnabledPolicy?.name ?? '',
         onConfirm: handleCreateWorkspaceReport,
+        shouldHandleNavigationBack: false,
     });
 
     const handleExpense = useCallback(
@@ -178,7 +186,7 @@ function QuickCreationActionsBar() {
                     (shouldRestrictUserBillableActions(workspaceIDForReportCreation, ownerBillingGracePeriodEnd, userBillingGracePeriodEnds, undefined, defaultChatEnabledPolicy) &&
                         groupPoliciesWithChatEnabled.length > 1)
                 ) {
-                    Navigation.navigate(ROUTES.NEW_REPORT_WORKSPACE_SELECTION.getRoute());
+                    Navigation.navigate(ROUTES.NEW_REPORT_WORKSPACE_SELECTION.getRoute(undefined, isHomeTopmostFullScreenRoute() ? getDefaultReportsPageRoute() : undefined));
                     return;
                 }
 

--- a/src/libs/Navigation/helpers/getCreateReportRoute.ts
+++ b/src/libs/Navigation/helpers/getCreateReportRoute.ts
@@ -1,0 +1,31 @@
+import {buildCannedSearchQuery} from '@libs/SearchQueryUtils';
+import CONST from '@src/CONST';
+import ROUTES from '@src/ROUTES';
+
+type GetCreateReportRouteParams = {
+    reportID: string;
+    searchBackTo?: string;
+    fallbackBackTo?: string;
+    shouldOpenInReports?: boolean;
+    shouldOpenInSearch?: boolean;
+};
+
+function getDefaultReportsPageRoute() {
+    return ROUTES.SEARCH_ROOT.getRoute({query: buildCannedSearchQuery({type: CONST.SEARCH.DATA_TYPES.EXPENSE_REPORT})});
+}
+
+function getCreateReportRoute({reportID, searchBackTo, fallbackBackTo, shouldOpenInReports = false, shouldOpenInSearch = false}: GetCreateReportRouteParams) {
+    if (shouldOpenInSearch) {
+        return searchBackTo ? ROUTES.SEARCH_MONEY_REQUEST_REPORT.getRoute({reportID, backTo: searchBackTo}) : ROUTES.SEARCH_MONEY_REQUEST_REPORT.getRoute({reportID});
+    }
+
+    if (shouldOpenInReports) {
+        const reportsBackTo = searchBackTo?.startsWith(ROUTES.SEARCH_ROOT.route) ? searchBackTo : getDefaultReportsPageRoute();
+        return ROUTES.SEARCH_MONEY_REQUEST_REPORT.getRoute({reportID, backTo: reportsBackTo});
+    }
+
+    return ROUTES.REPORT_WITH_ID.getRoute(reportID, undefined, undefined, fallbackBackTo);
+}
+
+export default getCreateReportRoute;
+export {getDefaultReportsPageRoute};

--- a/src/libs/Navigation/helpers/isHomeTopmostFullScreenRoute.ts
+++ b/src/libs/Navigation/helpers/isHomeTopmostFullScreenRoute.ts
@@ -1,0 +1,16 @@
+import {navigationRef} from '@libs/Navigation/Navigation';
+import type {RootNavigatorParamList, State} from '@libs/Navigation/types';
+import SCREENS from '@src/SCREENS';
+import {isFullScreenName} from './isNavigatorName';
+
+const isHomeTopmostFullScreenRoute = (): boolean => {
+    const rootState = navigationRef.getRootState() as State<RootNavigatorParamList>;
+
+    if (!rootState) {
+        return false;
+    }
+
+    return rootState.routes.findLast((route) => isFullScreenName(route.name))?.name === SCREENS.HOME;
+};
+
+export default isHomeTopmostFullScreenRoute;

--- a/src/pages/NewReportWorkspaceSelectionPage.tsx
+++ b/src/pages/NewReportWorkspaceSelectionPage.tsx
@@ -21,6 +21,7 @@ import usePermissions from '@hooks/usePermissions';
 import useResponsiveLayout from '@hooks/useResponsiveLayout';
 import useThemeStyles from '@hooks/useThemeStyles';
 import {createNewReport} from '@libs/actions/Report';
+import getCreateReportRoute from '@libs/Navigation/helpers/getCreateReportRoute';
 import isSearchTopmostFullScreenRoute from '@libs/Navigation/helpers/isSearchTopmostFullScreenRoute';
 import setNavigationActionToMicrotaskQueue from '@libs/Navigation/helpers/setNavigationActionToMicrotaskQueue';
 import Navigation from '@libs/Navigation/Navigation';
@@ -99,8 +100,14 @@ function NewReportWorkspaceSelectionPage({route}: NewReportWorkspaceSelectionPag
         }
 
         Navigation.setNavigationActionToMicrotaskQueue(() => {
+            const shouldOpenInReports = !!backTo?.startsWith(ROUTES.SEARCH_ROOT.route);
             Navigation.navigate(
-                isSearchTopmostFullScreenRoute() ? ROUTES.SEARCH_MONEY_REQUEST_REPORT.getRoute({reportID: optimisticReportID}) : ROUTES.REPORT_WITH_ID.getRoute(optimisticReportID),
+                getCreateReportRoute({
+                    reportID: optimisticReportID,
+                    searchBackTo: shouldOpenInReports ? backTo : undefined,
+                    shouldOpenInReports,
+                    shouldOpenInSearch: isSearchTopmostFullScreenRoute(),
+                }),
                 {forceReplace: isRHPOnReportInSearch || shouldUseNarrowLayout},
             );
         });
@@ -165,6 +172,7 @@ function NewReportWorkspaceSelectionPage({route}: NewReportWorkspaceSelectionPag
         onCancel: () => {
             setPendingPolicySelection(null);
         },
+        shouldHandleNavigationBack: false,
     });
 
     // Open the confirmation modal after pendingPolicySelection is committed so the hook has the correct policyName

--- a/src/pages/inbox/sidebar/FABPopoverContent/menuItems/CreateReportMenuItem.tsx
+++ b/src/pages/inbox/sidebar/FABPopoverContent/menuItems/CreateReportMenuItem.tsx
@@ -10,6 +10,8 @@ import usePermissions from '@hooks/usePermissions';
 import useResponsiveLayout from '@hooks/useResponsiveLayout';
 import {createNewReport} from '@libs/actions/Report';
 import interceptAnonymousUser from '@libs/interceptAnonymousUser';
+import getCreateReportRoute, {getDefaultReportsPageRoute} from '@libs/Navigation/helpers/getCreateReportRoute';
+import isHomeTopmostFullScreenRoute from '@libs/Navigation/helpers/isHomeTopmostFullScreenRoute';
 import isSearchTopmostFullScreenRoute from '@libs/Navigation/helpers/isSearchTopmostFullScreenRoute';
 import Navigation from '@libs/Navigation/Navigation';
 import {getDefaultChatEnabledPolicy, isPaidGroupPolicy, shouldShowPolicy} from '@libs/PolicyUtils';
@@ -99,10 +101,15 @@ function CreateReportMenuItem() {
             shouldDismissEmptyReportsConfirmation,
         );
         Navigation.setNavigationActionToMicrotaskQueue(() => {
+            const activeRoute = Navigation.getActiveRoute();
             Navigation.navigate(
-                isSearchTopmostFullScreenRoute()
-                    ? ROUTES.SEARCH_MONEY_REQUEST_REPORT.getRoute({reportID: createdReportID, backTo: Navigation.getActiveRoute()})
-                    : ROUTES.REPORT_WITH_ID.getRoute(createdReportID, undefined, undefined, Navigation.getActiveRoute()),
+                getCreateReportRoute({
+                    reportID: createdReportID,
+                    searchBackTo: activeRoute,
+                    fallbackBackTo: activeRoute,
+                    shouldOpenInReports: isHomeTopmostFullScreenRoute(),
+                    shouldOpenInSearch: isSearchTopmostFullScreenRoute(),
+                }),
                 {forceReplace: isReportInSearch},
             );
         });
@@ -138,7 +145,7 @@ function CreateReportMenuItem() {
                         !workspaceIDForReportCreation ||
                         (shouldRestrictUserBillableActions(workspaceIDForReportCreation, ownerBillingGracePeriodEnd, userBillingGracePeriodEnds) && groupPoliciesWithChatEnabled.length > 1)
                     ) {
-                        Navigation.navigate(ROUTES.NEW_REPORT_WORKSPACE_SELECTION.getRoute());
+                        Navigation.navigate(ROUTES.NEW_REPORT_WORKSPACE_SELECTION.getRoute(undefined, isHomeTopmostFullScreenRoute() ? getDefaultReportsPageRoute() : undefined));
                         return;
                     }
 

--- a/tests/ui/components/QuickCreationActionsBarTest.tsx
+++ b/tests/ui/components/QuickCreationActionsBarTest.tsx
@@ -1,0 +1,161 @@
+import {act, fireEvent, render, screen} from '@testing-library/react-native';
+import {getUnixTime, subDays} from 'date-fns';
+import React from 'react';
+import Onyx from 'react-native-onyx';
+import ComposeProviders from '@components/ComposeProviders';
+import QuickCreationActionsBar from '@components/Navigation/QuickCreationActionsBar';
+import OnyxListItemProvider from '@components/OnyxListItemProvider';
+import usePolicyForMovingExpenses from '@hooks/usePolicyForMovingExpenses';
+import {createNewReport} from '@libs/actions/Report';
+import {getDefaultReportsPageRoute} from '@libs/Navigation/helpers/getCreateReportRoute';
+import Navigation from '@libs/Navigation/Navigation';
+import CONST from '@src/CONST';
+import ONYXKEYS from '@src/ONYXKEYS';
+import ROUTES from '@src/ROUTES';
+import waitForBatchedUpdatesWithAct from '../../utils/waitForBatchedUpdatesWithAct';
+
+jest.mock('@libs/Navigation/Navigation', () => ({
+    navigate: jest.fn(),
+    setNavigationActionToMicrotaskQueue: jest.fn((cb: () => void) => cb()),
+    getActiveRoute: jest.fn(() => 'home'),
+}));
+
+jest.mock('@libs/actions/Report', () => ({
+    createNewReport: jest.fn(() => ({reportID: 'mock-report-id'})),
+}));
+
+jest.mock('@libs/interceptAnonymousUser', () => jest.fn((callback: () => void) => callback()));
+jest.mock('@libs/actions/IOU', () => ({
+    startMoneyRequest: jest.fn(),
+    startDistanceRequest: jest.fn(),
+}));
+jest.mock('@libs/actions/Link', () => ({
+    openOldDotLink: jest.fn(),
+}));
+jest.mock('@libs/openTravelDotLink', () => ({
+    openTravelDotLink: jest.fn(),
+}));
+jest.mock('@hooks/usePolicyForMovingExpenses');
+jest.mock('@hooks/useHasEmptyReportsForPolicy', () => () => false);
+jest.mock('@hooks/useCreateEmptyReportConfirmation', () => () => ({
+    openCreateReportConfirmation: jest.fn(),
+}));
+jest.mock('@hooks/useLocalize', () => () => ({
+    translate: (key: string) => {
+        switch (key) {
+            case 'common.expense':
+                return 'Expense';
+            case 'common.report':
+                return 'Report';
+            case 'common.distance':
+                return 'Distance';
+            case 'workspace.common.travel':
+                return 'Travel';
+            default:
+                return key;
+        }
+    },
+}));
+jest.mock('@libs/Navigation/helpers/isSearchTopmostFullScreenRoute', () => () => false);
+jest.mock('@libs/Navigation/helpers/isHomeTopmostFullScreenRoute', () => () => true);
+
+const mockUsePolicyForMovingExpenses = jest.mocked(usePolicyForMovingExpenses);
+const mockNavigate = jest.mocked(Navigation.navigate);
+const mockCreateNewReport = jest.mocked(createNewReport);
+
+const CURRENT_USER_ACCOUNT_ID = 1;
+const CURRENT_USER_EMAIL = 'user@test.com';
+const MOCK_POLICY_ID = 'policy-123';
+const MOCK_POLICY = {
+    id: MOCK_POLICY_ID,
+    name: 'Test Workspace',
+    type: CONST.POLICY.TYPE.TEAM,
+    role: CONST.POLICY.ROLE.ADMIN,
+    isPolicyExpenseChatEnabled: true,
+    pendingAction: null,
+    avatarURL: '',
+    areInvoicesEnabled: false,
+    owner: CURRENT_USER_EMAIL,
+    outputCurrency: CONST.CURRENCY.USD,
+};
+
+function renderComponent() {
+    return render(
+        <ComposeProviders components={[OnyxListItemProvider]}>
+            <QuickCreationActionsBar />
+        </ComposeProviders>,
+    );
+}
+
+describe('QuickCreationActionsBar', () => {
+    beforeAll(() => {
+        Onyx.init({
+            keys: ONYXKEYS,
+        });
+    });
+
+    beforeEach(async () => {
+        mockUsePolicyForMovingExpenses.mockReturnValue({
+            policyForMovingExpensesID: MOCK_POLICY_ID,
+            policyForMovingExpenses: MOCK_POLICY,
+            shouldSelectPolicy: false,
+        });
+
+        await act(async () => {
+            await Onyx.merge(ONYXKEYS.SESSION, {
+                accountID: CURRENT_USER_ACCOUNT_ID,
+                email: CURRENT_USER_EMAIL,
+            });
+            await Onyx.merge(`${ONYXKEYS.COLLECTION.POLICY}${MOCK_POLICY_ID}`, MOCK_POLICY);
+            await Onyx.merge(ONYXKEYS.NVP_ACTIVE_POLICY_ID, MOCK_POLICY_ID);
+        });
+        await waitForBatchedUpdatesWithAct();
+    });
+
+    afterEach(async () => {
+        jest.clearAllMocks();
+        await act(async () => {
+            await Onyx.clear();
+        });
+        await waitForBatchedUpdatesWithAct();
+    });
+
+    it('opens the created report in Reports when Home quick action Report is pressed', async () => {
+        renderComponent();
+        await waitForBatchedUpdatesWithAct();
+
+        fireEvent.press(screen.getByText('Report'));
+        await waitForBatchedUpdatesWithAct();
+
+        expect(mockCreateNewReport).toHaveBeenCalled();
+        expect(mockNavigate).toHaveBeenCalledWith(ROUTES.SEARCH_MONEY_REQUEST_REPORT.getRoute({reportID: 'mock-report-id', backTo: getDefaultReportsPageRoute()}));
+    });
+
+    it('preserves the Reports destination when Home quick action Report goes through workspace selection', async () => {
+        const pastDueGracePeriod = getUnixTime(subDays(new Date(), 3));
+
+        await act(async () => {
+            await Onyx.merge(`${ONYXKEYS.COLLECTION.POLICY}${MOCK_POLICY_ID}`, {
+                ...MOCK_POLICY,
+                ownerAccountID: CURRENT_USER_ACCOUNT_ID,
+            });
+            await Onyx.merge(`${ONYXKEYS.COLLECTION.POLICY}policy-456`, {
+                ...MOCK_POLICY,
+                id: 'policy-456',
+                name: 'Second Workspace',
+                ownerAccountID: CURRENT_USER_ACCOUNT_ID,
+            });
+            await Onyx.merge(ONYXKEYS.NVP_PRIVATE_OWNER_BILLING_GRACE_PERIOD_END, pastDueGracePeriod);
+            await Onyx.merge(ONYXKEYS.NVP_PRIVATE_AMOUNT_OWED, 8010);
+        });
+        await waitForBatchedUpdatesWithAct();
+
+        renderComponent();
+        await waitForBatchedUpdatesWithAct();
+
+        fireEvent.press(screen.getByText('Report'));
+        await waitForBatchedUpdatesWithAct();
+
+        expect(mockNavigate).toHaveBeenCalledWith(ROUTES.NEW_REPORT_WORKSPACE_SELECTION.getRoute(undefined, getDefaultReportsPageRoute()));
+    });
+});

--- a/tests/unit/getCreateReportRouteTest.ts
+++ b/tests/unit/getCreateReportRouteTest.ts
@@ -1,0 +1,44 @@
+import getCreateReportRoute, {getDefaultReportsPageRoute} from '@libs/Navigation/helpers/getCreateReportRoute';
+import ROUTES from '@src/ROUTES';
+
+describe('getCreateReportRoute', () => {
+    const reportID = '123';
+
+    it('returns the Search route with the current search state when already in Search', () => {
+        const route = getCreateReportRoute({
+            reportID,
+            searchBackTo: 'search?q=type:expense-report',
+            shouldOpenInSearch: true,
+        });
+
+        expect(route).toBe(ROUTES.SEARCH_MONEY_REQUEST_REPORT.getRoute({reportID, backTo: 'search?q=type:expense-report'}));
+    });
+
+    it('returns the Reports route with the default expense reports page when opening from Home', () => {
+        const route = getCreateReportRoute({
+            reportID,
+            shouldOpenInReports: true,
+        });
+
+        expect(route).toBe(ROUTES.SEARCH_MONEY_REQUEST_REPORT.getRoute({reportID, backTo: getDefaultReportsPageRoute()}));
+    });
+
+    it('preserves an explicit Reports backTo route when reopening after workspace selection', () => {
+        const route = getCreateReportRoute({
+            reportID,
+            searchBackTo: 'search?q=type:expense-report sortBy:date sortOrder:desc',
+            shouldOpenInReports: true,
+        });
+
+        expect(route).toBe(ROUTES.SEARCH_MONEY_REQUEST_REPORT.getRoute({reportID, backTo: 'search?q=type:expense-report sortBy:date sortOrder:desc'}));
+    });
+
+    it('falls back to the Inbox-owned report route outside Home and Search', () => {
+        const route = getCreateReportRoute({
+            reportID,
+            fallbackBackTo: 'inbox',
+        });
+
+        expect(route).toBe(ROUTES.REPORT_WITH_ID.getRoute(reportID, undefined, undefined, 'inbox'));
+    });
+});


### PR DESCRIPTION
### Explanation of Change
This keeps the fix intentionally narrow.

It routes Home-originated report creation into the Reports/Search-side report route instead of the Inbox-owned `REPORT_WITH_ID` fallback, and it preserves that same Reports destination when the Home flow goes through workspace selection.

Search-originated behavior stays unchanged.

### Fixed Issues
$ https://github.com/Expensify/App/issues/87073
PROPOSAL: https://github.com/Expensify/App/issues/87073#issuecomment-4183077306

### Tests
1. Run `npx jest tests/unit/getCreateReportRouteTest.ts tests/ui/components/QuickCreationActionsBarTest.tsx --runInBand` and verify both suites pass.
2. From Home, tap the `Report` quick action and verify the app navigates to `Reports` and opens the new empty report in the wide RHP.
3. From Home, open the FAB and tap `Create report`. Verify the app navigates to `Reports` and opens the new empty report in the wide RHP.
4. From Home, trigger report creation through workspace selection and verify selecting a workspace still lands on `Reports` with the new empty report open in the wide RHP.
5. From Search, create a report and verify Search behavior is unchanged.
- [ ] Verify that no errors appear in the JS console

### Offline tests
1. Not run yet. Draft PR for route-review scope.

### QA Steps
1. Same as Tests.
- [ ] Verify that no errors appear in the JS console

### PR Author Checklist
- [ ] I linked the correct issue in the `### Fixed Issues` section above
- [ ] I wrote clear testing steps that cover the changes made in this PR
    - [ ] I added steps for local testing in the `Tests` section
    - [ ] I added steps for the expected offline behavior in the `Offline steps` section
    - [ ] I added steps for Staging and/or Production testing in the `QA steps` section
    - [ ] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [ ] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [ ] I tested this PR with a High Traffic account against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability)
- [ ] I verified there are no console errors related to my changes
- [ ] I added unit tests for the bug fix in this PR
- [ ] I followed the PR title convention (`fix: concise description`)
