### PR TITLE
Fix foreign currency default tax rate not applied in skip-confirmation path

### DIFF
--- a/src/pages/iou/request/step/IOURequestStepAmount.tsx
+++ b/src/pages/iou/request/step/IOURequestStepAmount.tsx
@@ -238,6 +238,14 @@ function IOURequestStepAmount({
                     participant,
                     transactionReportID: report?.reportID,
                 });
+
+                // Calculate the correct tax for the selected currency. Foreign currency expenses may have a
+                // different default tax rate than the workspace default, so we resolve it here rather than
+                // relying on downstream defaults (which fall back to an empty taxCode and zero taxAmount).
+                const skipTaxCode = getDefaultTaxCode(policy, transaction, selectedCurrency) ?? '';
+                const skipTaxPercentage = getTaxValue(policy, transaction, skipTaxCode) ?? '';
+                const skipTaxAmount = convertToBackendAmount(calculateTaxAmount(skipTaxPercentage, backendAmount, decimals));
+
                 if (iouType === CONST.IOU.TYPE.PAY || iouType === CONST.IOU.TYPE.SEND) {
                     if (paymentMethod && paymentMethod === CONST.IOU.PAYMENT_TYPE.EXPENSIFY) {
                         sendMoneyWithWallet(report, quickAction, backendAmount, selectedCurrency, '', currentUserAccountIDParam, participants.at(0) ?? {});
@@ -265,6 +273,8 @@ function IOURequestStepAmount({
                             merchant: CONST.TRANSACTION.PARTIAL_TRANSACTION_MERCHANT,
                             attendees: transaction?.comment?.attendees,
                             reimbursable: defaultReimbursable,
+                            taxCode: skipTaxCode,
+                            taxAmount: skipTaxAmount,
                         },
                         backToReport,
                         shouldGenerateTransactionThreadReport,
@@ -296,6 +306,8 @@ function IOURequestStepAmount({
                             created: transaction?.created,
                             merchant: CONST.TRANSACTION.PARTIAL_TRANSACTION_MERCHANT,
                             reimbursable: defaultReimbursable,
+                            taxCode: skipTaxCode,
+                            taxAmount: skipTaxAmount,
                         },
                         isASAPSubmitBetaEnabled,
                         currentUserAccountIDParam,


### PR DESCRIPTION
## Fix

$ #87499

When a workspace has a foreign currency default tax rate configured, submitting an expense via the quick-submit path (`shouldSkipConfirmation`) was applying the workspace default tax rate instead of the foreign currency rate. The confirmation screen path worked correctly because it called `getDefaultTaxCode` explicitly — but the skip path bypassed that entirely, leaving `taxCode` and `taxAmount` unpopulated in `transactionParams`, which caused downstream code to fall back to empty defaults.

**Root cause:** `shouldSkipConfirmation` branch in `IOURequestStepAmount.tsx` called `requestMoney` and `trackExpense` without `taxCode`/`taxAmount` in `transactionParams`.

**Fix:** Calculate `skipTaxCode` and `skipTaxAmount` at the top of the skip block using the same `getDefaultTaxCode` → `getTaxValue` → `calculateTaxAmount` pattern already used in the split/update path (lines 390–395). All needed functions and `decimals` were already in scope.

### Changes

- `src/pages/iou/request/step/IOURequestStepAmount.tsx` — 7 lines added in the `shouldSkipConfirmation` block

### Testing

1. Configure a workspace with output currency CAD and a foreign currency (USD) default tax rate different from the workspace default
2. Submit an expense in USD using the quick-submit path (skip confirmation)
3. Verify the expense uses the USD foreign currency tax rate, not the CAD workspace default