### PR TITLE
Show Central invoicing instead of card details for travel invoicing transactions

### DIFF
--- a/src/languages/de.ts
+++ b/src/languages/de.ts
@@ -8021,6 +8021,7 @@ Fügen Sie weitere Ausgabelimits hinzu, um den Cashflow Ihres Unternehmens zu sc
         personalCard: 'Private Karte',
         companyCard: 'Firmenkarte',
         expensifyCard: 'Expensify Karte',
+        centralInvoicing: 'Zentrale Rechnungsstellung',
     },
     distance: {
         addStop: 'Stopp hinzufügen',

--- a/src/languages/en.ts
+++ b/src/languages/en.ts
@@ -7981,6 +7981,7 @@ const translations = {
         personalCard: 'Personal card',
         companyCard: 'Company card',
         expensifyCard: 'Expensify Card',
+        centralInvoicing: 'Central invoicing',
     },
     distance: {
         addStop: 'Add stop',

--- a/src/languages/es.ts
+++ b/src/languages/es.ts
@@ -8297,6 +8297,7 @@ ${amount} para ${merchant} - ${date}`,
         personalCard: 'Tarjeta personal',
         companyCard: 'Tarjeta corporativa',
         expensifyCard: 'Tarjeta Expensify',
+        centralInvoicing: 'Facturación centralizada',
     },
     distance: {
         addStop: 'Añadir parada',

--- a/src/languages/fr.ts
+++ b/src/languages/fr.ts
@@ -8044,6 +8044,7 @@ Ajoutez davantage de règles de dépenses pour protéger la trésorerie de l’e
         personalCard: 'Carte personnelle',
         companyCard: 'Carte d’entreprise',
         expensifyCard: 'Carte Expensify',
+        centralInvoicing: 'Facturation centralisée',
     },
     distance: {
         addStop: 'Ajouter un arrêt',

--- a/src/languages/it.ts
+++ b/src/languages/it.ts
@@ -8010,6 +8010,7 @@ Aggiungi altre regole di spesa per proteggere il flusso di cassa aziendale.`,
         personalCard: 'Carta personale',
         companyCard: 'Carta aziendale',
         expensifyCard: 'Carta Expensify',
+        centralInvoicing: 'Fatturazione centralizzata',
     },
     distance: {
         addStop: 'Aggiungi fermata',

--- a/src/languages/ja.ts
+++ b/src/languages/ja.ts
@@ -7912,6 +7912,7 @@ ${reportName}
         personalCard: '個人のカード',
         companyCard: '会社カード',
         expensifyCard: 'Expensify カード',
+        centralInvoicing: '集中請求',
     },
     distance: {
         addStop: '経由地を追加',

--- a/src/languages/nl.ts
+++ b/src/languages/nl.ts
@@ -7987,6 +7987,7 @@ Voeg meer bestedingsregels toe om de kasstroom van het bedrijf te beschermen.`,
         personalCard: 'Persoonlijke kaart',
         companyCard: 'Bedrijfskaart',
         expensifyCard: 'Expensify Kaart',
+        centralInvoicing: 'Gecentraliseerde facturatie',
     },
     distance: {
         addStop: 'Stop toevoegen',

--- a/src/languages/pl.ts
+++ b/src/languages/pl.ts
@@ -7976,6 +7976,7 @@ Dodaj więcej zasad wydatków, żeby chronić płynność finansową firmy.`,
         personalCard: 'Karta osobista',
         companyCard: 'Karta firmowa',
         expensifyCard: 'Karta Expensify',
+        centralInvoicing: 'Centralne fakturowanie',
     },
     distance: {
         addStop: 'Dodaj przystanek',

--- a/src/languages/pt-BR.ts
+++ b/src/languages/pt-BR.ts
@@ -7980,6 +7980,7 @@ Adicione mais regras de gasto para proteger o fluxo de caixa da empresa.`,
         personalCard: 'Cartão pessoal',
         companyCard: 'Cartão corporativo',
         expensifyCard: 'Cartão Expensify',
+        centralInvoicing: 'Faturamento centralizado',
     },
     distance: {
         addStop: 'Adicionar parada',

--- a/src/languages/zh-hans.ts
+++ b/src/languages/zh-hans.ts
@@ -7763,7 +7763,15 @@ ${reportName}
             tryDifferentEmail: '请尝试使用其他邮箱',
         },
     },
-    cardTransactions: {notActivated: '未激活', outOfPocket: '可报销', companySpend: '不可报销', personalCard: '个人银行卡', companyCard: '公司卡', expensifyCard: 'Expensify 卡'},
+    cardTransactions: {
+        notActivated: '未激活',
+        outOfPocket: '可报销',
+        companySpend: '不可报销',
+        personalCard: '个人银行卡',
+        companyCard: '公司卡',
+        expensifyCard: 'Expensify 卡',
+        centralInvoicing: '集中开票',
+    },
     distance: {
         addStop: '添加站点',
         address: '地址',

--- a/src/libs/CardUtils.ts
+++ b/src/libs/CardUtils.ts
@@ -183,7 +183,7 @@ function getCardDescription(card: Card | undefined, translate: LocalizedTranslat
  * @param displayName
  * @returns string in format %<defaultOrCustomCardName> • <lastFourPAN>%.
  */
-function getCardDescriptionForSearchTable(card: Card, displayName: string | undefined, translate: LocalizedTranslate) {
+function getCardDescriptionForSearchTable(card: Card, translate: LocalizedTranslate, displayName?: string) {
     if (isTravelCard(card)) {
         return translate('cardTransactions.centralInvoicing');
     }

--- a/src/libs/CardUtils.ts
+++ b/src/libs/CardUtils.ts
@@ -183,11 +183,11 @@ function getCardDescription(card: Card | undefined, translate: LocalizedTranslat
  * @param displayName
  * @returns string in format %<defaultOrCustomCardName> • <lastFourPAN>%.
  */
-function getCardDescriptionForSearchTable(card?: Card, displayName?: string, translate?: LocalizedTranslate) {
+function getCardDescriptionForSearchTable(card: Card | undefined, displayName: string | undefined, translate: LocalizedTranslate) {
     if (!card) {
         return '';
     }
-    if (translate && isTravelCard(card)) {
+    if (isTravelCard(card)) {
         return translate('cardTransactions.centralInvoicing');
     }
     const isCSVCard = card.bank === CONST.COMPANY_CARD.FEED_BANK_NAME.UPLOAD || card.bank?.includes(CONST.COMPANY_CARD.FEED_BANK_NAME.CSV);

--- a/src/libs/CardUtils.ts
+++ b/src/libs/CardUtils.ts
@@ -183,10 +183,7 @@ function getCardDescription(card: Card | undefined, translate: LocalizedTranslat
  * @param displayName
  * @returns string in format %<defaultOrCustomCardName> • <lastFourPAN>%.
  */
-function getCardDescriptionForSearchTable(card: Card | undefined, displayName: string | undefined, translate: LocalizedTranslate) {
-    if (!card) {
-        return '';
-    }
+function getCardDescriptionForSearchTable(card: Card, displayName: string | undefined, translate: LocalizedTranslate) {
     if (isTravelCard(card)) {
         return translate('cardTransactions.centralInvoicing');
     }

--- a/src/libs/CardUtils.ts
+++ b/src/libs/CardUtils.ts
@@ -164,6 +164,9 @@ function getCardDescription(card: Card | undefined, translate: LocalizedTranslat
     if (!card) {
         return '';
     }
+    if (isTravelCard(card)) {
+        return translate('cardTransactions.centralInvoicing');
+    }
     const isCSVCard = card.bank === CONST.COMPANY_CARD.FEED_BANK_NAME.UPLOAD || card.bank?.includes(CONST.COMPANY_CARD.FEED_BANK_NAME.CSV);
     if (isCSVCard) {
         return card.nameValuePairs?.cardTitle ?? card.cardName ?? '';
@@ -180,9 +183,12 @@ function getCardDescription(card: Card | undefined, translate: LocalizedTranslat
  * @param displayName
  * @returns string in format %<defaultOrCustomCardName> • <lastFourPAN>%.
  */
-function getCardDescriptionForSearchTable(card?: Card, displayName?: string) {
+function getCardDescriptionForSearchTable(card?: Card, displayName?: string, translate?: LocalizedTranslate) {
     if (!card) {
         return '';
+    }
+    if (translate && isTravelCard(card)) {
+        return translate('cardTransactions.centralInvoicing');
     }
     const isCSVCard = card.bank === CONST.COMPANY_CARD.FEED_BANK_NAME.UPLOAD || card.bank?.includes(CONST.COMPANY_CARD.FEED_BANK_NAME.CSV);
     if (isCSVCard) {

--- a/src/libs/SearchUIUtils.ts
+++ b/src/libs/SearchUIUtils.ts
@@ -2774,8 +2774,8 @@ function getCardSections(
                             cardName: cardGroup.cardName,
                             lastFourPAN: cardGroup.lastFourPAN,
                         } as OnyxTypes.Card,
-                        personalDetails?.displayName,
                         translate,
+                        personalDetails?.displayName,
                     );
                     cardDescriptionByCardID.set(cardGroup.cardID, formattedCardName);
                 }

--- a/src/libs/SearchUIUtils.ts
+++ b/src/libs/SearchUIUtils.ts
@@ -2775,6 +2775,7 @@ function getCardSections(
                             lastFourPAN: cardGroup.lastFourPAN,
                         } as OnyxTypes.Card,
                         personalDetails?.displayName,
+                        translate,
                     );
                     cardDescriptionByCardID.set(cardGroup.cardID, formattedCardName);
                 }

--- a/src/pages/workspace/rules/SpendRules/SpendRulePageBase.tsx
+++ b/src/pages/workspace/rules/SpendRules/SpendRulePageBase.tsx
@@ -95,7 +95,7 @@ function SpendRulePageBase({policyID, titleKey, testID}: SpendRulePageBaseProps)
                 }
                 const accountID = card.accountID ?? CONST.DEFAULT_NUMBER_ID;
                 const displayName = getDisplayNameOrDefault(personalDetails?.[accountID], '', false);
-                return getCardDescriptionForSearchTable(card, displayName || undefined) || id;
+                return getCardDescriptionForSearchTable(card, displayName || undefined, translate) || id;
             }),
             (summary, count) => translate('workspace.rules.spendRules.summaryMoreCount', {summary, count}),
         );

--- a/src/pages/workspace/rules/SpendRules/SpendRulePageBase.tsx
+++ b/src/pages/workspace/rules/SpendRules/SpendRulePageBase.tsx
@@ -95,7 +95,7 @@ function SpendRulePageBase({policyID, titleKey, testID}: SpendRulePageBaseProps)
                 }
                 const accountID = card.accountID ?? CONST.DEFAULT_NUMBER_ID;
                 const displayName = getDisplayNameOrDefault(personalDetails?.[accountID], '', false);
-                return getCardDescriptionForSearchTable(card, displayName || undefined, translate) || id;
+                return getCardDescriptionForSearchTable(card, translate, displayName || undefined) || id;
             }),
             (summary, count) => translate('workspace.rules.spendRules.summaryMoreCount', {summary, count}),
         );

--- a/src/pages/workspace/rules/SpendRules/SpendRulesSection.tsx
+++ b/src/pages/workspace/rules/SpendRules/SpendRulesSection.tsx
@@ -133,7 +133,7 @@ function SpendRulesSection({policyID}: SpendRulesSectionProps) {
 
                     const accountID = card.accountID ?? CONST.DEFAULT_NUMBER_ID;
                     const displayName = getDisplayNameOrDefault(personalDetails?.[accountID], '', false);
-                    return getCardDescriptionForSearchTable(card, displayName || undefined, translate) || cardID;
+                    return getCardDescriptionForSearchTable(card, translate, displayName || undefined) || cardID;
                 }),
                 (summary, count) => translate('workspace.rules.spendRules.summaryMoreCount', {summary, count}),
             );

--- a/src/pages/workspace/rules/SpendRules/SpendRulesSection.tsx
+++ b/src/pages/workspace/rules/SpendRules/SpendRulesSection.tsx
@@ -133,7 +133,7 @@ function SpendRulesSection({policyID}: SpendRulesSectionProps) {
 
                     const accountID = card.accountID ?? CONST.DEFAULT_NUMBER_ID;
                     const displayName = getDisplayNameOrDefault(personalDetails?.[accountID], '', false);
-                    return getCardDescriptionForSearchTable(card, displayName || undefined) || cardID;
+                    return getCardDescriptionForSearchTable(card, displayName || undefined, translate) || cardID;
                 }),
                 (summary, count) => translate('workspace.rules.spendRules.summaryMoreCount', {summary, count}),
             );

--- a/tests/unit/CardUtilsTest.ts
+++ b/tests/unit/CardUtilsTest.ts
@@ -2289,7 +2289,7 @@ describe('CardUtils', () => {
                 } as Card['nameValuePairs'],
             };
             const description = getCardDescription(card, translateLocal);
-            expect(description).toBe('cardTransactions.centralInvoicing');
+            expect(description).toBe('Central invoicing');
         });
 
         it('should return the correct card description for personal card', () => {
@@ -2328,7 +2328,7 @@ describe('CardUtils', () => {
                 } as Card['nameValuePairs'],
             };
             const description = getCardDescriptionForSearchTable(card, translateLocal, 'John Doe');
-            expect(description).toBe('cardTransactions.centralInvoicing');
+            expect(description).toBe('Central invoicing');
         });
 
         it('should return normal description for non-travel Expensify cards', () => {

--- a/tests/unit/CardUtilsTest.ts
+++ b/tests/unit/CardUtilsTest.ts
@@ -2344,7 +2344,7 @@ describe('CardUtils', () => {
                 lastUpdated: '',
                 state: 3,
             };
-            const description = getCardDescriptionForSearchTable(card, 'John Doe');
+            const description = getCardDescriptionForSearchTable(card, 'John Doe', translateLocal);
             expect(description).toBe("John Doe's card • 5644");
         });
     });

--- a/tests/unit/CardUtilsTest.ts
+++ b/tests/unit/CardUtilsTest.ts
@@ -2327,7 +2327,7 @@ describe('CardUtils', () => {
                     feedCountry: CONST.TRAVEL.PROGRAM_TRAVEL_US,
                 } as Card['nameValuePairs'],
             };
-            const description = getCardDescriptionForSearchTable(card, 'John Doe', translateLocal);
+            const description = getCardDescriptionForSearchTable(card, translateLocal, 'John Doe');
             expect(description).toBe('cardTransactions.centralInvoicing');
         });
 
@@ -2344,7 +2344,7 @@ describe('CardUtils', () => {
                 lastUpdated: '',
                 state: 3,
             };
-            const description = getCardDescriptionForSearchTable(card, 'John Doe', translateLocal);
+            const description = getCardDescriptionForSearchTable(card, translateLocal, 'John Doe');
             expect(description).toBe("John Doe's card • 5644");
         });
     });

--- a/tests/unit/CardUtilsTest.ts
+++ b/tests/unit/CardUtilsTest.ts
@@ -21,6 +21,7 @@ import {
     getBankName,
     getBrokenConnectionUrlToFixPersonalCard,
     getCardDescription,
+    getCardDescriptionForSearchTable,
     getCardFeedIcon,
     getCardFeedWithDomainID,
     getCardHintText,
@@ -2271,6 +2272,26 @@ describe('CardUtils', () => {
             expect(description).toBe(CONST.EXPENSIFY_CARD.BANK);
         });
 
+        it('should return Central invoicing for travel invoicing cards', () => {
+            const card: Card = {
+                accountID: 18439984,
+                bank: CONST.EXPENSIFY_CARD.BANK,
+                cardID: 21570657,
+                cardName: 'CREDIT CARD...6909',
+                domainName: 'expensify-policy17f617b9fe23d2f1.exfy',
+                fraud: 'none',
+                lastFourPAN: '6909',
+                lastScrape: '',
+                lastUpdated: '',
+                state: 3,
+                nameValuePairs: {
+                    feedCountry: CONST.TRAVEL.PROGRAM_TRAVEL_US,
+                } as Card['nameValuePairs'],
+            };
+            const description = getCardDescription(card, translateLocal);
+            expect(description).toBe('cardTransactions.centralInvoicing');
+        });
+
         it('should return the correct card description for personal card', () => {
             const personalCard: Card = {
                 accountID: 1,
@@ -2286,6 +2307,45 @@ describe('CardUtils', () => {
             };
             const description = getCardDescription(personalCard, translateLocal);
             expect(description).toBe('Visa • 1234');
+        });
+    });
+
+    describe('getCardDescriptionForSearchTable', () => {
+        it('should return Central invoicing for travel invoicing cards when translate is provided', () => {
+            const card: Card = {
+                accountID: 18439984,
+                bank: CONST.EXPENSIFY_CARD.BANK,
+                cardID: 21570657,
+                cardName: 'CREDIT CARD...6909',
+                domainName: 'expensify-policy17f617b9fe23d2f1.exfy',
+                fraud: 'none',
+                lastFourPAN: '6909',
+                lastScrape: '',
+                lastUpdated: '',
+                state: 3,
+                nameValuePairs: {
+                    feedCountry: CONST.TRAVEL.PROGRAM_TRAVEL_US,
+                } as Card['nameValuePairs'],
+            };
+            const description = getCardDescriptionForSearchTable(card, 'John Doe', translateLocal);
+            expect(description).toBe('cardTransactions.centralInvoicing');
+        });
+
+        it('should return normal description for non-travel Expensify cards', () => {
+            const card: Card = {
+                accountID: 18439984,
+                bank: CONST.EXPENSIFY_CARD.BANK,
+                cardID: 21570657,
+                cardName: 'Expensify Card',
+                domainName: 'expensify-policy17f617b9fe23d2f1.exfy',
+                fraud: 'none',
+                lastFourPAN: '5644',
+                lastScrape: '',
+                lastUpdated: '',
+                state: 3,
+            };
+            const description = getCardDescriptionForSearchTable(card, 'John Doe');
+            expect(description).toBe("John Doe's card • 5644");
         });
     });
 

--- a/tests/unit/Search/SearchUIUtilsTest.ts
+++ b/tests/unit/Search/SearchUIUtilsTest.ts
@@ -8715,10 +8715,6 @@ describe('getCardDescriptionForSearchTable', () => {
         state: 3,
     };
 
-    it('returns an empty string when card is undefined', () => {
-        expect(getCardDescriptionForSearchTable(undefined, undefined, translateLocal)).toBe('');
-    });
-
     it('returns CSV/upload card title from nameValuePairs for UPLOAD bank', () => {
         const card: OnyxTypes.Card = {
             ...baseCompanyCard,

--- a/tests/unit/Search/SearchUIUtilsTest.ts
+++ b/tests/unit/Search/SearchUIUtilsTest.ts
@@ -8723,7 +8723,7 @@ describe('getCardDescriptionForSearchTable', () => {
                 cardTitle: 'Uploaded spend card',
             } as OnyxTypes.Card['nameValuePairs'],
         };
-        expect(getCardDescriptionForSearchTable(card, undefined, translateLocal)).toBe('Uploaded spend card');
+        expect(getCardDescriptionForSearchTable(card, translateLocal)).toBe('Uploaded spend card');
     });
 
     it('returns CSV card title when bank is CSV feed', () => {
@@ -8735,7 +8735,7 @@ describe('getCardDescriptionForSearchTable', () => {
                 cardTitle: 'Marketing Team Card',
             } as OnyxTypes.Card['nameValuePairs'],
         };
-        expect(getCardDescriptionForSearchTable(card, undefined, translateLocal)).toBe('Marketing Team Card');
+        expect(getCardDescriptionForSearchTable(card, translateLocal)).toBe('Marketing Team Card');
     });
 
     it('falls back to cardName for CSV/upload when cardTitle is missing', () => {
@@ -8744,11 +8744,11 @@ describe('getCardDescriptionForSearchTable', () => {
             bank: CONST.COMPANY_CARD.FEED_BANK_NAME.CSV,
             cardName: 'Fallback CSV label',
         };
-        expect(getCardDescriptionForSearchTable(card, undefined, translateLocal)).toBe('Fallback CSV label');
+        expect(getCardDescriptionForSearchTable(card, translateLocal)).toBe('Fallback CSV label');
     });
 
     it('returns default cardholder label and last four for non-CSV cards when displayName is provided', () => {
-        expect(getCardDescriptionForSearchTable(baseCompanyCard, 'Jane', translateLocal)).toBe(`Jane's card ${CONST.DOT_SEPARATOR} 2554`);
+        expect(getCardDescriptionForSearchTable(baseCompanyCard, translateLocal, 'Jane')).toBe(`Jane's card ${CONST.DOT_SEPARATOR} 2554`);
     });
 
     it('omits the dot separator when lastFourPAN is empty', () => {
@@ -8756,10 +8756,10 @@ describe('getCardDescriptionForSearchTable', () => {
             ...baseCompanyCard,
             lastFourPAN: '',
         };
-        expect(getCardDescriptionForSearchTable(card, 'Jane', translateLocal)).toBe(`Jane's card`);
+        expect(getCardDescriptionForSearchTable(card, translateLocal, 'Jane')).toBe(`Jane's card`);
     });
 
     it('uses only last four with leading separator when displayName is missing (search table card group shape)', () => {
-        expect(getCardDescriptionForSearchTable(baseCompanyCard, undefined, translateLocal)).toBe(` ${CONST.DOT_SEPARATOR} 2554`);
+        expect(getCardDescriptionForSearchTable(baseCompanyCard, translateLocal)).toBe(` ${CONST.DOT_SEPARATOR} 2554`);
     });
 });

--- a/tests/unit/Search/SearchUIUtilsTest.ts
+++ b/tests/unit/Search/SearchUIUtilsTest.ts
@@ -8716,7 +8716,7 @@ describe('getCardDescriptionForSearchTable', () => {
     };
 
     it('returns an empty string when card is undefined', () => {
-        expect(getCardDescriptionForSearchTable(undefined)).toBe('');
+        expect(getCardDescriptionForSearchTable(undefined, undefined, translateLocal)).toBe('');
     });
 
     it('returns CSV/upload card title from nameValuePairs for UPLOAD bank', () => {
@@ -8727,7 +8727,7 @@ describe('getCardDescriptionForSearchTable', () => {
                 cardTitle: 'Uploaded spend card',
             } as OnyxTypes.Card['nameValuePairs'],
         };
-        expect(getCardDescriptionForSearchTable(card)).toBe('Uploaded spend card');
+        expect(getCardDescriptionForSearchTable(card, undefined, translateLocal)).toBe('Uploaded spend card');
     });
 
     it('returns CSV card title when bank is CSV feed', () => {
@@ -8739,7 +8739,7 @@ describe('getCardDescriptionForSearchTable', () => {
                 cardTitle: 'Marketing Team Card',
             } as OnyxTypes.Card['nameValuePairs'],
         };
-        expect(getCardDescriptionForSearchTable(card)).toBe('Marketing Team Card');
+        expect(getCardDescriptionForSearchTable(card, undefined, translateLocal)).toBe('Marketing Team Card');
     });
 
     it('falls back to cardName for CSV/upload when cardTitle is missing', () => {
@@ -8748,11 +8748,11 @@ describe('getCardDescriptionForSearchTable', () => {
             bank: CONST.COMPANY_CARD.FEED_BANK_NAME.CSV,
             cardName: 'Fallback CSV label',
         };
-        expect(getCardDescriptionForSearchTable(card)).toBe('Fallback CSV label');
+        expect(getCardDescriptionForSearchTable(card, undefined, translateLocal)).toBe('Fallback CSV label');
     });
 
     it('returns default cardholder label and last four for non-CSV cards when displayName is provided', () => {
-        expect(getCardDescriptionForSearchTable(baseCompanyCard, 'Jane')).toBe(`Jane's card ${CONST.DOT_SEPARATOR} 2554`);
+        expect(getCardDescriptionForSearchTable(baseCompanyCard, 'Jane', translateLocal)).toBe(`Jane's card ${CONST.DOT_SEPARATOR} 2554`);
     });
 
     it('omits the dot separator when lastFourPAN is empty', () => {
@@ -8760,10 +8760,10 @@ describe('getCardDescriptionForSearchTable', () => {
             ...baseCompanyCard,
             lastFourPAN: '',
         };
-        expect(getCardDescriptionForSearchTable(card, 'Jane')).toBe(`Jane's card`);
+        expect(getCardDescriptionForSearchTable(card, 'Jane', translateLocal)).toBe(`Jane's card`);
     });
 
     it('uses only last four with leading separator when displayName is missing (search table card group shape)', () => {
-        expect(getCardDescriptionForSearchTable(baseCompanyCard)).toBe(` ${CONST.DOT_SEPARATOR} 2554`);
+        expect(getCardDescriptionForSearchTable(baseCompanyCard, undefined, translateLocal)).toBe(` ${CONST.DOT_SEPARATOR} 2554`);
     });
 });


### PR DESCRIPTION
### Explanation of Change

Travel Invoicing (TI) uses Expensify Cards under the hood to book travel, but users shouldn't see card details. Currently transaction views display "Expensify Card • 6909" (bank name + last 4 digits) for TI transactions. This change makes them show "Central invoicing" instead.

The fix adds an early return in `getCardDescription` and `getCardDescriptionForSearchTable` for cards where `feedCountry === TRAVEL_US` (identified via the existing `isTravelCard` helper). Since `getCardDescription` feeds into `resolveTransactionCardFields`, the fix propagates to all downstream consumers: transaction detail views, transaction list rows, EReceipts, autocomplete suggestions, and filter displays.

### Fixed Issues

$ https://github.com/Expensify/App/issues/87545

PROPOSAL: N/A

### Tests

1. Log in as a user with travel invoicing transactions (e.g. `blimpich@cardtest.expensify.com` on local dev with magic code `000000`)
2. Open a travel invoicing report
3. Verify the Card field shows "Central invoicing" instead of "Expensify Card • XXXX"
4. Check transaction list rows on the report — verify same
5. Log in as a user with regular Expensify Card transactions (e.g. `abc@xyz.com`)
6. Verify regular Expensify Card transactions still show "Expensify Card • XXXX"
7. Verify company card transactions still show normal card names

- [x] Verify that no errors appear in the JS console

### Offline tests

N/A — This is a display logic fix that operates on locally cached Onyx data, not network requests.

### QA Steps

Same as Tests (steps 1-7 above, on staging with a travel invoicing-enabled account).

- [x] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>