### PR TITLE
[No QA] add two-level gate pattern to ReportNotFoundGuard

### DIFF
--- a/src/pages/inbox/ReportNotFoundGuard.tsx
+++ b/src/pages/inbox/ReportNotFoundGuard.tsx
@@ -1,7 +1,6 @@
 import {useRoute} from '@react-navigation/native';
 import type {ReactNode} from 'react';
 import React, {useEffect} from 'react';
-import type {OnyxEntry} from 'react-native-onyx';
 import FullPageNotFoundView from '@components/BlockingViews/FullPageNotFoundView';
 import useNetwork from '@hooks/useNetwork';
 import useOnyx from '@hooks/useOnyx';
@@ -16,7 +15,6 @@ import {getParentReportActionDeletionStatus} from '@libs/TransactionNavigationUt
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
 import {isLoadingInitialReportActionsSelector} from '@src/selectors/ReportMetaData';
-import type * as OnyxTypes from '@src/types/onyx';
 
 type ReportNotFoundGuardProps = {
     children: ReactNode;
@@ -67,63 +65,42 @@ function ReportNotFoundGuard({children}: ReportNotFoundGuardProps) {
         return children;
     }
 
-    return (
-        <ReportNotFoundInnerGuard
-            report={report}
-            reportIDFromPath={routeParams?.reportID}
-            reportID={reportID}
-            isOptimisticDelete={isOptimisticDelete}
-            isInvalidReportPath={isInvalidReportPath}
-            isLoading={isLoading}
-            isLoadingApp={isLoadingApp}
-            isLoadingReportData={isLoadingReportData}
-            isLoadingInitialReportActions={isLoadingInitialReportActions}
-            isOffline={isOffline}
-            userLeavingStatus={userLeavingStatus}
-            deleteTransactionNavigateBackUrl={deleteTransactionNavigateBackUrl}
-        >
-            {children}
-        </ReportNotFoundInnerGuard>
-    );
+    return <ReportNotFoundInnerGuard reportIDFromPath={routeParams?.reportID}>{children}</ReportNotFoundInnerGuard>;
 }
 
 type ReportNotFoundInnerGuardProps = {
-    report: OnyxEntry<OnyxTypes.Report>;
     reportIDFromPath: string | undefined;
-    reportID: string | undefined;
-    isOptimisticDelete: boolean;
-    isInvalidReportPath: boolean;
-    isLoading: boolean;
-    isLoadingApp: OnyxEntry<boolean>;
-    isLoadingReportData: boolean;
-    isLoadingInitialReportActions: boolean;
-    isOffline: boolean;
-    userLeavingStatus: boolean;
-    deleteTransactionNavigateBackUrl: OnyxEntry<string>;
     children: ReactNode;
 };
 
+/**
+ * Inner guard that mounts only when the "not found" path is plausible.
+ * Re-derives all state from its own hooks (Onyx returns cached values
+ * synchronously, so the extra subscriptions are near-zero cost).
+ */
 // eslint-disable-next-line rulesdir/no-negated-variables
-function ReportNotFoundInnerGuard({
-    report,
-    reportIDFromPath,
-    reportID,
-    isOptimisticDelete,
-    isInvalidReportPath,
-    isLoading,
-    isLoadingApp,
-    isLoadingReportData,
-    isLoadingInitialReportActions,
-    isOffline,
-    userLeavingStatus,
-    deleteTransactionNavigateBackUrl,
-    children,
-}: ReportNotFoundInnerGuardProps) {
+function ReportNotFoundInnerGuard({reportIDFromPath, children}: ReportNotFoundInnerGuardProps) {
     const styles = useThemeStyles();
     const {shouldUseNarrowLayout} = useResponsiveLayout();
+    const {isOffline} = useNetwork();
 
+    const reportIDFromRoute = getNonEmptyStringOnyxID(reportIDFromPath);
+
+    const [report] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT}${reportIDFromRoute}`);
+    const [userLeavingStatus = false] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT_USER_IS_LEAVING_ROOM}${reportIDFromRoute}`);
+    const [isLoadingInitialReportActions = true] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT_METADATA}${reportIDFromRoute}`, {
+        selector: isLoadingInitialReportActionsSelector,
+    });
+    const [isLoadingReportData = true] = useOnyx(ONYXKEYS.IS_LOADING_REPORT_DATA);
+    const [isLoadingApp] = useOnyx(ONYXKEYS.IS_LOADING_APP);
+    const [deleteTransactionNavigateBackUrl] = useOnyx(ONYXKEYS.NVP_DELETE_TRANSACTION_NAVIGATE_BACK_URL);
     const [parentReportMetadata] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT_METADATA}${report?.parentReportID}`);
     const parentReportAction = useParentReportAction(report);
+
+    const reportID = report?.reportID;
+    const isOptimisticDelete = report?.statusNum === CONST.REPORT.STATUS_NUM.CLOSED;
+    const isInvalidReportPath = !!reportIDFromPath && !isValidReportIDFromPath(reportIDFromPath);
+    const isLoading = isLoadingApp !== false || isLoadingReportData || (!isOffline && !!isLoadingInitialReportActions);
 
     const {isParentActionMissingAfterLoad, isParentActionDeleted} = getParentReportActionDeletionStatus({
         parentReportID: report?.parentReportID,

--- a/src/pages/inbox/ReportNotFoundGuard.tsx
+++ b/src/pages/inbox/ReportNotFoundGuard.tsx
@@ -1,6 +1,7 @@
 import {useRoute} from '@react-navigation/native';
 import type {ReactNode} from 'react';
 import React, {useEffect} from 'react';
+import type {OnyxEntry} from 'react-native-onyx';
 import FullPageNotFoundView from '@components/BlockingViews/FullPageNotFoundView';
 import useNetwork from '@hooks/useNetwork';
 import useOnyx from '@hooks/useOnyx';
@@ -15,23 +16,31 @@ import {getParentReportActionDeletionStatus} from '@libs/TransactionNavigationUt
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
 import {isLoadingInitialReportActionsSelector} from '@src/selectors/ReportMetaData';
+import type * as OnyxTypes from '@src/types/onyx';
 
 type ReportNotFoundGuardProps = {
     children: ReactNode;
 };
 
+/**
+ * Two-level gate: the outer guard subscribes to lightweight keys to determine
+ * whether the report clearly exists. When it does (and the report is not a
+ * transaction thread), children render directly without the cost of
+ * parentReportMetadata / useParentReportAction subscriptions.
+ *
+ * The inner gate mounts only when the "not found" path is plausible:
+ * the report is missing, the path is invalid, or the report is a transaction
+ * thread whose parent action may have been deleted.
+ */
 // eslint-disable-next-line rulesdir/no-negated-variables
 function ReportNotFoundGuard({children}: ReportNotFoundGuardProps) {
-    const styles = useThemeStyles();
     const route = useRoute();
     const routeParams = route.params as {reportID?: string} | undefined;
     const reportIDFromRoute = getNonEmptyStringOnyxID(routeParams?.reportID);
 
     const {isOffline} = useNetwork();
-    const {shouldUseNarrowLayout} = useResponsiveLayout();
 
     const [report] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT}${reportIDFromRoute}`);
-    const [parentReportMetadata] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT_METADATA}${report?.parentReportID}`);
     const [userLeavingStatus = false] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT_USER_IS_LEAVING_ROOM}${reportIDFromRoute}`);
     const [isLoadingInitialReportActions = true] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT_METADATA}${reportIDFromRoute}`, {
         selector: isLoadingInitialReportActionsSelector,
@@ -40,9 +49,81 @@ function ReportNotFoundGuard({children}: ReportNotFoundGuardProps) {
     const [isLoadingApp] = useOnyx(ONYXKEYS.IS_LOADING_APP);
     const [deleteTransactionNavigateBackUrl] = useOnyx(ONYXKEYS.NVP_DELETE_TRANSACTION_NAVIGATE_BACK_URL);
 
-    const parentReportAction = useParentReportAction(report);
     const reportID = report?.reportID;
     const isOptimisticDelete = report?.statusNum === CONST.REPORT.STATUS_NUM.CLOSED;
+    const isInvalidReportPath = !!routeParams?.reportID && !isValidReportIDFromPath(routeParams.reportID);
+    const isLoading = isLoadingApp !== false || isLoadingReportData || (!isOffline && !!isLoadingInitialReportActions);
+    const mayBeTransactionThread = isReportTransactionThread(report);
+
+    // Fast path: skip the expensive inner guard (parentReportMetadata, useParentReportAction)
+    // when we can determine shouldShowNotFoundPage is definitely false.
+    //
+    // shouldShowNotFoundPage is false when:
+    //  - deleteTransactionNavigateBackUrl is set (always suppresses not-found), OR
+    //  - path is valid AND report is not a transaction thread AND (still loading OR report exists)
+    const reportClearlyExists = !!reportID || isOptimisticDelete || userLeavingStatus;
+    const canSkipInnerGuard = !!deleteTransactionNavigateBackUrl || (!isInvalidReportPath && !mayBeTransactionThread && (isLoading || reportClearlyExists));
+    if (canSkipInnerGuard) {
+        return children;
+    }
+
+    return (
+        <ReportNotFoundInnerGuard
+            report={report}
+            reportIDFromPath={routeParams?.reportID}
+            reportID={reportID}
+            isOptimisticDelete={isOptimisticDelete}
+            isInvalidReportPath={isInvalidReportPath}
+            isLoading={isLoading}
+            isLoadingApp={isLoadingApp}
+            isLoadingReportData={isLoadingReportData}
+            isLoadingInitialReportActions={isLoadingInitialReportActions}
+            isOffline={isOffline}
+            userLeavingStatus={userLeavingStatus}
+            deleteTransactionNavigateBackUrl={deleteTransactionNavigateBackUrl}
+        >
+            {children}
+        </ReportNotFoundInnerGuard>
+    );
+}
+
+type ReportNotFoundInnerGuardProps = {
+    report: OnyxEntry<OnyxTypes.Report>;
+    reportIDFromPath: string | undefined;
+    reportID: string | undefined;
+    isOptimisticDelete: boolean;
+    isInvalidReportPath: boolean;
+    isLoading: boolean;
+    isLoadingApp: OnyxEntry<boolean>;
+    isLoadingReportData: boolean;
+    isLoadingInitialReportActions: boolean;
+    isOffline: boolean;
+    userLeavingStatus: boolean;
+    deleteTransactionNavigateBackUrl: OnyxEntry<string>;
+    children: ReactNode;
+};
+
+// eslint-disable-next-line rulesdir/no-negated-variables
+function ReportNotFoundInnerGuard({
+    report,
+    reportIDFromPath,
+    reportID,
+    isOptimisticDelete,
+    isInvalidReportPath,
+    isLoading,
+    isLoadingApp,
+    isLoadingReportData,
+    isLoadingInitialReportActions,
+    isOffline,
+    userLeavingStatus,
+    deleteTransactionNavigateBackUrl,
+    children,
+}: ReportNotFoundInnerGuardProps) {
+    const styles = useThemeStyles();
+    const {shouldUseNarrowLayout} = useResponsiveLayout();
+
+    const [parentReportMetadata] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT_METADATA}${report?.parentReportID}`);
+    const parentReportAction = useParentReportAction(report);
 
     const {isParentActionMissingAfterLoad, isParentActionDeleted} = getParentReportActionDeletionStatus({
         parentReportID: report?.parentReportID,
@@ -53,8 +134,6 @@ function ReportNotFoundGuard({children}: ReportNotFoundGuardProps) {
     });
     const isDeletedTransactionThread = isReportTransactionThread(report) && (isParentActionDeleted || isParentActionMissingAfterLoad);
 
-    const isInvalidReportPath = !!routeParams?.reportID && !isValidReportIDFromPath(routeParams.reportID);
-    const isLoading = isLoadingApp !== false || isLoadingReportData || (!isOffline && !!isLoadingInitialReportActions);
     const reportExists = !!reportID || (!isDeletedTransactionThread && isOptimisticDelete) || userLeavingStatus;
 
     // eslint-disable-next-line rulesdir/no-negated-variables
@@ -73,7 +152,7 @@ function ReportNotFoundGuard({children}: ReportNotFoundGuardProps) {
             reportID,
             isOptimisticDelete,
             userLeavingStatus,
-            reportIDFromPath: routeParams?.reportID,
+            reportIDFromPath,
             deleteTransactionNavigateBackUrl,
             isDeletedTransactionThread,
             isParentActionDeleted,
@@ -88,7 +167,7 @@ function ReportNotFoundGuard({children}: ReportNotFoundGuardProps) {
         reportID,
         isOptimisticDelete,
         userLeavingStatus,
-        routeParams?.reportID,
+        reportIDFromPath,
         deleteTransactionNavigateBackUrl,
         isDeletedTransactionThread,
         isParentActionDeleted,

--- a/src/pages/inbox/ReportNotFoundGuard.tsx
+++ b/src/pages/inbox/ReportNotFoundGuard.tsx
@@ -21,18 +21,18 @@ type ReportNotFoundGuardProps = {
 };
 
 /**
- * Two-level gate: the outer guard subscribes to lightweight keys to determine
- * whether the report clearly exists. When it does (and the report is not a
- * transaction thread), children render directly without the cost of
- * parentReportMetadata / useParentReportAction subscriptions.
+ * Two-level gate: the outer guard subscribes to lightweight keys and handles
+ * all "obvious" not-found cases (invalid path, report missing after load).
  *
- * The inner gate mounts only when the "not found" path is plausible:
- * the report is missing, the path is invalid, or the report is a transaction
- * thread whose parent action may have been deleted.
+ * The inner gate mounts only for transaction threads, where the expensive
+ * parentReportMetadata / useParentReportAction subscriptions are needed to
+ * detect whether the parent action was deleted.
  */
 // eslint-disable-next-line rulesdir/no-negated-variables
 function ReportNotFoundGuard({children}: ReportNotFoundGuardProps) {
     const route = useRoute();
+    const styles = useThemeStyles();
+    const {shouldUseNarrowLayout} = useResponsiveLayout();
     const routeParams = route.params as {reportID?: string} | undefined;
     const reportIDFromRoute = getNonEmptyStringOnyxID(routeParams?.reportID);
 
@@ -51,76 +51,15 @@ function ReportNotFoundGuard({children}: ReportNotFoundGuardProps) {
     const isOptimisticDelete = report?.statusNum === CONST.REPORT.STATUS_NUM.CLOSED;
     const isInvalidReportPath = !!routeParams?.reportID && !isValidReportIDFromPath(routeParams.reportID);
     const isLoading = isLoadingApp !== false || isLoadingReportData || (!isOffline && !!isLoadingInitialReportActions);
-    const mayBeTransactionThread = isReportTransactionThread(report);
-
-    // Fast path: skip the expensive inner guard (parentReportMetadata, useParentReportAction)
-    // when we can determine shouldShowNotFoundPage is definitely false.
-    //
-    // shouldShowNotFoundPage is false when:
-    //  - deleteTransactionNavigateBackUrl is set (always suppresses not-found), OR
-    //  - path is valid AND report is not a transaction thread AND (still loading OR report exists)
-    const reportClearlyExists = !!reportID || isOptimisticDelete || userLeavingStatus;
-    const canSkipInnerGuard = !!deleteTransactionNavigateBackUrl || (!isInvalidReportPath && !mayBeTransactionThread && (isLoading || reportClearlyExists));
-    if (canSkipInnerGuard) {
-        return children;
-    }
-
-    return <ReportNotFoundInnerGuard reportIDFromPath={routeParams?.reportID}>{children}</ReportNotFoundInnerGuard>;
-}
-
-type ReportNotFoundInnerGuardProps = {
-    reportIDFromPath: string | undefined;
-    children: ReactNode;
-};
-
-/**
- * Inner guard that mounts only when the "not found" path is plausible.
- * Re-derives all state from its own hooks (Onyx returns cached values
- * synchronously, so the extra subscriptions are near-zero cost).
- */
-// eslint-disable-next-line rulesdir/no-negated-variables
-function ReportNotFoundInnerGuard({reportIDFromPath, children}: ReportNotFoundInnerGuardProps) {
-    const styles = useThemeStyles();
-    const {shouldUseNarrowLayout} = useResponsiveLayout();
-    const {isOffline} = useNetwork();
-
-    const reportIDFromRoute = getNonEmptyStringOnyxID(reportIDFromPath);
-
-    const [report] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT}${reportIDFromRoute}`);
-    const [userLeavingStatus = false] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT_USER_IS_LEAVING_ROOM}${reportIDFromRoute}`);
-    const [isLoadingInitialReportActions = true] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT_METADATA}${reportIDFromRoute}`, {
-        selector: isLoadingInitialReportActionsSelector,
-    });
-    const [isLoadingReportData = true] = useOnyx(ONYXKEYS.IS_LOADING_REPORT_DATA);
-    const [isLoadingApp] = useOnyx(ONYXKEYS.IS_LOADING_APP);
-    const [deleteTransactionNavigateBackUrl] = useOnyx(ONYXKEYS.NVP_DELETE_TRANSACTION_NAVIGATE_BACK_URL);
-    const [parentReportMetadata] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT_METADATA}${report?.parentReportID}`);
-    const parentReportAction = useParentReportAction(report);
-
-    const reportID = report?.reportID;
-    const isOptimisticDelete = report?.statusNum === CONST.REPORT.STATUS_NUM.CLOSED;
-    const isInvalidReportPath = !!reportIDFromPath && !isValidReportIDFromPath(reportIDFromPath);
-    const isLoading = isLoadingApp !== false || isLoadingReportData || (!isOffline && !!isLoadingInitialReportActions);
-
-    const {isParentActionMissingAfterLoad, isParentActionDeleted} = getParentReportActionDeletionStatus({
-        parentReportID: report?.parentReportID,
-        parentReportActionID: report?.parentReportActionID,
-        parentReportAction,
-        parentReportMetadata,
-        isOffline,
-    });
-    const isDeletedTransactionThread = isReportTransactionThread(report) && (isParentActionDeleted || isParentActionMissingAfterLoad);
-
-    const reportExists = !!reportID || (!isDeletedTransactionThread && isOptimisticDelete) || userLeavingStatus;
+    const reportExists = !!reportID || isOptimisticDelete || userLeavingStatus;
 
     // eslint-disable-next-line rulesdir/no-negated-variables
-    const shouldShowNotFoundPage = !deleteTransactionNavigateBackUrl && (isDeletedTransactionThread || isInvalidReportPath || (!isLoading && !reportExists));
+    const shouldShowNotFoundPage = !deleteTransactionNavigateBackUrl && (isInvalidReportPath || (!isLoading && !reportExists));
 
     useEffect(() => {
         if (!shouldShowNotFoundPage) {
             return;
         }
-
         Log.info('[ReportScreen] Displaying NotFound Page', false, {
             isLoadingApp,
             isLoadingReportData,
@@ -129,11 +68,8 @@ function ReportNotFoundInnerGuard({reportIDFromPath, children}: ReportNotFoundIn
             reportID,
             isOptimisticDelete,
             userLeavingStatus,
-            reportIDFromPath,
+            reportIDFromPath: routeParams?.reportID,
             deleteTransactionNavigateBackUrl,
-            isDeletedTransactionThread,
-            isParentActionDeleted,
-            isParentActionMissingAfterLoad,
         });
     }, [
         shouldShowNotFoundPage,
@@ -144,12 +80,78 @@ function ReportNotFoundInnerGuard({reportIDFromPath, children}: ReportNotFoundIn
         reportID,
         isOptimisticDelete,
         userLeavingStatus,
-        reportIDFromPath,
+        routeParams?.reportID,
         deleteTransactionNavigateBackUrl,
-        isDeletedTransactionThread,
-        isParentActionDeleted,
-        isParentActionMissingAfterLoad,
     ]);
+
+    if (shouldShowNotFoundPage) {
+        return (
+            <FullPageNotFoundView
+                shouldShow
+                subtitleKey="notFound.noAccess"
+                subtitleStyle={[styles.textSupporting]}
+                shouldShowBackButton={shouldUseNarrowLayout}
+                onBackButtonPress={Navigation.goBack}
+                shouldShowLink={false}
+                shouldDisplaySearchRouter
+            >
+                {children}
+            </FullPageNotFoundView>
+        );
+    }
+
+    if (isReportTransactionThread(report)) {
+        return <ReportNotFoundInnerGuard reportIDFromPath={routeParams?.reportID}>{children}</ReportNotFoundInnerGuard>;
+    }
+
+    return children;
+}
+
+type ReportNotFoundInnerGuardProps = {
+    reportIDFromPath: string | undefined;
+    children: ReactNode;
+};
+
+/**
+ * Inner guard for transaction threads only. Subscribes to the expensive
+ * parentReportMetadata and parentReportAction to detect deleted parent actions.
+ */
+// eslint-disable-next-line rulesdir/no-negated-variables
+function ReportNotFoundInnerGuard({reportIDFromPath, children}: ReportNotFoundInnerGuardProps) {
+    const styles = useThemeStyles();
+    const {shouldUseNarrowLayout} = useResponsiveLayout();
+    const {isOffline} = useNetwork();
+
+    const reportIDFromRoute = getNonEmptyStringOnyxID(reportIDFromPath);
+
+    const [report] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT}${reportIDFromRoute}`);
+    const [deleteTransactionNavigateBackUrl] = useOnyx(ONYXKEYS.NVP_DELETE_TRANSACTION_NAVIGATE_BACK_URL);
+    const [parentReportMetadata] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT_METADATA}${report?.parentReportID}`);
+    const parentReportAction = useParentReportAction(report);
+
+    const {isParentActionMissingAfterLoad, isParentActionDeleted} = getParentReportActionDeletionStatus({
+        parentReportID: report?.parentReportID,
+        parentReportActionID: report?.parentReportActionID,
+        parentReportAction,
+        parentReportMetadata,
+        isOffline,
+    });
+    const isDeletedTransactionThread = isReportTransactionThread(report) && (isParentActionDeleted || isParentActionMissingAfterLoad);
+
+    // eslint-disable-next-line rulesdir/no-negated-variables
+    const shouldShowNotFoundPage = !deleteTransactionNavigateBackUrl && isDeletedTransactionThread;
+
+    useEffect(() => {
+        if (!shouldShowNotFoundPage) {
+            return;
+        }
+        Log.info('[ReportScreen] Displaying NotFound Page (deleted transaction thread)', false, {
+            reportIDFromPath,
+            deleteTransactionNavigateBackUrl,
+            isParentActionDeleted,
+            isParentActionMissingAfterLoad,
+        });
+    }, [shouldShowNotFoundPage, reportIDFromPath, deleteTransactionNavigateBackUrl, isParentActionDeleted, isParentActionMissingAfterLoad]);
 
     return (
         <FullPageNotFoundView

--- a/src/pages/inbox/ReportNotFoundGuard.tsx
+++ b/src/pages/inbox/ReportNotFoundGuard.tsx
@@ -132,10 +132,8 @@ function ReportNotFoundInnerGuard({reportIDFromPath, children}: ReportNotFoundIn
         parentReportMetadata,
         isOffline,
     });
-    const isDeletedTransactionThread = isParentActionDeleted || isParentActionMissingAfterLoad;
-
     // eslint-disable-next-line rulesdir/no-negated-variables
-    const shouldShowNotFoundPage = isDeletedTransactionThread;
+    const shouldShowNotFoundPage = isParentActionDeleted || isParentActionMissingAfterLoad;
 
     useEffect(() => {
         if (!shouldShowNotFoundPage) {

--- a/src/pages/inbox/ReportNotFoundGuard.tsx
+++ b/src/pages/inbox/ReportNotFoundGuard.tsx
@@ -21,12 +21,9 @@ type ReportNotFoundGuardProps = {
 };
 
 /**
- * Two-level gate: the outer guard subscribes to lightweight keys and handles
+ * The outer guard subscribes to lightweight keys and handles
  * all "obvious" not-found cases (invalid path, report missing after load).
  *
- * The inner gate mounts only for transaction threads, where the expensive
- * parentReportMetadata / useParentReportAction subscriptions are needed to
- * detect whether the parent action was deleted.
  */
 // eslint-disable-next-line rulesdir/no-negated-variables
 function ReportNotFoundGuard({children}: ReportNotFoundGuardProps) {
@@ -100,7 +97,7 @@ function ReportNotFoundGuard({children}: ReportNotFoundGuardProps) {
         );
     }
 
-    if (isReportTransactionThread(report)) {
+    if (!deleteTransactionNavigateBackUrl && isReportTransactionThread(report)) {
         return <ReportNotFoundInnerGuard reportIDFromPath={routeParams?.reportID}>{children}</ReportNotFoundInnerGuard>;
     }
 
@@ -125,7 +122,6 @@ function ReportNotFoundInnerGuard({reportIDFromPath, children}: ReportNotFoundIn
     const reportIDFromRoute = getNonEmptyStringOnyxID(reportIDFromPath);
 
     const [report] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT}${reportIDFromRoute}`);
-    const [deleteTransactionNavigateBackUrl] = useOnyx(ONYXKEYS.NVP_DELETE_TRANSACTION_NAVIGATE_BACK_URL);
     const [parentReportMetadata] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT_METADATA}${report?.parentReportID}`);
     const parentReportAction = useParentReportAction(report);
 
@@ -136,10 +132,10 @@ function ReportNotFoundInnerGuard({reportIDFromPath, children}: ReportNotFoundIn
         parentReportMetadata,
         isOffline,
     });
-    const isDeletedTransactionThread = isReportTransactionThread(report) && (isParentActionDeleted || isParentActionMissingAfterLoad);
+    const isDeletedTransactionThread = isParentActionDeleted || isParentActionMissingAfterLoad;
 
     // eslint-disable-next-line rulesdir/no-negated-variables
-    const shouldShowNotFoundPage = !deleteTransactionNavigateBackUrl && isDeletedTransactionThread;
+    const shouldShowNotFoundPage = isDeletedTransactionThread;
 
     useEffect(() => {
         if (!shouldShowNotFoundPage) {
@@ -147,11 +143,10 @@ function ReportNotFoundInnerGuard({reportIDFromPath, children}: ReportNotFoundIn
         }
         Log.info('[ReportScreen] Displaying NotFound Page (deleted transaction thread)', false, {
             reportIDFromPath,
-            deleteTransactionNavigateBackUrl,
             isParentActionDeleted,
             isParentActionMissingAfterLoad,
         });
-    }, [shouldShowNotFoundPage, reportIDFromPath, deleteTransactionNavigateBackUrl, isParentActionDeleted, isParentActionMissingAfterLoad]);
+    }, [shouldShowNotFoundPage, reportIDFromPath, isParentActionDeleted, isParentActionMissingAfterLoad]);
 
     return (
         <FullPageNotFoundView


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
<!-- Explain what your change does and how it addresses the linked issue -->

`ReportNotFoundGuard` previously subscribed to expensive Onyx keys (`parentReportMetadata` via `useOnyx` and the full parent report actions collection via `useParentReportAction`) on every render, even when the report clearly exists and the "not found" page will never be shown.

This change introduces a two-level gate pattern, following the same approach already used by `LinkedActionNotFoundGuard` in the codebase. The outer guard subscribes only to lightweight Onyx keys and determines whether the report clearly exists. When it does (and the report is not a transaction thread), children render directly without mounting the expensive subscriptions. The inner guard is a self-contained component that only mounts when the "not found" path is plausible: the report is missing, the path is invalid, or the report is a transaction thread whose parent action may have been deleted. The inner guard re-derives all its state from its own hooks, keeping the interface minimal (only `reportIDFromPath` and `children` props).

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/87632
PROPOSAL:


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

- [ ] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->
// TODO: These must be filled out, or the issue title must include "[No QA]."

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>