### PR TITLE
Adjust Spend Over Time widget's visibility on home page

### DIFF
--- a/src/pages/home/SpendOverTimeSection/SpendOverTimeSectionContent.tsx
+++ b/src/pages/home/SpendOverTimeSection/SpendOverTimeSectionContent.tsx
@@ -30,7 +30,7 @@ function SpendOverTimeSectionContent() {
         return null;
     }
 
-    if (!shouldShowErrorIndicator && sortedData?.length === 0) {
+    if (!shouldShowErrorIndicator && (sortedData?.length ?? 0 < 2)) {
         return null;
     }
 

--- a/src/pages/home/SpendOverTimeSection/SpendOverTimeSectionContent.tsx
+++ b/src/pages/home/SpendOverTimeSection/SpendOverTimeSectionContent.tsx
@@ -30,7 +30,7 @@ function SpendOverTimeSectionContent() {
         return null;
     }
 
-    if (!shouldShowErrorIndicator && (sortedData?.length ?? 0 < 2)) {
+    if (!shouldShowErrorIndicator && (sortedData?.length ?? 0) < 2) {
         return null;
     }
 

--- a/src/pages/home/SpendOverTimeSection/SpendOverTimeSectionContent.tsx
+++ b/src/pages/home/SpendOverTimeSection/SpendOverTimeSectionContent.tsx
@@ -14,7 +14,7 @@ import Navigation from '@libs/Navigation/Navigation';
 import variables from '@styles/variables';
 import CONST from '@src/CONST';
 import ROUTES from '@src/ROUTES';
-import useSpendOverTimeData from './useSpendOverTimeData';
+import useSpendOverTimeData, {SPEND_OVER_TIME_STATE} from './useSpendOverTimeData';
 
 function SpendOverTimeSectionContent() {
     const styles = useThemeStyles();
@@ -24,13 +24,9 @@ function SpendOverTimeSectionContent() {
     const illustrations = useMemoizedLazyIllustrations(['BrokenMagnifyingGlass']);
     const {shouldUseNarrowLayout} = useResponsiveLayout();
 
-    const {query, queryJSON, groupBy, view, sortedData, shouldShowOfflineIndicator, shouldShowErrorIndicator, shouldShowLoadingIndicator} = useSpendOverTimeData();
+    const {query, queryJSON, groupBy, view, sortedData, state} = useSpendOverTimeData();
 
-    if (!queryJSON || !view || !groupBy || view === CONST.SEARCH.VIEW.TABLE) {
-        return null;
-    }
-
-    if (!shouldShowErrorIndicator && !shouldShowLoadingIndicator && (sortedData?.length ?? 0) < 2) {
+    if (!queryJSON || !view || !groupBy || view === CONST.SEARCH.VIEW.TABLE || state === SPEND_OVER_TIME_STATE.HIDDEN) {
         return null;
     }
 
@@ -38,7 +34,7 @@ function SpendOverTimeSectionContent() {
         <WidgetContainer
             title={translate('search.spendOverTime')}
             titleRightContent={
-                shouldShowOfflineIndicator || shouldShowLoadingIndicator || shouldShowErrorIndicator ? null : (
+                state === SPEND_OVER_TIME_STATE.READY ? (
                     <Button
                         small
                         text={translate('common.view')}
@@ -49,10 +45,10 @@ function SpendOverTimeSectionContent() {
                         style={styles.widgetItemButton}
                         isContentCentered
                     />
-                )
+                ) : null
             }
         >
-            {shouldShowOfflineIndicator && (
+            {state === SPEND_OVER_TIME_STATE.OFFLINE && (
                 <BlockingView
                     icon={icons.OfflineCloud}
                     iconColor={theme.offline}
@@ -64,7 +60,7 @@ function SpendOverTimeSectionContent() {
                     containerStyle={[{minHeight: CHART_CONTENT_MIN_HEIGHT}, styles.gap5]}
                 />
             )}
-            {shouldShowErrorIndicator && (
+            {state === SPEND_OVER_TIME_STATE.ERROR && (
                 <BlockingView
                     icon={illustrations.BrokenMagnifyingGlass}
                     iconHeight={variables.iconSizeMegaLarge}
@@ -78,14 +74,14 @@ function SpendOverTimeSectionContent() {
                     contentFitImage="contain"
                 />
             )}
-            {!shouldShowOfflineIndicator && !shouldShowErrorIndicator && (
+            {(state === SPEND_OVER_TIME_STATE.LOADING || state === SPEND_OVER_TIME_STATE.READY) && (
                 <View style={[shouldUseNarrowLayout ? styles.ph5 : [styles.ph8, styles.pt3]]}>
                     <SearchChartView
                         queryJSON={queryJSON}
                         view={view}
                         groupBy={groupBy}
                         data={sortedData ?? []}
-                        isLoading={shouldShowLoadingIndicator}
+                        isLoading={state === SPEND_OVER_TIME_STATE.LOADING}
                     />
                 </View>
             )}

--- a/src/pages/home/SpendOverTimeSection/SpendOverTimeSectionContent.tsx
+++ b/src/pages/home/SpendOverTimeSection/SpendOverTimeSectionContent.tsx
@@ -30,7 +30,7 @@ function SpendOverTimeSectionContent() {
         return null;
     }
 
-    if (!shouldShowErrorIndicator && (sortedData?.length ?? 0) < 2) {
+    if (!shouldShowErrorIndicator && !shouldShowLoadingIndicator && (sortedData?.length ?? 0) < 2) {
         return null;
     }
 

--- a/src/pages/home/SpendOverTimeSection/index.tsx
+++ b/src/pages/home/SpendOverTimeSection/index.tsx
@@ -10,14 +10,9 @@ function SpendOverTimeSection() {
     const [isAnyPolicyEligibleForSpendOverTime] = useOnyx(ONYXKEYS.COLLECTION.POLICY, {
         selector: (policies) => Object.values(policies ?? {}).some((policy) => !!policy && isPolicyEligibleForSpendOverTime(policy, login)),
     });
-    const [hasTransactions] = useOnyx(ONYXKEYS.COLLECTION.TRANSACTION, {
-        selector: (transactions) => Object.keys(transactions ?? {}).length > 0,
-    });
 
     // The widget is only shown for workspace admins/auditors/approvers.
-    // If there are no transactions (e.g. a brand new account) we expect the Search results to be empty,
-    // so we don't show the section to avoid briefly displaying a loading widget that disappears once the empty results load.
-    if (!isAnyPolicyEligibleForSpendOverTime || !hasTransactions) {
+    if (!isAnyPolicyEligibleForSpendOverTime) {
         return null;
     }
 

--- a/src/pages/home/SpendOverTimeSection/useSpendOverTimeData.ts
+++ b/src/pages/home/SpendOverTimeSection/useSpendOverTimeData.ts
@@ -28,7 +28,7 @@ function getSpendOverTimeState(
     queryJSON: SearchQueryJSON | undefined,
     sortedData: GroupedItem[] | undefined,
 ): SpendOverTimeState {
-    if (isOffline && (sortedData?.length ?? 0) < 2) {
+    if (isOffline && !sortedData) {
         return SPEND_OVER_TIME_STATE.OFFLINE;
     }
     if (!isOffline && Object.keys(searchResults?.errors ?? {}).length > 0) {

--- a/src/pages/home/SpendOverTimeSection/useSpendOverTimeData.ts
+++ b/src/pages/home/SpendOverTimeSection/useSpendOverTimeData.ts
@@ -28,7 +28,7 @@ function getSpendOverTimeState(
     queryJSON: SearchQueryJSON | undefined,
     sortedData: GroupedItem[] | undefined,
 ): SpendOverTimeState {
-    if (isOffline && (!sortedData || sortedData.length === 0)) {
+    if (isOffline && (sortedData?.length ?? 0) < 2) {
         return SPEND_OVER_TIME_STATE.OFFLINE;
     }
     if (!isOffline && Object.keys(searchResults?.errors ?? {}).length > 0) {
@@ -112,5 +112,5 @@ function useSpendOverTimeData() {
     };
 }
 
-export {SPEND_OVER_TIME_STATE};
+export {SPEND_OVER_TIME_STATE, getSpendOverTimeState};
 export default useSpendOverTimeData;

--- a/src/pages/home/SpendOverTimeSection/useSpendOverTimeData.ts
+++ b/src/pages/home/SpendOverTimeSection/useSpendOverTimeData.ts
@@ -28,13 +28,15 @@ function getSpendOverTimeState(
     queryJSON: SearchQueryJSON | undefined,
     sortedData: GroupedItem[] | undefined,
 ): SpendOverTimeState {
-    if (isOffline && !sortedData) {
+    const isDataLoaded = isSearchDataLoaded(searchResults, queryJSON);
+
+    if (isOffline && !isDataLoaded) {
         return SPEND_OVER_TIME_STATE.OFFLINE;
     }
     if (!isOffline && Object.keys(searchResults?.errors ?? {}).length > 0) {
         return SPEND_OVER_TIME_STATE.ERROR;
     }
-    if (!isSearchDataLoaded(searchResults, queryJSON)) {
+    if (!isDataLoaded) {
         return SPEND_OVER_TIME_STATE.LOADING;
     }
     if ((sortedData?.length ?? 0) < 2) {

--- a/src/pages/home/SpendOverTimeSection/useSpendOverTimeData.ts
+++ b/src/pages/home/SpendOverTimeSection/useSpendOverTimeData.ts
@@ -1,5 +1,7 @@
 import {useEffect, useEffectEvent} from 'react';
-import type {GroupedItem} from '@components/Search/types';
+import type {OnyxEntry} from 'react-native-onyx';
+import type {ValueOf} from 'type-fest';
+import type {GroupedItem, SearchQueryJSON} from '@components/Search/types';
 import useCurrentUserPersonalDetails from '@hooks/useCurrentUserPersonalDetails';
 import useLocalize from '@hooks/useLocalize';
 import useNetwork from '@hooks/useNetwork';
@@ -8,6 +10,38 @@ import {search} from '@libs/actions/Search';
 import {getSections, getSortedSections, getSuggestedSearches, isSearchDataLoaded} from '@libs/SearchUIUtils';
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
+import type SearchResults from '@src/types/onyx/SearchResults';
+
+const SPEND_OVER_TIME_STATE = {
+    OFFLINE: 'offline',
+    ERROR: 'error',
+    LOADING: 'loading',
+    HIDDEN: 'hidden',
+    READY: 'ready',
+} as const;
+
+type SpendOverTimeState = ValueOf<typeof SPEND_OVER_TIME_STATE>;
+
+function getSpendOverTimeState(
+    isOffline: boolean,
+    searchResults: OnyxEntry<SearchResults>,
+    queryJSON: SearchQueryJSON | undefined,
+    sortedData: GroupedItem[] | undefined,
+): SpendOverTimeState {
+    if (isOffline && (!sortedData || sortedData.length === 0)) {
+        return SPEND_OVER_TIME_STATE.OFFLINE;
+    }
+    if (!isOffline && Object.keys(searchResults?.errors ?? {}).length > 0) {
+        return SPEND_OVER_TIME_STATE.ERROR;
+    }
+    if (!isSearchDataLoaded(searchResults, queryJSON)) {
+        return SPEND_OVER_TIME_STATE.LOADING;
+    }
+    if ((sortedData?.length ?? 0) < 2) {
+        return SPEND_OVER_TIME_STATE.HIDDEN;
+    }
+    return SPEND_OVER_TIME_STATE.READY;
+}
 
 function useSpendOverTimeData() {
     const config = getSuggestedSearches()[CONST.SEARCH.SEARCH_KEYS.SPEND_OVER_TIME];
@@ -21,7 +55,7 @@ function useSpendOverTimeData() {
 
     const {isOffline} = useNetwork();
 
-    const fetchData = () => {
+    const onConfigChanged = useEffectEvent(() => {
         if (!queryJSON || isSearchLoading || isOffline) {
             return;
         }
@@ -34,9 +68,7 @@ function useSpendOverTimeData() {
             isLoading: false,
             shouldUpdateLastSearchParams: false,
         });
-    };
-
-    const onConfigChanged = useEffectEvent(fetchData);
+    });
 
     useEffect(() => {
         onConfigChanged();
@@ -68,9 +100,7 @@ function useSpendOverTimeData() {
               ) as GroupedItem[])
             : undefined;
 
-    const shouldShowOfflineIndicator = isOffline && (!sortedData || sortedData.length === 0);
-    const shouldShowErrorIndicator = !isOffline && Object.keys(searchResults?.errors ?? {}).length > 0;
-    const shouldShowLoadingIndicator = !shouldShowOfflineIndicator && !shouldShowErrorIndicator && !isSearchDataLoaded(searchResults, queryJSON);
+    const state = getSpendOverTimeState(isOffline, searchResults, queryJSON, sortedData);
 
     return {
         query,
@@ -78,10 +108,9 @@ function useSpendOverTimeData() {
         groupBy,
         view,
         sortedData,
-        shouldShowOfflineIndicator,
-        shouldShowErrorIndicator,
-        shouldShowLoadingIndicator,
+        state,
     };
 }
 
+export {SPEND_OVER_TIME_STATE};
 export default useSpendOverTimeData;

--- a/tests/unit/Search/getSpendOverTimeStateTest.ts
+++ b/tests/unit/Search/getSpendOverTimeStateTest.ts
@@ -24,7 +24,6 @@ const makeData = (count: number): GroupedItem[] => Array.from({length: count}, (
 describe('getSpendOverTimeState', () => {
     it('returns OFFLINE when offline with no data', () => {
         expect(getSpendOverTimeState(true, undefined, queryJSON, undefined)).toBe(SPEND_OVER_TIME_STATE.OFFLINE);
-        expect(getSpendOverTimeState(true, undefined, queryJSON, [])).toBe(SPEND_OVER_TIME_STATE.OFFLINE);
     });
 
     it('returns READY when offline but cached data exists', () => {
@@ -35,11 +34,6 @@ describe('getSpendOverTimeState', () => {
     it('returns ERROR when online and searchResults has errors', () => {
         const results = makeSearchResults({errors: {someError: 'Something went wrong'}});
         expect(getSpendOverTimeState(false, results, queryJSON, makeData(5))).toBe(SPEND_OVER_TIME_STATE.ERROR);
-    });
-
-    it('does not return ERROR when offline even if errors exist', () => {
-        const results = makeSearchResults({errors: {someError: 'err'}});
-        expect(getSpendOverTimeState(true, results, queryJSON, [])).toBe(SPEND_OVER_TIME_STATE.OFFLINE);
     });
 
     it('returns LOADING when data has not loaded yet', () => {

--- a/tests/unit/Search/getSpendOverTimeStateTest.ts
+++ b/tests/unit/Search/getSpendOverTimeStateTest.ts
@@ -1,0 +1,60 @@
+import type {GroupedItem, SearchQueryJSON} from '@components/Search/types';
+import {getSpendOverTimeState, SPEND_OVER_TIME_STATE} from '@pages/home/SpendOverTimeSection/useSpendOverTimeData';
+import CONST from '@src/CONST';
+import type SearchResults from '@src/types/onyx/SearchResults';
+
+const queryJSON: SearchQueryJSON = {
+    type: CONST.SEARCH.DATA_TYPES.EXPENSE,
+    status: CONST.SEARCH.STATUS.EXPENSE.ALL,
+    groupBy: CONST.SEARCH.GROUP_BY.MONTH,
+    view: CONST.SEARCH.VIEW.LINE,
+    sortBy: CONST.SEARCH.TABLE_COLUMNS.GROUP_MONTH,
+    sortOrder: CONST.SEARCH.SORT_ORDER.ASC,
+} as SearchQueryJSON;
+
+const makeSearchResults = (overrides: Partial<SearchResults> = {}): SearchResults =>
+    ({
+        search: {offset: 0, type: queryJSON.type, status: queryJSON.status, hasMoreResults: false, hasResults: true, isLoading: false},
+        data: {},
+        ...overrides,
+    }) as SearchResults;
+
+const makeData = (count: number): GroupedItem[] => Array.from({length: count}, (_, i) => ({keyForList: String(i)})) as unknown as GroupedItem[];
+
+describe('getSpendOverTimeState', () => {
+    it('returns OFFLINE when offline with no data', () => {
+        expect(getSpendOverTimeState(true, undefined, queryJSON, undefined)).toBe(SPEND_OVER_TIME_STATE.OFFLINE);
+        expect(getSpendOverTimeState(true, undefined, queryJSON, [])).toBe(SPEND_OVER_TIME_STATE.OFFLINE);
+    });
+
+    it('returns READY when offline but cached data exists', () => {
+        const results = makeSearchResults();
+        expect(getSpendOverTimeState(true, results, queryJSON, makeData(3))).toBe(SPEND_OVER_TIME_STATE.READY);
+    });
+
+    it('returns ERROR when online and searchResults has errors', () => {
+        const results = makeSearchResults({errors: {someError: 'Something went wrong'}});
+        expect(getSpendOverTimeState(false, results, queryJSON, makeData(5))).toBe(SPEND_OVER_TIME_STATE.ERROR);
+    });
+
+    it('does not return ERROR when offline even if errors exist', () => {
+        const results = makeSearchResults({errors: {someError: 'err'}});
+        expect(getSpendOverTimeState(true, results, queryJSON, [])).toBe(SPEND_OVER_TIME_STATE.OFFLINE);
+    });
+
+    it('returns LOADING when data has not loaded yet', () => {
+        expect(getSpendOverTimeState(false, undefined, queryJSON, undefined)).toBe(SPEND_OVER_TIME_STATE.LOADING);
+    });
+
+    it('returns HIDDEN when loaded but fewer than 2 data points', () => {
+        const results = makeSearchResults();
+        expect(getSpendOverTimeState(false, results, queryJSON, [])).toBe(SPEND_OVER_TIME_STATE.HIDDEN);
+        expect(getSpendOverTimeState(false, results, queryJSON, makeData(1))).toBe(SPEND_OVER_TIME_STATE.HIDDEN);
+    });
+
+    it('returns READY when loaded with 2+ data points', () => {
+        const results = makeSearchResults();
+        expect(getSpendOverTimeState(false, results, queryJSON, makeData(2))).toBe(SPEND_OVER_TIME_STATE.READY);
+        expect(getSpendOverTimeState(false, results, queryJSON, makeData(10))).toBe(SPEND_OVER_TIME_STATE.READY);
+    });
+});


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
<!-- Explain what your change does and how it addresses the linked issue -->

Hides the Spend Over Time widget on the home screen when there are fewer than two data points, as a single point doesn't provide a meaningful visualization.

Also removes the pre-check that required at least one transaction before showing the widget. This condition was originally added to prevent brand new accounts with new workspaces from briefly seeing a loading widget that disappears once empty results load. However, it was found to sometimes hide the widget when it should be visible.

Known issues present even with the fixes:
- On initial load, the widget briefly shows a loading state that disappears if the data from the backend is empty or contains fewer than two data points.
- If the widget is hidden due to insufficient data and the data later changes to meet the visibility threshold, the widget appears without a loading state, causing a layout shift.

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/87481
$ https://github.com/Expensify/App/issues/87277
PROPOSAL: https://github.com/Expensify/App/issues/87481#issuecomment-4213540491


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

* Widget visible - eligible user with sufficient data

1. Log in as a workspace admin/auditor/approver whose workspace has expenses across 2+ months in the last 12 months
2. Navigate to the home screen
3. Expected: Spend Over Time widget is visible with a line chart

* Widget hidden - single data point

1. Log in as an eligible user whose workspace's expenses in the last 12 months all fall within a
single month
3. Navigate to the home screen
4. Expected: Widget is not shown

* Widget hidden - no data

1. Log in as an eligible user who has no expenses in the last 12 months
2. Navigate to the home screen
3. Expected: Widget is not shown

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

1. Go offline while on the home page and the widget is showing a line chart.
2. Expected: Widget should still show.
3. Go offline while on the home page and the widget is not shown due to there being 0 or 1 data points.
2. Expected: Widget should still not show.
4. Go back online.
5. Go to Troubleshooting > Clear cache and restart.
6. Go offline.
7. Go to home page.
8. Expected: Offline indicator should be shown instead.

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
4. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->

Same as tests.

Known issues present even with the fixes:
- On initial load, the widget briefly shows a loading state that disappears if the data from the backend is empty or contains fewer than two data points.
- If the widget is hidden due to insufficient data and the data later changes to meet the visibility threshold, the widget appears without a loading state, causing a layout shift.

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

https://github.com/user-attachments/assets/407b0943-9b2c-4408-aa6f-d75206b26211

</details>