### PR TITLE
Fix Chat - App returns to main chat after refreshing Flag as offensive RHP in thread 

### DIFF
--- a/src/libs/Navigation/helpers/dynamicRoutesUtils/isDynamicRouteScreen.ts
+++ b/src/libs/Navigation/helpers/dynamicRoutesUtils/isDynamicRouteScreen.ts
@@ -1,0 +1,21 @@
+import {normalizedConfigs} from '@libs/Navigation/linkingConfig/config';
+import type {DynamicRouteSuffix} from '@src/ROUTES';
+import type {Screen} from '@src/SCREENS';
+import {dynamicRoutePaths} from './isDynamicRouteSuffix';
+
+/**
+ * Checks if a screen name is a dynamic route screen
+ * @param screenName - The name of the screen to check.
+ * @returns True if the screen name is a dynamic route screen, false otherwise.
+ */
+function isDynamicRouteScreen(screenName: Screen): boolean {
+    const screenPath = normalizedConfigs[screenName]?.path;
+
+    if (!screenPath) {
+        return false;
+    }
+
+    return dynamicRoutePaths.has(screenPath as DynamicRouteSuffix);
+}
+
+export default isDynamicRouteScreen;

--- a/src/libs/Navigation/helpers/getAdaptedStateFromPath.ts
+++ b/src/libs/Navigation/helpers/getAdaptedStateFromPath.ts
@@ -54,7 +54,6 @@ function getSearchScreenNameForRoute(route: NavigationPartialRoute): string {
 }
 
 function getMatchingFullScreenRoute(route: NavigationPartialRoute) {
-
     const isDynamicScreen = route.name.startsWith('Dynamic_');
     const dynamicSuffixMatch = findMatchingDynamicSuffix(route?.path);
 

--- a/src/libs/Navigation/helpers/getAdaptedStateFromPath.ts
+++ b/src/libs/Navigation/helpers/getAdaptedStateFromPath.ts
@@ -54,8 +54,16 @@ function getSearchScreenNameForRoute(route: NavigationPartialRoute): string {
 }
 
 function getMatchingFullScreenRoute(route: NavigationPartialRoute) {
+
+    const isDynamicScreen = route.name.startsWith('Dynamic_');
+    const dynamicSuffixMatch = findMatchingDynamicSuffix(route?.path);
+
     // Check for backTo param. One screen with different backTo value may need different screens visible under the overlay.
-    if (isRouteWithBackToParam(route)) {
+    // Before checking backTo, we verify the URL doesn't end with a dynamic route suffix.
+    // Dynamic routes never carry their own backTo - they only inherit it from the screen underneath.
+    // So when a dynamic suffix is present, we must strip it first to resolve the correct full-screen
+    // route from the base path, rather than letting backTo (which belongs to the underlying screen) dictate it.
+    if (isRouteWithBackToParam(route) && !dynamicSuffixMatch && !isDynamicScreen) {
         const stateForBackTo = getStateFromPath(route.params.backTo as RoutePath);
 
         // This may happen if the backTo url is invalid.
@@ -184,41 +192,38 @@ function getMatchingFullScreenRoute(route: NavigationPartialRoute) {
     }
 
     // Handle dynamic routes: find the appropriate full screen route
-    if (route.path) {
-        const suffixMatch = findMatchingDynamicSuffix(route.path);
-        if (suffixMatch) {
-            // Strip the suffix from the URL. For parametric routes we pass both the actual URL
-            // suffix and the registered pattern so query params can be resolved correctly.
-            const pathWithoutDynamicSuffix = getPathWithoutDynamicSuffix(route.path, suffixMatch.actualSuffix, suffixMatch.pattern);
+    if (route.path && dynamicSuffixMatch) {
+        // Strip the suffix from the URL. For parametric routes we pass both the actual URL
+        // suffix and the registered pattern so query params can be resolved correctly.
+        const pathWithoutDynamicSuffix = getPathWithoutDynamicSuffix(route.path, dynamicSuffixMatch.actualSuffix, dynamicSuffixMatch.pattern);
 
-            if (!pathWithoutDynamicSuffix) {
-                return undefined;
-            }
-
-            // Parse the base path (without dynamic suffix) into a navigation state
-            // to determine which full-screen route should be visible underneath the overlay.
-            const stateUnderDynamicRoute = getStateFromPath(pathWithoutDynamicSuffix);
-            const lastRoute = stateUnderDynamicRoute?.routes.at(-1);
-
-            if (!stateUnderDynamicRoute || !lastRoute || lastRoute.name === SCREENS.NOT_FOUND) {
-                return undefined;
-            }
-
-            const isLastRouteFullScreen = isFullScreenName(lastRoute.name);
-
-            if (isLastRouteFullScreen) {
-                return lastRoute;
-            }
-
-            const focusedRouteUnderDynamicRoute = findFocusedRouteWithOnyxTabGuard(stateUnderDynamicRoute);
-
-            if (!focusedRouteUnderDynamicRoute) {
-                return undefined;
-            }
-
-            // Recursively find the matching full screen route for the focused dynamic route
-            return getMatchingFullScreenRoute(focusedRouteUnderDynamicRoute);
+        if (!pathWithoutDynamicSuffix) {
+            return undefined;
         }
+
+        // Parse the base path (without dynamic suffix) into a navigation state
+        // to determine which full-screen route should be visible underneath the overlay.
+        const stateUnderDynamicRoute = getStateFromPath(pathWithoutDynamicSuffix);
+        const lastRoute = stateUnderDynamicRoute?.routes.at(-1);
+
+        if (!stateUnderDynamicRoute || !lastRoute || lastRoute.name === SCREENS.NOT_FOUND) {
+            return undefined;
+        }
+
+        const isLastRouteFullScreen = isFullScreenName(lastRoute.name);
+
+        if (isLastRouteFullScreen) {
+            return lastRoute;
+        }
+
+        const focusedRouteUnderDynamicRoute = findFocusedRouteWithOnyxTabGuard(stateUnderDynamicRoute);
+
+        if (!focusedRouteUnderDynamicRoute) {
+            return undefined;
+        }
+
+        // Recursively find the matching full screen route for the focused dynamic route
+        return getMatchingFullScreenRoute(focusedRouteUnderDynamicRoute);
     }
 
     return undefined;

--- a/src/libs/Navigation/helpers/getAdaptedStateFromPath.ts
+++ b/src/libs/Navigation/helpers/getAdaptedStateFromPath.ts
@@ -10,8 +10,10 @@ import NAVIGATORS from '@src/NAVIGATORS';
 import type {Route as RoutePath} from '@src/ROUTES';
 import ROUTES from '@src/ROUTES';
 import SCREENS from '@src/SCREENS';
+import type {Screen} from '@src/SCREENS';
 import findMatchingDynamicSuffix from './dynamicRoutesUtils/findMatchingDynamicSuffix';
 import getPathWithoutDynamicSuffix from './dynamicRoutesUtils/getPathWithoutDynamicSuffix';
+import isDynamicRouteScreen from './dynamicRoutesUtils/isDynamicRouteScreen';
 import findFocusedRouteWithOnyxTabGuard from './findFocusedRouteWithOnyxTabGuard';
 import getMatchingNewRoute from './getMatchingNewRoute';
 import getParamsFromRoute from './getParamsFromRoute';
@@ -54,15 +56,14 @@ function getSearchScreenNameForRoute(route: NavigationPartialRoute): string {
 }
 
 function getMatchingFullScreenRoute(route: NavigationPartialRoute) {
-    const isDynamicScreen = route.name.startsWith('Dynamic_');
-    const dynamicSuffixMatch = findMatchingDynamicSuffix(route?.path);
+    const isDynamicScreen = isDynamicRouteScreen(route.name as Screen);
 
     // Check for backTo param. One screen with different backTo value may need different screens visible under the overlay.
     // Before checking backTo, we verify the URL doesn't end with a dynamic route suffix.
     // Dynamic routes never carry their own backTo - they only inherit it from the screen underneath.
     // So when a dynamic suffix is present, we must strip it first to resolve the correct full-screen
     // route from the base path, rather than letting backTo (which belongs to the underlying screen) dictate it.
-    if (isRouteWithBackToParam(route) && !dynamicSuffixMatch && !isDynamicScreen) {
+    if (isRouteWithBackToParam(route) && !isDynamicScreen) {
         const stateForBackTo = getStateFromPath(route.params.backTo as RoutePath);
 
         // This may happen if the backTo url is invalid.
@@ -190,6 +191,7 @@ function getMatchingFullScreenRoute(route: NavigationPartialRoute) {
         };
     }
 
+    const dynamicSuffixMatch = findMatchingDynamicSuffix(route?.path);
     // Handle dynamic routes: find the appropriate full screen route
     if (route.path && dynamicSuffixMatch) {
         // Strip the suffix from the URL. For parametric routes we pass both the actual URL

--- a/src/libs/Navigation/helpers/getAdaptedStateFromPath.ts
+++ b/src/libs/Navigation/helpers/getAdaptedStateFromPath.ts
@@ -190,40 +190,42 @@ function getMatchingFullScreenRoute(route: NavigationPartialRoute) {
         };
     }
 
-    const dynamicSuffixMatch = findMatchingDynamicSuffix(route?.path);
     // Handle dynamic routes: find the appropriate full screen route
-    if (route.path && dynamicSuffixMatch) {
-        // Strip the suffix from the URL. For parametric routes we pass both the actual URL
-        // suffix and the registered pattern so query params can be resolved correctly.
-        const pathWithoutDynamicSuffix = getPathWithoutDynamicSuffix(route.path, dynamicSuffixMatch.actualSuffix, dynamicSuffixMatch.pattern);
+    if (route.path) {
+        const suffixMatch = findMatchingDynamicSuffix(route.path);
+        if (suffixMatch) {
+            // Strip the suffix from the URL. For parametric routes we pass both the actual URL
+            // suffix and the registered pattern so query params can be resolved correctly.
+            const pathWithoutDynamicSuffix = getPathWithoutDynamicSuffix(route.path, suffixMatch.actualSuffix, suffixMatch.pattern);
 
-        if (!pathWithoutDynamicSuffix) {
-            return undefined;
+            if (!pathWithoutDynamicSuffix) {
+                return undefined;
+            }
+
+            // Parse the base path (without dynamic suffix) into a navigation state
+            // to determine which full-screen route should be visible underneath the overlay.
+            const stateUnderDynamicRoute = getStateFromPath(pathWithoutDynamicSuffix);
+            const lastRoute = stateUnderDynamicRoute?.routes.at(-1);
+
+            if (!stateUnderDynamicRoute || !lastRoute || lastRoute.name === SCREENS.NOT_FOUND) {
+                return undefined;
+            }
+
+            const isLastRouteFullScreen = isFullScreenName(lastRoute.name);
+
+            if (isLastRouteFullScreen) {
+                return lastRoute;
+            }
+
+            const focusedRouteUnderDynamicRoute = findFocusedRouteWithOnyxTabGuard(stateUnderDynamicRoute);
+
+            if (!focusedRouteUnderDynamicRoute) {
+                return undefined;
+            }
+
+            // Recursively find the matching full screen route for the focused dynamic route
+            return getMatchingFullScreenRoute(focusedRouteUnderDynamicRoute);
         }
-
-        // Parse the base path (without dynamic suffix) into a navigation state
-        // to determine which full-screen route should be visible underneath the overlay.
-        const stateUnderDynamicRoute = getStateFromPath(pathWithoutDynamicSuffix);
-        const lastRoute = stateUnderDynamicRoute?.routes.at(-1);
-
-        if (!stateUnderDynamicRoute || !lastRoute || lastRoute.name === SCREENS.NOT_FOUND) {
-            return undefined;
-        }
-
-        const isLastRouteFullScreen = isFullScreenName(lastRoute.name);
-
-        if (isLastRouteFullScreen) {
-            return lastRoute;
-        }
-
-        const focusedRouteUnderDynamicRoute = findFocusedRouteWithOnyxTabGuard(stateUnderDynamicRoute);
-
-        if (!focusedRouteUnderDynamicRoute) {
-            return undefined;
-        }
-
-        // Recursively find the matching full screen route for the focused dynamic route
-        return getMatchingFullScreenRoute(focusedRouteUnderDynamicRoute);
     }
 
     return undefined;

--- a/src/libs/Navigation/helpers/getAdaptedStateFromPath.ts
+++ b/src/libs/Navigation/helpers/getAdaptedStateFromPath.ts
@@ -59,10 +59,9 @@ function getMatchingFullScreenRoute(route: NavigationPartialRoute) {
     const isDynamicScreen = isDynamicRouteScreen(route.name as Screen);
 
     // Check for backTo param. One screen with different backTo value may need different screens visible under the overlay.
-    // Before checking backTo, we verify the URL doesn't end with a dynamic route suffix.
-    // Dynamic routes never carry their own backTo - they only inherit it from the screen underneath.
-    // So when a dynamic suffix is present, we must strip it first to resolve the correct full-screen
-    // route from the base path, rather than letting backTo (which belongs to the underlying screen) dictate it.
+    // Dynamic screens are skipped here because they never carry their own backTo - they only
+    // inherit it from the screen underneath. Letting backTo dictate the full-screen route for
+    // a dynamic screen would resolve the wrong page.
     if (isRouteWithBackToParam(route) && !isDynamicScreen) {
         const stateForBackTo = getStateFromPath(route.params.backTo as RoutePath);
 

--- a/src/libs/Navigation/helpers/getPathFromState.ts
+++ b/src/libs/Navigation/helpers/getPathFromState.ts
@@ -1,26 +1,12 @@
 import {findFocusedRoute, getPathFromState as RNGetPathFromState} from '@react-navigation/native';
 import type {NavigationState, PartialState} from '@react-navigation/routers';
 import {config, normalizedConfigs} from '@libs/Navigation/linkingConfig/config';
-import type {DynamicRouteSuffix} from '@src/ROUTES';
 import type {Screen} from '@src/SCREENS';
 import getDynamicRouteQueryParams from './dynamicRoutesUtils/getDynamicRouteQueryParams';
-import {dynamicRoutePaths} from './dynamicRoutesUtils/isDynamicRouteSuffix';
+import isDynamicRouteScreen from './dynamicRoutesUtils/isDynamicRouteScreen';
 import splitPathAndQuery from './dynamicRoutesUtils/splitPathAndQuery';
 
 type State = NavigationState | Omit<PartialState<NavigationState>, 'stale'>;
-
-/**
- * Checks if a screen name is a dynamic route screen
- */
-function isDynamicRouteScreen(screenName: Screen): boolean {
-    const screenPath = normalizedConfigs[screenName]?.path;
-
-    if (!screenPath) {
-        return false;
-    }
-
-    return dynamicRoutePaths.has(screenPath as DynamicRouteSuffix);
-}
 
 /**
  * Resolves a single path segment: if it's a `:param` placeholder, replaces it

--- a/tests/navigation/getMatchingFullScreenRouteTests.ts
+++ b/tests/navigation/getMatchingFullScreenRouteTests.ts
@@ -4,7 +4,9 @@ import getStateFromPath from '@libs/Navigation/helpers/getStateFromPath';
 import SCREENS from '@src/SCREENS';
 
 jest.mock('@libs/Navigation/linkingConfig/config', () => ({
-    normalizedConfigs: {},
+    normalizedConfigs: {
+        DynamicScreen: {path: 'suffix-a'},
+    },
     screensWithOnyxTabNavigator: new Set(),
 }));
 
@@ -179,5 +181,31 @@ describe('getMatchingFullScreenRoute - dynamic suffix', () => {
 
         expect(mockGetStateFromPath).toHaveBeenCalledWith('/broken/path/suffix-a');
         expect(result).toBeUndefined();
+    });
+
+    it('should ignore backTo for a dynamic screen and resolve full screen route via dynamic suffix instead', () => {
+        const route = {
+            name: 'DynamicScreen',
+            path: '/base/suffix-a',
+            params: {backTo: '/some/other/path'},
+        };
+        const fullScreenRoute = {name: SCREENS.HOME};
+        const basePathState = {
+            routes: [{name: 'BaseScreen'}, fullScreenRoute],
+            index: 1,
+        };
+
+        mockGetStateFromPath.mockImplementation((path: string) => {
+            if (path === '/base') {
+                return basePathState;
+            }
+            return {routes: [{name: 'WrongScreen'}], index: 0};
+        });
+
+        const result = getMatchingFullScreenRoute(route);
+
+        expect(mockGetStateFromPath).toHaveBeenCalledWith('/base');
+        expect(mockGetStateFromPath).not.toHaveBeenCalledWith('/some/other/path');
+        expect(result).toEqual(fullScreenRoute);
     });
 });

--- a/tests/navigation/isDynamicRouteScreenTests.ts
+++ b/tests/navigation/isDynamicRouteScreenTests.ts
@@ -1,0 +1,41 @@
+import isDynamicRouteScreen from '@libs/Navigation/helpers/dynamicRoutesUtils/isDynamicRouteScreen';
+import type {Screen} from '@src/SCREENS';
+import SCREENS from '@src/SCREENS';
+
+describe('isDynamicRouteScreen', () => {
+    it('should return true for a static dynamic route screen (DYNAMIC_VERIFY_ACCOUNT)', () => {
+        expect(isDynamicRouteScreen(SCREENS.SETTINGS.DYNAMIC_VERIFY_ACCOUNT)).toBe(true);
+    });
+
+    it('should return true for a multi-segment dynamic route screen (DYNAMIC_ADD_BANK_ACCOUNT_VERIFY_ACCOUNT)', () => {
+        expect(isDynamicRouteScreen(SCREENS.SETTINGS.DYNAMIC_ADD_BANK_ACCOUNT_VERIFY_ACCOUNT)).toBe(true);
+    });
+
+    it('should return true for a parametric dynamic route screen (DYNAMIC_FLAG_COMMENT)', () => {
+        expect(isDynamicRouteScreen(SCREENS.DYNAMIC_FLAG_COMMENT)).toBe(true);
+    });
+
+    it('should return true for DYNAMIC_KEYBOARD_SHORTCUTS', () => {
+        expect(isDynamicRouteScreen(SCREENS.SETTINGS.DYNAMIC_KEYBOARD_SHORTCUTS)).toBe(true);
+    });
+
+    it('should return true for DYNAMIC_ADDRESS_COUNTRY', () => {
+        expect(isDynamicRouteScreen(SCREENS.SETTINGS.PROFILE.DYNAMIC_ADDRESS_COUNTRY)).toBe(true);
+    });
+
+    it('should return false for a regular screen (HOME)', () => {
+        expect(isDynamicRouteScreen(SCREENS.HOME)).toBe(false);
+    });
+
+    it('should return false for a regular screen (REPORT)', () => {
+        expect(isDynamicRouteScreen(SCREENS.REPORT)).toBe(false);
+    });
+
+    it('should return false for a regular settings screen (Settings_Root)', () => {
+        expect(isDynamicRouteScreen(SCREENS.SETTINGS.ROOT)).toBe(false);
+    });
+
+    it('should return false for a screen name not present in normalizedConfigs', () => {
+        expect(isDynamicRouteScreen('NonExistentScreen_12345' as Screen)).toBe(false);
+    });
+});


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
<!-- Explain what your change does and how it addresses the linked issue -->

Fix the screen-underneath resolution logic for dynamic routes in `getMatchingFullScreenRoute`. Dynamic routes never carry their own `backTo` - they inherit it from the screen underneath. Previously, the `backTo` param on a dynamic route was incorrectly used to resolve the full-screen route, leading to wrong screens being shown underneath overlays. Now the function checks whether the route is a dynamic screen via `isDynamicRouteScreen` (which verifies against the navigation config's `dynamicRoutePaths`) and skips `backTo` handling for dynamic screens. The `isDynamicRouteScreen` utility was also extracted into a shared file to be reused by both `getPathFromState` and `getAdaptedStateFromPath`.


### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/87602

<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

Precondition:
User has received a message from another user.

1. Go to staging.new.expensify.com
2. Open 1:1 DM with received message.
3. Right click on the message > Reply in thread.
4. Right click on the parent message in thread >  Flag as offensive.
5. Refresh the page.
6. Verify that app stays in thread after refreshing Flag as offensive RHP in thread.

- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->
Same as tests

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.


### Screenshots/Videos

<details>
<summary>MacOS: Chrome / Safari</summary>


https://github.com/user-attachments/assets/e90444b1-bd8e-4fff-bd0e-76aa8380a61a


</details>