### PR TITLE
Fix frozen card admin name font size

### DIFF
--- a/src/components/FrozenCardHeader.tsx
+++ b/src/components/FrozenCardHeader.tsx
@@ -56,7 +56,7 @@ function FrozenCardHeader({cardPreview, onUnfreezePress, onAskToUnfreezePress, c
                     {adminFrozenTextPrefix}
                     <TextLink
                         onPress={() => Navigation.navigate(ROUTES.PROFILE.getRoute(Number(frozenByAccountID), Navigation.getActiveRoute()))}
-                        style={styles.link}
+                        style={[styles.textLabel, styles.link]}
                     >
                         {frozenByName}
                     </TextLink>
@@ -71,7 +71,7 @@ function FrozenCardHeader({cardPreview, onUnfreezePress, onAskToUnfreezePress, c
                 {frozenNeedsUnfreezePrefix}
                 <TextLink
                     onPress={() => Navigation.navigate(ROUTES.PROFILE.getRoute(Number(frozenByAccountID), Navigation.getActiveRoute()))}
-                    style={styles.link}
+                    style={[styles.textLabel, styles.link]}
                 >
                     {frozenByName}
                 </TextLink>


### PR DESCRIPTION
## Summary
- Apply the same label text style to the frozen card admin name link as the surrounding message text.
- Keep the link color while preventing the name from rendering at the default normal text size.

## Test plan
- Not run (manual testing implementation request; skipped lint, TypeScript, and tests per repo instructions).