### PR TITLE
Fix: Show broken card connection violations to policy admins on open expense reports

### DIFF
--- a/src/hooks/useTransactionViolations.ts
+++ b/src/hooks/useTransactionViolations.ts
@@ -1,6 +1,6 @@
 import {useMemo} from 'react';
 import getNonEmptyStringOnyxID from '@libs/getNonEmptyStringOnyxID';
-import {isViolationDismissed, mergeProhibitedViolations, shouldShowViolation} from '@libs/TransactionUtils';
+import {isBrokenConnectionViolation, isViolationDismissed, mergeProhibitedViolations, shouldShowBrokenConnectionViolation, shouldShowViolation} from '@libs/TransactionUtils';
 import ONYXKEYS from '@src/ONYXKEYS';
 import type {TransactionViolation, TransactionViolations} from '@src/types/onyx';
 import getEmptyArray from '@src/types/utils/getEmptyArray';
@@ -15,14 +15,27 @@ function useTransactionViolations(transactionID?: string, shouldShowRterForSettl
     const currentUserDetails = useCurrentUserPersonalDetails();
 
     return useMemo(
-        () =>
-            mergeProhibitedViolations(
-                transactionViolations.filter(
-                    (violation: TransactionViolation) =>
-                        !isViolationDismissed(transaction, violation, currentUserDetails.email ?? '', currentUserDetails.accountID, iouReport, policy) &&
-                        shouldShowViolation(iouReport, policy, violation.name, currentUserDetails.email ?? '', shouldShowRterForSettledReport, transaction),
-                ),
-            ),
+        () => {
+            const notDismissed = transactionViolations.filter(
+                (violation: TransactionViolation) =>
+                    !isViolationDismissed(transaction, violation, currentUserDetails.email ?? '', currentUserDetails.accountID, iouReport, policy),
+            );
+
+            // Broken card connection violations have their own display logic that accounts for policy admin visibility
+            // on open reports — separate them so we can apply the correct check for each group.
+            const brokenConnectionViolations = notDismissed.filter((v) => isBrokenConnectionViolation(v));
+            const otherViolations = notDismissed.filter((v) => !isBrokenConnectionViolation(v));
+
+            const visibleOtherViolations = otherViolations.filter((violation: TransactionViolation) =>
+                shouldShowViolation(iouReport, policy, violation.name, currentUserDetails.email ?? '', shouldShowRterForSettledReport, transaction),
+            );
+
+            // shouldShowBrokenConnectionViolation correctly handles visibility for policy admins on open reports,
+            // whereas the general shouldShowViolation RTER branch only checks isSubmitter || isInstantSubmitEnabled.
+            const visibleBrokenConnectionViolations = shouldShowBrokenConnectionViolation(iouReport, policy, brokenConnectionViolations) ? brokenConnectionViolations : [];
+
+            return mergeProhibitedViolations([...visibleOtherViolations, ...visibleBrokenConnectionViolations]);
+        },
         [transaction, transactionViolations, iouReport, policy, shouldShowRterForSettledReport, currentUserDetails.email, currentUserDetails.accountID],
     );
 }

--- a/src/libs/TransactionUtils/index.ts
+++ b/src/libs/TransactionUtils/index.ts
@@ -1617,17 +1617,13 @@ function shouldShowBrokenConnectionViolationForMultipleTransactions(
             return [];
         }
 
-        return violations.filter((violation) => {
-            if (!isBrokenConnectionViolation(violation)) {
-                return false;
-            }
-
-            if (isViolationDismissed(transaction, violation, currentUserEmail, currentUserAccountID, report, policy)) {
-                return false;
-            }
-
-            return shouldShowViolation(report, policy, violation.name, currentUserEmail, true, transaction);
-        });
+        // Do not pre-filter with shouldShowViolation here — shouldShowBrokenConnectionViolationInternal
+        // handles the admin/open-report visibility logic. Pre-filtering with shouldShowViolation would
+        // incorrectly exclude broken card connection violations for policy admins on non-instant-submit policies.
+        return violations.filter(
+            (violation) =>
+                isBrokenConnectionViolation(violation) && !isViolationDismissed(transaction, violation, currentUserEmail, currentUserAccountID, report, policy),
+        );
     });
 
     return shouldShowBrokenConnectionViolationInternal(brokenConnectionViolations, report, policy);

--- a/src/libs/Violations/ViolationsUtils.ts
+++ b/src/libs/Violations/ViolationsUtils.ts
@@ -23,7 +23,7 @@ import {
 } from '@libs/PolicyUtils';
 import {isCurrentUserSubmitter} from '@libs/ReportUtils';
 import * as TransactionUtils from '@libs/TransactionUtils';
-import {hasValidModifiedAmount, isViolationDismissed, shouldShowViolation} from '@libs/TransactionUtils';
+import {hasValidModifiedAmount, isBrokenConnectionViolation, isViolationDismissed, shouldShowBrokenConnectionViolation, shouldShowViolation} from '@libs/TransactionUtils';
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
 import type {Card, CardList, Policy, PolicyCategories, PolicyTagLists, PolicyTags, Report, ReportAction, Transaction, TransactionViolation, ViolationName} from '@src/types/onyx';
@@ -896,13 +896,22 @@ const ViolationsUtils = {
                 return false;
             }
 
-            // Check if any violation is not dismissed and should be shown based on user role and violation type
-            return transactionViolations.some((violation: TransactionViolation) => {
-                return (
-                    !isViolationDismissed(transaction, violation, currentUserEmail, currentUserAccountID, report, policy) &&
-                    shouldShowViolation(report, policy, violation.name, currentUserEmail, true, transaction)
-                );
-            });
+            // Check if any violation is not dismissed and should be shown based on user role and violation type.
+            // Broken card connection violations require their own display check to correctly handle policy admin
+            // visibility on open reports — shouldShowViolation's RTER branch only checks isSubmitter || isInstantSubmitEnabled.
+            const notDismissed = transactionViolations.filter(
+                (violation: TransactionViolation) => !isViolationDismissed(transaction, violation, currentUserEmail, currentUserAccountID, report, policy),
+            );
+
+            const brokenConnectionViolations = notDismissed.filter((v) => isBrokenConnectionViolation(v));
+            const otherViolations = notDismissed.filter((v) => !isBrokenConnectionViolation(v));
+
+            const hasVisibleOtherViolation = otherViolations.some((violation: TransactionViolation) =>
+                shouldShowViolation(report, policy, violation.name, currentUserEmail, true, transaction),
+            );
+            const hasVisibleBrokenConnectionViolation = shouldShowBrokenConnectionViolation(report, policy, brokenConnectionViolations);
+
+            return hasVisibleOtherViolation || hasVisibleBrokenConnectionViolation;
         });
     },
 };


### PR DESCRIPTION
### Explanation of Change

Policy admins were not seeing `brokenCardConnection` violations on expense reports they administer but didn't submit. The root cause is that `shouldShowViolation` gates all RTER violations (including `brokenCardConnection`) with:

```ts
return (isSubmitter || isInstantSubmitEnabled(policy)) && (shouldShowRterForSettledReport || !isSettled(iouReport));
```

But `shouldShowBrokenConnectionViolationInternal` has the correct, more nuanced logic that also shows the violation to policy admins on open reports. The two functions were not being used consistently.

**Three files fixed:**

1. **`src/hooks/useTransactionViolations.ts`** — Separates broken card connection violations from other violations before filtering. Other violations continue using `shouldShowViolation`; broken connection violations now use `shouldShowBrokenConnectionViolation`, which correctly applies the admin/open-report logic.

2. **`src/libs/TransactionUtils/index.ts`** (`shouldShowBrokenConnectionViolationForMultipleTransactions`) — Removes the incorrect `shouldShowViolation` pre-filter from the inner violation loop. `shouldShowBrokenConnectionViolationInternal` already owns this logic; pre-filtering with `shouldShowViolation` caused it to receive an empty array for admins on non-instant-submit policies, returning `false` when it should return `true`.

3. **`src/libs/Violations/ViolationsUtils.ts`** (`hasVisibleViolationsForUser`) — Applies the same separation pattern so the violations badge also correctly reflects broken connection violations for policy admins.

### Fixed Issues
$ https://github.com/Expensify/App/issues/87673
PROPOSAL: https://github.com/Expensify/App/issues/87673#issuecomment-2800733285

### Tests
1. Log in as a policy admin who is **not** the submitter of an expense report
2. Ensure the report contains a broken card connection violation (card feed disconnected)
3. Verify the broken connection violation **is now visible** in the expense row
4. Log in as the submitter — verify violation still shows
5. Log in as a regular policy member — verify violation does not show (no change)

### Offline tests
- Offline state: verify no console errors, violation state reflects last known Onyx data

### QA Steps
1. As a policy admin (non-submitter), open an expense report on a workspace with a broken card feed connection
2. Verify the broken connection warning appears on the relevant transaction row
3. Dismiss the violation as admin — verify it disappears
4. As the submitter on the same report, verify the violation is also visible

- [ ] Verify that no errors appear in the JS console