### PR TITLE
Bump onyx to 3.0.59

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -114,7 +114,7 @@
         "react-native-localize": "^3.5.4",
         "react-native-nitro-modules": "0.29.4",
         "react-native-nitro-sqlite": "9.2.0",
-        "react-native-onyx": "3.0.58",
+        "react-native-onyx": "3.0.59",
         "react-native-pager-view": "8.0.0",
         "react-native-pdf": "7.0.2",
         "react-native-permissions": "^5.4.0",
@@ -34788,9 +34788,9 @@
       }
     },
     "node_modules/react-native-onyx": {
-      "version": "3.0.58",
-      "resolved": "https://registry.npmjs.org/react-native-onyx/-/react-native-onyx-3.0.58.tgz",
-      "integrity": "sha512-S304EAUL76orw18DCvXU/ZzYGXzVGCuB4EfKD1QDnewVC5KrLGCxAJDmKy0B3FaLpqX7cuAPi+R4IdOaKbxyjQ==",
+      "version": "3.0.59",
+      "resolved": "https://registry.npmjs.org/react-native-onyx/-/react-native-onyx-3.0.59.tgz",
+      "integrity": "sha512-HNm1kCSpY2bFC2gEdsr8gssJsZEaH9f/rNkI9AP2h464z74VMlkR/01a1UkCXPWwAmPnKeS2MAHdmOyfzjuSaQ==",
       "license": "MIT",
       "dependencies": {
         "ascii-table": "0.0.9",

--- a/package.json
+++ b/package.json
@@ -177,7 +177,7 @@
     "react-native-localize": "^3.5.4",
     "react-native-nitro-modules": "0.29.4",
     "react-native-nitro-sqlite": "9.2.0",
-    "react-native-onyx": "3.0.58",
+    "react-native-onyx": "3.0.59",
     "react-native-pager-view": "8.0.0",
     "react-native-pdf": "7.0.2",
     "react-native-permissions": "^5.4.0",

--- a/patches/react-native-onyx/details.md
+++ b/patches/react-native-onyx/details.md
@@ -1,0 +1,7 @@
+# `react-native-onyx` patches
+
+### [react-native-onyx+3.0.59.patch](react-native-onyx+3.0.59.patch)
+
+- Reason: Onyx v3.0.59 ([PR #756](https://github.com/Expensify/react-native-onyx/pull/756)) added a state reset inside the `subscribe` callback of `useOnyx` to fix stale data when keys change dynamically. However, this reset runs unconditionally — including on initial mount — which causes `useSyncExternalStore` to see a new snapshot reference after subscription, triggering one extra render per `useOnyx` hook. This patch guards the reset with a `hasMountedRef` flag so it only runs on key-change re-subscriptions, not on initial mount.
+- E/App issue: https://github.com/Expensify/App/issues/85416
+- Upstream PR/issue: N/A

--- a/patches/react-native-onyx/react-native-onyx+3.0.59.patch
+++ b/patches/react-native-onyx/react-native-onyx+3.0.59.patch
@@ -1,0 +1,35 @@
+diff --git a/node_modules/react-native-onyx/dist/useOnyx.js b/node_modules/react-native-onyx/dist/useOnyx.js
+index 8e0f03a..9e29ace 100644
+--- a/node_modules/react-native-onyx/dist/useOnyx.js
++++ b/node_modules/react-native-onyx/dist/useOnyx.js
+@@ -97,6 +97,9 @@ function useOnyx(key, options, dependencies = []) {
+     // after cleanup), so the hook automatically enters first-connection mode for the new key without any
+     // explicit reset logic — eliminating the race condition where cleanup could clobber a boolean flag.
+     const connectedKeyRef = (0, react_1.useRef)(null);
++    // Tracks whether the hook has completed its initial mount subscription.
++    // Unlike connectedKeyRef (which gets nulled by cleanup), this persists across re-subscriptions.
++    const hasMountedRef = (0, react_1.useRef)(false);
+     // Indicates if the hook is connecting to an Onyx key.
+     const isConnectingRef = (0, react_1.useRef)(false);
+     // Stores the `onStoreChange()` function, which can be used to trigger a `getSnapshot()` update when desired.
+@@ -234,11 +237,15 @@ function useOnyx(key, options, dependencies = []) {
+     const subscribe = (0, react_1.useCallback)((onStoreChange) => {
+         // Reset internal state so the hook properly transitions through loading
+         // for the new key instead of preserving stale state from the previous one.
+-        previousValueRef.current = null;
+-        newValueRef.current = null;
+-        shouldGetCachedValueRef.current = true;
+-        sourceValueRef.current = undefined;
+-        resultRef.current = [undefined, { status: (options === null || options === void 0 ? void 0 : options.initWithStoredValues) === false ? 'loaded' : 'loading' }];
++        // Only reset when the key has actually changed (not on initial mount).
++        if (hasMountedRef.current) {
++            previousValueRef.current = null;
++            newValueRef.current = null;
++            shouldGetCachedValueRef.current = true;
++            sourceValueRef.current = undefined;
++            resultRef.current = [undefined, { status: (options === null || options === void 0 ? void 0 : options.initWithStoredValues) === false ? 'loaded' : 'loading' }];
++        }
++        hasMountedRef.current = true;
+         isConnectingRef.current = true;
+         onStoreChangeFnRef.current = onStoreChange;
+         connectionRef.current = OnyxConnectionManager_1.default.connect({


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
<!-- Explain what your change does and how it addresses the linked issue -->

Bump Onyx to v3.0.59 to apply next onyx changes: https://github.com/Expensify/react-native-onyx/pull/756.

Onyx v3.0.59 includes a fix for stale data when dynamically switching useOnyx keys. It added a state reset inside useOnyx's subscribe callback to clear stale values during key transitions.

However, the reset runs unconditionally — including on initial mount — which introduces an extra render per useOnyx hook.  It got caugt by our [reassure tests](https://github.com/Expensify/App/actions/runs/24332133423/job/71040227714).                                                                                                                                                      
**To fix that, I've added a patch** `react-native-onyx+3.0.59.patch`: 
It adds a `hasMountedRef` flag that skips the reset on initial mount and only applies it on key-change re-subscriptions, which is the only case the reset was designed for. This eliminates the extra mount render while preserving the dynamic key-switching fix. 
_This update will also be raised in the onyx in a separate version._

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/85416
PROPOSAL: N/A


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

- [x] Verify that no errors appear in the JS console

1. Log into the app
2. Navigate between different chats quickly
3. Open an expense, go back, open a different expense
4. Go to the search screen and perform multiple searches one after another
5. Open a report via deep link, then navigate to a different one

In all of the cases above look out for:

- No stale data flash - when switching between items, you shouldn't briefly see the previous item's data
- Proper loading states - the hook should transition through loading → loaded for the new key
- No crashes - the old code threw errors for non-collection dynamic key changes; your branch removes that restriction, so arbitrary key changes should work now

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

Same, as in **Tests** section

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->
// TODO: These must be filled out, or the issue title must include "[No QA]."

- [x] Verify that no errors appear in the JS console

Same, as in **Tests** section

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->


https://github.com/user-attachments/assets/eb5fbf38-3367-449a-825b-9e4ab05f16b6



</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->


https://github.com/user-attachments/assets/07fecda5-6adb-4256-bc29-d080ec79df58



</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->


https://github.com/user-attachments/assets/6bf00b89-f19a-4b43-9d90-75322058a592



</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->


https://github.com/user-attachments/assets/c91ecbd6-b30c-43cd-ac25-7d94be2a76ff



</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->


https://github.com/user-attachments/assets/d5e391c5-731e-488a-9bbb-30949668e27f


</details>