### PR TITLE
Fix issue: Home - Connect to accounting task is checked off when connection fails

### DIFF
--- a/src/CONST/index.ts
+++ b/src/CONST/index.ts
@@ -3796,6 +3796,15 @@ const CONST = {
         DEFAULT_MAX_EXPENSE_AMOUNT: 200000,
         DEFAULT_MAX_AMOUNT_NO_RECEIPT: 2500,
         DEFAULT_MAX_AMOUNT_NO_ITEMIZED_RECEIPT: 7500,
+        DEFAULT_PROHIBITED_EXPENSES: {
+            alcohol: false,
+            hotelIncidentals: false,
+            gambling: true,
+            tobacco: false,
+            adultEntertainment: true,
+        },
+        DEFAULT_BILLABLE: false,
+        DEFAULT_REIMBURSABLE: true,
         DEFAULT_TAG_LIST: {
             Tag: {
                 name: 'Tag',

--- a/src/languages/de.ts
+++ b/src/languages/de.ts
@@ -1033,6 +1033,7 @@ const translations: TranslationDeepObject<typeof en> = {
             title: 'Erste Schritte',
             createWorkspace: 'Workspace erstellen',
             connectAccounting: ({integrationName}: {integrationName: string}) => `Mit ${integrationName} verbinden`,
+            connectAccountingDefault: 'Mit Buchhaltung verbinden',
             customizeCategories: 'Buchhaltungskategorien anpassen',
             linkCompanyCards: 'Firmenkarten verknüpfen',
             setupRules: 'Ausgabelimits einrichten',

--- a/src/languages/en.ts
+++ b/src/languages/en.ts
@@ -1083,6 +1083,7 @@ const translations = {
             title: 'Getting started',
             createWorkspace: 'Create a workspace',
             connectAccounting: ({integrationName}: {integrationName: string}) => `Connect to ${integrationName}`,
+            connectAccountingDefault: 'Connect to accounting',
             customizeCategories: 'Customize accounting categories',
             linkCompanyCards: 'Link company cards',
             setupRules: 'Set up spend rules',

--- a/src/languages/es.ts
+++ b/src/languages/es.ts
@@ -968,6 +968,7 @@ const translations: TranslationDeepObject<typeof en> = {
             title: 'Primeros pasos',
             createWorkspace: 'Crear un espacio de trabajo',
             connectAccounting: ({integrationName}: {integrationName: string}) => `Conectar con ${integrationName}`,
+            connectAccountingDefault: 'Conectar a contabilidad',
             customizeCategories: 'Personalizar categorías contables',
             linkCompanyCards: 'Vincular tarjetas corporativas',
             setupRules: 'Configurar reglas de gasto',

--- a/src/languages/fr.ts
+++ b/src/languages/fr.ts
@@ -1049,6 +1049,7 @@ const translations: TranslationDeepObject<typeof en> = {
             title: 'Premiers pas',
             createWorkspace: 'Créer un espace de travail',
             connectAccounting: ({integrationName}: {integrationName: string}) => `Se connecter à ${integrationName}`,
+            connectAccountingDefault: 'Connecter à la comptabilité',
             customizeCategories: 'Personnaliser les catégories comptables',
             linkCompanyCards: 'Lier des cartes d’entreprise',
             setupRules: 'Configurer les règles de dépense',

--- a/src/languages/it.ts
+++ b/src/languages/it.ts
@@ -1046,6 +1046,7 @@ const translations: TranslationDeepObject<typeof en> = {
             title: 'Per iniziare',
             createWorkspace: 'Crea uno spazio di lavoro',
             connectAccounting: ({integrationName}: {integrationName: string}) => `Connetti a ${integrationName}`,
+            connectAccountingDefault: 'Connetti alla contabilità',
             customizeCategories: 'Personalizza le categorie contabili',
             linkCompanyCards: 'Collega carte aziendali',
             setupRules: 'Configura le regole di spesa',

--- a/src/languages/ja.ts
+++ b/src/languages/ja.ts
@@ -1029,6 +1029,7 @@ const translations: TranslationDeepObject<typeof en> = {
             title: 'はじめに',
             createWorkspace: 'ワークスペースを作成',
             connectAccounting: ({integrationName}: {integrationName: string}) => `${integrationName}に接続する`,
+            connectAccountingDefault: '会計ソフトに接続',
             customizeCategories: '会計カテゴリをカスタマイズする',
             linkCompanyCards: '会社カードを連携',
             setupRules: '支出ルールを設定',

--- a/src/languages/nl.ts
+++ b/src/languages/nl.ts
@@ -1045,6 +1045,7 @@ const translations: TranslationDeepObject<typeof en> = {
             title: 'Aan de slag',
             createWorkspace: 'Maak een werkruimte',
             connectAccounting: ({integrationName}: {integrationName: string}) => `Verbind met ${integrationName}`,
+            connectAccountingDefault: 'Verbind met boekhouding',
             customizeCategories: 'Boekhoudcategorieën aanpassen',
             linkCompanyCards: 'Bedrijfspassen koppelen',
             setupRules: 'Uitgavenregels instellen',

--- a/src/languages/pl.ts
+++ b/src/languages/pl.ts
@@ -1046,6 +1046,7 @@ const translations: TranslationDeepObject<typeof en> = {
             title: 'Pierwsze kroki',
             createWorkspace: 'Utwórz przestrzeń roboczą',
             connectAccounting: ({integrationName}: {integrationName: string}) => `Połącz z ${integrationName}`,
+            connectAccountingDefault: 'Połącz z księgowością',
             customizeCategories: 'Dostosuj kategorie księgowe',
             linkCompanyCards: 'Połącz firmowe karty',
             setupRules: 'Skonfiguruj zasady wydatków',

--- a/src/languages/pt-BR.ts
+++ b/src/languages/pt-BR.ts
@@ -1044,6 +1044,7 @@ const translations: TranslationDeepObject<typeof en> = {
             title: 'Introdução',
             createWorkspace: 'Criar um workspace',
             connectAccounting: ({integrationName}: {integrationName: string}) => `Conectar ao ${integrationName}`,
+            connectAccountingDefault: 'Conectar à contabilidade',
             customizeCategories: 'Personalizar categorias contábeis',
             linkCompanyCards: 'Vincular cartões corporativos',
             setupRules: 'Configurar regras de gasto',

--- a/src/languages/zh-hans.ts
+++ b/src/languages/zh-hans.ts
@@ -1012,6 +1012,7 @@ const translations: TranslationDeepObject<typeof en> = {
             title: '入门',
             createWorkspace: '创建工作区',
             connectAccounting: ({integrationName}: {integrationName: string}) => `连接到 ${integrationName}`,
+            connectAccountingDefault: '连接会计系统',
             customizeCategories: '自定义会计类别',
             linkCompanyCards: '关联公司卡',
             setupRules: '设置消费规则',

--- a/src/libs/PolicyUtils.ts
+++ b/src/libs/PolicyUtils.ts
@@ -698,52 +698,63 @@ function hasConfiguredRules(policy: OnyxEntry<Policy>): boolean {
     if (!policy) {
         return false;
     }
-    const hasCustomRules = !!policy.customRules && policy.customRules.trim().length > 0;
+
+    if (!!policy.customRules && policy.customRules.trim().length > 0) {
+        return true;
+    }
 
     const {rules} = policy;
-    const hasApprovalRules = !!rules?.approvalRules && rules.approvalRules.length > 0;
-    const hasExpenseRules = !!rules?.expenseRules && rules.expenseRules.length > 0;
-    const hasCodingRules = !!rules?.codingRules && Object.keys(rules.codingRules).length > 0;
+    if (!!rules?.approvalRules && rules.approvalRules.length > 0) {
+        return true;
+    }
+    if (!!rules?.expenseRules && rules.expenseRules.length > 0) {
+        return true;
+    }
+    if (!!rules?.codingRules && Object.keys(rules.codingRules).length > 0) {
+        return true;
+    }
 
-    const hasModifiedMaxExpenseAmount =
-        !!policy.maxExpenseAmount && policy.maxExpenseAmount !== CONST.DISABLED_MAX_EXPENSE_VALUE && policy.maxExpenseAmount !== CONST.POLICY.DEFAULT_MAX_EXPENSE_AMOUNT;
-    const hasModifiedMaxExpenseAge = !!policy.maxExpenseAge && policy.maxExpenseAge !== CONST.DISABLED_MAX_EXPENSE_VALUE && policy.maxExpenseAge !== CONST.POLICY.DEFAULT_MAX_EXPENSE_AGE;
-    const hasModifiedMaxExpenseAmountNoReceipt =
+    if (!!policy.maxExpenseAmount && policy.maxExpenseAmount !== CONST.DISABLED_MAX_EXPENSE_VALUE && policy.maxExpenseAmount !== CONST.POLICY.DEFAULT_MAX_EXPENSE_AMOUNT) {
+        return true;
+    }
+    if (!!policy.maxExpenseAge && policy.maxExpenseAge !== CONST.DISABLED_MAX_EXPENSE_VALUE && policy.maxExpenseAge !== CONST.POLICY.DEFAULT_MAX_EXPENSE_AGE) {
+        return true;
+    }
+    if (
         !!policy.maxExpenseAmountNoReceipt &&
         policy.maxExpenseAmountNoReceipt !== CONST.DISABLED_MAX_EXPENSE_VALUE &&
-        policy.maxExpenseAmountNoReceipt !== CONST.POLICY.DEFAULT_MAX_AMOUNT_NO_RECEIPT;
-    const hasModifiedMaxExpenseAmountNoItemizedReceipt =
+        policy.maxExpenseAmountNoReceipt !== CONST.POLICY.DEFAULT_MAX_AMOUNT_NO_RECEIPT
+    ) {
+        return true;
+    }
+    if (
         !!policy.maxExpenseAmountNoItemizedReceipt &&
         policy.maxExpenseAmountNoItemizedReceipt !== CONST.DISABLED_MAX_EXPENSE_VALUE &&
-        policy.maxExpenseAmountNoItemizedReceipt !== CONST.POLICY.DEFAULT_MAX_AMOUNT_NO_ITEMIZED_RECEIPT;
+        policy.maxExpenseAmountNoItemizedReceipt !== CONST.POLICY.DEFAULT_MAX_AMOUNT_NO_ITEMIZED_RECEIPT
+    ) {
+        return true;
+    }
 
-    const hasModifiedBillable = !!policy.defaultBillable;
-    const hasModifiedReimbursable = policy.defaultReimbursable === false;
-    const hasEReceiptsEnabled = !!policy.eReceipts;
-    const hasRequireCompanyCardsEnabled = !!policy.requireCompanyCardsEnabled;
+    if (policy.defaultBillable) {
+        return true;
+    }
+    if (policy.defaultReimbursable === false) {
+        return true;
+    }
+    if (policy.eReceipts) {
+        return true;
+    }
+    if (policy.requireCompanyCardsEnabled) {
+        return true;
+    }
 
     const {prohibitedExpenses} = policy;
-    const hasModifiedProhibitedExpenses =
+    return (
         !!prohibitedExpenses &&
         Object.entries(CONST.POLICY.DEFAULT_PROHIBITED_EXPENSES).some(([key, defaultValue]) => {
             const value = prohibitedExpenses[key as keyof typeof CONST.POLICY.DEFAULT_PROHIBITED_EXPENSES];
             return value !== undefined && value !== defaultValue;
-        });
-
-    return (
-        hasCustomRules ||
-        hasApprovalRules ||
-        hasExpenseRules ||
-        hasCodingRules ||
-        hasModifiedMaxExpenseAmount ||
-        hasModifiedMaxExpenseAge ||
-        hasModifiedMaxExpenseAmountNoReceipt ||
-        hasModifiedMaxExpenseAmountNoItemizedReceipt ||
-        hasModifiedBillable ||
-        hasModifiedReimbursable ||
-        hasEReceiptsEnabled ||
-        hasRequireCompanyCardsEnabled ||
-        hasModifiedProhibitedExpenses
+        })
     );
 }
 

--- a/src/libs/PolicyUtils.ts
+++ b/src/libs/PolicyUtils.ts
@@ -692,14 +692,12 @@ function hasCustomCategories(policyCategories: OnyxEntry<PolicyCategories>): boo
 }
 
 /**
- * Checks if a policy has any non-default rules configured.
- * Defaults are: no approval/expense/coding rules and no custom rules text.
+ * Checks if a policy has any rules configured (structured rules, individual expense limits, or prohibited expenses).
  */
-function hasNonDefaultRules(policy: OnyxEntry<Policy>): boolean {
+function hasConfiguredRules(policy: OnyxEntry<Policy>): boolean {
     if (!policy) {
         return false;
     }
-
     const hasCustomRules = !!policy.customRules && policy.customRules.trim().length > 0;
 
     const {rules} = policy;
@@ -707,7 +705,46 @@ function hasNonDefaultRules(policy: OnyxEntry<Policy>): boolean {
     const hasExpenseRules = !!rules?.expenseRules && rules.expenseRules.length > 0;
     const hasCodingRules = !!rules?.codingRules && Object.keys(rules.codingRules).length > 0;
 
-    return hasCustomRules || hasApprovalRules || hasExpenseRules || hasCodingRules;
+    const hasModifiedMaxExpenseAmount =
+        !!policy.maxExpenseAmount && policy.maxExpenseAmount !== CONST.DISABLED_MAX_EXPENSE_VALUE && policy.maxExpenseAmount !== CONST.POLICY.DEFAULT_MAX_EXPENSE_AMOUNT;
+    const hasModifiedMaxExpenseAge = !!policy.maxExpenseAge && policy.maxExpenseAge !== CONST.DISABLED_MAX_EXPENSE_VALUE && policy.maxExpenseAge !== CONST.POLICY.DEFAULT_MAX_EXPENSE_AGE;
+    const hasModifiedMaxExpenseAmountNoReceipt =
+        !!policy.maxExpenseAmountNoReceipt &&
+        policy.maxExpenseAmountNoReceipt !== CONST.DISABLED_MAX_EXPENSE_VALUE &&
+        policy.maxExpenseAmountNoReceipt !== CONST.POLICY.DEFAULT_MAX_AMOUNT_NO_RECEIPT;
+    const hasModifiedMaxExpenseAmountNoItemizedReceipt =
+        !!policy.maxExpenseAmountNoItemizedReceipt &&
+        policy.maxExpenseAmountNoItemizedReceipt !== CONST.DISABLED_MAX_EXPENSE_VALUE &&
+        policy.maxExpenseAmountNoItemizedReceipt !== CONST.POLICY.DEFAULT_MAX_AMOUNT_NO_ITEMIZED_RECEIPT;
+
+    const hasModifiedBillable = !!policy.defaultBillable;
+    const hasModifiedReimbursable = policy.defaultReimbursable === false;
+    const hasEReceiptsEnabled = !!policy.eReceipts;
+    const hasRequireCompanyCardsEnabled = !!policy.requireCompanyCardsEnabled;
+
+    const {prohibitedExpenses} = policy;
+    const hasModifiedProhibitedExpenses =
+        !!prohibitedExpenses &&
+        Object.entries(CONST.POLICY.DEFAULT_PROHIBITED_EXPENSES).some(([key, defaultValue]) => {
+            const value = prohibitedExpenses[key as keyof typeof CONST.POLICY.DEFAULT_PROHIBITED_EXPENSES];
+            return value !== undefined && value !== defaultValue;
+        });
+
+    return (
+        hasCustomRules ||
+        hasApprovalRules ||
+        hasExpenseRules ||
+        hasCodingRules ||
+        hasModifiedMaxExpenseAmount ||
+        hasModifiedMaxExpenseAge ||
+        hasModifiedMaxExpenseAmountNoReceipt ||
+        hasModifiedMaxExpenseAmountNoItemizedReceipt ||
+        hasModifiedBillable ||
+        hasModifiedReimbursable ||
+        hasEReceiptsEnabled ||
+        hasRequireCompanyCardsEnabled ||
+        hasModifiedProhibitedExpenses
+    );
 }
 
 /**
@@ -2132,7 +2169,7 @@ export {
     getTagLists,
     hasTags,
     hasCustomCategories,
-    hasNonDefaultRules,
+    hasConfiguredRules,
     getTaxByID,
     getUnitRateValue,
     getRateDisplayValue,

--- a/src/pages/home/GettingStartedSection/hooks/useGettingStartedItems.ts
+++ b/src/pages/home/GettingStartedSection/hooks/useGettingStartedItems.ts
@@ -4,14 +4,13 @@ import useOnyx from '@hooks/useOnyx';
 import useResponsiveLayout from '@hooks/useResponsiveLayout';
 import {hasCompanyCardFeeds} from '@libs/CardUtils';
 import Navigation from '@libs/Navigation/Navigation';
-import {getValidConnectedIntegration, hasAccountingConnections, hasCustomCategories, hasNonDefaultRules, isPaidGroupPolicy, isPendingDeletePolicy, isPolicyAdmin} from '@libs/PolicyUtils';
+import {getValidConnectedIntegration, hasCustomCategories, hasNonDefaultRules, isPaidGroupPolicy, isPendingDeletePolicy, isPolicyAdmin} from '@libs/PolicyUtils';
 import isWithinGettingStartedPeriod from '@pages/home/GettingStartedSection/utils/isWithinGettingStartedPeriod';
-import {enablePolicyCategories} from '@userActions/Policy/Category';
-import {enableCompanyCards, enablePolicyConnections, enablePolicyRules} from '@userActions/Policy/Policy';
+import {enableCompanyCards} from '@userActions/Policy/Policy';
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
-import ROUTES from '@src/ROUTES';
 import type {Route} from '@src/ROUTES';
+import ROUTES from '@src/ROUTES';
 
 type GettingStartedItem = {
     key: string;
@@ -77,7 +76,7 @@ function useGettingStartedItems(): UseGettingStartedItemsResult {
 
     const isDirectConnect = !!reportedIntegration && DIRECT_CONNECT_INTEGRATIONS.has(reportedIntegration);
 
-    if (isDirectConnect || (!reportedIntegration && hasAccountingConnections(policy))) {
+    if (policy?.areAccountingEnabled) {
         const integrationName = isDirectConnect
             ? (CONST.ONBOARDING_ACCOUNTING_MAPPING[reportedIntegration as keyof typeof CONST.ONBOARDING_ACCOUNTING_MAPPING] ?? String(reportedIntegration))
             : undefined;
@@ -86,17 +85,15 @@ function useGettingStartedItems(): UseGettingStartedItemsResult {
             label: integrationName ? translate('homePage.gettingStartedSection.connectAccounting', {integrationName}) : translate('homePage.gettingStartedSection.connectAccountingDefault'),
             isComplete: !!getValidConnectedIntegration(policy) || Object.values(policy?.connections ?? {}).some((conn) => !!conn?.lastSync?.successfulDate),
             route: ROUTES.WORKSPACE_ACCOUNTING.getRoute(activePolicyID),
-            isFeatureEnabled: policy.areConnectionsEnabled,
-            enableFeature: () => enablePolicyConnections(activePolicyID, true, false),
         });
-    } else {
+    }
+
+    if (policy?.areCategoriesEnabled) {
         items.push({
             key: 'customizeCategories',
             label: translate('homePage.gettingStartedSection.customizeCategories'),
             isComplete: hasCustomCategories(policyCategories),
             route: ROUTES.WORKSPACE_CATEGORIES.getRoute(activePolicyID),
-            isFeatureEnabled: policy.areCategoriesEnabled,
-            enableFeature: () => enablePolicyCategories({policy, categories: policyCategories ?? {}, tags: {}, reports: [], transactionsAndViolations: {}}, true, false),
         });
     }
 
@@ -115,8 +112,6 @@ function useGettingStartedItems(): UseGettingStartedItemsResult {
             label: translate('homePage.gettingStartedSection.setupRules'),
             isComplete: hasNonDefaultRules(policy),
             route: ROUTES.WORKSPACE_RULES.getRoute(activePolicyID),
-            isFeatureEnabled: policy.areRulesEnabled,
-            enableFeature: () => enablePolicyRules(policy, true, false),
         });
     }
 

--- a/src/pages/home/GettingStartedSection/hooks/useGettingStartedItems.ts
+++ b/src/pages/home/GettingStartedSection/hooks/useGettingStartedItems.ts
@@ -2,6 +2,7 @@ import useCardFeeds from '@hooks/useCardFeeds';
 import useLocalize from '@hooks/useLocalize';
 import useOnyx from '@hooks/useOnyx';
 import useResponsiveLayout from '@hooks/useResponsiveLayout';
+import {enablePolicyCategories} from '@libs/actions/Policy/Category';
 import {hasCompanyCardFeeds} from '@libs/CardUtils';
 import Navigation from '@libs/Navigation/Navigation';
 import {
@@ -101,6 +102,8 @@ function useGettingStartedItems(): UseGettingStartedItemsResult {
             label: translate('homePage.gettingStartedSection.customizeCategories'),
             isComplete: hasCustomCategories(policyCategories),
             route: ROUTES.WORKSPACE_CATEGORIES.getRoute(activePolicyID),
+            isFeatureEnabled: policy.areCategoriesEnabled,
+            enableFeature: () => enablePolicyCategories({policy, categories: policyCategories ?? {}, tags: {}, reports: [], transactionsAndViolations: {}}, true, false),
         });
     }
 

--- a/src/pages/home/GettingStartedSection/hooks/useGettingStartedItems.ts
+++ b/src/pages/home/GettingStartedSection/hooks/useGettingStartedItems.ts
@@ -4,7 +4,7 @@ import useOnyx from '@hooks/useOnyx';
 import useResponsiveLayout from '@hooks/useResponsiveLayout';
 import {hasCompanyCardFeeds} from '@libs/CardUtils';
 import Navigation from '@libs/Navigation/Navigation';
-import {getValidConnectedIntegration, hasAccountingConnections, hasCustomCategories, hasNonDefaultRules, isPaidGroupPolicy, isPendingDeletePolicy, isPolicyAdmin} from '@libs/PolicyUtils';
+import {getValidConnectedIntegration, hasCustomCategories, hasNonDefaultRules, isPaidGroupPolicy, isPendingDeletePolicy, isPolicyAdmin} from '@libs/PolicyUtils';
 import isWithinGettingStartedPeriod from '@pages/home/GettingStartedSection/utils/isWithinGettingStartedPeriod';
 import {enablePolicyCategories} from '@userActions/Policy/Category';
 import {enableCompanyCards, enablePolicyConnections, enablePolicyRules} from '@userActions/Policy/Policy';
@@ -75,17 +75,16 @@ function useGettingStartedItems(): UseGettingStartedItemsResult {
         route: shouldUseNarrowLayout ? ROUTES.WORKSPACE_INITIAL.getRoute(activePolicyID, Navigation.getActiveRoute()) : ROUTES.WORKSPACE_OVERVIEW.getRoute(activePolicyID),
     });
 
-    const isDirectConnect = policy.areConnectionsEnabled && !hasAccountingConnections(policy);
+    const isDirectConnect = !!reportedIntegration && DIRECT_CONNECT_INTEGRATIONS.has(reportedIntegration);
 
-    if (isDirectConnect) {
-        const integrationName =
-            reportedIntegration && DIRECT_CONNECT_INTEGRATIONS.has(reportedIntegration)
-                ? (CONST.ONBOARDING_ACCOUNTING_MAPPING[reportedIntegration as keyof typeof CONST.ONBOARDING_ACCOUNTING_MAPPING] ?? String(reportedIntegration))
-                : undefined;
+    if (isDirectConnect || !reportedIntegration) {
+        const integrationName = isDirectConnect
+            ? (CONST.ONBOARDING_ACCOUNTING_MAPPING[reportedIntegration as keyof typeof CONST.ONBOARDING_ACCOUNTING_MAPPING] ?? String(reportedIntegration))
+            : undefined;
         items.push({
             key: 'connectAccounting',
             label: integrationName ? translate('homePage.gettingStartedSection.connectAccounting', {integrationName}) : translate('homePage.gettingStartedSection.connectAccountingDefault'),
-            isComplete: !!getValidConnectedIntegration(policy),
+            isComplete: !!getValidConnectedIntegration(policy) || Object.values(policy?.connections ?? {}).some((conn) => !!conn?.lastSync?.successfulDate),
             route: ROUTES.WORKSPACE_ACCOUNTING.getRoute(activePolicyID),
             isFeatureEnabled: policy.areConnectionsEnabled,
             enableFeature: () => enablePolicyConnections(activePolicyID, true, false),

--- a/src/pages/home/GettingStartedSection/hooks/useGettingStartedItems.ts
+++ b/src/pages/home/GettingStartedSection/hooks/useGettingStartedItems.ts
@@ -15,7 +15,7 @@ import {
     isPolicyAdmin,
 } from '@libs/PolicyUtils';
 import isWithinGettingStartedPeriod from '@pages/home/GettingStartedSection/utils/isWithinGettingStartedPeriod';
-import {enableCompanyCards} from '@userActions/Policy/Policy';
+import {enableCompanyCards, enablePolicyConnections} from '@userActions/Policy/Policy';
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
 import type {Route} from '@src/ROUTES';
@@ -95,6 +95,8 @@ function useGettingStartedItems(): UseGettingStartedItemsResult {
             label: integrationName ? translate('homePage.gettingStartedSection.connectAccounting', {integrationName}) : translate('homePage.gettingStartedSection.connectAccountingDefault'),
             isComplete: !!getValidConnectedIntegration(policy) || Object.values(policy?.connections ?? {}).some((conn) => !!conn?.lastSync?.successfulDate),
             route: ROUTES.WORKSPACE_ACCOUNTING.getRoute(activePolicyID),
+            isFeatureEnabled: policy.areConnectionsEnabled,
+            enableFeature: () => enablePolicyConnections(activePolicyID, true, false),
         });
     } else {
         items.push({

--- a/src/pages/home/GettingStartedSection/hooks/useGettingStartedItems.ts
+++ b/src/pages/home/GettingStartedSection/hooks/useGettingStartedItems.ts
@@ -4,7 +4,15 @@ import useOnyx from '@hooks/useOnyx';
 import useResponsiveLayout from '@hooks/useResponsiveLayout';
 import {hasCompanyCardFeeds} from '@libs/CardUtils';
 import Navigation from '@libs/Navigation/Navigation';
-import {getValidConnectedIntegration, hasConfiguredRules, hasCustomCategories, isPaidGroupPolicy, isPendingDeletePolicy, isPolicyAdmin} from '@libs/PolicyUtils';
+import {
+    getValidConnectedIntegration,
+    hasAccountingFeatureConnection,
+    hasConfiguredRules,
+    hasCustomCategories,
+    isPaidGroupPolicy,
+    isPendingDeletePolicy,
+    isPolicyAdmin,
+} from '@libs/PolicyUtils';
 import isWithinGettingStartedPeriod from '@pages/home/GettingStartedSection/utils/isWithinGettingStartedPeriod';
 import {enableCompanyCards} from '@userActions/Policy/Policy';
 import CONST from '@src/CONST';
@@ -45,6 +53,7 @@ function useGettingStartedItems(): UseGettingStartedItemsResult {
     const [policy] = useOnyx(`${ONYXKEYS.COLLECTION.POLICY}${activePolicyID}`);
     const [policyCategories] = useOnyx(`${ONYXKEYS.COLLECTION.POLICY_CATEGORIES}${activePolicyID}`);
     const [allCardFeeds] = useCardFeeds(activePolicyID);
+    const isAccountingEnabled = !!policy?.areConnectionsEnabled || hasAccountingFeatureConnection(policy);
 
     const emptyResult: UseGettingStartedItemsResult = {shouldShowSection: false, items: []};
 
@@ -76,7 +85,7 @@ function useGettingStartedItems(): UseGettingStartedItemsResult {
 
     const isDirectConnect = !!reportedIntegration && DIRECT_CONNECT_INTEGRATIONS.has(reportedIntegration);
 
-    if (policy?.areAccountingEnabled) {
+    if (isAccountingEnabled) {
         const integrationName = isDirectConnect
             ? (CONST.ONBOARDING_ACCOUNTING_MAPPING[reportedIntegration as keyof typeof CONST.ONBOARDING_ACCOUNTING_MAPPING] ?? String(reportedIntegration))
             : undefined;
@@ -86,9 +95,7 @@ function useGettingStartedItems(): UseGettingStartedItemsResult {
             isComplete: !!getValidConnectedIntegration(policy) || Object.values(policy?.connections ?? {}).some((conn) => !!conn?.lastSync?.successfulDate),
             route: ROUTES.WORKSPACE_ACCOUNTING.getRoute(activePolicyID),
         });
-    }
-
-    if (policy?.areCategoriesEnabled) {
+    } else {
         items.push({
             key: 'customizeCategories',
             label: translate('homePage.gettingStartedSection.customizeCategories'),

--- a/src/pages/home/GettingStartedSection/hooks/useGettingStartedItems.ts
+++ b/src/pages/home/GettingStartedSection/hooks/useGettingStartedItems.ts
@@ -4,7 +4,7 @@ import useOnyx from '@hooks/useOnyx';
 import useResponsiveLayout from '@hooks/useResponsiveLayout';
 import {hasCompanyCardFeeds} from '@libs/CardUtils';
 import Navigation from '@libs/Navigation/Navigation';
-import {getValidConnectedIntegration, hasCustomCategories, hasNonDefaultRules, isPaidGroupPolicy, isPendingDeletePolicy, isPolicyAdmin} from '@libs/PolicyUtils';
+import {getValidConnectedIntegration, hasAccountingConnections, hasCustomCategories, hasNonDefaultRules, isPaidGroupPolicy, isPendingDeletePolicy, isPolicyAdmin} from '@libs/PolicyUtils';
 import isWithinGettingStartedPeriod from '@pages/home/GettingStartedSection/utils/isWithinGettingStartedPeriod';
 import {enablePolicyCategories} from '@userActions/Policy/Category';
 import {enableCompanyCards, enablePolicyConnections, enablePolicyRules} from '@userActions/Policy/Policy';
@@ -77,7 +77,7 @@ function useGettingStartedItems(): UseGettingStartedItemsResult {
 
     const isDirectConnect = !!reportedIntegration && DIRECT_CONNECT_INTEGRATIONS.has(reportedIntegration);
 
-    if (isDirectConnect || !reportedIntegration) {
+    if (isDirectConnect || (!reportedIntegration && hasAccountingConnections(policy))) {
         const integrationName = isDirectConnect
             ? (CONST.ONBOARDING_ACCOUNTING_MAPPING[reportedIntegration as keyof typeof CONST.ONBOARDING_ACCOUNTING_MAPPING] ?? String(reportedIntegration))
             : undefined;

--- a/src/pages/home/GettingStartedSection/hooks/useGettingStartedItems.ts
+++ b/src/pages/home/GettingStartedSection/hooks/useGettingStartedItems.ts
@@ -4,7 +4,7 @@ import useOnyx from '@hooks/useOnyx';
 import useResponsiveLayout from '@hooks/useResponsiveLayout';
 import {hasCompanyCardFeeds} from '@libs/CardUtils';
 import Navigation from '@libs/Navigation/Navigation';
-import {hasAccountingConnections, hasCustomCategories, hasNonDefaultRules, isPaidGroupPolicy, isPendingDeletePolicy, isPolicyAdmin} from '@libs/PolicyUtils';
+import {getValidConnectedIntegration, hasCustomCategories, hasNonDefaultRules, isPaidGroupPolicy, isPendingDeletePolicy, isPolicyAdmin} from '@libs/PolicyUtils';
 import isWithinGettingStartedPeriod from '@pages/home/GettingStartedSection/utils/isWithinGettingStartedPeriod';
 import {enablePolicyCategories} from '@userActions/Policy/Category';
 import {enableCompanyCards, enablePolicyConnections, enablePolicyRules} from '@userActions/Policy/Policy';
@@ -12,6 +12,7 @@ import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
 import ROUTES from '@src/ROUTES';
 import type {Route} from '@src/ROUTES';
+import type {ConnectionName} from '@src/types/onyx/Policy';
 
 type GettingStartedItem = {
     key: string;
@@ -82,7 +83,12 @@ function useGettingStartedItems(): UseGettingStartedItemsResult {
         items.push({
             key: 'connectAccounting',
             label: translate('homePage.gettingStartedSection.connectAccounting', {integrationName}),
-            isComplete: hasAccountingConnections(policy),
+            // Use getValidConnectedIntegration for currently-healthy connections. Additionally check
+            // successfulDate so that a task completed by a once-working integration stays checked
+            // even if the connection later breaks (e.g. auth expires). successfulDate is never
+            // cleared by subsequent error syncs due to Onyx deep-merge semantics.
+            isComplete:
+                !!getValidConnectedIntegration(policy, [reportedIntegration as ConnectionName]) || !!policy?.connections?.[reportedIntegration as ConnectionName]?.lastSync?.successfulDate,
             route: ROUTES.WORKSPACE_ACCOUNTING.getRoute(activePolicyID),
             isFeatureEnabled: policy.areConnectionsEnabled,
             enableFeature: () => enablePolicyConnections(activePolicyID, true, false),

--- a/src/pages/home/GettingStartedSection/hooks/useGettingStartedItems.ts
+++ b/src/pages/home/GettingStartedSection/hooks/useGettingStartedItems.ts
@@ -4,7 +4,7 @@ import useOnyx from '@hooks/useOnyx';
 import useResponsiveLayout from '@hooks/useResponsiveLayout';
 import {hasCompanyCardFeeds} from '@libs/CardUtils';
 import Navigation from '@libs/Navigation/Navigation';
-import {getValidConnectedIntegration, hasCustomCategories, hasNonDefaultRules, isPaidGroupPolicy, isPendingDeletePolicy, isPolicyAdmin} from '@libs/PolicyUtils';
+import {getValidConnectedIntegration, hasAccountingConnections, hasCustomCategories, hasNonDefaultRules, isPaidGroupPolicy, isPendingDeletePolicy, isPolicyAdmin} from '@libs/PolicyUtils';
 import isWithinGettingStartedPeriod from '@pages/home/GettingStartedSection/utils/isWithinGettingStartedPeriod';
 import {enablePolicyCategories} from '@userActions/Policy/Category';
 import {enableCompanyCards, enablePolicyConnections, enablePolicyRules} from '@userActions/Policy/Policy';
@@ -12,7 +12,6 @@ import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
 import ROUTES from '@src/ROUTES';
 import type {Route} from '@src/ROUTES';
-import type {ConnectionName} from '@src/types/onyx/Policy';
 
 type GettingStartedItem = {
     key: string;
@@ -76,19 +75,17 @@ function useGettingStartedItems(): UseGettingStartedItemsResult {
         route: shouldUseNarrowLayout ? ROUTES.WORKSPACE_INITIAL.getRoute(activePolicyID, Navigation.getActiveRoute()) : ROUTES.WORKSPACE_OVERVIEW.getRoute(activePolicyID),
     });
 
-    const isDirectConnect = !!reportedIntegration && DIRECT_CONNECT_INTEGRATIONS.has(reportedIntegration);
+    const isDirectConnect = policy.areConnectionsEnabled && !hasAccountingConnections(policy);
 
     if (isDirectConnect) {
-        const integrationName = CONST.ONBOARDING_ACCOUNTING_MAPPING[reportedIntegration as keyof typeof CONST.ONBOARDING_ACCOUNTING_MAPPING] ?? String(reportedIntegration);
+        const integrationName =
+            reportedIntegration && DIRECT_CONNECT_INTEGRATIONS.has(reportedIntegration)
+                ? (CONST.ONBOARDING_ACCOUNTING_MAPPING[reportedIntegration as keyof typeof CONST.ONBOARDING_ACCOUNTING_MAPPING] ?? String(reportedIntegration))
+                : undefined;
         items.push({
             key: 'connectAccounting',
-            label: translate('homePage.gettingStartedSection.connectAccounting', {integrationName}),
-            // Use getValidConnectedIntegration for currently-healthy connections. Additionally check
-            // successfulDate so that a task completed by a once-working integration stays checked
-            // even if the connection later breaks (e.g. auth expires). successfulDate is never
-            // cleared by subsequent error syncs due to Onyx deep-merge semantics.
-            isComplete:
-                !!getValidConnectedIntegration(policy, [reportedIntegration as ConnectionName]) || !!policy?.connections?.[reportedIntegration as ConnectionName]?.lastSync?.successfulDate,
+            label: integrationName ? translate('homePage.gettingStartedSection.connectAccounting', {integrationName}) : translate('homePage.gettingStartedSection.connectAccountingDefault'),
+            isComplete: !!getValidConnectedIntegration(policy),
             route: ROUTES.WORKSPACE_ACCOUNTING.getRoute(activePolicyID),
             isFeatureEnabled: policy.areConnectionsEnabled,
             enableFeature: () => enablePolicyConnections(activePolicyID, true, false),

--- a/src/pages/home/GettingStartedSection/hooks/useGettingStartedItems.ts
+++ b/src/pages/home/GettingStartedSection/hooks/useGettingStartedItems.ts
@@ -4,7 +4,7 @@ import useOnyx from '@hooks/useOnyx';
 import useResponsiveLayout from '@hooks/useResponsiveLayout';
 import {hasCompanyCardFeeds} from '@libs/CardUtils';
 import Navigation from '@libs/Navigation/Navigation';
-import {getValidConnectedIntegration, hasCustomCategories, hasNonDefaultRules, isPaidGroupPolicy, isPendingDeletePolicy, isPolicyAdmin} from '@libs/PolicyUtils';
+import {getValidConnectedIntegration, hasConfiguredRules, hasCustomCategories, isPaidGroupPolicy, isPendingDeletePolicy, isPolicyAdmin} from '@libs/PolicyUtils';
 import isWithinGettingStartedPeriod from '@pages/home/GettingStartedSection/utils/isWithinGettingStartedPeriod';
 import {enableCompanyCards} from '@userActions/Policy/Policy';
 import CONST from '@src/CONST';
@@ -110,7 +110,7 @@ function useGettingStartedItems(): UseGettingStartedItemsResult {
         items.push({
             key: 'setupRules',
             label: translate('homePage.gettingStartedSection.setupRules'),
-            isComplete: hasNonDefaultRules(policy),
+            isComplete: hasConfiguredRules(policy),
             route: ROUTES.WORKSPACE_RULES.getRoute(activePolicyID),
         });
     }

--- a/tests/unit/PolicyUtilsTest.ts
+++ b/tests/unit/PolicyUtilsTest.ts
@@ -26,6 +26,7 @@ import {
     getTagListByOrderWeight,
     getUberConnectionErrorDirectlyFromPolicy,
     getUnitRateValue,
+    hasConfiguredRules,
     hasDependentTags,
     hasDynamicExternalWorkflow,
     hasIndependentTags,
@@ -2447,6 +2448,197 @@ describe('PolicyUtils', () => {
         it('returns false when policyTagList is undefined', () => {
             const policy = {hasMultipleTagLists: true} as Policy;
             expect(hasIndependentTags(policy, undefined)).toBe(false);
+        });
+    });
+
+    describe('hasConfiguredRules', () => {
+        it('returns false when policy is undefined', () => {
+            expect(hasConfiguredRules(undefined)).toBe(false);
+        });
+
+        it('returns false when policy has no rules configured', () => {
+            expect(hasConfiguredRules({} as Policy)).toBe(false);
+        });
+
+        describe('customRules', () => {
+            it('returns true when customRules is non-empty', () => {
+                expect(hasConfiguredRules({customRules: 'some rule'} as Policy)).toBe(true);
+            });
+
+            it('returns false when customRules is an empty string', () => {
+                expect(hasConfiguredRules({customRules: ''} as Policy)).toBe(false);
+            });
+
+            it('returns false when customRules is only whitespace', () => {
+                expect(hasConfiguredRules({customRules: '   '} as Policy)).toBe(false);
+            });
+        });
+
+        describe('rules.approvalRules', () => {
+            it('returns true when approvalRules has items', () => {
+                const policy = {rules: {approvalRules: [{id: '1', applyWhen: [], approver: 'approver@test.com'}]}} as unknown as Policy;
+                expect(hasConfiguredRules(policy)).toBe(true);
+            });
+
+            it('returns false when approvalRules is empty', () => {
+                expect(hasConfiguredRules({rules: {approvalRules: []}} as unknown as Policy)).toBe(false);
+            });
+        });
+
+        describe('rules.expenseRules', () => {
+            it('returns true when expenseRules has items', () => {
+                const policy = {
+                    rules: {
+                        expenseRules: [
+                            {
+                                id: '1',
+                                applyWhen: [],
+                                tax: {field_id_TAX: {externalID: 'TAX_US'}},
+                            },
+                        ],
+                    },
+                } as unknown as Policy;
+                expect(hasConfiguredRules(policy)).toBe(true);
+            });
+
+            it('returns false when expenseRules is empty', () => {
+                expect(hasConfiguredRules({rules: {expenseRules: []}} as unknown as Policy)).toBe(false);
+            });
+        });
+
+        describe('rules.codingRules', () => {
+            it('returns true when codingRules has entries', () => {
+                const policy = {
+                    rules: {
+                        codingRules: {
+                            rule1: {
+                                ruleID: 'rule1',
+                                filters: {left: 'merchant', operator: CONST.SEARCH.SYNTAX_OPERATORS.EQUAL_TO, right: 'Starbucks'},
+                            },
+                        },
+                    },
+                } as unknown as Policy;
+                expect(hasConfiguredRules(policy)).toBe(true);
+            });
+
+            it('returns false when codingRules is empty', () => {
+                expect(hasConfiguredRules({rules: {codingRules: {}}} as unknown as Policy)).toBe(false);
+            });
+        });
+
+        describe('maxExpenseAmount', () => {
+            it('returns true when maxExpenseAmount is set to a non-default value', () => {
+                expect(hasConfiguredRules({maxExpenseAmount: 500000} as Policy)).toBe(true);
+            });
+
+            it('returns false when maxExpenseAmount is the default value', () => {
+                expect(hasConfiguredRules({maxExpenseAmount: CONST.POLICY.DEFAULT_MAX_EXPENSE_AMOUNT} as Policy)).toBe(false);
+            });
+
+            it('returns false when maxExpenseAmount is the disabled value', () => {
+                expect(hasConfiguredRules({maxExpenseAmount: CONST.DISABLED_MAX_EXPENSE_VALUE} as Policy)).toBe(false);
+            });
+        });
+
+        describe('maxExpenseAge', () => {
+            it('returns true when maxExpenseAge is set to a non-default value', () => {
+                expect(hasConfiguredRules({maxExpenseAge: 30} as Policy)).toBe(true);
+            });
+
+            it('returns false when maxExpenseAge is the default value', () => {
+                expect(hasConfiguredRules({maxExpenseAge: CONST.POLICY.DEFAULT_MAX_EXPENSE_AGE} as Policy)).toBe(false);
+            });
+
+            it('returns false when maxExpenseAge is the disabled value', () => {
+                expect(hasConfiguredRules({maxExpenseAge: CONST.DISABLED_MAX_EXPENSE_VALUE} as Policy)).toBe(false);
+            });
+        });
+
+        describe('maxExpenseAmountNoReceipt', () => {
+            it('returns true when maxExpenseAmountNoReceipt is set to a non-default value', () => {
+                expect(hasConfiguredRules({maxExpenseAmountNoReceipt: 5000} as Policy)).toBe(true);
+            });
+
+            it('returns false when maxExpenseAmountNoReceipt is the default value', () => {
+                expect(hasConfiguredRules({maxExpenseAmountNoReceipt: CONST.POLICY.DEFAULT_MAX_AMOUNT_NO_RECEIPT} as Policy)).toBe(false);
+            });
+
+            it('returns false when maxExpenseAmountNoReceipt is the disabled value', () => {
+                expect(hasConfiguredRules({maxExpenseAmountNoReceipt: CONST.DISABLED_MAX_EXPENSE_VALUE} as Policy)).toBe(false);
+            });
+        });
+
+        describe('maxExpenseAmountNoItemizedReceipt', () => {
+            it('returns true when maxExpenseAmountNoItemizedReceipt is set to a non-default value', () => {
+                expect(hasConfiguredRules({maxExpenseAmountNoItemizedReceipt: 10000} as Policy)).toBe(true);
+            });
+
+            it('returns false when maxExpenseAmountNoItemizedReceipt is the default value', () => {
+                expect(hasConfiguredRules({maxExpenseAmountNoItemizedReceipt: CONST.POLICY.DEFAULT_MAX_AMOUNT_NO_ITEMIZED_RECEIPT} as Policy)).toBe(false);
+            });
+
+            it('returns false when maxExpenseAmountNoItemizedReceipt is the disabled value', () => {
+                expect(hasConfiguredRules({maxExpenseAmountNoItemizedReceipt: CONST.DISABLED_MAX_EXPENSE_VALUE} as Policy)).toBe(false);
+            });
+        });
+
+        describe('defaultBillable', () => {
+            it('returns true when defaultBillable is true', () => {
+                expect(hasConfiguredRules({defaultBillable: true} as Policy)).toBe(true);
+            });
+
+            it('returns false when defaultBillable is false', () => {
+                expect(hasConfiguredRules({defaultBillable: false} as Policy)).toBe(false);
+            });
+        });
+
+        describe('defaultReimbursable', () => {
+            it('returns true when defaultReimbursable is false', () => {
+                expect(hasConfiguredRules({defaultReimbursable: false} as Policy)).toBe(true);
+            });
+
+            it('returns false when defaultReimbursable is true', () => {
+                expect(hasConfiguredRules({defaultReimbursable: true} as Policy)).toBe(false);
+            });
+        });
+
+        describe('eReceipts', () => {
+            it('returns true when eReceipts is true', () => {
+                expect(hasConfiguredRules({eReceipts: true} as Policy)).toBe(true);
+            });
+
+            it('returns false when eReceipts is false', () => {
+                expect(hasConfiguredRules({eReceipts: false} as Policy)).toBe(false);
+            });
+        });
+
+        describe('requireCompanyCardsEnabled', () => {
+            it('returns true when requireCompanyCardsEnabled is true', () => {
+                expect(hasConfiguredRules({requireCompanyCardsEnabled: true} as Policy)).toBe(true);
+            });
+
+            it('returns false when requireCompanyCardsEnabled is false', () => {
+                expect(hasConfiguredRules({requireCompanyCardsEnabled: false} as Policy)).toBe(false);
+            });
+        });
+
+        describe('prohibitedExpenses', () => {
+            it('returns true when a prohibitedExpenses value differs from its default', () => {
+                // alcohol defaults to false — setting it to true triggers the rule
+                expect(hasConfiguredRules({prohibitedExpenses: {alcohol: true}} as Policy)).toBe(true);
+            });
+
+            it('returns true when gambling is disabled (differs from default true)', () => {
+                expect(hasConfiguredRules({prohibitedExpenses: {gambling: false}} as Policy)).toBe(true);
+            });
+
+            it('returns false when prohibitedExpenses matches all defaults', () => {
+                expect(hasConfiguredRules({prohibitedExpenses: {...CONST.POLICY.DEFAULT_PROHIBITED_EXPENSES}} as Policy)).toBe(false);
+            });
+
+            it('returns false when prohibitedExpenses is an empty object', () => {
+                expect(hasConfiguredRules({prohibitedExpenses: {}} as Policy)).toBe(false);
+            });
         });
     });
 });

--- a/tests/unit/hooks/useGettingStartedItems.test.ts
+++ b/tests/unit/hooks/useGettingStartedItems.test.ts
@@ -231,7 +231,7 @@ describe('useGettingStartedItems', () => {
         ];
 
         it.each(directConnectIntegrations)('should show "Connect to $name" when user selected $key in onboarding', async ({key, name}) => {
-            await setupManageTeamScenario({accounting: key, policy: {areAccountingEnabled: true}});
+            await setupManageTeamScenario({accounting: key, policy: {areConnectionsEnabled: true}});
 
             const {result} = renderHook(() => useGettingStartedItems());
 
@@ -241,7 +241,7 @@ describe('useGettingStartedItems', () => {
         });
 
         it('should navigate to workspace accounting route', async () => {
-            await setupManageTeamScenario({accounting: CONST.POLICY.CONNECTIONS.NAME.QBO, policy: {areAccountingEnabled: true}});
+            await setupManageTeamScenario({accounting: CONST.POLICY.CONNECTIONS.NAME.QBO, policy: {areConnectionsEnabled: true}});
 
             const {result} = renderHook(() => useGettingStartedItems());
 
@@ -252,7 +252,7 @@ describe('useGettingStartedItems', () => {
         it('should be not completed when workspace has no accounting connection', async () => {
             await setupManageTeamScenario({
                 accounting: CONST.POLICY.CONNECTIONS.NAME.QBO,
-                policy: {areAccountingEnabled: true, connections: undefined},
+                policy: {areConnectionsEnabled: true, connections: undefined},
             });
 
             const {result} = renderHook(() => useGettingStartedItems());
@@ -265,7 +265,7 @@ describe('useGettingStartedItems', () => {
             await setupManageTeamScenario({
                 accounting: CONST.POLICY.CONNECTIONS.NAME.QBO,
                 policy: {
-                    areAccountingEnabled: true,
+                    areConnectionsEnabled: true,
                     connections: {
                         [CONST.POLICY.CONNECTIONS.NAME.QBO]: {
                             config: {},
@@ -286,7 +286,7 @@ describe('useGettingStartedItems', () => {
             await setupManageTeamScenario({
                 accounting: CONST.POLICY.CONNECTIONS.NAME.QBO,
                 policy: {
-                    areAccountingEnabled: true,
+                    areConnectionsEnabled: true,
                     connections: {
                         [CONST.POLICY.CONNECTIONS.NAME.QBO]: {
                             config: {},
@@ -307,7 +307,7 @@ describe('useGettingStartedItems', () => {
             await setupManageTeamScenario({
                 accounting: CONST.POLICY.CONNECTIONS.NAME.QBO,
                 policy: {
-                    areAccountingEnabled: true,
+                    areConnectionsEnabled: true,
                     connections: {
                         [CONST.POLICY.CONNECTIONS.NAME.QBO]: {
                             config: {},
@@ -325,7 +325,7 @@ describe('useGettingStartedItems', () => {
         });
 
         it('should not show the categories row when showing the connect row', async () => {
-            await setupManageTeamScenario({accounting: CONST.POLICY.CONNECTIONS.NAME.QBO, policy: {areAccountingEnabled: true}});
+            await setupManageTeamScenario({accounting: CONST.POLICY.CONNECTIONS.NAME.QBO, policy: {areConnectionsEnabled: true}});
 
             const {result} = renderHook(() => useGettingStartedItems());
 
@@ -336,7 +336,7 @@ describe('useGettingStartedItems', () => {
         it('should show generic "Connect to accounting" when reportedIntegration is not set but a connection already exists (e.g. cache cleared after connecting)', async () => {
             await setupManageTeamScenario({
                 policy: {
-                    areAccountingEnabled: true,
+                    areConnectionsEnabled: true,
                     connections: {
                         [CONST.POLICY.CONNECTIONS.NAME.QBO]: {
                             config: {},
@@ -355,7 +355,7 @@ describe('useGettingStartedItems', () => {
         });
 
         it('should show "Customize accounting categories" when reportedIntegration is not set and no connections exist (e.g. cache cleared before connecting)', async () => {
-            await setupManageTeamScenario({policy: {areCategoriesEnabled: true}});
+            await setupManageTeamScenario({});
 
             const {result} = renderHook(() => useGettingStartedItems());
 
@@ -368,7 +368,7 @@ describe('useGettingStartedItems', () => {
         const categoriesIntegrations = ['sap', 'oracle', 'microsoftDynamics', 'other', 'none'];
 
         it.each(categoriesIntegrations)('should show "Customize accounting categories" when accounting choice is %s', async (accounting) => {
-            await setupManageTeamScenario({accounting, policy: {areCategoriesEnabled: true}});
+            await setupManageTeamScenario({accounting});
 
             const {result} = renderHook(() => useGettingStartedItems());
 
@@ -377,7 +377,7 @@ describe('useGettingStartedItems', () => {
         });
 
         it('should navigate to workspace categories route', async () => {
-            await setupManageTeamScenario({accounting: 'none', policy: {areCategoriesEnabled: true}});
+            await setupManageTeamScenario({accounting: 'none'});
 
             const {result} = renderHook(() => useGettingStartedItems());
 
@@ -386,7 +386,7 @@ describe('useGettingStartedItems', () => {
         });
 
         it('should not show the connect accounting row when showing the categories row', async () => {
-            await setupManageTeamScenario({accounting: 'none', policy: {areCategoriesEnabled: true}});
+            await setupManageTeamScenario({accounting: 'none'});
 
             const {result} = renderHook(() => useGettingStartedItems());
 
@@ -395,7 +395,7 @@ describe('useGettingStartedItems', () => {
         });
 
         it('should be not completed when workspace has only default categories', async () => {
-            await setupManageTeamScenario({accounting: 'none', policy: {areCategoriesEnabled: true}});
+            await setupManageTeamScenario({accounting: 'none'});
 
             const {result} = renderHook(() => useGettingStartedItems());
 
@@ -419,7 +419,7 @@ describe('useGettingStartedItems', () => {
                 },
             };
             await Onyx.merge(`${ONYXKEYS.COLLECTION.POLICY_CATEGORIES}${POLICY_ID}`, customCategories);
-            await setupManageTeamScenario({accounting: 'none', policy: {areCategoriesEnabled: true}});
+            await setupManageTeamScenario({accounting: 'none'});
 
             const {result} = renderHook(() => useGettingStartedItems());
 
@@ -594,7 +594,7 @@ describe('useGettingStartedItems', () => {
         it('should return items in the correct order: createWorkspace, accounting/categories, companyCards, rules', async () => {
             await setupManageTeamScenario({
                 accounting: CONST.POLICY.CONNECTIONS.NAME.QBO,
-                policy: {areAccountingEnabled: true, areCompanyCardsEnabled: true, areRulesEnabled: true},
+                policy: {areConnectionsEnabled: true, areCompanyCardsEnabled: true, areRulesEnabled: true},
             });
 
             const {result} = renderHook(() => useGettingStartedItems());
@@ -606,7 +606,7 @@ describe('useGettingStartedItems', () => {
         it('should return items in the correct order with categories instead of connect', async () => {
             await setupManageTeamScenario({
                 accounting: 'none',
-                policy: {areCategoriesEnabled: true, areCompanyCardsEnabled: true, areRulesEnabled: true},
+                policy: {areCompanyCardsEnabled: true, areRulesEnabled: true},
             });
 
             const {result} = renderHook(() => useGettingStartedItems());
@@ -618,7 +618,7 @@ describe('useGettingStartedItems', () => {
         it('should contain three rows when areRulesEnabled is false', async () => {
             await setupManageTeamScenario({
                 accounting: CONST.POLICY.CONNECTIONS.NAME.QBO,
-                policy: {areAccountingEnabled: true, areCompanyCardsEnabled: false, areRulesEnabled: false},
+                policy: {areConnectionsEnabled: true, areCompanyCardsEnabled: false, areRulesEnabled: false},
             });
 
             const {result} = renderHook(() => useGettingStartedItems());

--- a/tests/unit/hooks/useGettingStartedItems.test.ts
+++ b/tests/unit/hooks/useGettingStartedItems.test.ts
@@ -269,6 +269,47 @@ describe('useGettingStartedItems', () => {
                         [CONST.POLICY.CONNECTIONS.NAME.QBO]: {
                             config: {},
                             data: {},
+                            lastSync: {isConnected: true},
+                        },
+                    } as Policy['connections'],
+                },
+            });
+
+            const {result} = renderHook(() => useGettingStartedItems());
+
+            const connectItem = result.current.items.find((item) => item.key === 'connectAccounting');
+            expect(connectItem?.isComplete).toBe(true);
+        });
+
+        it('should not be completed when the initial connection attempt failed', async () => {
+            await setupManageTeamScenario({
+                accounting: CONST.POLICY.CONNECTIONS.NAME.QBO,
+                policy: {
+                    connections: {
+                        [CONST.POLICY.CONNECTIONS.NAME.QBO]: {
+                            config: {},
+                            data: {},
+                            lastSync: {isConnected: false},
+                        },
+                    } as Policy['connections'],
+                },
+            });
+
+            const {result} = renderHook(() => useGettingStartedItems());
+
+            const connectItem = result.current.items.find((item) => item.key === 'connectAccounting');
+            expect(connectItem?.isComplete).toBe(false);
+        });
+
+        it('should stay completed when a previously successful connection later breaks', async () => {
+            await setupManageTeamScenario({
+                accounting: CONST.POLICY.CONNECTIONS.NAME.QBO,
+                policy: {
+                    connections: {
+                        [CONST.POLICY.CONNECTIONS.NAME.QBO]: {
+                            config: {},
+                            data: {},
+                            lastSync: {isConnected: false, successfulDate: '2024-01-01'},
                         },
                     } as Policy['connections'],
                 },

--- a/tests/unit/hooks/useGettingStartedItems.test.ts
+++ b/tests/unit/hooks/useGettingStartedItems.test.ts
@@ -330,8 +330,18 @@ describe('useGettingStartedItems', () => {
             expect(categoriesItem).toBeUndefined();
         });
 
-        it('should show generic "Connect to accounting" when reportedIntegration is not set (e.g. cache cleared)', async () => {
-            await setupManageTeamScenario();
+        it('should show generic "Connect to accounting" when reportedIntegration is not set but a connection already exists (e.g. cache cleared after connecting)', async () => {
+            await setupManageTeamScenario({
+                policy: {
+                    connections: {
+                        [CONST.POLICY.CONNECTIONS.NAME.QBO]: {
+                            config: {},
+                            data: {},
+                            lastSync: {isConnected: true},
+                        },
+                    } as Policy['connections'],
+                },
+            });
 
             const {result} = renderHook(() => useGettingStartedItems());
 
@@ -340,13 +350,13 @@ describe('useGettingStartedItems', () => {
             expect(connectItem?.label).toContain('connectAccountingDefault');
         });
 
-        it('should not show the categories row when reportedIntegration is not set', async () => {
+        it('should show "Customize accounting categories" when reportedIntegration is not set and no connections exist (e.g. cache cleared before connecting)', async () => {
             await setupManageTeamScenario();
 
             const {result} = renderHook(() => useGettingStartedItems());
 
             const categoriesItem = result.current.items.find((item) => item.key === 'customizeCategories');
-            expect(categoriesItem).toBeUndefined();
+            expect(categoriesItem).toBeDefined();
         });
     });
 

--- a/tests/unit/hooks/useGettingStartedItems.test.ts
+++ b/tests/unit/hooks/useGettingStartedItems.test.ts
@@ -329,10 +329,29 @@ describe('useGettingStartedItems', () => {
             const categoriesItem = result.current.items.find((item) => item.key === 'customizeCategories');
             expect(categoriesItem).toBeUndefined();
         });
+
+        it('should show generic "Connect to accounting" when reportedIntegration is not set (e.g. cache cleared)', async () => {
+            await setupManageTeamScenario();
+
+            const {result} = renderHook(() => useGettingStartedItems());
+
+            const connectItem = result.current.items.find((item) => item.key === 'connectAccounting');
+            expect(connectItem).toBeDefined();
+            expect(connectItem?.label).toContain('connectAccountingDefault');
+        });
+
+        it('should not show the categories row when reportedIntegration is not set', async () => {
+            await setupManageTeamScenario();
+
+            const {result} = renderHook(() => useGettingStartedItems());
+
+            const categoriesItem = result.current.items.find((item) => item.key === 'customizeCategories');
+            expect(categoriesItem).toBeUndefined();
+        });
     });
 
     describe('row 2b - Customize accounting categories', () => {
-        const categoriesIntegrations = ['sap', 'oracle', 'microsoftDynamics', 'other', 'none', null];
+        const categoriesIntegrations = ['sap', 'oracle', 'microsoftDynamics', 'other', 'none'];
 
         it.each(categoriesIntegrations)('should show "Customize accounting categories" when accounting choice is %s', async (accounting) => {
             await setupManageTeamScenario({accounting});

--- a/tests/unit/hooks/useGettingStartedItems.test.ts
+++ b/tests/unit/hooks/useGettingStartedItems.test.ts
@@ -362,6 +362,37 @@ describe('useGettingStartedItems', () => {
             const categoriesItem = result.current.items.find((item) => item.key === 'customizeCategories');
             expect(categoriesItem).toBeDefined();
         });
+
+        it('should have isFeatureEnabled=true when accounting connections feature is enabled', async () => {
+            await setupManageTeamScenario({accounting: CONST.POLICY.CONNECTIONS.NAME.QBO, policy: {areConnectionsEnabled: true}});
+
+            const {result} = renderHook(() => useGettingStartedItems());
+
+            const connectItem = result.current.items.find((item) => item.key === 'connectAccounting');
+            expect(connectItem?.isFeatureEnabled).toBe(true);
+        });
+
+        it('should have isFeatureEnabled=false when accounting connections feature is not enabled but an existing connection makes the row visible', async () => {
+            await setupManageTeamScenario({
+                accounting: CONST.POLICY.CONNECTIONS.NAME.QBO,
+                policy: {
+                    areConnectionsEnabled: false,
+                    connections: {
+                        [CONST.POLICY.CONNECTIONS.NAME.QBO]: {
+                            config: {},
+                            data: {},
+                            lastSync: {isConnected: true},
+                        },
+                    } as Policy['connections'],
+                },
+            });
+
+            const {result} = renderHook(() => useGettingStartedItems());
+
+            const connectItem = result.current.items.find((item) => item.key === 'connectAccounting');
+            expect(connectItem).toBeDefined();
+            expect(connectItem?.isFeatureEnabled).toBe(false);
+        });
     });
 
     describe('row 2b - Customize accounting categories', () => {

--- a/tests/unit/hooks/useGettingStartedItems.test.ts
+++ b/tests/unit/hooks/useGettingStartedItems.test.ts
@@ -231,7 +231,7 @@ describe('useGettingStartedItems', () => {
         ];
 
         it.each(directConnectIntegrations)('should show "Connect to $name" when user selected $key in onboarding', async ({key, name}) => {
-            await setupManageTeamScenario({accounting: key});
+            await setupManageTeamScenario({accounting: key, policy: {areAccountingEnabled: true}});
 
             const {result} = renderHook(() => useGettingStartedItems());
 
@@ -241,7 +241,7 @@ describe('useGettingStartedItems', () => {
         });
 
         it('should navigate to workspace accounting route', async () => {
-            await setupManageTeamScenario({accounting: CONST.POLICY.CONNECTIONS.NAME.QBO});
+            await setupManageTeamScenario({accounting: CONST.POLICY.CONNECTIONS.NAME.QBO, policy: {areAccountingEnabled: true}});
 
             const {result} = renderHook(() => useGettingStartedItems());
 
@@ -252,7 +252,7 @@ describe('useGettingStartedItems', () => {
         it('should be not completed when workspace has no accounting connection', async () => {
             await setupManageTeamScenario({
                 accounting: CONST.POLICY.CONNECTIONS.NAME.QBO,
-                policy: {connections: undefined},
+                policy: {areAccountingEnabled: true, connections: undefined},
             });
 
             const {result} = renderHook(() => useGettingStartedItems());
@@ -265,6 +265,7 @@ describe('useGettingStartedItems', () => {
             await setupManageTeamScenario({
                 accounting: CONST.POLICY.CONNECTIONS.NAME.QBO,
                 policy: {
+                    areAccountingEnabled: true,
                     connections: {
                         [CONST.POLICY.CONNECTIONS.NAME.QBO]: {
                             config: {},
@@ -285,6 +286,7 @@ describe('useGettingStartedItems', () => {
             await setupManageTeamScenario({
                 accounting: CONST.POLICY.CONNECTIONS.NAME.QBO,
                 policy: {
+                    areAccountingEnabled: true,
                     connections: {
                         [CONST.POLICY.CONNECTIONS.NAME.QBO]: {
                             config: {},
@@ -305,6 +307,7 @@ describe('useGettingStartedItems', () => {
             await setupManageTeamScenario({
                 accounting: CONST.POLICY.CONNECTIONS.NAME.QBO,
                 policy: {
+                    areAccountingEnabled: true,
                     connections: {
                         [CONST.POLICY.CONNECTIONS.NAME.QBO]: {
                             config: {},
@@ -322,7 +325,7 @@ describe('useGettingStartedItems', () => {
         });
 
         it('should not show the categories row when showing the connect row', async () => {
-            await setupManageTeamScenario({accounting: CONST.POLICY.CONNECTIONS.NAME.QBO});
+            await setupManageTeamScenario({accounting: CONST.POLICY.CONNECTIONS.NAME.QBO, policy: {areAccountingEnabled: true}});
 
             const {result} = renderHook(() => useGettingStartedItems());
 
@@ -333,6 +336,7 @@ describe('useGettingStartedItems', () => {
         it('should show generic "Connect to accounting" when reportedIntegration is not set but a connection already exists (e.g. cache cleared after connecting)', async () => {
             await setupManageTeamScenario({
                 policy: {
+                    areAccountingEnabled: true,
                     connections: {
                         [CONST.POLICY.CONNECTIONS.NAME.QBO]: {
                             config: {},
@@ -351,7 +355,7 @@ describe('useGettingStartedItems', () => {
         });
 
         it('should show "Customize accounting categories" when reportedIntegration is not set and no connections exist (e.g. cache cleared before connecting)', async () => {
-            await setupManageTeamScenario();
+            await setupManageTeamScenario({policy: {areCategoriesEnabled: true}});
 
             const {result} = renderHook(() => useGettingStartedItems());
 
@@ -364,7 +368,7 @@ describe('useGettingStartedItems', () => {
         const categoriesIntegrations = ['sap', 'oracle', 'microsoftDynamics', 'other', 'none'];
 
         it.each(categoriesIntegrations)('should show "Customize accounting categories" when accounting choice is %s', async (accounting) => {
-            await setupManageTeamScenario({accounting});
+            await setupManageTeamScenario({accounting, policy: {areCategoriesEnabled: true}});
 
             const {result} = renderHook(() => useGettingStartedItems());
 
@@ -373,7 +377,7 @@ describe('useGettingStartedItems', () => {
         });
 
         it('should navigate to workspace categories route', async () => {
-            await setupManageTeamScenario({accounting: 'none'});
+            await setupManageTeamScenario({accounting: 'none', policy: {areCategoriesEnabled: true}});
 
             const {result} = renderHook(() => useGettingStartedItems());
 
@@ -382,7 +386,7 @@ describe('useGettingStartedItems', () => {
         });
 
         it('should not show the connect accounting row when showing the categories row', async () => {
-            await setupManageTeamScenario({accounting: 'none'});
+            await setupManageTeamScenario({accounting: 'none', policy: {areCategoriesEnabled: true}});
 
             const {result} = renderHook(() => useGettingStartedItems());
 
@@ -391,7 +395,7 @@ describe('useGettingStartedItems', () => {
         });
 
         it('should be not completed when workspace has only default categories', async () => {
-            await setupManageTeamScenario({accounting: 'none'});
+            await setupManageTeamScenario({accounting: 'none', policy: {areCategoriesEnabled: true}});
 
             const {result} = renderHook(() => useGettingStartedItems());
 
@@ -415,7 +419,7 @@ describe('useGettingStartedItems', () => {
                 },
             };
             await Onyx.merge(`${ONYXKEYS.COLLECTION.POLICY_CATEGORIES}${POLICY_ID}`, customCategories);
-            await setupManageTeamScenario({accounting: 'none'});
+            await setupManageTeamScenario({accounting: 'none', policy: {areCategoriesEnabled: true}});
 
             const {result} = renderHook(() => useGettingStartedItems());
 
@@ -511,18 +515,6 @@ describe('useGettingStartedItems', () => {
             expect(rulesItem).toBeUndefined();
         });
 
-        it('should have isFeatureEnabled=true when rules feature is enabled', async () => {
-            await setupManageTeamScenario({
-                accounting: CONST.POLICY.CONNECTIONS.NAME.QBO,
-                policy: {areRulesEnabled: true},
-            });
-
-            const {result} = renderHook(() => useGettingStartedItems());
-
-            const rulesItem = result.current.items.find((item) => item.key === 'setupRules');
-            expect(rulesItem?.isFeatureEnabled).toBe(true);
-        });
-
         it('should not be included in items when rules feature is not enabled', async () => {
             await setupManageTeamScenario({
                 accounting: CONST.POLICY.CONNECTIONS.NAME.QBO,
@@ -602,7 +594,7 @@ describe('useGettingStartedItems', () => {
         it('should return items in the correct order: createWorkspace, accounting/categories, companyCards, rules', async () => {
             await setupManageTeamScenario({
                 accounting: CONST.POLICY.CONNECTIONS.NAME.QBO,
-                policy: {areCompanyCardsEnabled: true, areRulesEnabled: true},
+                policy: {areAccountingEnabled: true, areCompanyCardsEnabled: true, areRulesEnabled: true},
             });
 
             const {result} = renderHook(() => useGettingStartedItems());
@@ -614,7 +606,7 @@ describe('useGettingStartedItems', () => {
         it('should return items in the correct order with categories instead of connect', async () => {
             await setupManageTeamScenario({
                 accounting: 'none',
-                policy: {areCompanyCardsEnabled: true, areRulesEnabled: true},
+                policy: {areCategoriesEnabled: true, areCompanyCardsEnabled: true, areRulesEnabled: true},
             });
 
             const {result} = renderHook(() => useGettingStartedItems());
@@ -626,7 +618,7 @@ describe('useGettingStartedItems', () => {
         it('should contain three rows when areRulesEnabled is false', async () => {
             await setupManageTeamScenario({
                 accounting: CONST.POLICY.CONNECTIONS.NAME.QBO,
-                policy: {areCompanyCardsEnabled: false, areRulesEnabled: false},
+                policy: {areAccountingEnabled: true, areCompanyCardsEnabled: false, areRulesEnabled: false},
             });
 
             const {result} = renderHook(() => useGettingStartedItems());

--- a/tests/unit/hooks/useGettingStartedItems.test.ts
+++ b/tests/unit/hooks/useGettingStartedItems.test.ts
@@ -355,7 +355,7 @@ describe('useGettingStartedItems', () => {
         });
 
         it('should show "Customize accounting categories" when reportedIntegration is not set and no connections exist (e.g. cache cleared before connecting)', async () => {
-            await setupManageTeamScenario({});
+            await setupManageTeamScenario({policy: {areCategoriesEnabled: true}});
 
             const {result} = renderHook(() => useGettingStartedItems());
 
@@ -368,7 +368,7 @@ describe('useGettingStartedItems', () => {
         const categoriesIntegrations = ['sap', 'oracle', 'microsoftDynamics', 'other', 'none'];
 
         it.each(categoriesIntegrations)('should show "Customize accounting categories" when accounting choice is %s', async (accounting) => {
-            await setupManageTeamScenario({accounting});
+            await setupManageTeamScenario({accounting, policy: {areCategoriesEnabled: true}});
 
             const {result} = renderHook(() => useGettingStartedItems());
 
@@ -376,8 +376,27 @@ describe('useGettingStartedItems', () => {
             expect(categoriesItem).toBeDefined();
         });
 
+        it('should have isFeatureEnabled=true when categories feature is enabled', async () => {
+            await setupManageTeamScenario({accounting: 'none', policy: {areCategoriesEnabled: true}});
+
+            const {result} = renderHook(() => useGettingStartedItems());
+
+            const categoriesItem = result.current.items.find((item) => item.key === 'customizeCategories');
+            expect(categoriesItem?.isFeatureEnabled).toBe(true);
+        });
+
+        it('should have isFeatureEnabled=false when categories feature is not enabled', async () => {
+            await setupManageTeamScenario({accounting: 'none', policy: {areCategoriesEnabled: false}});
+
+            const {result} = renderHook(() => useGettingStartedItems());
+
+            const categoriesItem = result.current.items.find((item) => item.key === 'customizeCategories');
+            expect(categoriesItem).toBeDefined();
+            expect(categoriesItem?.isFeatureEnabled).toBe(false);
+        });
+
         it('should navigate to workspace categories route', async () => {
-            await setupManageTeamScenario({accounting: 'none'});
+            await setupManageTeamScenario({accounting: 'none', policy: {areCategoriesEnabled: true}});
 
             const {result} = renderHook(() => useGettingStartedItems());
 
@@ -386,7 +405,7 @@ describe('useGettingStartedItems', () => {
         });
 
         it('should not show the connect accounting row when showing the categories row', async () => {
-            await setupManageTeamScenario({accounting: 'none'});
+            await setupManageTeamScenario({accounting: 'none', policy: {areCategoriesEnabled: true}});
 
             const {result} = renderHook(() => useGettingStartedItems());
 
@@ -395,7 +414,7 @@ describe('useGettingStartedItems', () => {
         });
 
         it('should be not completed when workspace has only default categories', async () => {
-            await setupManageTeamScenario({accounting: 'none'});
+            await setupManageTeamScenario({accounting: 'none', policy: {areCategoriesEnabled: true}});
 
             const {result} = renderHook(() => useGettingStartedItems());
 
@@ -419,7 +438,7 @@ describe('useGettingStartedItems', () => {
                 },
             };
             await Onyx.merge(`${ONYXKEYS.COLLECTION.POLICY_CATEGORIES}${POLICY_ID}`, customCategories);
-            await setupManageTeamScenario({accounting: 'none'});
+            await setupManageTeamScenario({accounting: 'none', policy: {areCategoriesEnabled: true}});
 
             const {result} = renderHook(() => useGettingStartedItems());
 
@@ -606,7 +625,7 @@ describe('useGettingStartedItems', () => {
         it('should return items in the correct order with categories instead of connect', async () => {
             await setupManageTeamScenario({
                 accounting: 'none',
-                policy: {areCompanyCardsEnabled: true, areRulesEnabled: true},
+                policy: {areCategoriesEnabled: true, areCompanyCardsEnabled: true, areRulesEnabled: true},
             });
 
             const {result} = renderHook(() => useGettingStartedItems());

--- a/tests/unit/pages/home/GettingStartedSection/GettingStartedSectionTest.tsx
+++ b/tests/unit/pages/home/GettingStartedSection/GettingStartedSectionTest.tsx
@@ -48,7 +48,7 @@ async function setManageTeamUserState(overrides?: {
     hasAccountingConnection?: boolean;
     hasCustomCategories?: boolean;
     hasCompanyCardConnection?: boolean;
-    hasNonDefaultRules?: boolean;
+    hasConfiguredRules?: boolean;
     trialStartDate?: string;
 }) {
     const trialStart = overrides?.trialStartDate ?? '2026-03-01';

--- a/tests/unit/pages/home/GettingStartedSection/GettingStartedSectionTest.tsx
+++ b/tests/unit/pages/home/GettingStartedSection/GettingStartedSectionTest.tsx
@@ -43,6 +43,8 @@ async function setManageTeamUserState(overrides?: {
     integration?: string | null;
     areCompanyCardsEnabled?: boolean;
     areRulesEnabled?: boolean;
+    areAccountingEnabled?: boolean;
+    areCategoriesEnabled?: boolean;
     hasAccountingConnection?: boolean;
     hasCustomCategories?: boolean;
     hasCompanyCardConnection?: boolean;
@@ -65,6 +67,8 @@ async function setManageTeamUserState(overrides?: {
         role: CONST.POLICY.ROLE.ADMIN,
         areCompanyCardsEnabled: overrides?.areCompanyCardsEnabled ?? true,
         areRulesEnabled: overrides?.areRulesEnabled ?? true,
+        areAccountingEnabled: overrides?.areAccountingEnabled,
+        areCategoriesEnabled: overrides?.areCategoriesEnabled,
     };
 
     if (overrides?.hasAccountingConnection) {
@@ -214,7 +218,7 @@ describe('GettingStartedSection', () => {
         });
 
         it('shows "Connect to [system]" row for QBO integration', async () => {
-            await setManageTeamUserState({integration: 'quickbooksOnline'});
+            await setManageTeamUserState({integration: 'quickbooksOnline', areAccountingEnabled: true});
 
             renderGettingStartedSection();
 
@@ -222,7 +226,7 @@ describe('GettingStartedSection', () => {
         });
 
         it('shows "Connect to [system]" row for Xero integration', async () => {
-            await setManageTeamUserState({integration: 'xero'});
+            await setManageTeamUserState({integration: 'xero', areAccountingEnabled: true});
 
             renderGettingStartedSection();
 
@@ -230,7 +234,7 @@ describe('GettingStartedSection', () => {
         });
 
         it('shows "Customize accounting categories" for non-direct-connect integrations', async () => {
-            await setManageTeamUserState({integration: 'other'});
+            await setManageTeamUserState({integration: 'other', areCategoriesEnabled: true});
 
             renderGettingStartedSection();
 
@@ -239,7 +243,7 @@ describe('GettingStartedSection', () => {
         });
 
         it('shows "Customize accounting categories" when no integration is selected', async () => {
-            await setManageTeamUserState({integration: 'none'});
+            await setManageTeamUserState({integration: 'none', areCategoriesEnabled: true});
 
             renderGettingStartedSection();
 
@@ -281,6 +285,7 @@ describe('GettingStartedSection', () => {
         it('renders rows in the expected order: workspace, accounting, cards, rules', async () => {
             await setManageTeamUserState({
                 integration: 'quickbooksOnline',
+                areAccountingEnabled: true,
                 areCompanyCardsEnabled: true,
                 areRulesEnabled: true,
             });
@@ -314,6 +319,7 @@ describe('GettingStartedSection', () => {
         it('accounting row is checked when workspace has a successful connection', async () => {
             await setManageTeamUserState({
                 integration: 'quickbooksOnline',
+                areAccountingEnabled: true,
                 hasAccountingConnection: true,
             });
 
@@ -336,7 +342,7 @@ describe('GettingStartedSection', () => {
         });
 
         it('navigates to workspace accounting when "Connect to [system]" row is pressed', async () => {
-            await setManageTeamUserState({integration: 'quickbooksOnline'});
+            await setManageTeamUserState({integration: 'quickbooksOnline', areAccountingEnabled: true});
 
             renderGettingStartedSection();
 
@@ -347,7 +353,7 @@ describe('GettingStartedSection', () => {
         });
 
         it('navigates to workspace categories when "Customize categories" row is pressed', async () => {
-            await setManageTeamUserState({integration: 'other'});
+            await setManageTeamUserState({integration: 'other', areCategoriesEnabled: true});
 
             renderGettingStartedSection();
 

--- a/tests/unit/pages/home/GettingStartedSection/GettingStartedSectionTest.tsx
+++ b/tests/unit/pages/home/GettingStartedSection/GettingStartedSectionTest.tsx
@@ -67,7 +67,7 @@ async function setManageTeamUserState(overrides?: {
         role: CONST.POLICY.ROLE.ADMIN,
         areCompanyCardsEnabled: overrides?.areCompanyCardsEnabled ?? true,
         areRulesEnabled: overrides?.areRulesEnabled ?? true,
-        areAccountingEnabled: overrides?.areAccountingEnabled,
+        areConnectionsEnabled: overrides?.areAccountingEnabled,
         areCategoriesEnabled: overrides?.areCategoriesEnabled,
     };
 


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
The "Connect to accounting" task in the Home page Getting Started section was using `hasAccountingConnections` to determine if the task was complete. This function returns `true` as soon as any connection entry exists on the policy — even if that connection failed. As a result, the task was being checked off after a failed connection attempt.

The fix replaces `hasAccountingConnections` with `getValidConnectedIntegration`, which only returns a truthy value when the policy has a successfully established integration. This ensures the task is only marked complete when the accounting connection is actually valid and working.

### Fixed Issues
$ https://github.com/Expensify/App/issues/87730
PROPOSAL:


### Tests

1. Verify that no errors appear in the JS console
2. Go through onboarding as a workspace admin and select a direct-connect accounting integration (e.g. QuickBooks Online)
3. On the Home page, find the "Connect to [integration]" task in the Getting Started section — verify it is **not** checked
4. Attempt to connect the accounting integration but cause the connection to fail (e.g. use incorrect credentials)
5. Return to the Home page — verify the "Connect to accounting" task is still **not** checked off
6. Successfully connect the accounting integration
7. Return to the Home page — verify the "Connect to accounting" task is now **checked off**

### Offline tests

No specific offline behavior is affected by this change. The `getValidConnectedIntegration` function reads from local Onyx state, so it works offline the same way `hasAccountingConnections` did.

### QA Steps

1. Verify that no errors appear in the JS console
2. Go through onboarding as a workspace admin and select a direct-connect accounting integration (e.g. QuickBooks Online)
3. On the Home page, find the "Connect to [integration]" task in the Getting Started section — verify it is **not** checked
4. Attempt to connect the accounting integration but let the connection fail
5. Return to the Home page — verify the "Connect to accounting" task is still **not** checked off
6. Successfully connect the accounting integration
7. Return to the Home page — verify the "Connect to accounting" task is now **checked off**

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/901ea040-f0de-4865-8692-fd01a017dac2


</details>
