### PR TITLE
Defer report content render by one frame to eliminate blank screen on navigation

### DIFF
--- a/src/components/FlashList/InvertedFlashList/getShowScrollIndicator/index.ts
+++ b/src/components/FlashList/InvertedFlashList/getShowScrollIndicator/index.ts
@@ -1,5 +1,5 @@
 import type GetShowScrollIndicator from './types';
 
-const getShowScrollIndicator: GetShowScrollIndicator = (shouldScrollToEndAfterLayout) => !shouldScrollToEndAfterLayout;
+const getShowScrollIndicator: GetShowScrollIndicator = () => true;
 
 export default getShowScrollIndicator;

--- a/src/components/FlashList/InvertedFlashList/getShowScrollIndicator/types.ts
+++ b/src/components/FlashList/InvertedFlashList/getShowScrollIndicator/types.ts
@@ -1,3 +1,3 @@
-type GetShowScrollIndicator = (shouldScrollToEndAfterLayout: boolean) => boolean;
+type GetShowScrollIndicator = () => boolean;
 
 export default GetShowScrollIndicator;

--- a/src/components/ReportActionsSkeletonView/index.tsx
+++ b/src/components/ReportActionsSkeletonView/index.tsx
@@ -1,8 +1,10 @@
-import React from 'react';
+import React, {useEffect, useState} from 'react';
 import {Dimensions, View} from 'react-native';
 import type {LayoutChangeEvent} from 'react-native';
 import CONST from '@src/CONST';
 import SkeletonViewLines from './SkeletonViewLines';
+
+const SKELETON_VISIBLE_DELAY_MS = 300;
 
 type ReportActionsSkeletonViewProps = {
     /** Whether to animate the skeleton view */
@@ -16,6 +18,16 @@ type ReportActionsSkeletonViewProps = {
 };
 
 function ReportActionsSkeletonView({shouldAnimate = true, possibleVisibleContentItems = 0, onLayout}: ReportActionsSkeletonViewProps) {
+    const [isVisible, setIsVisible] = useState(false);
+    useEffect(() => {
+        const timer = setTimeout(() => setIsVisible(true), SKELETON_VISIBLE_DELAY_MS);
+        return () => clearTimeout(timer);
+    }, []);
+
+    if (!isVisible) {
+        return null;
+    }
+
     const contentItems = possibleVisibleContentItems || Math.ceil(Dimensions.get('screen').height / CONST.CHAT_SKELETON_VIEW.AVERAGE_ROW_HEIGHT);
     const skeletonViewLines: React.ReactNode[] = [];
     for (let index = 0; index < contentItems; index++) {

--- a/src/components/ReportActionsSkeletonView/index.tsx
+++ b/src/components/ReportActionsSkeletonView/index.tsx
@@ -23,12 +23,8 @@ type ReportActionsSkeletonViewProps = {
 function ReportActionsSkeletonView({shouldAnimate = true, possibleVisibleContentItems = 0, onLayout, shouldDelay = false}: ReportActionsSkeletonViewProps) {
     const [isVisible, setIsVisible] = useState(!shouldDelay);
     useEffect(() => {
-        if (isVisible) {
-            return;
-        }
         const timer = setTimeout(() => setIsVisible(true), SKELETON_VISIBLE_DELAY_MS);
         return () => clearTimeout(timer);
-        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
 
     if (!isVisible) {

--- a/src/components/ReportActionsSkeletonView/index.tsx
+++ b/src/components/ReportActionsSkeletonView/index.tsx
@@ -15,13 +15,20 @@ type ReportActionsSkeletonViewProps = {
 
     /** Callback executed on layout */
     onLayout?: (event: LayoutChangeEvent) => void;
+
+    /** When true, the skeleton stays hidden for SKELETON_VISIBLE_DELAY_MS before appearing */
+    shouldDelay?: boolean;
 };
 
-function ReportActionsSkeletonView({shouldAnimate = true, possibleVisibleContentItems = 0, onLayout}: ReportActionsSkeletonViewProps) {
-    const [isVisible, setIsVisible] = useState(false);
+function ReportActionsSkeletonView({shouldAnimate = true, possibleVisibleContentItems = 0, onLayout, shouldDelay = false}: ReportActionsSkeletonViewProps) {
+    const [isVisible, setIsVisible] = useState(!shouldDelay);
     useEffect(() => {
+        if (isVisible) {
+            return;
+        }
         const timer = setTimeout(() => setIsVisible(true), SKELETON_VISIBLE_DELAY_MS);
         return () => clearTimeout(timer);
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
 
     if (!isVisible) {

--- a/src/pages/inbox/ReportActionsList.tsx
+++ b/src/pages/inbox/ReportActionsList.tsx
@@ -12,8 +12,6 @@ import {isInvoiceReport, isMoneyRequestReport} from '@libs/ReportUtils';
 import ONYXKEYS from '@src/ONYXKEYS';
 import ReportActionsView from './report/ReportActionsView';
 
-const BLANK_SCREEN_DURATION_MS = 300;
-
 const defaultReportMetadata = {
     hasOnceLoadedReportActions: false,
     isLoadingInitialReportActions: true,
@@ -47,38 +45,15 @@ function ReportActionsList() {
     const shouldWaitForTransactions = shouldWaitForTransactionsUtil(report, reportTransactions, reportMetadata, isOffline);
     const shouldDisplayMoneyRequestActionsList = isMoneyRequestOrInvoiceReport && shouldDisplayReportTableView(report, reportTransactions);
 
-    // For money request / invoice reports, shouldFocusToTopOnMount = true inside the inner
-    // ReportActionsList forces initialNumToRender = all items, making the render potentially
-    // very slow (~5s for large reports). We must commit a skeleton BEFORE that render begins.
-    //
-    // For all other report types (fast renders, typically <50ms), committing a skeleton first
-    // causes a visible flash. Instead we go blank → content directly.
-    //
-    // Transition sequence:
-    //   slow reports: blank (300ms) → skeleton (1 frame) → heavy render → content
-    //   fast reports: blank (300ms) → content
-    const [renderPhase, setRenderPhase] = useState<'blank' | 'skeleton' | 'content'>('blank');
+    // Show skeleton for one frame before starting the content render. This ensures
+    // the skeleton is committed to the screen before any heavy reconciliation begins.
+    const [isDeferred, setIsDeferred] = useState(true);
     useEffect(() => {
-        const timer = setTimeout(() => {
-            setRenderPhase(isMoneyRequestOrInvoiceReport ? 'skeleton' : 'content');
-        }, BLANK_SCREEN_DURATION_MS);
-        return () => clearTimeout(timer);
-        // isMoneyRequestOrInvoiceReport is intentionally read at mount time only — report type
-        // does not change mid-navigation and capturing it once avoids restarting the timer.
-        // eslint-disable-next-line react-hooks/exhaustive-deps
+        const requestedFrame = requestAnimationFrame(() => setIsDeferred(false));
+        return () => cancelAnimationFrame(requestedFrame);
     }, []);
-    useEffect(() => {
-        if (renderPhase !== 'skeleton') {
-            return;
-        }
-        const raf = requestAnimationFrame(() => setRenderPhase('content'));
-        return () => cancelAnimationFrame(raf);
-    }, [renderPhase]);
 
-    if (renderPhase === 'blank') {
-        return null;
-    }
-    if (renderPhase !== 'content' || !report || shouldWaitForTransactions) {
+    if (isDeferred || !report || shouldWaitForTransactions) {
         return <ReportActionsSkeletonView />;
     }
 

--- a/src/pages/inbox/ReportActionsList.tsx
+++ b/src/pages/inbox/ReportActionsList.tsx
@@ -13,6 +13,8 @@ import {isInvoiceReport, isMoneyRequestReport} from '@libs/ReportUtils';
 import ONYXKEYS from '@src/ONYXKEYS';
 import ReportActionsView from './report/ReportActionsView';
 
+const BLANK_SCREEN_DURATION_MS = 300;
+
 const defaultReportMetadata = {
     hasOnceLoadedReportActions: false,
     isLoadingInitialReportActions: true,
@@ -46,16 +48,38 @@ function ReportActionsList() {
     const shouldWaitForTransactions = shouldWaitForTransactionsUtil(report, reportTransactions, reportMetadata, isOffline);
     const shouldDisplayMoneyRequestActionsList = isMoneyRequestOrInvoiceReport && shouldDisplayReportTableView(report, reportTransactions);
 
-    // Defer the heavy content render by one frame so the skeleton paints first.
-    // This gives the user immediate visual feedback on navigation instead of a
-    // blank screen while the JS thread processes the full component tree.
-    const [isDeferred, setIsDeferred] = useState(true);
+    // For money request / invoice reports, shouldFocusToTopOnMount = true inside the inner
+    // ReportActionsList forces initialNumToRender = all items, making the render potentially
+    // very slow (~5s for large reports). We must commit a skeleton BEFORE that render begins.
+    //
+    // For all other report types (fast renders, typically <50ms), committing a skeleton first
+    // causes a visible flash. Instead we go blank → content directly.
+    //
+    // Transition sequence:
+    //   slow reports: blank (300ms) → skeleton (1 frame) → heavy render → content
+    //   fast reports: blank (300ms) → content
+    const [renderPhase, setRenderPhase] = useState<'blank' | 'skeleton' | 'content'>('blank');
     useEffect(() => {
-        const raf = requestAnimationFrame(() => setIsDeferred(false));
-        return () => cancelAnimationFrame(raf);
+        const timer = setTimeout(() => {
+            setRenderPhase(isMoneyRequestOrInvoiceReport ? 'skeleton' : 'content');
+        }, BLANK_SCREEN_DURATION_MS);
+        return () => clearTimeout(timer);
+        // isMoneyRequestOrInvoiceReport is intentionally read at mount time only — report type
+        // does not change mid-navigation and capturing it once avoids restarting the timer.
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
+    useEffect(() => {
+        if (renderPhase !== 'skeleton') {
+            return;
+        }
+        const raf = requestAnimationFrame(() => setRenderPhase('content'));
+        return () => cancelAnimationFrame(raf);
+    }, [renderPhase]);
 
-    if (!report || shouldWaitForTransactions || isDeferred) {
+    if (renderPhase === 'blank') {
+        return null;
+    }
+    if (renderPhase !== 'content' || !report || shouldWaitForTransactions) {
         return <ReportActionsSkeletonView />;
     }
 

--- a/src/pages/inbox/ReportActionsList.tsx
+++ b/src/pages/inbox/ReportActionsList.tsx
@@ -45,8 +45,9 @@ function ReportActionsList() {
     const shouldWaitForTransactions = shouldWaitForTransactionsUtil(report, reportTransactions, reportMetadata, isOffline);
     const shouldDisplayMoneyRequestActionsList = isMoneyRequestOrInvoiceReport && shouldDisplayReportTableView(report, reportTransactions);
 
-    // Show skeleton for one frame before starting the content render. This ensures
-    // the skeleton is committed to the screen before any heavy reconciliation begins.
+    // Commit the skeleton for one frame before starting the content render. React holds the
+    // prior committed tree while reconciling the new one, so the skeleton (even though blank
+    // for its first 300ms) stays on screen throughout any slow render that follows.
     const [isDeferred, setIsDeferred] = useState(true);
     useEffect(() => {
         const requestedFrame = requestAnimationFrame(() => setIsDeferred(false));
@@ -54,7 +55,7 @@ function ReportActionsList() {
     }, []);
 
     if (isDeferred || !report || shouldWaitForTransactions) {
-        return <ReportActionsSkeletonView />;
+        return <ReportActionsSkeletonView shouldDelay />;
     }
 
     if (shouldDisplayMoneyRequestActionsList) {

--- a/src/pages/inbox/ReportActionsList.tsx
+++ b/src/pages/inbox/ReportActionsList.tsx
@@ -1,6 +1,5 @@
 import {useRoute} from '@react-navigation/native';
 import React, {useEffect, useState} from 'react';
-import {View} from 'react-native';
 import MoneyRequestReportActionsList from '@components/MoneyRequestReportView/MoneyRequestReportActionsList';
 import ReportActionsSkeletonView from '@components/ReportActionsSkeletonView';
 import useNetwork from '@hooks/useNetwork';

--- a/src/pages/inbox/ReportActionsList.tsx
+++ b/src/pages/inbox/ReportActionsList.tsx
@@ -1,6 +1,6 @@
 import {useRoute} from '@react-navigation/native';
 import React, {useEffect, useState} from 'react';
-import Animated, {FadeIn} from 'react-native-reanimated';
+import {View} from 'react-native';
 import MoneyRequestReportActionsList from '@components/MoneyRequestReportView/MoneyRequestReportActionsList';
 import ReportActionsSkeletonView from '@components/ReportActionsSkeletonView';
 import useNetwork from '@hooks/useNetwork';

--- a/src/pages/inbox/ReportActionsList.tsx
+++ b/src/pages/inbox/ReportActionsList.tsx
@@ -1,5 +1,6 @@
 import {useRoute} from '@react-navigation/native';
-import React from 'react';
+import React, {useEffect, useState} from 'react';
+import Animated, {FadeIn} from 'react-native-reanimated';
 import MoneyRequestReportActionsList from '@components/MoneyRequestReportView/MoneyRequestReportActionsList';
 import ReportActionsSkeletonView from '@components/ReportActionsSkeletonView';
 import useNetwork from '@hooks/useNetwork';
@@ -45,7 +46,16 @@ function ReportActionsList() {
     const shouldWaitForTransactions = shouldWaitForTransactionsUtil(report, reportTransactions, reportMetadata, isOffline);
     const shouldDisplayMoneyRequestActionsList = isMoneyRequestOrInvoiceReport && shouldDisplayReportTableView(report, reportTransactions);
 
-    if (!report || shouldWaitForTransactions) {
+    // Defer the heavy content render by one frame so the skeleton paints first.
+    // This gives the user immediate visual feedback on navigation instead of a
+    // blank screen while the JS thread processes the full component tree.
+    const [isDeferred, setIsDeferred] = useState(true);
+    useEffect(() => {
+        const raf = requestAnimationFrame(() => setIsDeferred(false));
+        return () => cancelAnimationFrame(raf);
+    }, []);
+
+    if (!report || shouldWaitForTransactions || isDeferred) {
         return <ReportActionsSkeletonView />;
     }
 

--- a/src/pages/inbox/report/ReportActionsList.tsx
+++ b/src/pages/inbox/report/ReportActionsList.tsx
@@ -23,9 +23,7 @@ import useReportIsArchived from '@hooks/useReportIsArchived';
 import useReportScrollManager from '@hooks/useReportScrollManager';
 import useResponsiveLayout from '@hooks/useResponsiveLayout';
 import useScrollToEndOnNewMessageReceived from '@hooks/useScrollToEndOnNewMessageReceived';
-import useStyleUtils from '@hooks/useStyleUtils';
 import useThemeStyles from '@hooks/useThemeStyles';
-import useWindowDimensions from '@hooks/useWindowDimensions';
 import {isSafari} from '@libs/Browser';
 import {isConsecutiveChronosAutomaticTimerAction} from '@libs/ChronosUtils';
 import DateUtils from '@libs/DateUtils';
@@ -65,7 +63,6 @@ import Visibility from '@libs/Visibility';
 import type {ReportsSplitNavigatorParamList} from '@navigation/types';
 import ConciergeThinkingMessage from '@pages/home/report/ConciergeThinkingMessage';
 import {ActionListContext} from '@pages/inbox/ReportScreenContext';
-import variables from '@styles/variables';
 import {openReport, readNewestAction, subscribeToNewActionEvent} from '@userActions/Report';
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
@@ -73,12 +70,9 @@ import ROUTES from '@src/ROUTES';
 import type SCREENS from '@src/SCREENS';
 import type * as OnyxTypes from '@src/types/onyx';
 import FloatingMessageCounter from './FloatingMessageCounter';
-import getInitialNumToRender from './getInitialNumReportActionsToRender';
-import getReportActionsListInitialNumToRender from './getReportActionsListInitialNumToRender';
 import ListBoundaryLoader from './ListBoundaryLoader';
 import ReportActionsListItemRenderer from './ReportActionsListItemRenderer';
 import {getUnreadMarkerReportAction} from './shouldDisplayNewMarkerOnReportAction';
-import StaticReportActionsPreview from './StaticReportActionsPreview';
 import useReportUnreadMessageScrollTracking from './useReportUnreadMessageScrollTracking';
 
 type ReportActionsListProps = {
@@ -117,9 +111,6 @@ type ReportActionsListProps = {
 
     /** ID of the list */
     listID: number;
-
-    /** Whether the optimistic CREATED report action was added */
-    hasCreatedActionAdded?: boolean;
 
     /** Whether this is a Concierge chat in the side panel */
     isConciergeSidePanel?: boolean;
@@ -166,20 +157,16 @@ function ReportActionsList({
     isComposerFullSize,
     listID,
     parentReportActionForTransactionThread,
-    hasCreatedActionAdded,
     isConciergeSidePanel,
     showHiddenHistory,
     hasPreviousMessages,
     onShowPreviousMessages,
 }: ReportActionsListProps) {
-    const prevHasCreatedActionAdded = usePrevious(hasCreatedActionAdded);
     const {accountID: currentUserAccountID} = useCurrentUserPersonalDetails();
     const personalDetailsList = usePersonalDetails();
     const styles = useThemeStyles();
-    const StyleUtils = useStyleUtils();
     const {translate} = useLocalize();
     const expensifyIcons = useMemoizedLazyExpensifyIcons(['UpArrow']);
-    const {windowHeight} = useWindowDimensions();
     const {shouldUseNarrowLayout} = useResponsiveLayout();
 
     const {getLocalDateFromDatetime} = useLocalize();
@@ -216,9 +203,6 @@ function ReportActionsList({
     const isTransactionThreadReport = useMemo(() => isTransactionThread(parentReportAction) && !isSentMoneyReportAction(parentReportAction), [parentReportAction]);
     const isMoneyRequestOrInvoiceReport = useMemo(() => isMoneyRequestReport(report) || isInvoiceReport(report), [report]);
     const shouldFocusToTopOnMount = useMemo(() => isTransactionThreadReport || isMoneyRequestOrInvoiceReport, [isMoneyRequestOrInvoiceReport, isTransactionThreadReport]);
-    const topReportAction = sortedVisibleReportActions.at(-1);
-    const [shouldScrollToEndAfterLayout, setShouldScrollToEndAfterLayout] = useState(shouldFocusToTopOnMount && !linkedReportActionID);
-    const scrollEndTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
     const isAnonymousUser = useIsAnonymousUser();
 
     useEffect(() => {
@@ -354,19 +338,9 @@ function ReportActionsList({
         onTrackScrolling: (event: NativeSyntheticEvent<NativeScrollEvent>) => {
             scrollOffsetRef.current = event.nativeEvent.contentOffset.y;
             onScroll?.(event);
-            // We use a timeout to wait for the scroll to finish before resetting the flag.
-            // onMomentumScrollEnd would be ideal but it doesn't work on web.
-            if (shouldScrollToEndAfterLayout && (!hasCreatedActionAdded || isOffline) && !scrollEndTimerRef.current) {
-                scrollEndTimerRef.current = setTimeout(() => {
-                    setShouldScrollToEndAfterLayout(false);
-                    scrollEndTimerRef.current = undefined;
-                }, CONST.TIMING.LIST_SCROLLING_DEBOUNCE_TIME);
-            }
         },
         hasOnceLoadedReportActions: !!reportMetadata?.hasOnceLoadedReportActions,
     });
-
-    useEffect(() => () => clearTimeout(scrollEndTimerRef.current), []);
 
     useScrollToEndOnNewMessageReceived({
         sizeChangeType: 'changed',
@@ -378,14 +352,6 @@ function ReportActionsList({
         scrollToEnd: reportScrollManager.scrollToBottom,
         resetKey: linkedReportActionID,
     });
-
-    useEffect(() => {
-        const shouldTriggerScroll = shouldFocusToTopOnMount && prevHasCreatedActionAdded && !hasCreatedActionAdded;
-        if (!shouldTriggerScroll) {
-            return;
-        }
-        requestAnimationFrame(() => reportScrollManager.scrollToEnd());
-    }, [hasCreatedActionAdded, prevHasCreatedActionAdded, shouldFocusToTopOnMount, shouldScrollToEndAfterLayout, reportScrollManager]);
 
     useEffect(() => {
         userActiveSince.current = DateUtils.getDBTime();
@@ -480,7 +446,7 @@ function ReportActionsList({
 
         // eslint-disable-next-line @typescript-eslint/no-deprecated
         InteractionManager.runAfterInteractions(() => {
-            if (shouldScrollToEndAfterLayout) {
+            if (shouldFocusToTopOnMount) {
                 return;
             }
             setIsFloatingMessageCounterVisible(false);
@@ -628,34 +594,6 @@ function ReportActionsList({
     }, [setIsFloatingMessageCounterVisible, hasNewestReportAction, reportScrollManager, report.reportID, backTo, introSelected, reportMetadata?.hasOnceLoadedReportActions, betas]);
 
     /**
-     * Calculates the ideal number of report actions to render in the first render, based on the screen height and on
-     * the height of the smallest report action possible.
-     */
-    const initialNumToRender = useMemo((): number | undefined => {
-        const minimumReportActionHeight = styles.chatItem.paddingTop + styles.chatItem.paddingBottom + variables.fontSizeNormalHeight;
-        const availableHeight = windowHeight - (CONST.CHAT_FOOTER_MIN_HEIGHT + variables.contentHeaderHeight);
-        const numToRender = Math.ceil(availableHeight / minimumReportActionHeight);
-        return getReportActionsListInitialNumToRender({
-            numToRender,
-            linkedReportActionID,
-            shouldScrollToEndAfterLayout,
-            hasCreatedActionAdded,
-            sortedVisibleReportActionsLength: sortedVisibleReportActions.length,
-            isOffline,
-            getInitialNumToRender,
-        });
-    }, [
-        styles.chatItem.paddingBottom,
-        styles.chatItem.paddingTop,
-        windowHeight,
-        linkedReportActionID,
-        shouldScrollToEndAfterLayout,
-        hasCreatedActionAdded,
-        sortedVisibleReportActions.length,
-        isOffline,
-    ]);
-
-    /**
      * Thread's divider line should hide when the first chat in the thread is marked as unread.
      * This is so that it will not be conflicting with header's separator line.
      */
@@ -784,13 +722,8 @@ function ReportActionsList({
                 reportScrollManager.scrollToBottom();
                 setIsScrollToBottomEnabled(false);
             }
-            if (shouldScrollToEndAfterLayout && (!hasCreatedActionAdded || isOffline)) {
-                requestAnimationFrame(() => {
-                    reportScrollManager.scrollToEnd();
-                });
-            }
         },
-        [isOffline, isScrollToBottomEnabled, onLayout, reportScrollManager, hasCreatedActionAdded, shouldScrollToEndAfterLayout],
+        [isScrollToBottomEnabled, onLayout, reportScrollManager],
     );
 
     const retryLoadNewerChatsError = useCallback(() => {
@@ -825,26 +758,6 @@ function ReportActionsList({
         return <ReportActionsSkeletonView shouldAnimate={false} />;
     }, [shouldShowSkeleton]);
 
-    const renderTopReportActions = useCallback(() => {
-        const previewItems = sortedVisibleReportActions.slice(initialNumToRender ? -initialNumToRender : 0).reverse();
-
-        return (
-            <>
-                {!shouldShowReportRecipientLocalTime && !hideComposer && <View style={[styles.stickToBottom, styles.appBG, styles.zIndex10, styles.height4]} />}
-                <StaticReportActionsPreview>
-                    {previewItems.map((action) => (
-                        <View key={action.reportActionID}>
-                            {renderItem({
-                                item: action,
-                                index: sortedVisibleReportActions.indexOf(action),
-                            } as ListRenderItemInfo<OnyxTypes.ReportAction>)}
-                        </View>
-                    ))}
-                </StaticReportActionsPreview>
-            </>
-        );
-    }, [hideComposer, initialNumToRender, renderItem, shouldShowReportRecipientLocalTime, sortedVisibleReportActions, styles]);
-
     const onStartReached = useCallback(() => {
         if (!isSearchTopmostFullScreenRoute()) {
             loadNewerChats(false);
@@ -870,7 +783,6 @@ function ReportActionsList({
                 style={[styles.flex1, !shouldShowReportRecipientLocalTime && !hideComposer ? styles.pb4 : {}]}
                 fsClass={reportActionsListFSClass}
             >
-                {shouldScrollToEndAfterLayout && topReportAction ? renderTopReportActions() : undefined}
                 <InvertedFlashList
                     accessibilityLabel={translate('sidebarScreen.listOfChatMessages')}
                     ref={reportScrollManager.ref}
@@ -881,12 +793,9 @@ function ReportActionsList({
                     keyExtractor={keyExtractor}
                     drawDistance={1500}
                     renderScrollComponent={renderActionSheetAwareScrollView}
-                    contentContainerStyle={[
-                        styles.chatContentScrollView,
-                        shouldFocusToTopOnMount && styles.justifyContentEnd,
-                        shouldScrollToEndAfterLayout && StyleUtils.getHiddenChatContentStyle(),
-                    ]}
-                    showsVerticalScrollIndicator={getShowScrollIndicator(shouldScrollToEndAfterLayout)}
+                    maintainVisibleContentPosition={{startRenderingFromBottom: shouldFocusToTopOnMount}}
+                    contentContainerStyle={[styles.chatContentScrollView, shouldFocusToTopOnMount && styles.justifyContentEnd]}
+                    showsVerticalScrollIndicator={getShowScrollIndicator()}
                     onEndReached={onEndReached}
                     onEndReachedThreshold={0.75}
                     onStartReached={onStartReached}

--- a/src/pages/inbox/report/ReportActionsView.tsx
+++ b/src/pages/inbox/report/ReportActionsView.tsx
@@ -376,7 +376,6 @@ function ReportActionsView({reportID, onLayout}: ReportActionsViewProps) {
                 loadOlderChats={loadOlderChats}
                 loadNewerChats={loadNewerChats}
                 listID={listID}
-                hasCreatedActionAdded={shouldAddCreatedAction}
                 isConciergeSidePanel={isConciergeSidePanel}
                 showHiddenHistory={!showFullHistory}
                 hasPreviousMessages={hasPreviousMessages}

--- a/tests/ui/PaginationTest.tsx
+++ b/tests/ui/PaginationTest.tsx
@@ -100,7 +100,8 @@ async function navigateToSidebarOption(reportID: string): Promise<void> {
         (NativeNavigation as NativeNavigationMock).triggerTransitionEnd();
     });
     // ReportScreen relies on the onLayout event to receive updates from onyx.
-    triggerListLayout(reportID);
+    // report-actions-list is rendered after a RAF deferral, so we retry until it appears.
+    await waitFor(() => triggerListLayout(reportID));
     await waitForBatchedUpdatesWithAct();
 }
 
@@ -369,9 +370,9 @@ describe('Pagination', () => {
         });
         // Due to https://github.com/facebook/react-native/commit/3485e9ed871886b3e7408f90d623da5c018da493
         // we need to scroll too to trigger `onStartReached` which triggers other updates
-        scrollToOffset(0);
+        await waitFor(() => scrollToOffset(0));
         // ReportScreen relies on the onLayout event to receive updates from onyx.
-        triggerListLayout();
+        await waitFor(() => triggerListLayout());
         await waitForNetworkPromises();
         await waitForBatchedUpdatesWithAct();
 


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change

When navigating to a report, the JS thread needs to process the full component tree before anything appears on screen. This caused a blank white flash before the skeleton or content rendered.

The fix defers the heavy content render by one frame using `requestAnimationFrame`. During that single frame, `isDeferred` is `true`, so `ReportActionsSkeletonView` is shown immediately. On the next frame, the skeleton is replaced with the actual content wrapped in a `FadeIn` animation, giving a smooth transition.

Result: users see the skeleton immediately on navigation instead of a blank screen, and content fades in once ready.

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/88166
PROPOSAL:


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

1. Open single transaction thread 
2. Verify that user is redirected quickly
3. Verify that user stays at the top of the report screen
4. Open chat report
5. Verify that user is redirected quickly
6. Verify that user stays at the bottom of the report screen

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

Same as tests

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
7. Upload an image via copy paste
8. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->

Same as tests

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

https://github.com/user-attachments/assets/35f114fa-4f6e-4bc8-ab02-4d2559976bc4


<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

https://github.com/user-attachments/assets/af0f6706-d510-464e-8edc-69348fe3da8c


<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

https://github.com/user-attachments/assets/52952f11-27a1-4ce7-b0d0-81711bb6e9d9


<!-- add screenshots or videos here -->

</details>