### PR TITLE
Fix Deleted card shown for non-admin users without cardFeeds data

### DIFF
--- a/src/libs/CardUtils.ts
+++ b/src/libs/CardUtils.ts
@@ -713,6 +713,15 @@ function doesCardFeedExist(feed: CardFeed | undefined, cardFeeds: OnyxCollection
 }
 
 /**
+ * Check if the cardFeeds collection has any loaded data.
+ * An empty collection ({}) means data was never fetched (e.g. non-admin users),
+ * which is different from having data that shows a feed was deleted.
+ */
+function hasLoadedCardFeeds(cardFeeds: OnyxCollection<CardFeeds> | undefined): boolean {
+    return !!cardFeeds && Object.keys(cardFeeds).length > 0;
+}
+
+/**
  * Retrieve the custom nickname for a feed from the card feeds collection.
  */
 function getCustomFeedNameFromFeeds(cardFeeds: OnyxCollection<CardFeeds> | undefined, feed: CompanyCardFeed | undefined): string | undefined {
@@ -1588,7 +1597,7 @@ function getCardHintText(validFrom: string | undefined, validThru: string | unde
 
 /**
  * Resolves card-related fields on transactions for report layout display.
- * The search API pre-resolves cardName and isCardFeedDeleted, but local Onyx transactions have raw values.
+ * The search API pre-resolves cardName, but local Onyx transactions have raw values.
  * This ensures the report layout matches the search page.
  */
 function resolveTransactionCardFields<T extends {cardID?: number; cardName?: string; bank?: string}>(
@@ -1611,8 +1620,8 @@ function resolveTransactionCardFields<T extends {cardID?: number; cardName?: str
             }
         }
 
-        // Resolve isCardFeedDeleted
-        if (cardFeeds !== undefined) {
+        // Resolve isCardFeedDeleted — only when we have actual feed data to make an informed judgment
+        if (hasLoadedCardFeeds(cardFeeds)) {
             updates = {...updates, isCardFeedDeleted: !!transaction.bank && !doesCardFeedExist(transaction.bank as CompanyCardFeed, cardFeeds)};
         }
 
@@ -1680,6 +1689,7 @@ export {
     lastFourNumbersFromCardName,
     isMatchingCard,
     normalizeCardName,
+    hasLoadedCardFeeds,
     hasIssuedExpensifyCard,
     isExpensifyCardFullySetUp,
     getCardSettings,

--- a/src/libs/SearchUIUtils.ts
+++ b/src/libs/SearchUIUtils.ts
@@ -97,7 +97,7 @@ import type {TransactionPreviewData} from './actions/Search';
 import {setOptimisticDataForTransactionThreadPreview} from './actions/Search';
 import type {CardFeedForDisplay} from './CardFeedUtils';
 import {getCardFeedsForDisplay} from './CardFeedUtils';
-import {doesCardFeedExist, getCardDescriptionForSearchTable, getFeedNameForDisplay} from './CardUtils';
+import {doesCardFeedExist, getCardDescriptionForSearchTable, getFeedNameForDisplay, hasLoadedCardFeeds} from './CardUtils';
 import {getDecodedCategoryName} from './CategoryUtils';
 import {convertToDisplayString} from './CurrencyUtils';
 import DateUtils from './DateUtils';
@@ -2074,8 +2074,8 @@ function getTransactionsSections({
             const from = fromAccountID ? (personalDetailsMap.get(fromAccountID.toString()) ?? emptyPersonalDetails) : emptyPersonalDetails;
             const to = getToFieldValueForTransaction(transactionItem, report, data.personalDetailsList, reportAction);
             const isIOUReport = report?.type === CONST.REPORT.TYPE.IOU;
-            // Check if the card feed has been deleted. If cardFeeds is still loading (undefined), return undefined to avoid showing incorrect state.
-            const isCardFeedDeleted = cardFeeds === undefined ? undefined : !!transactionItem.bank && !doesCardFeedExist(transactionItem.bank as OnyxTypes.CompanyCardFeed, cardFeeds);
+            // Only compute isCardFeedDeleted when we have actual feed data — an empty collection means feed data was never loaded (e.g. non-admin users)
+            const isCardFeedDeleted = hasLoadedCardFeeds(cardFeeds) ? !!transactionItem.bank && !doesCardFeedExist(transactionItem.bank as OnyxTypes.CompanyCardFeed, cardFeeds) : undefined;
 
             const {formattedFrom, formattedTo, formattedTotal, formattedMerchant, date, submitted, approved, posted} = getTransactionItemCommonFormattedProperties(
                 transactionItem,

--- a/tests/unit/Search/SearchUIUtilsTest.ts
+++ b/tests/unit/Search/SearchUIUtilsTest.ts
@@ -5401,18 +5401,18 @@ describe('SearchUIUtils', () => {
                 expect(item?.isCardFeedDeleted).toBeUndefined();
             });
 
-            it('should set isCardFeedDeleted to true when card feed does not exist', () => {
+            it('should leave isCardFeedDeleted undefined when cardFeeds is an empty collection', () => {
                 const data = makeFilterTestData({}, {bank: 'deleted-bank-feed'});
                 const [sections] = callGetTransactionsSections(data, {cardFeeds: {}});
                 const item = sections.find((s) => s.transactionID === filterTestTxID);
-                expect(item?.isCardFeedDeleted).toBe(true);
+                expect(item?.isCardFeedDeleted).toBeUndefined();
             });
 
-            it('should set isCardFeedDeleted to false when bank is empty', () => {
+            it('should leave isCardFeedDeleted undefined when cardFeeds is empty even with no bank', () => {
                 const data = makeFilterTestData({}, {bank: ''});
                 const [sections] = callGetTransactionsSections(data, {cardFeeds: {}});
                 const item = sections.find((s) => s.transactionID === filterTestTxID);
-                expect(item?.isCardFeedDeleted).toBe(false);
+                expect(item?.isCardFeedDeleted).toBeUndefined();
             });
 
             it('should set exported to empty string when transaction has no reportID', () => {


### PR DESCRIPTION
### Explanation of Change

Non-admin users never have `cardFeeds` data loaded (it's only fetched when visiting the company cards admin page via `openPolicyCompanyCardsPage()`). The `isCardFeedDeleted` computation treated an empty `cardFeeds` collection (`{}`) as valid data and concluded every feed was deleted, causing all company card transactions to show "Deleted card" for regular employees.

The fix adds a `hasLoadedCardFeeds()` helper that distinguishes between "no feed data loaded" (`{}`) and "feed data loaded but feed is missing." When feed data isn't loaded, `isCardFeedDeleted` is left as `undefined` instead of being computed as `true`, so the card column shows the card name rather than "Deleted card."

Also corrects a misleading code comment that claimed the search API pre-resolves `isCardFeedDeleted` — it does not.

### Fixed Issues

$ https://github.com/Expensify/Expensify/issues/623736

PROPOSAL: N/A

### Tests

1. Log in as a non-admin member of a workspace that has a third-party card feed (e.g. Capital One, Visa)
2. Navigate to Search > Expenses
3. Find transactions made on the company card
4. Verify the Card column shows the correct card name — not "Deleted card"
5. Log in as a workspace admin for the same workspace
6. Navigate to Settings > Company Cards and wait for the page to load (this loads `cardFeeds`)
7. Go back to Search > Expenses
8. Verify transactions from active feeds show the correct card name
9. If the workspace has a genuinely deleted feed, verify those transactions still show "Deleted card"

- [x] Verify that no errors appear in the JS console

### Offline tests

N/A — display logic fix operating on cached Onyx data.

### QA Steps

1. Find a workspace on staging with a third-party card feed (e.g. Capital One) and a non-admin member who has card transactions
2. Log in as that non-admin member
3. Go to Search > Expenses and verify card transactions show the correct card name, not "Deleted card"
4. Log in as the workspace admin
5. Go to Search > Expenses and verify the same transactions show correct card names
6. If available, verify a genuinely deleted feed still shows "Deleted card" for the admin

- [x] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>