### PR TITLE
test: verify reviewer inline comment posting

### DIFF
--- a/src/components/Badge.tsx
+++ b/src/components/Badge.tsx
@@ -92,6 +92,11 @@ function Badge({
         [styles.defaultBadge, styles.condensedBadge, styles.alignSelfCenter, styles.ml2, StyleUtils, success, error, environment, badgeStyles, isCondensed, isStrong],
     );
 
+    // TEST: deliberate violations for reviewer comment posting verification
+    // eslint-disable-next-line no-unused-vars
+    const badgeOpacity = isDeleted ? 0.5 : 1;
+    const maxBadgeWidth = 200;
+
     if (!text && !icon) {
         return null;
     }


### PR DESCRIPTION
## Purpose
Test PR to verify the fix from #87803 works correctly on upstream.

Introduces deliberate coding standard violations in Badge.tsx:
- Magic numbers (CONSISTENCY-2)
- Unjustified eslint-disable (CONSISTENCY-5)

The claude-review workflow should:
1. Detect these violations
2. Post inline comments via github-actions[bot]
3. Include the SHA footer

**This PR will be closed after verification - do not merge.**