### PR TITLE
fix: arrow keys immediately wrap to opposite end on Reports > Reports page

### DIFF
--- a/src/components/Search/SearchList/BaseSearchList/index.tsx
+++ b/src/components/Search/SearchList/BaseSearchList/index.tsx
@@ -29,7 +29,6 @@ function BaseSearchList({
     onViewableItemsChanged,
     onLayout,
     contentContainerStyle,
-    flattenedItemsLength,
     newTransactions,
     selectedTransactions,
     customCardNames,
@@ -48,7 +47,7 @@ function BaseSearchList({
 
     const [focusedIndex, setFocusedIndex] = useArrowKeyFocusManager({
         initialFocusedIndex: -1,
-        maxIndex: flattenedItemsLength - 1,
+        maxIndex: data.length - 1,
         isActive: isFocused,
         onFocusedIndexChange: (index: number) => {
             scrollToIndex?.(index);

--- a/src/components/Search/SearchList/BaseSearchList/types.ts
+++ b/src/components/Search/SearchList/BaseSearchList/types.ts
@@ -31,7 +31,6 @@ type BaseSearchListProps = Pick<
     newTransactions: Transaction[];
 
     /** The length of the flattened items in the list */
-    flattenedItemsLength: number;
 
     /** The callback, which is run when a row is pressed */
     onSelectRow: (item: SearchListItem) => void;

--- a/src/components/Search/SearchList/index.tsx
+++ b/src/components/Search/SearchList/index.tsx
@@ -533,7 +533,6 @@ function SearchList({
                 ref={listRef}
                 columns={columns}
                 scrollToIndex={scrollToIndex}
-                flattenedItemsLength={flattenedItems.length}
                 onEndReached={onEndReached}
                 onEndReachedThreshold={onEndReachedThreshold}
                 ListFooterComponent={ListFooterComponent}


### PR DESCRIPTION
## Summary

Fixed the issue where pressing Up/Down arrow keys on the Reports > Reports page required multiple presses before focus wrapped to the opposite end of the list.

## Testing

Tested on Chrome (web):
1. Open Reports > Reports
2. Navigate to the first item using arrow keys
3. Press Up arrow - focus immediately wraps to the last item in the list ✅
4. Press Down arrow from the last item - focus immediately wraps to the first item ✅

## Technical Details

The bug was in `BaseSearchList` component. The `useArrowKeyFocusManager` hook received `flattenedItemsLength - 1` as `maxIndex`, but FlashList renders the full `data` array which includes section headers for grouped expense reports. When `data` contains grouped items, `data.length > flattenedItemsLength`, so the hook's maxIndex pointed to a mid-list item instead of the actual last rendered item.

Changed `maxIndex` to `data.length - 1` so the hook's index space correctly matches FlashList's data array indices.

## Issue

$ #87379