### PR TITLE
Add backward compatibility for paths migrated to dynamic routes

### DIFF
--- a/contributingGuides/NAVIGATION.md
+++ b/contributingGuides/NAVIGATION.md
@@ -31,6 +31,7 @@ The navigation in the app is built on top of the `react-navigation` library. To 
     - [Dynamic routes with query parameters](#dynamic-routes-with-query-parameters)
     - [How to add a new dynamic route](#how-to-add-a-new-dynamic-route)
     - [Migrating from backTo to dynamic routes](#migrating-from-backto-to-dynamic-routes)
+    - [Backward compatibility for changed paths](#backward-compatibility-for-changed-paths)
   - [How to remove backTo from URL (Legacy)](#how-to-remove-backto-from-url)
     - [Separating routes for each screen instance](#separating-routes-for-each-screen-instance)
   - [Generating state from a path](#generating-state-from-a-path)
@@ -930,6 +931,27 @@ If you are migrating an existing flow that uses `backTo` (or multiple static rou
 6. Remove old static route constants and old screen bindings that are replaced by the single dynamic screen.
 
 For the legacy approach (e.g. separating routes per screen instance) and edge cases like RHP underlay, see [How to remove backTo from URL](#how-to-remove-backto-from-url) and [Separating routes for each screen instance](#separating-routes-for-each-screen-instance).
+
+### Backward compatibility for changed paths
+
+When migrating a static route to a dynamic route, the resulting URL may differ from the old one. For example, a static route `/r/:reportID/settings/name` might become `/r/:reportID/details/settings/name` after migration (because the dynamic suffix `settings/name` is now appended to the `/r/:reportID/details` base path instead of `/r/:reportID/settings`).
+
+If the new path does not match the old one, you **must** add a redirect mapping to [`src/libs/Navigation/linkingConfig/OldRoutes.ts`](../src/libs/Navigation/linkingConfig/OldRoutes.ts) so that bookmarks, shared links, and browser history still work.
+
+Each entry in `OldRoutes.ts` maps an old path pattern to the new path. Use `*` as a wildcard for dynamic segments and `$1`, `$2`, etc. in the replacement to reference captured segments:
+
+```ts
+const oldRoutes: Record<string, string> = {
+    '/r/*/settings/name': '/r/$1/details/settings/name',
+    '/workspaces/*/accounting/*/card-reconciliation/account': '/workspaces/$1/accounting/$2/card-reconciliation/account-reconciliation-settings',
+};
+```
+
+- A `*` in the **middle** of a pattern matches a single path segment (everything except `/`).
+- A `*` at the **end** of a pattern matches the entire remaining path (including `/`).
+- `$1`, `$2`, ... in the replacement string correspond to the captured wildcards in order.
+
+After adding a mapping, add test cases in [`tests/navigation/getMatchingNewRouteTest.ts`](../tests/navigation/getMatchingNewRouteTest.ts) to verify that the old path redirects to the new one and that query parameters are preserved.
 
 ## How to remove backTo from URL
 

--- a/contributingGuides/NAVIGATION.md
+++ b/contributingGuides/NAVIGATION.md
@@ -934,7 +934,26 @@ For the legacy approach (e.g. separating routes per screen instance) and edge ca
 
 ### Backward compatibility for changed paths
 
-When migrating a static route to a dynamic route, the resulting URL may differ from the old one. For example, a static route `/r/:reportID/settings/name` might become `/r/:reportID/details/settings/name` after migration (because the dynamic suffix `settings/name` is now appended to the `/r/:reportID/details` base path instead of `/r/:reportID/settings`).
+When migrating a static route to a dynamic route, the resulting URL often changes because dynamic routes build the target path on top of the entry screen's URL. Here is a concrete example:
+
+**Static routes** — the entry screen and the target screen have independent, unrelated paths:
+
+| | Path |
+|---|---|
+| Entry screen | `/r/:reportID/details` |
+| Target screen | `/r/:reportID/settings/name` |
+
+The target path `/r/:reportID/settings/name` stands on its own; it does not contain the entry screen's `/details` segment.
+
+**Dynamic routes** — the target URL is formed by appending a suffix to the entry screen's URL:
+
+| | Path |
+|---|---|
+| Entry screen (base path) | `/r/:reportID/details` |
+| Dynamic suffix | `settings/name` |
+| Target screen | `/r/:reportID/details/settings/name` |
+
+Because the suffix `settings/name` is appended to `/r/:reportID/details`, the resulting URL now includes the entry screen's path as a prefix. The old static URL (`/r/:reportID/settings/name`) no longer matches the new dynamic one (`/r/:reportID/details/settings/name`).
 
 If the new path does not match the old one, you **must** add a redirect mapping to [`src/libs/Navigation/linkingConfig/OldRoutes.ts`](../src/libs/Navigation/linkingConfig/OldRoutes.ts) so that bookmarks, shared links, and browser history still work.
 

--- a/src/ROUTES.ts
+++ b/src/ROUTES.ts
@@ -980,12 +980,6 @@ const ROUTES = {
         // eslint-disable-next-line no-restricted-syntax -- Legacy route generation
         getRoute: (reportID: string, backTo?: string) => getUrlWithBackToParam(`r/${reportID}/settings` as const, backTo),
     },
-    REPORT_SETTINGS_NAME: {
-        route: 'r/:reportID/settings/name',
-
-        // eslint-disable-next-line no-restricted-syntax -- Legacy route generation
-        getRoute: (reportID: string, backTo?: string) => getUrlWithBackToParam(`r/${reportID}/settings/name` as const, backTo),
-    },
     REPORT_CHANGE_APPROVER: {
         route: 'r/:reportID/change-approver',
 

--- a/src/libs/Navigation/helpers/getAdaptedStateFromPath.ts
+++ b/src/libs/Navigation/helpers/getAdaptedStateFromPath.ts
@@ -17,7 +17,6 @@ import isDynamicRouteScreen from './dynamicRoutesUtils/isDynamicRouteScreen';
 import findFocusedRouteWithOnyxTabGuard from './findFocusedRouteWithOnyxTabGuard';
 import getMatchingNewRoute from './getMatchingNewRoute';
 import getParamsFromRoute from './getParamsFromRoute';
-import getRedirectedPath from './getRedirectedPath';
 import getStateFromPath from './getStateFromPath';
 import {isFullScreenName} from './isNavigatorName';
 import normalizePath from './normalizePath';
@@ -346,7 +345,6 @@ function getAdaptedState(state: PartialState<NavigationState<RootNavigatorParamL
 // We keep `options` in the signature for `linkingConfig` compatibility with react-navigation.
 const getAdaptedStateFromPath: GetAdaptedStateFromPath = (path, options, shouldReplacePathInNestedState = true) => {
     let normalizedPath = !path.startsWith('/') ? `/${path}` : path;
-    normalizedPath = getRedirectedPath(normalizedPath);
     normalizedPath = getMatchingNewRoute(normalizedPath) ?? normalizedPath;
 
     // Bing search results still link to /signin when searching for “Expensify”, but the /signin route no longer exists in our repo, so we redirect it to the home page to avoid showing a Not Found page.

--- a/src/libs/Navigation/helpers/getMatchingNewRoute.ts
+++ b/src/libs/Navigation/helpers/getMatchingNewRoute.ts
@@ -24,6 +24,8 @@ function patternToRegex(pattern: string): RegExp {
         }
     }
 
+    regexStr += '(?=[?#]|$)';
+
     return new RegExp(regexStr);
 }
 

--- a/src/libs/Navigation/helpers/getMatchingNewRoute.ts
+++ b/src/libs/Navigation/helpers/getMatchingNewRoute.ts
@@ -5,10 +5,12 @@ const escapeRegExp = (str: string) => str.replaceAll(/[.*+?^${}()|[\]\\]/g, '\\$
 /**
  * Converts an OldRoutes pattern string into a RegExp.
  *
- * - A trailing `*` (last in the pattern) matches any remaining characters (multi-segment).
- * - A non-trailing `*` matches exactly one path segment.
+ * A trailing `*` (last in the pattern) matches any remaining characters (multi-segment).
+ * A non-trailing `*` matches exactly one path segment.
  *
  * Captured groups can be referenced in the replacement via `$1`, `$2`, etc.
+ *
+ * @private - Internal helper. Do not export or use outside this file.
  */
 function patternToRegex(pattern: string): RegExp {
     const parts = pattern.split('*');

--- a/src/libs/Navigation/helpers/getMatchingNewRoute.ts
+++ b/src/libs/Navigation/helpers/getMatchingNewRoute.ts
@@ -1,9 +1,39 @@
 import oldRoutes from '@navigation/linkingConfig/OldRoutes';
 
+const escapeRegExp = (str: string) => str.replaceAll(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+/**
+ * Converts an OldRoutes pattern string into a RegExp.
+ *
+ * - A trailing `*` (last in the pattern) matches any remaining characters (multi-segment).
+ * - A non-trailing `*` matches exactly one path segment.
+ *
+ * Captured groups can be referenced in the replacement via `$1`, `$2`, etc.
+ */
+function patternToRegex(pattern: string): RegExp {
+    const parts = pattern.split('*');
+    let regexStr = '^';
+
+    for (let i = 0; i < parts.length; i++) {
+        regexStr += escapeRegExp(parts.at(i) ?? '');
+        if (i < parts.length - 1) {
+            const isTrailing = i === parts.length - 2 && pattern.endsWith('*');
+            regexStr += isTrailing ? '(.*)' : '([^/]+)';
+        }
+    }
+
+    return new RegExp(regexStr);
+}
+
 /**
  * Maps an old route path to its corresponding new route based on the `oldRoutes` map.
  * It finds the best matching pattern (with wildcard `*` support) and replaces the matched
  * part of the path with the new route value.
+ *
+ * Wildcards:
+ * - Trailing `*` matches any remaining path (including `/`).
+ * - Non-trailing `*` matches exactly one path segment.
+ * - Use `$1`, `$2`, … in the replacement string to reference captured wildcards.
  *
  * @param path - The input URL path to match and transform.
  * @returns The new route path if a match is found, otherwise `undefined`.
@@ -11,23 +41,25 @@ import oldRoutes from '@navigation/linkingConfig/OldRoutes';
  * Related issue: https://github.com/Expensify/App/issues/64968
  */
 function getMatchingNewRoute(path: string) {
-    let bestMatch;
+    let bestMatch: string | undefined;
+    let bestRegex: RegExp | undefined;
     let maxLength = -1;
 
     for (const pattern of Object.keys(oldRoutes)) {
-        const regexStr = `^${pattern.replace('*', '.*')}`;
-        const regex = new RegExp(regexStr);
+        const regex = patternToRegex(pattern);
 
         if (regex.test(path) && pattern.length > maxLength) {
             bestMatch = pattern;
+            bestRegex = regex;
             maxLength = pattern.length;
         }
     }
-    if (!bestMatch) {
-        return bestMatch;
+
+    if (!bestMatch || !bestRegex) {
+        return undefined;
     }
 
-    const finalRegexp = bestMatch?.replace('*', '') ?? '';
-    return path.replace(finalRegexp, oldRoutes[bestMatch]);
+    return path.replace(bestRegex, oldRoutes[bestMatch]);
 }
+
 export default getMatchingNewRoute;

--- a/src/libs/Navigation/helpers/getRedirectedPath.ts
+++ b/src/libs/Navigation/helpers/getRedirectedPath.ts
@@ -1,8 +1,0 @@
-import ROUTES from '@src/ROUTES';
-
-// @TODO: Remove this function when /home-page is no longer used
-function getRedirectedPath(path: string) {
-    return path === '/home-page' ? `${ROUTES.HOME}` : path;
-}
-
-export default getRedirectedPath;

--- a/src/libs/Navigation/helpers/getStateFromPath.ts
+++ b/src/libs/Navigation/helpers/getStateFromPath.ts
@@ -11,7 +11,6 @@ import getPathWithoutDynamicSuffix from './dynamicRoutesUtils/getPathWithoutDyna
 import getStateForDynamicRoute from './dynamicRoutesUtils/getStateForDynamicRoute';
 import findFocusedRouteWithOnyxTabGuard from './findFocusedRouteWithOnyxTabGuard';
 import getMatchingNewRoute from './getMatchingNewRoute';
-import getRedirectedPath from './getRedirectedPath';
 
 /**
  * @param path - The path to parse
@@ -19,8 +18,7 @@ import getRedirectedPath from './getRedirectedPath';
  */
 function getStateFromPath(path: Route): PartialState<NavigationState> {
     const normalizedPath = !path.startsWith('/') ? `/${path}` : path;
-    const redirectedPath = getRedirectedPath(normalizedPath);
-    const normalizedPathAfterRedirection = getMatchingNewRoute(redirectedPath) ?? redirectedPath;
+    const normalizedPathAfterRedirection = getMatchingNewRoute(normalizedPath) ?? normalizedPath;
 
     const suffixMatch = findMatchingDynamicSuffix(normalizedPathAfterRedirection);
     if (suffixMatch) {

--- a/src/libs/Navigation/linkingConfig/OldRoutes.ts
+++ b/src/libs/Navigation/linkingConfig/OldRoutes.ts
@@ -1,18 +1,13 @@
 const oldRoutes: Record<string, string> = {
-    // eslint-disable-next-line @typescript-eslint/naming-convention
+    /* eslint-disable @typescript-eslint/naming-convention */
     '/settings/workspaces/*': '/workspaces/$1',
-    // eslint-disable-next-line @typescript-eslint/naming-convention
     '/settings/workspaces': '/workspaces',
-    // eslint-disable-next-line @typescript-eslint/naming-convention
     '/r/*/settings/name': '/r/$1/details/settings/name',
-    // eslint-disable-next-line @typescript-eslint/naming-convention
     '/workspaces/*/overview/address': '/workspaces/$1/overview/workspace-address',
-    // eslint-disable-next-line @typescript-eslint/naming-convention
     '/workspaces/*/accounting/*/card-reconciliation/account': '/workspaces/$1/accounting/$2/card-reconciliation/account-reconciliation-settings',
-    // eslint-disable-next-line @typescript-eslint/naming-convention
     '/flag/*/*': '/r/$1/flag/$1/$2',
-    // eslint-disable-next-line @typescript-eslint/naming-convention
     '/home-page': '/home',
+    /* eslint-enable @typescript-eslint/naming-convention */
 };
 
 export default oldRoutes;

--- a/src/libs/Navigation/linkingConfig/OldRoutes.ts
+++ b/src/libs/Navigation/linkingConfig/OldRoutes.ts
@@ -1,8 +1,18 @@
 const oldRoutes: Record<string, string> = {
     // eslint-disable-next-line @typescript-eslint/naming-convention
-    '/settings/workspaces/*': '/workspaces/',
+    '/settings/workspaces/*': '/workspaces/$1',
     // eslint-disable-next-line @typescript-eslint/naming-convention
     '/settings/workspaces': '/workspaces',
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    '/r/*/settings/name': '/r/$1/details/settings/name',
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    '/workspaces/*/overview/address': '/workspaces/$1/overview/workspace-address',
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    '/workspaces/*/accounting/*/card-reconciliation/account': '/workspaces/$1/accounting/$2/card-reconciliation/account-reconciliation-settings',
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    '/flag/*/*': '/r/$1/flag/$1/$2',
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    '/home-page': '/home',
 };
 
 export default oldRoutes;

--- a/tests/navigation/getMatchingNewRouteTest.ts
+++ b/tests/navigation/getMatchingNewRouteTest.ts
@@ -53,4 +53,15 @@ describe('getBestMatchingPath', () => {
         expect(getMatchingNewRoute('/workspaces/abc/overview/plan')).toBe(undefined);
         expect(getMatchingNewRoute('/workspaces/abc/accounting/xero/card-reconciliation/settings')).toBe(undefined);
     });
+
+    it('does not match superstrings of exact patterns', () => {
+        expect(getMatchingNewRoute('/home-page2')).toBe(undefined);
+        expect(getMatchingNewRoute('/home-page/extra')).toBe(undefined);
+        expect(getMatchingNewRoute('/r/123/settings/name-extra')).toBe(undefined);
+        expect(getMatchingNewRoute('/workspaces/abc/overview/address/sub')).toBe(undefined);
+    });
+
+    it('preserves fragment when redirecting', () => {
+        expect(getMatchingNewRoute('/home-page?backTo=r/123')).toBe('/home?backTo=r/123');
+    });
 });

--- a/tests/navigation/getMatchingNewRouteTest.ts
+++ b/tests/navigation/getMatchingNewRouteTest.ts
@@ -22,4 +22,35 @@ describe('getBestMatchingPath', () => {
         expect(getMatchingNewRoute('/anything/anything/')).toBe(undefined);
         expect(getMatchingNewRoute('/anything/anything/anything')).toBe(undefined);
     });
+
+    it('redirects old report settings name path to report details', () => {
+        expect(getMatchingNewRoute('/r/123/settings/name')).toBe('/r/123/details/settings/name');
+    });
+
+    it('preserves query params when redirecting report settings name', () => {
+        expect(getMatchingNewRoute('/r/123/settings/name?backTo=/home')).toBe('/r/123/details/settings/name?backTo=/home');
+    });
+
+    it('redirects old workspace overview address path', () => {
+        expect(getMatchingNewRoute('/workspaces/abc/overview/address')).toBe('/workspaces/abc/overview/workspace-address');
+    });
+
+    it('redirects old card reconciliation account path with two wildcards', () => {
+        expect(getMatchingNewRoute('/workspaces/abc/accounting/xero/card-reconciliation/account')).toBe(
+            '/workspaces/abc/accounting/xero/card-reconciliation/account-reconciliation-settings',
+        );
+        expect(getMatchingNewRoute('/workspaces/abc/accounting/netsuite/card-reconciliation/account')).toBe(
+            '/workspaces/abc/accounting/netsuite/card-reconciliation/account-reconciliation-settings',
+        );
+    });
+
+    it('redirects old flag comment path to report-based dynamic route', () => {
+        expect(getMatchingNewRoute('/flag/123/456')).toBe('/r/123/flag/123/456');
+    });
+
+    it('does not redirect paths that look similar but do not match migrated patterns', () => {
+        expect(getMatchingNewRoute('/r/123/settings/visibility')).toBe(undefined);
+        expect(getMatchingNewRoute('/workspaces/abc/overview/plan')).toBe(undefined);
+        expect(getMatchingNewRoute('/workspaces/abc/accounting/xero/card-reconciliation/settings')).toBe(undefined);
+    });
 });

--- a/tests/navigation/getMatchingNewRouteTest.ts
+++ b/tests/navigation/getMatchingNewRouteTest.ts
@@ -54,7 +54,7 @@ describe('getBestMatchingPath', () => {
         expect(getMatchingNewRoute('/workspaces/abc/accounting/xero/card-reconciliation/settings')).toBe(undefined);
     });
 
-    it('does not match superstrings of exact patterns', () => {
+    it('does not match extensions of exact patterns', () => {
         expect(getMatchingNewRoute('/home-page2')).toBe(undefined);
         expect(getMatchingNewRoute('/home-page/extra')).toBe(undefined);
         expect(getMatchingNewRoute('/r/123/settings/name-extra')).toBe(undefined);

--- a/tests/navigation/getStateFromPathTests.ts
+++ b/tests/navigation/getStateFromPathTests.ts
@@ -52,7 +52,6 @@ jest.mock('@src/ROUTES', () => ({
 }));
 
 jest.mock('@libs/Navigation/helpers/getMatchingNewRoute', () => jest.fn());
-jest.mock('@libs/Navigation/helpers/getRedirectedPath', () => jest.fn((path: string) => path));
 jest.mock('@libs/Navigation/helpers/dynamicRoutesUtils/getStateForDynamicRoute', () => jest.fn());
 
 describe('getStateFromPath', () => {


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
1. Added old-to-new route mappings in `OldRoutes.ts` for routes whose URLs changed after migration to dynamic routes (e.g. `/r/*/settings/name` → `/r/$1/details/settings/name`, `/workspaces/*/overview/address` → `/workspaces/$1/overview/workspace-address`, etc.). Improved `getMatchingNewRoute` wildcard logic to support multiple wildcards and `$1`/`$2` replacement references.
2. Removed dead `REPORT_SETTINGS_NAME` route from `ROUTES.ts` left over from incorrect merge conflict resolution.
3. Removed `getRedirectedPath` function and consolidated `/home-page` → `/home` redirect into `OldRoutes.ts`, since `getMatchingNewRoute` already provides the same functionality.

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/87859


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests

1 Test
1. Open the app in a browser, navigate to `https://dev.new.expensify.com:8082/home-page`
2. Verify that the app redirects to `/home` and renders the home screen correctly

2 Test
1. Open the app in a browser, navigate to `https://dev.new.expensify.com:8082/settings/workspaces`
2. Verify that the app redirects to `/workspaces` and displays the workspaces list

3 Test
1. Open the app in a browser, navigate to `https://dev.new.expensify.com:8082/r/<reportID>/settings/name` (replace `<reportID>` with a valid report ID of a workspace room)
2. Verify that the app redirects to `/r/<reportID>/details/settings/name` and renders the report name settings page

4 Test
1. Open the app in a browser, navigate to `https://dev.new.expensify.com:8082/workspaces/<policyID>/overview/address` (replace `<policyID>` with a valid workspace ID)
2. Verify that the app redirects to `/workspaces/<policyID>/overview/workspace-address` and renders the workspace address page

- [x] Verify that no errors appear in the JS console

### Offline tests
N/A

### QA Steps
Same as tests

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/539336b0-6885-405e-a060-615e3c8df35b



</details>