### PR TITLE
fix: guard getPersonalDetailByEmail against undefined email

### DIFF
--- a/src/libs/PersonalDetailsUtils.ts
+++ b/src/libs/PersonalDetailsUtils.ts
@@ -141,6 +141,9 @@ function getPersonalDetailsByIDs({
 }
 
 function getPersonalDetailByEmail(email: string): PersonalDetails | undefined {
+    if (!email) {
+        return undefined;
+    }
     return emailToPersonalDetailsCache[email.toLowerCase()];
 }
 


### PR DESCRIPTION
$ #86781

## Problem
`getPersonalDetailByEmail()` in `src/libs/PersonalDetailsUtils.ts` calls `email.toLowerCase()` without guarding against `undefined`. When an attendee has no email (legacy data from OldDot), this throws a `TypeError: Cannot read properties of undefined (reading 'toLowerCase')` and crashes the app with the "Uh-oh, something went wrong!" screen.

## Fix
Added a simple falsy guard at the top of `getPersonalDetailByEmail()`:
```typescript
if (!email) {
    return undefined;
}
```

This is a defensive fix at the single point of failure, protecting all 50+ callers across the codebase that pass attendee emails to this function.

## How to Verify
1. Open a report that has a transaction with an attendee whose `email` field is `undefined`
2. Before fix: app crashes with "Uh-oh" screen
3. After fix: renders normally, `getPersonalDetailByEmail` returns `undefined` gracefully