### PR TITLE
Keep deleted report actions visible while offline

### DIFF
--- a/src/pages/inbox/report/PureReportActionItem.tsx
+++ b/src/pages/inbox/report/PureReportActionItem.tsx
@@ -50,6 +50,7 @@ import useCurrentUserPersonalDetails from '@hooks/useCurrentUserPersonalDetails'
 import useEnvironment from '@hooks/useEnvironment';
 import {useMemoizedLazyExpensifyIcons} from '@hooks/useLazyAsset';
 import useLocalize from '@hooks/useLocalize';
+import useNetwork from '@hooks/useNetwork';
 import useOnyx from '@hooks/useOnyx';
 import usePreferredPolicy from '@hooks/usePreferredPolicy';
 import usePrevious from '@hooks/usePrevious';
@@ -478,6 +479,7 @@ function PureReportActionItem({
     const reportID = report?.reportID ?? action?.reportID;
     const theme = useTheme();
     const styles = useThemeStyles();
+    const {isOffline} = useNetwork();
     const StyleUtils = useStyleUtils();
     const [isContextMenuActive, setIsContextMenuActive] = useState(() => isActiveReportAction(action.reportActionID));
     const [isEmojiPickerActive, setIsEmojiPickerActive] = useState<boolean | undefined>();
@@ -1689,7 +1691,7 @@ function PureReportActionItem({
                                     pendingAction={
                                         draftMessage !== undefined ? undefined : (action.pendingAction ?? (action.isOptimisticAction ? CONST.RED_BRICK_ROAD_PENDING_ACTION.ADD : undefined))
                                     }
-                                    shouldHideOnDelete={!isDeletedParentAction}
+                                    shouldHideOnDelete={!isDeletedParentAction && !isOffline}
                                     errors={(linkedTransactionRouteError ?? !isOnSearch) ? getLatestErrorMessageField(action as OnyxDataWithErrors) : {}}
                                     errorRowStyles={[styles.ml10, styles.mr2]}
                                     needsOffscreenAlphaCompositing={isMoneyRequestAction(action)}


### PR DESCRIPTION
### Details

This addresses the offline delete behavior for report actions where a deleted message can disappear instead of remaining visible in its pending deleted state.

In `PureReportActionItem`, `OfflineWithFeedback` was receiving:

```tsx
shouldHideOnDelete={!isDeletedParentAction}

This meant non-parent deleted actions were still routed into the hide-on-delete path without considering offline state.

This patch changes that to:

shouldHideOnDelete={!isDeletedParentAction && !isOffline}

Root cause

The report action wrapper was deciding hide-on-delete behavior without checking whether the app was offline. For offline pending deletes, this could cause the message to disappear rather than remain visible in its deleted state.

Solution

Gate shouldHideOnDelete with !isOffline so deleted report actions remain visible while offline.

Tests
Reasoned through the offline delete render path
Verified the patch is isolated to PureReportActionItem
Confirmed the branch builds as a focused single-file change
Risk

Low. This only changes delete-hide behavior for offline rendering of report actions and does not affect unrelated action types.