### PR TITLE
iOS: Fix cached images not displaying offline

### DIFF
--- a/src/components/Image/getImageSource.ts
+++ b/src/components/Image/getImageSource.ts
@@ -1,0 +1,44 @@
+import {isExpiredSession} from '@libs/actions/Session';
+import CONST from '@src/CONST';
+import type Session from '@src/types/onyx/Session';
+import type {ImageProps} from './types';
+
+type GetImageSourceParams = {
+    propsSource: ImageProps['source'];
+    session: Session | undefined;
+    isAuthTokenRequired: boolean;
+    isOffline: boolean;
+};
+
+type GetImageSourceReturn = {
+    source: ImageProps['source'];
+    shouldReauthenticate: boolean;
+};
+
+export default function getImageSource({propsSource, session, isAuthTokenRequired, isOffline}: GetImageSourceParams): GetImageSourceReturn {
+    if (typeof propsSource === 'object' && propsSource !== null && 'uri' in propsSource) {
+        if (typeof propsSource.uri === 'number') {
+            return {source: propsSource.uri, shouldReauthenticate: false};
+        }
+
+        const authToken = session?.encryptedAuthToken ?? null;
+        if (isAuthTokenRequired && authToken) {
+            if (isOffline || (!!session?.creationDate && !isExpiredSession(session.creationDate))) {
+                return {
+                    source: {
+                        ...propsSource,
+                        cacheKey: propsSource.uri,
+                        headers: {
+                            [CONST.CHAT_ATTACHMENT_TOKEN_KEY]: authToken,
+                        },
+                    },
+                    shouldReauthenticate: false,
+                };
+            }
+
+            return {source: undefined, shouldReauthenticate: !!session};
+        }
+    }
+
+    return {source: propsSource, shouldReauthenticate: false};
+}

--- a/src/components/Image/index.tsx
+++ b/src/components/Image/index.tsx
@@ -1,10 +1,12 @@
 import React, {useCallback, useContext, useEffect, useMemo, useRef, useState} from 'react';
 import LoadingIndicator from '@components/LoadingIndicator';
 import {useSession} from '@components/OnyxListItemProvider';
+import useNetwork from '@hooks/useNetwork';
 import {isExpiredSession} from '@libs/actions/Session';
 import activateReauthenticator from '@libs/actions/Session/AttachmentImageReauthenticator';
 import CONST from '@src/CONST';
 import BaseImage from './BaseImage';
+import getImageSource from './getImageSource';
 import {ImageBehaviorContext} from './ImageBehaviorContextProvider';
 import type {ImageOnLoadEvent, ImageProps} from './types';
 
@@ -23,6 +25,7 @@ function Image({
     const [aspectRatio, setAspectRatio] = useState<string | number | null>(null);
     const isObjectPositionTop = objectPosition === CONST.IMAGE_OBJECT_POSITION.TOP;
     const session = useSession();
+    const {isOffline} = useNetwork();
 
     const {shouldSetAspectRatioInStyle} = useContext(ImageBehaviorContext);
 
@@ -114,33 +117,23 @@ function Image({
      * to the source.
      */
     const source = useMemo(() => {
-        if (typeof propsSource === 'object' && 'uri' in propsSource) {
-            if (typeof propsSource.uri === 'number') {
-                return propsSource.uri;
-            }
-            const authToken = session?.encryptedAuthToken ?? null;
-            if (isAuthTokenRequired && authToken) {
-                if (!!session?.creationDate && !isExpiredSession(session.creationDate)) {
-                    return {
-                        ...propsSource,
-                        cacheKey: propsSource.uri,
-                        headers: {
-                            [CONST.CHAT_ATTACHMENT_TOKEN_KEY]: authToken,
-                        },
-                    };
-                }
-                if (session) {
-                    activateReauthenticator(session);
-                }
-                return undefined;
-            }
+        const resolvedImageSource = getImageSource({
+            propsSource,
+            session,
+            isAuthTokenRequired,
+            isOffline,
+        });
+
+        if (resolvedImageSource.shouldReauthenticate && session) {
+            activateReauthenticator(session);
         }
-        return propsSource;
+
+        return resolvedImageSource.source;
         // The session prop is not required, as it causes the image to reload whenever the session changes. For more information, please refer to issue #26034.
         // but we still need the image to reload sometimes (example : when the current session is expired)
         // by forcing a recalculation of the source (which value could indeed change) through the modification of the variable validSessionAge
         // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [propsSource, isAuthTokenRequired, validSessionAge]);
+    }, [propsSource, isAuthTokenRequired, validSessionAge, isOffline]);
     useEffect(() => {
         if (!isAuthTokenRequired || source !== undefined) {
             return;

--- a/tests/unit/components/Image/getImageSource.test.ts
+++ b/tests/unit/components/Image/getImageSource.test.ts
@@ -1,0 +1,111 @@
+import getImageSource from '@components/Image/getImageSource';
+import CONST from '@src/CONST';
+import type Session from '@src/types/onyx/Session';
+
+const NOW = new Date('2026-04-15T00:00:00Z');
+const MOCK_URI = 'https://example.com/receipt.jpg';
+const MOCK_TOKEN = 'encrypted-token';
+type GetImageSourceParams = Parameters<typeof getImageSource>[0];
+
+describe('getImageSource', () => {
+    beforeAll(() => {
+        jest.useFakeTimers();
+        jest.setSystemTime(NOW);
+    });
+
+    afterAll(() => {
+        jest.useRealTimers();
+    });
+
+    it('returns the original source for images that do not require auth', () => {
+        const source = {uri: MOCK_URI};
+
+        expect(
+            getImageSource({
+                propsSource: source,
+                session: undefined,
+                isAuthTokenRequired: false,
+                isOffline: false,
+            }),
+        ).toEqual({source, shouldReauthenticate: false});
+    });
+
+    it('returns an authenticated source with cacheKey when the session is fresh', () => {
+        const propsSource = {uri: MOCK_URI};
+        const session: Session = {
+            encryptedAuthToken: MOCK_TOKEN,
+            creationDate: NOW.getTime(),
+        };
+
+        expect(
+            getImageSource({
+                propsSource,
+                session,
+                isAuthTokenRequired: true,
+                isOffline: false,
+            }),
+        ).toEqual({
+            source: {
+                ...propsSource,
+                cacheKey: MOCK_URI,
+                headers: {
+                    [CONST.CHAT_ATTACHMENT_TOKEN_KEY]: MOCK_TOKEN,
+                },
+            },
+            shouldReauthenticate: false,
+        });
+    });
+
+    it('returns an authenticated source offline even when the session is expired', () => {
+        const propsSource = {uri: MOCK_URI};
+        const session: Session = {
+            encryptedAuthToken: MOCK_TOKEN,
+            creationDate: NOW.getTime() - CONST.SESSION_EXPIRATION_TIME_MS - 1,
+        };
+
+        expect(
+            getImageSource({
+                propsSource,
+                session,
+                isAuthTokenRequired: true,
+                isOffline: true,
+            }),
+        ).toEqual({
+            source: {
+                ...propsSource,
+                cacheKey: MOCK_URI,
+                headers: {
+                    [CONST.CHAT_ATTACHMENT_TOKEN_KEY]: MOCK_TOKEN,
+                },
+            },
+            shouldReauthenticate: false,
+        });
+    });
+
+    it('returns undefined and requests reauthentication online when the session is expired', () => {
+        const session: Session = {
+            encryptedAuthToken: MOCK_TOKEN,
+            creationDate: NOW.getTime() - CONST.SESSION_EXPIRATION_TIME_MS - 1,
+        };
+
+        expect(
+            getImageSource({
+                propsSource: {uri: MOCK_URI},
+                session,
+                isAuthTokenRequired: true,
+                isOffline: false,
+            }),
+        ).toEqual({source: undefined, shouldReauthenticate: true});
+    });
+
+    it('preserves numeric image sources', () => {
+        expect(
+            getImageSource({
+                propsSource: {uri: 42} as unknown as GetImageSourceParams['propsSource'],
+                session: undefined,
+                isAuthTokenRequired: true,
+                isOffline: false,
+            }),
+        ).toEqual({source: 42, shouldReauthenticate: false});
+    });
+});


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
<!-- Explain what your change does and how it addresses the linked issue -->

This change fixes offline receipt rendering on iOS at the point where the image source is decided.

Before this update, if an attachment/receipt session had expired, `Image/index.tsx` returned `undefined` and triggered reauthentication. That was fine online, but offline, it meant `ExpoImage` never received a source at all, so it had no chance to reuse the already cached native image. The result was a loading state instead of the cached receipt.

Now the image source decision is centralized in `getImageSource()`. When the app is offline, we still pass the authenticated source with the existing `cacheKey` and auth header, even if the session is stale, so native can display the cached file. When the app is online and the session has expired, the old behavior stays the same: the source is withheld, and reauthentication is triggered.

### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ #86666
PROPOSAL: [#86666 (comment)](https://github.com/Expensify/App/issues/86666#issuecomment-4160667672)


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

1. Open the chat with expenses with receipt images
2. Make sure the receipt images are loaded
3. Go back to the inbox or any other page
4. Turn off the internet connection (real offline, not simulation)
5. Return to the chat from step 1
6. Verify that the receipt images that were loaded previously are displayed.

- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->

Same as Tests.

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->

Same as Tests.

// TODO: These must be filled out, or the issue title must include "[No QA]."

- [X] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [X] I linked the correct issue in the `### Fixed Issues` section above
- [X] I wrote clear testing steps that cover the changes made in this PR
    - [X] I added steps for local testing in the `Tests` section
    - [X] I added steps for the expected offline behavior in the `Offline steps` section
    - [X] I added steps for Staging and/or Production testing in the `QA steps` section
    - [X] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [X] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [X] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [X] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [X] I ran the tests on **all platforms** & verified they passed on:
    - [X] Android: Native
    - [X] Android: mWeb Chrome
    - [X] iOS: Native
    - [X] iOS: mWeb Safari
    - [X] MacOS: Chrome / Safari
- [X] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [X] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [X] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [X] I verified that comments were added to code that is not self explanatory
    - [X] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [X] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [X] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [X] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [X] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [X] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [X] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [X] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [X] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [X] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [X] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [X] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [X] I verified that if a function's arguments changed that all usages have also been updated correctly
- [X] If any new file was added I verified that:
    - [X] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [X] If a new CSS style is added I verified that:
    - [X] A similar style doesn't already exist
    - [X] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [X] If new assets were added or existing ones were modified, I verified that:
    - [X] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [X] The assets load correctly across all supported platforms.
- [X] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [X] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [X] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [X] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [X] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [X] I verified that all the inputs inside a form are aligned with each other.
    - [X] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [X] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [X] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [X] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->


https://github.com/user-attachments/assets/7fb365c2-db4f-40ed-90d5-0552ed16614f




</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->


https://github.com/user-attachments/assets/969e2592-4aad-4b0f-9832-bd884c5aec60



</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->


https://github.com/user-attachments/assets/fc49b3ee-c24c-437e-8a1e-833dd431f528



</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->



https://github.com/user-attachments/assets/f6704577-080c-48aa-a42b-2ed348b847e4



</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->



https://github.com/user-attachments/assets/ba9049d1-2bd0-410c-84cd-2dea6c399c9d



</details>