### PR TITLE
[CP Staging] fix: share sheet upload edited receipt and keep Category after upgrade

### DIFF
--- a/src/components/MoneyRequestConfirmationList.tsx
+++ b/src/components/MoneyRequestConfirmationList.tsx
@@ -323,7 +323,7 @@ function MoneyRequestConfirmationList({
 
     // A flag for showing the categories field
     const shouldShowCategories = isTrackExpense
-        ? !policy || shouldSelectPolicy || hasEnabledOptions(Object.values(policyCategories ?? {}))
+        ? !policy || shouldSelectPolicy || !!iouCategory || hasEnabledOptions(Object.values(policyCategories ?? {}))
         : (isPolicyExpenseChat || isTypeInvoice) && (!!iouCategory || hasEnabledOptions(Object.values(policyCategories ?? {})));
 
     const shouldShowMerchant = (shouldShowSmartScanFields || isTypeSend) && !isDistanceRequest && !isPerDiemRequest && (!isTimeRequest || action !== CONST.IOU.ACTION.CREATE);

--- a/src/pages/Share/ShareDetailsPage.tsx
+++ b/src/pages/Share/ShareDetailsPage.tsx
@@ -97,12 +97,7 @@ function ShareDetailsPage({route}: ShareDetailsPageProps) {
         Navigation.navigate(ROUTES.SHARE_DETAILS_ATTACHMENT);
     }, [reportAttachmentsContext, fileSource, validateFileName, icons.FallbackAvatar]);
 
-    const setShareError = useCallback((errorTitleArg: string, errorMessageArg: string) => {
-        setErrorTitle(errorTitleArg);
-        setErrorMessage(errorMessageArg);
-    }, []);
-
-    useShareFileSizeValidation(currentAttachment?.content, setShareError, !errorTitle && shouldShowAttachment);
+    useShareFileSizeValidation(currentAttachment?.content, setErrorTitle, setErrorMessage, !errorTitle && shouldShowAttachment);
 
     useEffect(() => {
         if (!errorTitle || !errorMessage) {

--- a/src/pages/Share/ShareDetailsPage.tsx
+++ b/src/pages/Share/ShareDetailsPage.tsx
@@ -37,9 +37,9 @@ import type SCREENS from '@src/SCREENS';
 import type {Report as ReportType} from '@src/types/onyx';
 import {isEmptyObject} from '@src/types/utils/EmptyObject';
 import KeyboardUtils from '@src/utils/keyboard';
-import getFileSize from './getFileSize';
 import ShareButton from './ShareButton';
 import {showErrorAlert} from './ShareRootPage';
+import useShareFileSizeValidation from './useShareFileSizeValidation';
 
 type ShareDetailsPageProps = StackScreenProps<ShareNavigatorParamList, typeof SCREENS.SHARE.SHARE_DETAILS>;
 
@@ -97,22 +97,12 @@ function ShareDetailsPage({route}: ShareDetailsPageProps) {
         Navigation.navigate(ROUTES.SHARE_DETAILS_ATTACHMENT);
     }, [reportAttachmentsContext, fileSource, validateFileName, icons.FallbackAvatar]);
 
-    useEffect(() => {
-        if (!currentAttachment?.content || errorTitle || !shouldShowAttachment) {
-            return;
-        }
-        getFileSize(currentAttachment?.content).then((size) => {
-            if (size > CONST.API_ATTACHMENT_VALIDATIONS.MAX_SIZE) {
-                setErrorTitle(translate('attachmentPicker.attachmentTooLarge'));
-                setErrorMessage(translate('attachmentPicker.sizeExceeded'));
-            }
+    const setShareError = useCallback((errorTitleArg: string, errorMessageArg: string) => {
+        setErrorTitle(errorTitleArg);
+        setErrorMessage(errorMessageArg);
+    }, []);
 
-            if (size < CONST.API_ATTACHMENT_VALIDATIONS.MIN_SIZE) {
-                setErrorTitle(translate('attachmentPicker.attachmentTooSmall'));
-                setErrorMessage(translate('attachmentPicker.sizeNotMet'));
-            }
-        });
-    }, [currentAttachment?.content, errorTitle, translate, shouldShowAttachment]);
+    useShareFileSizeValidation(currentAttachment?.content, setShareError, !errorTitle && shouldShowAttachment);
 
     useEffect(() => {
         if (!errorTitle || !errorMessage) {

--- a/src/pages/Share/SubmitDetailsPage.tsx
+++ b/src/pages/Share/SubmitDetailsPage.tsx
@@ -1,7 +1,7 @@
 import type {StackScreenProps} from '@react-navigation/stack';
 import {hasSeenTourSelector} from '@selectors/Onboarding';
 import {validTransactionDraftsSelector} from '@selectors/TransactionDraft';
-import React, {useCallback, useEffect, useMemo, useState} from 'react';
+import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import {View} from 'react-native';
 import type {OnyxEntry} from 'react-native-onyx';
 import FullPageNotFoundView from '@components/BlockingViews/FullPageNotFoundView';
@@ -102,6 +102,10 @@ function SubmitDetailsPage({
     const currentUserPersonalDetails = useCurrentUserPersonalDetails();
     const personalPolicy = usePersonalPolicy();
     const [startLocationPermissionFlow, setStartLocationPermissionFlow] = useState(false);
+    const [selectedParticipantList, setSelectedParticipantList] = useState<Participant[]>([]);
+    const [isConfirming, setIsConfirming] = useState(false);
+    const formHasBeenSubmitted = useRef(false);
+    const [userLocation] = useOnyx(ONYXKEYS.USER_LOCATION);
 
     const [errorTitle, setErrorTitle] = useState<string | undefined>(undefined);
     const [errorMessage, setErrorMessage] = useState<string | undefined>(undefined);
@@ -294,39 +298,54 @@ function SubmitDetailsPage({
     const onSuccess = (participant: Participant, file: File, locationPermissionGranted?: boolean) => {
         const receipt: Receipt = file;
         receipt.state = file && CONST.IOU.RECEIPT_STATE.SCAN_READY;
-        if (locationPermissionGranted) {
-            getCurrentPosition(
-                (successData) => {
-                    finishRequestAndNavigate(participant, receipt, {
-                        lat: successData.coords.latitude,
-                        long: successData.coords.longitude,
-                    });
-                },
-                (errorData) => {
-                    Log.info('[SubmitDetailsPage] getCurrentPosition failed', false, errorData);
-                    finishRequestAndNavigate(participant, receipt);
-                },
-            );
+        if (!locationPermissionGranted) {
+            finishRequestAndNavigate(participant, receipt);
             return;
         }
-        finishRequestAndNavigate(participant, receipt);
+        // Use cached userLocation when available — avoids an extra getCurrentPosition round-trip.
+        if (userLocation) {
+            finishRequestAndNavigate(participant, receipt, {
+                lat: userLocation.latitude,
+                long: userLocation.longitude,
+            });
+            return;
+        }
+        getCurrentPosition(
+            (successData) => {
+                finishRequestAndNavigate(participant, receipt, {
+                    lat: successData.coords.latitude,
+                    long: successData.coords.longitude,
+                });
+            },
+            (errorData) => {
+                Log.info('[SubmitDetailsPage] getCurrentPosition failed', false, errorData);
+                finishRequestAndNavigate(participant, receipt);
+            },
+        );
     };
 
     // Extracted from onConfirm — re-entering onConfirm from the permission modal deadlocked when OS permission was pre-granted.
     const performUpload = (participant: Participant, locationPermissionGranted: boolean) => {
-        if (!currentAttachment) {
+        if (formHasBeenSubmitted.current || !currentAttachment) {
+            setIsConfirming(false);
             return;
         }
+        formHasBeenSubmitted.current = true;
         readFileAsync(
             currentReceiptSource,
             currentReceiptName,
             (file) => onSuccess(participant, file, locationPermissionGranted),
-            () => {},
+            () => {
+                // Allow retry after a file-read failure.
+                formHasBeenSubmitted.current = false;
+                setIsConfirming(false);
+            },
             currentReceiptType,
         );
     };
 
     const onConfirm = (listOfParticipants?: Participant[], gpsRequired?: boolean) => {
+        setIsConfirming(true);
         const shouldStartLocationPermissionFlow =
             gpsRequired &&
             (!lastLocationPermissionPrompt ||
@@ -334,12 +353,14 @@ function SubmitDetailsPage({
                     DateUtils.getDifferenceInDaysFromNow(new Date(lastLocationPermissionPrompt ?? '')) > CONST.IOU.LOCATION_PERMISSION_PROMPT_THRESHOLD_DAYS));
 
         if (shouldStartLocationPermissionFlow) {
+            setSelectedParticipantList(listOfParticipants ?? selectedParticipants);
             setStartLocationPermissionFlow(true);
             return;
         }
 
         const participant = listOfParticipants?.at(0) ?? selectedParticipants.at(0);
         if (!participant) {
+            setIsConfirming(false);
             return;
         }
         performUpload(participant, false);
@@ -362,11 +383,15 @@ function SubmitDetailsPage({
                 />
                 <LocationPermissionModal
                     startPermissionFlow={startLocationPermissionFlow}
-                    resetPermissionFlow={() => setStartLocationPermissionFlow(false)}
+                    resetPermissionFlow={() => {
+                        setStartLocationPermissionFlow(false);
+                        setIsConfirming(false);
+                    }}
                     onGrant={() => {
                         setStartLocationPermissionFlow(false);
-                        const participant = selectedParticipants.at(0);
+                        const participant = selectedParticipantList.at(0) ?? selectedParticipants.at(0);
                         if (!participant) {
+                            setIsConfirming(false);
                             return;
                         }
                         navigateAfterInteraction(() => performUpload(participant, true));
@@ -374,12 +399,14 @@ function SubmitDetailsPage({
                     onDeny={() => {
                         updateLastLocationPermissionPrompt();
                         setStartLocationPermissionFlow(false);
-                        const participant = selectedParticipants.at(0);
+                        const participant = selectedParticipantList.at(0) ?? selectedParticipants.at(0);
                         if (!participant) {
+                            setIsConfirming(false);
                             return;
                         }
                         navigateAfterInteraction(() => performUpload(participant, false));
                     }}
+                    onInitialGetLocationCompleted={() => setIsConfirming(false)}
                 />
                 <View style={[styles.containerWithSpaceBetween, styles.pointerEventsBoxNone]}>
                     <MoneyRequestConfirmationList
@@ -390,6 +417,7 @@ function SubmitDetailsPage({
                         onToggleReimbursable={setReimbursable}
                         isPolicyExpenseChat={isPolicyExpenseChat}
                         policyID={policy?.id}
+                        isConfirming={isConfirming}
                         onConfirm={(updatedParticipants) => onConfirm(updatedParticipants, true)}
                         receiptPath={currentReceiptSource}
                         receiptFilename={currentReceiptName}

--- a/src/pages/Share/SubmitDetailsPage.tsx
+++ b/src/pages/Share/SubmitDetailsPage.tsx
@@ -311,6 +311,20 @@ function SubmitDetailsPage({
         finishRequestAndNavigate(participant, receipt);
     };
 
+    // Extracted from onConfirm — re-entering onConfirm from the permission modal deadlocked when OS permission was pre-granted.
+    const performUpload = (participant: Participant, locationPermissionGranted: boolean) => {
+        if (!currentAttachment) {
+            return;
+        }
+        readFileAsync(
+            currentReceiptSource,
+            currentReceiptName,
+            (file) => onSuccess(participant, file, locationPermissionGranted),
+            () => {},
+            currentReceiptType,
+        );
+    };
+
     const onConfirm = (listOfParticipants?: Participant[], gpsRequired?: boolean) => {
         const shouldStartLocationPermissionFlow =
             gpsRequired &&
@@ -322,22 +336,12 @@ function SubmitDetailsPage({
             setStartLocationPermissionFlow(true);
             return;
         }
-        if (!currentAttachment) {
-            return;
-        }
 
         const participant = listOfParticipants?.at(0) ?? selectedParticipants.at(0);
         if (!participant) {
             return;
         }
-
-        readFileAsync(
-            currentReceiptSource,
-            currentReceiptName,
-            (file) => onSuccess(participant, file, shouldStartLocationPermissionFlow),
-            () => {},
-            currentReceiptType,
-        );
+        performUpload(participant, false);
     };
 
     return (
@@ -358,13 +362,22 @@ function SubmitDetailsPage({
                 <LocationPermissionModal
                     startPermissionFlow={startLocationPermissionFlow}
                     resetPermissionFlow={() => setStartLocationPermissionFlow(false)}
-                    onGrant={() => onConfirm(undefined, true)}
+                    onGrant={() => {
+                        setStartLocationPermissionFlow(false);
+                        const participant = selectedParticipants.at(0);
+                        if (!participant) {
+                            return;
+                        }
+                        navigateAfterInteraction(() => performUpload(participant, true));
+                    }}
                     onDeny={() => {
                         updateLastLocationPermissionPrompt();
                         setStartLocationPermissionFlow(false);
-                        navigateAfterInteraction(() => {
-                            onConfirm(undefined, false);
-                        });
+                        const participant = selectedParticipants.at(0);
+                        if (!participant) {
+                            return;
+                        }
+                        navigateAfterInteraction(() => performUpload(participant, false));
                     }}
                 />
                 <View style={[styles.containerWithSpaceBetween, styles.pointerEventsBoxNone]}>

--- a/src/pages/Share/SubmitDetailsPage.tsx
+++ b/src/pages/Share/SubmitDetailsPage.tsx
@@ -65,8 +65,16 @@ function SubmitDetailsPage({
     const [personalDetails] = useOnyx(`${ONYXKEYS.PERSONAL_DETAILS_LIST}`);
     const report: OnyxEntry<ReportType> = getReportOrDraftReport(reportOrAccountID);
     const [parentReport] = useOnyx(`${ONYXKEYS.COLLECTION.REPORT}${report?.parentReportID}`);
-    const [policy] = useOnyx(`${ONYXKEYS.COLLECTION.POLICY}${report?.policyID}`);
     const [transaction] = useOnyx(`${ONYXKEYS.COLLECTION.TRANSACTION_DRAFT}${CONST.IOU.OPTIMISTIC_TRANSACTION_ID}`);
+    const iouType = isSelfDM(report) ? CONST.IOU.TYPE.TRACK : CONST.IOU.TYPE.SUBMIT;
+    // Self-DM has a FAKE report policyID — usePolicyForTransaction (same hook MoneyRequestConfirmationList uses) returns the active workspace for self-DM track expense, covering the upgrade-from-free flow.
+    const {policy} = usePolicyForTransaction({
+        transaction,
+        reportPolicyID: getIOURequestPolicyID(transaction, report),
+        action: CONST.IOU.ACTION.CREATE,
+        iouType,
+        isPerDiemRequest: false,
+    });
     const [policyCategories] = useOnyx(`${ONYXKEYS.COLLECTION.POLICY_CATEGORIES}${getIOURequestPolicyID(transaction, report)}`);
     const [policyTags] = useOnyx(`${ONYXKEYS.COLLECTION.POLICY_TAGS}${getIOURequestPolicyID(transaction, report)}`);
     const [lastLocationPermissionPrompt] = useOnyx(ONYXKEYS.NVP_LAST_LOCATION_PERMISSION_PROMPT);
@@ -131,18 +139,24 @@ function SubmitDetailsPage({
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [reportOrAccountID, policy, personalPolicy, report, parentReport, currentDate, currentUserPersonalDetails, hasOnlyPersonalPolicies]);
 
-    // Set receipt on the transaction draft so isScanRequest() returns true and
-    // compact mode, "Automatic" labels, and receipt image rendering all work correctly
-    const receiptSource = currentAttachment?.content ?? fileUri;
-    const receiptFileName = getFileName(currentAttachment?.content ?? '') || fileName;
-    const receiptFileType = currentAttachment?.mimeType ?? fileType;
+    // The original file from the OS share extension — seeded into the transaction draft below.
+    const sharedFileSource = currentAttachment?.content ?? fileUri;
+    const sharedFileName = getFileName(currentAttachment?.content ?? '') || fileName;
+    const sharedFileType = currentAttachment?.mimeType ?? fileType;
 
+    // Seed the transaction draft so isScanRequest() returns true and compact mode, "Automatic" labels, and receipt image rendering all work correctly.
     useEffect(() => {
-        if (!receiptSource) {
+        if (!sharedFileSource) {
             return;
         }
-        setMoneyRequestReceipt(CONST.IOU.OPTIMISTIC_TRANSACTION_ID, receiptSource, receiptFileName, true, receiptFileType);
-    }, [receiptSource, receiptFileName, receiptFileType]);
+        setMoneyRequestReceipt(CONST.IOU.OPTIMISTIC_TRANSACTION_ID, sharedFileSource, sharedFileName, true, sharedFileType);
+    }, [sharedFileSource, sharedFileName, sharedFileType]);
+
+    // The current receipt — prefers the transaction draft (reflects Replace/Crop), falls back to the shared file; used for both display and upload so they stay in sync.
+    const currentReceiptSource = typeof transaction?.receipt?.source === 'string' ? transaction.receipt.source : sharedFileSource;
+    // Strip filesystem path segments without URL-decoding — getFileName() decodes via decodeURIComponent and would throw on raw filenames containing a literal '%' (e.g., "Receipt 100%.jpg").
+    const currentReceiptName = (transaction?.receipt?.filename?.split('/').pop() ?? '') || sharedFileName;
+    const currentReceiptType = transaction?.receipt?.type ?? sharedFileType;
 
     const selectedParticipants = unknownUserDetails ? [unknownUserDetails] : getMoneyRequestParticipantsFromReport(report, currentUserPersonalDetails.accountID);
     const participants = selectedParticipants.map((participant) => {
@@ -155,19 +169,8 @@ function SubmitDetailsPage({
     const isPolicyExpenseChat = useMemo(() => participants?.some((participant) => participant.isPolicyExpenseChat), [participants]);
     const policyExpenseChatPolicyID = participants?.find((participant) => participant.isPolicyExpenseChat)?.policyID;
     const senderPolicyID = participants?.find((participant) => !!participant && 'isSender' in participant && participant.isSender)?.policyID;
-    const iouType = isSelfDM(report) ? CONST.IOU.TYPE.TRACK : CONST.IOU.TYPE.SUBMIT;
     const {isOffline} = useNetwork();
     const isCreatingTrackExpense = iouType === CONST.IOU.TYPE.TRACK;
-
-    // Self-DM has a FAKE report policyID — resolve via the same hook MoneyRequestConfirmationList uses, so we pick up the active workspace after upgrade.
-    const {policy: resolvedPolicy} = usePolicyForTransaction({
-        transaction,
-        reportPolicyID: getIOURequestPolicyID(transaction, report),
-        action: CONST.IOU.ACTION.CREATE,
-        iouType,
-        isPerDiemRequest: false,
-    });
-    const resolvedPolicyID = resolvedPolicy?.id;
 
     // Initialize billable/reimbursable from policy defaults (mirrors IOURequestStepConfirmation)
     const defaultBillable = !!policy?.defaultBillable;
@@ -326,17 +329,12 @@ function SubmitDetailsPage({
             return;
         }
 
-        // Prefer the transaction draft's receipt — reflects Replace/Crop updates.
-        const uploadSource = typeof transaction?.receipt?.source === 'string' ? transaction.receipt.source : receiptSource;
-        const uploadFileName = getFileName(transaction?.receipt?.filename ?? '') || receiptFileName;
-        const uploadFileType = transaction?.receipt?.type ?? receiptFileType;
-
         readFileAsync(
-            uploadSource,
-            uploadFileName,
+            currentReceiptSource,
+            currentReceiptName,
             (file) => onSuccess(participant, file, shouldStartLocationPermissionFlow),
             () => {},
-            uploadFileType,
+            currentReceiptType,
         );
     };
 
@@ -345,8 +343,8 @@ function SubmitDetailsPage({
             <FullPageNotFoundView shouldShow={!reportOrAccountID}>
                 <DraftWorkspaceOpener
                     isCreatingTrackExpense={isCreatingTrackExpense}
-                    policyID={resolvedPolicyID}
-                    policyPendingAction={resolvedPolicy?.pendingAction}
+                    policyID={policy?.id}
+                    policyPendingAction={policy?.pendingAction}
                     policyExpenseChatPolicyID={policyExpenseChatPolicyID}
                     senderPolicyID={senderPolicyID}
                     isOffline={isOffline}
@@ -375,10 +373,10 @@ function SubmitDetailsPage({
                         onToggleBillable={setBillable}
                         onToggleReimbursable={setReimbursable}
                         isPolicyExpenseChat={isPolicyExpenseChat}
-                        policyID={resolvedPolicyID}
+                        policyID={policy?.id}
                         onConfirm={(updatedParticipants) => onConfirm(updatedParticipants, true)}
-                        receiptPath={receiptSource}
-                        receiptFilename={receiptFileName}
+                        receiptPath={currentReceiptSource}
+                        receiptFilename={currentReceiptName}
                         reportID={reportOrAccountID}
                         shouldShowSmartScanFields={false}
                         shouldDisplayReceipt

--- a/src/pages/Share/SubmitDetailsPage.tsx
+++ b/src/pages/Share/SubmitDetailsPage.tsx
@@ -15,6 +15,7 @@ import useNetwork from '@hooks/useNetwork';
 import useOnyx from '@hooks/useOnyx';
 import usePermissions from '@hooks/usePermissions';
 import usePersonalPolicy from '@hooks/usePersonalPolicy';
+import usePolicyForTransaction from '@hooks/usePolicyForTransaction';
 import usePrivateIsArchivedMap from '@hooks/usePrivateIsArchivedMap';
 import useReportAttributes from '@hooks/useReportAttributes';
 import useReportIsArchived from '@hooks/useReportIsArchived';
@@ -157,6 +158,16 @@ function SubmitDetailsPage({
     const iouType = isSelfDM(report) ? CONST.IOU.TYPE.TRACK : CONST.IOU.TYPE.SUBMIT;
     const {isOffline} = useNetwork();
     const isCreatingTrackExpense = iouType === CONST.IOU.TYPE.TRACK;
+
+    // Self-DM has a FAKE report policyID — resolve via the same hook MoneyRequestConfirmationList uses, so we pick up the active workspace after upgrade.
+    const {policy: resolvedPolicy} = usePolicyForTransaction({
+        transaction,
+        reportPolicyID: getIOURequestPolicyID(transaction, report),
+        action: CONST.IOU.ACTION.CREATE,
+        iouType,
+        isPerDiemRequest: false,
+    });
+    const resolvedPolicyID = resolvedPolicy?.id;
 
     // Initialize billable/reimbursable from policy defaults (mirrors IOURequestStepConfirmation)
     const defaultBillable = !!policy?.defaultBillable;
@@ -315,12 +326,17 @@ function SubmitDetailsPage({
             return;
         }
 
+        // Prefer the transaction draft's receipt — reflects Replace/Crop updates.
+        const uploadSource = typeof transaction?.receipt?.source === 'string' ? transaction.receipt.source : receiptSource;
+        const uploadFileName = getFileName(transaction?.receipt?.filename ?? '') || receiptFileName;
+        const uploadFileType = transaction?.receipt?.type ?? receiptFileType;
+
         readFileAsync(
-            receiptSource,
-            receiptFileName,
+            uploadSource,
+            uploadFileName,
             (file) => onSuccess(participant, file, shouldStartLocationPermissionFlow),
             () => {},
-            receiptFileType,
+            uploadFileType,
         );
     };
 
@@ -329,8 +345,8 @@ function SubmitDetailsPage({
             <FullPageNotFoundView shouldShow={!reportOrAccountID}>
                 <DraftWorkspaceOpener
                     isCreatingTrackExpense={isCreatingTrackExpense}
-                    policyID={policy?.id}
-                    policyPendingAction={policy?.pendingAction}
+                    policyID={resolvedPolicyID}
+                    policyPendingAction={resolvedPolicy?.pendingAction}
                     policyExpenseChatPolicyID={policyExpenseChatPolicyID}
                     senderPolicyID={senderPolicyID}
                     isOffline={isOffline}
@@ -359,7 +375,7 @@ function SubmitDetailsPage({
                         onToggleBillable={setBillable}
                         onToggleReimbursable={setReimbursable}
                         isPolicyExpenseChat={isPolicyExpenseChat}
-                        policyID={policy?.id}
+                        policyID={resolvedPolicyID}
                         onConfirm={(updatedParticipants) => onConfirm(updatedParticipants, true)}
                         receiptPath={receiptSource}
                         receiptFilename={receiptFileName}

--- a/src/pages/Share/SubmitDetailsPage.tsx
+++ b/src/pages/Share/SubmitDetailsPage.tsx
@@ -114,8 +114,6 @@ function SubmitDetailsPage({
     const fileType = shouldUsePreValidatedFile ? (validFilesToUpload?.type ?? CONST.RECEIPT_ALLOWED_FILE_TYPES.JPEG) : (currentAttachment?.mimeType ?? '');
     const [hasOnlyPersonalPolicies = false] = useOnyx(ONYXKEYS.COLLECTION.POLICY, {selector: hasOnlyPersonalPoliciesUtil});
 
-    useShareFileSizeValidation(currentAttachment?.content, setErrorTitle, setErrorMessage, !errorTitle);
-
     useEffect(() => {
         if (!errorTitle || !errorMessage) {
             return;
@@ -159,6 +157,9 @@ function SubmitDetailsPage({
     // Strip filesystem path segments without URL-decoding — getFileName() decodes via decodeURIComponent and would throw on raw filenames containing a literal '%' (e.g., "Receipt 100%.jpg").
     const currentReceiptName = (transaction?.receipt?.filename?.split('/').pop() ?? '') || sharedFileName;
     const currentReceiptType = transaction?.receipt?.type ?? sharedFileType;
+
+    // Validate the same source that performUpload reads — so Replace/Crop to an oversized file is still caught before submit.
+    useShareFileSizeValidation(currentReceiptSource, setErrorTitle, setErrorMessage, !errorTitle);
 
     const selectedParticipants = unknownUserDetails ? [unknownUserDetails] : getMoneyRequestParticipantsFromReport(report, currentUserPersonalDetails.accountID);
     const participants = selectedParticipants.map((participant) => {

--- a/src/pages/Share/SubmitDetailsPage.tsx
+++ b/src/pages/Share/SubmitDetailsPage.tsx
@@ -114,12 +114,7 @@ function SubmitDetailsPage({
     const fileType = shouldUsePreValidatedFile ? (validFilesToUpload?.type ?? CONST.RECEIPT_ALLOWED_FILE_TYPES.JPEG) : (currentAttachment?.mimeType ?? '');
     const [hasOnlyPersonalPolicies = false] = useOnyx(ONYXKEYS.COLLECTION.POLICY, {selector: hasOnlyPersonalPoliciesUtil});
 
-    const setShareError = useCallback((title: string, message: string) => {
-        setErrorTitle(title);
-        setErrorMessage(message);
-    }, []);
-
-    useShareFileSizeValidation(currentAttachment?.content, setShareError, !errorTitle);
+    useShareFileSizeValidation(currentAttachment?.content, setErrorTitle, setErrorMessage, !errorTitle);
 
     useEffect(() => {
         if (!errorTitle || !errorMessage) {

--- a/src/pages/Share/SubmitDetailsPage.tsx
+++ b/src/pages/Share/SubmitDetailsPage.tsx
@@ -52,6 +52,7 @@ import type {Report as ReportType} from '@src/types/onyx';
 import type {Participant} from '@src/types/onyx/IOU';
 import type {Receipt} from '@src/types/onyx/Transaction';
 import {showErrorAlert} from './ShareRootPage';
+import useShareFileSizeValidation from './useShareFileSizeValidation';
 
 type ShareDetailsPageProps = StackScreenProps<ShareNavigatorParamList, typeof SCREENS.SHARE.SUBMIT_DETAILS>;
 function SubmitDetailsPage({
@@ -113,6 +114,13 @@ function SubmitDetailsPage({
     const fileType = shouldUsePreValidatedFile ? (validFilesToUpload?.type ?? CONST.RECEIPT_ALLOWED_FILE_TYPES.JPEG) : (currentAttachment?.mimeType ?? '');
     const [hasOnlyPersonalPolicies = false] = useOnyx(ONYXKEYS.COLLECTION.POLICY, {selector: hasOnlyPersonalPoliciesUtil});
 
+    const setShareError = useCallback((title: string, message: string) => {
+        setErrorTitle(title);
+        setErrorMessage(message);
+    }, []);
+
+    useShareFileSizeValidation(currentAttachment?.content, setShareError, !errorTitle);
+
     useEffect(() => {
         if (!errorTitle || !errorMessage) {
             return;
@@ -139,12 +147,11 @@ function SubmitDetailsPage({
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [reportOrAccountID, policy, personalPolicy, report, parentReport, currentDate, currentUserPersonalDetails, hasOnlyPersonalPolicies]);
 
-    // The original file from the OS share extension — seeded into the transaction draft below.
     const sharedFileSource = currentAttachment?.content ?? fileUri;
     const sharedFileName = getFileName(currentAttachment?.content ?? '') || fileName;
     const sharedFileType = currentAttachment?.mimeType ?? fileType;
 
-    // Seed the transaction draft so isScanRequest() returns true and compact mode, "Automatic" labels, and receipt image rendering all work correctly.
+    // Seed the transaction draft so isScanRequest() returns true and compact mode / "Automatic" labels / receipt rendering work.
     useEffect(() => {
         if (!sharedFileSource) {
             return;

--- a/src/pages/Share/useShareFileSizeValidation.ts
+++ b/src/pages/Share/useShareFileSizeValidation.ts
@@ -1,28 +1,38 @@
 import {useEffect} from 'react';
+import type {Dispatch, SetStateAction} from 'react';
 import useLocalize from '@hooks/useLocalize';
 import CONST from '@src/CONST';
 import getFileSize from './getFileSize';
 
-type SetShareError = (title: string, message: string) => void;
+type SetState = Dispatch<SetStateAction<string | undefined>>;
 
 /** Validate the shared file against API min/max size limits. Pass `enabled: false` to skip (e.g., when an earlier error already took precedence). */
-function useShareFileSizeValidation(content: string | undefined, setError: SetShareError, enabled = true) {
+function useShareFileSizeValidation(content: string | undefined, setErrorTitle: SetState, setErrorMessage: SetState, enabled = true) {
     const {translate} = useLocalize();
 
     useEffect(() => {
         if (!content || !enabled) {
             return;
         }
+        let ignore = false;
         getFileSize(content).then((size) => {
+            if (ignore) {
+                return;
+            }
             if (size > CONST.API_ATTACHMENT_VALIDATIONS.MAX_SIZE) {
-                setError(translate('attachmentPicker.attachmentTooLarge'), translate('attachmentPicker.sizeExceeded'));
+                setErrorTitle(translate('attachmentPicker.attachmentTooLarge'));
+                setErrorMessage(translate('attachmentPicker.sizeExceeded'));
             }
 
             if (size < CONST.API_ATTACHMENT_VALIDATIONS.MIN_SIZE) {
-                setError(translate('attachmentPicker.attachmentTooSmall'), translate('attachmentPicker.sizeNotMet'));
+                setErrorTitle(translate('attachmentPicker.attachmentTooSmall'));
+                setErrorMessage(translate('attachmentPicker.sizeNotMet'));
             }
         });
-    }, [content, enabled, setError, translate]);
+        return () => {
+            ignore = true;
+        };
+    }, [content, enabled, setErrorTitle, setErrorMessage, translate]);
 }
 
 export default useShareFileSizeValidation;

--- a/src/pages/Share/useShareFileSizeValidation.ts
+++ b/src/pages/Share/useShareFileSizeValidation.ts
@@ -1,0 +1,28 @@
+import {useEffect} from 'react';
+import useLocalize from '@hooks/useLocalize';
+import CONST from '@src/CONST';
+import getFileSize from './getFileSize';
+
+type SetShareError = (title: string, message: string) => void;
+
+/** Validate the shared file against API min/max size limits. Pass `enabled: false` to skip (e.g., when an earlier error already took precedence). */
+function useShareFileSizeValidation(content: string | undefined, setError: SetShareError, enabled = true) {
+    const {translate} = useLocalize();
+
+    useEffect(() => {
+        if (!content || !enabled) {
+            return;
+        }
+        getFileSize(content).then((size) => {
+            if (size > CONST.API_ATTACHMENT_VALIDATIONS.MAX_SIZE) {
+                setError(translate('attachmentPicker.attachmentTooLarge'), translate('attachmentPicker.sizeExceeded'));
+            }
+
+            if (size < CONST.API_ATTACHMENT_VALIDATIONS.MIN_SIZE) {
+                setError(translate('attachmentPicker.attachmentTooSmall'), translate('attachmentPicker.sizeNotMet'));
+            }
+        });
+    }, [content, enabled, setError, translate]);
+}
+
+export default useShareFileSizeValidation;


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Explanation of Change
<!-- Explain what your change does and how it addresses the linked issue -->



Fixes four deploy blockers from #87142 in the native share sheet flow:

- **#88068** — Replace/Crop receipt: original receipt was uploaded instead of the new one
- **#88045** — Category disappeared on the confirm page after upgrading from a free workspace in self-DM
- **#88100** — Create expense button unresponsive on iOS when OS location permission was pre-granted

All exposed by UI surfaces #87142 newly enabled inheriting broken downstream reads or missing gates except #88100.

#88068

`onConfirm` was reading from `currentAttachment` (frozen original file). Now reads from `transaction.receipt` (which Replace/Crop updates), with fallback to the original.

#88045

`SubmitDetailsPage` passed `policyID` from `useOnyx(POLICY + report?.policyID)`. For self-DM, `report?.policyID === "_FAKE_"`, so the subscription never resolved to a real workspace after upgrade. Now uses `usePolicyForTransaction` (same hook `MoneyRequestConfirmationList` uses internally), which returns the active workspace for self-DM track expenses.

Also added `!!iouCategory` to the track branch of `shouldShowCategories` in `MoneyRequestConfirmationList` — one-line consistency fix matching the non-track branch's existing safeguard, so a selected category stays visible while categories load.

#88100

PR changed `onGrant={onConfirm}` to `onGrant={() => onConfirm(undefined, true)}`, which re-entered `onConfirm` with `gpsRequired=true`. On iOS with permission pre-granted, `LocationPermissionModal` fires `onGrant` immediately — the re-entry hit the same "permission flow" branch, `setStartLocationPermissionFlow(true)` was a no-op (state already true), and the button stayed dead. Extracted a `performUpload(participant, locationPermissionGranted)` helper (mirrors `IOURequestStepConfirmation`'s `createTransaction` pattern); modal callbacks now call it directly with the correct location flag instead of re-entering `onConfirm`.

Enhancement

`SubmitDetailsPage` had no file-size validation while `ShareDetailsPage` did. Extracted the shared logic into a new `useShareFileSizeValidation` hook and wired both consumers to it — Submit flow now shows the same "too large / too small" error as the Share flow.
 
### Fixed Issues
<!---
1. Please postfix `$` with a URL link to the GitHub issue this Pull Request is fixing. For example, `$ https://github.com/Expensify/App/issues/<issueID>`.
2. Please postfix  `PROPOSAL:` with a URL link to your GitHub comment, which contains the approved proposal (i.e. the proposal that was approved by Expensify).  For example, `PROPOSAL: https://github.com/Expensify/App/issues/<issueID>#issuecomment-1369752925`

Do NOT add the special GH keywords like `fixed` etc, we have our own process of managing the flow.
It MUST be an entire link to the github issue and your comment proposal ; otherwise, the linking and its automation will not work as expected.

Make sure this section looks similar to this (you can link multiple issues using the same formatting, just add a new line):

$ https://github.com/Expensify/App/issues/<issueID>
$ https://github.com/Expensify/App/issues/<issueID(comment)>

Do NOT only link the issue number like this: $ #<issueID>
--->
$ https://github.com/Expensify/App/issues/88068
$ https://github.com/Expensify/App/issues/88045
$ https://github.com/Expensify/App/issues/88100
PROPOSAL:


<!--- 
If you want to trigger adhoc build of hybrid app from specific Mobile-Expensify PR please link it like this:

MOBILE-EXPENSIFY: https://github.com/Expensify/Mobile-Expensify/pull/<PR-number>

--->

### Tests
<!---
Add a numbered list of manual tests you performed that validates your changes work on all platforms, and that there are no regressions present.
Add any additional test steps if test steps are unique to a particular platform.
Manual test steps should be written so that your reviewer can repeat and verify one or more expected outcomes in the development environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image
--->

**Test 1: Replace receipt (#88068)**
1. Share a receipt image from device gallery to Expensify app
2. Go to **Submit** tab
3. Select a workspace chat
4. On the confirm page, tap on the receipt thumbnail
5. Tap **Replace**
6. Select a different receipt image
7. Tap **Create expense**
8. Open the created expense
9. **Verify**: The new receipt from step 6 is shown — not the original

**Test 2: Crop receipt (#88068)**
1. Share a receipt from gallery → Submit tab → select a workspace chat
2. On the confirm page, tap on the receipt thumbnail
3. Crop the receipt
4. Tap **Create expense**
5. Open the created expense
6. **Verify**: The cropped receipt is shown — not the uncropped original

**Test 3: Category visible after upgrade in self-DM (#88045)**

Precondition: Account does NOT have a workspace.

1. Share a receipt image from gallery to Expensify app
2. Go to **Submit** tab
3. Select **self DM**
4. **Verify**: Category field is visible (because `!policy` is true)
5. Tap **Show more** → tap **Category**
6. Tap **Upgrade** → **Confirm** → **Got it, thanks**
7. Select a category (e.g., Advertising)
8. **Verify**: Category field still appears on the confirm page (does not disappear), with the selected value shown

**Test 4: Large file size validation in Submit flow**

1. From device gallery, pick a file larger than the API max attachment size (~25 MB — e.g., a long PDF or high-resolution image)
2. Share it to Expensify app
3. Go to **Submit** tab
4. Select a workspace chat (or self DM)
5. **Verify**: An error alert is shown ("Attachment too large / size exceeded") and the user is returned to the inbox
6. Repeat the flow but pick an extremely small file
7. **Verify**: An error alert is shown ("Attachment too small / size not met")
8. Repeat the flow with a normally-sized file
9. **Verify**: The confirm page renders normally — no false-positive size errors

**Test 5: Create expense button responsive with location permission pre-granted (#88100)**

Precondition: Expensify already has location permission granted at the OS level (iOS).

1. On iOS, share a receipt image from device gallery to Expensify
2. Go to **Submit** tab
3. Select a workspace (or self DM)
4. Tap **Create expense**
5. **Verify**: The expense is created and the user lands on the confirmation/report screen — the button is not stuck
6. Repeat the flow but with location permission **denied** at the OS level
7. Tap **Create expense** → system permission prompt appears (if not seen recently)
8. Tap **Allow** or **Don't allow**
9. **Verify** (Allow): Expense is created with GPS coordinates attached
10. **Verify** (Don't allow): Expense is created without GPS coordinates — still works

- [x] Verify that no errors appear in the JS console

### Offline tests
<!---
Add any relevant steps that validate your changes work as expected in a variety of network states e.g. "offline", "spotty connection", "slow internet", etc. Manual test steps should be written so that your reviewer and QA testers can repeat and verify one or more expected outcomes. If you are unsure how the behavior should work ask for advice in the `#expensify-open-source` Slack channel.
--->
Same as tests

### QA Steps
<!---
Add a numbered list of manual tests that can be performed by our QA engineers on the staging environment to validate that your changes work on all platforms, and that there are no regressions present.
Add any additional QA steps if test steps are unique to a particular platform.
Manual test steps should be written so that the QA engineer can repeat and verify one or more expected outcomes in the staging environment.

For example:
1. Click on the text input to bring it into focus
2. Upload an image via copy paste
3. Verify a modal appears displaying a preview of that image

It's acceptable to write "Same as tests" if the QA team is able to run the tests in the above "Tests" section.
--->
// TODO: These must be filled out, or the issue title must include "[No QA]."
Same as tests

- [x] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I verified there are no new alerts related to the `canBeMissing` param for `useOnyx`
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>