### PR TITLE
Fix navigation arrows disappearing during report browsing

### DIFF
--- a/src/components/MoneyRequestReportView/MoneyRequestReportNavigation.tsx
+++ b/src/components/MoneyRequestReportView/MoneyRequestReportNavigation.tsx
@@ -84,6 +84,7 @@ function MoneyRequestReportNavigation({reportID, shouldDisplayNarrowVersion}: Mo
                 shouldCalculateTotals: false,
                 searchKey: lastSearchQuery.searchKey,
                 isLoading: isSearchLoading,
+                shouldUpdateLastSearchParams: true,
             });
         }
 

--- a/src/components/Search/index.tsx
+++ b/src/components/Search/index.tsx
@@ -23,6 +23,7 @@ import useSearchHighlightAndScroll from '@hooks/useSearchHighlightAndScroll';
 import useSearchShouldCalculateTotals from '@hooks/useSearchShouldCalculateTotals';
 import useThemeStyles from '@hooks/useThemeStyles';
 import {turnOffMobileSelectionMode, turnOnMobileSelectionMode} from '@libs/actions/MobileSelectionMode';
+import {saveLastSearchParams} from '@libs/actions/ReportNavigation';
 import type {TransactionPreviewData} from '@libs/actions/Search';
 import {setOptimisticDataForTransactionThreadPreview} from '@libs/actions/Search';
 import {flushDeferredWrite, getOptimisticWatchKey, hasDeferredWrite} from '@libs/deferredLayoutWrite';
@@ -1136,6 +1137,16 @@ function Search({
                     unmarkReportIDAsMultiTransactionExpense(reportID);
                 }
 
+                // Persist the current search context so prev/next navigation arrows
+                // in the report RHP can reference the correct result set.
+                saveLastSearchParams({
+                    queryJSON,
+                    offset,
+                    searchKey: currentSearchKey,
+                    hasMoreResults: !!searchResults?.search?.hasMoreResults,
+                    allowPostSearchRecount: true,
+                });
+
                 requestAnimationFrame(() => Navigation.navigate(ROUTES.SEARCH_MONEY_REQUEST_REPORT.getRoute({reportID, backTo})));
                 return;
             }
@@ -1176,6 +1187,9 @@ function Search({
             betas,
             email,
             accountID,
+            queryJSON,
+            offset,
+            searchResults?.search?.hasMoreResults,
         ],
     );
 

--- a/src/libs/actions/Search.ts
+++ b/src/libs/actions/Search.ts
@@ -516,7 +516,7 @@ function search({
     prevReportsLength,
     isOffline = false,
     isLoading,
-    shouldUpdateLastSearchParams = true,
+    shouldUpdateLastSearchParams = false,
     skipWaitForWrites = false,
 }: {
     queryJSON: SearchQueryJSON;


### PR DESCRIPTION
When viewing an expense report opened from search results, the prev/next navigation arrows disappear unexpectedly. Background search calls (from `useSearchHighlightAndScroll` and `useSearchPageSetup`) overwrite the global `REPORT_NAVIGATION_LAST_SEARCH_QUERY` Onyx key with a different search type (e.g. `expense` instead of `expense-report`), causing the arrows component to hide because `type !== CONST.SEARCH.DATA_TYPES.EXPENSE_REPORT`.

### Explanation of Change

Flip `shouldUpdateLastSearchParams` default to `false` in the `search()` action so background searches no longer overwrite the global last-search-params key. Only 2 out of ~10 callers actually need to persist search params — all others are background refreshes, chart data, or bulk action follow-ups.

Persist params explicitly at the two points that establish or extend the navigation context:
- In `Search/index.tsx` `onSelectRow`: save params when the user clicks an expense report row to open the RHP
- In `MoneyRequestReportNavigation.tsx` `goToNextReport`: pass `shouldUpdateLastSearchParams: true` when prefetching more results via arrows (75% threshold)

### Fixed Issues

$ https://github.com/Expensify/App/issues/87784
PROPOSAL:


### Tests

1. Navigate to Search → Reports (expense reports)
2. Click on any expense report row to open it in the RHP
3. Verify the navigation arrows are visible and show "X of Y" counter
4. Use the prev/next arrows to navigate between reports
5. Verify the arrows remain visible and functional after each navigation
6. Verify the counter updates correctly
7. Navigate past 75% of results and verify more results are prefetched (arrows continue working)
8. Close the RHP and return to search results

- [ ] Verify that no errors appear in the JS console

### Offline tests

1. Open an expense report via search while online
2. Go offline
3. Verify arrows still show for cached reports
4. Navigate between cached reports using arrows
5. Verify no crash occurs

### QA Steps

Same as Tests above.

- [ ] Verify that no errors appear in the JS console
