### PR TITLE
fix: replace HOME instead of pushing when navigating to Settings RHP

### DIFF
--- a/src/libs/Navigation/helpers/linkTo/index.ts
+++ b/src/libs/Navigation/helpers/linkTo/index.ts
@@ -94,12 +94,6 @@ function shouldChangeToMatchingFullScreen(
     lastFullScreenRoute: NavigationPartialRoute,
 ) {
     if (matchingFullScreenRoute.name !== lastFullScreenRoute.name) {
-        // HOME has no RHP children (HOME_TO_RHP maps to []).
-        // Pushing another fullscreen under HOME causes Android to trim HOME
-        // from the render tree, reversing the back animation direction.
-        if (lastFullScreenRoute.name === SCREENS.HOME) {
-            return false;
-        }
         return true;
     }
 
@@ -174,15 +168,20 @@ export default function linkTo(navigation: NavigationContainerRef<RootNavigatorP
 
             const lastFullScreenRoute = currentState.routes.findLast((route) => isFullScreenName(route.name));
             if (matchingFullScreenRoute && lastFullScreenRoute && shouldChangeToMatchingFullScreen(newFocusedRoute, matchingFullScreenRoute, lastFullScreenRoute as NavigationPartialRoute)) {
+                // When navigating from HOME to an RHP that maps to a different fullscreen (e.g. Settings),
+                // replace HOME instead of pushing on top. Pushing creates [HOME, SETTINGS, RHP] which causes
+                // Android's useCustomRootStackNavigatorState to trim HOME from the render tree, producing
+                // a wrong back animation. Replacing matches the reload state shape: [SETTINGS, RHP].
+                const shouldReplace = lastFullScreenRoute.name === SCREENS.HOME;
                 if (isRoutePreloaded(currentState, matchingFullScreenRoute)) {
-                    navigation.dispatch(StackActions.push(matchingFullScreenRoute.name));
+                    navigation.dispatch(shouldReplace ? StackActions.replace(matchingFullScreenRoute.name) : StackActions.push(matchingFullScreenRoute.name));
                 } else {
                     const lastRouteInMatchingFullScreen = matchingFullScreenRoute.state?.routes?.at(-1);
-                    const additionalAction = StackActions.push(matchingFullScreenRoute.name, {
+                    const routeParams = {
                         screen: lastRouteInMatchingFullScreen?.name,
                         params: lastRouteInMatchingFullScreen?.params,
-                    });
-                    navigation.dispatch(additionalAction);
+                    };
+                    navigation.dispatch(shouldReplace ? StackActions.replace(matchingFullScreenRoute.name, routeParams) : StackActions.push(matchingFullScreenRoute.name, routeParams));
                 }
             }
         }


### PR DESCRIPTION
### Explanation of Change

Regression fix from #87128.

PR #87128 (merged Apr 8) added a guard in `shouldChangeToMatchingFullScreen` that returned `false` when `lastFullScreenRoute.name === SCREENS.HOME`. This fixed the back animation issue (#85122) but broke navigation from Home to Settings RHP routes (#87655).

The guard was too broad: it blocked ALL fullscreen changes when on HOME, including legitimate ones like "Add address" which needs to navigate to Settings/Wallet.

This PR replaces HOME with the matching fullscreen via `StackActions.replace` instead of blocking the fullscreen change entirely. The stack shape now matches a page reload (`[SETTINGS_SPLIT_NAVIGATOR, RHP]`), which fixes both:

- #85122: correct back animation (no extra fullscreen pushed between HOME and RHP)
- #87655: working navigation from Home to Settings (fullscreen is replaced, not blocked)

One boolean: `shouldReplace = lastFullScreenRoute.name === SCREENS.HOME`. Uses `replace` instead of `push` only for HOME. All other routes use `push` as before.

### Fixed Issues

$ https://github.com/Expensify/App/issues/87655
PROPOSAL: https://github.com/Expensify/App/pull/88117

### Tests

1. Sign in, land on Home
2. Open a Time Sensitive card that has an "Add address" action
3. Tap the action, verify it navigates to Settings Wallet card page
4. Tap back, verify it lands on Settings Wallet (matches reload behavior)
5. On Android, verify the back animation direction is correct (not reversed)
6. Verify non-HOME RHP navigations (e.g. from any Settings page to another RHP) still use push and behave as before

- [x] Verify that no errors appear in the JS console

### Offline tests

Same as tests. Navigation logic is client-side and not affected by network state.

### QA Steps

1. Sign in, land on Home
2. Open a Time Sensitive card that has an "Add address" action
3. Tap the action, verify it navigates to Settings Wallet card page
4. Tap back, verify it lands on Settings Wallet
5. On Android, verify the back animation direction is correct
6. Verify non-HOME RHP navigations still use push and behave as before

- [x] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos

<details>
<summary>Android: Native</summary>

N/A

</details>

<details>
<summary>Android: mWeb Chrome</summary>

N/A

</details>

<details>
<summary>iOS: Native</summary>

N/A

</details>

<details>
<summary>iOS: mWeb Safari</summary>

N/A

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

N/A

</details>
