### PR TITLE
[$250] Fix custom report title briefly showing "Chat Report" when clicking a report row

### DIFF
--- a/src/libs/actions/Report/index.ts
+++ b/src/libs/actions/Report/index.ts
@@ -1272,10 +1272,11 @@ function openReport(params: OpenReportActionParams) {
         return;
     }
 
+    const existingReport = allReports?.[`${ONYXKEYS.COLLECTION.REPORT}${reportID}`];
     const optimisticReport = reportActionsExist(reportID)
         ? {}
         : {
-              reportName: allReports?.[`${ONYXKEYS.COLLECTION.REPORT}${reportID}`]?.reportName ?? CONST.REPORT.DEFAULT_REPORT_NAME,
+              ...(existingReport?.reportName ? {} : {reportName: CONST.REPORT.DEFAULT_REPORT_NAME}),
           };
 
     const optimisticData: Array<


### PR DESCRIPTION
## Summary

$ #88162

When clicking a report row on the Reports page, the custom report title (set via title formula) briefly flickers to "Chat Report" before reverting to the correct title once the report loads.

## Root Cause

In `openReport()`, when `reportActionsExist(reportID)` returns `false` (common when navigating from the Reports page since report actions aren't cached yet), an optimistic report update is created that unconditionally overwrites `reportName`. It reads the name from the global `allReports` collection, and if missing, falls back to `CONST.REPORT.DEFAULT_REPORT_NAME` (`"Chat Report"`). This optimistic merge temporarily overwrites the correct custom title in Onyx, causing the flicker.

## Fix

Changed the optimistic `reportName` logic in `openReport()` to only set `reportName` to `"Chat Report"` when the report doesn't already have a name. If the report exists in `allReports` with a valid `reportName`, we preserve it instead of overwriting.

**Before:**
```typescript
const optimisticReport = reportActionsExist(reportID)
    ? {}
    : {
          reportName: allReports?.[`${ONYXKEYS.COLLECTION.REPORT}${reportID}`]?.reportName ?? CONST.REPORT.DEFAULT_REPORT_NAME,
      };
```

**After:**
```typescript
const existingReport = allReports?.[`${ONYXKEYS.COLLECTION.REPORT}${reportID}`];
const optimisticReport = reportActionsExist(reportID)
    ? {}
    : {
          ...(existingReport?.reportName ? {} : {reportName: CONST.REPORT.DEFAULT_REPORT_NAME}),
      };
```

## Tests

- [ ] Navigate to Reports page with custom title formula reports
- [ ] Click a report row — title should remain stable (no flicker to "Chat Report")
- [ ] Open a brand new report with no cached name — should still show "Chat Report" as fallback