### PR TITLE
[50] Unable to mark expenses as billable

### DIFF
--- a/src/components/ReportActionItem/MoneyRequestView.tsx
+++ b/src/components/ReportActionItem/MoneyRequestView.tsx
@@ -420,8 +420,11 @@ function MoneyRequestView({
     // transactionTag can be an empty string
     // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
     const shouldShowTag = (isPolicyExpenseChat || isExpenseUnreported) && (transactionTag || (canEdit && hasEnabledTags(policyTagLists)));
+    const isCurrentTransactionBillableDifferentFromPolicyDefault =
+        policy?.defaultBillable !== undefined && !!(updatedTransaction?.billable ?? transactionBillable) !== policy.defaultBillable;
     const shouldShowBillable =
-        (isPolicyExpenseChat || isExpenseUnreported) && (!!transactionBillable || !(policy?.disabledFields?.defaultBillable ?? true) || !!updatedTransaction?.billable);
+        (isPolicyExpenseChat || isExpenseUnreported) &&
+        (policy?.disabledFields?.defaultBillable !== true || isCurrentTransactionBillableDifferentFromPolicyDefault);
     const isCurrentTransactionReimbursableDifferentFromPolicyDefault =
         policy?.defaultReimbursable !== undefined && !!(updatedTransaction?.reimbursable ?? transactionReimbursable) !== policy.defaultReimbursable;
     const shouldShowReimbursable =


### PR DESCRIPTION
## Details
<!-- Provide a clear explanation of the bug and how your fix addresses it -->

The billable toggle in the expense detail view (MoneyRequestView) was not showing for users when the workspace's `disabledFields.defaultBillable` was `undefined` or `true`. This was caused by an inconsistent condition:

```typescript
// Old (buggy):
const shouldShowBillable =
    (isPolicyExpenseChat || isExpenseUnreported) && 
    (!!transactionBillable || !(policy?.disabledFields?.defaultBillable ?? true) || !!updatedTransaction?.billable);
```

The `!(policy?.disabledFields?.defaultBillable ?? true)` expression incorrectly treated `undefined` as `true`, hiding the toggle. Other parts of the codebase (SearchEditMultiplePage, MoneyRequestConfirmationListFooter) use `defaultBillable === false` which correctly shows the toggle when the value is `undefined`.

## Fixed Code
Changed to match the `shouldShowReimbursable` pattern used in the same file:

```typescript
// New (fixed):
const isCurrentTransactionBillableDifferentFromPolicyDefault =
    policy?.defaultBillable !== undefined && 
    !!(updatedTransaction?.billable ?? transactionBillable) !== policy.defaultBillable;
const shouldShowBillable =
    (isPolicyExpenseChat || isExpenseUnreported) &&
    (policy?.disabledFields?.defaultBillable !== true || isCurrentTransactionBillableDifferentFromPolicyDefault);
```

This ensures:
- The billable toggle shows when the feature is enabled (`defaultBillable !== true`)
- The billable toggle also shows when the current transaction's billable value differs from the policy default, allowing users to toggle it back
- Consistent with how `shouldShowReimbursable` works in the same file

## Fixed Issues
$ #88153

## Tests
N/A - logic change only, mirrors existing reimbursable pattern