### PR TITLE
Fix iOS crash caused by navigation race condition after Onfido exit

### DIFF
--- a/src/components/Onfido/index.native.tsx
+++ b/src/components/Onfido/index.native.tsx
@@ -1,6 +1,6 @@
 import {OnfidoCaptureType, OnfidoCountryCode, OnfidoDocumentType, OnfidoNFCOptions, Onfido as OnfidoSDK, OnfidoTheme} from '@onfido/react-native-sdk';
-import React, {useEffect} from 'react';
-import {Alert, NativeModules} from 'react-native';
+import React, {useEffect, useRef} from 'react';
+import {Alert, InteractionManager, NativeModules} from 'react-native';
 import {checkMultiple, PERMISSIONS, RESULTS} from 'react-native-permissions';
 import FullscreenLoadingIndicator from '@components/FullscreenLoadingIndicator';
 import useLocalize from '@hooks/useLocalize';
@@ -15,6 +15,71 @@ const {AppStateTracker} = NativeModules;
 
 function Onfido({sdkToken, onUserExit, onSuccess, onError}: OnfidoProps) {
     const {translate} = useLocalize();
+    const isExitInProgress = useRef(false);
+    const isMounted = useRef(true);
+    const exitInteractionTask = useRef<ReturnType<typeof InteractionManager.runAfterInteractions> | null>(null);
+    const exitAnimationFrame = useRef<number | null>(null);
+    const resetExitGuardFrame = useRef<number | null>(null);
+
+    const clearScheduledUserExit = () => {
+        exitInteractionTask.current?.cancel();
+        exitInteractionTask.current = null;
+
+        if (exitAnimationFrame.current !== null) {
+            cancelAnimationFrame(exitAnimationFrame.current);
+            exitAnimationFrame.current = null;
+        }
+
+        if (resetExitGuardFrame.current !== null) {
+            cancelAnimationFrame(resetExitGuardFrame.current);
+            resetExitGuardFrame.current = null;
+        }
+    };
+
+    const scheduleUserExit = (isUserInitiated?: boolean) => {
+        if (getPlatform() !== CONST.PLATFORM.IOS) {
+            onUserExit(isUserInitiated);
+            return;
+        }
+
+        if (isExitInProgress.current) {
+            return;
+        }
+
+        isExitInProgress.current = true;
+
+        exitInteractionTask.current = InteractionManager.runAfterInteractions(() => {
+            exitInteractionTask.current = null;
+            exitAnimationFrame.current = requestAnimationFrame(() => {
+                exitAnimationFrame.current = null;
+
+                if (!isMounted.current) {
+                    return;
+                }
+
+                onUserExit(isUserInitiated);
+
+                // Reset the guard only if the component is still mounted on the next frame.
+                // This preserves deduplication during teardown but avoids trapping the instance
+                // if navigation is ignored or the screen remains mounted unexpectedly.
+                resetExitGuardFrame.current = requestAnimationFrame(() => {
+                    resetExitGuardFrame.current = null;
+                    if (!isMounted.current) {
+                        return;
+                    }
+
+                    isExitInProgress.current = false;
+                });
+            });
+        });
+    };
+
+    useEffect(() => {
+        return () => {
+            isMounted.current = false;
+            clearScheduledUserExit();
+        };
+    }, []);
 
     useEffect(() => {
         OnfidoSDK.start({
@@ -50,7 +115,7 @@ function Onfido({sdkToken, onUserExit, onSuccess, onError}: OnfidoProps) {
                         return;
                     }
 
-                    onUserExit(true);
+                    scheduleUserExit(true);
                     return;
                 }
 
@@ -76,12 +141,12 @@ function Onfido({sdkToken, onUserExit, onSuccess, onError}: OnfidoProps) {
                                     [
                                         {
                                             text: translate('common.cancel'),
-                                            onPress: () => onUserExit(true),
+                                            onPress: () => scheduleUserExit(true),
                                         },
                                         {
                                             text: translate('common.settings'),
                                             onPress: () => {
-                                                onUserExit();
+                                                scheduleUserExit();
                                                 goToSettings();
                                             },
                                         },


### PR DESCRIPTION
### Explanation of Change

On iOS, the Onfido SDK triggers the exit callback before its native view controller has fully completed dismissal. The existing implementation immediately called `onUserExit`, which triggered React Navigation transitions while the native dismissal animation was still in progress.

This created a race condition between:
- Native Onfido view controller dismissal
- React Navigation stack updates
- Immediate user re-entry into the flow

iOS does not allow overlapping view controller transitions, resulting in a crash.

This PR introduces a deferred exit mechanism to synchronize navigation with the completion of native interactions.

---

### Fixed Issues

$ https://github.com/Expensify/App/issues/88173  
PROPOSAL: https://github.com/Expensify/App/issues/88173#issuecomment-4265907663
---

### Fix

- Introduced `scheduleUserExit` to defer navigation on iOS
- Used `InteractionManager.runAfterInteractions` to wait for ongoing interactions
- Added `requestAnimationFrame` chaining to align with render cycle
- Added instance-scoped guard (`isExitInProgress`) to prevent duplicate triggers
- Implemented cleanup for scheduled tasks on unmount to prevent memory leaks
- Ensured all Onfido exit paths use the new scheduling mechanism

Android behavior remains unchanged.

---

### Tests

1. Start Onfido verification flow
2. Exit using back button
3. Immediately tap "Pay with wallet" again
4. Verify app does NOT crash
5. Repeat exit multiple times rapidly
6. Verify no duplicate navigation occurs
7. Verify normal navigation flow continues correctly

- [x] Verified no JS console errors

---

### Offline tests

1. Disable network connection
2. Start Onfido flow
3. Exit flow
4. Verify no crash occurs
5. Re-enable network and repeat

---

### QA Steps

Same as Tests

- [x] Verify no console errors