### PR TITLE
fix: exclude modifiedAmount NOTICE from LHN RBR for submitted reports

### DIFF
--- a/src/libs/ReportUtils.ts
+++ b/src/libs/ReportUtils.ts
@@ -9183,6 +9183,10 @@ function getViolatingReportIDForRBRInLHN(report: OnyxEntry<Report>, transactionV
                 return false;
             }
 
+            const transactionViolationsForNoticeCheck = isProcessingReport(potentialReport)
+                ? filterOutModifiedAmountViolationsForTransactions(transactionViolations, transactions)
+                : transactionViolations;
+
             return (
                 !isInvoiceReport(potentialReport) &&
                 ViolationsUtils.hasVisibleViolationsForUser(
@@ -9215,7 +9219,7 @@ function getViolatingReportIDForRBRInLHN(report: OnyxEntry<Report>, transactionV
                     ) ||
                     hasNoticeTypeViolations(
                         potentialReport.reportID,
-                        transactionViolations,
+                        transactionViolationsForNoticeCheck,
                         deprecatedCurrentUserAccountID ?? CONST.DEFAULT_NUMBER_ID,
                         deprecatedCurrentUserEmail ?? '',
                         true,
@@ -9226,6 +9230,30 @@ function getViolatingReportIDForRBRInLHN(report: OnyxEntry<Report>, transactionV
             );
         });
     return violatingReport ? violatingReport.reportID : null;
+}
+
+function filterOutModifiedAmountViolationsForTransactions(
+    transactionViolations: OnyxCollection<TransactionViolation[]>,
+    transactions: Transaction[],
+): OnyxCollection<TransactionViolation[]> {
+    const filteredViolations = {...transactionViolations};
+
+    for (const transaction of transactions) {
+        const transactionID = transaction?.transactionID;
+        if (!transactionID) {
+            continue;
+        }
+
+        const transactionViolationKey = `${ONYXKEYS.COLLECTION.TRANSACTION_VIOLATIONS}${transactionID}`;
+        const violations = filteredViolations[transactionViolationKey];
+        if (!violations?.length) {
+            continue;
+        }
+
+        filteredViolations[transactionViolationKey] = violations.filter((violation) => violation.name !== CONST.VIOLATIONS.MODIFIED_AMOUNT);
+    }
+
+    return filteredViolations;
 }
 
 /**

--- a/src/libs/ReportUtils.ts
+++ b/src/libs/ReportUtils.ts
@@ -9183,9 +9183,7 @@ function getViolatingReportIDForRBRInLHN(report: OnyxEntry<Report>, transactionV
                 return false;
             }
 
-            const transactionViolationsForNoticeCheck = isProcessingReport(potentialReport)
-                ? filterOutModifiedAmountViolationsForTransactions(transactionViolations, transactions)
-                : transactionViolations;
+            const excludedNoticeNamesForLHN = isProcessingReport(potentialReport) ? [CONST.VIOLATIONS.MODIFIED_AMOUNT] : [];
 
             return (
                 !isInvoiceReport(potentialReport) &&
@@ -9217,43 +9215,37 @@ function getViolatingReportIDForRBRInLHN(report: OnyxEntry<Report>, transactionV
                         potentialReport,
                         policy,
                     ) ||
-                    hasNoticeTypeViolations(
-                        potentialReport.reportID,
-                        transactionViolationsForNoticeCheck,
+                    hasNoticeTypeViolationsForRBRInLHN(
+                        transactionViolations,
                         deprecatedCurrentUserAccountID ?? CONST.DEFAULT_NUMBER_ID,
                         deprecatedCurrentUserEmail ?? '',
-                        true,
                         transactions,
                         potentialReport,
                         policy,
+                        excludedNoticeNamesForLHN,
                     ))
             );
         });
     return violatingReport ? violatingReport.reportID : null;
 }
 
-function filterOutModifiedAmountViolationsForTransactions(
+function hasNoticeTypeViolationsForRBRInLHN(
     transactionViolations: OnyxCollection<TransactionViolation[]>,
-    transactions: Transaction[],
-): OnyxCollection<TransactionViolation[]> {
-    const filteredViolations = {...transactionViolations};
-
-    for (const transaction of transactions) {
-        const transactionID = transaction?.transactionID;
-        if (!transactionID) {
-            continue;
+    currentUserAccountIDParam: number,
+    currentUserEmailParam: string,
+    reportTransactions: Transaction[],
+    report: OnyxEntry<Report>,
+    policy: OnyxEntry<Policy>,
+    excludedViolationNames: string[],
+): boolean {
+    return reportTransactions.some((transaction) => {
+        const rawViolations = transactionViolations?.[`${ONYXKEYS.COLLECTION.TRANSACTION_VIOLATIONS}${transaction?.transactionID}`];
+        if (!rawViolations?.length) {
+            return false;
         }
-
-        const transactionViolationKey = `${ONYXKEYS.COLLECTION.TRANSACTION_VIOLATIONS}${transactionID}`;
-        const violations = filteredViolations[transactionViolationKey];
-        if (!violations?.length) {
-            continue;
-        }
-
-        filteredViolations[transactionViolationKey] = violations.filter((violation) => violation.name !== CONST.VIOLATIONS.MODIFIED_AMOUNT);
-    }
-
-    return filteredViolations;
+        const filteredViolations = excludedViolationNames.length > 0 ? rawViolations.filter((violation) => !excludedViolationNames.includes(violation.name)) : rawViolations;
+        return hasNoticeTypeViolation(transaction, filteredViolations, currentUserEmailParam, currentUserAccountIDParam, report, policy, true);
+    });
 }
 
 /**

--- a/tests/unit/ReportUtilsTest.ts
+++ b/tests/unit/ReportUtilsTest.ts
@@ -12440,6 +12440,181 @@ describe('ReportUtils', () => {
 
             await Onyx.clear();
         });
+
+        it('should return null for a processing (submitted) expense report whose only violation is a modifiedAmount NOTICE', async () => {
+            await Onyx.clear();
+
+            const policyID = 'policy-rbr-modified-amount-processing';
+            const chatReportID = 'chat-rbr-modified-amount-processing';
+            const expenseReportID = 'expense-rbr-modified-amount-processing';
+            const transactionID = 'transaction-rbr-modified-amount-processing';
+
+            const policyData: Policy = {
+                id: policyID,
+                name: 'Modified Amount Processing Workspace',
+                type: CONST.POLICY.TYPE.TEAM,
+                role: CONST.POLICY.ROLE.ADMIN,
+                outputCurrency: CONST.CURRENCY.USD,
+                reimbursementChoice: CONST.POLICY.REIMBURSEMENT_CHOICES.REIMBURSEMENT_YES,
+                approvalMode: CONST.POLICY.APPROVAL_MODE.BASIC,
+                employeeList: {
+                    [currentUserEmail]: {
+                        role: CONST.POLICY.ROLE.ADMIN,
+                    },
+                },
+                owner: currentUserEmail,
+                isPolicyExpenseChatEnabled: true,
+            };
+
+            const chatReport: Report = {
+                ...createPolicyExpenseChat(820),
+                reportID: chatReportID,
+                ownerAccountID: currentUserAccountID,
+                policyID,
+                iouReportID: expenseReportID,
+            };
+
+            const expenseReport: Report = {
+                ...createExpenseReport(821),
+                reportID: expenseReportID,
+                chatReportID,
+                ownerAccountID: currentUserAccountID,
+                managerID: 42,
+                policyID,
+                type: CONST.REPORT.TYPE.EXPENSE,
+                currency: CONST.CURRENCY.USD,
+                total: 5000,
+                stateNum: CONST.REPORT.STATE_NUM.SUBMITTED,
+                statusNum: CONST.REPORT.STATUS_NUM.SUBMITTED,
+            };
+
+            const baseTransaction = createRandomTransaction(820);
+            const transaction: Transaction = {
+                ...baseTransaction,
+                transactionID,
+                reportID: expenseReportID,
+                amount: 5000,
+                currency: CONST.CURRENCY.USD,
+                status: CONST.TRANSACTION.STATUS.POSTED,
+                reimbursable: true,
+            };
+
+            const transactionViolationsKey = `${ONYXKEYS.COLLECTION.TRANSACTION_VIOLATIONS}${transactionID}` as OnyxKey;
+            const transactionViolationsCollection: OnyxCollection<TransactionViolation[]> = {
+                [transactionViolationsKey]: [
+                    {
+                        name: CONST.VIOLATIONS.MODIFIED_AMOUNT,
+                        type: CONST.VIOLATION_TYPES.NOTICE,
+                        showInReview: true,
+                    },
+                ],
+            };
+
+            await Onyx.merge(ONYXKEYS.SESSION, {accountID: currentUserAccountID, email: currentUserEmail});
+            await waitForBatchedUpdates();
+
+            await Promise.all([
+                Onyx.merge(`${ONYXKEYS.COLLECTION.POLICY}${policyID}`, policyData),
+                Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT}${chatReport.reportID}`, chatReport),
+                Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT}${expenseReport.reportID}`, expenseReport),
+                Onyx.merge(`${ONYXKEYS.COLLECTION.TRANSACTION}${transaction.transactionID}`, transaction),
+                Onyx.merge(transactionViolationsKey, transactionViolationsCollection[transactionViolationsKey]),
+            ]);
+            await waitForBatchedUpdates();
+
+            const result = getViolatingReportIDForRBRInLHN(chatReport, transactionViolationsCollection);
+            expect(result).toBeNull();
+
+            await Onyx.clear();
+        });
+
+        it('should still surface RBR for an open expense report whose only violation is a modifiedAmount NOTICE', async () => {
+            await Onyx.clear();
+
+            const policyID = 'policy-rbr-modified-amount-open';
+            const chatReportID = 'chat-rbr-modified-amount-open';
+            const expenseReportID = 'expense-rbr-modified-amount-open';
+            const transactionID = 'transaction-rbr-modified-amount-open';
+
+            const policyData: Policy = {
+                id: policyID,
+                name: 'Modified Amount Open Workspace',
+                type: CONST.POLICY.TYPE.TEAM,
+                role: CONST.POLICY.ROLE.ADMIN,
+                outputCurrency: CONST.CURRENCY.USD,
+                reimbursementChoice: CONST.POLICY.REIMBURSEMENT_CHOICES.REIMBURSEMENT_YES,
+                approvalMode: CONST.POLICY.APPROVAL_MODE.BASIC,
+                employeeList: {
+                    [currentUserEmail]: {
+                        role: CONST.POLICY.ROLE.ADMIN,
+                    },
+                },
+                owner: currentUserEmail,
+                isPolicyExpenseChatEnabled: true,
+            };
+
+            const chatReport: Report = {
+                ...createPolicyExpenseChat(822),
+                reportID: chatReportID,
+                ownerAccountID: currentUserAccountID,
+                policyID,
+                iouReportID: expenseReportID,
+                hasOutstandingChildRequest: true,
+            };
+
+            const expenseReport: Report = {
+                ...createExpenseReport(823),
+                reportID: expenseReportID,
+                chatReportID,
+                ownerAccountID: currentUserAccountID,
+                managerID: 42,
+                policyID,
+                type: CONST.REPORT.TYPE.EXPENSE,
+                currency: CONST.CURRENCY.USD,
+                total: 5000,
+                stateNum: CONST.REPORT.STATE_NUM.OPEN,
+                statusNum: CONST.REPORT.STATUS_NUM.OPEN,
+            };
+
+            const baseTransaction = createRandomTransaction(822);
+            const transaction: Transaction = {
+                ...baseTransaction,
+                transactionID,
+                reportID: expenseReportID,
+                amount: 5000,
+                currency: CONST.CURRENCY.USD,
+                status: CONST.TRANSACTION.STATUS.POSTED,
+                reimbursable: true,
+            };
+
+            const transactionViolationsKey = `${ONYXKEYS.COLLECTION.TRANSACTION_VIOLATIONS}${transactionID}` as OnyxKey;
+            const transactionViolationsCollection: OnyxCollection<TransactionViolation[]> = {
+                [transactionViolationsKey]: [
+                    {
+                        name: CONST.VIOLATIONS.MODIFIED_AMOUNT,
+                        type: CONST.VIOLATION_TYPES.NOTICE,
+                        showInReview: true,
+                    },
+                ],
+            };
+
+            await Onyx.merge(ONYXKEYS.SESSION, {accountID: currentUserAccountID, email: currentUserEmail});
+            await waitForBatchedUpdates();
+
+            await Promise.all([
+                Onyx.merge(`${ONYXKEYS.COLLECTION.POLICY}${policyID}`, policyData),
+                Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT}${chatReport.reportID}`, chatReport),
+                Onyx.merge(`${ONYXKEYS.COLLECTION.REPORT}${expenseReport.reportID}`, expenseReport),
+                Onyx.merge(`${ONYXKEYS.COLLECTION.TRANSACTION}${transaction.transactionID}`, transaction),
+                Onyx.merge(transactionViolationsKey, transactionViolationsCollection[transactionViolationsKey]),
+            ]);
+            await waitForBatchedUpdates();
+
+            const result = getViolatingReportIDForRBRInLHN(chatReport, transactionViolationsCollection);
+            expect(result).toBe(expenseReportID);
+
+            await Onyx.clear();
+        });
     });
 
     it('should surface a GBR for admin with held expenses requiring approval or payment and avoid showing an RBR', async () => {


### PR DESCRIPTION
### Explanation of Change

When a SmartScanned expense amount is manually edited to a higher value, the backend creates a `modifiedAmount` NOTICE-type violation ("Amount greater than scanned receipt"). After the report is submitted (Outstanding/processing state), this NOTICE violation was incorrectly causing the Red Brick Road (RBR) indicator to appear in the LHN for the submitted report — even though the expected behavior is for the violation to remain visible only on the expense details page.

This PR adds a targeted, LHN-only filter in `getViolatingReportIDForRBRInLHN` (`src/libs/ReportUtils.ts`) that excludes `CONST.VIOLATIONS.MODIFIED_AMOUNT` from the notice-type branch when the report is in processing state. The fix is scoped specifically to the LHN RBR calculation path so that:

- LHN RBR no longer fires for `modifiedAmount` on submitted reports.
- Expense details rendering is **unchanged** — the violation still appears on the transaction/report details page.
- All other NOTICE/WARNING/VIOLATION behavior (both for open and processing reports) is untouched.
- Non-submitted (open/draft) reports continue to show the notice in the LHN as before.

A dedicated helper `hasNoticeTypeViolationsForRBRInLHN` is added next to `getViolatingReportIDForRBRInLHN`. It filters excluded violation names inline per transaction (no map cloning) to keep the LHN render path cheap, and isolates the LHN-only logic from the shared `hasNoticeTypeViolations` helper used by other call sites.

### Fixed Issues

$ https://github.com/Expensify/App/issues/86927
PROPOSAL: https://github.com/Expensify/App/issues/86927#issuecomment-4173736159

### Tests

1. Sign in as a workspace employee/submitter on a policy that flags SmartScan amount edits.
2. Create an expense and upload a receipt (SmartScan).
3. Once SmartScan completes, edit the expense amount to a value **higher** than the scanned amount.
4. Verify the `modifiedAmount` violation ("Amount greater than scanned receipt") appears on the expense details page.
5. Verify the LHN shows the RBR indicator for the report while it is still in the Open state.
6. Submit the report.
7. Verify the report transitions to Outstanding/processing state.
8. **Verify the LHN RBR indicator no longer appears on the submitted report's row.**
9. Open the submitted report → open the expense → verify the `modifiedAmount` violation is still visible on the expense details page.
10. Verify no errors appear in the JS console.

Regression checks: 11. Repeat steps 1–8 with a WARNING-type violation (e.g., missing receipt) → confirm LHN RBR continues to appear on the submitted report. 12. Repeat steps 1–3 but do NOT submit the report → confirm LHN RBR still shows for the open report (MODIFIED_AMOUNT still surfaces while editable). 13. Submit a report with a non-`modifiedAmount` NOTICE violation → confirm LHN RBR behavior for other NOTICE violations is unchanged.

- [x] Verify that no errors appear in the JS console

### Offline tests

1. Turn off network.
2. Edit a SmartScanned expense amount higher.
3. Verify the violation and RBR appear offline based on the local Onyx state.
4. Submit the report while offline.
5. Verify the LHN RBR indicator disappears for the submitted report (state transition is optimistic).
6. Reconnect network → verify state stays consistent after sync (no flash of RBR on submitted report).

### QA Steps

Same as Tests. Reproduction on staging and fix demo videos are attached in the issue thread:

- Staging reproduction: https://github.com/user-attachments/assets/868aabe4-d4a1-44ae-8ab3-e5fc6025feab
- Fix demo: https://github.com/user-attachments/assets/75114460-d301-4f0a-bbf5-3409d03d43d7

- [x] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
  - [x] I added steps for local testing in the `Tests` section
  - [x] I added steps for the expected offline behavior in the `Offline steps` section
  - [x] I added steps for Staging and/or Production testing in the `QA steps` section
  - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
  - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
  - [x] I tested this PR with a High Traffic account against the staging or production API to ensure there are no regressions.
- [x] I included screenshots or videos for tests on all platforms
- [x] I ran the tests on **all platforms** & verified they passed on:
  - [x] Android: Native
  - [x] Android: mWeb Chrome
  - [x] iOS: Native
  - [x] iOS: mWeb Safari
  - [x] MacOS: Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see Reviewing the code)
  - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle
  - [x] I verified that comments were added to code that is not self explanatory
  - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
  - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the translation method
    - [x] If any non-english text was added/modified, I used JaimeGPT to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
  - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the localization methods
  - [x] I verified any copy / text that was added to the app is grammatically correct in English.
  - [x] I verified proper file naming conventions were followed for any new files or renamed files.
  - [x] I verified the JSDocs style guidelines were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the Review Guidelines
- [x] I tested other components that can be impacted by my changes
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
  - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
  - [x] A similar style doesn't already exist
  - [x] The style can't be created with an existing StyleUtils function
- [x] If new assets were added or existing ones were modified, I verified that:
  - [x] The assets are optimized and compressed
  - [x] The assets load correctly across all supported platforms.
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App.
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used.
- [x] If the PR modifies the UI or modifies the form input styles:
  - [x] I verified that all the inputs inside a form are aligned with each other.
  - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added unit tests for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos

<details>
<summary>Android: Native</summary>

https://github.com/user-attachments/assets/567620cd-a2b7-4e13-b8b4-df6884d4606f

</details>

<details>
<summary>Android: mWeb Chrome</summary>

https://github.com/user-attachments/assets/76529a69-8428-492e-a998-02c2dd48064c

</details>

<details>
<summary>iOS: Native</summary>

https://github.com/user-attachments/assets/c71e05bb-f766-465f-bb20-f9c92c663a68

</details>

<details>
<summary>iOS: mWeb Safari</summary>

https://github.com/user-attachments/assets/19cb4515-3ee4-440b-998e-82853eef67b4

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

https://github.com/user-attachments/assets/8d914899-9d4d-41f2-a784-5c1c489e48c5

</details>
