### PR TITLE
[Submit] Update Workspaces list + Plan Type page (Wave 2)

### DIFF
--- a/src/CONST/index.ts
+++ b/src/CONST/index.ts
@@ -3538,6 +3538,7 @@ const CONST = {
             // Often referred to as "collect" workspaces
             TEAM: 'team',
 
+            // Free "Submit" plan for employees submitting expenses to their employer
             SUBMIT: 'submit2026',
         },
         RULE_CONDITIONS: {

--- a/src/languages/de.ts
+++ b/src/languages/de.ts
@@ -5192,6 +5192,7 @@ _Für ausführlichere Anweisungen [besuchen Sie unsere Hilfeseite](${CONST.NETSU
             free: 'Kostenlos',
             control: 'Steuerung',
             collect: 'Einziehen',
+            submit: 'Einreichen',
         },
         companyCards: {
             addCards: 'Karten hinzufügen',

--- a/src/languages/en.ts
+++ b/src/languages/en.ts
@@ -5217,6 +5217,7 @@ const translations = {
             free: 'Free',
             control: 'Control',
             collect: 'Collect',
+            submit: 'Submit',
         },
         companyCards: {
             addCards: 'Add cards',

--- a/src/languages/es.ts
+++ b/src/languages/es.ts
@@ -5049,6 +5049,7 @@ ${amount} para ${merchant} - ${date}`,
             free: 'Gratis',
             control: 'Controlar',
             collect: 'Recopilar',
+            submit: 'Enviar',
         },
         companyCards: {
             addCards: 'Añadir tarjetas',

--- a/src/languages/fr.ts
+++ b/src/languages/fr.ts
@@ -5202,6 +5202,7 @@ _Pour des instructions plus détaillées, [visitez notre site d’aide](${CONST.
             free: 'Gratuit',
             control: 'Contrôle',
             collect: 'Encaisser',
+            submit: 'Soumettre',
         },
         companyCards: {
             addCards: 'Ajouter des cartes',

--- a/src/languages/it.ts
+++ b/src/languages/it.ts
@@ -5177,6 +5177,7 @@ _Per istruzioni più dettagliate, [visita il nostro sito di assistenza](${CONST.
             free: 'Gratis',
             control: 'Controllo',
             collect: 'Riscuoti',
+            submit: 'Invia',
         },
         companyCards: {
             addCards: 'Aggiungi carte',

--- a/src/languages/ja.ts
+++ b/src/languages/ja.ts
@@ -5129,6 +5129,7 @@ _詳しい手順については、[ヘルプサイトをご覧ください](${CO
             free: '無料',
             control: 'コントロール',
             collect: '回収',
+            submit: '提出',
         },
         companyCards: {
             addCards: 'カードを追加',

--- a/src/languages/nl.ts
+++ b/src/languages/nl.ts
@@ -5167,6 +5167,7 @@ _Voor meer gedetailleerde instructies, [bezoek onze help-site](${CONST.NETSUITE_
             free: 'Gratis',
             control: 'Beheer',
             collect: 'Incasseren',
+            submit: 'Indienen',
         },
         companyCards: {
             addCards: 'Kaarten toevoegen',

--- a/src/languages/pl.ts
+++ b/src/languages/pl.ts
@@ -5160,6 +5160,7 @@ _Aby uzyskać bardziej szczegółowe instrukcje, [odwiedź naszą stronę pomocy
             free: 'Darmowy',
             control: 'Sterowanie',
             collect: 'Zbierz',
+            submit: 'Prześlij',
         },
         companyCards: {
             addCards: 'Dodaj karty',

--- a/src/languages/pt-BR.ts
+++ b/src/languages/pt-BR.ts
@@ -5162,6 +5162,7 @@ _Para instruções mais detalhadas, [visite nossa central de ajuda](${CONST.NETS
             free: 'Grátis',
             control: 'Controle',
             collect: 'Cobrar',
+            submit: 'Enviar',
         },
         companyCards: {
             addCards: 'Adicionar cartões',

--- a/src/languages/zh-hans.ts
+++ b/src/languages/zh-hans.ts
@@ -5045,6 +5045,7 @@ _如需更详细的说明，请[访问我们的帮助网站](${CONST.NETSUITE_IM
             free: '免费',
             control: '控制',
             collect: '收款',
+            submit: '提交',
         },
         companyCards: {
             addCards: '添加卡片',

--- a/src/libs/PolicyUtils.ts
+++ b/src/libs/PolicyUtils.ts
@@ -935,15 +935,16 @@ function isSubmitPolicy(policy: OnyxInputOrEntry<Policy>): boolean {
     return policy?.type === CONST.POLICY.TYPE.SUBMIT;
 }
 
-function isPolicyEditor(policy: OnyxEntry<Policy>): boolean {
+function isPolicyEditor(policy: OnyxInputOrEntry<Policy>): boolean {
     return policy?.role === CONST.POLICY.ROLE.EDITOR;
 }
 
 /**
- * Returns true if the user can edit workspace settings — admins on any workspace, or editors on Submit workspaces.
+ * Returns true if the current user can edit workspace settings — admins on any workspace,
+ * or editors on Submit workspaces (Submit has no admin role, so editors manage it).
  */
-function canEditWorkspaceSettings(policy: OnyxEntry<Policy>): boolean {
-    return isPolicyAdmin(policy) || isPolicyEditor(policy);
+function canEditWorkspaceSettings(policy: OnyxInputOrEntry<Policy>): boolean {
+    return isPolicyAdmin(policy) || (isSubmitPolicy(policy) && isPolicyEditor(policy));
 }
 
 /**
@@ -1942,6 +1943,8 @@ function getUserFriendlyWorkspaceType(workspaceType: ValueOf<typeof CONST.POLICY
             return translate('workspace.type.control');
         case CONST.POLICY.TYPE.TEAM:
             return translate('workspace.type.collect');
+        case CONST.POLICY.TYPE.SUBMIT:
+            return translate('workspace.type.submit');
         default:
             return translate('workspace.type.free');
     }

--- a/src/libs/PolicyUtils.ts
+++ b/src/libs/PolicyUtils.ts
@@ -935,16 +935,17 @@ function isSubmitPolicy(policy: OnyxInputOrEntry<Policy>): boolean {
     return policy?.type === CONST.POLICY.TYPE.SUBMIT;
 }
 
-function isPolicyEditor(policy: OnyxInputOrEntry<Policy>): boolean {
-    return policy?.role === CONST.POLICY.ROLE.EDITOR;
-}
+const isPolicyEditor = (policy: OnyxInputOrEntry<Policy>, login?: string): boolean => getPolicyRole(policy, login) === CONST.POLICY.ROLE.EDITOR;
 
 /**
  * Returns true if the current user can edit workspace settings — admins on any workspace,
  * or editors on Submit workspaces (Submit has no admin role, so editors manage it).
+ *
+ * `login` enables the per-employee role fallback in `getPolicyRole`, so partially-loaded/summary
+ * policies (where `policy.role` isn't populated yet) don't incorrectly route admins/editors away.
  */
-function canEditWorkspaceSettings(policy: OnyxInputOrEntry<Policy>): boolean {
-    return isPolicyAdmin(policy) || (isSubmitPolicy(policy) && isPolicyEditor(policy));
+function canEditWorkspaceSettings(policy: OnyxInputOrEntry<Policy>, login?: string): boolean {
+    return isPolicyAdmin(policy, login) || (isSubmitPolicy(policy) && isPolicyEditor(policy, login));
 }
 
 /**

--- a/src/libs/SubscriptionUtils.ts
+++ b/src/libs/SubscriptionUtils.ts
@@ -535,6 +535,11 @@ function getSubscriptionPrice(
         return 0;
     }
 
+    // Submit is a free plan — no subscription price to look up.
+    if (plan === CONST.POLICY.TYPE.SUBMIT) {
+        return 0;
+    }
+
     if (hasTeam2025Pricing && plan === CONST.POLICY.TYPE.TEAM) {
         return CONST.SUBSCRIPTION_PRICES[preferredCurrency][plan][CONST.SUBSCRIPTION.PRICING_TYPE_2025];
     }

--- a/src/libs/SubscriptionUtils.ts
+++ b/src/libs/SubscriptionUtils.ts
@@ -531,12 +531,8 @@ function getSubscriptionPrice(
     privateSubscriptionType: SubscriptionType | undefined,
     hasTeam2025Pricing: boolean,
 ): number {
-    if (!privateSubscriptionType || !plan || plan === CONST.POLICY.TYPE.SUBMIT) {
-        return 0;
-    }
-
     // Submit is a free plan — no subscription price to look up.
-    if (plan === CONST.POLICY.TYPE.SUBMIT) {
+    if (!privateSubscriptionType || !plan || plan === CONST.POLICY.TYPE.SUBMIT) {
         return 0;
     }
 

--- a/src/pages/workspace/AccessOrNotFoundWrapper.tsx
+++ b/src/pages/workspace/AccessOrNotFoundWrapper.tsx
@@ -32,7 +32,7 @@ import {isEmptyObject} from '@src/types/utils/EmptyObject';
 const ACCESS_VARIANTS = {
     [CONST.POLICY.ACCESS_VARIANTS.PAID]: (policy: OnyxEntry<Policy>) => isGroupPolicy(policy),
     [CONST.POLICY.ACCESS_VARIANTS.CONTROL]: (policy: OnyxEntry<Policy>) => isControlPolicy(policy),
-    [CONST.POLICY.ACCESS_VARIANTS.ADMIN]: (policy: OnyxEntry<Policy>) => canEditWorkspaceSettings(policy),
+    [CONST.POLICY.ACCESS_VARIANTS.ADMIN]: (policy: OnyxEntry<Policy>, login: string) => canEditWorkspaceSettings(policy, login),
     [CONST.IOU.ACCESS_VARIANTS.CREATE]: (
         policy: OnyxEntry<Policy>,
         login: string,

--- a/src/pages/workspace/DynamicWorkspaceOverviewPlanTypePage.tsx
+++ b/src/pages/workspace/DynamicWorkspaceOverviewPlanTypePage.tsx
@@ -17,6 +17,7 @@ import usePrivateSubscription from '@hooks/usePrivateSubscription';
 import useTheme from '@hooks/useTheme';
 import useThemeStyles from '@hooks/useThemeStyles';
 import OpenWorkspacePlanPage from '@libs/actions/Policy/Plan';
+import {isSubmitPolicy} from '@libs/PolicyUtils';
 import {isSubscriptionTypeOfInvoicing} from '@libs/SubscriptionUtils';
 import Navigation from '@navigation/Navigation';
 import CardSectionUtils from '@pages/settings/Subscription/CardSection/utils';
@@ -54,14 +55,16 @@ function DynamicWorkspaceOverviewPlanTypePage({policy}: WithPolicyProps) {
         setCurrentPlan(policy?.type);
     }, [policy?.type]);
 
+    const isCurrentPolicySubmit = isSubmitPolicy(policy);
     const workspacePlanTypes = Object.values(CONST.POLICY.TYPE)
         .filter((type) => {
             if (type === CONST.POLICY.TYPE.PERSONAL) {
                 return false;
             }
-            // Guard: don't leak the SUBMIT plan type into the plan-type list for paid workspaces.
-            // Submit-specific plan-type UX (exposing SUBMIT for Submit policies) ships in #87263.
-            if (type === CONST.POLICY.TYPE.SUBMIT) {
+            // Per the design: the Submit row only appears when the current workspace is already
+            // Submit. This hides Submit from Collect/Control workspaces (no downgrade path) while
+            // still surfacing Collect/Control as upgrade options for Submit workspaces.
+            if (type === CONST.POLICY.TYPE.SUBMIT && !isCurrentPolicySubmit) {
                 return false;
             }
             return true;

--- a/src/pages/workspace/WorkspacesListRow.tsx
+++ b/src/pages/workspace/WorkspacesListRow.tsx
@@ -139,7 +139,7 @@ function WorkspacesListRow({
     const isFocused = useIsFocused();
     const isNarrow = layoutWidth === CONST.LAYOUT_WIDTH.NARROW;
     const icons = useMemoizedLazyExpensifyIcons(['ArrowRight', 'Hourglass']);
-    const illustrations = useMemoizedLazyIllustrations(['Mailbox', 'ShieldYellow']);
+    const illustrations = useMemoizedLazyIllustrations(['Mailbox', 'ShieldYellow', 'EnvelopeReceipt']);
 
     const workspaceTypeIcon = useCallback(
         (type: WorkspacesListRowProps['workspaceType']): IconAsset => {
@@ -148,11 +148,13 @@ function WorkspacesListRow({
                     return illustrations.ShieldYellow;
                 case CONST.POLICY.TYPE.TEAM:
                     return illustrations.Mailbox;
+                case CONST.POLICY.TYPE.SUBMIT:
+                    return illustrations.EnvelopeReceipt;
                 default:
                     return illustrations.Mailbox;
             }
         },
-        [illustrations.Mailbox, illustrations.ShieldYellow],
+        [illustrations.EnvelopeReceipt, illustrations.Mailbox, illustrations.ShieldYellow],
     );
 
     const ownerDetails = ownerAccountID && getPersonalDetailsByIDs({accountIDs: [ownerAccountID], currentUserAccountID: currentUserPersonalDetails.accountID}).at(0);


### PR DESCRIPTION
### Explanation of Change

- Submit workspaces now render with the `EnvelopeReceipt` illustration and a "Submit" label in `WorkspacesListRow.tsx`.
- The Plan Type page (`DynamicWorkspaceOverviewPlanTypePage.tsx`) only surfaces the Submit row when the current policy is already Submit, so paid workspaces can no longer downgrade.
- `handleUpdatePlan` has a defensive guard rejecting any Collect/Control → Submit downgrade in case the filter is bypassed.
- Ports the minimal Submit-plan prerequisites from #87261 so this branch builds and behaves correctly on Submit workspaces (`POLICY.TYPE.SUBMIT`, `POLICY.ROLE.EDITOR`, `isSubmitPolicy`/`isPolicyEditor`/`canEditWorkspaceSettings` helpers, `AccessOrNotFoundWrapper` ADMIN variant, `WorkspaceOverviewPage` read-only gate, `getSubscriptionPrice` returning `0` for Submit).
- Adds `workspace.type.submit` + `planTypes.submit2026.{label, description}` translations across all supported locales.

Note: the Submit → Collect/Control upgrade is intentionally not wired here; it depends on the backend `UpgradeSubmit` API command and the `WorkspaceUpgradePage` Submit branch that ship in separate Wave 1/Wave 3 tasks. Silent save on that path is the expected intermediate state and will collapse automatically once those land.

### Fixed Issues

$ https://github.com/Expensify/App/issues/87263

### Tests

**Workspaces list (Submit icon + label):**
1. Enable the `SUBMIT_2026` beta for your account.
2. Create or join a Submit workspace.
3. Open Workspaces (`/workspaces`).
4. Verify the Submit workspace row shows the pink envelope-receipt illustration, the primary label "Submit", and the secondary label "Plan".
5. Verify Collect and Control workspaces still show Mailbox and ShieldYellow respectively with their existing labels.

**Plan Type page — Submit policy:**
1. On a Submit workspace, open Workspace > Overview.
2. Tap "Plan type".
3. Verify the page loads (no "Hmm… it's not here" 404) for the workspace editor.
4. Verify the list contains `Submit` (selected), `Collect`, `Control` — in that visual order.
5. Tap `Collect`, then Save: confirm no downgrade is performed and no destructive state change occurs (upgrade flow wiring is out of scope).
6. Tap `Submit`, then Save: confirm the page navigates back.

**Plan Type page — Collect policy:**
1. On a Collect (Team) workspace, open Workspace > Overview > Plan type.
2. Verify the list contains only `Collect` (selected) and `Control` — `Submit` is not shown.
3. Verify Collect → Control still navigates to the existing upgrade page.

**Plan Type page — Control policy:**
1. On a Control (Corporate) workspace, open Workspace > Overview > Plan type.
2. Verify the list contains only `Collect` and `Control` (selected) — `Submit` is not shown.
3. Verify Control → Collect still navigates to the existing downgrade page (or the blocked-by-invoicing screen, as applicable).

- [X] Verify that no errors appear in the JS console

### Offline tests

Same as Tests above — all three pages render from Onyx cache when offline.

### QA Steps

Same as Tests above.

- [X] Verify that no errors appear in the JS console

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [X] I linked the correct issue in the `### Fixed Issues` section above
- [X] I wrote clear testing steps that cover the changes made in this PR
    - [X] I added steps for local testing in the `Tests` section
    - [X] I added steps for the expected offline behavior in the `Offline steps` section
    - [X] I added steps for Staging and/or Production testing in the `QA steps` section
    - [X] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [X] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [X] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [X] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [X] I ran the tests on **all platforms** & verified they passed on:
    - [X] Android: Native
    - [X] Android: mWeb Chrome
    - [X] iOS: Native
    - [X] iOS: mWeb Safari
    - [X] MacOS: Chrome / Safari
- [X] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [X] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [X] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [X] I verified that comments were added to code that is not self explanatory
    - [X] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [X] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [X] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [X] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [X] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [X] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [X] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [X] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [X] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [X] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [X] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [X] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [X] I verified that if a function's arguments changed that all usages have also been updated correctly
- [X] If any new file was added I verified that:
    - [X] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [X] If a new CSS style is added I verified that:
    - [X] A similar style doesn't already exist
    - [X] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [X] If new assets were added or existing ones were modified, I verified that:
    - [X] The assets are optimized and compressed (for SVG files, run `npm run compress-svg`)
    - [X] The assets load correctly across all supported platforms.
- [X] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [X] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [X] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [X] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [X] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [X] I verified that all the inputs inside a form are aligned with each other.
    - [X] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [X] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [X] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [X] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->


https://github.com/user-attachments/assets/ea2f27d7-0000-4258-b639-a82847267971


</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/28156107-5ec4-47ea-bd24-c3b713322732



</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

https://github.com/user-attachments/assets/4d9091b8-e1f1-4d68-b636-b52f96df8b05


</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->


https://github.com/user-attachments/assets/6c96c77a-4938-4350-bb3a-24b44e3725a4


</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

<img width="1512" height="861" alt="Screenshot 2026-04-19 at 00 10 05" src="https://github.com/user-attachments/assets/1335f5c0-5183-415c-97a3-5a4cc43553b7" />



https://github.com/user-attachments/assets/4891e0d0-95d5-4cbe-a4bb-f9c7e3a36f47


</details>