### PR TITLE
Fix #79837: Cancel pending MARK_AS_UNREAD when reading report

### DIFF
--- a/src/libs/actions/Report/index.ts
+++ b/src/libs/actions/Report/index.ts
@@ -175,7 +175,7 @@ import {clearByKey} from '@userActions/CachedPDFPaths';
 import {setDownload} from '@userActions/Download';
 import {close} from '@userActions/Modal';
 import navigateFromNotification from '@userActions/navigateFromNotification';
-import {getAll} from '@userActions/PersistedRequests';
+import {getAll, deleteRequestsByIndices} from '@userActions/PersistedRequests';
 import {buildAddMembersToWorkspaceOnyxData, buildRoomMembersOnyxData} from '@userActions/Policy/Member';
 import {createPolicyExpenseChats} from '@userActions/Policy/Policy';
 import {
@@ -2330,6 +2330,21 @@ function readNewestAction(reportID: string | undefined, hasOnceLoadedReportActio
         if (!hasReportActions) {
             return;
         }
+    }
+
+    // Cancel any pending MARK_AS_UNREAD requests for this report
+    // This prevents the unread state from being applied after the user has read the report
+    // Fixes issue #79837 where report remains marked as unread in LHN after returning online
+    const persistedRequests = getAll();
+    const markAsUnreadIndices: number[] = [];
+    persistedRequests.forEach((request, index) => {
+        if (request.command === WRITE_COMMANDS.MARK_AS_UNREAD && request.data?.reportID === reportID) {
+            markAsUnreadIndices.push(index);
+        }
+    });
+
+    if (markAsUnreadIndices.length > 0) {
+        deleteRequestsByIndices(markAsUnreadIndices);
     }
 
     const lastReadTime = getDBTimeWithSkew();


### PR DESCRIPTION
### Details
Fixes issue #79837 where report remains marked as unread (bold) in LHN after returning online, even though the message was previously read offline.

### Root Cause
When offline, if a user marks a message as unread and then reads it, both `MARK_AS_UNREAD` and `READ_NEWEST_ACTION` requests are queued. When coming online, if `MARK_AS_UNREAD` is processed after `READ_NEWEST_ACTION`, it overwrites the newer `lastReadTime` with an older timestamp.

### Solution
Cancel any pending `MARK_AS_UNREAD` requests when `readNewestAction` is called for the same report.

### Fixed Issues
$ #79837

### Tests
- Verified that unread state is correctly cleared when reading a report
- No impact on other read/unread functionality