### PR TITLE
Fix: From filter visible workspace members

### DIFF
--- a/src/components/Search/FilterDropdowns/UserSelectPopup.tsx
+++ b/src/components/Search/FilterDropdowns/UserSelectPopup.tsx
@@ -1,5 +1,5 @@
 import isEmpty from 'lodash/isEmpty';
-import React, {memo, useCallback, useEffect, useMemo, useRef, useState} from 'react';
+import React, {memo, useCallback, useMemo, useRef} from 'react';
 import {usePersonalDetails} from '@components/OnyxListItemProvider';
 import SelectionList from '@components/SelectionList';
 import UserSelectionListItem from '@components/SelectionList/ListItem/UserSelectionListItem';
@@ -13,10 +13,12 @@ import useThemeStyles from '@hooks/useThemeStyles';
 import useWindowDimensions from '@hooks/useWindowDimensions';
 import canFocusInputOnScreenFocus from '@libs/canFocusInputOnScreenFocus';
 import {getParticipantsOption} from '@libs/OptionsListUtils';
+import {getNonVisibleWorkspaceMemberExclusionLogins, getVisibleWorkspaceMemberLogins} from '@libs/PolicyUtils';
 import type {OptionData} from '@libs/ReportUtils';
 import variables from '@styles/variables';
 import CONST from '@src/CONST';
 import ONYXKEYS from '@src/ONYXKEYS';
+import type {PersonalDetailsList} from '@src/types/onyx';
 import BasePopup from './BasePopup';
 
 type UserSelectPopupProps = {
@@ -38,9 +40,41 @@ type UserSelectPopupProps = {
      * Set to true to always show search, or false to never show search regardless of user count.
      */
     isSearchable?: boolean;
+
+    /** Whether to scope suggestions to visible workspace members while preserving free-text entry */
+    shouldScopeToVisibleWorkspaceMembers?: boolean;
 };
 
-function UserSelectPopup({value, label, closeOverlay, onChange, isSearchable}: UserSelectPopupProps) {
+function getFreeTextOption(identifier: string): OptionData {
+    return {
+        text: identifier,
+        alternateText: identifier,
+        login: identifier,
+        displayName: identifier,
+        accountID: CONST.DEFAULT_NUMBER_ID,
+        // eslint-disable-next-line rulesdir/no-default-id-values
+        reportID: '-1',
+        keyForList: identifier,
+        selected: true,
+        isSelected: true,
+        icons: [],
+        searchText: identifier,
+    };
+}
+
+function getOptionFromStoredValue(identifier: string, personalDetails: PersonalDetailsList | undefined, shouldAllowFreeText: boolean): OptionData | undefined {
+    const participant = personalDetails?.[identifier] ?? Object.values(personalDetails ?? {}).find((personalDetail) => personalDetail?.login?.toLowerCase() === identifier.toLowerCase());
+    if (participant) {
+        return {
+            ...getParticipantsOption(participant, personalDetails),
+            isSelected: true,
+        } as OptionData;
+    }
+
+    return shouldAllowFreeText ? getFreeTextOption(identifier) : undefined;
+}
+
+function UserSelectPopup({value, label, closeOverlay, onChange, isSearchable, shouldScopeToVisibleWorkspaceMembers = false}: UserSelectPopupProps) {
     const selectionListRef = useRef<SelectionListHandle<ListItem> | null>(null);
     const styles = useThemeStyles();
     const {translate} = useLocalize();
@@ -49,27 +83,29 @@ function UserSelectPopup({value, label, closeOverlay, onChange, isSearchable}: U
     const {shouldUseNarrowLayout, isInLandscapeMode} = useResponsiveLayout();
     const currentUserPersonalDetails = useCurrentUserPersonalDetails();
     const currentUserAccountID = currentUserPersonalDetails.accountID;
+    const currentUserLogin = currentUserPersonalDetails.login ?? currentUserPersonalDetails.email ?? '';
     const shouldFocusInputOnScreenFocus = canFocusInputOnScreenFocus();
     const [isSearchingForReports] = useOnyx(ONYXKEYS.RAM_ONLY_IS_SEARCHING_FOR_REPORTS);
+    const [allPolicies] = useOnyx(ONYXKEYS.COLLECTION.POLICY);
+    const visibleWorkspaceMemberLogins = useMemo(
+        () => (shouldScopeToVisibleWorkspaceMembers ? getVisibleWorkspaceMemberLogins(allPolicies, currentUserLogin) : CONST.EMPTY_OBJECT),
+        [allPolicies, currentUserLogin, shouldScopeToVisibleWorkspaceMembers],
+    );
+    const excludeFromSuggestionsOnly = useMemo(
+        () => (shouldScopeToVisibleWorkspaceMembers ? getNonVisibleWorkspaceMemberExclusionLogins(personalDetails, visibleWorkspaceMemberLogins) : CONST.EMPTY_OBJECT),
+        [personalDetails, shouldScopeToVisibleWorkspaceMembers, visibleWorkspaceMemberLogins],
+    );
     const initialSelectedOptions = useMemo(() => {
         return value.reduce<OptionData[]>((options, id) => {
-            const participant = personalDetails?.[id];
-            if (!participant) {
+            const optionData = getOptionFromStoredValue(id, personalDetails, shouldScopeToVisibleWorkspaceMembers);
+            if (!optionData) {
                 return options;
             }
 
-            const optionData = {
-                ...getParticipantsOption(participant, personalDetails),
-                isSelected: true,
-            };
-
-            if (optionData) {
-                options.push(optionData as OptionData);
-            }
-
+            options.push(optionData);
             return options;
         }, []);
-    }, [value, personalDetails]);
+    }, [value, personalDetails, shouldScopeToVisibleWorkspaceMembers]);
 
     const {searchTerm, debouncedSearchTerm, setSearchTerm, availableOptions, selectedOptions, toggleSelection, areOptionsInitialized, selectedOptionsForDisplay, onListEndReached} =
         useSearchSelector({
@@ -77,9 +113,12 @@ function UserSelectPopup({value, label, closeOverlay, onChange, isSearchable}: U
             searchContext: CONST.SEARCH_SELECTOR.SEARCH_CONTEXT_GENERAL,
             initialSelected: initialSelectedOptions,
             excludeLogins: CONST.EXPENSIFY_EMAILS_OBJECT,
+            excludeFromSuggestionsOnly,
             maxRecentReportsToShow: CONST.IOU.MAX_RECENT_REPORTS_TO_SHOW,
-            includeUserToInvite: false,
+            includeUserToInvite: shouldScopeToVisibleWorkspaceMembers,
             includeCurrentUser: true,
+            includeRecentReports: !shouldScopeToVisibleWorkspaceMembers,
+            shouldAllowNameOnlyOptions: shouldScopeToVisibleWorkspaceMembers,
         });
 
     const listData = useMemo(() => {
@@ -87,11 +126,16 @@ function UserSelectPopup({value, label, closeOverlay, onChange, isSearchable}: U
             ...participant,
             keyForList: String(participant.accountID),
         }));
-        const recentReports = availableOptions.recentReports.map((report) => ({
-            ...report,
-            keyForList: String(report.reportID),
-        }));
-        const combinedOptions = [...selectedOptionsForDisplay, ...personalDetailsList, ...recentReports];
+        const recentReports = shouldScopeToVisibleWorkspaceMembers
+            ? []
+            : availableOptions.recentReports.map((report) => ({
+                  ...report,
+                  keyForList: String(report.reportID),
+              }));
+        const userToInvite = availableOptions.userToInvite
+            ? [{...availableOptions.userToInvite, keyForList: availableOptions.userToInvite.keyForList ?? availableOptions.userToInvite.login ?? ''}]
+            : [];
+        const combinedOptions = [...selectedOptionsForDisplay, ...userToInvite, ...personalDetailsList, ...recentReports];
 
         // Sort the options so that selected items appear first, and the current user appears right after that, followed by the rest of the options in their original order
         combinedOptions.sort((a, b) => {
@@ -118,7 +162,14 @@ function UserSelectPopup({value, label, closeOverlay, onChange, isSearchable}: U
             keyForList: option.keyForList ?? option.login ?? '',
         }));
         return combinedOptionsWithKeyForList;
-    }, [availableOptions.personalDetails, availableOptions.recentReports, selectedOptionsForDisplay, currentUserAccountID]);
+    }, [
+        availableOptions.personalDetails,
+        availableOptions.recentReports,
+        availableOptions.userToInvite,
+        selectedOptionsForDisplay,
+        currentUserAccountID,
+        shouldScopeToVisibleWorkspaceMembers,
+    ]);
 
     const headerMessage = useMemo(() => {
         const noResultsFound = isEmpty(listData);
@@ -134,10 +185,23 @@ function UserSelectPopup({value, label, closeOverlay, onChange, isSearchable}: U
     );
 
     const applyChanges = useCallback(() => {
-        const accountIDs = selectedOptions.flatMap((option) => (option.accountID ? [option.accountID.toString()] : []));
+        const selectedUsers = selectedOptions
+            .map((option) => {
+                if (!shouldScopeToVisibleWorkspaceMembers) {
+                    return option.accountID ? option.accountID.toString() : undefined;
+                }
+
+                if (option.accountID && option.accountID !== CONST.DEFAULT_NUMBER_ID && personalDetails?.[option.accountID]) {
+                    return option.accountID.toString();
+                }
+
+                // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing -- need || to handle empty string
+                return option.displayName || option.login || option.text;
+            })
+            .filter(Boolean) as string[];
         closeOverlay();
-        onChange(accountIDs);
-    }, [closeOverlay, onChange, selectedOptions]);
+        onChange(selectedUsers);
+    }, [closeOverlay, onChange, personalDetails, selectedOptions, shouldScopeToVisibleWorkspaceMembers]);
 
     const resetChanges = useCallback(() => {
         onChange([]);
@@ -145,16 +209,9 @@ function UserSelectPopup({value, label, closeOverlay, onChange, isSearchable}: U
     }, [closeOverlay, onChange]);
 
     const isLoadingNewOptions = !!isSearchingForReports;
-    const [totalOptionsCount, setTotalOptionsCount] = useState(() => selectedOptionsForDisplay.length + availableOptions.personalDetails.length + availableOptions.recentReports.length);
+    const optionsCount = selectedOptionsForDisplay.length + availableOptions.personalDetails.length + availableOptions.recentReports.length + (availableOptions.userToInvite ? 1 : 0);
 
-    useEffect(() => {
-        if (debouncedSearchTerm) {
-            return;
-        }
-        setTotalOptionsCount(selectedOptionsForDisplay.length + availableOptions.personalDetails.length + availableOptions.recentReports.length);
-    }, [debouncedSearchTerm, selectedOptionsForDisplay.length, availableOptions.personalDetails.length, availableOptions.recentReports.length]);
-
-    const shouldShowSearchInput = isSearchable ?? totalOptionsCount >= CONST.STANDARD_LIST_ITEM_LIMIT;
+    const shouldShowSearchInput = shouldScopeToVisibleWorkspaceMembers || !!debouncedSearchTerm || (isSearchable ?? optionsCount >= CONST.STANDARD_LIST_ITEM_LIMIT);
 
     const textInputOptions = useMemo(
         () =>

--- a/src/components/Search/SearchFiltersParticipantsSelector.tsx
+++ b/src/components/Search/SearchFiltersParticipantsSelector.tsx
@@ -11,6 +11,7 @@ import useScreenWrapperTransitionStatus from '@hooks/useScreenWrapperTransitionS
 import useSearchSelector from '@hooks/useSearchSelector';
 import {canUseTouchScreen} from '@libs/DeviceCapabilities';
 import {formatSectionsFromSearchTerm, getFilteredRecentAttendees, getParticipantsOption} from '@libs/OptionsListUtils';
+import {getNonVisibleWorkspaceMemberExclusionLogins, getVisibleWorkspaceMemberLogins} from '@libs/PolicyUtils';
 import type {OptionData} from '@libs/ReportUtils';
 import {getDisplayNameForParticipant} from '@libs/ReportUtils';
 import Navigation from '@navigation/Navigation';
@@ -55,9 +56,17 @@ type SearchFiltersParticipantsSelectorProps = {
 
     /** Whether to allow name-only options (for attendee filter only) */
     shouldAllowNameOnlyOptions?: boolean;
+
+    /** Whether to scope suggestions to visible workspace members while preserving free-text entry */
+    shouldScopeToVisibleWorkspaceMembers?: boolean;
 };
 
-function SearchFiltersParticipantsSelector({initialAccountIDs, onFiltersUpdate, shouldAllowNameOnlyOptions = false}: SearchFiltersParticipantsSelectorProps) {
+function SearchFiltersParticipantsSelector({
+    initialAccountIDs,
+    onFiltersUpdate,
+    shouldAllowNameOnlyOptions = false,
+    shouldScopeToVisibleWorkspaceMembers = false,
+}: SearchFiltersParticipantsSelectorProps) {
     const {translate, formatPhoneNumber} = useLocalize();
     const personalDetails = usePersonalDetails();
     const {didScreenTransitionEnd} = useScreenWrapperTransitionStatus();
@@ -67,8 +76,18 @@ function SearchFiltersParticipantsSelector({initialAccountIDs, onFiltersUpdate, 
     const currentUserPersonalDetails = useCurrentUserPersonalDetails();
     const currentUserAccountID = currentUserPersonalDetails.accountID;
     const currentUserEmail = currentUserPersonalDetails.email ?? '';
+    const currentUserLogin = currentUserPersonalDetails.login ?? currentUserEmail;
     const [recentAttendees] = useOnyx(ONYXKEYS.NVP_RECENT_ATTENDEES);
     const [allPolicies] = useOnyx(ONYXKEYS.COLLECTION.POLICY);
+    const shouldAllowFreeTextOptions = shouldAllowNameOnlyOptions || shouldScopeToVisibleWorkspaceMembers;
+    const visibleWorkspaceMemberLogins = useMemo(
+        () => (shouldScopeToVisibleWorkspaceMembers ? getVisibleWorkspaceMemberLogins(allPolicies, currentUserLogin) : CONST.EMPTY_OBJECT),
+        [allPolicies, currentUserLogin, shouldScopeToVisibleWorkspaceMembers],
+    );
+    const excludeFromSuggestionsOnly = useMemo(
+        () => (shouldScopeToVisibleWorkspaceMembers ? getNonVisibleWorkspaceMemberExclusionLogins(personalDetails, visibleWorkspaceMemberLogins) : CONST.EMPTY_OBJECT),
+        [personalDetails, shouldScopeToVisibleWorkspaceMembers, visibleWorkspaceMemberLogins],
+    );
 
     // Transform raw recentAttendees into Option[] format for use with getValidOptions (only for attendee filter)
     const recentAttendeeLists = useMemo(
@@ -82,11 +101,12 @@ function SearchFiltersParticipantsSelector({initialAccountIDs, onFiltersUpdate, 
         maxRecentReportsToShow: CONST.IOU.MAX_RECENT_REPORTS_TO_SHOW,
         includeUserToInvite: true,
         excludeLogins: CONST.EXPENSIFY_EMAILS_OBJECT,
-        includeRecentReports: true,
+        excludeFromSuggestionsOnly,
+        includeRecentReports: !shouldScopeToVisibleWorkspaceMembers,
         shouldInitialize: didScreenTransitionEnd,
         includeCurrentUser: true,
         recentAttendees: recentAttendeeLists,
-        shouldAllowNameOnlyOptions,
+        shouldAllowNameOnlyOptions: shouldAllowFreeTextOptions,
     });
 
     const {sections, headerMessage} = useMemo(() => {
@@ -146,6 +166,14 @@ function SearchFiltersParticipantsSelector({initialAccountIDs, onFiltersUpdate, 
             data: formattedResults.section.data.map((option) => ({...option, isSelected: true})) as OptionData[],
         });
 
+        if (chatOptions.userToInvite) {
+            newSections.push({
+                title: '',
+                data: [chatOptions.userToInvite],
+                sectionIndex: 1,
+            });
+        }
+
         // Filter current user from recentReports to avoid duplicate with currentUserOption section
         // Only filter if both the report and currentUserOption have valid accountIDs to avoid
         // accidentally filtering out name-only attendees (which have accountID: undefined)
@@ -156,16 +184,16 @@ function SearchFiltersParticipantsSelector({initialAccountIDs, onFiltersUpdate, 
         newSections.push({
             title: '',
             data: filteredRecentReports,
-            sectionIndex: 1,
+            sectionIndex: 2,
         });
 
         newSections.push({
             title: '',
             data: chatOptions.personalDetails,
-            sectionIndex: 2,
+            sectionIndex: 3,
         });
 
-        const noResultsFound = chatOptions.personalDetails.length === 0 && chatOptions.recentReports.length === 0 && !chatOptions.currentUserOption;
+        const noResultsFound = chatOptions.personalDetails.length === 0 && chatOptions.recentReports.length === 0 && !chatOptions.currentUserOption && !chatOptions.userToInvite;
         const message = noResultsFound ? translate('common.noResultsFound') : undefined;
 
         return {
@@ -193,7 +221,7 @@ function SearchFiltersParticipantsSelector({initialAccountIDs, onFiltersUpdate, 
     const applyChanges = useCallback(() => {
         let selectedIdentifiers: string[];
 
-        if (shouldAllowNameOnlyOptions) {
+        if (shouldAllowFreeTextOptions) {
             selectedIdentifiers = selectedOptions
                 .map((option) => {
                     // For real users (with valid accountID in personalDetails), use accountID
@@ -201,9 +229,9 @@ function SearchFiltersParticipantsSelector({initialAccountIDs, onFiltersUpdate, 
                         return option.accountID.toString();
                     }
 
-                    // For name-only attendees, use displayName or login as identifier
+                    // For name-only attendees and free-text From values, use the typed identifier
                     // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing -- need || to handle empty string
-                    return option.displayName || option.login;
+                    return option.displayName || option.login || option.text;
                 })
                 .filter(Boolean) as string[];
         } else {
@@ -212,21 +240,22 @@ function SearchFiltersParticipantsSelector({initialAccountIDs, onFiltersUpdate, 
 
         onFiltersUpdate(selectedIdentifiers);
         Navigation.goBack(ROUTES.SEARCH_ADVANCED_FILTERS.getRoute());
-    }, [onFiltersUpdate, selectedOptions, personalDetails, shouldAllowNameOnlyOptions]);
+    }, [onFiltersUpdate, selectedOptions, personalDetails, shouldAllowFreeTextOptions]);
 
     // This effect handles setting initial selectedOptions based on accountIDs (or displayNames for attendee filter)
     useEffect(() => {
-        if (!initialAccountIDs || initialAccountIDs.length === 0 || !personalDetails) {
+        if (!initialAccountIDs || initialAccountIDs.length === 0 || (!personalDetails && !shouldAllowFreeTextOptions)) {
             return;
         }
 
         let preSelectedOptions: OptionData[];
 
-        if (shouldAllowNameOnlyOptions) {
+        if (shouldAllowFreeTextOptions) {
             preSelectedOptions = initialAccountIDs
                 .map((identifier) => {
                     // First, try to look up as accountID in personalDetails
-                    const participant = personalDetails[identifier];
+                    const participant =
+                        personalDetails?.[identifier] ?? Object.values(personalDetails ?? {}).find((personalDetail) => personalDetail?.login?.toLowerCase() === identifier.toLowerCase());
                     if (participant) {
                         const optionData = {
                             ...getParticipantsOption(participant, personalDetails),
@@ -237,7 +266,9 @@ function SearchFiltersParticipantsSelector({initialAccountIDs, onFiltersUpdate, 
 
                     // If not found in personalDetails, this might be a name-only attendee
                     // Search in recentAttendees by displayName or email
-                    const attendee = recentAttendees?.find((recentAttendee) => recentAttendee.displayName === identifier || recentAttendee.email === identifier);
+                    const attendee = shouldAllowNameOnlyOptions
+                        ? recentAttendees?.find((recentAttendee) => recentAttendee.displayName === identifier || recentAttendee.email === identifier)
+                        : undefined;
                     if (attendee) {
                         return getOptionDataFromAttendee(attendee);
                     }
@@ -252,7 +283,9 @@ function SearchFiltersParticipantsSelector({initialAccountIDs, onFiltersUpdate, 
                         accountID: CONST.DEFAULT_NUMBER_ID,
                         // eslint-disable-next-line rulesdir/no-default-id-values
                         reportID: '-1',
+                        keyForList: identifier,
                         selected: true,
+                        isSelected: true,
                         icons: [],
                         searchText: identifier,
                     };
@@ -261,7 +294,7 @@ function SearchFiltersParticipantsSelector({initialAccountIDs, onFiltersUpdate, 
         } else {
             preSelectedOptions = initialAccountIDs
                 .map((accountID) => {
-                    const participant = personalDetails[accountID];
+                    const participant = personalDetails?.[accountID];
                     if (!participant) {
                         return undefined;
                     }
@@ -276,7 +309,7 @@ function SearchFiltersParticipantsSelector({initialAccountIDs, onFiltersUpdate, 
 
         setSelectedOptions(preSelectedOptions);
         // eslint-disable-next-line react-hooks/exhaustive-deps -- this should react only to changes in form data
-    }, [initialAccountIDs, personalDetails, recentAttendees, shouldAllowNameOnlyOptions]);
+    }, [initialAccountIDs, personalDetails, recentAttendees, shouldAllowNameOnlyOptions, shouldAllowFreeTextOptions]);
 
     const handleParticipantSelection = useCallback(
         (option: OptionData) => {

--- a/src/components/Search/SearchPageHeader/useSearchFiltersBar.tsx
+++ b/src/components/Search/SearchPageHeader/useSearchFiltersBar.tsx
@@ -360,6 +360,7 @@ function useSearchFiltersBar(queryJSON: SearchQueryJSON): UseSearchFiltersBarRes
                             value={searchAdvancedFiltersForm[filterKey] ?? []}
                             label={translate(label)}
                             closeOverlay={closeOverlay}
+                            shouldScopeToVisibleWorkspaceMembers={filterKey === FILTER_KEYS.FROM}
                             onChange={(selectedUsers) => {
                                 const update: Partial<SearchAdvancedFiltersForm> = {};
                                 update[filterKey] = selectedUsers;

--- a/src/hooks/useAutocompleteSuggestions.ts
+++ b/src/hooks/useAutocompleteSuggestions.ts
@@ -7,7 +7,7 @@ import {getCardDescription, isCard, isCardHiddenFromSearch} from '@libs/CardUtil
 import {getDecodedCategoryName} from '@libs/CategoryUtils';
 import type {OptionList} from '@libs/OptionsListUtils';
 import {getSearchOptions} from '@libs/OptionsListUtils';
-import {getAllTaxRates, getCleanedTagName, shouldShowPolicy} from '@libs/PolicyUtils';
+import {getAllTaxRates, getCleanedTagName, getNonVisibleWorkspaceMemberExclusionLogins, getVisibleWorkspaceMemberLogins, shouldShowPolicy} from '@libs/PolicyUtils';
 import {
     getAutocompleteCategories,
     getAutocompleteRecentCategories,
@@ -213,6 +213,10 @@ function useAutocompleteSuggestions({
         case CONST.SEARCH.SYNTAX_FILTER_KEYS.PAYER:
         case CONST.SEARCH.SYNTAX_FILTER_KEYS.ATTENDEE:
         case CONST.SEARCH.SYNTAX_FILTER_KEYS.EXPORTER: {
+            const excludeFromSuggestionsOnly =
+                autocompleteKey === CONST.SEARCH.SYNTAX_FILTER_KEYS.FROM
+                    ? getNonVisibleWorkspaceMemberExclusionLogins(personalDetails, getVisibleWorkspaceMemberLogins(policies, currentUserEmail))
+                    : CONST.EMPTY_OBJECT;
             const participants = getSearchOptions({
                 options,
                 draftComments,
@@ -225,6 +229,7 @@ function useAutocompleteSuggestions({
                 includeUserToInvite: false,
                 includeRecentReports: false,
                 includeCurrentUser: true,
+                excludeFromSuggestionsOnly,
                 countryCode,
                 loginList,
                 shouldShowGBR: true,

--- a/src/libs/OptionsListUtils/index.ts
+++ b/src/libs/OptionsListUtils/index.ts
@@ -2743,6 +2743,7 @@ type SearchOptionsConfig = {
     includeUserToInvite?: boolean;
     includeRecentReports?: boolean;
     includeCurrentUser?: boolean;
+    excludeFromSuggestionsOnly?: Record<string, boolean>;
     countryCode?: number;
     shouldShowGBR?: boolean;
     shouldUnreadBeBold?: boolean;
@@ -2772,6 +2773,7 @@ function getSearchOptions({
     includeUserToInvite,
     includeRecentReports = true,
     includeCurrentUser = false,
+    excludeFromSuggestionsOnly = {},
     countryCode = CONST.DEFAULT_COUNTRY_CODE,
     shouldShowGBR = false,
     shouldUnreadBeBold = false,
@@ -2801,6 +2803,7 @@ function getSearchOptions({
         excludeHiddenThreads: true,
         maxElements: maxResults,
         includeCurrentUser,
+        excludeFromSuggestionsOnly,
         searchString: searchQuery,
         includeUserToInvite,
         shouldShowGBR,

--- a/src/libs/PolicyUtils.ts
+++ b/src/libs/PolicyUtils.ts
@@ -490,6 +490,50 @@ function shouldFilterExpensifyTeam(policyOwner: string | undefined, currentUserL
 }
 
 /**
+ * Get visible workspace member logins for customer-facing member selectors.
+ * This reads policy employeeList keys directly so results do not depend on personal details hydration.
+ */
+function getVisibleWorkspaceMemberLogins(policies: OnyxCollection<Policy> | undefined, currentUserLogin: string | undefined, isOffline = false): Record<string, boolean> {
+    const visibleWorkspaceMemberLogins: Record<string, boolean> = {};
+
+    for (const policy of Object.values(policies ?? {})) {
+        if (!policy || !isPaidGroupPolicy(policy) || isPendingDeletePolicy(policy)) {
+            continue;
+        }
+
+        const shouldHideExpensifyTeam = shouldFilterExpensifyTeam(policy.owner, currentUserLogin);
+        for (const [email, policyEmployee] of Object.entries(policy.employeeList ?? {})) {
+            if (!email || isDeletedPolicyEmployee(policyEmployee, isOffline) || (shouldHideExpensifyTeam && isExpensifyTeam(email))) {
+                continue;
+            }
+
+            visibleWorkspaceMemberLogins[email.toLowerCase()] = true;
+        }
+    }
+
+    return visibleWorkspaceMemberLogins;
+}
+
+/**
+ * Build a soft-exclusion map for hydrated personal details that are not visible workspace members.
+ * Callers can still accept manually typed values while hiding these entries from suggestions.
+ */
+function getNonVisibleWorkspaceMemberExclusionLogins(personalDetails: OnyxEntry<PersonalDetailsList>, visibleWorkspaceMemberLogins: Record<string, boolean>): Record<string, boolean> {
+    const exclusions: Record<string, boolean> = {};
+
+    for (const personalDetail of Object.values(personalDetails ?? {})) {
+        const login = personalDetail?.login;
+        if (!login || visibleWorkspaceMemberLogins[login.toLowerCase()]) {
+            continue;
+        }
+
+        exclusions[login] = true;
+    }
+
+    return exclusions;
+}
+
+/**
  * Checks if the current user is of the role "user" on the policy.
  */
 const isPolicyUser = (policy: OnyxInputOrEntry<Policy>, currentUserLogin?: string): boolean => getPolicyRole(policy, currentUserLogin) === CONST.POLICY.ROLE.USER;
@@ -2167,6 +2211,8 @@ export {
     getCountOfEnabledTagsOfList,
     getIneligibleInvitees,
     getMemberAccountIDsForWorkspace,
+    getVisibleWorkspaceMemberLogins,
+    getNonVisibleWorkspaceMemberExclusionLogins,
     getHRConnectionNames,
     getGuideAndAccountManagerInfo,
     getSoftExclusionsForGuideAndAccountManager,

--- a/src/pages/Search/SearchAdvancedFiltersPage/SearchFiltersFromPage.tsx
+++ b/src/pages/Search/SearchAdvancedFiltersPage/SearchFiltersFromPage.tsx
@@ -34,6 +34,7 @@ function SearchFiltersFromPage() {
             <View style={[styles.flex1]}>
                 <SearchFiltersParticipantsSelector
                     initialAccountIDs={searchAdvancedFiltersForm?.from ?? []}
+                    shouldScopeToVisibleWorkspaceMembers
                     onFiltersUpdate={(selectedAccountIDs) => {
                         updateAdvancedFilters({
                             from: selectedAccountIDs,

--- a/tests/unit/PolicyUtilsTest.ts
+++ b/tests/unit/PolicyUtilsTest.ts
@@ -17,6 +17,7 @@ import {
     getDefaultTimeTrackingRate,
     getEligibleBankAccountShareRecipients,
     getManagerAccountID,
+    getNonVisibleWorkspaceMemberExclusionLogins,
     getPolicyEmployeeAccountIDs,
     getPolicyNameByID,
     getRateDisplayValue,
@@ -26,6 +27,7 @@ import {
     getTagListByOrderWeight,
     getUberConnectionErrorDirectlyFromPolicy,
     getUnitRateValue,
+    getVisibleWorkspaceMemberLogins,
     hasConfiguredRules,
     hasDependentTags,
     hasDynamicExternalWorkflow,
@@ -230,6 +232,101 @@ describe('PolicyUtils', () => {
     beforeAll(() => {
         Onyx.init({
             keys: ONYXKEYS,
+        });
+    });
+
+    describe('getVisibleWorkspaceMemberLogins', () => {
+        const makePolicy = (id: string, owner: string, policyEmployeeList: PolicyEmployeeList, type: Policy['type'] = CONST.POLICY.TYPE.TEAM): Policy =>
+            ({
+                id,
+                name: `Policy ${id}`,
+                type,
+                role: CONST.POLICY.ROLE.USER,
+                owner,
+                outputCurrency: CONST.CURRENCY.USD,
+                isPolicyExpenseChatEnabled: true,
+                employeeList: policyEmployeeList,
+            }) as Policy;
+
+        it('hides Expensify team members for external customers', () => {
+            const policies = {
+                [`${ONYXKEYS.COLLECTION.POLICY}1`]: makePolicy('1', 'owner@example.com', {
+                    'owner@example.com': {email: 'owner@example.com'},
+                    'employee@example.com': {email: 'employee@example.com'},
+                    'account.manager@expensify.com': {email: 'account.manager@expensify.com'},
+                    'guide@team.expensify.com': {email: 'guide@team.expensify.com'},
+                }),
+            };
+
+            expect(getVisibleWorkspaceMemberLogins(policies, 'employee@example.com')).toEqual({
+                'owner@example.com': true,
+                'employee@example.com': true,
+            });
+        });
+
+        it('shows Expensify team members for internal workspaces or internal viewers', () => {
+            const policies = {
+                [`${ONYXKEYS.COLLECTION.POLICY}1`]: makePolicy('1', 'owner@expensify.com', {
+                    'owner@expensify.com': {email: 'owner@expensify.com'},
+                    'employee@example.com': {email: 'employee@example.com'},
+                    'guide@team.expensify.com': {email: 'guide@team.expensify.com'},
+                }),
+                [`${ONYXKEYS.COLLECTION.POLICY}2`]: makePolicy('2', 'customer@example.com', {
+                    'account.manager@expensify.com': {email: 'account.manager@expensify.com'},
+                }),
+            };
+
+            expect(getVisibleWorkspaceMemberLogins(policies, 'employee@team.expensify.com')).toEqual({
+                'owner@expensify.com': true,
+                'employee@example.com': true,
+                'guide@team.expensify.com': true,
+                'account.manager@expensify.com': true,
+            });
+        });
+
+        it('excludes deleted members and non-workspace policies without personal details hydration', () => {
+            const policies = {
+                [`${ONYXKEYS.COLLECTION.POLICY}1`]: makePolicy('1', 'owner@example.com', {
+                    'visible@example.com': {email: 'visible@example.com'},
+                    'deleted@example.com': {email: 'deleted@example.com', pendingAction: CONST.RED_BRICK_ROAD_PENDING_ACTION.DELETE},
+                }),
+                [`${ONYXKEYS.COLLECTION.POLICY}2`]: makePolicy(
+                    '2',
+                    'owner@example.com',
+                    {
+                        'personal@example.com': {email: 'personal@example.com'},
+                    },
+                    CONST.POLICY.TYPE.PERSONAL,
+                ),
+                [`${ONYXKEYS.COLLECTION.POLICY}3`]: {
+                    ...makePolicy('3', 'owner@example.com', {
+                        'deleted-policy@example.com': {email: 'deleted-policy@example.com'},
+                    }),
+                    pendingAction: CONST.RED_BRICK_ROAD_PENDING_ACTION.DELETE,
+                },
+            };
+
+            expect(getVisibleWorkspaceMemberLogins(policies, 'visible@example.com')).toEqual({
+                'visible@example.com': true,
+            });
+        });
+    });
+
+    describe('getNonVisibleWorkspaceMemberExclusionLogins', () => {
+        it('builds suggestion-only exclusions from personal details outside the visible workspace member allowlist', () => {
+            expect(
+                getNonVisibleWorkspaceMemberExclusionLogins(
+                    {
+                        1: {accountID: 1, login: 'visible@example.com'},
+                        2: {accountID: 2, login: 'hidden@expensify.com'},
+                        3: {accountID: 3, login: 'other@example.com'},
+                    },
+                    {'visible@example.com': true},
+                ),
+            ).toEqual({
+                'hidden@expensify.com': true,
+                'other@example.com': true,
+            });
         });
     });
 

--- a/tests/unit/hooks/useAutocompleteSuggestions.test.ts
+++ b/tests/unit/hooks/useAutocompleteSuggestions.test.ts
@@ -36,21 +36,38 @@ jest.mock('@libs/SearchAutocompleteUtils', () => ({
 }));
 
 jest.mock('@libs/OptionsListUtils', () => ({
-    getSearchOptions: jest.fn(() => ({
-        personalDetails: [
+    getSearchOptions: jest.fn(({excludeFromSuggestionsOnly = {}}: {excludeFromSuggestionsOnly?: Record<string, boolean>} = {}) => {
+        const personalDetails = [
             {text: 'John Doe', login: 'john@example.com', accountID: 1},
             {text: 'Jane Smith', login: 'jane@example.com', accountID: 2},
-        ],
-        recentReports: [
-            {text: 'General Chat', reportID: 'report1'},
-            {text: 'Team Updates', reportID: 'report2'},
-        ],
-    })),
+            {text: 'Account Manager', login: 'account.manager@expensify.com', accountID: 3},
+        ];
+
+        return {
+            personalDetails: personalDetails.filter((personalDetail) => !excludeFromSuggestionsOnly[personalDetail.login]),
+            recentReports: [
+                {text: 'General Chat', reportID: 'report1'},
+                {text: 'Team Updates', reportID: 'report2'},
+            ],
+        };
+    }),
 }));
 
 jest.mock('@libs/PolicyUtils', () => ({
     getAllTaxRates: jest.fn(() => ({})),
     getCleanedTagName: jest.fn((tag: string) => tag),
+    getVisibleWorkspaceMemberLogins: jest.fn(() => Object.fromEntries([['john@example.com', true]])),
+    getNonVisibleWorkspaceMemberExclusionLogins: jest.fn((personalDetails: Record<string, {login?: string} | null> = {}, visibleWorkspaceMemberLogins: Record<string, boolean> = {}) => {
+        const exclusions: Record<string, boolean> = {};
+        for (const personalDetail of Object.values(personalDetails)) {
+            const login = personalDetail?.login;
+            if (!login || visibleWorkspaceMemberLogins[login.toLowerCase()]) {
+                continue;
+            }
+            exclusions[login] = true;
+        }
+        return exclusions;
+    }),
     shouldShowPolicy: jest.fn(() => true),
 }));
 
@@ -193,6 +210,50 @@ describe('useAutocompleteSuggestions', () => {
         expect(result.current.length).toBeGreaterThan(0);
         expect(result.current.at(0)?.filterKey).toBe(CONST.SEARCH.SYNTAX_FILTER_KEYS.FROM);
         expect(result.current.at(0)?.mapKey).toBe(CONST.SEARCH.SYNTAX_FILTER_KEYS.FROM);
+    });
+
+    it('scopes from suggestions to visible workspace members', () => {
+        parseForAutocomplete.mockReturnValue({
+            autocomplete: {key: CONST.SEARCH.SYNTAX_FILTER_KEYS.FROM, value: ''},
+            ranges: [],
+        });
+        const personalDetails = Object.fromEntries([
+            ['1', {accountID: 1, login: 'john@example.com'}],
+            ['2', {accountID: 2, login: 'jane@example.com'}],
+            ['3', {accountID: 3, login: 'account.manager@expensify.com'}],
+        ]);
+
+        const {result} = renderHook(() =>
+            useAutocompleteSuggestions({
+                ...defaultParams,
+                autocompleteQueryValue: 'from:',
+                personalDetails,
+            }),
+        );
+
+        expect(result.current.map((item) => item.text)).toEqual(['John Doe']);
+    });
+
+    it('does not scope to: suggestions to visible workspace members', () => {
+        parseForAutocomplete.mockReturnValue({
+            autocomplete: {key: CONST.SEARCH.SYNTAX_FILTER_KEYS.TO, value: ''},
+            ranges: [],
+        });
+        const personalDetails = Object.fromEntries([
+            ['1', {accountID: 1, login: 'john@example.com'}],
+            ['2', {accountID: 2, login: 'jane@example.com'}],
+            ['3', {accountID: 3, login: 'account.manager@expensify.com'}],
+        ]);
+
+        const {result} = renderHook(() =>
+            useAutocompleteSuggestions({
+                ...defaultParams,
+                autocompleteQueryValue: 'to:',
+                personalDetails,
+            }),
+        );
+
+        expect(result.current.map((item) => item.text)).toEqual(['John Doe', 'Jane Smith', 'Account Manager']);
     });
 
     it('returns type suggestions when autocomplete key is type', () => {


### PR DESCRIPTION
### Explanation of Change

- This PR fixes the issue where internal Expensify users, including current and previous Account Managers, appear in the Reports/Search `From` filter for customer workspaces.
- It updates the advanced `From` filter page, the wide search filter popover, and inline `from:` autocomplete so `From` suggestions match Classic behavior: only visible workspace members are suggested, while arbitrary free-text email input remains supported.

**Root Cause:**

- The `From` filter used the same generic participant suggestion pipeline as other people filters.
- That generic pipeline is built from hydrated `personalDetails` and recent reports, so internal Expensify contacts can appear if they exist locally in Onyx.
- `From` also did not opt into the free-text path, even though Classic allows manually typed email values.
- Inline `from:` autocomplete used the same generic participant path, so it could leak the same non-visible internal users.

**Solution:**

- Add visible workspace member helpers in `PolicyUtils` that read policy `employeeList` keys directly and reuse the same Expensify-team visibility rule used by workspace member surfaces.
- Use a soft-exclusion map for `From` suggestions so non-visible hydrated personal details are hidden from suggestions but manually typed values can still be preserved.
- Opt the advanced `From` page into visible-workspace-member mode and free-text preservation.
- Opt only the wide `From` filter popover into the same mode, keeping `to`, `assignee`, and `attendee` unchanged.
- Pass `excludeFromSuggestionsOnly` through `getSearchOptions()` and apply it only for inline `from:` autocomplete.
- Add unit coverage for the visible workspace member allowlist and `from:` autocomplete scoping.

**Known limitation:**

- The allowlist controls suggestions from already hydrated option data. It intentionally does not synthesize visible workspace members whose personal details have not hydrated yet. Free-text entry still allows arbitrary email filtering in that state.

### Fixed Issues

$ https://github.com/Expensify/App/issues/83879
PROPOSAL: https://github.com/Expensify/App/issues/83879#issuecomment-4066771306

### Tests

**Primary Tests (Fix Validation):**

1. Log in as a customer user on a workspace that has visible workspace members and an internal Expensify AM/Guide/support user in the workspace data
2. Navigate to Reports/Search
3. Open Advanced filters
4. Open the `From` filter page
5. Verify visible workspace members are suggested
6. Verify internal Expensify AM/Guide/support users are not suggested
7. Type an arbitrary email address that is not in the suggestion list
8. Select/apply the free-text email
9. Reopen the `From` filter
10. Verify the free-text email is preserved

**Wide Search Header Popover Test:**

11. On wide layout, open the search filter bar `From` popup
12. Verify visible workspace members are suggested
13. Verify internal Expensify AM/Guide/support users are not suggested
14. Type and apply an arbitrary email address
15. Reopen the popup and verify the free-text value is preserved

**Inline Autocomplete Test:**

16. In the search input, type `from:`
17. Verify visible workspace members are suggested
18. Verify internal Expensify AM/Guide/support users are not suggested
19. Type `to:`
20. Verify `to:` still uses the existing generic participant suggestions and is not scoped like `from:`

**Non-Regression Tests:**

21. Open the `To` filter from the search filter bar
22. Verify it still behaves as a normal account-ID participant picker
23. Open the `Assignee` filter from the search filter bar
24. Verify it still behaves as a normal account-ID participant picker
25. Open the `Attendee` filter
26. Verify attendee free-text behavior still works as before
27. Verify that no errors appear in the JS console

### Offline tests

N/A - This change filters locally available Onyx/search option data and preserves manually typed values client-side. It does not add a new network dependency.

### QA Steps

Same as Primary Tests (steps 1-10), Wide Search Header Popover Test (steps 11-15), Inline Autocomplete Test (steps 16-20), and Non-Regression Tests (steps 21-27) above.

- [ ] Verify that no errors appear in the JS console

### PR Author Checklist

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios
    - [ ] I turned off my network connection and tested it while offline to ensure it matches the expected behavior
    - [ ] I tested this PR with a High Traffic account against the staging or production API to ensure there are no regressions
- [ ] I included screenshots or videos for tests on all platforms
- [ ] I ran the tests on all platforms & verified they passed on:
    - [ ] Android: Native
    - [ ] Android: mWeb Chrome
    - [ ] iOS: Native
    - [ ] iOS: mWeb Safari
    - [ ] MacOS: Chrome / Safari
    - [ ] Windows: Chrome
- [ ] I verified there are no console errors
- [x] I verified there are no new alerts related to the `canBeMissing` param for `useOnyx`
- [x] I followed proper code patterns
    - [x] I verified that any callback methods that were added or modified are named for what the method does
    - [x] I verified that comments were added only where the code is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained why the code was doing something
    - [x] I verified any copy / text shown in the product is localized
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using localization methods
    - [x] I verified proper file naming conventions were followed
    - [x] I verified the JSDocs style guidelines were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the Review Guidelines
- [x] I tested other components that can be impacted by my changes
- [x] I verified all code is DRY
- [x] I verified any variables that can be defined as constants are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] N/A - no new product source files were added
- [x] If a new CSS style is added I verified that:
    - [x] N/A - no new styles were added
- [x] If new assets were added or existing ones were modified, I verified that:
    - [x] N/A - no assets were added or modified
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown
    - [x] N/A - this PR does not modify message editing or sending
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected
    - [x] N/A - no Storybook stories were modified
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used
    - [x] N/A - no deeplink behavior was changed
- [x] If the PR modifies the UI or modifies the form input styles:
    - [x] N/A - this PR changes suggestion filtering behavior, not layout or form input styling
- [x] If a new page is added, I verified it's using the `ScrollView` component
    - [x] N/A - no new page was added
- [x] I added unit tests for this bug fix to help automatically prevent regressions in this user flow
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps
    - [x] N/A - `main` was not merged into this branch after review

### Screenshots/Videos

<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Windows: Chrome</summary>

<!-- add screenshots or videos here -->

</details>
